### PR TITLE
[synthetics] gracefully handle non-parsable start urls

### DIFF
--- a/src/commands/synthetics/interfaces.ts
+++ b/src/commands/synthetics/interfaces.ts
@@ -185,15 +185,15 @@ interface BasicAuthCredentials {
 }
 
 export interface TemplateContext extends NodeJS.ProcessEnv {
-  DOMAIN: string
-  HOST: string
-  HOSTNAME: string
-  ORIGIN: string
-  PARAMS: string
-  PATHNAME: string
-  PORT: string
-  PROTOCOL: string
-  SUBDOMAIN: string | undefined
+  DOMAIN?: string
+  HOST?: string
+  HOSTNAME?: string
+  ORIGIN?: string
+  PARAMS?: string
+  PATHNAME?: string
+  PORT?: string
+  PROTOCOL?: string
+  SUBDOMAIN?: string
   URL: string
 }
 

--- a/src/commands/synthetics/utils.ts
+++ b/src/commands/synthetics/utils.ts
@@ -33,9 +33,14 @@ const PUBLIC_ID_REGEX = /^[\d\w]{3}-[\d\w]{3}-[\d\w]{3}$/
 const SUBDOMAIN_REGEX = /(.*?)\.(?=[^\/]*\..{2,5})/
 
 const template = (st: string, context: any): string =>
-  st.replace(/{{([A-Z_]+)}}/g, (match: string, p1: string) => (context[p1] ? context[p1] : ''))
+  st.replace(/{{([A-Z_]+)}}/g, (match: string, p1: string) => (context[p1] ? context[p1] : match))
 
-export const handleConfig = (test: Test, publicId: string, config?: ConfigOverride): Payload => {
+export const handleConfig = (
+  test: Test,
+  publicId: string,
+  write: Writable['write'],
+  config?: ConfigOverride
+): Payload => {
   let handledConfig: Payload = {public_id: publicId}
   if (!config || !Object.keys(config).length) {
     return handledConfig
@@ -58,22 +63,7 @@ export const handleConfig = (test: Test, publicId: string, config?: ConfigOverri
     ]),
   }
 
-  const objUrl = new URL(test.config.request.url)
-  const subdomainMatch = objUrl.hostname.match(SUBDOMAIN_REGEX)
-  const domain = subdomainMatch ? objUrl.hostname.replace(`${subdomainMatch[1]}.`, '') : objUrl.hostname
-  const context: TemplateContext = {
-    ...process.env,
-    DOMAIN: domain,
-    HOST: objUrl.host,
-    HOSTNAME: objUrl.hostname,
-    ORIGIN: objUrl.origin,
-    PARAMS: objUrl.search,
-    PATHNAME: objUrl.pathname,
-    PORT: objUrl.port,
-    PROTOCOL: objUrl.protocol,
-    SUBDOMAIN: subdomainMatch ? subdomainMatch[1] : undefined,
-    URL: test.config.request.url,
-  }
+  const context = parseUrlVariables(test.config.request.url, write)
 
   if (config.startUrl) {
     handledConfig.startUrl = template(config.startUrl, context)
@@ -91,6 +81,32 @@ export const handleConfig = (test: Test, publicId: string, config?: ConfigOverri
   }
 
   return handledConfig
+}
+
+const parseUrlVariables = (url: string, write: Writable['write']) => {
+  const context: TemplateContext = {
+    ...process.env,
+    URL: url,
+  }
+  try {
+    const objUrl = new URL(url)
+    const subdomainMatch = objUrl.hostname.match(SUBDOMAIN_REGEX)
+    const domain = subdomainMatch ? objUrl.hostname.replace(`${subdomainMatch[1]}.`, '') : objUrl.hostname
+
+    context.DOMAIN = domain
+    context.HOST = objUrl.host
+    context.HOSTNAME = objUrl.hostname
+    context.ORIGIN = objUrl.origin
+    context.PARAMS = objUrl.search
+    context.PATHNAME = objUrl.pathname
+    context.PORT = objUrl.port
+    context.PROTOCOL = objUrl.protocol
+    context.SUBDOMAIN = subdomainMatch ? subdomainMatch[1] : undefined
+  } catch {
+    write(`Unable to parse start url: ${url}`)
+  }
+
+  return context
 }
 
 export const getStrictestExecutionRule = (configRule: ExecutionRule, testRule?: ExecutionRule): ExecutionRule => {
@@ -265,7 +281,7 @@ export const runTests = async (
       }
 
       write(renderTrigger(test, id, config))
-      const overloadedConfig = handleConfig(test, id, config)
+      const overloadedConfig = handleConfig(test, id, write, config)
       write(renderWait(test))
       testsToTrigger.push(overloadedConfig)
 

--- a/src/commands/synthetics/utils.ts
+++ b/src/commands/synthetics/utils.ts
@@ -88,23 +88,27 @@ const parseUrlVariables = (url: string, write: Writable['write']) => {
     ...process.env,
     URL: url,
   }
+  let objUrl
   try {
-    const objUrl = new URL(url)
-    const subdomainMatch = objUrl.hostname.match(SUBDOMAIN_REGEX)
-    const domain = subdomainMatch ? objUrl.hostname.replace(`${subdomainMatch[1]}.`, '') : objUrl.hostname
-
-    context.DOMAIN = domain
-    context.HOST = objUrl.host
-    context.HOSTNAME = objUrl.hostname
-    context.ORIGIN = objUrl.origin
-    context.PARAMS = objUrl.search
-    context.PATHNAME = objUrl.pathname
-    context.PORT = objUrl.port
-    context.PROTOCOL = objUrl.protocol
-    context.SUBDOMAIN = subdomainMatch ? subdomainMatch[1] : undefined
+    objUrl = new URL(url)
   } catch {
-    write(`Unable to parse start url: ${url}`)
+    write(`The start url ${url} contains variables, CI overrides will be ignored`)
+
+    return context
   }
+
+  const subdomainMatch = objUrl.hostname.match(SUBDOMAIN_REGEX)
+  const domain = subdomainMatch ? objUrl.hostname.replace(`${subdomainMatch[1]}.`, '') : objUrl.hostname
+
+  context.DOMAIN = domain
+  context.HOST = objUrl.host
+  context.HOSTNAME = objUrl.hostname
+  context.ORIGIN = objUrl.origin
+  context.PARAMS = objUrl.search
+  context.PATHNAME = objUrl.pathname
+  context.PORT = objUrl.port
+  context.PROTOCOL = objUrl.protocol
+  context.SUBDOMAIN = subdomainMatch ? subdomainMatch[1] : undefined
 
   return context
 }


### PR DESCRIPTION
### What and why?

Gracefully handle non-parsable start urls of synthetics tests.

### How?

The parsing is now in a `try/catch` block and variables replacing is done on a "best-effort" basis.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)

