### PR TITLE
Use latest datatog-metrics instead of Git dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "axios": "0.21.1",
     "chalk": "2.4.2",
     "clipanion": "2.2.2",
-    "datadog-metrics": "https://github.com/DataDog/node-datadog-metrics#12d16a80ea2a8846c91d80f5e127fb7b81b9f347",
+    "datadog-metrics": "0.9.0",
     "dd-trace": "0.30.1",
     "deep-extend": "0.6.0",
     "form-data": "3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2074,12 +2074,13 @@ data-urls@^2.0.0:
     whatwg-mimetype "^2.3.0"
     whatwg-url "^8.0.0"
 
-"datadog-metrics@https://github.com/DataDog/node-datadog-metrics#12d16a80ea2a8846c91d80f5e127fb7b81b9f347":
-  version "0.8.1"
-  resolved "https://github.com/DataDog/node-datadog-metrics#12d16a80ea2a8846c91d80f5e127fb7b81b9f347"
+datadog-metrics@0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/datadog-metrics/-/datadog-metrics-0.9.0.tgz#8b1568ed5c0de157cd753ee7ccc1dd3154ab2f2a"
+  integrity sha512-sZK/grPEk6mZLamE5LUXbCB0ykzEzmlFjqzPK514LN6bgeep0NIkaNRy4nYQQzZj+Dfr6aZUYu7tGVuI7W7pSQ==
   dependencies:
     debug "3.1.0"
-    dogapi "1.1.0"
+    dogapi "2.8.3"
 
 dd-trace@0.30.1:
   version "0.30.1"
@@ -2255,15 +2256,16 @@ diff@^4.0.1:
   resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
   integrity sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==
 
-dogapi@1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/dogapi/-/dogapi-1.1.0.tgz#71a43865ad4bb4cb18bc3e13cf769971f501030a"
-  integrity sha1-caQ4Za1LtMsYvD4Tz3aZcfUBAwo=
+dogapi@2.8.3:
+  version "2.8.3"
+  resolved "https://registry.yarnpkg.com/dogapi/-/dogapi-2.8.3.tgz#f7b2210bb03e17b54bd7c9fce7894152efc15481"
+  integrity sha512-CzJIllAcv17H8hylyuljldJv+2EGal5+Fa+gsXFrXDo1zl8cq9jk7FDCXDqH4C/tPNAusS9ckV8wuBFtCiuTUg==
   dependencies:
     extend "^3.0.0"
     json-bigint "^0.1.4"
+    lodash "^4.17.10"
     minimist "^1.1.1"
-    rc "^1.0.0"
+    rc "^1.2.8"
 
 domexception@^2.0.1:
   version "2.0.1"
@@ -3776,7 +3778,7 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-lodash@^4.17.11, lodash@^4.17.19:
+lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.19:
   version "4.17.20"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
   integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
@@ -4486,7 +4488,7 @@ raw-body@^2.2.0:
     iconv-lite "0.4.24"
     unpipe "1.0.0"
 
-rc@^1.0.0:
+rc@^1.2.8:
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.8.tgz#cd924bf5200a075b83c188cd6b9e211b7fc0d3ed"
   integrity sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==


### PR DESCRIPTION
### What and why?

Uses [datadog-metrics 0.9.0](https://www.npmjs.com/package/datadog-metrics/v/0.9.0) instead of Datadog's fork. https://github.com/dbader/node-datadog-metrics/pull/50 has been merged, including the changes that we wanted. There is no need to have a dependency though git anymore, which is causing security concerns for some customers.

### How?


### Review checklist


