### PR TITLE
[prettier] fix prettier script + prettier --fix codebase

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "launch": "ts-node --transpile-only src/index.ts",
     "lint": "tslint -p tsconfig.json -c tslint.json",
     "prepack": "yarn build && node ./bin/make-it-executable.js",
-    "prettier-check": "prettier --check \"src/**/*.{ts,js,json,yml}\" --ignore-path .gitignore || echo \"\nYou can fix this by running ==> yarn prettier-write <==\n\"",
+    "prettier-check": "prettier --check \"src/**/*.{ts,js,json,yml}\" --ignore-path .gitignore || (echo \"\nYou can fix this by running ==> yarn prettier-write <==\n\" && false)",
     "prettier-write": "prettier --write \"src/**/*.{ts,js,json,yml}\" --ignore-path .gitignore",
     "test": "jest",
     "typecheck": "bash bin/typecheck.sh",

--- a/src/commands/synthetics/__tests__/ci-metadata.test.ts
+++ b/src/commands/synthetics/__tests__/ci-metadata.test.ts
@@ -1,14 +1,14 @@
-import { CI_ENGINES, getCIMetadata } from '../ci-metadata';
+import {CI_ENGINES, getCIMetadata} from '../ci-metadata'
 
 describe('ci-metadata', () => {
-  const branch = 'fakeBranch';
-  const commit = 'fakeCommitSha';
-  const pipelineURL = 'fakePipelineUrl';
+  const branch = 'fakeBranch'
+  const commit = 'fakeCommitSha'
+  const pipelineURL = 'fakePipelineUrl'
 
   test('non-recognized CI returns undefined', () => {
-    process.env = { };
-    expect(getCIMetadata()).toBeUndefined();
-  });
+    process.env = {}
+    expect(getCIMetadata()).toBeUndefined()
+  })
 
   test('circle CI is recognized', () => {
     process.env = {
@@ -16,14 +16,14 @@ describe('ci-metadata', () => {
       CIRCLE_BRANCH: branch,
       CIRCLE_BUILD_URL: pipelineURL,
       CIRCLE_SHA1: commit,
-    };
+    }
     expect(getCIMetadata()).toEqual({
       branch,
       commit,
       engine: CI_ENGINES.CIRCLECI,
       pipelineURL,
-    });
-  });
+    })
+  })
 
   test('travis CI is recognized', () => {
     process.env = {
@@ -31,14 +31,14 @@ describe('ci-metadata', () => {
       TRAVIS_BRANCH: branch,
       TRAVIS_COMMIT: commit,
       TRAVIS_JOB_WEB_URL: pipelineURL,
-    };
+    }
     expect(getCIMetadata()).toEqual({
       branch,
       commit,
       engine: CI_ENGINES.TRAVIS,
       pipelineURL,
-    });
-  });
+    })
+  })
 
   test('gitlab CI is recognized', () => {
     process.env = {
@@ -46,14 +46,14 @@ describe('ci-metadata', () => {
       CI_COMMIT_SHA: commit,
       CI_JOB_URL: pipelineURL,
       GITLAB_CI: 'true',
-    };
+    }
     expect(getCIMetadata()).toEqual({
       branch,
       commit,
       engine: CI_ENGINES.GITLAB,
       pipelineURL,
-    });
-  });
+    })
+  })
 
   test('github actions is recognized', () => {
     process.env = {
@@ -62,16 +62,16 @@ describe('ci-metadata', () => {
       GITHUB_REPOSITORY: 'DataDog/datadog-ci',
       GITHUB_RUN_ID: '42',
       GITHUB_SHA: commit,
-    };
+    }
 
-    const expectedPipelineURL = 'https://github.com/DataDog/datadog-ci/actions/runs/42';
+    const expectedPipelineURL = 'https://github.com/DataDog/datadog-ci/actions/runs/42'
     expect(getCIMetadata()).toEqual({
       branch,
       commit,
       engine: CI_ENGINES.GITHUB,
       pipelineURL: expectedPipelineURL,
-    });
-  });
+    })
+  })
 
   test('jenkins is recognized', () => {
     process.env = {
@@ -79,12 +79,12 @@ describe('ci-metadata', () => {
       GIT_BRANCH: branch,
       GIT_COMMIT: commit,
       JENKINS_URL: 'https://fakebuildserver.url/',
-    };
+    }
     expect(getCIMetadata()).toEqual({
       branch,
       commit,
       engine: CI_ENGINES.JENKINS,
       pipelineURL,
-    });
-  });
-});
+    })
+  })
+})

