### PR TITLE
[synthetics] fix result rendering for multistep API tests

### DIFF
--- a/src/commands/synthetics/interfaces.ts
+++ b/src/commands/synthetics/interfaces.ts
@@ -67,6 +67,7 @@ export interface Test {
       timeout: number
       url: string
     }
+    steps?: {subtype: string}[]
     variables: string[]
   }
   created_at: string

--- a/src/commands/synthetics/renderer.ts
+++ b/src/commands/synthetics/renderer.ts
@@ -161,7 +161,11 @@ const renderApiRequestDescription = (subType: string, config: Test['config']): s
     return `Multistep test containing ${stepsDescription}`
   }
 
-  return `${chalk.bold(request.method)} - ${request.url}`
+  if (subType === 'http') {
+    return `${chalk.bold(request.method)} - ${request.url}`
+  }
+
+  return `${chalk.bold(subType)} test`
 }
 
 const getResultUrl = (baseUrl: string, test: Test, resultId: string) => {

--- a/src/commands/synthetics/renderer.ts
+++ b/src/commands/synthetics/renderer.ts
@@ -108,7 +108,7 @@ const renderResultOutcome = (result: Result, test: Test, icon: string, color: ty
   }
 
   if (test.type === 'api') {
-    const requestDescription = renderApiRequestDescription(test.subtype, test.config.request)
+    const requestDescription = renderApiRequestDescription(test.subtype, test.config)
 
     if (result.errorCode && result.errorMessage) {
       return [
@@ -130,7 +130,8 @@ const renderResultOutcome = (result: Result, test: Test, icon: string, color: ty
   }
 }
 
-const renderApiRequestDescription = (subType: string, request: Test['config']['request']): string => {
+const renderApiRequestDescription = (subType: string, config: Test['config']): string => {
+  const {request, steps} = config
   if (subType === 'dns') {
     const text = `Query for ${request.host}`
     if (request.dnsServer) {
@@ -142,6 +143,22 @@ const renderApiRequestDescription = (subType: string, request: Test['config']['r
 
   if (subType === 'ssl' || subType === 'tcp') {
     return `Host: ${request.host}:${request.port}`
+  }
+
+  if (subType === 'multi' && steps) {
+    const stepsDescription = Object.entries(
+      steps
+        .map((step) => step.subtype)
+        .reduce((counts, type) => {
+          counts[type] = (counts[type] || 0) + 1
+
+          return counts
+        }, {} as {[key: string]: number})
+    )
+      .map(([type, count]) => `${count} ${type.toUpperCase()} test`)
+      .join(', ')
+
+    return `Multistep test containing ${stepsDescription}`
   }
 
   return `${chalk.bold(request.method)} - ${request.url}`


### PR DESCRIPTION
### What and why?

Rendering of Multistep API results was not handled and made `datadog-ci` crash. This PR adds a simplistic interface definition as well as a specific description for multistep tests counting the number of requests it is composed of.

Closes: #177 
