### PR TITLE
[Synthetics][SW-952] Add override option `defaultStepTimeout` for Browser tests

### DIFF
--- a/src/commands/synthetics/README.md
+++ b/src/commands/synthetics/README.md
@@ -46,6 +46,7 @@ The configuration file structure is the following:
         "body": "{\"fakeContent\":true}",
         "bodyType": "application/json",
         "cookies": "name1=value1;name2=value2;",
+        "defaultStepTimeout": 15,
         "deviceIds": ["laptop_large"],
         "executionRule": "skipped",
         "followRedirects": true,
@@ -111,6 +112,7 @@ Your test files must be named with a `.synthetics.json` suffix.
                 "body": "{\"fakeContent\":true}",
                 "bodyType": "application/json",
                 "cookies": "name1=value1;name2=value2;",
+                "defaultStepTimeout": 15,
                 "deviceIds": ["laptop_large"],
                 "executionRule": "skipped",
                 "followRedirects": true,
@@ -137,6 +139,7 @@ All options under the `config` key allow overriding the configuration of the tes
 - `body`: (string) data to send in a synthetics API test.
 - `bodyType`: (string) type of the data sent in a synthetics API test.
 - `cookies`: (string) use provided string as Cookie header in API or Browser test.
+- `defaultStepTimeout`: (number) maximum duration of steps in seconds for Browser tests, does not override individually set step timeouts.
 - `deviceIds`: (array) list of devices on which to run the Browser test.
 - `executionRule`: (string) execution rule of the test: it defines the behavior of the CLI in case of a failing test, it can be either:
   - `blocking`: the CLI returns an error if the test fails.

--- a/src/commands/synthetics/README.md
+++ b/src/commands/synthetics/README.md
@@ -130,29 +130,29 @@ The `<TEST_PUBLIC_ID>` can be either the identifier of the test found in the URL
 
 All options under the `config` key allow overriding the configuration of the test as stored in Datadog.
 
-- allowInsecureCertificates: (boolean) disable certificate checks in API tests
-- basicAuth: (object) credentials to provide in case a basic authentication is encountered
-  - username: (string) username to use in basic authentication
-  - password: (string) password to use in basic authentication
-- body: (string) data to send in a synthetics API test
-- bodyType: (string) type of the data sent in a synthetics API test
-- cookies: (string) use provided string as Cookie header in API or Browser test
-- deviceIds: (array) list of devices on which to run the Browser test
-- executionRule: (string) execution rule of the test: it defines the behavior of the CLI in case of a failing test, it can be either:
-  - blocking: the CLI returns an error if the test fails
-  - non_blocking: the CLI only prints a warning if the test fails
-  - skipped: the test is not executed at all
-- followRedirects: (boolean) indicates whether to follow or not HTTP redirections in API tests
-- headers: (object) headers to replace in the test. This object should contain as keys the name of the header to replace and as values the new value of the header.
-- locations: (array) list of locations from which the test should be run.
-- pollingTimeout: (integer) maximum duration in milliseconds of a test, if execution exceeds this value it is considered failed.
-- retry: (object) retry policy for the test
-  - count: (integer) number of attempts to perform in case of test failure
-  - interval: (integer) interval between the attempts (in milliseconds)
-- startUrl: (string) new start URL to provide to the test
-- variables: (object) variables to replace in the test. This object should contain as keys the name of the variable to replace and as values the new value of the variable.
+- `allowInsecureCertificates`: (boolean) disable certificate checks in API tests.
+- `basicAuth`: (object) credentials to provide in case a basic authentication is encountered.
+  - `username`: (string) username to use in basic authentication.
+  - `password`: (string) password to use in basic authentication.
+- `body`: (string) data to send in a synthetics API test.
+- `bodyType`: (string) type of the data sent in a synthetics API test.
+- `cookies`: (string) use provided string as Cookie header in API or Browser test.
+- `deviceIds`: (array) list of devices on which to run the Browser test.
+- `executionRule`: (string) execution rule of the test: it defines the behavior of the CLI in case of a failing test, it can be either:
+  - `blocking`: the CLI returns an error if the test fails.
+  - `non_blocking`: the CLI only prints a warning if the test fails.
+  - `skipped`: the test is not executed at all.
+- `followRedirects`: (boolean) indicates whether to follow or not HTTP redirections in API tests.
+- `headers`: (object) headers to replace in the test. This object should contain as keys the name of the header to replace and as values the new value of the header.
+- `locations`: (array) list of locations from which the test should be run.
+- `pollingTimeout`: (integer) maximum duration in milliseconds of a test, if execution exceeds this value it is considered failed.
+- `retry`: (object) retry policy for the test.
+  - `count`: (integer) number of attempts to perform in case of test failure.
+  - `interval`: (integer) interval between the attempts (in milliseconds).
+- `startUrl`: (string) new start URL to provide to the test.
+- `variables`: (object) variables to replace in the test. This object should contain as keys the name of the variable to replace and as values the new value of the variable.
 
