### PR TITLE
Changed codeowners of datadog-ci command.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,5 +3,5 @@
 src/commands  @m-rousse
 src/commands/synthetics  @m-rousse @DataDog/synthetics-worker
 src/commands/lambda @DataDog/serverless
-src/commands/sourcemaps/ @lraucy @alxch-
+src/commands/sourcemaps/ @DataDog/error-tracking
 *.md @DataDog/documentation


### PR DESCRIPTION
### What and why?

The entire team is responsible for the CLI command so let's make sure the team is assigned, rather than the first contributors to this tool.
