### PR TITLE
Change the sourcemap URL matching

### DIFF
--- a/src/commands/sourcemaps/README.md
+++ b/src/commands/sourcemaps/README.md
@@ -38,8 +38,9 @@ The folder structure should match the structure of the served static files.
 
 * `--release-version` (required) is similar and will be used to match the `version` tag set on the RUM SDK.
 
-* `--minified-path-prefix` (required) is the URL prefix that will be matched against the URL we got the error from. It must be set to the actual url exposed on the server (and used by browsers to retrieve the minified file).
-When un-minifying the stack traces, the URL of the static files will be match against the concatenation of this prefix and the relative path to the folder you're uploading sourcemaps from of the JS file.
+* `--minified-path-prefix` (required) is the URL or absolute path prefix that will be matched against the URL we got the error from. It must be set to the actual url or the absolute path exposed on the server (and used by browsers to retrieve the minified file).
+When un-minifying the stack traces, the URL of the static files will be matched against the concatenation of this prefix and the relative path to the folder you're uploading sourcemaps from of the JS file.
+Full URLs matching will be prioritized over absolute paths matches.
 
 In addition, some optional parameters are available:
 

--- a/src/commands/sourcemaps/README.md
+++ b/src/commands/sourcemaps/README.md
@@ -38,9 +38,11 @@ The folder structure should match the structure of the served static files.
 
 * `--release-version` (required) is similar and will be used to match the `version` tag set on the RUM SDK.
 
-* `--minified-path-prefix` (required) is the URL or absolute path prefix that will be matched against the URL we got the error from. It must be set to the actual url or the absolute path exposed on the server (and used by browsers to retrieve the minified file).
+* `--minified-path-prefix` (required) is the URL or absolute path prefix that will be matched against the URL we got the error from. It must be set to the actual url or the absolute path exposed on the server (and used by browsers to retrieve the minified file). 
 When un-minifying the stack traces, the URL of the static files will be matched against the concatenation of this prefix and the relative path to the folder you're uploading sourcemaps from of the JS file.
 Full URLs matching will be prioritized over absolute paths matches.
+Absolute paths must always begin with a leading slash.
+The protocol will be ignored when matching using full URLs. The protocol can be explicitly omitted, for example: //static.datadog.com/js
 
 In addition, some optional parameters are available:
 

--- a/src/commands/sourcemaps/README.md
+++ b/src/commands/sourcemaps/README.md
@@ -41,8 +41,8 @@ The folder structure should match the structure of the served static files.
 * `--minified-path-prefix` (required) is the URL or absolute path prefix that will be matched against the URL we got the error from. It must be set to the actual url or the absolute path exposed on the server (and used by browsers to retrieve the minified file). 
 When un-minifying the stack traces, the URL of the static files will be matched against the concatenation of this prefix and the relative path to the folder you're uploading sourcemaps from of the JS file.
 Full URLs matching will be prioritized over absolute paths matches.
-Absolute paths must always begin with a leading slash.
-The protocol will be ignored when matching using full URLs. The protocol can be explicitly omitted, for example: //static.datadog.com/js
+The protocol will be ignored when matching using full URLs. The protocol can be explicitly omitted, for example: `//static.datadog.com/js`.  
+Absolute paths must always begin with a leading slash. Simply specify `/` if the content is expected to be at the root directory on the server.
 
 In addition, some optional parameters are available:
 

--- a/src/commands/sourcemaps/__tests__/upload.test.ts
+++ b/src/commands/sourcemaps/__tests__/upload.test.ts
@@ -34,15 +34,39 @@ describe('upload', () => {
     })
   })
 
-  describe('getMinifiedURL: minifiedPathPrefix has no leading slash', () => {
-    test('should throw an error', () => {
+  describe('isMinifiedPathPrefixValid: full URL', () => {
+    test('should return false', () => {
       const command = new UploadCommand()
-      command['basePath'] = '/js/sourcemaps'
+      command['minifiedPathPrefix'] = 'http://datadog.com/js'
+
+      expect(command['isMinifiedPathPrefixValid']()).toBe(true)
+    })
+  })
+
+  describe('isMinifiedPathPrefixValid: URL without protocol', () => {
+    test('should return false', () => {
+      const command = new UploadCommand()
+      command['minifiedPathPrefix'] = '//datadog.com/js'
+
+      expect(command['isMinifiedPathPrefixValid']()).toBe(true)
+    })
+  })
+
+  describe('isMinifiedPathPrefixValid: leading slash', () => {
+    test('should return false', () => {
+      const command = new UploadCommand()
+      command['minifiedPathPrefix'] = '/js'
+
+      expect(command['isMinifiedPathPrefixValid']()).toBe(true)
+    })
+  })
+
+  describe('isMinifiedPathPrefixValid: no leading slash', () => {
+    test('should return false', () => {
+      const command = new UploadCommand()
       command['minifiedPathPrefix'] = 'js'
 
-      expect(() => command['getMinifiedURL']('/js/sourcemaps/common.min.js.map')).toThrow(
-        'Absolute path must have a leading slash'
-      )
+      expect(command['isMinifiedPathPrefixValid']()).toBe(false)
     })
   })
 

--- a/src/commands/sourcemaps/__tests__/upload.test.ts
+++ b/src/commands/sourcemaps/__tests__/upload.test.ts
@@ -21,9 +21,7 @@ describe('upload', () => {
       const command = new UploadCommand()
       command['basePath'] = '/js/sourcemaps'
       command['minifiedPathPrefix'] = '/js'
-      expect(command['getMinifiedURL']('/js/sourcemaps/common.min.js.map')).toBe(
-        '/js/common.min.js.map'
-      )
+      expect(command['getMinifiedURL']('/js/sourcemaps/common.min.js.map')).toBe('/js/common.min.js.map')
     })
   })
 

--- a/src/commands/sourcemaps/__tests__/upload.test.ts
+++ b/src/commands/sourcemaps/__tests__/upload.test.ts
@@ -16,12 +16,33 @@ describe('upload', () => {
     })
   })
 
