### PR TITLE
[synthetics] add log when test are skipped from local config

### DIFF
--- a/src/commands/synthetics/utils.ts
+++ b/src/commands/synthetics/utils.ts
@@ -248,6 +248,8 @@ export const runTests = async (
       }
 
       if (!test || config.executionRule === ExecutionRule.SKIPPED) {
+        write(`[${chalk.bold.dim(id)}] Test skipped as per test or global configuration.\n`)
+
         return
       }
 


### PR DESCRIPTION
### What and why?

This PR adds a log when a test is skipped by local configuration (whether it is from test configuration or global configuration).
