### PR TITLE
[synthetics] bump yamux dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "sshpk": "1.16.1",
     "tiny-async-pool": "1.1.0",
     "ws": "7.4.0",
-    "yamux-js": "0.0.4"
+    "yamux-js": "0.0.6"
   },
   "devDependencies": {
     "@babel/core": "7.4.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5760,10 +5760,10 @@ yallist@^4.0.0:
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
   integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
-yamux-js@0.0.4:
-  version "0.0.4"
-  resolved "https://registry.yarnpkg.com/yamux-js/-/yamux-js-0.0.4.tgz#93319464cff2fca79ee8aa0ca4cf0e7fa352d038"
-  integrity sha512-uobZnzA7kpt0bNqbMBt+RF1Pi/w8iE+VqUMSdyW4gJFHU6tRys5JX6sPUR4ACY6dR2FE6T96h7WORMhTEfLhSw==
+yamux-js@0.0.6:
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/yamux-js/-/yamux-js-0.0.6.tgz#55ebe91006d61e346ee0aa962121da37a6338e2c"
+  integrity sha512-+WeGMUJxaiHeAxLOGDzfRmeEpsEZQ32yG1YpaEmltWF2r/JgcywWeaYoLnHulIdpfu0PPXQjU5OVoZJsLDByKw==
 
 yargs-parser@20.x:
   version "20.2.4"


### PR DESCRIPTION
### What and why?

Yamux 0.0.6 brings an improved protocol support with tracked window size which is required to improve synthetics tunnel support.