### PR TITLE
[ci-app] Add `ci.level` and `ci.build_level` Tags to Created Spans 

### DIFF
--- a/src/commands/trace/command.ts
+++ b/src/commands/trace/command.ts
@@ -3,7 +3,17 @@ import {Command} from 'clipanion'
 import tracer from 'dd-trace'
 
 import {getCIMetadata} from '../../helpers/ci'
-import {CI_PIPELINE_URL, CI_PROVIDER_NAME, GIT_BRANCH, GIT_SHA, PARENT_SPAN_ID, TRACE_ID} from '../../helpers/tags'
+import {
+  CI_PIPELINE_URL,
+  CI_PROVIDER_NAME,
+  GIT_BRANCH,
+  GIT_SHA,
+  PARENT_SPAN_ID,
+  TRACE_ID,
+  CI_LEVEL,
+  CI_BUILD_LEVEL,
+  SPAN_TYPE,
+} from '../../helpers/tags'
 
 export class TraceInstructionCommand extends Command {
   public static usage = Command.Usage({
@@ -20,7 +30,9 @@ export class TraceInstructionCommand extends Command {
     if (!this.instruction.length) {
       throw new Error('No instruction to trace')
     }
-    tracer.init()
+    tracer.init({
+      startupLogs: false,
+    })
 
     const ciMetadata = getCIMetadata()
     let parentSpan
@@ -40,16 +52,19 @@ export class TraceInstructionCommand extends Command {
 
     tracer.trace(
       instruction,
-      {childOf: parentSpan},
+      {
+        childOf: parentSpan,
+        tags: {
+          [SPAN_TYPE]: 'ci',
+          [CI_BUILD_LEVEL]: 'custom',
+          [CI_LEVEL]: 'custom',
+        },
+      },
       (span) =>
         new Promise<number>((resolve) => {
           const [command, ...rest] = this.instruction
 
-          const commandToTrace = spawn(command, rest)
-          process.stdin.pipe(commandToTrace.stdin)
-
-          commandToTrace.stdout.pipe(this.context.stdout)
-          commandToTrace.stderr.pipe(this.context.stderr)
+          const commandToTrace = spawn(command, rest, {stdio: 'inherit'})
 
           commandToTrace.on('exit', (exitCode: number) => {
             span?.addTags({

--- a/src/commands/trace/command.ts
+++ b/src/commands/trace/command.ts
@@ -4,15 +4,15 @@ import tracer from 'dd-trace'
 
 import {getCIMetadata} from '../../helpers/ci'
 import {
+  CI_BUILD_LEVEL,
+  CI_LEVEL,
   CI_PIPELINE_URL,
   CI_PROVIDER_NAME,
   GIT_BRANCH,
   GIT_SHA,
   PARENT_SPAN_ID,
-  TRACE_ID,
-  CI_LEVEL,
-  CI_BUILD_LEVEL,
   SPAN_TYPE,
+  TRACE_ID,
 } from '../../helpers/tags'
 
 export class TraceInstructionCommand extends Command {

--- a/src/helpers/tags.ts
+++ b/src/helpers/tags.ts
@@ -8,7 +8,13 @@ export const CI_ENV_TRACE_ID = 'X_DATADOG_TRACE_ID'
 // Build
 export const CI_PIPELINE_URL = 'ci.pipeline.url'
 export const CI_PROVIDER_NAME = 'ci.provider.name'
+export const CI_LEVEL = '_dd.ci.level'
+// @deprecated TODO: remove this once backend is updated
+export const CI_BUILD_LEVEL = '_dd.ci.build_level'
 
 // Git
 export const GIT_BRANCH = 'git.branch'
 export const GIT_SHA = 'git.commit.sha'
+
+// General
+export const SPAN_TYPE = 'span.type'


### PR DESCRIPTION
### What and why?

Be able to distinguish spans created by the CLI tool vs the ones created from "native" instrumentation (like Jenkins and Gitlab)

### How?

* Add `_dd.ci.level`, `_dd.ci.build_level` and `span.type` tags to the created spans.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)

