### PR TITLE
[ci] bump to version 0.10.7-alpha

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci",
-  "version": "0.10.6-alpha",
+  "version": "0.10.7-alpha",
   "description": "Run datadog actions from the CI.",
   "main": "dist/index.js",
   "repository": "https://github.com/DataDog/datadog-ci",


### PR DESCRIPTION
### What and why?

Release version 0.10.7-alpha of the package with an improved support for the tunnel feature of the synthetics command.