### PR TITLE
[synthetics] add --public-id flag to run specific test

### DIFF
--- a/src/commands/synthetics/README.md
+++ b/src/commands/synthetics/README.md
@@ -59,7 +59,7 @@ The available command is:
 
 - `run-tests`: run the tests discovered in the folder according to the `files` configuration key
 
-It accepts the `--public-id` argument to trigger only the specified test. It can be set multiple times to run multiple tests:
+It accepts the `--public-id` (or shorthand `-p`) argument to trigger only the specified test. It can be set multiple times to run multiple tests:
 
 ```bash
 datadog-ci synthetics run-test --public-id pub-lic-id1 --public-id pub-lic-id2

--- a/src/commands/synthetics/run-test.ts
+++ b/src/commands/synthetics/run-test.ts
@@ -145,4 +145,4 @@ RunTestCommand.addPath('synthetics', 'run-tests');
 RunTestCommand.addOption('apiKey', Command.String('--apiKey'));
 RunTestCommand.addOption('appKey', Command.String('--appKey'));
 RunTestCommand.addOption('configPath', Command.String('--config'));
-RunTestCommand.addOption('publicIds', Command.Array('--public-id'));
+RunTestCommand.addOption('publicIds', Command.Array('-p,--public-id'));


### PR DESCRIPTION
### What and why?

When troubleshooting or iterating on tests to add to CI, it is useful to be able to start one specific test.
This PR adds a `--public-id` flag to specify one/multiple test(s) to run.

### How?

An array argument stores the list of public ids to launch. If provided by the command line, the test suite files are not searched for and the list of tests to start comes directly from this array.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)

