### PR TITLE
v0.10.6-alpha

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci",
-  "version": "0.10.5-alpha",
+  "version": "0.10.6-alpha",
   "description": "Run datadog actions from the CI.",
   "main": "dist/index.js",
   "repository": "https://github.com/DataDog/datadog-ci",


### PR DESCRIPTION
### What and why?

Add synthetics-tunnel work (in https://github.com/DataDog/datadog-ci/pull/169 as WIP until properly tested) to the alpha release channel
