### PR TITLE
[synthetics] print location names in results

### DIFF
--- a/src/commands/synthetics/__tests__/api.test.ts
+++ b/src/commands/synthetics/__tests__/api.test.ts
@@ -4,6 +4,13 @@ import { apiConstructor } from '../api';
 import { Payload, PollResult, Result, Trigger } from '../interfaces';
 
 describe('dd-api', () => {
+  const LOCATION = {
+    display_name: 'fake location',
+    id: 42,
+    is_active: true,
+    name: 'fake-loc',
+    region: 'fake-region',
+  };
   const RESULT_ID = '123';
   const POLL_RESULTS: { results: PollResult[] } = {
     results: [
@@ -16,6 +23,7 @@ describe('dd-api', () => {
   };
   const TRIGGERED_TEST_ID = 'fakeId';
   const TRIGGER_RESULTS: Trigger = {
+    locations: [LOCATION],
     results: [
       {
         device: 'laptop_large',

--- a/src/commands/synthetics/interfaces.ts
+++ b/src/commands/synthetics/interfaces.ts
@@ -102,7 +102,20 @@ export interface TriggerResult {
   result_id: string;
 }
 
+interface Location {
+  display_name: string;
+  id: number;
+  is_active: boolean;
+  name: string;
+  region: string;
+}
+
+export interface LocationsMapping {
+  [key: number]: string;
+}
+
 export interface Trigger {
+  locations: Location[];
   results: TriggerResult[];
   triggered_check_ids: string[];
 }

--- a/src/commands/synthetics/run-test.ts
+++ b/src/commands/synthetics/run-test.ts
@@ -6,7 +6,7 @@ import { Command } from 'clipanion';
 import deepExtend from 'deep-extend';
 
 import { apiConstructor } from './api';
-import { ConfigOverride, ExecutionRule } from './interfaces';
+import { ConfigOverride, ExecutionRule, LocationsMapping } from './interfaces';
 import { renderHeader, renderResult } from './renderer';
 import { getSuites, hasTestSucceeded, runTests, waitForResults } from './utils';
 
@@ -67,9 +67,16 @@ export class RunTestCommand extends Command {
 
       // Rendering the results.
       this.context.stdout.write(renderHeader({ startTime }));
+      const locationNames = triggers.locations
+        .reduce((mapping, location) => {
+          mapping[location.id] = location.display_name;
+
+          return mapping;
+        }, { } as LocationsMapping);
+
       for (const test of tests) {
         this.context.stdout.write(
-          renderResult(test, results[test.public_id], this.getAppBaseURL())
+          renderResult(test, results[test.public_id], this.getAppBaseURL(), locationNames)
         );
       }
 


### PR DESCRIPTION
### What and why?

It retrieves locations details with the `trigger` request to print location names instead of locations identifiers in results

### Example output

This is the output of the command with the correct location names instead of location identifiers in the results:
![image](https://user-images.githubusercontent.com/8783168/79885772-d14f0900-83f7-11ea-93d9-5e2b9bbf5b3d.png)
