### PR TITLE
Update Lambda instrumentation command readme

### DIFF
--- a/src/commands/lambda/README.md
+++ b/src/commands/lambda/README.md
@@ -40,13 +40,13 @@ Use `instrument` to apply Datadog instrumentation to a Lambda. This command auto
 This command is the quickest way to try out Datadog instrumentation on an existing Lambda function. To use in the production environment, run this command in your CI/CD pipelines to ensure your Lambda functions are always updated for instrumentation.
 
 ```bash
-# instrument a function specified by ARN
+# Instrument a function specified by ARN
 datadog-ci lambda instrument --function arn:aws:lambda:us-east-1:000000000000:function:functionname --layerVersion 10
 
 # Use the shorthand formats
 datadog-ci lambda instrument -f arn:aws:lambda:us-east-1:000000000000:function:functionname -v 10
 
-# Instrument multiple functions specified by their names (--region must be defined)
+# Instrument multiple functions specified by names (--region must be defined)
 datadog-ci lambda instrument -f functionname -f another-functionname -r us-east-1 -v 10
 
 # Dry run of all update commands
@@ -59,11 +59,11 @@ All arguments:
 | -------- | --------- | ----------- | ------- |
 | --function | -f | The ARN of the Lambda function to be instrumented, or the name of the Lambda function (--region must be defined) | |
 | --region | -r | Default region to use, when `--function` is specified by the function name instead of the ARN | |
-| --layerVersion | -v | Version of the Datadog layer to apply. This varies between runtimes. To see the latest layer version check the [JS][3] or [python][4] datadog-lambda-layer repo release notes. | |
-| --tracing |  | Whether to enable dd-trace tracing on your Lambda. | true |
+| --layerVersion | -v | Version of the Datadog layer to apply. This varies between runtimes. To see the latest layer version check the [JS][3] or [python][4] datadog-lambda-layer repo release notes | |
+| --tracing |  | Whether to enable dd-trace tracing on your Lambda | true |
 | --mergeXrayTraces | | Whether to join dd-trace traces to AWS X-Ray traces. Useful for tracing API Gateway spans. | false |
 | --flushMetricsToLogs | | Whether to send metrics via the Datadog Forwarder [asynchronously](https://docs.datadoghq.com/serverless/custom_metrics?tab=python#enabling-asynchronous-custom-metrics) | true |
-| --forwarder | | The ARN of the [datadog forwarder](https://docs.datadoghq.com/serverless/forwarder/) to attach this functions LogGroup to. | |
+| --forwarder | | The ARN of the [datadog forwarder](https://docs.datadoghq.com/serverless/forwarder/) to attach this function's LogGroup to. | |
 | --dry | -d | Preview changes running command would apply. | false |
 
 [1]: https://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/setting-credentials-node.html

--- a/src/commands/lambda/README.md
+++ b/src/commands/lambda/README.md
@@ -62,7 +62,7 @@ All arguments:
 | --layerVersion | -v | Version of the Datadog layer to apply. This varies between runtimes. To see the latest layer version check the [JS][3] or [python][4] datadog-lambda-layer repo release notes. | |
 | --tracing |  | Whether to enable dd-trace tracing on your Lambda. | true |
 | --mergeXrayTraces | | Whether to join dd-trace traces to AWS X-Ray traces. Useful for tracing API Gateway spans. | false |
-| --flushMetricsToLogs | | Whether to send metrics via the Datadog Forwarder[asynchronously](https://docs.datadoghq.com/serverless/custom_metrics?tab=python#enabling-asynchronous-custom-metrics) | true |
+| --flushMetricsToLogs | | Whether to send metrics via the Datadog Forwarder [asynchronously](https://docs.datadoghq.com/serverless/custom_metrics?tab=python#enabling-asynchronous-custom-metrics) | true |
 | --forwarder | | The ARN of the [datadog forwarder](https://docs.datadoghq.com/serverless/forwarder/) to attach this functions LogGroup to. | |
 | --dry | -d | Preview changes running command would apply. | false |
 

--- a/src/commands/lambda/README.md
+++ b/src/commands/lambda/README.md
@@ -2,7 +2,7 @@
 This feature is in open beta. Let us know of any questions or issues by filing an <a href="https://github.com/DataDog/datadog-ci/issues">issue</a> in our repo.
 </div>
 
-You can use the CLI to instrument your AWS Lambda functions with Datadog.
+You can use the CLI to instrument your AWS Lambda functions with Datadog. Only Python and Node.js runtimes are currently supported.
 
 ### Before you begin
 
@@ -35,29 +35,35 @@ Configuration is done using a JSON file. Specify the `datadog-ci.json` using the
 
 #### Commands
 
-Use `instrument` to apply Datadog instrumentation to a Lambda.
+Use `instrument` to apply Datadog instrumentation to a Lambda. This command automatically adds the Datadog Lambda library as layers to the instrumented Lambda functions and modifies their configurations. 
 
-The CLI accepts the `--function` (or shorthand `-f`) argument to specify which function to instrument. This should be a function ARN.
+This command is the quickest way to try out Datadog instrumentation on an existing Lambda function. To use in the production environment, run this command in your CI/CD pipelines to ensure your Lambda functions are always updated for instrumentation.
 
 ```bash
