### PR TITLE
[api] factorize API authentication

### DIFF
--- a/src/commands/sourcemaps/api.ts
+++ b/src/commands/sourcemaps/api.ts
@@ -3,7 +3,7 @@ import FormData from 'form-data'
 import fs from 'fs'
 import {Writable} from 'stream'
 
-import {requestBuilder} from '../../helpers/utils'
+import {getRequestBuilder} from '../../helpers/utils'
 
 import {Payload} from './interfaces'
 import {renderUpload} from './renderer'
@@ -35,7 +35,7 @@ export const uploadSourcemap = (request: (args: AxiosRequestConfig) => AxiosProm
 }
 
 export const apiConstructor = (baseIntakeUrl: string, apiKey: string) => {
-  const requestIntake = requestBuilder(baseIntakeUrl, apiKey)
+  const requestIntake = getRequestBuilder(baseIntakeUrl, apiKey)
 
   return {
     uploadSourcemap: uploadSourcemap(requestIntake),

--- a/src/commands/sourcemaps/api.ts
+++ b/src/commands/sourcemaps/api.ts
@@ -1,9 +1,11 @@
-import {AxiosPromise, AxiosRequestConfig, AxiosResponse, default as axios} from 'axios'
+import {AxiosPromise, AxiosRequestConfig, AxiosResponse} from 'axios'
 import FormData from 'form-data'
 import fs from 'fs'
 import {Writable} from 'stream'
 
-import {APIConfiguration, Payload} from './interfaces'
+import {requestBuilder} from '../../helpers/utils'
+
+import {Payload} from './interfaces'
 import {renderUpload} from './renderer'
 
 // Dependcy follows-redirects sets a default maxBodyLentgh of 10 MB https://github.com/follow-redirects/follow-redirects/blob/b774a77e582b97174813b3eaeb86931becba69db/index.js#L391
@@ -32,21 +34,10 @@ export const uploadSourcemap = (request: (args: AxiosRequestConfig) => AxiosProm
   })
 }
 
