### PR TITLE
[synthetics] support full url instead of public id

### DIFF
--- a/src/commands/synthetics/README.md
+++ b/src/commands/synthetics/README.md
@@ -95,6 +95,8 @@ Your test files must be named with a `.synthetics.json` suffix.
 }
 ```
 
+The `<TEST_PUBLIC_ID>` can be either the identifier of the test found in the URL of a test details page (eg. for `https://app.datadoghq.com/synthetics/details/abc-def-ghi` it would be `abc-def-ghi`) or the full URL to the details page (ie. directly `https://app.datadoghq.com/synthetics/details/abc-def-ghi`).
+
 You can configure on which url your test starts by providing a `config.startUrl` to your test object and build your own starting url using any part of your test's original starting url and the following environment variables: 
 
 | Environment variable | Description                  | Example                                                |

--- a/src/commands/synthetics/__tests__/utils.test.ts
+++ b/src/commands/synthetics/__tests__/utils.test.ts
@@ -2,9 +2,12 @@ jest.mock('glob');
 jest.useFakeTimers();
 
 import * as fs from 'fs';
-import glob from 'glob';
 
-import { getSuites } from '../utils';
+import glob from 'glob';
+import request from 'request-promise-native';
+
+import { apiConstructor } from '../api';
+import { getSuites, runTest } from '../utils';
 
 describe('utils', () => {
   describe('getSuites', () => {
@@ -21,6 +24,44 @@ describe('utils', () => {
     test('should get suites', async () => {
       const suites = await getSuites(GLOB, process.stdout.write.bind(process.stdout));
       expect(JSON.stringify(suites)).toBe(`[${FILES_CONTENT.file1},${FILES_CONTENT.file2}]`);
+    });
+  });
+
+  describe('runTest', () => {
+    const api = apiConstructor({ apiKey: '123', appKey: '123', baseUrl: 'base' });
+    const processWrite = process.stdout.write.bind(process.stdout);
+    const fakeTest = {
+      name: 'Fake Test',
+      public_id: '123-456-789',
+    };
+    const fakeTrigger = {
+      results: [],
+      triggered_check_ids: [fakeTest.public_id],
+    };
+    jest.spyOn(request, 'defaults').mockImplementation((() => (e: request.RequestPromise) => {
+      if (e.uri as any === '/synthetics/tests/trigger/ci') {
+        return fakeTrigger;
+      }
+
+      if (e.uri as any === `/synthetics/tests/${fakeTest.public_id}`) {
+        return fakeTest;
+      }
+    }) as any);
+
+    test('should run test', async () => {
+      const output = await runTest(api, { id: fakeTest.public_id, config: { } }, processWrite);
+      expect(output).toEqual([fakeTest, fakeTrigger.results]);
+    });
+
+    test('should run test with publicId from url', async () => {
+      const output = await runTest(
+        api, {
+          config: { },
+          id: `http://localhost/synthetics/tests/details/${fakeTest.public_id}`,
+        },
+        processWrite
+      );
+      expect(output).toEqual([fakeTest, fakeTrigger.results]);
     });
   });
 });

--- a/src/commands/synthetics/utils.ts
+++ b/src/commands/synthetics/utils.ts
@@ -26,6 +26,7 @@ import { pick } from '../../helpers/utils';
 
 const INTERVAL_CHECKING = 5000; // In ms
 const MAX_RETRIES = 2;
+const PUBLIC_ID_REGEX = /^[\d\w]{3}-[\d\w]{3}-[\d\w]{3}$/;
 const SUBDOMAIN_REGEX = /(.*?)\.(?=[^\/]*\..{2,5})/;
 
 const template = (st: string, context: any): string =>
@@ -190,6 +191,7 @@ export const waitForTests = async (
 export const runTest = async (api: APIHelper, { id, config }: TriggerConfig, write: Writable['write']):
   Promise<[Test, TriggerResult[]] | []> => {
   let test: Test | undefined;
+  id = PUBLIC_ID_REGEX.test(id) ? id : id.substr(id.lastIndexOf('/') + 1);
   try {
     test = await api.getTest(id);
   } catch (e) {


### PR DESCRIPTION
### What and why?

Support defining synthetics tests via their full URL instead of their public Id.

### How?

The id of the test is matched against a regular expression to determine whether it is a public id or if it should be extracted from an URL.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)

