### PR TITLE
[ci] use immutable installs to detect outdated yarn.lock

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: '12.x'
-      - run: yarn install
+      - run: yarn install --immutable
       - run: yarn build
       - run: yarn prettier-check
       - run: yarn lint


### PR DESCRIPTION
### What and why?

In order to detect outdated yarn lockfile in the repository, this PR adds the `immutable` flag to `yarn install`.
