### PR TITLE
Publish v0.9.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "description": "Run datadog actions from the CI.",
   "main": "dist/index.js",
   "repository": "https://github.com/DataDog/datadog-ci",


### PR DESCRIPTION
### What and why?

Release v0.9.4 which fixes global configuration override for Synthetics tests when launched via public ID: https://github.com/DataDog/datadog-ci/pull/147