### PR TITLE
bump to v0.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci",
-  "version": "0.3.2",
+  "version": "0.5.0",
   "description": "Run datadog actions from the CI.",
   "main": "dist/index.js",
   "repository": "https://github.com/DataDog/datadog-ci",
@@ -28,8 +28,8 @@
     "watch": "tsc -w"
   },
   "dependencies": {
-    "aws-sdk": "2.682.0",
     "async-retry": "1.3.1",
+    "aws-sdk": "2.682.0",
     "axios": "0.19.2",
     "chalk": "2.4.2",
     "clipanion": "2.2.2",


### PR DESCRIPTION
### What and why?

This PR bumps the version to 0.5.0. The tag has already been pushed but let's keep the `package.json` up to date. I missed that last time I released.
