### PR TITLE
[build] disable source maps

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "es6",
     "module": "commonjs",
-    "sourceMap": true,
+    "sourceMap": false,
     "outDir": "dist",
     "rootDir": "src",
     "strict": true,


### PR DESCRIPTION
### What and why?

Disable the sourcemaps to not leak source code until the repo is made public.