### PR TITLE
Publish v0.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci",
-  "version": "0.8.7",
+  "version": "0.9.0",
   "description": "Run datadog actions from the CI.",
   "main": "dist/index.js",
   "repository": "https://github.com/DataDog/datadog-ci",


### PR DESCRIPTION
### What and why?

This PR releases https://github.com/DataDog/datadog-ci/pull/131 which updates the `--minified-path-prefix` flag usage in the sourcemaps upload command.