### PR TITLE
v0.10.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "description": "Run datadog actions from the CI.",
   "main": "dist/index.js",
   "repository": "https://github.com/DataDog/datadog-ci",


### PR DESCRIPTION
This PR releases v0.10.3, which includes the `node-datadog-metrics` dependency change from https://github.com/DataDog/datadog-ci/pull/158