### PR TITLE
[npm] publish package privately

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "repository": "https://github.com/DataDog/datadog-ci",
   "author": "Yoann Moinet <yoann.moinet@datadoghq.com>",
   "license": "Apache-2.0",
-  "private": false,
   "bin": {
     "datadog-ci": "dist/index.js"
   },


### PR DESCRIPTION
### What and why?

This PR changes the name, repo, version and access config of the package to prepare its first private publication.
