### PR TITLE
Use posix version of normalize when working with sourcemaps file paths.

### DIFF
--- a/src/commands/sourcemaps/upload.ts
+++ b/src/commands/sourcemaps/upload.ts
@@ -81,7 +81,8 @@ export class UploadCommand extends Command {
 
     const api = this.getApiHelper()
     // Normalizing the basePath to resolve .. and .
-    this.basePath = path.normalize(this.basePath!)
+    // Always using the posix version to avoid \ on Windows.
+    this.basePath = path.posix.normalize(this.basePath!)
     this.context.stdout.write(
       renderCommandInfo(
         this.basePath!,


### PR DESCRIPTION
### What and why?

Using the "standard" version of normalize default to the current system.
We expect to have `/` in the path and not `\` to make it match with the URL.

Forcing the use of posix version seems to fix the issue. Tested on a Windows VM.

### How?

A brief description of implementation details of this PR.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)

