### PR TITLE
[synthetics] do not parse url if type or subtype is not correct

### DIFF
--- a/src/commands/synthetics/__tests__/utils.test.ts
+++ b/src/commands/synthetics/__tests__/utils.test.ts
@@ -162,20 +162,34 @@ describe('utils', () => {
       expectHandledConfigToBe(SKIPPED, SKIPPED, NON_BLOCKING)
     })
 
-    test('startUrl template is rendered', () => {
+    test('startUrl template is rendered if correct test type or subtype', () => {
       const publicId = 'abc-def-ghi'
       const fakeTest = {
         config: {request: {url: 'http://example.org/path'}},
         public_id: publicId,
+        type: 'browser',
       } as Test
       const configOverride = {
         startUrl: 'https://{{DOMAIN}}/newPath?oldPath={{PATHNAME}}',
       }
       const expectedUrl = 'https://example.org/newPath?oldPath=/path'
-      const handledConfig = utils.handleConfig(fakeTest, publicId, processWrite, configOverride)
 
+      let handledConfig = utils.handleConfig(fakeTest, publicId, processWrite, configOverride)
       expect(handledConfig.public_id).toBe(publicId)
       expect(handledConfig.startUrl).toBe(expectedUrl)
+
+      fakeTest.type = 'api'
+      fakeTest.subtype = 'http'
+
+      handledConfig = utils.handleConfig(fakeTest, publicId, processWrite, configOverride)
+      expect(handledConfig.public_id).toBe(publicId)
+      expect(handledConfig.startUrl).toBe(expectedUrl)
+
+      fakeTest.subtype = 'dns'
+
+      handledConfig = utils.handleConfig(fakeTest, publicId, processWrite, configOverride)
+      expect(handledConfig.public_id).toBe(publicId)
+      expect(handledConfig.startUrl).toBeUndefined()
     })
 
     test('startUrl is not parsable', () => {
@@ -185,6 +199,7 @@ describe('utils', () => {
       const fakeTest = {
         config: {request: {url: 'http://{{ FAKE_VAR }}/path'}},
         public_id: publicId,
+        type: 'browser',
       } as Test
       const configOverride = {
         startUrl: 'https://{{DOMAIN}}/newPath?oldPath={{CUSTOMVAR}}',
@@ -202,6 +217,7 @@ describe('utils', () => {
       const fakeTest = {
         config: {request: {url: 'http://exmaple.org/path'}},
         public_id: publicId,
+        type: 'browser',
       } as Test
       const configOverride = {
         startUrl: 'http://127.0.0.1/newPath{{PARAMS}}',

--- a/src/commands/synthetics/utils.ts
+++ b/src/commands/synthetics/utils.ts
@@ -70,9 +70,8 @@ export const handleConfig = (
     ]),
   }
 
-  const context = parseUrlVariables(test.config.request.url, write)
-
   if ((test.type === 'browser' || test.subtype === 'http') && config.startUrl) {
+    const context = parseUrlVariables(test.config.request.url, write)
     handledConfig.startUrl = template(config.startUrl, context)
   }
 

--- a/src/commands/synthetics/utils.ts
+++ b/src/commands/synthetics/utils.ts
@@ -72,7 +72,7 @@ export const handleConfig = (
 
   const context = parseUrlVariables(test.config.request.url, write)
 
-  if (config.startUrl) {
+  if ((test.type === 'browser' || test.subtype === 'http') && config.startUrl) {
     handledConfig.startUrl = template(config.startUrl, context)
   }
 


### PR DESCRIPTION
### What and why?

Parse `startUrl` for `browser` and `http` tests
