### PR TITLE
[synthetics] add support for overridden config in result rendering

### DIFF
--- a/src/commands/synthetics/__tests__/api.test.ts
+++ b/src/commands/synthetics/__tests__/api.test.ts
@@ -3,7 +3,7 @@ import {AxiosError, AxiosResponse, default as axios} from 'axios'
 import {ProxyConfiguration} from '../../../helpers/utils'
 
 import {apiConstructor} from '../api'
-import {Payload, PollResult, Result, Test, Trigger} from '../interfaces'
+import {Payload, PollResult, Result, Trigger} from '../interfaces'
 
 import {getApiTest} from './fixtures'
 

--- a/src/commands/synthetics/__tests__/api.test.ts
+++ b/src/commands/synthetics/__tests__/api.test.ts
@@ -3,7 +3,9 @@ import {AxiosError, AxiosResponse, default as axios} from 'axios'
 import {ProxyConfiguration} from '../../../helpers/utils'
 
 import {apiConstructor} from '../api'
-import {Payload, PollResult, Result, Trigger} from '../interfaces'
+import {Payload, PollResult, Result, Test, Trigger} from '../interfaces'
+
+import {getApiTest} from './fixtures'
 
 describe('dd-api', () => {
   const apiConfiguration = {
@@ -24,6 +26,7 @@ describe('dd-api', () => {
   const POLL_RESULTS: {results: PollResult[]} = {
     results: [
       {
+        check: getApiTest('abc-def-ghi'),
         dc_id: 0,
         result: {} as Result,
         resultID: RESULT_ID,

--- a/src/commands/synthetics/__tests__/fixtures.ts
+++ b/src/commands/synthetics/__tests__/fixtures.ts
@@ -1,0 +1,42 @@
+import {Test, User} from '../interfaces'
+
+const mockUser: User = {
+  email: '',
+  handle: '',
+  id: 42,
+  name: '',
+}
+
+export const getApiTest = (publicId: string): Test => ({
+  config: {
+    assertions: [],
+    request: {
+      headers: {},
+      method: 'GET',
+      timeout: 60000,
+      url: 'http://fake.url',
+    },
+    variables: [],
+  },
+  created_at: '',
+  created_by: mockUser,
+  locations: [],
+  message: '',
+  modified_at: '',
+  modified_by: mockUser,
+  monitor_id: 0,
+  name: '',
+  options: {
+    device_ids: [],
+    min_failure_duration: 0,
+    min_location_failed: 0,
+    tick_every: 3600,
+  },
+  overall_state: 0,
+  overall_state_modified: '',
+  public_id: publicId,
+  status: '',
+  stepCount: 0,
+  tags: [],
+  type: 'api',
+})

--- a/src/commands/synthetics/__tests__/utils.test.ts
+++ b/src/commands/synthetics/__tests__/utils.test.ts
@@ -261,7 +261,6 @@ describe('utils', () => {
       const expectedResults: {[key: string]: PollResult[]} = {}
       expectedResults[publicId] = [
         {
-          check: testConfiguration,
           dc_id: triggerResult.location,
           result: {
             device: {id: triggerResult.device},
@@ -280,7 +279,6 @@ describe('utils', () => {
       const expectedResults: {[key: string]: PollResult[]} = {}
       expectedResults[publicId] = [
         {
-          check: testConfiguration,
           dc_id: triggerResult.location,
           result: {
             device: {id: triggerResult.device},
@@ -312,7 +310,6 @@ describe('utils', () => {
       expectedResults[publicId] = [
         passingPollResult(triggerResultPass.result_id),
         {
-          check: testConfiguration,
           dc_id: triggerResultTimeOut.location,
           result: {
             device: {id: triggerResultTimeOut.device},

--- a/src/commands/synthetics/__tests__/utils.test.ts
+++ b/src/commands/synthetics/__tests__/utils.test.ts
@@ -12,6 +12,8 @@ import {apiConstructor} from '../api'
 import {ExecutionRule, PollResult, Result, Test} from '../interfaces'
 import * as utils from '../utils'
 
+import {getApiTest} from './fixtures'
+
 describe('utils', () => {
   const apiConfiguration = {
     apiKey: '123',
@@ -176,6 +178,7 @@ describe('utils', () => {
   })
 
   test('hasTestSucceeded', () => {
+    const testConfiguration = getApiTest('abc-def-ghi')
     const passingResult = {
       device: {
         id: 'laptop_large',
@@ -185,11 +188,13 @@ describe('utils', () => {
       stepDetails: [],
     }
     const passingPollResult = {
+      check: testConfiguration,
       dc_id: 42,
       result: passingResult,
       resultID: '0123456789',
     }
     const failingPollResult = {
+      check: testConfiguration,
       dc_id: 42,
       result: {...passingResult, passed: false},
       resultID: '0123456789',
@@ -224,12 +229,14 @@ describe('utils', () => {
       passed: true,
       stepDetails: [],
     }
+    const publicId = 'abc-def-ghi'
+    const testConfiguration = getApiTest(publicId)
     const passingPollResult = (resultID: string) => ({
+      check: testConfiguration,
       dc_id: 42,
       result: passingResult,
       resultID,
     })
-    const publicId = 'abc-def-ghi'
     const triggerResult = {
       device: 'laptop_large',
       location: 42,
@@ -254,6 +261,7 @@ describe('utils', () => {
       const expectedResults: {[key: string]: PollResult[]} = {}
       expectedResults[publicId] = [
         {
+          check: testConfiguration,
           dc_id: triggerResult.location,
           result: {
             device: {id: triggerResult.device},
@@ -272,6 +280,7 @@ describe('utils', () => {
       const expectedResults: {[key: string]: PollResult[]} = {}
       expectedResults[publicId] = [
         {
+          check: testConfiguration,
           dc_id: triggerResult.location,
           result: {
             device: {id: triggerResult.device},
@@ -303,6 +312,7 @@ describe('utils', () => {
       expectedResults[publicId] = [
         passingPollResult(triggerResultPass.result_id),
         {
+          check: testConfiguration,
           dc_id: triggerResultTimeOut.location,
           result: {
             device: {id: triggerResultTimeOut.device},

--- a/src/commands/synthetics/interfaces.ts
+++ b/src/commands/synthetics/interfaces.ts
@@ -26,6 +26,7 @@ export interface Result {
 }
 
 export interface PollResult {
+  check: Test
   dc_id: number
   result: Result
   resultID: string

--- a/src/commands/synthetics/interfaces.ts
+++ b/src/commands/synthetics/interfaces.ts
@@ -26,7 +26,7 @@ export interface Result {
 }
 
 export interface PollResult {
-  check: Test
+  check?: Test
   dc_id: number
   result: Result
   resultID: string
@@ -115,7 +115,7 @@ export enum Operator {
   isInLessThan = 'isInLessThan',
 }
 
-interface User {
+export interface User {
   email: string
   handle: string
   id: number

--- a/src/commands/synthetics/renderer.ts
+++ b/src/commands/synthetics/renderer.ts
@@ -137,7 +137,7 @@ const getResultUrl = (baseUrl: string, test: Test, resultId: string) => {
 }
 
 const renderExecutionResult = (test: Test, execution: PollResult, baseUrl: string, locationNames: LocationsMapping) => {
-  const {dc_id, resultID, result} = execution
+  const {check: overridedTest, dc_id, resultID, result} = execution
   const isSuccess = hasResultPassed(result)
   const color = getTestResultColor(isSuccess, test.options.ci?.executionRule === ExecutionRule.NON_BLOCKING)
   const icon = isSuccess ? ICONS.SUCCESS : ICONS.FAILED
@@ -153,7 +153,7 @@ const renderExecutionResult = (test: Test, execution: PollResult, baseUrl: strin
   return [
     resultIdentification,
     `    ⎋${durationText} result url: ${chalk.dim.cyan(resultUrl)}`,
-    renderResultOutcome(result, test, icon, color),
+    renderResultOutcome(result, overridedTest, icon, color),
   ].join('\n')
 }
 

--- a/src/commands/synthetics/renderer.ts
+++ b/src/commands/synthetics/renderer.ts
@@ -153,7 +153,7 @@ const renderExecutionResult = (test: Test, execution: PollResult, baseUrl: strin
   return [
     resultIdentification,
     `    ⎋${durationText} result url: ${chalk.dim.cyan(resultUrl)}`,
-    renderResultOutcome(result, overridedTest, icon, color),
+    renderResultOutcome(result, overridedTest || test, icon, color),
   ].join('\n')
 }
 


### PR DESCRIPTION
### What and why?

This PR adds support for overridden config in results rendering for synthetics tests. (only for the start URL as other config parameters are not rendered in results)
