### PR TITLE
[synthetics] add retry machanism on synthetics command requests

### DIFF
--- a/src/commands/synthetics/__tests__/utils.test.ts
+++ b/src/commands/synthetics/__tests__/utils.test.ts
@@ -330,4 +330,56 @@ describe('utils', () => {
     expect(utils.getStrictestExecutionRule(BLOCKING, undefined)).toBe(BLOCKING)
     expect(utils.getStrictestExecutionRule(SKIPPED, undefined)).toBe(SKIPPED)
   })
+
+  describe('retry', () => {
+    test('retry works fine', async () => {
+      const result = await utils.retry(
+        async () => 42,
+        () => 1
+      )
+      expect(result).toBe(42)
+    })
+
+    test('retry works fine after some retries', async () => {
+      let counter = 0
+      const start = +new Date()
+      const result = await utils.retry(
+        async () => {
+          if (counter === 3) {
+            return 42
+          }
+          counter += 1
+          throw new Error('')
+        },
+        (retries: number) => 100 * (retries + 1)
+      )
+      const end = +new Date()
+      const approximateWait = 100 + 100 * 2 + 100 * 3
+
+      expect(result).toBe(42)
+      expect(counter).toBe(3)
+      expect(end - start - approximateWait < 50).toBeTruthy()
+    })
+
+    test('retry rethrows after some retries', async () => {
+      let counter = 0
+      try {
+        await utils.retry(
+          async () => {
+            counter += 1
+            throw new Error('FAILURE')
+          },
+          (retries: number) => {
+            if (retries < 2) {
+              return 1
+            }
+          }
+        )
+        expect('Retry should have thrown.').toBeFalsy()
+      } catch (e) {
+        expect(counter).toBe(3)
+        expect(e.message).toBe('FAILURE')
+      }
+    })
+  })
 })

--- a/src/commands/synthetics/utils.ts
+++ b/src/commands/synthetics/utils.ts
@@ -291,3 +291,28 @@ export const runTests = async (
 }
 
 const definedTypeGuard = <T>(o: T | undefined): o is T => !!o
+
+export async function retry<T, E extends Error>(
+  func: () => Promise<T>,
+  shouldRetryAfterWait: (retries: number, error: E) => number | undefined
+): Promise<T> {
+  const trier = async (retries = 0): Promise<T> => {
+    try {
+      return await func()
+    } catch (e) {
+      const waiter = shouldRetryAfterWait(retries, e)
+      if (waiter) {
+        if (typeof waiter === 'number') {
+          await wait(waiter)
+        } else {
+          await waiter
+        }
+
+        return trier(retries + 1)
+      }
+      throw e
+    }
+  }
+
+  return trier()
+}

--- a/src/commands/synthetics/utils.ts
+++ b/src/commands/synthetics/utils.ts
@@ -302,11 +302,7 @@ export async function retry<T, E extends Error>(
     } catch (e) {
       const waiter = shouldRetryAfterWait(retries, e)
       if (waiter) {
-        if (typeof waiter === 'number') {
-          await wait(waiter)
-        } else {
-          await waiter
-        }
+        await wait(waiter)
 
         return trier(retries + 1)
       }


### PR DESCRIPTION
### What and why?

Sometimes the backend may return 5xx errors on which we want to retry. So this PR adds a retry mechanism on all requests performed by the synthetics command to retry every 500 milliseconds if the status code of the response is in the 5xx class - three times at most

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)

