### PR TITLE
[synthetics] improve tunnel connection and bump yamux-js

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "sshpk": "1.16.1",
     "tiny-async-pool": "1.1.0",
     "ws": "7.4.0",
-    "yamux-js": "0.0.2"
+    "yamux-js": "0.0.4"
   },
   "devDependencies": {
     "@babel/core": "7.4.5",

--- a/src/commands/synthetics/__tests__/tunnel.test.ts
+++ b/src/commands/synthetics/__tests__/tunnel.test.ts
@@ -12,13 +12,14 @@ describe('Tunnel', () => {
   const mockConnect = jest.fn()
   const mockClose = jest.fn()
   const mockWebSocket = {
-    addEventListener: (event: 'message', handler: (message: string) => void) => {
-      const tunnelInfo = {host: 'host', id: 'tunnel-id'}
-      handler(JSON.stringify(tunnelInfo))
-    },
     close: mockClose,
     connect: mockConnect,
     duplex: () => new PassThrough(),
+    waitForFirstMessage: () => {
+      const tunnelInfo = {host: 'host', id: 'tunnel-id'}
+
+      return JSON.stringify(tunnelInfo)
+    },
   }
 
   const defaultProxyOpts: ProxyConfiguration = {protocol: 'http'}

--- a/src/commands/synthetics/tunnel.ts
+++ b/src/commands/synthetics/tunnel.ts
@@ -6,6 +6,7 @@ import {Duplex, Writable} from 'stream'
 import chalk from 'chalk'
 import {AuthContext, Connection as SSHConnection, Server as SSHServer, ServerChannel as SSHServerChannel} from 'ssh2'
 import {ParsedKey, SSH2Stream, SSH2StreamConfig} from 'ssh2-streams'
+import WebSocket from 'ws'
 import {Config as MultiplexerConfig, Server as Multiplexer} from 'yamux-js'
 
 import {ProxyConfiguration} from '../../helpers/utils'
@@ -27,6 +28,7 @@ const webSocketReconnect = {
 }
 
 export class Tunnel {
+  private firstMessagePromise: Promise<WebSocket.Data>
   private forwardSockets: Socket[] = []
   private log: Writable['write']
   private logError: Writable['write']
@@ -58,10 +60,15 @@ export class Tunnel {
       },
       server: true,
     }
+
+    let onFirstMessage: (data: WebSocket.Data) => void
+    this.firstMessagePromise = new Promise((resolve) => (onFirstMessage = resolve))
+
     this.ws = new WebSocketWithReconnect(
       this.url,
       this.log,
       proxy,
+      onFirstMessage!,
       webSocketReconnect.maxRetries,
       webSocketReconnect.interval
     )
@@ -223,7 +230,7 @@ export class Tunnel {
   }
 
   private async getConnectionInfo() {
-    const [rawConnectionInfo] = (await once(this.ws!, 'message')) as (string | Buffer)[]
+    const rawConnectionInfo = await this.firstMessagePromise
 
     try {
       const connectionInfo: TunnelInfo = {

--- a/src/commands/synthetics/websocket.ts
+++ b/src/commands/synthetics/websocket.ts
@@ -16,6 +16,7 @@ import {ProxyConfiguration} from '../../helpers/utils'
  *  - on/once message
  */
 export class WebSocketWithReconnect extends EventEmitter {
+  private firstMessage?: Promise<WebSocket.Data>
   private keepAliveWebsocket?: Promise<void> // Artificial promise that resolves when closing and will reject in case of error
   private reconnectRetries = 0
   private websocket?: WebSocket
@@ -24,7 +25,6 @@ export class WebSocketWithReconnect extends EventEmitter {
     private url: string,
     private log: Writable['write'],
     private proxyOpts: ProxyConfiguration,
-    private firstMessageHandler: (message: WebSocket.Data) => void = () => undefined,
     private reconnectMaxRetries = 3,
     private reconnectInterval = 3000 // In ms
   ) {
@@ -107,6 +107,14 @@ export class WebSocketWithReconnect extends EventEmitter {
     return this
   }
 
+  public waitForFirstMessage() {
+    if (!this.firstMessage) {
+      throw new Error('Websocket connection was not established before reading first message')
+    }
+
+    return this.firstMessage
+  }
+
   private establishWebsocketConnection(resolve: (value: void) => void, reject: (error: Error) => void) {
     if (!this.websocket) {
       this.reconnectRetries++
@@ -116,6 +124,14 @@ export class WebSocketWithReconnect extends EventEmitter {
       }
       this.websocket = new WebSocket(this.url, options)
     }
+
+    this.firstMessage = new Promise((firstMessageResolve, firstMessageReject) => {
+      if (!this.websocket) {
+        firstMessageReject(Error('Unable to start websocket connection'))
+      } else {
+        this.websocket.once('message', firstMessageResolve)
+      }
+    })
 
     this.websocket.on('unexpected-response', (req, res) => {
       let body = ''
@@ -131,10 +147,6 @@ export class WebSocketWithReconnect extends EventEmitter {
 
     this.websocket.on('open', () => {
       resolve()
-    })
-
-    this.websocket.once('message', (data: WebSocket.Data) => {
-      this.firstMessageHandler(data)
     })
 
     this.websocket.on('close', (code, reason) => {

--- a/src/commands/synthetics/websocket.ts
+++ b/src/commands/synthetics/websocket.ts
@@ -24,6 +24,7 @@ export class WebSocketWithReconnect extends EventEmitter {
     private url: string,
     private log: Writable['write'],
     private proxyOpts: ProxyConfiguration,
+    private firstMessageHandler: (message: WebSocket.Data) => void = () => undefined,
     private reconnectMaxRetries = 3,
     private reconnectInterval = 3000 // In ms
   ) {
@@ -130,6 +131,10 @@ export class WebSocketWithReconnect extends EventEmitter {
 
     this.websocket.on('open', () => {
       resolve()
+    })
+
+    this.websocket.once('message', (data: WebSocket.Data) => {
+      this.firstMessageHandler(data)
     })
 
     this.websocket.on('close', (code, reason) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5760,10 +5760,10 @@ yallist@^4.0.0:
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
   integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
-yamux-js@0.0.2:
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/yamux-js/-/yamux-js-0.0.2.tgz#414767173b5c517e5f65e7722ef4f83a4b92d615"
-  integrity sha512-HK5H907/JfTLMPETbV4pY65ScltIgfILyVH5GBgAfX0xoXaABao2EIvLnTAHYMG2Dq4gCOj6GQ7tYkWofMyrew==
+yamux-js@0.0.4:
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/yamux-js/-/yamux-js-0.0.4.tgz#93319464cff2fca79ee8aa0ca4cf0e7fa352d038"
+  integrity sha512-uobZnzA7kpt0bNqbMBt+RF1Pi/w8iE+VqUMSdyW4gJFHU6tRys5JX6sPUR4ACY6dR2FE6T96h7WORMhTEfLhSw==
 
 yargs-parser@20.x:
   version "20.2.4"


### PR DESCRIPTION
### What and why?

This PR does:
- bump `yamux-js` to version `0.0.4` to benefit from latest bug fixes preventing performing tunneled tests with files >100KB
- modify the websocket handler to be able to obtain the first message sent over the connection. Before this PR, we had a race-condition where the first message was already sent but the client did not register the event listener yet and the `once` (cf. [code](https://github.com/DataDog/datadog-ci/blob/9eae78e9d07ffca6c4a51145486a0e156455137d/src/commands/synthetics/tunnel.ts#L226)) callback was never called.
