### PR TITLE
[synthetics] update renderer to display tunneled location

### DIFF
--- a/src/commands/synthetics/interfaces.ts
+++ b/src/commands/synthetics/interfaces.ts
@@ -23,6 +23,7 @@ export interface Result {
   passed: boolean
   stepDetails: Step[]
   timings?: Timings
+  tunnel?: boolean
   unhealthy?: boolean
 }
 

--- a/src/commands/synthetics/renderer.ts
+++ b/src/commands/synthetics/renderer.ts
@@ -183,7 +183,7 @@ const renderExecutionResult = (test: Test, execution: PollResult, baseUrl: strin
   const color = getTestResultColor(isSuccess, test.options.ci?.executionRule === ExecutionRule.NON_BLOCKING)
   const icon = isSuccess ? ICONS.SUCCESS : ICONS.FAILED
 
-  const locationName = locationNames[dc_id] || dc_id.toString()
+  const locationName = !!result.tunnel ? 'Tunneled' : locationNames[dc_id] || dc_id.toString()
   const device = test.type === 'browser' && result.device ? ` - device: ${chalk.bold(result.device.id)}` : ''
   const resultIdentification = color(`  ${icon} location: ${chalk.bold(locationName)}${device}`)
 


### PR DESCRIPTION
### What and why?

When using tunnel to run tests the location of the effective datacenter is currently shown, this PR changes this behavior to show `Tunneled` instead so the user knows the test went performed using the tunnel feature.