### PR TITLE
[doc] update README to further scope token configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,14 @@ registry=https://registry.npmjs.org/
 //registry.npmjs.org/:_authToken=<TOKEN>
 ```
 
-If using Yarn v2, it is possible to scope the token to the `@datadog` scope in the `.yarnrc` file as describe [in the documentation](https://yarnpkg.com/configuration/yarnrc#npmScopes).
+If using Yarn v2, it is possible to scope the token to the `@datadog` scope in the `.yarnrc` file as described [in the documentation](https://yarnpkg.com/configuration/yarnrc#npmScopes):
+
+```yaml
+npmScopes:
+  datadog:
+    npmRegistryServer: "https://registry.npmjs.org"
+    npmAuthToken: "ffffffff-ffff-ffff-ffff-ffffffffffff"
+```
 
 Then, installing the package is done through NPM or Yarn:
 


### PR DESCRIPTION
### What and why?

Describe how to have the token tied to a specific registry (or scope if using Yarn v2).