### PR TITLE
Release 0.10.9-alpha

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci",
-  "version": "0.10.8-alpha",
+  "version": "0.10.9-alpha",
   "description": "Run datadog actions from the CI.",
   "main": "dist/index.js",
   "repository": "https://github.com/DataDog/datadog-ci",


### PR DESCRIPTION
### What and why?

Create version 0.10.9 in the alpha channel to push fixes to synthetics tunnel feature.
