### PR TITLE
[Alpha release] Use posix version of normalize when working with sourcemaps file paths.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci",
-  "version": "0.10.10-alpha",
+  "version": "0.10.11-alpha",
   "description": "Run datadog actions from the CI.",
   "main": "dist/index.js",
   "repository": "https://github.com/DataDog/datadog-ci",

--- a/src/commands/sourcemaps/upload.ts
+++ b/src/commands/sourcemaps/upload.ts
@@ -84,7 +84,8 @@ export class UploadCommand extends Command {
 
     const api = this.getApiHelper()
     // Normalizing the basePath to resolve .. and .
-    this.basePath = path.normalize(this.basePath!)
+    // Always using the posix version to avoid \ on Windows.
+    this.basePath = path.posix.normalize(this.basePath!)
     this.context.stdout.write(
       renderCommandInfo(
         this.basePath!,


### PR DESCRIPTION
### What and why?

Alpha release of https://github.com/DataDog/datadog-ci/pull/189