-export const apiConstructor = ({apiKey, baseIntakeUrl}: APIConfiguration) => {
-  const overrideArgs = (args: AxiosRequestConfig) => ({
-    ...args,
-    headers: {
-      'DD-API-KEY': apiKey,
-      ...args.headers,
-    },
-  })
-
-  const request = (args: AxiosRequestConfig) =>
-    axios.create({
-      baseURL: baseIntakeUrl,
-    })(overrideArgs(args))
+export const apiConstructor = (baseIntakeUrl: string, apiKey: string) => {
+  const requestIntake = requestBuilder(baseIntakeUrl, apiKey)
 
   return {
-    uploadSourcemap: uploadSourcemap(request),
+    uploadSourcemap: uploadSourcemap(requestIntake),
   }
 }

--- a/src/commands/sourcemaps/interfaces.ts
+++ b/src/commands/sourcemaps/interfaces.ts
@@ -11,11 +11,6 @@ export interface Payload {
   version: string
 }
 
-export interface APIConfiguration {
-  apiKey: string
-  baseIntakeUrl: string
-}
-
 export interface APIHelper {
   uploadSourcemap(sourcemap: Payload, write: Writable['write']): AxiosPromise<AxiosResponse>
 }

--- a/src/commands/sourcemaps/upload.ts
+++ b/src/commands/sourcemaps/upload.ts
@@ -101,10 +101,7 @@ export class UploadCommand extends Command {
       throw new Error('API key is missing')
     }
 
-    return apiConstructor({
-      apiKey: this.config.apiKey!,
-      baseIntakeUrl: getBaseIntakeUrl(),
-    })
+    return apiConstructor(this.config.apiKey!, getBaseIntakeUrl())
   }
 
   private getMatchingSourcemapFiles(): Payload[] {

--- a/src/commands/synthetics/__tests__/api.test.ts
+++ b/src/commands/synthetics/__tests__/api.test.ts
@@ -1,7 +1,9 @@
 import axios from 'axios'
 
+import {ProxyConfiguration} from '../../../helpers/utils'
+
 import {apiConstructor} from '../api'
-import {Payload, PollResult, ProxyConfiguration, Result, Trigger} from '../interfaces'
+import {Payload, PollResult, Result, Trigger} from '../interfaces'
 
 describe('dd-api', () => {
   const apiConfiguration = {

--- a/src/commands/synthetics/__tests__/utils.test.ts
+++ b/src/commands/synthetics/__tests__/utils.test.ts
@@ -6,8 +6,10 @@ import * as fs from 'fs'
 import * as axios from 'axios'
 import glob from 'glob'
 
+import {ProxyConfiguration} from '../../../helpers/utils'
+
 import {apiConstructor} from '../api'
-import {ExecutionRule, PollResult, ProxyConfiguration, Result, Test} from '../interfaces'
+import {ExecutionRule, PollResult, Result, Test} from '../interfaces'
 import * as utils from '../utils'
 
 describe('utils', () => {

--- a/src/commands/synthetics/api.ts
+++ b/src/commands/synthetics/api.ts
@@ -1,5 +1,6 @@
-import {AxiosError, AxiosPromise, AxiosRequestConfig, default as axios} from 'axios'
-import ProxyAgent from 'proxy-agent'
+import {AxiosError, AxiosPromise, AxiosRequestConfig} from 'axios'
+
+import {requestBuilder} from '../../helpers/utils'
 
 import {APIConfiguration, Payload, PollResult, Test, TestSearchResult, Trigger} from './interfaces'
 
@@ -62,31 +63,15 @@ const pollResults = (request: (args: AxiosRequestConfig) => AxiosPromise<{result
   return resp.data
 }
 
-export const apiConstructor = ({appKey, apiKey, baseUrl, baseIntakeUrl, proxyOpts}: APIConfiguration) => {
-  const overrideArgs = (args: AxiosRequestConfig) => {
-    const newArguments = {
-      ...args,
-      params: {
-        api_key: apiKey,
-        application_key: appKey,
-        ...args.params,
-      },
-    }
-
-    if (proxyOpts.host && proxyOpts.port) {
-      newArguments.httpsAgent = new ProxyAgent(proxyOpts)
-    }
-
-    return newArguments
-  }
-
-  const request = (args: AxiosRequestConfig) => axios.create({baseURL: baseUrl})(overrideArgs(args))
-  const requestTrigger = (args: AxiosRequestConfig) => axios.create({baseURL: baseIntakeUrl})(overrideArgs(args))
+export const apiConstructor = (configuration: APIConfiguration) => {
+  const {baseUrl, baseIntakeUrl, apiKey, appKey, proxyOpts} = configuration
+  const request = requestBuilder(baseUrl, apiKey, appKey, proxyOpts)
+  const requestIntake = requestBuilder(baseIntakeUrl, apiKey, appKey, proxyOpts)
 
   return {
     getTest: getTest(request),
     pollResults: pollResults(request),
     searchTests: searchTests(request),
-    triggerTests: triggerTests(requestTrigger),
+    triggerTests: triggerTests(requestIntake),
   }
 }

--- a/src/commands/synthetics/api.ts
+++ b/src/commands/synthetics/api.ts
@@ -1,6 +1,6 @@
 import {AxiosError, AxiosPromise, AxiosRequestConfig} from 'axios'
 
-import {requestBuilder} from '../../helpers/utils'
+import {getRequestBuilder} from '../../helpers/utils'
 
 import {APIConfiguration, Payload, PollResult, Test, TestSearchResult, Trigger} from './interfaces'
 
@@ -65,8 +65,8 @@ const pollResults = (request: (args: AxiosRequestConfig) => AxiosPromise<{result
 
 export const apiConstructor = (configuration: APIConfiguration) => {
   const {baseUrl, baseIntakeUrl, apiKey, appKey, proxyOpts} = configuration
-  const request = requestBuilder(baseUrl, apiKey, appKey, proxyOpts)
-  const requestIntake = requestBuilder(baseIntakeUrl, apiKey, appKey, proxyOpts)
+  const request = getRequestBuilder(baseUrl, apiKey, appKey, proxyOpts)
+  const requestIntake = getRequestBuilder(baseIntakeUrl, apiKey, appKey, proxyOpts)
 
   return {
     getTest: getTest(request),

--- a/src/commands/synthetics/interfaces.ts
+++ b/src/commands/synthetics/interfaces.ts
@@ -1,3 +1,5 @@
+import {ProxyConfiguration} from '../../helpers/utils'
+
 interface Timings {
   dns: number
   download: number
@@ -234,30 +236,6 @@ export interface APIHelper {
   pollResults(resultIds: string[]): Promise<{results: PollResult[]}>
   searchTests(query: string): Promise<TestSearchResult>
   triggerTests(testsToTrigger: Payload[]): Promise<Trigger>
-}
-
-export type ProxyType =
-  | 'http'
-  | 'https'
-  | 'socks'
-  | 'socks4'
-  | 'socks4a'
-  | 'socks5'
-  | 'socks5h'
-  | 'pac+data'
-  | 'pac+file'
-  | 'pac+ftp'
-  | 'pac+http'
-  | 'pac+https'
-
-export interface ProxyConfiguration {
-  auth?: {
-    password: string
-    username: string
-  }
-  host?: string
-  port?: number
-  protocol: ProxyType
 }
 
 export interface APIConfiguration {

--- a/src/commands/synthetics/run-test.ts
+++ b/src/commands/synthetics/run-test.ts
@@ -1,17 +1,9 @@
 import chalk from 'chalk'
 import {Command} from 'clipanion'
 
-import {parseConfigFile} from '../../helpers/utils'
+import {parseConfigFile, ProxyConfiguration} from '../../helpers/utils'
 import {apiConstructor} from './api'
-import {
-  APIHelper,
-  ConfigOverride,
-  ExecutionRule,
-  LocationsMapping,
-  PollResult,
-  ProxyConfiguration,
-  Test,
-} from './interfaces'
+import {APIHelper, ConfigOverride, ExecutionRule, LocationsMapping, PollResult, Test} from './interfaces'
 import {renderHeader, renderResults} from './renderer'
 import {getSuites, hasTestSucceeded, runTests, waitForResults} from './utils'
 

--- a/src/helpers/__tests__/utils.test.ts
+++ b/src/helpers/__tests__/utils.test.ts
@@ -4,7 +4,7 @@ import * as fs from 'fs'
 
 import {AxiosPromise, AxiosRequestConfig, default as axios} from 'axios'
 
-import {parseConfigFile, pick, ProxyConfiguration, requestBuilder} from '../utils'
+import {parseConfigFile, pick, ProxyConfiguration, getRequestBuilder} from '../utils'
 
 jest.useFakeTimers()
 
@@ -57,19 +57,19 @@ describe('utils', () => {
     })
   })
 
-  describe('requestBuilder', () => {
+  describe('getRequestBuilder', () => {
     const fakeEndpointBuilder = (request: (args: AxiosRequestConfig) => AxiosPromise) => async () => request({})
 
     test('should add api key header', async () => {
       jest.spyOn(axios, 'create').mockImplementation((() => (args: AxiosRequestConfig) => args.headers) as any)
-      const request = requestBuilder('http://fake-base.url/', 'apiKey')
+      const request = getRequestBuilder('http://fake-base.url/', 'apiKey')
       const fakeEndpoint = fakeEndpointBuilder(request)
       expect(await fakeEndpoint()).toStrictEqual({'DD-API-KEY': 'apiKey'})
     })
 
     test('should add api and application key header', async () => {
       jest.spyOn(axios, 'create').mockImplementation((() => (args: AxiosRequestConfig) => args.headers) as any)
-      const request = requestBuilder('http://fake-base.url/', 'apiKey', 'applicationKey')
+      const request = getRequestBuilder('http://fake-base.url/', 'apiKey', 'applicationKey')
       const fakeEndpoint = fakeEndpointBuilder(request)
       expect(await fakeEndpoint()).toStrictEqual({'DD-API-KEY': 'apiKey', 'DD-APPLICATION-KEY': 'applicationKey'})
     })
@@ -77,7 +77,7 @@ describe('utils', () => {
     test('should add proxy configuration', async () => {
       jest.spyOn(axios, 'create').mockImplementation((() => (args: AxiosRequestConfig) => args.httpsAgent.proxy) as any)
       const proxyConf: ProxyConfiguration = {protocol: 'http', host: '1.2.3.4', port: 1234}
-      const request = requestBuilder('http://fake-base.url/', 'apiKey', 'applicationKey', proxyConf)
+      const request = getRequestBuilder('http://fake-base.url/', 'apiKey', 'applicationKey', proxyConf)
       const fakeEndpoint = fakeEndpointBuilder(request)
       expect(await fakeEndpoint()).toStrictEqual(proxyConf)
     })

--- a/src/helpers/__tests__/utils.test.ts
+++ b/src/helpers/__tests__/utils.test.ts
@@ -4,7 +4,7 @@ import * as fs from 'fs'
 
 import {AxiosPromise, AxiosRequestConfig, default as axios} from 'axios'
 
-import {parseConfigFile, pick, ProxyConfiguration, getRequestBuilder} from '../utils'
+import {getRequestBuilder, parseConfigFile, pick, ProxyConfiguration} from '../utils'
 
 jest.useFakeTimers()
 

--- a/src/helpers/__tests__/utils.test.ts
+++ b/src/helpers/__tests__/utils.test.ts
@@ -1,7 +1,11 @@
 jest.mock('fs')
 
 import * as fs from 'fs'
-import {parseConfigFile, pick} from '../utils'
+
+import {AxiosPromise, AxiosRequestConfig, default as axios} from 'axios'
+
+import {parseConfigFile, pick, ProxyConfiguration, requestBuilder} from '../utils'
+
 jest.useFakeTimers()
 
 describe('utils', () => {
@@ -50,6 +54,32 @@ describe('utils', () => {
 
       const config = await parseConfigFile({configKey: 'configvalue'})
       await expect(config.configKey).toBe('newconfigvalue')
+    })
+  })
+
+  describe('requestBuilder', () => {
+    const fakeEndpointBuilder = (request: (args: AxiosRequestConfig) => AxiosPromise) => async () => request({})
+
+    test('should add api key header', async () => {
+      jest.spyOn(axios, 'create').mockImplementation((() => (args: AxiosRequestConfig) => args.headers) as any)
+      const request = requestBuilder('http://fake-base.url/', 'apiKey')
+      const fakeEndpoint = fakeEndpointBuilder(request)
+      expect(await fakeEndpoint()).toStrictEqual({'DD-API-KEY': 'apiKey'})
+    })
+
+    test('should add api and application key header', async () => {
+      jest.spyOn(axios, 'create').mockImplementation((() => (args: AxiosRequestConfig) => args.headers) as any)
+      const request = requestBuilder('http://fake-base.url/', 'apiKey', 'applicationKey')
+      const fakeEndpoint = fakeEndpointBuilder(request)
+      expect(await fakeEndpoint()).toStrictEqual({'DD-API-KEY': 'apiKey', 'DD-APPLICATION-KEY': 'applicationKey'})
+    })
+
+    test('should add proxy configuration', async () => {
+      jest.spyOn(axios, 'create').mockImplementation((() => (args: AxiosRequestConfig) => args.httpsAgent.proxy) as any)
+      const proxyConf: ProxyConfiguration = {protocol: 'http', host: '1.2.3.4', port: 1234}
+      const request = requestBuilder('http://fake-base.url/', 'apiKey', 'applicationKey', proxyConf)
+      const fakeEndpoint = fakeEndpointBuilder(request)
+      expect(await fakeEndpoint()).toStrictEqual(proxyConf)
     })
   })
 })

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -60,7 +60,7 @@ export interface ProxyConfiguration {
   protocol: ProxyType
 }
 
-export const requestBuilder = (baseUrl: string, apiKey: string, appKey?: string, proxyOpts?: ProxyConfiguration) => {
+export const getRequestBuilder = (baseUrl: string, apiKey: string, appKey?: string, proxyOpts?: ProxyConfiguration) => {
   const overrideArgs = (args: AxiosRequestConfig) => {
     const newArguments = {
       ...args,


### PR DESCRIPTION
### What and why?

This PR moves API request constructor to one common helper to ease authentication (now commands only need to fetch api/app keys as they need and pass it to the request constructor)

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)

