### PR TITLE
[ci-app] Bump `dd-trace`

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "chalk": "3.0.0",
     "clipanion": "2.2.2",
     "datadog-metrics": "0.9.0",
-    "dd-trace": "0.31.0",
+    "dd-trace": "0.32.0",
     "deep-extend": "0.6.0",
     "form-data": "3.0.0",
     "glob": "7.1.4",

--- a/testEnvironment.js
+++ b/testEnvironment.js
@@ -1,6 +1,8 @@
 require('dd-trace').init({
   startupLogs: false,
   enabled: !!process.env.CI,
+  debug: true,
+  logLevel: 'error',
 })
 
 module.exports = require('jest-environment-node')

--- a/yarn.lock
+++ b/yarn.lock
@@ -2051,11 +2051,6 @@ core-js-pure@3.1.4:
   resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.1.4.tgz#5fa17dc77002a169a3566cc48dc774d2e13e3769"
   integrity sha512-uJ4Z7iPNwiu1foygbcZYJsJs1jiXrTTCvxfLDXNhI/I+NHbSIEyr548y4fcsCEyWY0XgfAG/qqaunJ1SThHenA==
 
-core-js@^3.6.0:
-  version "3.8.3"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.8.3.tgz#c21906e1f14f3689f93abcc6e26883550dd92dd0"
-  integrity sha512-KPYXeVZYemC2TkNEkX/01I+7yd+nX3KddKwZ1Ww7SKWdI2wQprSgLmrTddT8nw92AjEklTsPBoSdQBhbI1bQ6Q==
-
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
@@ -2127,14 +2122,13 @@ datadog-metrics@0.9.0:
     debug "3.1.0"
     dogapi "2.8.3"
 
-dd-trace@0.31.0:
-  version "0.31.0"
-  resolved "https://registry.yarnpkg.com/dd-trace/-/dd-trace-0.31.0.tgz#5193b51b7d8ba1ea3aba17f5132703a2dae28f35"
-  integrity sha512-/a95KtcmOq6lQxYpdbgjDuQOuDwlHKtPW2r5RywSmibHkZVPeRsHjmS4YZB7o9xVNZijJr++QcvXDpJ0b2ITmQ==
+dd-trace@0.32.0:
+  version "0.32.0"
+  resolved "https://registry.yarnpkg.com/dd-trace/-/dd-trace-0.32.0.tgz#a42dc275a526b5b7f976a95f76d7b0595086c8b9"
+  integrity sha512-WJedEGdSvin7YCnqszDWRJ0eEfgO2/saZzPmihdpcC6jqVsuOFU4nfYwdxXyPG/uzFPDJ1O0f5bqKJtKPg4+Gw==
   dependencies:
     "@types/node" "^10.12.18"
     axios "^0.21.1"
-    core-js "^3.6.0"
     form-data "^3.0.0"
     hdr-histogram-js "^2.0.1"
     koalas "^1.0.2"
@@ -2156,11 +2150,10 @@ dd-trace@0.31.0:
     read-pkg-up "^3.0.0"
     require-in-the-middle "^2.2.2"
     semver "^5.5.0"
-    shimmer "^1.2.0"
+    shimmer "1.2.1"
     source-map "^0.7.3"
     source-map-resolve "^0.6.0"
     url-parse "^1.4.3"
-    whatwg-fetch "^3.0.0"
 
 debug@2, debug@^2.2.0, debug@^2.3.3:
   version "2.6.9"
@@ -4928,7 +4921,7 @@ shellwords@^0.1.1:
   resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
   integrity sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==
 
-shimmer@^1.2.0:
+shimmer@1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/shimmer/-/shimmer-1.2.1.tgz#610859f7de327b587efebf501fb43117f9aff337"
   integrity sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw==
@@ -5629,11 +5622,6 @@ whatwg-encoding@^1.0.5:
   integrity sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==
   dependencies:
     iconv-lite "0.4.24"
-
-whatwg-fetch@^3.0.0:
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.5.0.tgz#605a2cd0a7146e5db141e29d1c62ab84c0c4c868"
-  integrity sha512-jXkLtsR42xhXg7akoDKvKWE40eJeI+2KZqcp2h3NsOrRnDvtWX36KcKl30dy+hxECivdk2BVUHVNrPtoMBUx6A==
 
 whatwg-mimetype@^2.3.0:
   version "2.3.0"


### PR DESCRIPTION
### What and why?

* Keep up with latest features in https://github.com/DataDog/dd-trace-js/releases/tag/v0.32.0.

### How?

* Bump `dd-trace` to `0.32.0`

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)

