### PR TITLE
[synthetics][SW-598] ignore *_PROXY environment variables

### DIFF
--- a/src/commands/synthetics/api.ts
+++ b/src/commands/synthetics/api.ts
@@ -88,7 +88,7 @@ const retryRequest = <T>(args: AxiosRequestConfig, request: (args: AxiosRequestC
 
 export const apiConstructor = (configuration: APIConfiguration) => {
   const {baseUrl, baseIntakeUrl, apiKey, appKey, proxyOpts} = configuration
-  const request = getRequestBuilder(baseUrl, apiKey, appKey, proxyOpts)
+  const request = getRequestBuilder(baseUrl, apiKey, appKey, proxyOpts, true)
   const requestIntake = getRequestBuilder(baseIntakeUrl, apiKey, appKey, proxyOpts)
 
   return {

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -60,7 +60,13 @@ export interface ProxyConfiguration {
   protocol: ProxyType
 }
 
-export const getRequestBuilder = (baseUrl: string, apiKey: string, appKey?: string, proxyOpts?: ProxyConfiguration) => {
+export const getRequestBuilder = (
+  baseUrl: string,
+  apiKey: string,
+  appKey?: string,
+  proxyOpts?: ProxyConfiguration,
+  disableEnvironmentVariables = false
+) => {
   const overrideArgs = (args: AxiosRequestConfig) => {
     const newArguments = {
       ...args,
@@ -78,7 +84,15 @@ export const getRequestBuilder = (baseUrl: string, apiKey: string, appKey?: stri
     return newArguments
   }
 
-  return (args: AxiosRequestConfig) => axios.create({baseURL: baseUrl})(overrideArgs(args))
+  const baseConfiguration: AxiosRequestConfig = {
+    baseURL: baseUrl,
+  }
+
+  if (disableEnvironmentVariables) {
+    baseConfiguration.proxy = false
+  }
+
+  return (args: AxiosRequestConfig) => axios.create(baseConfiguration)(overrideArgs(args))
 }
 
 export const getApiHostForSite = (site: string) => {


### PR DESCRIPTION
### What and why?

It allows ignoring *_PROXY environment variables, and leverages this in synthetics command.

### How?

It does so by setting the `proxy: false` config in axios when building the axios instance. (cf. https://github.com/axios/axios/pull/691)

### Review checklist

No unit tests were added to test this behavior as it would require setting an HTTP server and was deemed too heavy.

