### PR TITLE
[synthetics] fix start url variable substitution

### DIFF
--- a/src/commands/synthetics/__tests__/utils.test.ts
+++ b/src/commands/synthetics/__tests__/utils.test.ts
@@ -169,6 +169,22 @@ describe('utils', () => {
       expect(handledConfig.startUrl).toBe(expectedUrl)
       process.env = envVars
     })
+
+    test('startUrl with empty variable is replaced', () => {
+      const publicId = 'abc-def-ghi'
+      const fakeTest = {
+        config: {request: {url: 'http://exmaple.org/path'}},
+        public_id: publicId,
+      } as Test
+      const configOverride = {
+        startUrl: 'http://127.0.0.1/newPath{{PARAMS}}',
+      }
+      const expectedUrl = 'http://127.0.0.1/newPath'
+      const handledConfig = utils.handleConfig(fakeTest, publicId, processWrite, configOverride)
+
+      expect(handledConfig.public_id).toBe(publicId)
+      expect(handledConfig.startUrl).toBe(expectedUrl)
+    })
   })
 
   describe('hasResultPassed', () => {

--- a/src/commands/synthetics/utils.ts
+++ b/src/commands/synthetics/utils.ts
@@ -33,7 +33,7 @@ const PUBLIC_ID_REGEX = /^[\d\w]{3}-[\d\w]{3}-[\d\w]{3}$/
 const SUBDOMAIN_REGEX = /(.*?)\.(?=[^\/]*\..{2,5})/
 
 const template = (st: string, context: any): string =>
-  st.replace(/{{([A-Z_]+)}}/g, (match: string, p1: string) => (context[p1] ? context[p1] : match))
+  st.replace(/{{([A-Z_]+)}}/g, (match: string, p1: string) => (p1 in context ? context[p1] : match))
 
 export const handleConfig = (
   test: Test,


### PR DESCRIPTION
### What and why?

Fix variable substitution by allowing variables with an empty content.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)

