### PR TITLE
[serverless] Tag lambdas with ci packege version

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@datadog/datadog-ci",
   "version": "0.5.6",
   "description": "Run datadog actions from the CI.",
-  "main": "dist/index.js",
+  "main": "dist/src/index.js",
   "repository": "https://github.com/DataDog/datadog-ci",
   "license": "Apache-2.0",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@datadog/datadog-ci",
   "version": "0.5.6",
   "description": "Run datadog actions from the CI.",
-  "main": "dist/src/index.js",
+  "main": "dist/index.js",
   "repository": "https://github.com/DataDog/datadog-ci",
   "license": "Apache-2.0",
   "bin": {

--- a/src/commands/lambda/__tests__/function.test.ts
+++ b/src/commands/lambda/__tests__/function.test.ts
@@ -9,6 +9,8 @@ const makeMockLambda = (functionConfigs: Record<string, Lambda.FunctionConfigura
     promise: () => Promise.resolve({Configuration: functionConfigs[FunctionName]}),
   })),
   updateFunctionConfiguration: jest.fn().mockImplementation(() => ({promise: () => Promise.resolve()})),
+  listTags: jest.fn().mockImplementation(() => ({promise: () => Promise.resolve({Tags: {}})})),
+  tagResource: jest.fn().mockImplementation(() => ({promise: () => Promise.resolve()})),
 })
 
 const makeMockCloudWatchLogs = () => ({})

--- a/src/commands/lambda/__tests__/function.test.ts
+++ b/src/commands/lambda/__tests__/function.test.ts
@@ -8,9 +8,9 @@ const makeMockLambda = (functionConfigs: Record<string, Lambda.FunctionConfigura
   getFunction: jest.fn().mockImplementation(({FunctionName}) => ({
     promise: () => Promise.resolve({Configuration: functionConfigs[FunctionName]}),
   })),
-  updateFunctionConfiguration: jest.fn().mockImplementation(() => ({promise: () => Promise.resolve()})),
   listTags: jest.fn().mockImplementation(() => ({promise: () => Promise.resolve({Tags: {}})})),
   tagResource: jest.fn().mockImplementation(() => ({promise: () => Promise.resolve()})),
+  updateFunctionConfiguration: jest.fn().mockImplementation(() => ({promise: () => Promise.resolve()})),
 })
 
 const makeMockCloudWatchLogs = () => ({})

