### PR TITLE
[synthetics] filter out missing test tunnel

### DIFF
--- a/src/commands/synthetics/__tests__/utils.test.ts
+++ b/src/commands/synthetics/__tests__/utils.test.ts
@@ -45,6 +45,42 @@ describe('utils', () => {
   })
 
   describe('runTest', () => {
+    const fakeId = '123-456-789'
+    const fakeTrigger = {
+      results: [],
+      triggered_check_ids: [fakeId],
+    }
+
+    beforeAll(() => {
+      const axiosMock = jest.spyOn(axios.default, 'create')
+      axiosMock.mockImplementation((() => (e: any) => {
+        if (e.url === '/synthetics/tests/trigger/ci') {
+          return {data: fakeTrigger}
+        }
+      }) as any)
+    })
+
+    afterAll(() => {
+      jest.clearAllMocks()
+    })
+
+    test('should run test', async () => {
+      const output = await utils.runTests(api, [{public_id: fakeId, executionRule: ExecutionRule.NON_BLOCKING}])
+      expect(output).toEqual(fakeTrigger)
+    })
+
+    test('should run test with publicId from url', async () => {
+      const output = await utils.runTests(api, [
+        {
+          executionRule: ExecutionRule.NON_BLOCKING,
+          public_id: `http://localhost/synthetics/tests/details/${fakeId}`,
+        },
+      ])
+      expect(output).toEqual(fakeTrigger)
+    })
+  })
+
+  describe('getTestsToTrigger', () => {
     const processWrite = process.stdout.write.bind(process.stdout)
     const fakeTest = {
       config: {
@@ -55,18 +91,10 @@ describe('utils', () => {
       name: 'Fake Test',
       public_id: '123-456-789',
     }
-    const fakeTrigger = {
-      results: [],
-      triggered_check_ids: [fakeTest.public_id],
-    }
 
     beforeAll(() => {
       const axiosMock = jest.spyOn(axios.default, 'create')
       axiosMock.mockImplementation((() => (e: any) => {
-        if (e.url === '/synthetics/tests/trigger/ci') {
-          return {data: fakeTrigger}
-        }
-
         if (e.url === `/synthetics/tests/${fakeTest.public_id}`) {
           return {data: fakeTest}
         }
@@ -77,27 +105,21 @@ describe('utils', () => {
       jest.clearAllMocks()
     })
 
-    test('should run test', async () => {
-      const output = await utils.runTests(api, [{id: fakeTest.public_id, config: {}}], processWrite)
-      expect(output).toEqual({tests: [fakeTest], triggers: fakeTrigger})
-    })
+    test('only existing tests are returned', async () => {
+      const triggerConfigs = [
+        {config: {}, id: '123-456-789'},
+        {config: {}, id: '987-654-321'},
+      ]
+      const {tests, overriddenTestsToTrigger} = await utils.getTestsToTrigger(api, triggerConfigs, processWrite)
 
-    test('should run test with publicId from url', async () => {
-      const output = await utils.runTests(
-        api,
-        [
-          {
-            config: {},
-            id: `http://localhost/synthetics/tests/details/${fakeTest.public_id}`,
-          },
-        ],
-        processWrite
-      )
-      expect(output).toEqual({tests: [fakeTest], triggers: fakeTrigger})
+      expect(tests).toStrictEqual([fakeTest])
+      expect(overriddenTestsToTrigger).toStrictEqual([
+        {executionRule: ExecutionRule.BLOCKING, public_id: '123-456-789'},
+      ])
     })
 
     test('no tests triggered throws an error', async () => {
-      await expect(utils.runTests(api, [], processWrite)).rejects.toEqual(new Error('No tests to trigger'))
+      await expect(utils.getTestsToTrigger(api, [], processWrite)).rejects.toEqual(new Error('No tests to trigger'))
     })
   })
 

--- a/src/commands/synthetics/run-test.ts
+++ b/src/commands/synthetics/run-test.ts
@@ -6,7 +6,7 @@ import {apiConstructor} from './api'
 import {APIHelper, ConfigOverride, ExecutionRule, LocationsMapping, PollResult, Test} from './interfaces'
 import {renderHeader, renderResults} from './renderer'
 import {Tunnel} from './tunnel'
-import {getSuites, hasTestSucceeded, runTests, waitForResults} from './utils'
+import {getSuites, getTestsToTrigger, hasTestSucceeded, runTests, waitForResults} from './utils'
 
 export class RunTestCommand extends Command {
   private apiKey?: string
@@ -36,13 +36,15 @@ export class RunTestCommand extends Command {
     const api = this.getApiHelper()
     const publicIdsFromCli = this.publicIds.map((id) => ({config: this.config.global, id}))
     const testsToTrigger = publicIdsFromCli.length ? publicIdsFromCli : await this.getTestsToTrigger(api)
-    const publicIdsToTrigger = testsToTrigger.map(({id}) => id)
 
     if (!testsToTrigger.length) {
       this.context.stdout.write('No test suites to run.\n')
 
       return 0
     }
+
+    const {tests, overriddenTestsToTrigger} = await getTestsToTrigger(api, testsToTrigger, stdoutLogger)
+    const publicIdsToTrigger = tests.map(({public_id}) => public_id)
 
     let tunnel: Tunnel | undefined
     if ((this.shouldOpenTunnel === undefined && this.config.tunnel) || this.shouldOpenTunnel) {
@@ -64,8 +66,7 @@ export class RunTestCommand extends Command {
         return 1
       }
     }
-
-    const {tests, triggers} = await runTests(api, testsToTrigger, stdoutLogger)
+    const triggers = await runTests(api, overriddenTestsToTrigger)
 
     // All tests have been skipped or are missing.
     if (!tests.length) {


### PR DESCRIPTION
### What and why?

On tunnel initialization, the list of ids of the tests to trigger is sent to the backend which will send a 404 if one of the test is missing.
This PR fixes this by splitting the code to fetch the test configs and to trigger the tests into two functions, between which the tunnel is initialized.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)

