### PR TITLE
[ci-app] Allow Single File Selection in `junit upload`

### DIFF
--- a/src/commands/junit/README.md
+++ b/src/commands/junit/README.md
@@ -19,11 +19,10 @@ datadog-ci junit upload [--service] [--max-concurrency] [--dry-run] [--tags] <pa
 For example:
 
 ```bash
-datadog-ci junit upload --service my-service --tags key1:value1 --tags key2:value2 unit-tests/junit-reports acceptance-tests/junit-reports
+datadog-ci junit upload --service my-service --tags key1:value1 --tags key2:value2 unit-tests/junit-reports acceptance-tests/junit-reports e2e-tests/single-report.xml
 ```
 
-- The positional arguments are the directories in which the jUnit XML reports are located. The CLI will look for all `.xml` files in these folders and subfolders recursively.
-
+- The positional arguments are the directories or file paths in which the jUnit XML reports are located. If you pass a folder, the CLI will look for all `.xml` files in it.
 - `--service` (default: `DD_SERVICE` env var) should be set as the name of the service you're uploading jUnit XML reports for.
 - `--tags` is a array of key value pairs of the shape `key:value`. This will set global tags applied to all spans.
   - The resulting dictionary will be merged with whatever is in the `DD_TAGS` environment variable. If a `key` appears both in `--tags` and `DD_TAGS`, whatever value is in `DD_TAGS` will take precedence.

--- a/src/commands/junit/upload.ts
+++ b/src/commands/junit/upload.ts
@@ -98,16 +98,14 @@ export class UploadJUnitXMLCommand extends Command {
   }
 
   private async getMatchingJUnitXMLFiles(): Promise<Payload[]> {
-    const jUnitXMLFiles = (this.basePaths || [])
-      .flatMap((basePath) => {
-        const isFile = !!path.extname(basePath)
-        if (isFile) {
-          return fs.existsSync(basePath) ? basePath : []
-        }
+    const jUnitXMLFiles = (this.basePaths || []).flatMap((basePath) => {
+      const isFile = !!path.extname(basePath)
+      if (isFile) {
+        return fs.existsSync(basePath) ? basePath : []
+      }
 
-        return glob.sync(buildPath(basePath, '*.xml'))
-      })
-      .filter((xmlPath) => !!xmlPath)
+      return glob.sync(buildPath(basePath, '*.xml'))
+    })
 
     const ciSpanTags = getCISpanTags()
     const gitSpanTags = await getGitMetadata()

--- a/src/commands/junit/upload.ts
+++ b/src/commands/junit/upload.ts
@@ -1,6 +1,7 @@
 import retry from 'async-retry'
 import chalk from 'chalk'
 import {Command} from 'clipanion'
+import fs from 'fs'
 import glob from 'glob'
 import path from 'path'
 import asyncPool from 'tiny-async-pool'
@@ -97,12 +98,16 @@ export class UploadJUnitXMLCommand extends Command {
   }
 
   private async getMatchingJUnitXMLFiles(): Promise<Payload[]> {
-    let jUnitXMLFiles: string[] = []
+    const jUnitXMLFiles = (this.basePaths || [])
+      .flatMap((basePath) => {
+        const isFile = !!path.extname(basePath)
+        if (isFile) {
+          return fs.existsSync(basePath) ? basePath : []
+        }
 
-    this.basePaths?.forEach((basePath) => {
-      const isFile = !!path.extname(basePath)
-      jUnitXMLFiles = jUnitXMLFiles.concat(isFile ? basePath : glob.sync(buildPath(basePath, '*.xml')))
-    })
+        return glob.sync(buildPath(basePath, '*.xml'))
+      })
+      .filter((xmlPath) => !!xmlPath)
 
     const ciSpanTags = getCISpanTags()
     const gitSpanTags = await getGitMetadata()
@@ -118,7 +123,7 @@ export class UploadJUnitXMLCommand extends Command {
       ...(this.config.env ? {env: this.config.env} : {}),
     }
 
-    return jUnitXMLFiles.map((jUnitXMLFilePath) => ({
+    return [...new Set(jUnitXMLFiles)].map((jUnitXMLFilePath) => ({
       service: this.service!,
       spanTags,
       xmlPath: jUnitXMLFilePath,

--- a/src/commands/junit/upload.ts
+++ b/src/commands/junit/upload.ts
@@ -100,7 +100,8 @@ export class UploadJUnitXMLCommand extends Command {
     let jUnitXMLFiles: string[] = []
 
     this.basePaths?.forEach((basePath) => {
-      jUnitXMLFiles = jUnitXMLFiles.concat(glob.sync(buildPath(basePath, '*.xml')))
+      const isFile = !!path.extname(basePath)
+      jUnitXMLFiles = jUnitXMLFiles.concat(isFile ? basePath : glob.sync(buildPath(basePath, '*.xml')))
     })
 
     const ciSpanTags = getCISpanTags()


### PR DESCRIPTION
### What and why?

We'd like to be able to select single XML files and not just folders.

### How?

* Allow single XML selection. 

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)