--- a/src/commands/synthetics/ci-metadata.ts
+++ b/src/commands/synthetics/ci-metadata.ts
@@ -1,4 +1,4 @@
-import { Metadata } from './interfaces';
+import {Metadata} from './interfaces'
 
 export const CI_ENGINES = {
   CIRCLECI: 'circleci',
@@ -6,10 +6,10 @@ export const CI_ENGINES = {
   GITLAB: 'gitlab',
   JENKINS: 'jenkins',
   TRAVIS: 'travis',
-};
+}
 
 export const getCIMetadata = (): Metadata['ci'] => {
-  const env = process.env;
+  const env = process.env
 
   if (env.CIRCLECI) {
     return {
@@ -17,7 +17,7 @@ export const getCIMetadata = (): Metadata['ci'] => {
       commit: env.CIRCLE_SHA1,
       engine: CI_ENGINES.CIRCLECI,
       pipelineURL: env.CIRCLE_BUILD_URL,
-    };
+    }
   }
 
   if (env.TRAVIS) {
@@ -26,7 +26,7 @@ export const getCIMetadata = (): Metadata['ci'] => {
       commit: env.TRAVIS_COMMIT,
       engine: CI_ENGINES.TRAVIS,
       pipelineURL: env.TRAVIS_JOB_WEB_URL,
-    };
+    }
   }
 
   if (env.GITLAB_CI) {
@@ -35,18 +35,18 @@ export const getCIMetadata = (): Metadata['ci'] => {
       commit: env.CI_COMMIT_SHA,
       engine: CI_ENGINES.GITLAB,
       pipelineURL: env.CI_JOB_URL,
-    };
+    }
   }
 
   if (env.GITHUB_ACTIONS) {
-    const pipelineURL = `https://github.com/${env.GITHUB_REPOSITORY}/actions/runs/${env.GITHUB_RUN_ID}`;
+    const pipelineURL = `https://github.com/${env.GITHUB_REPOSITORY}/actions/runs/${env.GITHUB_RUN_ID}`
 
     return {
       branch: env.GITHUB_REF,
       commit: env.GITHUB_SHA,
       engine: CI_ENGINES.GITHUB,
       pipelineURL,
-    };
+    }
   }
 
   if (env.JENKINS_URL) {
@@ -55,6 +55,6 @@ export const getCIMetadata = (): Metadata['ci'] => {
       commit: env.GIT_COMMIT,
       engine: CI_ENGINES.JENKINS,
       pipelineURL: env.BUILD_URL,
-    };
+    }
   }
-};
+}

--- a/src/commands/synthetics/interfaces.ts
+++ b/src/commands/synthetics/interfaces.ts
@@ -166,11 +166,11 @@ export interface ConfigOverride {
 
 export interface Metadata {
   ci?: {
-    branch?: string;
-    commit?: string;
-    engine?: string;
-    pipelineURL?: string;
-  };
+    branch?: string
+    commit?: string
+    engine?: string
+    pipelineURL?: string
+  }
 }
 
 export interface Payload extends ConfigOverride {


### PR DESCRIPTION
### What and why?

Fix `prettier-check` package.json script as it did not return an error code if `prettier --check` command failed (it displayed a message to fix files but returned 0 to the shell).
This resulted in files not compliant with prettier in `master` branch, so this PR fixes them too.
