### PR TITLE
[synthetics] Add --files parameter

### DIFF
--- a/src/commands/synthetics/README.md
+++ b/src/commands/synthetics/README.md
@@ -96,6 +96,13 @@ It is also possible to trigger tests corresponding to a search query by using th
 datadog-ci synthetics run-tests -s 'tag:e2e-tests' --config global.config.json
 ```
 
+You can use `--files` (shorthand `-f`) to override the global file selector.
+It's particularely useful when you want to run multiple suites in parallel with a single global configuration file.
+
+```bash
+datadog-ci synthetics run-tests -f ./component-1/**/*.synthetics.json -f ./component-2/**/*.synthetics.json
+```
+
 ### Test files
 
 Your test files must be named with a `.synthetics.json` suffix.

--- a/src/commands/synthetics/__tests__/run-test.test.ts
+++ b/src/commands/synthetics/__tests__/run-test.test.ts
@@ -211,6 +211,27 @@ describe('run-test', () => {
         },
       ])
     })
+
+    test('should use given globs to get tests list', async () => {
+      const mockFn = jest.spyOn(utils, 'getSuites').mockImplementation((() => [conf1, conf2]) as any)
+      const command = new RunTestCommand()
+      command.context = process
+      command['config'].global = {startUrl}
+      command['config'].files = 'random glob'
+
+      command['files'] = ['new glob', 'another one']
+      await command['getTestsList'].bind(command)(fakeApi)
+      expect(utils.getSuites).toHaveBeenCalledTimes(2)
+      expect(utils.getSuites).toHaveBeenCalledWith('new glob', expect.any(Function))
+      expect(utils.getSuites).toHaveBeenCalledWith('another one', expect.any(Function))
+
+      mockFn.mockClear();
+
+      command['files'] = undefined
+      await command['getTestsList'].bind(command)(fakeApi)
+      expect(utils.getSuites).toHaveBeenCalledTimes(1)
+      expect(utils.getSuites).toHaveBeenCalledWith('random glob', expect.any(Function))
+    });
   })
 
   describe('sortTestsByOutcome', () => {

--- a/src/commands/synthetics/__tests__/run-test.test.ts
+++ b/src/commands/synthetics/__tests__/run-test.test.ts
@@ -219,7 +219,7 @@ describe('run-test', () => {
       command['config'].global = {startUrl}
       command['config'].files = 'random glob'
 
-      command['files'] = ['new glob', 'another one']
+      command['fileGlobs'] = ['new glob', 'another one']
       await command['getTestsList'].bind(command)(fakeApi)
       expect(utils.getSuites).toHaveBeenCalledTimes(2)
       expect(utils.getSuites).toHaveBeenCalledWith('new glob', expect.any(Function))
@@ -227,7 +227,7 @@ describe('run-test', () => {
 
       mockFn.mockClear()
 
-      command['files'] = undefined
+      command['fileGlobs'] = undefined
       await command['getTestsList'].bind(command)(fakeApi)
       expect(utils.getSuites).toHaveBeenCalledTimes(1)
       expect(utils.getSuites).toHaveBeenCalledWith('random glob', expect.any(Function))

--- a/src/commands/synthetics/__tests__/run-test.test.ts
+++ b/src/commands/synthetics/__tests__/run-test.test.ts
@@ -225,13 +225,13 @@ describe('run-test', () => {
       expect(utils.getSuites).toHaveBeenCalledWith('new glob', expect.any(Function))
       expect(utils.getSuites).toHaveBeenCalledWith('another one', expect.any(Function))
 
-      mockFn.mockClear();
+      mockFn.mockClear()
 
       command['files'] = undefined
       await command['getTestsList'].bind(command)(fakeApi)
       expect(utils.getSuites).toHaveBeenCalledTimes(1)
       expect(utils.getSuites).toHaveBeenCalledWith('random glob', expect.any(Function))
-    });
+    })
   })
 
   describe('sortTestsByOutcome', () => {

--- a/src/commands/synthetics/__tests__/run-test.test.ts
+++ b/src/commands/synthetics/__tests__/run-test.test.ts
@@ -161,7 +161,7 @@ describe('run-test', () => {
     })
   })
 
-  describe('getTestsToTrigger', () => {
+  describe('getTestsList', () => {
     const conf1 = {
       tests: [{config: {}, id: 'abc-def-ghi'}],
     }
@@ -185,7 +185,7 @@ describe('run-test', () => {
       command.context = process
       command['config'].global = {startUrl}
 
-      expect(await command['getTestsToTrigger'].bind(command)(fakeApi)).toEqual([
+      expect(await command['getTestsList'].bind(command)(fakeApi)).toEqual([
         {
           config: {startUrl},
           id: 'abc-def-ghi',
@@ -204,7 +204,7 @@ describe('run-test', () => {
       command['config'].global = {startUrl}
       command['testSearchQuery'] = 'fake search'
 
-      expect(await command['getTestsToTrigger'].bind(command)(fakeApi)).toEqual([
+      expect(await command['getTestsList'].bind(command)(fakeApi)).toEqual([
         {
           config: {startUrl},
           id: 'stu-vwx-yza',

--- a/src/commands/synthetics/run-test.ts
+++ b/src/commands/synthetics/run-test.ts
@@ -35,7 +35,7 @@ export class RunTestCommand extends Command {
 
     const api = this.getApiHelper()
     const publicIdsFromCli = this.publicIds.map((id) => ({config: this.config.global, id}))
-    const testsToTrigger = publicIdsFromCli.length ? publicIdsFromCli : await this.getTestsToTrigger(api)
+    const testsToTrigger = publicIdsFromCli.length ? publicIdsFromCli : await this.getTestsList(api)
 
     if (!testsToTrigger.length) {
       this.context.stdout.write('No test suites to run.\n')
@@ -174,7 +174,7 @@ export class RunTestCommand extends Command {
     return `${host}/${apiPath}`
   }
 
-  private async getTestsToTrigger(api: APIHelper) {
+  private async getTestsList(api: APIHelper) {
     if (this.testSearchQuery) {
       const testSearchResults = await api.searchTests(this.testSearchQuery)
 

--- a/src/commands/synthetics/run-test.ts
+++ b/src/commands/synthetics/run-test.ts
@@ -23,8 +23,8 @@ export class RunTestCommand extends Command {
     tunnel: false,
   }
   private configPath?: string
+  private fileGlobs?: string[]
   private publicIds: string[] = []
-  private files?: string[]
   private shouldOpenTunnel?: boolean
   private testSearchQuery?: string
 
@@ -182,10 +182,12 @@ export class RunTestCommand extends Command {
       return testSearchResults.tests.map((test) => ({config: this.config.global, id: test.public_id}))
     }
 
-    const files = this.files || [this.config.files]
+    const listOfGlobs = this.fileGlobs || [this.config.files]
 
     const suites = (
-      await Promise.all(files.map((f: string) => getSuites(f, this.context.stdout.write.bind(this.context.stdout))))
+      await Promise.all(
+        listOfGlobs.map((glob: string) => getSuites(glob, this.context.stdout.write.bind(this.context.stdout)))
+      )
     )
       .flat()
       .map((suite) => suite.tests)
@@ -228,4 +230,4 @@ RunTestCommand.addOption('configPath', Command.String('--config'))
 RunTestCommand.addOption('publicIds', Command.Array('-p,--public-id'))
 RunTestCommand.addOption('testSearchQuery', Command.String('-s,--search'))
 RunTestCommand.addOption('shouldOpenTunnel', Command.Boolean('-t,--tunnel'))
-RunTestCommand.addOption('files', Command.Array('-f,--files'))
+RunTestCommand.addOption('fileGlobs', Command.Array('-f,--files'))

--- a/src/commands/synthetics/run-test.ts
+++ b/src/commands/synthetics/run-test.ts
@@ -182,13 +182,14 @@ export class RunTestCommand extends Command {
       return testSearchResults.tests.map((test) => ({config: this.config.global, id: test.public_id}))
     }
 
-    const files = this.files || [this.config.files];
+    const files = this.files || [this.config.files]
 
-    const suites = (await Promise.all(
-        files.map(
-          (f: string) => getSuites(f, this.context.stdout.write.bind(this.context.stdout))
-        )
-    )).flat().map((suite) => suite.tests).filter((suiteTests) => !!suiteTests)
+    const suites = (
+      await Promise.all(files.map((f: string) => getSuites(f, this.context.stdout.write.bind(this.context.stdout))))
+    )
+      .flat()
+      .map((suite) => suite.tests)
+      .filter((suiteTests) => !!suiteTests)
 
     const testsToTrigger = suites
       .reduce((acc, suiteTests) => acc.concat(suiteTests), [])


### PR DESCRIPTION
### What and why?

I need to run multiple suites in parallel, so we can reduce the number of tests per run.
But I still want to use a global configuration file.

### How?

Add a `--files`, `-f` parameter so you can override the glob pattern used by the global configuration file.
This way, I can run multiple suites using the same configuration on each run.

I also renamed the function `getTestsToTrigger` in the class, it was quite confusing to have two different functions using the same name in the same file.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)

