### PR TITLE
[helpers] fix config parsing to overwrite base config

### DIFF
--- a/src/helpers/__tests__/utils.test.ts
+++ b/src/helpers/__tests__/utils.test.ts
@@ -20,6 +20,7 @@ describe('utils', () => {
     afterEach(() => {
       ;(fs.readFile as any).mockRestore()
     })
+
     test('should read a config file', async () => {
       ;(fs.readFile as any).mockImplementation((_path: string, _opts: any, callback: any) =>
         callback(undefined, '{"newconfigkey":"newconfigvalue"}')
@@ -40,6 +41,15 @@ describe('utils', () => {
       ;(fs.readFile as any).mockImplementation((p: string, o: any, cb: any) => cb(undefined, 'thisisnoJSON'))
 
       await expect(parseConfigFile({})).rejects.toEqual(Error('Config file is not correct JSON'))
+    })
+
+    test('config file should overwrite default configuration', async () => {
+      ;(fs.readFile as any).mockImplementation((_path: string, _opts: any, callback: any) =>
+        callback(undefined, '{"configKey":"newconfigvalue"}')
+      )
+
+      const config = await parseConfigFile({configKey: 'configvalue'})
+      await expect(config.configKey).toBe('newconfigvalue')
     })
   })
 })

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -14,13 +14,13 @@ export function pick<T extends object, K extends keyof T>(base: T, keys: K[]) {
   return pickedObject
 }
 
-export const parseConfigFile = async <T>(config: T, configPath?: string) => {
+export const parseConfigFile = async <T>(baseConfig: T, configPath?: string) => {
   try {
     const resolvedConfigPath = configPath ?? 'datadog-ci.json'
     const configFile = await promisify(fs.readFile)(resolvedConfigPath, 'utf-8')
     const parsedConfig = JSON.parse(configFile)
 
-    return deepExtend(parsedConfig, config) as T
+    return deepExtend(baseConfig, parsedConfig) as T
   } catch (e) {
     if (e.code === 'ENOENT' && configPath) {
       throw new Error('Config file not found')
@@ -31,5 +31,5 @@ export const parseConfigFile = async <T>(config: T, configPath?: string) => {
     }
   }
 
-  return config
+  return baseConfig
 }


### PR DESCRIPTION
### What and why?

This PR changes the `parseConfigFile` helper to have it overwriting the base config with the config file.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)

