### PR TITLE
PROF-2265 - Dependencies upload retry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-# This workflow will do a clean install of node dependencies.json, build the source code and run tests
+# This workflow will do a clean install of node dependencies, build the source code and run tests
 
 name: Continuous Integration
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-# This workflow will do a clean install of node dependencies, build the source code and run tests
+# This workflow will do a clean install of node dependencies.json, build the source code and run tests
 
 name: Continuous Integration
 
@@ -44,6 +44,11 @@ jobs:
       - run: yarn add ./artifacts/datadog-ci.tgz
       - name: Run synthetics test
         run: yarn datadog-ci synthetics run-tests --config artifacts/e2e/global.config.json
+        env:
+          DATADOG_API_KEY: ${{ secrets.datadog_api_key }}
+          DATADOG_APP_KEY: ${{ secrets.datadog_app_key }}
+      - name: Run dependencies upload test
+        run: yarn datadog-ci dependencies upload artifacts/e2e/test.dependencies.json --source=snyk --service=my-service --release-version=1.23.4
         env:
           DATADOG_API_KEY: ${{ secrets.datadog_api_key }}
           DATADOG_APP_KEY: ${{ secrets.datadog_app_key }}

--- a/.github/workflows/e2e/test.dependencies.json
+++ b/.github/workflows/e2e/test.dependencies.json
@@ -16,8 +16,3 @@
   "type": "gradle",
   "packageFormatVersion": "gradle:0.0.1"
 }
-{
-  "ok": false,
-  "error": "This authentication token has been revoked. Try re-authenticating: run `snyk auth`.\nSee more information about authentication in our docs: https://snyk.io/docs/cli-authentication/",
-  "path": "/Users/developer/my-example-service/src"
-}

--- a/src/commands/dependencies/README.md
+++ b/src/commands/dependencies/README.md
@@ -50,17 +50,17 @@ To verify this command works as expected, you can send some mock data and valida
 export DATADOG_API_KEY='<API key>'
 export DATADOG_APP_KEY='<application key>'
 
-yarn launch dependencies upload ./src/commands/dependencies/__tests__/fixtures/dependencies --source snyk --service test_datadog-ci --release-version 0.0.1
+yarn launch dependencies upload ./.github/workflows/e2e/test.dependencies.json --source snyk --service test_datadog-ci --release-version 0.0.1
 ```
 
 Successful output should look like this:
 
 ```bash
-File:    /<path>/datadog-ci/src/commands/dependencies/__tests__/fixtures/dependencies
+File:    /<path>/.github/workflows/e2e/test.dependencies.json
 Source:  snyk
 Service: test_datadog-ci
 Version: 0.0.1
 
 Uploading dependencies...
