### PR TITLE
Publish `v0.6.0`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci",
-  "version": "0.5.6",
+  "version": "0.6.0",
   "description": "Run datadog actions from the CI.",
   "main": "dist/index.js",
   "repository": "https://github.com/DataDog/datadog-ci",


### PR DESCRIPTION
### What and why?

-  [serverless] Tag lambdas with ci package version https://github.com/DataDog/datadog-ci/pull/91
