### PR TITLE
Bump to 0.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "description": "Run datadog actions from the CI.",
   "main": "dist/index.js",
   "repository": "https://github.com/DataDog/datadog-ci",


### PR DESCRIPTION
### What and why?

This PR bumps the package to version 0.8.0, releasing:
* [trace] New `trace command` for wrapping your bash commands (**note**: this command is not ready for production environments yet). 