### PR TITLE
[Synthetics][SW-638] Replace `Unknown error` with `General Error` in results output

### DIFF
--- a/src/commands/synthetics/renderer.ts
+++ b/src/commands/synthetics/renderer.ts
@@ -101,7 +101,10 @@ const renderResultOutcome = (result: Result, test: Test, icon: string, color: ty
   }
 
   if (result.unhealthy) {
-    return `    ${chalk.bold(`✖ | ${result.errorMessage || 'General Error'}`)}`
+    const errorName =
+      result.errorMessage && result.errorMessage !== 'Unknown error' ? result.errorMessage : 'General Error'
+
+    return `    ${chalk.bold(`✖ | ${errorName}`)}`
   }
 
   if (test.type === 'api') {


### PR DESCRIPTION
### What and why?

[SW-628](https://datadoghq.atlassian.net/browse/SW-628)

### How?

Use default `General Error` error name for `Unknown error`.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)

