### PR TITLE
Git support: improve performance

### DIFF
--- a/src/commands/sourcemaps/__tests__/git.test.ts
+++ b/src/commands/sourcemaps/__tests__/git.test.ts
@@ -98,7 +98,9 @@ describe('git', () => {
     })
     describe('more complex cases', () => {
       test('filename not at the end of tracked file', () => {
-        const sources = ['webpack:///./.yarn/cache/testfile.js-npm-1.2.3-abc1234567-abc1234567.zip/node_modules/testfile.js/testfile.js']
+        const sources = [
+          'webpack:///./.yarn/cache/testfile.js-npm-1.2.3-abc1234567-abc1234567.zip/node_modules/testfile.js/testfile.js',
+        ]
         const trackedFiles = ['.yarn/cache/testfile.js-npm-1.1.1-abc1234567-abc1234567.zip']
         const matcher = new TrackedFilesMatcher(trackedFiles)
         expect(matcher.matchSources(sources)).toHaveLength(0)
@@ -111,9 +113,9 @@ describe('git', () => {
       })
       test('mix of related and not related', () => {
         const sources = ['folder/file.ts', 'folder/other.ts']
-        const trackedFiles = ['src/file.ts','file.ts', 'src/other2.ts']
+        const trackedFiles = ['src/file.ts', 'file.ts', 'src/other2.ts']
         const matcher = new TrackedFilesMatcher(trackedFiles)
-        expect(matcher.matchSources(sources)).toStrictEqual(['src/file.ts','file.ts'])
+        expect(matcher.matchSources(sources)).toStrictEqual(['src/file.ts', 'file.ts'])
       })
     })
   })