-Dependencies uploaded in 1.008 seconds.
+Dependencies uploaded in ? seconds.
 ```

--- a/src/commands/dependencies/__tests__/fixtures/dependencies.json
+++ b/src/commands/dependencies/__tests__/fixtures/dependencies.json
@@ -1,0 +1,18 @@
+{
+  "name": "my-example-service",
+  "version": "0.0.1",
+  "dependencies": {
+    "com.google.guava:guava": {
+      "name": "com.google.guava:guava",
+      "version": "54.3",
+      "dependencies": {
+        "com.google.guava:failureaccess": {
+          "name": "com.google.guava:failureaccess",
+          "version": "12.4.6"
+        }
+      }
+    }
+  },
+  "type": "gradle",
+  "packageFormatVersion": "gradle:0.0.1"
+}

--- a/src/commands/dependencies/__tests__/upload.test.ts
+++ b/src/commands/dependencies/__tests__/upload.test.ts
@@ -21,7 +21,7 @@ describe('execute', () => {
   })
 
   test('runs with --dry-run parameter', async () => {
-    const filePath = './src/commands/dependencies/__tests__/fixtures/dependencies'
+    const filePath = './src/commands/dependencies/__tests__/fixtures/dependencies.json'
     const resolvedFilePath = path.resolve(filePath)
     const {context, code} = await runUploadCommand(filePath, {
       apiKey: 'DD_API_KEY_EXAMPLE',
@@ -48,7 +48,7 @@ describe('execute', () => {
   })
 
   test('exits if missing api key', async () => {
-    const {context, code} = await runUploadCommand('./src/commands/dependencies/__tests__/fixtures/dependencies', {
+    const {context, code} = await runUploadCommand('./src/commands/dependencies/__tests__/fixtures/dependencies.json', {
       appKey: 'DD_APP_KEY_EXAMPLE',
       dryRun: true,
       releaseVersion: '1.234',
@@ -65,7 +65,7 @@ describe('execute', () => {
   })
 
   test('exits if missing app key', async () => {
-    const {context, code} = await runUploadCommand('./src/commands/dependencies/__tests__/fixtures/dependencies', {
+    const {context, code} = await runUploadCommand('./src/commands/dependencies/__tests__/fixtures/dependencies.json', {
       apiKey: 'DD_API_KEY_EXAMPLE',
       dryRun: true,
       releaseVersion: '1.234',
@@ -82,7 +82,7 @@ describe('execute', () => {
   })
 
   test('exits if missing --service parameter', async () => {
-    const {context, code} = await runUploadCommand('./src/commands/dependencies/__tests__/fixtures/dependencies', {
+    const {context, code} = await runUploadCommand('./src/commands/dependencies/__tests__/fixtures/dependencies.json', {
       apiKey: 'DD_API_KEY_EXAMPLE',
       appKey: 'DD_APP_KEY_EXAMPLE',
       dryRun: true,
@@ -99,7 +99,7 @@ describe('execute', () => {
   })
 
   test('exits if missing --source parameter', async () => {
-    const {context, code} = await runUploadCommand('./src/commands/dependencies/__tests__/fixtures/dependencies', {
+    const {context, code} = await runUploadCommand('./src/commands/dependencies/__tests__/fixtures/dependencies.json', {
       apiKey: 'DD_API_KEY_EXAMPLE',
       appKey: 'DD_APP_KEY_EXAMPLE',
       dryRun: true,
@@ -116,7 +116,7 @@ describe('execute', () => {
   })
 
   test('exits if invalid --source parameter', async () => {
-    const {context, code} = await runUploadCommand('./src/commands/dependencies/__tests__/fixtures/dependencies', {
+    const {context, code} = await runUploadCommand('./src/commands/dependencies/__tests__/fixtures/dependencies.json', {
       apiKey: 'DD_API_KEY_EXAMPLE',
       appKey: 'DD_APP_KEY_EXAMPLE',
       dryRun: true,
@@ -154,7 +154,7 @@ describe('execute', () => {
   })
 
   test('shows warning if missing --release-version parameter', async () => {
-    const {context, code} = await runUploadCommand('./src/commands/dependencies/__tests__/fixtures/dependencies', {
+    const {context, code} = await runUploadCommand('./src/commands/dependencies/__tests__/fixtures/dependencies.json', {
       apiKey: 'DD_API_KEY_EXAMPLE',
       appKey: 'DD_APP_KEY_EXAMPLE',
       dryRun: true,
@@ -172,7 +172,7 @@ describe('execute', () => {
   })
 
   test('makes a valid API request', async () => {
-    const filePath = './src/commands/dependencies/__tests__/fixtures/dependencies'
+    const filePath = './src/commands/dependencies/__tests__/fixtures/dependencies.json'
     const resolvedFilePath = path.resolve(filePath)
 
     const {context, code} = await runUploadCommand(filePath, {
@@ -213,15 +213,15 @@ describe('execute', () => {
     // Read stream and normalize EOL
     const formPayload = (await streamToString(formData)).replace(/\r\n|\r|\n/g, '\n')
 
-    const dependenciesContent = fs.readFileSync('./src/commands/dependencies/__tests__/fixtures/dependencies')
+    const dependenciesContent = fs.readFileSync('./src/commands/dependencies/__tests__/fixtures/dependencies.json')
     expect(dependenciesContent).not.toBeFalsy()
     expect(formPayload).toContain(['Content-Disposition: form-data; name="service"', '', 'my-service'].join('\n'))
     expect(formPayload).toContain(['Content-Disposition: form-data; name="version"', '', '1.234'].join('\n'))
     expect(formPayload).toContain(['Content-Disposition: form-data; name="source"', '', 'snyk'].join('\n'))
     expect(formPayload).toContain(
       [
-        'Content-Disposition: form-data; name="file"; filename="dependencies"',
-        'Content-Type: application/octet-stream',
+        'Content-Disposition: form-data; name="file"; filename="dependencies.json"',
+        'Content-Type: application/json',
         '',
         dependenciesContent,
       ].join('\n')
@@ -229,7 +229,7 @@ describe('execute', () => {
   })
 
   test('handles API errors', async () => {
-    const filePath = './src/commands/dependencies/__tests__/fixtures/dependencies'
+    const filePath = './src/commands/dependencies/__tests__/fixtures/dependencies.json'
     const resolvedFilePath = path.resolve(filePath)
     ;(axios.post as jest.Mock).mockImplementation(() => Promise.reject(new Error('No access granted')))
 
@@ -260,7 +260,7 @@ describe('execute', () => {
       Promise.reject({message: 'Forbidden', isAxiosError: true, response: {status: 403}})
     )
 
-    const {context, code} = await runUploadCommand('./src/commands/dependencies/__tests__/fixtures/dependencies', {
+    const {context, code} = await runUploadCommand('./src/commands/dependencies/__tests__/fixtures/dependencies.json', {
       apiKey: 'DD_API_KEY_EXAMPLE',
       appKey: 'DD_APP_KEY_EXAMPLE',
       releaseVersion: '1.234',
@@ -280,16 +280,16 @@ describe('execute', () => {
   })
 
   test('retries on error', async () => {
-    const filePath = './src/commands/dependencies/__tests__/fixtures/dependencies'
-    let didReject = false;
+    const filePath = './src/commands/dependencies/__tests__/fixtures/dependencies.json'
+    let didReject = false
     ;(axios.post as jest.Mock).mockImplementation(() => {
       if (!didReject) {
-        didReject = true;
+        didReject = true
 
         return Promise.reject({message: 'Internal Server Error', isAxiosError: true, response: {status: 500}})
       }
 
-      return Promise.resolve();
+      return Promise.resolve()
     })
 
     const {context, code} = await runUploadCommand(filePath, {

--- a/src/commands/dependencies/renderer.ts
+++ b/src/commands/dependencies/renderer.ts
@@ -29,18 +29,6 @@ export const renderMissingReleaseVersionParameter = () => {
 
 export const renderCannotFindFile = (file: string) => chalk.red(`Cannot find "${file}" file.\n`)
 
-export const renderFailedUpload = (errorMessage: string) => chalk.red(`Failed upload dependencies: ${errorMessage}\n`)
-
-export const renderFailedUploadBecauseOf403 = (errorMessage: string) =>
-  renderFailedUpload(
-    `${errorMessage}. Check ${chalk.bold('DATADOG_API_KEY')} and ${chalk.bold(
-      'DATADOG_APP_KEY'
-    )} environment variables.`
-  )
-
-export const renderSuccessfulCommand = (duration: number) =>
-  chalk.green(`Dependencies uploaded in ${duration} seconds.\n`)
-
 export const renderCommandInfo = (
   dependenciesFilePath: string,
   source: string,
@@ -68,3 +56,18 @@ export const renderCommandInfo = (
 export const renderDryRunUpload = (): string => `[DRYRUN] ${renderUpload()}`
 
 export const renderUpload = (): string => 'Uploading dependencies...\n'
+
+export const renderRetriedUpload = (errorMessage: string, attempt: number): string =>
+  chalk.yellow(`[attempt ${attempt}] Retrying dependencies upload: ${errorMessage}\n`)
+
+export const renderFailedUploadBecauseOf403 = (errorMessage: string) =>
+  renderFailedUpload(
+    `${errorMessage}. Check ${chalk.bold('DATADOG_API_KEY')} and ${chalk.bold(
+      'DATADOG_APP_KEY'
+    )} environment variables.`
+  )
+
+export const renderFailedUpload = (errorMessage: string) => chalk.red(`Failed upload dependencies: ${errorMessage}\n`)
+
+export const renderSuccessfulCommand = (duration: number) =>
+  chalk.green(`Dependencies uploaded in ${duration} seconds.\n`)


### PR DESCRIPTION
### What and why?
Add retry logic for dependencies upload to avoid breaking client's CI jobs because random issues in our API

### How?
I implemented it by copy-pasting code from the synthetics test command

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)