-datadog-ci lambda instrument --function arn:aws:lambda:us-east-1:000000000000:function:autoinstrument --layerVersion 10
-# Can also use shorthand formats
-datadog-ci lambda instrument -f autoinstrument -f another-func -r us-east-1 -v 10
+# instrument a function specified by ARN
+datadog-ci lambda instrument --function arn:aws:lambda:us-east-1:000000000000:function:functionname --layerVersion 10
+
+# Use the shorthand formats
+datadog-ci lambda instrument -f arn:aws:lambda:us-east-1:000000000000:function:functionname -v 10
+
+# Instrument multiple functions specified by their names (--region must be defined)
+datadog-ci lambda instrument -f functionname -f another-functionname -r us-east-1 -v 10
+
 # Dry run of all update commands
-datadog-ci lambda instrument -f autoinstrument -r us-east-1 -v 10 --dry
+datadog-ci lambda instrument -f functionname -r us-east-1 -v 10 --dry
 ```
 
 All arguments:
 
 | Argument | Shorthand | Description | Default |
 | -------- | --------- | ----------- | ------- |
-| --function | -f | Specificy a function to instrument | |
-| --region | -r | Default region to use, when region isn't specified in function ARN | |
+| --function | -f | The ARN of the Lambda function to be instrumented, or the name of the Lambda function (--region must be defined) | |
+| --region | -r | Default region to use, when `--function` is specified by the function name instead of the ARN | |
 | --layerVersion | -v | Version of the Datadog layer to apply. This varies between runtimes. To see the latest layer version check the [JS][3] or [python][4] datadog-lambda-layer repo release notes. | |
 | --tracing |  | Whether to enable dd-trace tracing on your Lambda. | true |
 | --mergeXrayTraces | | Whether to join dd-trace traces to AWS X-Ray traces. Useful for tracing API Gateway spans. | false |
-| --flushMetricsToLogs | | Whether to send metrics asynchronously to Datadog via our [Forwarder](https://docs.datadoghq.com/serverless/forwarder/) | true |
-| --forwarder | | The ARN of the [datadog forwarder](https://github.com/DataDog/datadog-serverless-functions/tree/master/aws/logs_monitoring) to attach this functions LogGroup to. | |
+| --flushMetricsToLogs | | Whether to send metrics via the Datadog Forwarder[asynchronously](https://docs.datadoghq.com/serverless/custom_metrics?tab=python#enabling-asynchronous-custom-metrics) | true |
+| --forwarder | | The ARN of the [datadog forwarder](https://docs.datadoghq.com/serverless/forwarder/) to attach this functions LogGroup to. | |
 | --dry | -d | Preview changes running command would apply. | false |
 
 [1]: https://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/setting-credentials-node.html

--- a/src/commands/lambda/README.md
+++ b/src/commands/lambda/README.md
@@ -35,7 +35,7 @@ Configuration is done using a JSON file. Specify the `datadog-ci.json` using the
 
 #### Commands
 
-Use `instrument` to apply Datadog instrumentation to a Lambda. This command automatically adds the Datadog Lambda library as layers to the instrumented Lambda functions and modifies their configurations. 
+Use `instrument` to apply Datadog instrumentation to a Lambda. This command automatically adds the Datadog Lambda library (as a Lambda Layer) to the instrumented Lambda functions and modifies their configurations. 
 
 This command is the quickest way to try out Datadog instrumentation on an existing Lambda function. To use in the production environment, run this command in your CI/CD pipelines to ensure your Lambda functions are always updated for instrumentation.
 


### PR DESCRIPTION
### What and why?

Update Lambda instrumentation command readme based on recent customer feedback.

### How?

- Clarify that only Python and Node.js Lambda functions are supported.
- Update sample commands
- Update arguments' descriptions

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)

