### PR TITLE
Mrousse/sw 910/add proxy support tunnel

### DIFF
--- a/src/commands/synthetics/__tests__/tunnel.test.ts
+++ b/src/commands/synthetics/__tests__/tunnel.test.ts
@@ -2,41 +2,41 @@ import {PassThrough} from 'stream'
 
 import {mocked} from 'ts-jest/utils'
 
+import {ProxyConfiguration} from '../../../helpers/utils'
 import {Tunnel} from '../tunnel'
 import {WebSocketWithReconnect} from '../websocket'
 
 jest.mock('../websocket')
 
 describe('Tunnel', () => {
-  const duplex = new PassThrough()
   const mockConnect = jest.fn()
   const mockClose = jest.fn()
+  const mockWebSocket = {
+    addEventListener: (event: 'message', handler: (message: string) => void) => {
+      const tunnelInfo = {host: 'host', id: 'tunnel-id'}
+      handler(JSON.stringify(tunnelInfo))
+    },
+    close: mockClose,
+    connect: mockConnect,
+    duplex: () => new PassThrough(),
+  }
 
+  const defaultProxyOpts: ProxyConfiguration = {protocol: 'http'}
   const noLog = () => true
   const testIDs = ['aaa-bbb-ccc']
   const wsPresignedURL = 'wss://tunnel.synthetics'
 
   const mockedWebSocketWithReconnect = mocked(WebSocketWithReconnect, true)
 
-  it('starts by connecting over WebSocket and closes the WebSocket when stopping', async () => {
-    mockedWebSocketWithReconnect.mockImplementation(
-      () =>
-        ({
-          addEventListener: (event: 'message', handler: (message: string) => void) => {
-            const tunnelInfo = {host: 'host', id: 'tunnel-id'}
-            handler(JSON.stringify(tunnelInfo))
-          },
-          close: mockClose,
-          connect: mockConnect,
-          duplex: () => duplex,
-        } as any)
-    ) // Casting to any to avoid re-defining all methods
+  test('starts by connecting over WebSocket and closes the WebSocket when stopping', async () => {
+    mockedWebSocketWithReconnect.mockImplementation(() => mockWebSocket as any)
 
-    const tunnel = new Tunnel(wsPresignedURL, testIDs, noLog)
+    const tunnel = new Tunnel(wsPresignedURL, testIDs, defaultProxyOpts, noLog)
     const connectionInfo = await tunnel.start()
     expect(WebSocketWithReconnect).toHaveBeenCalledWith(
       wsPresignedURL,
       expect.any(Function),
+      expect.any(Object),
       expect.any(Number),
       expect.any(Number)
     )
@@ -52,21 +52,43 @@ describe('Tunnel', () => {
     expect(mockClose).toHaveBeenCalled()
   })
 
-  it('throws an error if the WebSocket connection fails', async () => {
+  test('throws an error if the WebSocket connection fails', async () => {
     mockedWebSocketWithReconnect.mockImplementation(
       () =>
         ({
           close: mockClose,
           connect: mockConnect,
         } as any)
-    ) // Casting to any to avoid re-defining all methods
+    )
 
     const websocketConnectError = new Error('Error when connecting over WebSocket!')
     mockConnect.mockImplementation(() => {
       throw websocketConnectError
     })
-    const tunnel = new Tunnel(wsPresignedURL, testIDs, noLog)
+    const tunnel = new Tunnel(wsPresignedURL, testIDs, defaultProxyOpts, noLog)
     await expect(tunnel.start()).rejects.toThrow(websocketConnectError)
     expect(mockClose).toBeCalled()
+    mockConnect.mockRestore()
+  })
+
+  test('sets websocket proxy options', async () => {
+    mockedWebSocketWithReconnect.mockImplementation(() => mockWebSocket as any)
+    const localProxyOpts: ProxyConfiguration = {
+      host: '127.0.0.1',
+      port: 8080,
+      protocol: 'http',
+    }
+    const tunnel = new Tunnel(wsPresignedURL, testIDs, localProxyOpts, noLog)
+    await tunnel.start()
+    expect(WebSocketWithReconnect).toHaveBeenCalledWith(
+      wsPresignedURL,
+      expect.any(Function),
+      localProxyOpts,
+      expect.any(Number),
+      expect.any(Number)
+    )
+
+    // Stop the tunnel
+    await tunnel.stop()
   })
 })

--- a/src/commands/synthetics/run-test.ts
+++ b/src/commands/synthetics/run-test.ts
@@ -29,6 +29,7 @@ export class RunTestCommand extends Command {
 
   public async execute() {
     const startTime = Date.now()
+    const stdoutLogger = this.context.stdout.write.bind(this.context.stdout)
 
     this.config = await parseConfigFile(this.config, this.configPath)
 
@@ -51,7 +52,7 @@ export class RunTestCommand extends Command {
       const {url: presignedURL} = await api.getPresignedURL(this.publicIds)
       // Open a tunnel to Datadog
       try {
-        tunnel = new Tunnel(presignedURL, this.publicIds, this.context.stdout.write.bind(this.context.stdout))
+        tunnel = new Tunnel(presignedURL, this.publicIds, this.config.proxy, stdoutLogger)
         const tunnelInfo = await tunnel.start()
         testsToTrigger.forEach((testToTrigger) => {
           testToTrigger.config.tunnel = tunnelInfo
@@ -63,7 +64,7 @@ export class RunTestCommand extends Command {
       }
     }
 
-    const {tests, triggers} = await runTests(api, testsToTrigger, this.context.stdout.write.bind(this.context.stdout))
+    const {tests, triggers} = await runTests(api, testsToTrigger, stdoutLogger)
 
     // All tests have been skipped or are missing.
     if (!tests.length) {

--- a/src/commands/synthetics/tunnel.ts
+++ b/src/commands/synthetics/tunnel.ts
@@ -27,7 +27,7 @@ const webSocketReconnect = {
 }
 
 export class Tunnel {
-  private forwardSockets: Array<Socket> = []
+  private forwardSockets: Socket[] = []
   private log: Writable['write']
   private logError: Writable['write']
   private multiplexer?: Multiplexer

--- a/src/commands/synthetics/tunnel.ts
+++ b/src/commands/synthetics/tunnel.ts
@@ -8,6 +8,8 @@ import {AuthContext, Connection as SSHConnection, Server as SSHServer, ServerCha
 import {ParsedKey, SSH2Stream, SSH2StreamConfig} from 'ssh2-streams'
 import {Config as MultiplexerConfig, Server as Multiplexer} from 'yamux-js'
 
+import {ProxyConfiguration} from '../../helpers/utils'
+
 import {generateOpenSSHKeys, parseSSHKey} from './crypto'
 import {WebSocketWithReconnect} from './websocket'
 
@@ -34,7 +36,7 @@ export class Tunnel {
   private sshStreamConfig: SSH2StreamConfig
   private ws: WebSocketWithReconnect
 
-  constructor(private url: string, private testIDs: string[], log: Writable['write']) {
+  constructor(private url: string, private testIDs: string[], proxy: ProxyConfiguration, log: Writable['write']) {
     this.log = (message: string) => log(`[${chalk.bold.blue('Tunnel')}] ${message}\n`)
     this.logError = (message: string) => log(`[${chalk.bold.red('Tunnel')}] ${message}\n`)
 
@@ -56,7 +58,13 @@ export class Tunnel {
       },
       server: true,
     }
-    this.ws = new WebSocketWithReconnect(this.url, this.log, webSocketReconnect.maxRetries, webSocketReconnect.interval)
+    this.ws = new WebSocketWithReconnect(
+      this.url,
+      this.log,
+      proxy,
+      webSocketReconnect.maxRetries,
+      webSocketReconnect.interval
+    )
   }
 
   /**

--- a/src/commands/synthetics/websocket.ts
+++ b/src/commands/synthetics/websocket.ts
@@ -111,7 +111,7 @@ export class WebSocketWithReconnect extends EventEmitter {
       this.reconnectRetries++
       const options: WebSocket.ClientOptions = {}
       if (this.proxyOpts.host && this.proxyOpts.port) {
-        options.agent = (new ProxyAgent(this.proxyOpts) as unknown) as Agent // proxy-agent typings are incomplete
+        options.agent = (new ProxyAgent(this.proxyOpts) as unknown) as Agent // Proxy-agent typings are incomplete
       }
       this.websocket = new WebSocket(this.url, options)
     }


### PR DESCRIPTION
### What and why?

The tunnel uses a websocket connection to encapsulate streams to datadog's infrastructure. This PR updates the tunnel to use the proxy defined by the proxy configuration of datadog-ci if there is one.

### How?

It passes the proxy options to the WebSocketWithReconnection object which then creates an agent and feeds it to the `ws` library. As `proxy-agent` typings are not up-to-date compared to latest nodes one, there is a `as unknown as Agent` cast before passing it to `ws`.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)

