### PR TITLE
v0.11.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "description": "Run datadog actions from the CI.",
   "main": "dist/index.js",
   "repository": "https://github.com/DataDog/datadog-ci",


### PR DESCRIPTION
### What and why?

Bump to version 0.11.2 to release two fixes for synthetics command:
- #190 - improve result rendering with tunnel feature
- #188 - bump dependency and improve tunnel connection resilience