### PR TITLE
[alpha] release version 0.10.12-alpha

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci",
-  "version": "0.10.11-alpha",
+  "version": "0.10.12-alpha",
   "description": "Run datadog actions from the CI.",
   "main": "dist/index.js",
   "repository": "https://github.com/DataDog/datadog-ci",


### PR DESCRIPTION
### What and why?

Release version 0.10.12-alpha of the package with merges version 0.11.3 in the alpha channel.