### PR TITLE
Mrousse/refactor request builder

### DIFF
--- a/src/commands/sourcemaps/api.ts
+++ b/src/commands/sourcemaps/api.ts
@@ -35,7 +35,7 @@ export const uploadSourcemap = (request: (args: AxiosRequestConfig) => AxiosProm
 }
 
 export const apiConstructor = (baseIntakeUrl: string, apiKey: string) => {
-  const requestIntake = getRequestBuilder(baseIntakeUrl, apiKey)
+  const requestIntake = getRequestBuilder({baseUrl: baseIntakeUrl, apiKey})
 
   return {
     uploadSourcemap: uploadSourcemap(requestIntake),

--- a/src/commands/synthetics/api.ts
+++ b/src/commands/synthetics/api.ts
@@ -88,8 +88,9 @@ const retryRequest = <T>(args: AxiosRequestConfig, request: (args: AxiosRequestC
 
 export const apiConstructor = (configuration: APIConfiguration) => {
   const {baseUrl, baseIntakeUrl, apiKey, appKey, proxyOpts} = configuration
-  const request = getRequestBuilder(baseUrl, apiKey, appKey, proxyOpts, true)
-  const requestIntake = getRequestBuilder(baseIntakeUrl, apiKey, appKey, proxyOpts)
+  const baseOptions = {apiKey, appKey, disableEnvironmentVariables: true, proxyOpts}
+  const request = getRequestBuilder({...baseOptions, baseUrl})
+  const requestIntake = getRequestBuilder({...baseOptions, baseUrl: baseIntakeUrl})
 
   return {
     getTest: getTest(request),

--- a/src/helpers/__tests__/utils.test.ts
+++ b/src/helpers/__tests__/utils.test.ts
@@ -62,24 +62,39 @@ describe('utils', () => {
 
     test('should add api key header', async () => {
       jest.spyOn(axios, 'create').mockImplementation((() => (args: AxiosRequestConfig) => args.headers) as any)
-      const request = getRequestBuilder('http://fake-base.url/', 'apiKey')
+      const requestOptions = {
+        apiKey: 'apiKey',
+        baseUrl: 'http://fake-base.url/',
+      }
+      const request = getRequestBuilder(requestOptions)
       const fakeEndpoint = fakeEndpointBuilder(request)
       expect(await fakeEndpoint()).toStrictEqual({'DD-API-KEY': 'apiKey'})
     })
 
     test('should add api and application key header', async () => {
       jest.spyOn(axios, 'create').mockImplementation((() => (args: AxiosRequestConfig) => args.headers) as any)
-      const request = getRequestBuilder('http://fake-base.url/', 'apiKey', 'applicationKey')
+      const requestOptions = {
+        apiKey: 'apiKey',
+        appKey: 'applicationKey',
+        baseUrl: 'http://fake-base.url/',
+      }
+      const request = getRequestBuilder(requestOptions)
       const fakeEndpoint = fakeEndpointBuilder(request)
       expect(await fakeEndpoint()).toStrictEqual({'DD-API-KEY': 'apiKey', 'DD-APPLICATION-KEY': 'applicationKey'})
     })
 
     test('should add proxy configuration', async () => {
       jest.spyOn(axios, 'create').mockImplementation((() => (args: AxiosRequestConfig) => args.httpsAgent.proxy) as any)
-      const proxyConf: ProxyConfiguration = {protocol: 'http', host: '1.2.3.4', port: 1234}
-      const request = getRequestBuilder('http://fake-base.url/', 'apiKey', 'applicationKey', proxyConf)
+      const proxyOpts: ProxyConfiguration = {protocol: 'http', host: '1.2.3.4', port: 1234}
+      const requestOptions = {
+        apiKey: 'apiKey',
+        appKey: 'applicationKey',
+        baseUrl: 'http://fake-base.url/',
+        proxyOpts,
+      }
+      const request = getRequestBuilder(requestOptions)
       const fakeEndpoint = fakeEndpointBuilder(request)
-      expect(await fakeEndpoint()).toStrictEqual(proxyConf)
+      expect(await fakeEndpoint()).toStrictEqual(proxyOpts)
     })
   })
 

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -60,13 +60,16 @@ export interface ProxyConfiguration {
   protocol: ProxyType
 }
 
-export const getRequestBuilder = (
-  baseUrl: string,
-  apiKey: string,
-  appKey?: string,
-  proxyOpts?: ProxyConfiguration,
-  disableEnvironmentVariables = false
-) => {
+export interface RequestOptions {
+  apiKey: string
+  appKey?: string
+  baseUrl: string
+  disableEnvironmentVariables?: boolean
+  proxyOpts?: ProxyConfiguration
+}
+
+export const getRequestBuilder = (options: RequestOptions) => {
+  const {apiKey, appKey, baseUrl, disableEnvironmentVariables, proxyOpts} = options
   const overrideArgs = (args: AxiosRequestConfig) => {
     const newArguments = {
       ...args,


### PR DESCRIPTION
### What and why?

Refactor to replace `requestBuilder` arguments with an object to ease arguments addition.

It comes as a follow up of https://github.com/DataDog/datadog-ci/pull/117