### PR TITLE
[synthetics] fix tests wrongfully reported as timeout-ed

### DIFF
--- a/src/commands/synthetics/utils.ts
+++ b/src/commands/synthetics/utils.ts
@@ -138,7 +138,8 @@ export const waitForResults = async (
     const timeout = setTimeout(() => {
       clearTimeout(pollTimeout);
       // Build and inject timeout errors.
-      triggerResults.forEach(triggerResult => {
+      pollingIds.forEach(resultId => {
+        const triggerResult = triggerResultsByResultID[resultId];
         const pollResult: PollResult = {
           dc_id: triggerResult.location,
           result: {


### PR DESCRIPTION
### What and why?

When multiple tests ran at the same time and one of them triggered a timeout, all results (except the one with a timeout) had an extra result with a timeout.
This PR fixes this bug by only setting as timeout-ed tests that were being polled at the time out expires.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)

