### PR TITLE
[doc] Update README documentation link titles

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,9 @@ Each command allows interacting with a product of the Datadog platform. The comm
 
 Further documentation for each command can be found in its folder, ie:
 
-- [lambda](src/commands/lambda)
-- [sourcemaps](src/commands/sourcemaps/)
-- [synthetics](src/commands/synthetics/)
+- [Lambda](src/commands/lambda)
+- [Sourcemaps](src/commands/sourcemaps/)
+- [Synthetics CI/CD Testing](src/commands/synthetics/)
 
 
 ## Contributing
@@ -59,7 +59,7 @@ The coding style is checked with [tslint](https://github.com/palantir/tslint) an
 
 ### Repository structure
 
-Commands are stored in the [src/commands](src/commands) folder. 
+Commands are stored in the [src/commands](src/commands) folder.
 
 The skeleton of a command is composed of a README, an `index.ts` and a folder for the tests.
 


### PR DESCRIPTION
### What and why?

[SW-293](https://datadoghq.atlassian.net/browse/SW-293)

Update README link title for `synthetics` to `Synthetics CI/CD Testing`, change other titles to uppercase.
