### PR TITLE
[Synthetics][SW-797] Fix config override for tests run by public ID

### DIFF
--- a/src/commands/synthetics/__tests__/run-test.test.ts
+++ b/src/commands/synthetics/__tests__/run-test.test.ts
@@ -1,6 +1,8 @@
 // tslint:disable: no-string-literal
 jest.mock('fs')
 
+import * as ciUtils from '../../../helpers/utils'
+
 import {ExecutionRule} from '../interfaces'
 import {RunTestCommand} from '../run-test'
 import * as utils from '../utils'
@@ -23,6 +25,37 @@ export const assertAsyncThrow = async (func: any, errorRegex?: RegExp) => {
 }
 
 describe('run-test', () => {
+  describe('execute', () => {
+    test('should apply config override for tests triggered by public id', async () => {
+      jest.spyOn(ciUtils, 'parseConfigFile').mockImplementation(async (config, _) => config)
+      const runTestsMock = jest.spyOn(utils, 'runTests').mockImplementation(async () => ({
+        tests: [],
+        triggers: {locations: [], results: [], triggered_check_ids: []},
+      }))
+
+      const startUrl = '{{PROTOCOL}}//myhost{{PATHNAME}}{{PARAMS}}'
+      const locations = ['location1', 'location2']
+      const configOverride = {locations, startUrl}
+
+      const apiHelper = {}
+      const command = new RunTestCommand()
+      command.context = {stdout: {write: jest.fn()}} as any
+      command['getApiHelper'] = (() => apiHelper) as any
+      command['config'].global = configOverride
+      command['publicIds'] = ['public-id-1', 'public-id-2']
+      await command.execute()
+
+      expect(runTestsMock).toHaveBeenCalledWith(
+        apiHelper,
+        expect.arrayContaining([
+          expect.objectContaining({id: 'public-id-1', config: configOverride}),
+          expect.objectContaining({id: 'public-id-2', config: configOverride}),
+        ]),
+        expect.anything()
+      )
+    })
+  })
+
   describe('getAppBaseURL', () => {
     test('should default to datadog us', async () => {
       process.env = {}

--- a/src/commands/synthetics/run-test.ts
+++ b/src/commands/synthetics/run-test.ts
@@ -30,7 +30,7 @@ export class RunTestCommand extends Command {
     this.config = await parseConfigFile(this.config, this.configPath)
 
     const api = this.getApiHelper()
-    const publicIdsTriggers = this.publicIds.map((id) => ({config: {}, id}))
+    const publicIdsTriggers = this.publicIds.map((id) => ({config: this.config.global, id}))
     const testsToTrigger = publicIdsTriggers.length ? publicIdsTriggers : await this.getTestsToTrigger(api)
 
     if (!testsToTrigger.length) {


### PR DESCRIPTION
### What and why?

When triggering tests with `--public-id`, the global config is ignored and tests are run with their original configuration.

### How?

Build `publicIdsTriggers` with global override configuration as config for each test instead of `{}`.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)

