### PR TITLE
[github] update codeowners - add synthetics-worker to synthetics command

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,4 @@
 * @yoannmoinet @m-rousse
 
 src/commands  @m-rousse
+src/commands/synthetics  @m-rousse @DataDog/synthetics-worker


### PR DESCRIPTION
### What and why?

Add synthetics worker team to the `src/commands/synthetics` directory in the CODEOWNERS