@@ -142,10 +144,10 @@ describe('git', () => {
       if (!data) {
         fail('data should not be undefined')
       }
-   
-      const files = await data.trackedFilesMatcher.matchSourcemap(
+
+      const files = data.trackedFilesMatcher.matchSourcemap(
         stdout,
-        'src/commands/sourcemaps/__tests__/fixtures/common.min.js.map',
+        'src/commands/sourcemaps/__tests__/fixtures/common.min.js.map'
       )
       expect(data.remote).toBe('git@github.com:user/repository.git')
       expect(data.hash).toBe('25da22df90210a40b919debe3f7ebfb0c1811898')
@@ -158,9 +160,9 @@ describe('git', () => {
       if (!data) {
         fail('data should not be undefined')
       }
-      const files = await data.trackedFilesMatcher.matchSourcemap(
+      const files = data.trackedFilesMatcher.matchSourcemap(
         stdout,
-        'src/commands/sourcemaps/__tests__/fixtures/common.min.js.map',
+        'src/commands/sourcemaps/__tests__/fixtures/common.min.js.map'
       )
       expect(data.remote).toBe('git@github.com:user/other.git')
       expect(data.hash).toBe('25da22df90210a40b919debe3f7ebfb0c1811898')

--- a/src/commands/sourcemaps/__tests__/git.test.ts
+++ b/src/commands/sourcemaps/__tests__/git.test.ts
@@ -1,4 +1,4 @@
-import {filterTrackedFiles, getRepositoryData, gitRemote, stripCredentials, trackedFileIsRelated} from '../git'
+import {getRepositoryData, gitRemote, stripCredentials, TrackedFilesMatcher} from '../git'
 
 describe('git', () => {
   describe('gitRemote', () => {
@@ -57,31 +57,47 @@ describe('git', () => {
 
   describe('trackedFileIsRelated', () => {
     test('related path', () => {
-      const source = 'webpack:///./src/commands/sourcemaps/__tests__/git.test.ts'
-      const trackedFile = 'src/commands/sourcemaps/__tests__/git.test.ts'
-      expect(trackedFileIsRelated(source, trackedFile)).toBe(true)
+      const sources = ['webpack:///./src/commands/sourcemaps/__tests__/git.test.ts']
+      const trackedFiles = ['src/commands/sourcemaps/__tests__/git.test.ts']
+      const matcher = new TrackedFilesMatcher(trackedFiles)
+      expect(matcher.matchSources(sources)).toStrictEqual(trackedFiles)
     })
-    test('related filename with query parameter', () => {
-      const source = 'git.test.ts?abc123'
-      const trackedFile = 'src/commands/sourcemaps/__tests__/git.test.ts'
-      expect(trackedFileIsRelated(source, trackedFile)).toBe(true)
+    test('related path with query parameter', () => {
+      const sources = ['git.test.ts?abc123']
+      const trackedFiles = ['src/commands/sourcemaps/__tests__/git.test.ts']
+      const matcher = new TrackedFilesMatcher(trackedFiles)
+      expect(matcher.matchSources(sources)).toStrictEqual(trackedFiles)
+    })
+    test('related path with legit question mark', () => {
+      const sources = ['git.test.ts?abc123']
+      const trackedFiles = ['src/commands/sourcemaps/__tests__/git.test.ts?abc123']
+      const matcher = new TrackedFilesMatcher(trackedFiles)
+      expect(matcher.matchSources(sources)).toStrictEqual(trackedFiles)
     })
     test('related hidden file', () => {
-      const source = 'folder/.git.test.ts'
-      const trackedFile = 'src/commands/sourcemaps/__tests__/.git.test.ts'
-      expect(trackedFileIsRelated(source, trackedFile)).toBe(true)
+      const sources = ['folder/.git.test.ts']
+      const trackedFiles = ['src/commands/sourcemaps/__tests__/.git.test.ts']
+      const matcher = new TrackedFilesMatcher(trackedFiles)
+      expect(matcher.matchSources(sources)).toStrictEqual(trackedFiles)
     })
     test('not related', () => {
-      const source = 'folder/other.test.ts'
-      const trackedFile = 'src/commands/sourcemaps/__tests__/.git.test.ts'
-      expect(trackedFileIsRelated(source, trackedFile)).toBe(false)
+      const sources = ['folder/other.test.ts']
+      const trackedFiles = ['src/commands/sourcemaps/__tests__/git.test.ts']
+      const matcher = new TrackedFilesMatcher(trackedFiles)
+      expect(matcher.matchSources(sources)).toHaveLength(0)
     })
     test('filename not at the end of tracked file', () => {
-      const source = 'webpack:///./.yarn/cache/testfile.js-npm-1.2.3-abc1234567-abc1234567.zip/node_modules/testfile.js/testfile.js'
-      const trackedFile = '.yarn/cache/testfile.js-npm-1.1.1-abc1234567-abc1234567.zip'
-      expect(trackedFileIsRelated(source, trackedFile)).toBe(false)
+      const sources = ['webpack:///./.yarn/cache/testfile.js-npm-1.2.3-abc1234567-abc1234567.zip/node_modules/testfile.js/testfile.js']
+      const trackedFiles = ['.yarn/cache/testfile.js-npm-1.1.1-abc1234567-abc1234567.zip']
+      const matcher = new TrackedFilesMatcher(trackedFiles)
+      expect(matcher.matchSources(sources)).toHaveLength(0)
     })
-    
+    test('multiple related path with same filename', () => {
+      const sources = ['webpack:///./src/commands/sourcemaps/__tests__/git.test.ts']
+      const trackedFiles = ['src/commands/sourcemaps/__tests__/git.test.ts', 'src/commands/sourcemaps/git.test.ts']
+      const matcher = new TrackedFilesMatcher(trackedFiles)
+      expect(matcher.matchSources(sources)).toStrictEqual(trackedFiles)
+    })
   })
 
   describe('GetRepositoryData', () => {
@@ -108,14 +124,14 @@ describe('git', () => {
       if (!data) {
         fail('data should not be undefined')
       }
-      const files = await filterTrackedFiles(
+   
+      const files = await data.trackedFilesMatcher.matchSourcemap(
         stdout,
         'src/commands/sourcemaps/__tests__/fixtures/common.min.js.map',
-        data.trackedFiles
       )
       expect(data.remote).toBe('git@github.com:user/repository.git')
       expect(data.hash).toBe('25da22df90210a40b919debe3f7ebfb0c1811898')
-      expect(files).toEqual(['src/commands/sourcemaps/__tests__/git.test.ts'])
+      expect(files).toStrictEqual(['src/commands/sourcemaps/__tests__/git.test.ts'])
     })
 
     test('integration: remote override', async () => {
@@ -124,14 +140,13 @@ describe('git', () => {
       if (!data) {
         fail('data should not be undefined')
       }
-      const files = await filterTrackedFiles(
+      const files = await data.trackedFilesMatcher.matchSourcemap(
         stdout,
         'src/commands/sourcemaps/__tests__/fixtures/common.min.js.map',
-        data.trackedFiles
       )
       expect(data.remote).toBe('git@github.com:user/other.git')
       expect(data.hash).toBe('25da22df90210a40b919debe3f7ebfb0c1811898')
-      expect(files).toEqual(['src/commands/sourcemaps/__tests__/git.test.ts'])
+      expect(files).toStrictEqual(['src/commands/sourcemaps/__tests__/git.test.ts'])
     })
   })
 })

--- a/src/commands/sourcemaps/__tests__/git.test.ts
+++ b/src/commands/sourcemaps/__tests__/git.test.ts
@@ -55,48 +55,66 @@ describe('git', () => {
     })
   })
 
-  describe('trackedFileIsRelated', () => {
-    test('related path', () => {
-      const sources = ['webpack:///./src/commands/sourcemaps/__tests__/git.test.ts']
-      const trackedFiles = ['src/commands/sourcemaps/__tests__/git.test.ts']
-      const matcher = new TrackedFilesMatcher(trackedFiles)
-      expect(matcher.matchSources(sources)).toStrictEqual(trackedFiles)
+  describe('TrackedFilesMatcher', () => {
+    describe('related cases', () => {
+      test('related path', () => {
+        const sources = ['webpack:///./src/file.ts']
+        const trackedFiles = ['src/file.ts']
+        const matcher = new TrackedFilesMatcher(trackedFiles)
+        expect(matcher.matchSources(sources)).toStrictEqual(trackedFiles)
+      })
+      test('related path in another folder', () => {
+        const sources = ['webpack:///./src/file.ts']
+        const trackedFiles = ['path/to/file.ts']
+        const matcher = new TrackedFilesMatcher(trackedFiles)
+        expect(matcher.matchSources(sources)).toStrictEqual(trackedFiles)
+      })
+      test('related path with query parameter', () => {
+        const sources = ['file.ts?abc123']
+        const trackedFiles = ['src/file.ts']
+        const matcher = new TrackedFilesMatcher(trackedFiles)
+        expect(matcher.matchSources(sources)).toStrictEqual(trackedFiles)
+      })
+      test('related path with legit question mark', () => {
+        const sources = ['file.ts?abc123']
+        const trackedFiles = ['src/file.ts?abc123']
+        const matcher = new TrackedFilesMatcher(trackedFiles)
+        expect(matcher.matchSources(sources)).toStrictEqual(trackedFiles)
+      })
+      test('related hidden file', () => {
+        const sources = ['src/.file.ts']
+        const trackedFiles = ['folder/.file.ts']
+        const matcher = new TrackedFilesMatcher(trackedFiles)
+        expect(matcher.matchSources(sources)).toStrictEqual(trackedFiles)
+      })
     })
-    test('related path with query parameter', () => {
-      const sources = ['git.test.ts?abc123']
-      const trackedFiles = ['src/commands/sourcemaps/__tests__/git.test.ts']
-      const matcher = new TrackedFilesMatcher(trackedFiles)
-      expect(matcher.matchSources(sources)).toStrictEqual(trackedFiles)
+    describe('not related cases', () => {
+      test('not related', () => {
+        const sources = ['folder/other.ts']
+        const trackedFiles = ['src/file.ts']
+        const matcher = new TrackedFilesMatcher(trackedFiles)
+        expect(matcher.matchSources(sources)).toHaveLength(0)
+      })
     })
-    test('related path with legit question mark', () => {
-      const sources = ['git.test.ts?abc123']
-      const trackedFiles = ['src/commands/sourcemaps/__tests__/git.test.ts?abc123']
-      const matcher = new TrackedFilesMatcher(trackedFiles)
-      expect(matcher.matchSources(sources)).toStrictEqual(trackedFiles)
-    })
-    test('related hidden file', () => {
-      const sources = ['folder/.git.test.ts']
-      const trackedFiles = ['src/commands/sourcemaps/__tests__/.git.test.ts']
-      const matcher = new TrackedFilesMatcher(trackedFiles)
-      expect(matcher.matchSources(sources)).toStrictEqual(trackedFiles)
-    })
-    test('not related', () => {
-      const sources = ['folder/other.test.ts']
-      const trackedFiles = ['src/commands/sourcemaps/__tests__/git.test.ts']
-      const matcher = new TrackedFilesMatcher(trackedFiles)
-      expect(matcher.matchSources(sources)).toHaveLength(0)
-    })
-    test('filename not at the end of tracked file', () => {
-      const sources = ['webpack:///./.yarn/cache/testfile.js-npm-1.2.3-abc1234567-abc1234567.zip/node_modules/testfile.js/testfile.js']
-      const trackedFiles = ['.yarn/cache/testfile.js-npm-1.1.1-abc1234567-abc1234567.zip']
-      const matcher = new TrackedFilesMatcher(trackedFiles)
-      expect(matcher.matchSources(sources)).toHaveLength(0)
-    })
-    test('multiple related path with same filename', () => {
-      const sources = ['webpack:///./src/commands/sourcemaps/__tests__/git.test.ts']
-      const trackedFiles = ['src/commands/sourcemaps/__tests__/git.test.ts', 'src/commands/sourcemaps/git.test.ts']
-      const matcher = new TrackedFilesMatcher(trackedFiles)
-      expect(matcher.matchSources(sources)).toStrictEqual(trackedFiles)
+    describe('more complex cases', () => {
+      test('filename not at the end of tracked file', () => {
+        const sources = ['webpack:///./.yarn/cache/testfile.js-npm-1.2.3-abc1234567-abc1234567.zip/node_modules/testfile.js/testfile.js']
+        const trackedFiles = ['.yarn/cache/testfile.js-npm-1.1.1-abc1234567-abc1234567.zip']
+        const matcher = new TrackedFilesMatcher(trackedFiles)
+        expect(matcher.matchSources(sources)).toHaveLength(0)
+      })
+      test('multiple related tracked files from one source', () => {
+        const sources = ['webpack:///./src/file.ts']
+        const trackedFiles = ['src/file.ts', 'src/commands/sourcemaps/file.ts', 'other']
+        const matcher = new TrackedFilesMatcher(trackedFiles)
+        expect(matcher.matchSources(sources)).toStrictEqual(['src/file.ts', 'src/commands/sourcemaps/file.ts'])
+      })
+      test('mix of related and not related', () => {
+        const sources = ['folder/file.ts', 'folder/other.ts']
+        const trackedFiles = ['src/file.ts','file.ts', 'src/other2.ts']
+        const matcher = new TrackedFilesMatcher(trackedFiles)
+        expect(matcher.matchSources(sources)).toStrictEqual(['src/file.ts','file.ts'])
+      })
     })
   })
 

--- a/src/commands/sourcemaps/__tests__/upload.test.ts
+++ b/src/commands/sourcemaps/__tests__/upload.test.ts
@@ -188,6 +188,7 @@ interface ExpectedOutput {
 }
 
 const checkConsoleOutput = (output: string[], expected: ExpectedOutput) => {
+  return // TODO(jb.pinalie) Skip temporarily
   expect(output[0]).toContain('DRY-RUN MODE ENABLED. WILL NOT UPLOAD SOURCEMAPS')
   expect(output[1]).toContain(`Starting upload with concurrency ${expected.concurrency}.`)
   expect(output[2]).toContain(`Will look for sourcemaps in ${expected.basePath}`)

--- a/src/commands/sourcemaps/__tests__/upload.test.ts
+++ b/src/commands/sourcemaps/__tests__/upload.test.ts
@@ -188,7 +188,6 @@ interface ExpectedOutput {
 }
 
 const checkConsoleOutput = (output: string[], expected: ExpectedOutput) => {
-  return // TODO(jb.pinalie) Skip temporarily
   expect(output[0]).toContain('DRY-RUN MODE ENABLED. WILL NOT UPLOAD SOURCEMAPS')
   expect(output[1]).toContain(`Starting upload with concurrency ${expected.concurrency}.`)
   expect(output[2]).toContain(`Will look for sourcemaps in ${expected.basePath}`)

--- a/src/commands/sourcemaps/git.ts
+++ b/src/commands/sourcemaps/git.ts
@@ -156,13 +156,13 @@ export class TrackedFilesMatcher {
 
   public matchSources(sources: string[]): string[] {
     let filtered: string[] = new Array()
-    const filenameAlreadyMatched = new Map<string, boolean>()
+    const filenameAlreadyMatched = new Set<string>()
     for (const source of sources) {
       const filename = this.getFilename(source)
       if (filenameAlreadyMatched.has(filename)) {
         continue
       }
-      filenameAlreadyMatched.set(filename, true)
+      filenameAlreadyMatched.add(filename)
       const trackedFiles = this.trackedFilenames.get(filename)
       if (trackedFiles) {
         filtered = filtered.concat(trackedFiles)

--- a/src/commands/sourcemaps/git.ts
+++ b/src/commands/sourcemaps/git.ts
@@ -2,7 +2,6 @@ import fs from 'fs'
 import * as simpleGit from 'simple-git'
 import {Writable} from 'stream'
 import {URL} from 'url'
-import {promisify} from 'util'
 import {renderGitWarning, renderSourcesNotFoundWarning} from './renderer'
 
 // Returns a configured SimpleGit.
@@ -67,37 +66,10 @@ export const gitTrackedFiles = async (git: simpleGit.SimpleGit): Promise<string[
   return files.split(/\r\n|\r|\n/)
 }
 
-// Checks if the given tracked file is relevant to the given source path.
-// It is used so that we don't send every tracked files to the backend since most won't be of any use.
-// The current implementation simply tries to extract out the filename portion of the source and checks
-// if its contained in the tracked file.
-//
-// We are removing any suffix that is after the character '?'. The only reason this is done
-// is because we noticed that a non-negligable (~5%) amount of source paths from our customers
-// source maps contained query parameters.
-// We are assuming that the files may not actually be named with the interrogation mark but that
-// it is only an artifact of the build process. The query parameters look random. It looks
-// like it may be used as a trick to force a web browser to reload the file content.
-// The only side effect of doing that operation is that more tracked files paths may be sent
-// alongside the sourcemap which is not a problem.
-// Example: webpack:///./src/folder/ui/select.vue?821e
-export const trackedFileIsRelated = (source: string, trackedFile: string): boolean => {
-  let start = source.lastIndexOf('/')
-  if (start === -1) {
-    start = 0
-  }
-  let end = source.lastIndexOf('?')
-  if (end === -1) {
-    end = source.length
-  }
-
-  return trackedFile.endsWith(source.substring(start, end))
-}
-
 export interface RepositoryData {
   hash: string
   remote: string
-  trackedFiles: string[]
+  trackedFilesMatcher: TrackedFilesMatcher
 }
 
 // Gathers repository data.
@@ -133,47 +105,97 @@ export const getRepositoryData = async (
   const data = {
     hash,
     remote,
-    trackedFiles,
+    trackedFilesMatcher: new TrackedFilesMatcher(trackedFiles),
   }
 
   return data
 }
 
-// Looks up the source paths declared in the sourcemap and try to filter out unrelated tracked files.
-// The list of filtered tracked files is returned.
-export const filterTrackedFiles = async (
-  stdout: Writable,
-  srcmapPath: string,
-  trackedFiles: string[]
-): Promise<string[] | undefined> => {
-  // Retrieve the sources attribute from the sourcemap file.
-  const srcmap = await promisify(fs.readFile)(srcmapPath)
-  const srcmapObj = JSON.parse(srcmap.toString())
-  if (!srcmapObj.sources) {
-    return undefined
-  }
-  const sources = srcmapObj.sources as string[]
-  if (!sources || sources.length === 0) {
-    return undefined
-  }
+// TrackedFilesMatcher can compute the list of tracked files related to a particular sourcemap.
+// The current implementation simply returns all tracked files whose filename is found inside
+// the sourcemap 'sources' field.
+// It is used so that we don't send every tracked files to the backend since most won't be of any use
+// for a particular sourcemap.
+export class TrackedFilesMatcher {
+  // A map with tracked filenames as key and the related tracked file paths as value.
+  trackedFilenames: Map<string, string[]>;
 
-  // Only keep tracked files that may be related to the sources declared in the sourcemap
-  const filtered: string[] = new Array()
-  for (const trackedFile of trackedFiles) {
-    for (const source of sources) {
-      const keep = trackedFileIsRelated(source, trackedFile)
-      if (keep) {
-        filtered.push(trackedFile)
-        break
+  constructor(trackedFiles: string[]) {
+    this.trackedFilenames = new Map<string, string[]>();
+    for (const f of trackedFiles) {
+      const filename = this.getFilename(f)
+      const list = this.trackedFilenames.get(filename)
+      if (list) {
+        list.push(f)
+      } else {
+        this.trackedFilenames.set(filename, new Array<string>(f))
       }
     }
   }
 
-  if (filtered.length === 0) {
-    stdout.write(renderSourcesNotFoundWarning(srcmapPath))
+  // Looks up the sources declared in the sourcemap and return a list of related tracked files.
+  async matchSourcemap(stdout: Writable, srcmapPath: string): Promise<string[] | undefined> {
+    const buff = fs.readFileSync(srcmapPath, 'utf8')
+    const srcmapObj = JSON.parse(buff)
+    if (!srcmapObj.sources) {
 
-    return undefined
+      return undefined
+    }
+    const sources = srcmapObj.sources as string[]
+    if (!sources || sources.length === 0) {
+      
+      return undefined
+    }
+    const filtered = this.matchSources(sources)
+    if (filtered.length === 0) {
+      stdout.write(renderSourcesNotFoundWarning(srcmapPath))
+
+      return undefined
+    }
+
+    return filtered
   }
 
-  return filtered
+  matchSources(sources: string[]): string[] {
+    let filtered: string[] = new Array()
+    let filenameAlreadyMatched = new Map<string, Boolean>();
+    for (const source of sources) {
+      const filename = this.getFilename(source)
+      if (filenameAlreadyMatched.has(filename)) {
+        continue
+      }
+      filenameAlreadyMatched.set(filename, true)
+      const trackedFiles = this.trackedFilenames.get(filename)
+      if (trackedFiles) {
+        filtered = filtered.concat(trackedFiles)
+      }
+    }
+
+    return filtered
+  }
+
+  // Extract the filename from a path.
+  //
+  // We are removing any suffix that is after the character '?'. The only reason this is done
+  // is because we noticed that a non-negligable (~5%) amount of source paths from our customers
+  // source maps contained query parameters.
+  // We are assuming that the files may not actually be named with the interrogation mark but that
+  // it is only an artifact of the build process. The query parameters look random. It looks
+  // like it may be used as a trick to force a web browser to reload the file content.
+  // The only side effect of doing that operation is that more tracked files paths may be sent
+  // alongside the sourcemap which is not a problem.
+  // Example: webpack:///./src/folder/ui/select.vue?821e
+  getFilename (s: string): string {
+    let start = s.lastIndexOf('/')
+    if (start === -1) {
+      start = 0
+    } else {
+      start++
+    }
+    let end = s.lastIndexOf('?')
+    if (end === -1 || end <= start) {
+      end = s.length
+    }
+    return s.substring(start, end)
+  }
 }

--- a/src/commands/sourcemaps/git.ts
+++ b/src/commands/sourcemaps/git.ts
@@ -118,10 +118,10 @@ export const getRepositoryData = async (
 // for a particular sourcemap.
 export class TrackedFilesMatcher {
   // A map with tracked filenames as key and the related tracked file paths as value.
-  trackedFilenames: Map<string, string[]>;
+  private trackedFilenames: Map<string, string[]>
 
   constructor(trackedFiles: string[]) {
-    this.trackedFilenames = new Map<string, string[]>();
+    this.trackedFilenames = new Map<string, string[]>()
     for (const f of trackedFiles) {
       const filename = this.getFilename(f)
       const list = this.trackedFilenames.get(filename)
@@ -134,16 +134,14 @@ export class TrackedFilesMatcher {
   }
 
   // Looks up the sources declared in the sourcemap and return a list of related tracked files.
-  async matchSourcemap(stdout: Writable, srcmapPath: string): Promise<string[] | undefined> {
+  public matchSourcemap(stdout: Writable, srcmapPath: string): string[] | undefined {
     const buff = fs.readFileSync(srcmapPath, 'utf8')
     const srcmapObj = JSON.parse(buff)
     if (!srcmapObj.sources) {
-
       return undefined
     }
     const sources = srcmapObj.sources as string[]
     if (!sources || sources.length === 0) {
-      
       return undefined
     }
     const filtered = this.matchSources(sources)
@@ -156,9 +154,9 @@ export class TrackedFilesMatcher {
     return filtered
   }
 
-  matchSources(sources: string[]): string[] {
+  public matchSources(sources: string[]): string[] {
     let filtered: string[] = new Array()
-    let filenameAlreadyMatched = new Map<string, Boolean>();
+    const filenameAlreadyMatched = new Map<string, boolean>()
     for (const source of sources) {
       const filename = this.getFilename(source)
       if (filenameAlreadyMatched.has(filename)) {
@@ -185,7 +183,7 @@ export class TrackedFilesMatcher {
   // The only side effect of doing that operation is that more tracked files paths may be sent
   // alongside the sourcemap which is not a problem.
   // Example: webpack:///./src/folder/ui/select.vue?821e
-  getFilename (s: string): string {
+  private getFilename(s: string): string {
     let start = s.lastIndexOf('/')
     if (start === -1) {
       start = 0
@@ -196,6 +194,7 @@ export class TrackedFilesMatcher {
     if (end === -1 || end <= start) {
       end = s.length
     }
+
     return s.substring(start, end)
   }
 }

--- a/src/commands/sourcemaps/upload.ts
+++ b/src/commands/sourcemaps/upload.ts
@@ -111,15 +111,13 @@ export class UploadCommand extends Command {
 
   // Fills the 'repository' field of each payload with data gathered using git.
   private addRepositoryDataToPayloads = async (payloads: Payload[]) => {
-    // Invoke git commands to retrive remote, hash and tracked files.
     const repositoryData = await getRepositoryData(await newSimpleGit(), this.context.stdout, this.repositoryURL)
     if (repositoryData === undefined) {
       return
     }
     await Promise.all(
       payloads.map(async (payload) => {
-        // Open each sourcemap to only include the related tracked files inside the repository payload.
-        payload.repository = await this.getRepositoryPayload(repositoryData, payload.sourcemapPath)
+        payload.repository = this.getRepositoryPayload(repositoryData, payload.sourcemapPath)
       })
     )
   }
@@ -169,18 +167,16 @@ export class UploadCommand extends Command {
     }
 
     await this.addRepositoryDataToPayloads(payloads)
+
     return payloads
   }
 
   // GetRepositoryPayload generates the repository payload for a specific sourcemap.
   // It specifically looks for the list of tracked files that are associated to the source paths
   // declared inside the sourcemap.
-  private getRepositoryPayload = async (
-    repositoryData: RepositoryData,
-    sourcemapPath: string
-  ): Promise<string | undefined> => {
+  private getRepositoryPayload = (repositoryData: RepositoryData, sourcemapPath: string): string | undefined => {
     let repositoryPayload: string | undefined
-    const files = await repositoryData.trackedFilesMatcher.matchSourcemap(this.context.stdout, sourcemapPath)
+    const files = repositoryData.trackedFilesMatcher.matchSourcemap(this.context.stdout, sourcemapPath)
     if (files) {
       repositoryPayload = JSON.stringify({
         data: [


### PR DESCRIPTION
### What and why?

Improve the performance of the sourcemap upload command with git support.

- Replace the nested loop with one loop + hash map lookups
- Encapsulate the whole tracked files matching logic into a single class for more clarity
- Use `fs.readFileSync` directly instead of "promisifying" `fs.readFile`
- Change the output of successful uploads to also include the time spent building payloads

### How?

Leverage hash maps to reduce the time complexity of the algorithm.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)

