### PR TITLE
Publish v0.10.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci",
-  "version": "0.9.4",
+  "version": "0.10.0",
   "description": "Run datadog actions from the CI.",
   "main": "dist/index.js",
   "repository": "https://github.com/DataDog/datadog-ci",


### PR DESCRIPTION
### What and why?

Publish v0.10.0.

This version introduce support for Synthetics batch CI tests results (https://github.com/DataDog/datadog-ci/pull/150).