### PR TITLE
Fix sourcemaps upload size limit.

### DIFF
--- a/src/commands/sourcemaps/api.ts
+++ b/src/commands/sourcemaps/api.ts
@@ -8,9 +8,9 @@ import {getRequestBuilder} from '../../helpers/utils'
 import {Payload} from './interfaces'
 import {renderUpload} from './renderer'
 
-// Dependcy follows-redirects sets a default maxBodyLentgh of 10 MB https://github.com/follow-redirects/follow-redirects/blob/b774a77e582b97174813b3eaeb86931becba69db/index.js#L391
+// Dependency follows-redirects sets a default maxBodyLength of 10 MB https://github.com/follow-redirects/follow-redirects/blob/b774a77e582b97174813b3eaeb86931becba69db/index.js#L391
 // We don't want any hard limit enforced by the CLI, the backend will enforce a max size by returning 413 errors.
-const maxContentLength = Infinity
+const maxBodyLength = Infinity
 
 export const uploadSourcemap = (request: (args: AxiosRequestConfig) => AxiosPromise<AxiosResponse>) => async (
   sourcemap: Payload,
@@ -28,7 +28,7 @@ export const uploadSourcemap = (request: (args: AxiosRequestConfig) => AxiosProm
   return request({
     data: form,
     headers: form.getHeaders(),
-    maxContentLength,
+    maxBodyLength,
     method: 'POST',
     url: 'v1/input',
   })


### PR DESCRIPTION
### What and why?

[Update of axios](https://github.com/DataDog/datadog-ci/pull/138) did introduce this change:
https://github.com/axios/axios/pull/2781

It broke upload of sourcemaps for requests larger than 10MB.

This PR intends to fix it.

### How?


### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)

