### PR TITLE
Release 0.10.10 alpha

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci",
-  "version": "0.10.9-alpha",
+  "version": "0.10.10-alpha",
   "description": "Run datadog actions from the CI.",
   "main": "dist/index.js",
   "repository": "https://github.com/DataDog/datadog-ci",


### PR DESCRIPTION
### What and why?

This PR releases v0.10.10 in alpha channel to pass tunnel configuration when triggering synthetics tests with tunnel feature.