--- a/src/commands/lambda/__tests__/instrument.test.ts
+++ b/src/commands/lambda/__tests__/instrument.test.ts
@@ -36,9 +36,9 @@ describe('lambda', () => {
     getFunction: jest.fn().mockImplementation(({FunctionName}) => ({
       promise: () => Promise.resolve({Configuration: functionConfigs[FunctionName]}),
     })),
-    updateFunctionConfiguration: jest.fn().mockImplementation(() => ({promise: () => Promise.resolve()})),
     listTags: jest.fn().mockImplementation(() => ({promise: () => Promise.resolve({Tags: {}})})),
     tagResource: jest.fn().mockImplementation(() => ({promise: () => Promise.resolve({})})),
+    updateFunctionConfiguration: jest.fn().mockImplementation(() => ({promise: () => Promise.resolve()})),
   })
 
   describe('instrument', () => {

--- a/src/commands/lambda/__tests__/instrument.test.ts
+++ b/src/commands/lambda/__tests__/instrument.test.ts
@@ -5,7 +5,10 @@ import {Lambda} from 'aws-sdk'
 import * as fs from 'fs'
 
 import {Cli} from 'clipanion/lib/advanced'
+import path from 'path'
 import {InstrumentCommand} from '../instrument'
+// tslint:disable-next-line
+const {version} = require(path.join(__dirname, '../../../../package.json'))
 
 describe('lambda', () => {
   const createMockContext = () => {
@@ -80,6 +83,10 @@ describe('lambda', () => {
                 \\"DD_FLUSH_TO_LOG\\": \\"true\\"
               }
             }
+          }
+          TagResource -> arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world
+          {
+            \\"dd_sls_ci\\": \\"v${version}\\"
           }
           "
         `)

--- a/src/commands/lambda/__tests__/instrument.test.ts
+++ b/src/commands/lambda/__tests__/instrument.test.ts
@@ -37,6 +37,8 @@ describe('lambda', () => {
       promise: () => Promise.resolve({Configuration: functionConfigs[FunctionName]}),
     })),
     updateFunctionConfiguration: jest.fn().mockImplementation(() => ({promise: () => Promise.resolve()})),
+    listTags: jest.fn().mockImplementation(() => ({promise: () => Promise.resolve({Tags: {}})})),
+    tagResource: jest.fn().mockImplementation(() => ({promise: () => Promise.resolve({})})),
   })
 
   describe('instrument', () => {

--- a/src/commands/lambda/__tests__/tags.test.ts
+++ b/src/commands/lambda/__tests__/tags.test.ts
@@ -1,0 +1,179 @@
+jest.mock('../loggroup')
+
+import {Lambda} from 'aws-sdk'
+import {applyTagConfig, calculateTagUpdateRequest, hasVersionTag} from '../tags'
+import {version} from '../../../../package.json'
+
+const makeMockLambda = (functionConfigs: Record<string, Lambda.FunctionConfiguration>) => ({
+  listTags: jest.fn().mockImplementation(() => ({promise: () => Promise.resolve({Tags: {}})})),
+  tagResource: jest.fn().mockImplementation(() => ({promise: () => Promise.resolve()})),
+})
+
+const VERSION_REGEX = /^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*)?(\+[0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*)?$/
+
+describe('tags', () => {
+  describe('applyTagConfig', () => {
+    test('Calls tagResource with config data', async () => {
+      const lambda = makeMockLambda({
+        'arn:aws:lambda:us-east-1:000000000000:function:autoinstrument': {
+          FunctionArn: 'arn:aws:lambda:us-east-1:000000000000:function:autoinstrument',
+          Handler: 'index.handler',
+          Runtime: 'nodejs12.x',
+        },
+      })
+      const config = {
+        tagResourceRequest: {
+          Resource: 'arn:aws:lambda:us-east-1:000000000000:function:autoinstrument',
+          Tags: {
+            dd_sls_ci: 'v0.0.0',
+          },
+        },
+      }
+      const result = await applyTagConfig(lambda as any, config)
+      expect(result).toEqual(undefined)
+      expect(lambda.tagResource).toHaveBeenCalledWith(config.tagResourceRequest)
+    })
+    test('Handles undefined config', async () => {
+      const lambda = makeMockLambda({
+        'arn:aws:lambda:us-east-1:000000000000:function:autoinstrument': {
+          FunctionArn: 'arn:aws:lambda:us-east-1:000000000000:function:autoinstrument',
+          Handler: 'index.handler',
+          Runtime: 'nodejs12.x',
+        },
+      })
+      const config = {
+        tagResourceRequest: undefined,
+      }
+      const result = await applyTagConfig(lambda as any, config)
+      expect(result).toEqual(undefined)
+      expect(lambda.tagResource).not.toHaveBeenCalled()
+    })
+  })
+  describe('calculateTagUpdateRequest', () => {
+    test('Handles no existing tags', async () => {
+      const functionARN = 'arn:aws:lambda:us-east-1:000000000000:function:autoinstrument'
+      const lambda = makeMockLambda({
+        'arn:aws:lambda:us-east-1:000000000000:function:autoinstrument': {
+          FunctionArn: functionARN,
+          Handler: 'index.handler',
+          Runtime: 'nodejs12.x',
+        },
+      })
+      const result = await calculateTagUpdateRequest(lambda as any, functionARN)
+      expect(result).toEqual({
+        tagResourceRequest: {
+          Resource: functionARN,
+          Tags: {
+            dd_sls_ci: expect.stringMatching(VERSION_REGEX),
+          },
+        },
+      })
+      expect(lambda.listTags).toHaveBeenCalledWith({Resource: functionARN})
+    })
+    test('Handles different version tag', async () => {
+      const functionARN = 'arn:aws:lambda:us-east-1:000000000000:function:autoinstrument'
+      const lambda = makeMockLambda({
+        'arn:aws:lambda:us-east-1:000000000000:function:autoinstrument': {
+          FunctionArn: functionARN,
+          Handler: 'index.handler',
+          Runtime: 'nodejs12.x',
+        },
+      })
+
+      lambda.listTags.mockImplementation(() => ({promise: () => Promise.resolve({Tags: {dd_sls_ci: 'v0.0.0'}})}))
+
+      const result = await calculateTagUpdateRequest(lambda as any, functionARN)
+      expect(result).toEqual({
+        tagResourceRequest: {
+          Resource: functionARN,
+          Tags: {
+            dd_sls_ci: expect.stringMatching(VERSION_REGEX),
+          },
+        },
+      })
+      expect(lambda.listTags).toHaveBeenCalledWith({Resource: functionARN})
+    })
+    test('Handles sam version tag', async () => {
+      const functionARN = 'arn:aws:lambda:us-east-1:000000000000:function:autoinstrument'
+      const lambda = makeMockLambda({
+        'arn:aws:lambda:us-east-1:000000000000:function:autoinstrument': {
+          FunctionArn: functionARN,
+          Handler: 'index.handler',
+          Runtime: 'nodejs12.x',
+        },
+      })
+
+      lambda.listTags.mockImplementation(() => ({promise: () => Promise.resolve({Tags: {dd_sls_ci: `v${version}`}})}))
+
+      const result = await calculateTagUpdateRequest(lambda as any, functionARN)
+      expect(result).toBe(undefined)
+      expect(lambda.listTags).toHaveBeenCalledWith({Resource: functionARN})
+    })
+  })
+  describe('hasVersionTag', () => {
+    test('handles no tags', async () => {
+      const functionARN = 'arn:aws:lambda:us-east-1:000000000000:function:autoinstrument'
+      const lambda = makeMockLambda({
+        'arn:aws:lambda:us-east-1:000000000000:function:autoinstrument': {
+          FunctionArn: functionARN,
+          Handler: 'index.handler',
+          Runtime: 'nodejs12.x',
+        },
+      })
+
+      // lambda.listTags.mockImplementation(() => ({promise: () => Promise.resolve({ Tags: { 'dd_sls_ci': `v${version}` }})}))
+
+      const result = await hasVersionTag(lambda as any, functionARN)
+      expect(result).toBe(false)
+      expect(lambda.listTags).toHaveBeenCalledWith({Resource: functionARN})
+    })
+    test('handles no version tag', async () => {
+      const functionARN = 'arn:aws:lambda:us-east-1:000000000000:function:autoinstrument'
+      const lambda = makeMockLambda({
+        'arn:aws:lambda:us-east-1:000000000000:function:autoinstrument': {
+          FunctionArn: functionARN,
+          Handler: 'index.handler',
+          Runtime: 'nodejs12.x',
+        },
+      })
+
+      lambda.listTags.mockImplementation(() => ({promise: () => Promise.resolve({Tags: {foo: 'bar'}})}))
+
+      const result = await hasVersionTag(lambda as any, functionARN)
+      expect(result).toBe(false)
+      expect(lambda.listTags).toHaveBeenCalledWith({Resource: functionARN})
+    })
+    test('handles different version tag', async () => {
+      const functionARN = 'arn:aws:lambda:us-east-1:000000000000:function:autoinstrument'
+      const lambda = makeMockLambda({
+        'arn:aws:lambda:us-east-1:000000000000:function:autoinstrument': {
+          FunctionArn: functionARN,
+          Handler: 'index.handler',
+          Runtime: 'nodejs12.x',
+        },
+      })
+
+      lambda.listTags.mockImplementation(() => ({promise: () => Promise.resolve({Tags: {dd_sls_ci: `v0.0.0`}})}))
+
+      const result = await hasVersionTag(lambda as any, functionARN)
+      expect(result).toBe(false)
+      expect(lambda.listTags).toHaveBeenCalledWith({Resource: functionARN})
+    })
+    test('handles same version tag', async () => {
+      const functionARN = 'arn:aws:lambda:us-east-1:000000000000:function:autoinstrument'
+      const lambda = makeMockLambda({
+        'arn:aws:lambda:us-east-1:000000000000:function:autoinstrument': {
+          FunctionArn: functionARN,
+          Handler: 'index.handler',
+          Runtime: 'nodejs12.x',
+        },
+      })
+
+      lambda.listTags.mockImplementation(() => ({promise: () => Promise.resolve({Tags: {dd_sls_ci: `v${version}`}})}))
+
+      const result = await hasVersionTag(lambda as any, functionARN)
+      expect(result).toBe(true)
+      expect(lambda.listTags).toHaveBeenCalledWith({Resource: functionARN})
+    })
+  })
+})

--- a/src/commands/lambda/__tests__/tags.test.ts
+++ b/src/commands/lambda/__tests__/tags.test.ts
@@ -3,6 +3,7 @@ import path from 'path'
 
 import {Lambda} from 'aws-sdk'
 import {applyTagConfig, calculateTagUpdateRequest, hasVersionTag} from '../tags'
+// tslint:disable-next-line
 const {version} = require(path.join(__dirname, '../../../../package.json'))
 
 const makeMockLambda = (functionConfigs: Record<string, Lambda.FunctionConfiguration>) => ({
@@ -152,7 +153,7 @@ describe('tags', () => {
         },
       })
 
-      lambda.listTags.mockImplementation(() => ({promise: () => Promise.resolve({Tags: {dd_sls_ci: `v0.0.0`}})}))
+      lambda.listTags.mockImplementation(() => ({promise: () => Promise.resolve({Tags: {dd_sls_ci: 'v0.0.0'}})}))
 
       const result = await hasVersionTag(lambda as any, functionARN)
       expect(result).toBe(false)

--- a/src/commands/lambda/__tests__/tags.test.ts
+++ b/src/commands/lambda/__tests__/tags.test.ts
@@ -1,8 +1,9 @@
 jest.mock('../loggroup')
+import path from 'path'
 
 import {Lambda} from 'aws-sdk'
 import {applyTagConfig, calculateTagUpdateRequest, hasVersionTag} from '../tags'
-import {version} from '../../../../package.json'
+const { version } = require(path.join(__dirname, '../../../../package.json'));
 
 const makeMockLambda = (functionConfigs: Record<string, Lambda.FunctionConfiguration>) => ({
   listTags: jest.fn().mockImplementation(() => ({promise: () => Promise.resolve({Tags: {}})})),

--- a/src/commands/lambda/__tests__/tags.test.ts
+++ b/src/commands/lambda/__tests__/tags.test.ts
@@ -3,7 +3,7 @@ import path from 'path'
 
 import {Lambda} from 'aws-sdk'
 import {applyTagConfig, calculateTagUpdateRequest, hasVersionTag} from '../tags'
-const { version } = require(path.join(__dirname, '../../../../package.json'));
+const {version} = require(path.join(__dirname, '../../../../package.json'))
 
 const makeMockLambda = (functionConfigs: Record<string, Lambda.FunctionConfiguration>) => ({
   listTags: jest.fn().mockImplementation(() => ({promise: () => Promise.resolve({Tags: {}})})),
@@ -121,8 +121,6 @@ describe('tags', () => {
           Runtime: 'nodejs12.x',
         },
       })
-
-      // lambda.listTags.mockImplementation(() => ({promise: () => Promise.resolve({ Tags: { 'dd_sls_ci': `v${version}` }})}))
 
       const result = await hasVersionTag(lambda as any, functionARN)
       expect(result).toBe(false)

--- a/src/commands/lambda/constants.ts
+++ b/src/commands/lambda/constants.ts
@@ -21,3 +21,4 @@ export const HANDLER_LOCATION = {
 
 export const DEFAULT_LAYER_AWS_ACCOUNT = '464622532012'
 export const SUBSCRIPTION_FILTER_NAME = 'datadog-ci-filter'
+export const TAG_VERSION_NAME = 'dd_sls_ci'

--- a/src/commands/lambda/function.ts
+++ b/src/commands/lambda/function.ts
@@ -1,6 +1,7 @@
 import {CloudWatchLogs, Lambda} from 'aws-sdk'
 import {DEFAULT_LAYER_AWS_ACCOUNT, HANDLER_LOCATION, Runtime, RUNTIME_LAYER_LOOKUP} from './constants'
 import {applyLogGroupConfig, calculateLogGroupUpdateRequest, LogGroupConfiguration} from './loggroup'
+import {applyTagConfig, calculateTagUpdateRequest, TagConfiguration} from './tags'
 
 export interface FunctionConfiguration {
   functionARN: string
@@ -8,6 +9,7 @@ export interface FunctionConfiguration {
   layerARN: string
   logGroupConfiguration?: LogGroupConfiguration
   updateRequest?: Lambda.UpdateFunctionConfigurationRequest
+  tagConfiguration?: TagConfiguration
 }
 
 export interface InstrumentationSettings {
@@ -45,7 +47,16 @@ export const getLambdaConfigs = async (
       logGroupConfiguration = await calculateLogGroupUpdateRequest(cloudWatch, arn, settings.forwarderARN)
     }
 
-    functionsToUpdate.push({functionARN, layerARN, lambdaConfig: config, updateRequest, logGroupConfiguration})
+    const tagConfiguration: TagConfiguration | undefined = await calculateTagUpdateRequest(lambda, functionARN)
+
+    functionsToUpdate.push({
+      functionARN,
+      layerARN,
+      lambdaConfig: config,
+      updateRequest,
+      logGroupConfiguration,
+      tagConfiguration,
+    })
   }
 
   return functionsToUpdate
@@ -62,6 +73,9 @@ export const updateLambdaConfigs = async (
     }
     if (c.logGroupConfiguration !== undefined) {
       await applyLogGroupConfig(cloudWatch, c.logGroupConfiguration)
+    }
+    if (c.tagConfiguration !== undefined) {
+      await applyTagConfig(lambda, c.tagConfiguration)
     }
   })
   await Promise.all(results)

--- a/src/commands/lambda/function.ts
+++ b/src/commands/lambda/function.ts
@@ -8,8 +8,8 @@ export interface FunctionConfiguration {
   lambdaConfig: Lambda.FunctionConfiguration
   layerARN: string
   logGroupConfiguration?: LogGroupConfiguration
-  updateRequest?: Lambda.UpdateFunctionConfigurationRequest
   tagConfiguration?: TagConfiguration
+  updateRequest?: Lambda.UpdateFunctionConfigurationRequest
 }
 
 export interface InstrumentationSettings {
@@ -51,11 +51,11 @@ export const getLambdaConfigs = async (
 
     functionsToUpdate.push({
       functionARN,
-      layerARN,
       lambdaConfig: config,
-      updateRequest,
+      layerARN,
       logGroupConfiguration,
       tagConfiguration,
+      updateRequest,
     })
   }
 

--- a/src/commands/lambda/instrument.ts
+++ b/src/commands/lambda/instrument.ts
@@ -149,7 +149,8 @@ export class InstrumentCommand extends Command {
         config.updateRequest !== undefined ||
         config.logGroupConfiguration?.createLogGroupRequest !== undefined ||
         config.logGroupConfiguration?.deleteSubscriptionFilterRequest !== undefined ||
-        config.logGroupConfiguration?.subscriptionFilterRequest !== undefined
+        config.logGroupConfiguration?.subscriptionFilterRequest !== undefined ||
+        config?.tagConfiguration !== undefined
       ) {
         anyUpdates = true
         break
@@ -171,7 +172,16 @@ export class InstrumentCommand extends Command {
           )}\n`
         )
       }
-      const {logGroupConfiguration} = config
+      const {logGroupConfiguration, tagConfiguration} = config
+      if (tagConfiguration?.tagResourceRequest) {
+        this.context.stdout.write(
+          `TagResource -> ${tagConfiguration.tagResourceRequest.Resource}\n${JSON.stringify(
+            tagConfiguration.tagResourceRequest.Tags,
+            undefined,
+            2
+          )}\n`
+        )
+      }
       if (logGroupConfiguration?.createLogGroupRequest) {
         this.context.stdout.write(
           `CreateLogGroup -> ${logGroupConfiguration.logGroupName}\n${JSON.stringify(

--- a/src/commands/lambda/tags.ts
+++ b/src/commands/lambda/tags.ts
@@ -1,0 +1,43 @@
+import {Lambda} from 'aws-sdk'
+import {TAG_VERSION_NAME} from './constants'
+import {version} from '../../../package.json'
+
+export interface TagConfiguration {
+  tagResourceRequest?: Lambda.TagResourceRequest
+}
+
+export const applyTagConfig = async (lambda: Lambda, configuration: TagConfiguration) => {
+  const {tagResourceRequest} = configuration
+  if (tagResourceRequest !== undefined) {
+    await lambda.tagResource(tagResourceRequest).promise()
+  }
+}
+
+export const calculateTagUpdateRequest = async (lambda: Lambda, functionARN: string) => {
+  const config: TagConfiguration = {}
+
+  const versionTagPresent = await hasVersionTag(lambda, functionARN)
+
+  if (!versionTagPresent) {
+    config.tagResourceRequest = {
+      Resource: functionARN,
+      Tags: {
+        [TAG_VERSION_NAME]: version,
+      },
+    }
+
+    return config
+  }
+
+  return
+}
+
+export const hasVersionTag = async (lambda: Lambda, functionARN: string): Promise<boolean> => {
+  const args = {
+    Resource: functionARN,
+  }
+  const result = await lambda.listTags(args).promise()
+  const {Tags} = result
+
+  return Tags !== undefined && Tags[TAG_VERSION_NAME] !== version
+}

--- a/src/commands/lambda/tags.ts
+++ b/src/commands/lambda/tags.ts
@@ -1,6 +1,7 @@
-import path from 'path'
 import {Lambda} from 'aws-sdk'
+import path from 'path'
 import {TAG_VERSION_NAME} from './constants'
+// tslint:disable-next-line
 const {version} = require(path.join(__dirname, '../../../package.json'))
 
 export interface TagConfiguration {

--- a/src/commands/lambda/tags.ts
+++ b/src/commands/lambda/tags.ts
@@ -1,7 +1,7 @@
 import path from 'path'
 import {Lambda} from 'aws-sdk'
 import {TAG_VERSION_NAME} from './constants'
-const { version } = require(path.join(__dirname, '../../../package.json'));
+const {version} = require(path.join(__dirname, '../../../package.json'))
 
 export interface TagConfiguration {
   tagResourceRequest?: Lambda.TagResourceRequest

--- a/src/commands/lambda/tags.ts
+++ b/src/commands/lambda/tags.ts
@@ -22,7 +22,7 @@ export const calculateTagUpdateRequest = async (lambda: Lambda, functionARN: str
     config.tagResourceRequest = {
       Resource: functionARN,
       Tags: {
-        [TAG_VERSION_NAME]: version,
+        [TAG_VERSION_NAME]: `v${version}`,
       },
     }
 
@@ -39,5 +39,5 @@ export const hasVersionTag = async (lambda: Lambda, functionARN: string): Promis
   const result = await lambda.listTags(args).promise()
   const {Tags} = result
 
-  return Tags !== undefined && Tags[TAG_VERSION_NAME] !== version
+  return Tags !== undefined && Tags[TAG_VERSION_NAME] === `v${version}`
 }

--- a/src/commands/lambda/tags.ts
+++ b/src/commands/lambda/tags.ts
@@ -1,6 +1,7 @@
+import path from 'path'
 import {Lambda} from 'aws-sdk'
 import {TAG_VERSION_NAME} from './constants'
-import {version} from '../../../package.json'
+const { version } = require(path.join(__dirname, '../../../package.json'));
 
 export interface TagConfiguration {
   tagResourceRequest?: Lambda.TagResourceRequest

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,8 @@
     "esModuleInterop": true,
     "lib": [
       "es2019"
-    ]
+    ],
+    "resolveJsonModule": true
   },
   "include": [
     "src/**/*"


### PR DESCRIPTION
### What and why?

This is part of a larger effort to track serverless usage. When a lambda function is provisioned and instrumented with this CLI tool, we want to get data on that and understand how many functions our customers have instrumented with different tools. We tag lambdas already with our macro version, and our serverless plugin version. So, this follows the same pattern to understand which versions are being.

### How?

When a lambda function is being processed, if the lambda has the version tag and it's the same as the current version we don't update at all. But, if no tag is found or a different version exists then we update with the new version tag.

### Review checklist

- [X] Feature or bugfix MUST have appropriate tests (unit, integration)

