### PR TITLE
v0.11.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci",
-  "version": "0.11.3",
+  "version": "0.11.4",
   "description": "Run datadog actions from the CI.",
   "main": "dist/index.js",
   "repository": "https://github.com/DataDog/datadog-ci",


### PR DESCRIPTION
### What and why?

Release v0.11.4, with:
- sourcemaps: fix bug with `\` and `/` in Windows environments.
