### PR TITLE
[github] update codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,3 @@
-* @sdeprez @yoannmoinet @m-rousse
+* @yoannmoinet @m-rousse
+
+src/commands  @m-rousse


### PR DESCRIPTION
### What and why?

Update codeowners to remove @sdeprez and have @yoannmoinet owning all except `src/commands`.

