### PR TITLE
Publish v0.8.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "description": "Run datadog actions from the CI.",
   "main": "dist/index.js",
   "repository": "https://github.com/DataDog/datadog-ci",


### PR DESCRIPTION
### What and why?

This PR bumps the package to version 0.8.5, releasing:
- [[sourcemaps] Add simple e2e test for sourcemaps upload](https://github.com/DataDog/datadog-ci/pull/121)
- [Fix Naming of Commit SHA](https://github.com/DataDog/datadog-ci/pull/107)
- [[synthetics\]\[SW-635] Don't display unhealthy results URLs](https://github.com/DataDog/datadog-ci/pull/122)
- [[synthetics][SW-638] Replace `Unknown error` with `General Error` in results output](https://github.com/DataDog/datadog-ci/pull/124)
- [[synthetics] Fix start url variable substitution](https://github.com/DataDog/datadog-ci/pull/125)


[SW-635]: https://datadoghq.atlassian.net/browse/SW-635