### PR TITLE
Publish v0.9.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "Run datadog actions from the CI.",
   "main": "dist/index.js",
   "repository": "https://github.com/DataDog/datadog-ci",


### PR DESCRIPTION
### What and why?

This PR bumps version to 0.9.2, releasing:

[sourcemaps] Fix max size of uploaded sourcemaps