+  describe('getMinifiedURL: minifiedPathPrefix has the protocol omitted', () => {
+    test('should return correct URL', () => {
+      const command = new UploadCommand()
+      command['basePath'] = '/js/sourcemaps'
+      command['minifiedPathPrefix'] = '//datadog.com/js'
+      expect(command['getMinifiedURL']('/js/sourcemaps/common.min.js.map')).toBe('//datadog.com/js/common.min.js.map')
+    })
+  })
+
   describe('getMinifiedURL: minifiedPathPrefix is an absolute path', () => {
     test('should return correct URL', () => {
       const command = new UploadCommand()
       command['basePath'] = '/js/sourcemaps'
       command['minifiedPathPrefix'] = '/js'
       expect(command['getMinifiedURL']('/js/sourcemaps/common.min.js.map')).toBe('/js/common.min.js.map')
+    })
+  })
+
+  describe('getMinifiedURL: minifiedPathPrefix has no leading slash', () => {
+    test('should throw an error', () => {
+      const command = new UploadCommand()
+      command['basePath'] = '/js/sourcemaps'
+      command['minifiedPathPrefix'] = 'js'
+
+      expect(() => command['getMinifiedURL']('/js/sourcemaps/common.min.js.map')).toThrow(
+        'Absolute path must have a leading slash'
+      )
     })
   })
 

--- a/src/commands/sourcemaps/__tests__/upload.test.ts
+++ b/src/commands/sourcemaps/__tests__/upload.test.ts
@@ -16,6 +16,17 @@ describe('upload', () => {
     })
   })
 
+  describe('getMinifiedURL: minifiedPathPrefix is an absolute path', () => {
+    test('should return correct URL', () => {
+      const command = new UploadCommand()
+      command['basePath'] = '/js/sourcemaps'
+      command['minifiedPathPrefix'] = '/js'
+      expect(command['getMinifiedURL']('/js/sourcemaps/common.min.js.map')).toBe(
+        '/js/common.min.js.map'
+      )
+    })
+  })
+
   describe('getApiHelper', () => {
     test('should throw an error if API key is undefined', async () => {
       process.env = {}

--- a/src/commands/sourcemaps/renderer.ts
+++ b/src/commands/sourcemaps/renderer.ts
@@ -8,6 +8,10 @@ const ICONS = {
   WARNING: chalk.bold.green('⚠️'),
 }
 
+export const renderInvalidPrefix = chalk.red(
+  `${ICONS.FAILED} --minified-path-prefix should either be an URL (such as "http://example.com/static") or an absolute path starting with a / such as "/static"\n`
+)
+
 export const renderFailedUpload = (payload: Payload, errorMessage: string) => {
   const sourcemapPathBold = `[${chalk.bold.dim(payload.sourcemapPath)}]`
 

--- a/src/commands/sourcemaps/upload.ts
+++ b/src/commands/sourcemaps/upload.ts
@@ -6,6 +6,7 @@ import fs from 'fs'
 import glob from 'glob'
 import path from 'path'
 import asyncPool from 'tiny-async-pool'
+import {URL} from 'url'
 
 import {apiConstructor} from './api'
 import {APIHelper, Payload} from './interfaces'
@@ -122,6 +123,17 @@ export class UploadCommand extends Command {
   }
 
   private getMinifiedURL(minifiedFilePath: string): string {
+    let protocol
+    try {
+      const objUrl = new URL(this.minifiedPathPrefix!)
+      protocol = objUrl.protocol
+    } catch {
+      // Do nothing.
+    }
+
+    if (!protocol && !this.minifiedPathPrefix!.startsWith('/')) {
+      throw new Error('Absolute path must have a leading slash')
+    }
     const relativePath = minifiedFilePath.replace(this.basePath!, '')
 
     return buildPath(this.minifiedPathPrefix!, relativePath)


### PR DESCRIPTION
### What and why?

Update the `--minified-path-prefix` flag usage.

### How?

The backend will now be able to match against the path portion of unminified URLs instead of just the full URL.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)

