### PR TITLE
New alpha release v0.10.5-alpha

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci",
-  "version": "0.10.4-alpha",
+  "version": "0.10.5-alpha",
   "description": "Run datadog actions from the CI.",
   "main": "dist/index.js",
   "repository": "https://github.com/DataDog/datadog-ci",


### PR DESCRIPTION
New `0.10.5-alpha` release with the changes of https://github.com/DataDog/datadog-ci/pull/161