### PR TITLE
[Synthetics] Add Tests Summary after execution, Better tests not found highlight

### DIFF
--- a/src/commands/synthetics/__tests__/run-test.test.ts
+++ b/src/commands/synthetics/__tests__/run-test.test.ts
@@ -28,9 +28,13 @@ describe('run-test', () => {
   describe('execute', () => {
     test('should apply config override for tests triggered by public id', async () => {
       jest.spyOn(ciUtils, 'parseConfigFile').mockImplementation(async (config, _) => config)
-      const getTestsToTriggersMock = jest
-        .spyOn(utils, 'getTestsToTrigger')
-        .mockReturnValue(Promise.resolve({tests: [], overriddenTestsToTrigger: []}))
+      const getTestsToTriggersMock = jest.spyOn(utils, 'getTestsToTrigger').mockReturnValue(
+        Promise.resolve({
+          overriddenTestsToTrigger: [],
+          summary: {passed: 0, failed: 0, skipped: 0, notFound: 0},
+          tests: [],
+        })
+      )
       jest.spyOn(utils, 'runTests').mockImplementation()
 
       const startUrl = '{{PROTOCOL}}//myhost{{PATHNAME}}{{PARAMS}}'
@@ -57,9 +61,13 @@ describe('run-test', () => {
 
     test('should not wait for `skipped` only tests batch results', async () => {
       jest.spyOn(ciUtils, 'parseConfigFile').mockImplementation(async (config, _) => config)
-      const getTestsToTriggersMock = jest
-        .spyOn(utils, 'getTestsToTrigger')
-        .mockReturnValue(Promise.resolve({tests: [], overriddenTestsToTrigger: []}))
+      const getTestsToTriggersMock = jest.spyOn(utils, 'getTestsToTrigger').mockReturnValue(
+        Promise.resolve({
+          overriddenTestsToTrigger: [],
+          summary: {passed: 0, failed: 0, skipped: 0, notFound: 0},
+          tests: [],
+        })
+      )
       const runTestsMock = jest
         .spyOn(utils, 'runTests')
         .mockReturnValue(Promise.resolve({locations: [], results: [], triggered_check_ids: []}))

--- a/src/commands/synthetics/api.ts
+++ b/src/commands/synthetics/api.ts
@@ -13,10 +13,17 @@ interface BackendError {
 
 export const formatBackendErrors = (requestError: AxiosError<BackendError>) => {
   if (requestError.response && requestError.response.data.errors) {
-    const errors = requestError.response.data.errors.map((message: string) => `  - ${message}`)
     const serverHead = `query on ${requestError.config.baseURL}${requestError.config.url} returned:`
+    const errors = requestError.response.data.errors
+    if (errors.length > 1) {
+      const formattedErrors = errors.map((message: string) => `  - ${message}`)
 
-    return `${serverHead}\n${errors.join('\n')}`
+      return `${serverHead}\n${formattedErrors.join('\n')}`
+    } else if (errors.length) {
+      return `${serverHead} "${errors[0]}"`
+    } else {
+      return `error querying ${requestError.config.baseURL}${requestError.config.url}`
+    }
   }
 
   return requestError.message

--- a/src/commands/synthetics/interfaces.ts
+++ b/src/commands/synthetics/interfaces.ts
@@ -226,6 +226,13 @@ export interface Suite {
   tests: TriggerConfig[]
 }
 
+export interface Summary {
+  failed: number
+  notFound: number
+  passed: number
+  skipped: number
+}
+
 export interface TestSearchResult {
   tests: {
     public_id: string

--- a/src/commands/synthetics/renderer.ts
+++ b/src/commands/synthetics/renderer.ts
@@ -9,6 +9,7 @@ import {
   PollResult,
   Result,
   Step,
+  Summary,
   Test,
 } from './interfaces'
 import {hasResultPassed, hasTestSucceeded} from './utils'
@@ -285,4 +286,20 @@ export const renderWait = (test: Test) => {
   const idDisplay = `[${chalk.bold.dim(test.public_id)}]`
 
   return `${idDisplay} Waiting results for "${chalk.green.bold(test.name)}"\n`
+}
+
+export const renderSummary = (summary: Summary) => {
+  const summaries = [
+    chalk.green(`${chalk.bold(summary.passed)} passed`),
+    chalk.red(`${chalk.bold(summary.failed)} failed`),
+  ]
+
+  if (summary.skipped) {
+    summaries.push(`${chalk.bold(summary.skipped)} skipped`)
+  }
+  if (summary.notFound) {
+    summaries.push(chalk.yellow(`${chalk.bold(summary.notFound)} not found`))
+  }
+
+  return `${chalk.bold('Tests execution summary:')} ${summaries.join(', ')}\n`
 }


### PR DESCRIPTION
### What and why?

Improve visibility of tests not found by highlighting them and displaying them at the end of triggered tests list.
Add tests summary at the end of tests execution.


### How?

- Store "Test not found" error messages and display them at the end of `getTestsToTrigger()` with warn highlighting.
- Update `formatBackendErrors()` to render single errors inline.
   Before:
![image](https://user-images.githubusercontent.com/19409477/114525146-2659df80-9c46-11eb-892e-713a26346122.png)
  After:
![image](https://user-images.githubusercontent.com/19409477/114524970-fad6f500-9c45-11eb-8379-490e2d7b7839.png)
- Add tests execution summary with passed, failed, skipped and not found counts.
![image](https://user-images.githubusercontent.com/19409477/114524252-594fa380-9c45-11eb-90c8-5dcd3e730ef0.png)

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)

