### PR TITLE
Bump to version 0.10.8-alpha

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci",
-  "version": "0.10.7-alpha",
+  "version": "0.10.8-alpha",
   "description": "Run datadog actions from the CI.",
   "main": "dist/index.js",
   "repository": "https://github.com/DataDog/datadog-ci",


### PR DESCRIPTION
Release version 0.10.8-alpha of the package with an improved support for the tunnel feature of the synthetics command.