-You can configure on which url your test starts by providing a `config.startUrl` to your test object and build your own starting url using any part of your test's original starting url and the following environment variables:
+You can configure on which url your Browser or HTTP test starts by providing a `config.startUrl` to your test object and build your own starting url using any part of your test's original starting url and the following environment variables:
 
 | Environment variable | Description                  | Example                                                |
 |----------------------|------------------------------|--------------------------------------------------------|

--- a/src/commands/synthetics/__tests__/utils.test.ts
+++ b/src/commands/synthetics/__tests__/utils.test.ts
@@ -9,7 +9,7 @@ import glob from 'glob'
 import {ProxyConfiguration} from '../../../helpers/utils'
 
 import {apiConstructor} from '../api'
-import {ExecutionRule, PollResult, Result, Test} from '../interfaces'
+import {ConfigOverride, ExecutionRule, PollResult, Result, Test} from '../interfaces'
 import {Tunnel} from '../tunnel'
 import * as utils from '../utils'
 
@@ -250,6 +250,38 @@ describe('utils', () => {
 
       expect(handledConfig.public_id).toBe(publicId)
       expect(handledConfig.startUrl).toBe(expectedUrl)
+    })
+
+    test('config overrides are applied', () => {
+      const publicId = 'abc-def-ghi'
+      const fakeTest = {
+        config: {request: {url: 'http://example.org/path'}},
+        public_id: publicId,
+        type: 'browser',
+      } as Test
+      const configOverride: ConfigOverride = {
+        allowInsecureCertificates: true,
+        basicAuth: {username: 'user', password: 'password'},
+        body: 'body',
+        bodyType: 'application/json',
+        cookies: 'name=value;',
+        defaultStepTimeout: 15,
+        deviceIds: ['device_id'],
+        executionRule: ExecutionRule.NON_BLOCKING,
+        followRedirects: true,
+        headers: {'header-name': 'value'},
+        locations: ['location'],
+        pollingTimeout: 60 * 1000,
+        retry: {count: 5, interval: 30},
+        startUrl: 'http://127.0.0.1:60/newPath',
+        tunnel: {host: 'host', id: 'id', privateKey: 'privateKey'},
+        variables: {VAR_1: 'value'},
+      }
+
+      expect(utils.handleConfig(fakeTest, publicId, processWrite, configOverride)).toEqual({
+        ...configOverride,
+        public_id: publicId,
+      })
     })
   })
 

--- a/src/commands/synthetics/interfaces.ts
+++ b/src/commands/synthetics/interfaces.ts
@@ -169,6 +169,7 @@ export interface ConfigOverride {
   body?: string
   bodyType?: string
   cookies?: string
+  defaultStepTimeout?: number
   deviceIds?: string[]
   executionRule?: ExecutionRule
   followRedirects?: boolean

--- a/src/commands/synthetics/utils.ts
+++ b/src/commands/synthetics/utils.ts
@@ -61,6 +61,7 @@ export const handleConfig = (
       'body',
       'bodyType',
       'cookies',
+      'defaultStepTimeout',
       'deviceIds',
       'followRedirects',
       'headers',

--- a/src/commands/synthetics/utils.ts
+++ b/src/commands/synthetics/utils.ts
@@ -89,7 +89,7 @@ const parseUrlVariables = (url: string, write: Writable['write']) => {
   try {
     objUrl = new URL(url)
   } catch {
-    write(`The start url ${url} contains variables, CI overrides will be ignored`)
+    write(`The start url ${url} contains variables, CI overrides will be ignored\n`)
 
     return context
   }


### PR DESCRIPTION
### What and why?

Support new `defaultStepTimeout` option for Browser tests configuration overrides.

### How?

Add `defaultStepTimeout` to CI override options.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)

