### PR TITLE
Publish v0.5.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "Run datadog actions from the CI.",
   "main": "dist/index.js",
   "repository": "https://github.com/DataDog/datadog-ci",


### PR DESCRIPTION
### What and why?

This PR bumps the package to version 0.5.3, releasing:
- [synthetics] unification of the metadata format passed with the CI triggered tests
- [synthetics] improve results of non-blocking tests rendering.
- [lambda] update README to mark as beta