### PR TITLE
[Synthetics][SW-843] Update test trigger payload for CI results batches

### DIFF
--- a/src/commands/synthetics/__tests__/api.test.ts
+++ b/src/commands/synthetics/__tests__/api.test.ts
@@ -3,7 +3,7 @@ import {AxiosError, AxiosResponse, default as axios} from 'axios'
 import {ProxyConfiguration} from '../../../helpers/utils'
 
 import {apiConstructor} from '../api'
-import {Payload, PollResult, Result, Trigger} from '../interfaces'
+import {PollResult, Result, TestPayload, Trigger} from '../interfaces'
 
 import {getApiTest} from './fixtures'
 
@@ -59,8 +59,8 @@ describe('dd-api', () => {
     jest.spyOn(axios, 'create').mockImplementation((() => () => ({data: TRIGGER_RESULTS})) as any)
     const api = apiConstructor(apiConfiguration)
     const {triggerTests} = api
-    const testsToTrigger: Payload[] = [{public_id: TRIGGERED_TEST_ID}]
-    const {results, triggered_check_ids} = await triggerTests(testsToTrigger)
+    const tests: TestPayload[] = [{public_id: TRIGGERED_TEST_ID}]
+    const {results, triggered_check_ids} = await triggerTests({tests})
     expect(triggered_check_ids).toEqual([TRIGGERED_TEST_ID])
     expect(results[0].public_id).toBe(TRIGGERED_TEST_ID)
     expect(results[0].result_id).toBe(RESULT_ID)

--- a/src/commands/synthetics/__tests__/api.test.ts
+++ b/src/commands/synthetics/__tests__/api.test.ts
@@ -3,7 +3,7 @@ import {AxiosError, AxiosResponse, default as axios} from 'axios'
 import {ProxyConfiguration} from '../../../helpers/utils'
 
 import {apiConstructor} from '../api'
-import {PollResult, Result, TestPayload, Trigger} from '../interfaces'
+import {ExecutionRule, PollResult, Result, TestPayload, Trigger} from '../interfaces'
 
 import {getApiTest} from './fixtures'
 
@@ -59,7 +59,7 @@ describe('dd-api', () => {
     jest.spyOn(axios, 'create').mockImplementation((() => () => ({data: TRIGGER_RESULTS})) as any)
     const api = apiConstructor(apiConfiguration)
     const {triggerTests} = api
-    const tests: TestPayload[] = [{public_id: TRIGGERED_TEST_ID}]
+    const tests: TestPayload[] = [{public_id: TRIGGERED_TEST_ID, executionRule: ExecutionRule.BLOCKING}]
     const {results, triggered_check_ids} = await triggerTests({tests})
     expect(triggered_check_ids).toEqual([TRIGGERED_TEST_ID])
     expect(results[0].public_id).toBe(TRIGGERED_TEST_ID)

--- a/src/commands/synthetics/__tests__/utils.test.ts
+++ b/src/commands/synthetics/__tests__/utils.test.ts
@@ -46,6 +46,11 @@ describe('utils', () => {
   describe('runTest', () => {
     const processWrite = process.stdout.write.bind(process.stdout)
     const fakeTest = {
+      config: {
+        request: {
+          url: 'http://example.org/',
+        },
+      },
       name: 'Fake Test',
       public_id: '123-456-789',
     }

--- a/src/commands/synthetics/__tests__/utils.test.ts
+++ b/src/commands/synthetics/__tests__/utils.test.ts
@@ -96,20 +96,7 @@ describe('utils', () => {
     })
 
     test('no tests triggered throws an error', async () => {
-      let hasThrown = false
-      try {
-        await utils.runTests(api, [], processWrite)
-      } catch (e) {
-        hasThrown = true
-      }
-      expect(hasThrown).toBeTruthy()
-    })
-
-    test("batch of skipped tests only doesn't trigger run", async () => {
       await expect(utils.runTests(api, [], processWrite)).rejects.toEqual(new Error('No tests to trigger'))
-
-      const test = [{config: {executionRule: ExecutionRule.SKIPPED}, id: fakeTest.public_id}]
-      await expect(utils.runTests(api, test, processWrite)).rejects.toEqual(new Error('No tests to trigger'))
     })
   })
 

--- a/src/commands/synthetics/api.ts
+++ b/src/commands/synthetics/api.ts
@@ -20,10 +20,10 @@ export const formatBackendErrors = (requestError: AxiosError<BackendError>) => {
   return requestError.message
 }
 
-const triggerTests = (request: (args: AxiosRequestConfig) => AxiosPromise<Trigger>) => async (tests: Payload[]) => {
+const triggerTests = (request: (args: AxiosRequestConfig) => AxiosPromise<Trigger>) => async (data: Payload) => {
   const resp = await retryRequest(
     {
-      data: {tests},
+      data,
       method: 'POST',
       url: '/synthetics/tests/trigger/ci',
     },

--- a/src/commands/synthetics/interfaces.ts
+++ b/src/commands/synthetics/interfaces.ts
@@ -184,6 +184,7 @@ export interface Payload {
 }
 
 export interface TestPayload extends ConfigOverride {
+  executionRule: ExecutionRule
   public_id: string
 }
 

--- a/src/commands/synthetics/interfaces.ts
+++ b/src/commands/synthetics/interfaces.ts
@@ -178,8 +178,12 @@ export interface ConfigOverride {
   variables?: {[key: string]: string}
 }
 
-export interface Payload extends ConfigOverride {
+export interface Payload {
   metadata?: Metadata
+  tests: TestPayload[]
+}
+
+export interface TestPayload extends ConfigOverride {
   public_id: string
 }
 
@@ -226,7 +230,7 @@ export interface APIHelper {
   getTest(testId: string): Promise<Test>
   pollResults(resultIds: string[]): Promise<{results: PollResult[]}>
   searchTests(query: string): Promise<TestSearchResult>
-  triggerTests(testsToTrigger: Payload[]): Promise<Trigger>
+  triggerTests(payload: Payload): Promise<Trigger>
 }
 
 export interface APIConfiguration {

--- a/src/commands/synthetics/renderer.ts
+++ b/src/commands/synthetics/renderer.ts
@@ -230,18 +230,22 @@ export const renderResults = (test: Test, results: PollResult[], baseUrl: string
 }
 
 // Other rendering
-export const renderTrigger = (test: Test | undefined, testId: string, config: ConfigOverride) => {
+export const renderTrigger = (test: Test, testId: string, executionRule: ExecutionRule, config: ConfigOverride) => {
   const idDisplay = `[${chalk.bold.dim(testId)}]`
 
   const getMessage = () => {
-    if (!test) {
-      return chalk.red.bold(`Could not find test "${testId}"`)
+    if (executionRule === ExecutionRule.SKIPPED) {
+      // Test is either skipped from datadog-ci config or from test config
+      const isSkippedByCIConfig = config.executionRule === ExecutionRule.SKIPPED
+      if (isSkippedByCIConfig) {
+        return `>> Skipped test "${chalk.yellow.dim(test.name)}"`
+      } else {
+        return `>> Skipped test "${chalk.yellow.dim(test.name)}" because of execution rule configuration in Datadog`
+      }
     }
-    if (config.executionRule === ExecutionRule.SKIPPED) {
-      return `>> Skipped test "${chalk.yellow.dim(test.name)}"`
-    }
-    if (test.options?.ci?.executionRule === ExecutionRule.SKIPPED) {
-      return `>> Skipped test "${chalk.yellow.dim(test.name)}" because of execution rule configuration in Datadog`
+
+    if (executionRule === ExecutionRule.NON_BLOCKING) {
+      return `Trigger test "${chalk.green.bold(test.name)}" (non-blocking)`
     }
 
     return `Trigger test "${chalk.green.bold(test.name)}"`

--- a/src/commands/synthetics/utils.ts
+++ b/src/commands/synthetics/utils.ts
@@ -58,6 +58,7 @@ export const handleConfig = (
       'followRedirects',
       'headers',
       'locations',
+      'pollingTimeout',
       'retry',
       'variables',
     ]),

--- a/src/commands/synthetics/utils.ts
+++ b/src/commands/synthetics/utils.ts
@@ -290,7 +290,7 @@ export const runTests = async (
     })
   )
 
-  if (!testsToTrigger.length || testsToTrigger.every((t: TestPayload) => t.executionRule === ExecutionRule.SKIPPED)) {
+  if (!testsToTrigger.length) {
     throw new Error('No tests to trigger')
   }
 

--- a/src/commands/synthetics/utils.ts
+++ b/src/commands/synthetics/utils.ts
@@ -279,15 +279,14 @@ export const runTests = async (
       }
 
       const overloadedConfig = handleConfig(test, id, write, config)
+      testsToTrigger.push(overloadedConfig)
 
       write(renderTrigger(test, id, overloadedConfig.executionRule, config))
       if (overloadedConfig.executionRule !== ExecutionRule.SKIPPED) {
         write(renderWait(test))
+
+        return test
       }
-
-      testsToTrigger.push(overloadedConfig)
-
-      return test
     })
   )
 


### PR DESCRIPTION
### What and why?

[SW-843](https://datadoghq.atlassian.net/browse/SW-843)

Update test trigger payload with necessary info for CI results batches.

### How?

- Add `pollingTimeout` to forwarded config overrides.
- Remove `metadata` from all tests' payload and only send it in payload root.
- Always send strictest `executionRule` in test config, stop overriding it in test `options.ci`.
- Send `skipped` tests (will now be skipped in backend only) evenfor batches of skipped-only tests.

Also appends `(non-blocking)` to non blocking tests trigger message.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)

