### PR TITLE
[ci-app] Add More CIs and Improve Testing

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "prettier-check": "prettier --check \"src/**/*.{ts,js,json,yml}\" --ignore-path .gitignore || (echo \"\nYou can fix this by running ==> yarn prettier-write <==\n\" && false)",
     "prettier-write": "prettier --write \"src/**/*.{ts,js,json,yml}\" --ignore-path .gitignore",
     "test": "jest",
-    "test:debug": "node --inspect-brk `which jest`",
+    "test:debug": "node --inspect-brk `which jest` --runInBand",
     "typecheck": "bash bin/typecheck.sh",
     "watch": "tsc -w"
   },

--- a/src/helpers/__tests__/ci-env/appveyor.json
+++ b/src/helpers/__tests__/ci-env/appveyor.json
@@ -1,0 +1,390 @@
+[
+  [
+    {
+      "APPVEYOR": "true",
+      "APPVEYOR_BUILD_FOLDER": "/foo/bar",
+      "APPVEYOR_BUILD_ID": "appveyor-build-id",
+      "APPVEYOR_BUILD_NUMBER": "appveyor-pipeline-number",
+      "APPVEYOR_REPO_BRANCH": "master",
+      "APPVEYOR_REPO_COMMIT": "appveyor-repo-commit",
+      "APPVEYOR_REPO_NAME": "appveyor-repo-name",
+      "APPVEYOR_REPO_PROVIDER": "github"
+    },
+    {
+      "ci.job.url": "https://ci.appveyor.com/project/appveyor-repo-name/builds/appveyor-build-id",
+      "ci.pipeline.id": "appveyor-build-id",
+      "ci.pipeline.name": "appveyor-repo-name",
+      "ci.pipeline.number": "appveyor-pipeline-number",
+      "ci.pipeline.url": "https://ci.appveyor.com/project/appveyor-repo-name/builds/appveyor-build-id",
+      "ci.provider.name": "appveyor",
+      "ci.workspace_path": "/foo/bar",
+      "git.branch": "master",
+      "git.commit.sha": "appveyor-repo-commit",
+      "git.repository_url": "https://github.com/appveyor-repo-name.git"
+    }
+  ],
+  [
+    {
+      "APPVEYOR": "true",
+      "APPVEYOR_BUILD_FOLDER": "/foo/bar",
+      "APPVEYOR_BUILD_ID": "appveyor-build-id",
+      "APPVEYOR_BUILD_NUMBER": "appveyor-pipeline-number",
+      "APPVEYOR_REPO_BRANCH": "master",
+      "APPVEYOR_REPO_COMMIT": "appveyor-repo-commit",
+      "APPVEYOR_REPO_NAME": "appveyor-repo-name",
+      "APPVEYOR_REPO_PROVIDER": "github"
+    },
+    {
+      "ci.job.url": "https://ci.appveyor.com/project/appveyor-repo-name/builds/appveyor-build-id",
+      "ci.pipeline.id": "appveyor-build-id",
+      "ci.pipeline.name": "appveyor-repo-name",
+      "ci.pipeline.number": "appveyor-pipeline-number",
+      "ci.pipeline.url": "https://ci.appveyor.com/project/appveyor-repo-name/builds/appveyor-build-id",
+      "ci.provider.name": "appveyor",
+      "ci.workspace_path": "/foo/bar",
+      "git.branch": "master",
+      "git.commit.sha": "appveyor-repo-commit",
+      "git.repository_url": "https://github.com/appveyor-repo-name.git"
+    }
+  ],
+  [
+    {
+      "APPVEYOR": "true",
+      "APPVEYOR_BUILD_FOLDER": "foo/bar",
+      "APPVEYOR_BUILD_ID": "appveyor-build-id",
+      "APPVEYOR_BUILD_NUMBER": "appveyor-pipeline-number",
+      "APPVEYOR_REPO_BRANCH": "master",
+      "APPVEYOR_REPO_COMMIT": "appveyor-repo-commit",
+      "APPVEYOR_REPO_NAME": "appveyor-repo-name",
+      "APPVEYOR_REPO_PROVIDER": "github"
+    },
+    {
+      "ci.job.url": "https://ci.appveyor.com/project/appveyor-repo-name/builds/appveyor-build-id",
+      "ci.pipeline.id": "appveyor-build-id",
+      "ci.pipeline.name": "appveyor-repo-name",
+      "ci.pipeline.number": "appveyor-pipeline-number",
+      "ci.pipeline.url": "https://ci.appveyor.com/project/appveyor-repo-name/builds/appveyor-build-id",
+      "ci.provider.name": "appveyor",
+      "ci.workspace_path": "foo/bar",
+      "git.branch": "master",
+      "git.commit.sha": "appveyor-repo-commit",
+      "git.repository_url": "https://github.com/appveyor-repo-name.git"
+    }
+  ],
+  [
+    {
+      "APPVEYOR": "true",
+      "APPVEYOR_BUILD_FOLDER": "/foo/bar~",
+      "APPVEYOR_BUILD_ID": "appveyor-build-id",
+      "APPVEYOR_BUILD_NUMBER": "appveyor-pipeline-number",
+      "APPVEYOR_REPO_BRANCH": "master",
+      "APPVEYOR_REPO_COMMIT": "appveyor-repo-commit",
+      "APPVEYOR_REPO_NAME": "appveyor-repo-name",
+      "APPVEYOR_REPO_PROVIDER": "github"
+    },
+    {
+      "ci.job.url": "https://ci.appveyor.com/project/appveyor-repo-name/builds/appveyor-build-id",
+      "ci.pipeline.id": "appveyor-build-id",
+      "ci.pipeline.name": "appveyor-repo-name",
+      "ci.pipeline.number": "appveyor-pipeline-number",
+      "ci.pipeline.url": "https://ci.appveyor.com/project/appveyor-repo-name/builds/appveyor-build-id",
+      "ci.provider.name": "appveyor",
+      "ci.workspace_path": "/foo/bar~",
+      "git.branch": "master",
+      "git.commit.sha": "appveyor-repo-commit",
+      "git.repository_url": "https://github.com/appveyor-repo-name.git"
+    }
+  ],
+  [
+    {
+      "APPVEYOR": "true",
+      "APPVEYOR_BUILD_FOLDER": "/foo/~/bar",
+      "APPVEYOR_BUILD_ID": "appveyor-build-id",
+      "APPVEYOR_BUILD_NUMBER": "appveyor-pipeline-number",
+      "APPVEYOR_REPO_BRANCH": "master",
+      "APPVEYOR_REPO_COMMIT": "appveyor-repo-commit",
+      "APPVEYOR_REPO_NAME": "appveyor-repo-name",
+      "APPVEYOR_REPO_PROVIDER": "github"
+    },
+    {
+      "ci.job.url": "https://ci.appveyor.com/project/appveyor-repo-name/builds/appveyor-build-id",
+      "ci.pipeline.id": "appveyor-build-id",
+      "ci.pipeline.name": "appveyor-repo-name",
+      "ci.pipeline.number": "appveyor-pipeline-number",
+      "ci.pipeline.url": "https://ci.appveyor.com/project/appveyor-repo-name/builds/appveyor-build-id",
+      "ci.provider.name": "appveyor",
+      "ci.workspace_path": "/foo/~/bar",
+      "git.branch": "master",
+      "git.commit.sha": "appveyor-repo-commit",
+      "git.repository_url": "https://github.com/appveyor-repo-name.git"
+    }
+  ],
+  [
+    {
+      "APPVEYOR": "true",
+      "APPVEYOR_BUILD_FOLDER": "~/foo/bar",
+      "APPVEYOR_BUILD_ID": "appveyor-build-id",
+      "APPVEYOR_BUILD_NUMBER": "appveyor-pipeline-number",
+      "APPVEYOR_REPO_BRANCH": "master",
+      "APPVEYOR_REPO_COMMIT": "appveyor-repo-commit",
+      "APPVEYOR_REPO_NAME": "appveyor-repo-name",
+      "APPVEYOR_REPO_PROVIDER": "github",
+      "HOME": "/not-my-home",
+      "USERPROFILE": "/not-my-home"
+    },
+    {
+      "ci.job.url": "https://ci.appveyor.com/project/appveyor-repo-name/builds/appveyor-build-id",
+      "ci.pipeline.id": "appveyor-build-id",
+      "ci.pipeline.name": "appveyor-repo-name",
+      "ci.pipeline.number": "appveyor-pipeline-number",
+      "ci.pipeline.url": "https://ci.appveyor.com/project/appveyor-repo-name/builds/appveyor-build-id",
+      "ci.provider.name": "appveyor",
+      "ci.workspace_path": "/not-my-home/foo/bar",
+      "git.branch": "master",
+      "git.commit.sha": "appveyor-repo-commit",
+      "git.repository_url": "https://github.com/appveyor-repo-name.git"
+    }
+  ],
+  [
+    {
+      "APPVEYOR": "true",
+      "APPVEYOR_BUILD_FOLDER": "~foo/bar",
+      "APPVEYOR_BUILD_ID": "appveyor-build-id",
+      "APPVEYOR_BUILD_NUMBER": "appveyor-pipeline-number",
+      "APPVEYOR_REPO_BRANCH": "master",
+      "APPVEYOR_REPO_COMMIT": "appveyor-repo-commit",
+      "APPVEYOR_REPO_NAME": "appveyor-repo-name",
+      "APPVEYOR_REPO_PROVIDER": "github"
+    },
+    {
+      "ci.job.url": "https://ci.appveyor.com/project/appveyor-repo-name/builds/appveyor-build-id",
+      "ci.pipeline.id": "appveyor-build-id",
+      "ci.pipeline.name": "appveyor-repo-name",
+      "ci.pipeline.number": "appveyor-pipeline-number",
+      "ci.pipeline.url": "https://ci.appveyor.com/project/appveyor-repo-name/builds/appveyor-build-id",
+      "ci.provider.name": "appveyor",
+      "ci.workspace_path": "~foo/bar",
+      "git.branch": "master",
+      "git.commit.sha": "appveyor-repo-commit",
+      "git.repository_url": "https://github.com/appveyor-repo-name.git"
+    }
+  ],
+  [
+    {
+      "APPVEYOR": "true",
+      "APPVEYOR_BUILD_FOLDER": "~",
+      "APPVEYOR_BUILD_ID": "appveyor-build-id",
+      "APPVEYOR_BUILD_NUMBER": "appveyor-pipeline-number",
+      "APPVEYOR_REPO_BRANCH": "master",
+      "APPVEYOR_REPO_COMMIT": "appveyor-repo-commit",
+      "APPVEYOR_REPO_NAME": "appveyor-repo-name",
+      "APPVEYOR_REPO_PROVIDER": "github",
+      "HOME": "/not-my-home",
+      "USERPROFILE": "/not-my-home"
+    },
+    {
+      "ci.job.url": "https://ci.appveyor.com/project/appveyor-repo-name/builds/appveyor-build-id",
+      "ci.pipeline.id": "appveyor-build-id",
+      "ci.pipeline.name": "appveyor-repo-name",
+      "ci.pipeline.number": "appveyor-pipeline-number",
+      "ci.pipeline.url": "https://ci.appveyor.com/project/appveyor-repo-name/builds/appveyor-build-id",
+      "ci.provider.name": "appveyor",
+      "ci.workspace_path": "/not-my-home",
+      "git.branch": "master",
+      "git.commit.sha": "appveyor-repo-commit",
+      "git.repository_url": "https://github.com/appveyor-repo-name.git"
+    }
+  ],
+  [
+    {
+      "APPVEYOR": "true",
+      "APPVEYOR_BUILD_FOLDER": "/foo/bar",
+      "APPVEYOR_BUILD_ID": "appveyor-build-id",
+      "APPVEYOR_BUILD_NUMBER": "appveyor-pipeline-number",
+      "APPVEYOR_REPO_BRANCH": "master",
+      "APPVEYOR_REPO_COMMIT": "appveyor-repo-commit",
+      "APPVEYOR_REPO_NAME": "appveyor-repo-name"
+    },
+    {
+      "ci.job.url": "https://ci.appveyor.com/project/appveyor-repo-name/builds/appveyor-build-id",
+      "ci.pipeline.id": "appveyor-build-id",
+      "ci.pipeline.name": "appveyor-repo-name",
+      "ci.pipeline.number": "appveyor-pipeline-number",
+      "ci.pipeline.url": "https://ci.appveyor.com/project/appveyor-repo-name/builds/appveyor-build-id",
+      "ci.provider.name": "appveyor",
+      "ci.workspace_path": "/foo/bar"
+    }
+  ],
+  [
+    {
+      "APPVEYOR": "true",
+      "APPVEYOR_BUILD_FOLDER": "/foo/bar",
+      "APPVEYOR_BUILD_ID": "appveyor-build-id",
+      "APPVEYOR_BUILD_NUMBER": "appveyor-pipeline-number",
+      "APPVEYOR_REPO_BRANCH": "origin/master",
+      "APPVEYOR_REPO_COMMIT": "appveyor-repo-commit",
+      "APPVEYOR_REPO_NAME": "appveyor-repo-name",
+      "APPVEYOR_REPO_PROVIDER": "github"
+    },
+    {
+      "ci.job.url": "https://ci.appveyor.com/project/appveyor-repo-name/builds/appveyor-build-id",
+      "ci.pipeline.id": "appveyor-build-id",
+      "ci.pipeline.name": "appveyor-repo-name",
+      "ci.pipeline.number": "appveyor-pipeline-number",
+      "ci.pipeline.url": "https://ci.appveyor.com/project/appveyor-repo-name/builds/appveyor-build-id",
+      "ci.provider.name": "appveyor",
+      "ci.workspace_path": "/foo/bar",
+      "git.branch": "master",
+      "git.commit.sha": "appveyor-repo-commit",
+      "git.repository_url": "https://github.com/appveyor-repo-name.git"
+    }
+  ],
+  [
+    {
+      "APPVEYOR": "true",
+      "APPVEYOR_BUILD_FOLDER": "/foo/bar",
+      "APPVEYOR_BUILD_ID": "appveyor-build-id",
+      "APPVEYOR_BUILD_NUMBER": "appveyor-pipeline-number",
+      "APPVEYOR_REPO_BRANCH": "refs/heads/master",
+      "APPVEYOR_REPO_COMMIT": "appveyor-repo-commit",
+      "APPVEYOR_REPO_NAME": "appveyor-repo-name",
+      "APPVEYOR_REPO_PROVIDER": "github"
+    },
+    {
+      "ci.job.url": "https://ci.appveyor.com/project/appveyor-repo-name/builds/appveyor-build-id",
+      "ci.pipeline.id": "appveyor-build-id",
+      "ci.pipeline.name": "appveyor-repo-name",
+      "ci.pipeline.number": "appveyor-pipeline-number",
+      "ci.pipeline.url": "https://ci.appveyor.com/project/appveyor-repo-name/builds/appveyor-build-id",
+      "ci.provider.name": "appveyor",
+      "ci.workspace_path": "/foo/bar",
+      "git.branch": "master",
+      "git.commit.sha": "appveyor-repo-commit",
+      "git.repository_url": "https://github.com/appveyor-repo-name.git"
+    }
+  ],
+  [
+    {
+      "APPVEYOR": "true",
+      "APPVEYOR_BUILD_FOLDER": "/foo/bar",
+      "APPVEYOR_BUILD_ID": "appveyor-build-id",
+      "APPVEYOR_BUILD_NUMBER": "appveyor-pipeline-number",
+      "APPVEYOR_REPO_BRANCH": "refs/heads/feature/one",
+      "APPVEYOR_REPO_COMMIT": "appveyor-repo-commit",
+      "APPVEYOR_REPO_NAME": "appveyor-repo-name",
+      "APPVEYOR_REPO_PROVIDER": "github"
+    },
+    {
+      "ci.job.url": "https://ci.appveyor.com/project/appveyor-repo-name/builds/appveyor-build-id",
+      "ci.pipeline.id": "appveyor-build-id",
+      "ci.pipeline.name": "appveyor-repo-name",
+      "ci.pipeline.number": "appveyor-pipeline-number",
+      "ci.pipeline.url": "https://ci.appveyor.com/project/appveyor-repo-name/builds/appveyor-build-id",
+      "ci.provider.name": "appveyor",
+      "ci.workspace_path": "/foo/bar",
+      "git.branch": "feature/one",
+      "git.commit.sha": "appveyor-repo-commit",
+      "git.repository_url": "https://github.com/appveyor-repo-name.git"
+    }
+  ],
+  [
+    {
+      "APPVEYOR": "true",
+      "APPVEYOR_BUILD_FOLDER": "/foo/bar",
+      "APPVEYOR_BUILD_ID": "appveyor-build-id",
+      "APPVEYOR_BUILD_NUMBER": "appveyor-pipeline-number",
+      "APPVEYOR_PULL_REQUEST_HEAD_REPO_BRANCH": "origin/pr",
+      "APPVEYOR_REPO_BRANCH": "origin/master",
+      "APPVEYOR_REPO_COMMIT": "appveyor-repo-commit",
+      "APPVEYOR_REPO_NAME": "appveyor-repo-name",
+      "APPVEYOR_REPO_PROVIDER": "github"
+    },
+    {
+      "ci.job.url": "https://ci.appveyor.com/project/appveyor-repo-name/builds/appveyor-build-id",
+      "ci.pipeline.id": "appveyor-build-id",
+      "ci.pipeline.name": "appveyor-repo-name",
+      "ci.pipeline.number": "appveyor-pipeline-number",
+      "ci.pipeline.url": "https://ci.appveyor.com/project/appveyor-repo-name/builds/appveyor-build-id",
+      "ci.provider.name": "appveyor",
+      "ci.workspace_path": "/foo/bar",
+      "git.branch": "pr",
+      "git.commit.sha": "appveyor-repo-commit",
+      "git.repository_url": "https://github.com/appveyor-repo-name.git"
+    }
+  ],
+  [
+    {
+      "APPVEYOR": "true",
+      "APPVEYOR_BUILD_FOLDER": "/foo/bar",
+      "APPVEYOR_BUILD_ID": "appveyor-build-id",
+      "APPVEYOR_BUILD_NUMBER": "appveyor-pipeline-number",
+      "APPVEYOR_PULL_REQUEST_HEAD_REPO_BRANCH": "refs/heads/pr",
+      "APPVEYOR_REPO_BRANCH": "refs/heads/master",
+      "APPVEYOR_REPO_COMMIT": "appveyor-repo-commit",
+      "APPVEYOR_REPO_NAME": "appveyor-repo-name",
+      "APPVEYOR_REPO_PROVIDER": "github"
+    },
+    {
+      "ci.job.url": "https://ci.appveyor.com/project/appveyor-repo-name/builds/appveyor-build-id",
+      "ci.pipeline.id": "appveyor-build-id",
+      "ci.pipeline.name": "appveyor-repo-name",
+      "ci.pipeline.number": "appveyor-pipeline-number",
+      "ci.pipeline.url": "https://ci.appveyor.com/project/appveyor-repo-name/builds/appveyor-build-id",
+      "ci.provider.name": "appveyor",
+      "ci.workspace_path": "/foo/bar",
+      "git.branch": "pr",
+      "git.commit.sha": "appveyor-repo-commit",
+      "git.repository_url": "https://github.com/appveyor-repo-name.git"
+    }
+  ],
+  [
+    {
+      "APPVEYOR": "true",
+      "APPVEYOR_BUILD_FOLDER": "/foo/bar",
+      "APPVEYOR_BUILD_ID": "appveyor-build-id",
+      "APPVEYOR_BUILD_NUMBER": "appveyor-pipeline-number",
+      "APPVEYOR_REPO_BRANCH": "origin/master",
+      "APPVEYOR_REPO_COMMIT": "appveyor-repo-commit",
+      "APPVEYOR_REPO_NAME": "appveyor-repo-name",
+      "APPVEYOR_REPO_PROVIDER": "github",
+      "APPVEYOR_REPO_TAG_NAME": "origin/tags/0.1.0"
+    },
+    {
+      "ci.job.url": "https://ci.appveyor.com/project/appveyor-repo-name/builds/appveyor-build-id",
+      "ci.pipeline.id": "appveyor-build-id",
+      "ci.pipeline.name": "appveyor-repo-name",
+      "ci.pipeline.number": "appveyor-pipeline-number",
+      "ci.pipeline.url": "https://ci.appveyor.com/project/appveyor-repo-name/builds/appveyor-build-id",
+      "ci.provider.name": "appveyor",
+      "ci.workspace_path": "/foo/bar",
+      "git.commit.sha": "appveyor-repo-commit",
+      "git.repository_url": "https://github.com/appveyor-repo-name.git",
+      "git.tag": "0.1.0"
+    }
+  ],
+  [
+    {
+      "APPVEYOR": "true",
+      "APPVEYOR_BUILD_FOLDER": "/foo/bar",
+      "APPVEYOR_BUILD_ID": "appveyor-build-id",
+      "APPVEYOR_BUILD_NUMBER": "appveyor-pipeline-number",
+      "APPVEYOR_REPO_BRANCH": "refs/heads/master",
+      "APPVEYOR_REPO_COMMIT": "appveyor-repo-commit",
+      "APPVEYOR_REPO_NAME": "appveyor-repo-name",
+      "APPVEYOR_REPO_PROVIDER": "github",
+      "APPVEYOR_REPO_TAG_NAME": "refs/heads/tags/0.1.0"
+    },
+    {
+      "ci.job.url": "https://ci.appveyor.com/project/appveyor-repo-name/builds/appveyor-build-id",
+      "ci.pipeline.id": "appveyor-build-id",
+      "ci.pipeline.name": "appveyor-repo-name",
+      "ci.pipeline.number": "appveyor-pipeline-number",
+      "ci.pipeline.url": "https://ci.appveyor.com/project/appveyor-repo-name/builds/appveyor-build-id",
+      "ci.provider.name": "appveyor",
+      "ci.workspace_path": "/foo/bar",
+      "git.commit.sha": "appveyor-repo-commit",
+      "git.repository_url": "https://github.com/appveyor-repo-name.git",
+      "git.tag": "0.1.0"
+    }
+  ]
+]

--- a/src/helpers/__tests__/ci-env/azurepipelines.json
+++ b/src/helpers/__tests__/ci-env/azurepipelines.json
@@ -1,0 +1,532 @@
+[
+  [
+    {
+      "BUILD_BUILDID": "azure-pipelines-build-id",
+      "BUILD_DEFINITIONNAME": "azure-pipelines-name",
+      "BUILD_REPOSITORY_URI": "sample",
+      "BUILD_SOURCEBRANCH": "master",
+      "BUILD_SOURCESDIRECTORY": "/foo/bar",
+      "BUILD_SOURCEVERSION": "commit",
+      "SYSTEM_JOBID": "azure-pipelines-job-id",
+      "SYSTEM_TASKINSTANCEID": "azure-pipelines-task-id",
+      "SYSTEM_TEAMFOUNDATIONSERVERURI": "azure-pipelines-server-uri/",
+      "SYSTEM_TEAMPROJECTID": "azure-pipelines-project-id",
+      "TF_BUILD": "True"
+    },
+    {
+      "ci.job.url": "azure-pipelines-server-uri/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id&view=logs&j=azure-pipelines-job-id&t=azure-pipelines-task-id",
+      "ci.pipeline.id": "azure-pipelines-build-id",
+      "ci.pipeline.name": "azure-pipelines-name",
+      "ci.pipeline.number": "azure-pipelines-build-id",
+      "ci.pipeline.url": "azure-pipelines-server-uri/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id",
+      "ci.provider.name": "azurepipelines",
+      "ci.workspace_path": "/foo/bar",
+      "git.branch": "master",
+      "git.commit.sha": "commit",
+      "git.repository_url": "sample"
+    }
+  ],
+  [
+    {
+      "BUILD_BUILDID": "azure-pipelines-build-id",
+      "BUILD_DEFINITIONNAME": "azure-pipelines-name",
+      "BUILD_REPOSITORY_URI": "sample",
+      "BUILD_SOURCEBRANCH": "master",
+      "BUILD_SOURCESDIRECTORY": "/foo/bar",
+      "BUILD_SOURCEVERSION": "commit",
+      "SYSTEM_JOBID": "azure-pipelines-job-id",
+      "SYSTEM_TASKINSTANCEID": "azure-pipelines-task-id",
+      "SYSTEM_TEAMFOUNDATIONSERVERURI": "azure-pipelines-server-uri/",
+      "SYSTEM_TEAMPROJECTID": "azure-pipelines-project-id",
+      "TF_BUILD": "True"
+    },
+    {
+      "ci.job.url": "azure-pipelines-server-uri/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id&view=logs&j=azure-pipelines-job-id&t=azure-pipelines-task-id",
+      "ci.pipeline.id": "azure-pipelines-build-id",
+      "ci.pipeline.name": "azure-pipelines-name",
+      "ci.pipeline.number": "azure-pipelines-build-id",
+      "ci.pipeline.url": "azure-pipelines-server-uri/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id",
+      "ci.provider.name": "azurepipelines",
+      "ci.workspace_path": "/foo/bar",
+      "git.branch": "master",
+      "git.commit.sha": "commit",
+      "git.repository_url": "sample"
+    }
+  ],
+  [
+    {
+      "BUILD_BUILDID": "azure-pipelines-build-id",
+      "BUILD_DEFINITIONNAME": "azure-pipelines-name",
+      "BUILD_REPOSITORY_URI": "sample",
+      "BUILD_SOURCEBRANCH": "master",
+      "BUILD_SOURCESDIRECTORY": "/foo/bar",
+      "BUILD_SOURCEVERSION": "commit",
+      "SYSTEM_JOBID": "azure-pipelines-job-id",
+      "SYSTEM_PULLREQUEST_SOURCEREPOSITORYURI": "sample2",
+      "SYSTEM_TASKINSTANCEID": "azure-pipelines-task-id",
+      "SYSTEM_TEAMFOUNDATIONSERVERURI": "azure-pipelines-server-uri/",
+      "SYSTEM_TEAMPROJECTID": "azure-pipelines-project-id",
+      "TF_BUILD": "True"
+    },
+    {
+      "ci.job.url": "azure-pipelines-server-uri/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id&view=logs&j=azure-pipelines-job-id&t=azure-pipelines-task-id",
+      "ci.pipeline.id": "azure-pipelines-build-id",
+      "ci.pipeline.name": "azure-pipelines-name",
+      "ci.pipeline.number": "azure-pipelines-build-id",
+      "ci.pipeline.url": "azure-pipelines-server-uri/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id",
+      "ci.provider.name": "azurepipelines",
+      "ci.workspace_path": "/foo/bar",
+      "git.branch": "master",
+      "git.commit.sha": "commit",
+      "git.repository_url": "sample2"
+    }
+  ],
+  [
+    {
+      "BUILD_BUILDID": "azure-pipelines-build-id",
+      "BUILD_DEFINITIONNAME": "azure-pipelines-name",
+      "BUILD_REPOSITORY_URI": "sample",
+      "BUILD_SOURCEBRANCH": "master",
+      "BUILD_SOURCESDIRECTORY": "/foo/bar",
+      "BUILD_SOURCEVERSION": "commit",
+      "SYSTEM_JOBID": "azure-pipelines-job-id",
+      "SYSTEM_TASKINSTANCEID": "azure-pipelines-task-id",
+      "SYSTEM_TEAMFOUNDATIONSERVERURI": "azure-pipelines-server-uri/",
+      "SYSTEM_TEAMPROJECTID": "azure-pipelines-project-id",
+      "TF_BUILD": "True"
+    },
+    {
+      "ci.job.url": "azure-pipelines-server-uri/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id&view=logs&j=azure-pipelines-job-id&t=azure-pipelines-task-id",
+      "ci.pipeline.id": "azure-pipelines-build-id",
+      "ci.pipeline.name": "azure-pipelines-name",
+      "ci.pipeline.number": "azure-pipelines-build-id",
+      "ci.pipeline.url": "azure-pipelines-server-uri/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id",
+      "ci.provider.name": "azurepipelines",
+      "ci.workspace_path": "/foo/bar",
+      "git.branch": "master",
+      "git.commit.sha": "commit",
+      "git.repository_url": "sample"
+    }
+  ],
+  [
+    {
+      "BUILD_BUILDID": "azure-pipelines-build-id",
+      "BUILD_DEFINITIONNAME": "azure-pipelines-name",
+      "BUILD_REPOSITORY_URI": "sample",
+      "BUILD_SOURCEBRANCH": "master",
+      "BUILD_SOURCESDIRECTORY": "/foo/bar",
+      "BUILD_SOURCEVERSION": "commit",
+      "SYSTEM_JOBID": "azure-pipelines-job-id",
+      "SYSTEM_TASKINSTANCEID": "azure-pipelines-task-id",
+      "SYSTEM_TEAMFOUNDATIONSERVERURI": "azure-pipelines-server-uri/",
+      "SYSTEM_TEAMPROJECTID": "azure-pipelines-project-id",
+      "TF_BUILD": "True"
+    },
+    {
+      "ci.job.url": "azure-pipelines-server-uri/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id&view=logs&j=azure-pipelines-job-id&t=azure-pipelines-task-id",
+      "ci.pipeline.id": "azure-pipelines-build-id",
+      "ci.pipeline.name": "azure-pipelines-name",
+      "ci.pipeline.number": "azure-pipelines-build-id",
+      "ci.pipeline.url": "azure-pipelines-server-uri/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id",
+      "ci.provider.name": "azurepipelines",
+      "ci.workspace_path": "/foo/bar",
+      "git.branch": "master",
+      "git.commit.sha": "commit",
+      "git.repository_url": "sample"
+    }
+  ],
+  [
+    {
+      "BUILD_BUILDID": "azure-pipelines-build-id",
+      "BUILD_DEFINITIONNAME": "azure-pipelines-name",
+      "BUILD_REPOSITORY_URI": "sample",
+      "BUILD_SOURCEBRANCH": "origin/master",
+      "BUILD_SOURCESDIRECTORY": "foo/bar",
+      "BUILD_SOURCEVERSION": "commit",
+      "SYSTEM_JOBID": "azure-pipelines-job-id",
+      "SYSTEM_TASKINSTANCEID": "azure-pipelines-task-id",
+      "SYSTEM_TEAMFOUNDATIONSERVERURI": "azure-pipelines-server-uri/",
+      "SYSTEM_TEAMPROJECTID": "azure-pipelines-project-id",
+      "TF_BUILD": "True"
+    },
+    {
+      "ci.job.url": "azure-pipelines-server-uri/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id&view=logs&j=azure-pipelines-job-id&t=azure-pipelines-task-id",
+      "ci.pipeline.id": "azure-pipelines-build-id",
+      "ci.pipeline.name": "azure-pipelines-name",
+      "ci.pipeline.number": "azure-pipelines-build-id",
+      "ci.pipeline.url": "azure-pipelines-server-uri/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id",
+      "ci.provider.name": "azurepipelines",
+      "ci.workspace_path": "foo/bar",
+      "git.branch": "master",
+      "git.commit.sha": "commit",
+      "git.repository_url": "sample"
+    }
+  ],
+  [
+    {
+      "BUILD_BUILDID": "azure-pipelines-build-id",
+      "BUILD_DEFINITIONNAME": "azure-pipelines-name",
+      "BUILD_REPOSITORY_URI": "sample",
+      "BUILD_SOURCEBRANCH": "origin/master",
+      "BUILD_SOURCESDIRECTORY": "/foo/bar~",
+      "BUILD_SOURCEVERSION": "commit",
+      "HOME": "/not-my-home",
+      "SYSTEM_JOBID": "azure-pipelines-job-id",
+      "SYSTEM_TASKINSTANCEID": "azure-pipelines-task-id",
+      "SYSTEM_TEAMFOUNDATIONSERVERURI": "azure-pipelines-server-uri/",
+      "SYSTEM_TEAMPROJECTID": "azure-pipelines-project-id",
+      "TF_BUILD": "True",
+      "USERPROFILE": "/not-my-home"
+    },
+    {
+      "ci.job.url": "azure-pipelines-server-uri/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id&view=logs&j=azure-pipelines-job-id&t=azure-pipelines-task-id",
+      "ci.pipeline.id": "azure-pipelines-build-id",
+      "ci.pipeline.name": "azure-pipelines-name",
+      "ci.pipeline.number": "azure-pipelines-build-id",
+      "ci.pipeline.url": "azure-pipelines-server-uri/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id",
+      "ci.provider.name": "azurepipelines",
+      "ci.workspace_path": "/foo/bar~",
+      "git.branch": "master",
+      "git.commit.sha": "commit",
+      "git.repository_url": "sample"
+    }
+  ],
+  [
+    {
+      "BUILD_BUILDID": "azure-pipelines-build-id",
+      "BUILD_DEFINITIONNAME": "azure-pipelines-name",
+      "BUILD_REPOSITORY_URI": "sample",
+      "BUILD_SOURCEBRANCH": "origin/master",
+      "BUILD_SOURCESDIRECTORY": "/foo/~/bar",
+      "BUILD_SOURCEVERSION": "commit",
+      "HOME": "/not-my-home",
+      "SYSTEM_JOBID": "azure-pipelines-job-id",
+      "SYSTEM_TASKINSTANCEID": "azure-pipelines-task-id",
+      "SYSTEM_TEAMFOUNDATIONSERVERURI": "azure-pipelines-server-uri/",
+      "SYSTEM_TEAMPROJECTID": "azure-pipelines-project-id",
+      "TF_BUILD": "True",
+      "USERPROFILE": "/not-my-home"
+    },
+    {
+      "ci.job.url": "azure-pipelines-server-uri/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id&view=logs&j=azure-pipelines-job-id&t=azure-pipelines-task-id",
+      "ci.pipeline.id": "azure-pipelines-build-id",
+      "ci.pipeline.name": "azure-pipelines-name",
+      "ci.pipeline.number": "azure-pipelines-build-id",
+      "ci.pipeline.url": "azure-pipelines-server-uri/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id",
+      "ci.provider.name": "azurepipelines",
+      "ci.workspace_path": "/foo/~/bar",
+      "git.branch": "master",
+      "git.commit.sha": "commit",
+      "git.repository_url": "sample"
+    }
+  ],
+  [
+    {
+      "BUILD_BUILDID": "azure-pipelines-build-id",
+      "BUILD_DEFINITIONNAME": "azure-pipelines-name",
+      "BUILD_REPOSITORY_URI": "sample",
+      "BUILD_SOURCEBRANCH": "origin/master",
+      "BUILD_SOURCESDIRECTORY": "~/foo/bar",
+      "BUILD_SOURCEVERSION": "commit",
+      "HOME": "/not-my-home",
+      "SYSTEM_JOBID": "azure-pipelines-job-id",
+      "SYSTEM_TASKINSTANCEID": "azure-pipelines-task-id",
+      "SYSTEM_TEAMFOUNDATIONSERVERURI": "azure-pipelines-server-uri/",
+      "SYSTEM_TEAMPROJECTID": "azure-pipelines-project-id",
+      "TF_BUILD": "True",
+      "USERPROFILE": "/not-my-home"
+    },
+    {
+      "ci.job.url": "azure-pipelines-server-uri/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id&view=logs&j=azure-pipelines-job-id&t=azure-pipelines-task-id",
+      "ci.pipeline.id": "azure-pipelines-build-id",
+      "ci.pipeline.name": "azure-pipelines-name",
+      "ci.pipeline.number": "azure-pipelines-build-id",
+      "ci.pipeline.url": "azure-pipelines-server-uri/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id",
+      "ci.provider.name": "azurepipelines",
+      "ci.workspace_path": "/not-my-home/foo/bar",
+      "git.branch": "master",
+      "git.commit.sha": "commit",
+      "git.repository_url": "sample"
+    }
+  ],
+  [
+    {
+      "BUILD_BUILDID": "azure-pipelines-build-id",
+      "BUILD_DEFINITIONNAME": "azure-pipelines-name",
+      "BUILD_REPOSITORY_URI": "sample",
+      "BUILD_SOURCEBRANCH": "origin/master",
+      "BUILD_SOURCESDIRECTORY": "~foo/bar",
+      "BUILD_SOURCEVERSION": "commit",
+      "HOME": "/not-my-home",
+      "SYSTEM_JOBID": "azure-pipelines-job-id",
+      "SYSTEM_TASKINSTANCEID": "azure-pipelines-task-id",
+      "SYSTEM_TEAMFOUNDATIONSERVERURI": "azure-pipelines-server-uri/",
+      "SYSTEM_TEAMPROJECTID": "azure-pipelines-project-id",
+      "TF_BUILD": "True",
+      "USERPROFILE": "/not-my-home"
+    },
+    {
+      "ci.job.url": "azure-pipelines-server-uri/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id&view=logs&j=azure-pipelines-job-id&t=azure-pipelines-task-id",
+      "ci.pipeline.id": "azure-pipelines-build-id",
+      "ci.pipeline.name": "azure-pipelines-name",
+      "ci.pipeline.number": "azure-pipelines-build-id",
+      "ci.pipeline.url": "azure-pipelines-server-uri/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id",
+      "ci.provider.name": "azurepipelines",
+      "ci.workspace_path": "~foo/bar",
+      "git.branch": "master",
+      "git.commit.sha": "commit",
+      "git.repository_url": "sample"
+    }
+  ],
+  [
+    {
+      "BUILD_BUILDID": "azure-pipelines-build-id",
+      "BUILD_DEFINITIONNAME": "azure-pipelines-name",
+      "BUILD_REPOSITORY_URI": "sample",
+      "BUILD_SOURCEBRANCH": "origin/master",
+      "BUILD_SOURCESDIRECTORY": "~",
+      "BUILD_SOURCEVERSION": "commit",
+      "HOME": "/not-my-home",
+      "SYSTEM_JOBID": "azure-pipelines-job-id",
+      "SYSTEM_TASKINSTANCEID": "azure-pipelines-task-id",
+      "SYSTEM_TEAMFOUNDATIONSERVERURI": "azure-pipelines-server-uri/",
+      "SYSTEM_TEAMPROJECTID": "azure-pipelines-project-id",
+      "TF_BUILD": "True",
+      "USERPROFILE": "/not-my-home"
+    },
+    {
+      "ci.job.url": "azure-pipelines-server-uri/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id&view=logs&j=azure-pipelines-job-id&t=azure-pipelines-task-id",
+      "ci.pipeline.id": "azure-pipelines-build-id",
+      "ci.pipeline.name": "azure-pipelines-name",
+      "ci.pipeline.number": "azure-pipelines-build-id",
+      "ci.pipeline.url": "azure-pipelines-server-uri/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id",
+      "ci.provider.name": "azurepipelines",
+      "ci.workspace_path": "/not-my-home",
+      "git.branch": "master",
+      "git.commit.sha": "commit",
+      "git.repository_url": "sample"
+    }
+  ],
+  [
+    {
+      "BUILD_BUILDID": "azure-pipelines-build-id",
+      "BUILD_DEFINITIONNAME": "azure-pipelines-name",
+      "BUILD_REPOSITORY_URI": "sample",
+      "BUILD_SOURCEBRANCH": "origin/master",
+      "BUILD_SOURCESDIRECTORY": "/foo/bar",
+      "BUILD_SOURCEVERSION": "commit",
+      "SYSTEM_JOBID": "azure-pipelines-job-id",
+      "SYSTEM_TASKINSTANCEID": "azure-pipelines-task-id",
+      "SYSTEM_TEAMFOUNDATIONSERVERURI": "azure-pipelines-server-uri/",
+      "SYSTEM_TEAMPROJECTID": "azure-pipelines-project-id",
+      "TF_BUILD": "True"
+    },
+    {
+      "ci.job.url": "azure-pipelines-server-uri/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id&view=logs&j=azure-pipelines-job-id&t=azure-pipelines-task-id",
+      "ci.pipeline.id": "azure-pipelines-build-id",
+      "ci.pipeline.name": "azure-pipelines-name",
+      "ci.pipeline.number": "azure-pipelines-build-id",
+      "ci.pipeline.url": "azure-pipelines-server-uri/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id",
+      "ci.provider.name": "azurepipelines",
+      "ci.workspace_path": "/foo/bar",
+      "git.branch": "master",
+      "git.commit.sha": "commit",
+      "git.repository_url": "sample"
+    }
+  ],
+  [
+    {
+      "BUILD_BUILDID": "azure-pipelines-build-id",
+      "BUILD_DEFINITIONNAME": "azure-pipelines-name",
+      "BUILD_REPOSITORY_URI": "sample",
+      "BUILD_SOURCEBRANCH": "refs/heads/master",
+      "BUILD_SOURCESDIRECTORY": "/foo/bar",
+      "BUILD_SOURCEVERSION": "commit",
+      "SYSTEM_JOBID": "azure-pipelines-job-id",
+      "SYSTEM_TASKINSTANCEID": "azure-pipelines-task-id",
+      "SYSTEM_TEAMFOUNDATIONSERVERURI": "azure-pipelines-server-uri/",
+      "SYSTEM_TEAMPROJECTID": "azure-pipelines-project-id",
+      "TF_BUILD": "True"
+    },
+    {
+      "ci.job.url": "azure-pipelines-server-uri/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id&view=logs&j=azure-pipelines-job-id&t=azure-pipelines-task-id",
+      "ci.pipeline.id": "azure-pipelines-build-id",
+      "ci.pipeline.name": "azure-pipelines-name",
+      "ci.pipeline.number": "azure-pipelines-build-id",
+      "ci.pipeline.url": "azure-pipelines-server-uri/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id",
+      "ci.provider.name": "azurepipelines",
+      "ci.workspace_path": "/foo/bar",
+      "git.branch": "master",
+      "git.commit.sha": "commit",
+      "git.repository_url": "sample"
+    }
+  ],
+  [
+    {
+      "BUILD_BUILDID": "azure-pipelines-build-id",
+      "BUILD_DEFINITIONNAME": "azure-pipelines-name",
+      "BUILD_REPOSITORY_URI": "sample",
+      "BUILD_SOURCEBRANCH": "refs/heads/feature/one",
+      "BUILD_SOURCESDIRECTORY": "/foo/bar",
+      "BUILD_SOURCEVERSION": "commit",
+      "SYSTEM_JOBID": "azure-pipelines-job-id",
+      "SYSTEM_TASKINSTANCEID": "azure-pipelines-task-id",
+      "SYSTEM_TEAMFOUNDATIONSERVERURI": "azure-pipelines-server-uri/",
+      "SYSTEM_TEAMPROJECTID": "azure-pipelines-project-id",
+      "TF_BUILD": "True"
+    },
+    {
+      "ci.job.url": "azure-pipelines-server-uri/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id&view=logs&j=azure-pipelines-job-id&t=azure-pipelines-task-id",
+      "ci.pipeline.id": "azure-pipelines-build-id",
+      "ci.pipeline.name": "azure-pipelines-name",
+      "ci.pipeline.number": "azure-pipelines-build-id",
+      "ci.pipeline.url": "azure-pipelines-server-uri/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id",
+      "ci.provider.name": "azurepipelines",
+      "ci.workspace_path": "/foo/bar",
+      "git.branch": "feature/one",
+      "git.commit.sha": "commit",
+      "git.repository_url": "sample"
+    }
+  ],
+  [
+    {
+      "BUILD_BUILDID": "azure-pipelines-build-id",
+      "BUILD_DEFINITIONNAME": "azure-pipelines-name",
+      "BUILD_REPOSITORY_URI": "sample",
+      "BUILD_SOURCEBRANCH": "origin/tags/0.1.0",
+      "BUILD_SOURCESDIRECTORY": "/foo/bar",
+      "BUILD_SOURCEVERSION": "commit",
+      "SYSTEM_JOBID": "azure-pipelines-job-id",
+      "SYSTEM_TASKINSTANCEID": "azure-pipelines-task-id",
+      "SYSTEM_TEAMFOUNDATIONSERVERURI": "azure-pipelines-server-uri/",
+      "SYSTEM_TEAMPROJECTID": "azure-pipelines-project-id",
+      "TF_BUILD": "True"
+    },
+    {
+      "ci.job.url": "azure-pipelines-server-uri/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id&view=logs&j=azure-pipelines-job-id&t=azure-pipelines-task-id",
+      "ci.pipeline.id": "azure-pipelines-build-id",
+      "ci.pipeline.name": "azure-pipelines-name",
+      "ci.pipeline.number": "azure-pipelines-build-id",
+      "ci.pipeline.url": "azure-pipelines-server-uri/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id",
+      "ci.provider.name": "azurepipelines",
+      "ci.workspace_path": "/foo/bar",
+      "git.commit.sha": "commit",
+      "git.repository_url": "sample",
+      "git.tag": "0.1.0"
+    }
+  ],
+  [
+    {
+      "BUILD_BUILDID": "azure-pipelines-build-id",
+      "BUILD_DEFINITIONNAME": "azure-pipelines-name",
+      "BUILD_REPOSITORY_URI": "sample",
+      "BUILD_SOURCEBRANCH": "refs/heads/tags/0.1.0",
+      "BUILD_SOURCESDIRECTORY": "/foo/bar",
+      "BUILD_SOURCEVERSION": "commit",
+      "SYSTEM_JOBID": "azure-pipelines-job-id",
+      "SYSTEM_TASKINSTANCEID": "azure-pipelines-task-id",
+      "SYSTEM_TEAMFOUNDATIONSERVERURI": "azure-pipelines-server-uri/",
+      "SYSTEM_TEAMPROJECTID": "azure-pipelines-project-id",
+      "TF_BUILD": "True"
+    },
+    {
+      "ci.job.url": "azure-pipelines-server-uri/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id&view=logs&j=azure-pipelines-job-id&t=azure-pipelines-task-id",
+      "ci.pipeline.id": "azure-pipelines-build-id",
+      "ci.pipeline.name": "azure-pipelines-name",
+      "ci.pipeline.number": "azure-pipelines-build-id",
+      "ci.pipeline.url": "azure-pipelines-server-uri/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id",
+      "ci.provider.name": "azurepipelines",
+      "ci.workspace_path": "/foo/bar",
+      "git.commit.sha": "commit",
+      "git.repository_url": "sample",
+      "git.tag": "0.1.0"
+    }
+  ],
+  [
+    {
+      "BUILD_BUILDID": "azure-pipelines-build-id",
+      "BUILD_DEFINITIONNAME": "azure-pipelines-name",
+      "BUILD_REPOSITORY_URI": "sample",
+      "BUILD_SOURCEBRANCH": "origin/master",
+      "BUILD_SOURCESDIRECTORY": "/foo/bar",
+      "BUILD_SOURCEVERSION": "commit",
+      "SYSTEM_JOBID": "azure-pipelines-job-id",
+      "SYSTEM_PULLREQUEST_SOURCEBRANCH": "origin/pr",
+      "SYSTEM_PULLREQUEST_SOURCECOMMITID": "commitPR",
+      "SYSTEM_TASKINSTANCEID": "azure-pipelines-task-id",
+      "SYSTEM_TEAMFOUNDATIONSERVERURI": "azure-pipelines-server-uri/",
+      "SYSTEM_TEAMPROJECTID": "azure-pipelines-project-id",
+      "TF_BUILD": "True"
+    },
+    {
+      "ci.job.url": "azure-pipelines-server-uri/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id&view=logs&j=azure-pipelines-job-id&t=azure-pipelines-task-id",
+      "ci.pipeline.id": "azure-pipelines-build-id",
+      "ci.pipeline.name": "azure-pipelines-name",
+      "ci.pipeline.number": "azure-pipelines-build-id",
+      "ci.pipeline.url": "azure-pipelines-server-uri/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id",
+      "ci.provider.name": "azurepipelines",
+      "ci.workspace_path": "/foo/bar",
+      "git.branch": "pr",
+      "git.commit.sha": "commitPR",
+      "git.repository_url": "sample"
+    }
+  ],
+  [
+    {
+      "BUILD_BUILDID": "azure-pipelines-build-id",
+      "BUILD_DEFINITIONNAME": "azure-pipelines-name",
+      "BUILD_REPOSITORY_URI": "sample",
+      "BUILD_SOURCEBRANCH": "refs/heads/master",
+      "BUILD_SOURCESDIRECTORY": "/foo/bar",
+      "BUILD_SOURCEVERSION": "commit",
+      "SYSTEM_JOBID": "azure-pipelines-job-id",
+      "SYSTEM_PULLREQUEST_SOURCEBRANCH": "refs/heads/pr",
+      "SYSTEM_PULLREQUEST_SOURCECOMMITID": "commitPR",
+      "SYSTEM_TASKINSTANCEID": "azure-pipelines-task-id",
+      "SYSTEM_TEAMFOUNDATIONSERVERURI": "azure-pipelines-server-uri/",
+      "SYSTEM_TEAMPROJECTID": "azure-pipelines-project-id",
+      "TF_BUILD": "True"
+    },
+    {
+      "ci.job.url": "azure-pipelines-server-uri/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id&view=logs&j=azure-pipelines-job-id&t=azure-pipelines-task-id",
+      "ci.pipeline.id": "azure-pipelines-build-id",
+      "ci.pipeline.name": "azure-pipelines-name",
+      "ci.pipeline.number": "azure-pipelines-build-id",
+      "ci.pipeline.url": "azure-pipelines-server-uri/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id",
+      "ci.provider.name": "azurepipelines",
+      "ci.workspace_path": "/foo/bar",
+      "git.branch": "pr",
+      "git.commit.sha": "commitPR",
+      "git.repository_url": "sample"
+    }
+  ],
+  [
+    {
+      "BUILD_BUILDID": "azure-pipelines-build-id",
+      "BUILD_DEFINITIONNAME": "azure-pipelines-name",
+      "BUILD_REPOSITORY_URI": "sample",
+      "BUILD_SOURCEBRANCH": "refs/heads/feature/one",
+      "BUILD_SOURCESDIRECTORY": "/foo/bar",
+      "BUILD_SOURCEVERSION": "commit",
+      "SYSTEM_JOBID": "azure-pipelines-job-id",
+      "SYSTEM_PULLREQUEST_SOURCEBRANCH": "refs/heads/pr",
+      "SYSTEM_PULLREQUEST_SOURCECOMMITID": "commitPR",
+      "SYSTEM_TASKINSTANCEID": "azure-pipelines-task-id",
+      "SYSTEM_TEAMFOUNDATIONSERVERURI": "azure-pipelines-server-uri/",
+      "SYSTEM_TEAMPROJECTID": "azure-pipelines-project-id",
+      "TF_BUILD": "True"
+    },
+    {
+      "ci.job.url": "azure-pipelines-server-uri/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id&view=logs&j=azure-pipelines-job-id&t=azure-pipelines-task-id",
+      "ci.pipeline.id": "azure-pipelines-build-id",
+      "ci.pipeline.name": "azure-pipelines-name",
+      "ci.pipeline.number": "azure-pipelines-build-id",
+      "ci.pipeline.url": "azure-pipelines-server-uri/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id",
+      "ci.provider.name": "azurepipelines",
+      "ci.workspace_path": "/foo/bar",
+      "git.branch": "pr",
+      "git.commit.sha": "commitPR",
+      "git.repository_url": "sample"
+    }
+  ]
+]

--- a/src/helpers/__tests__/ci-env/bitbucket.json
+++ b/src/helpers/__tests__/ci-env/bitbucket.json
@@ -1,0 +1,374 @@
+[
+  [
+    {
+      "BITBUCKET_BRANCH": "master",
+      "BITBUCKET_BUILD_NUMBER": "bitbucket-build-num",
+      "BITBUCKET_CLONE_DIR": "/foo/bar",
+      "BITBUCKET_COMMIT": "bitbucket-commit",
+      "BITBUCKET_GIT_SSH_ORIGIN": "bitbucket-repo-url",
+      "BITBUCKET_PIPELINE_UUID": "{bitbucket-uuid}",
+      "BITBUCKET_REPO_FULL_NAME": "bitbucket-repo"
+    },
+    {
+      "ci.job.url": "https://bitbucket.org/bitbucket-repo/addon/pipelines/home#!/results/bitbucket-build-num",
+      "ci.pipeline.id": "bitbucket-uuid",
+      "ci.pipeline.name": "bitbucket-repo",
+      "ci.pipeline.number": "bitbucket-build-num",
+      "ci.pipeline.url": "https://bitbucket.org/bitbucket-repo/addon/pipelines/home#!/results/bitbucket-build-num",
+      "ci.provider.name": "bitbucket",
+      "ci.workspace_path": "/foo/bar",
+      "git.branch": "master",
+      "git.commit.sha": "bitbucket-commit",
+      "git.repository_url": "bitbucket-repo-url"
+    }
+  ],
+  [
+    {
+      "BITBUCKET_BRANCH": "master",
+      "BITBUCKET_BUILD_NUMBER": "bitbucket-build-num",
+      "BITBUCKET_CLONE_DIR": "/foo/bar",
+      "BITBUCKET_COMMIT": "bitbucket-commit",
+      "BITBUCKET_GIT_SSH_ORIGIN": "bitbucket-repo-url",
+      "BITBUCKET_PIPELINE_UUID": "{bitbucket-uuid}",
+      "BITBUCKET_REPO_FULL_NAME": "bitbucket-repo"
+    },
+    {
+      "ci.job.url": "https://bitbucket.org/bitbucket-repo/addon/pipelines/home#!/results/bitbucket-build-num",
+      "ci.pipeline.id": "bitbucket-uuid",
+      "ci.pipeline.name": "bitbucket-repo",
+      "ci.pipeline.number": "bitbucket-build-num",
+      "ci.pipeline.url": "https://bitbucket.org/bitbucket-repo/addon/pipelines/home#!/results/bitbucket-build-num",
+      "ci.provider.name": "bitbucket",
+      "ci.workspace_path": "/foo/bar",
+      "git.branch": "master",
+      "git.commit.sha": "bitbucket-commit",
+      "git.repository_url": "bitbucket-repo-url"
+    }
+  ],
+  [
+    {
+      "BITBUCKET_BRANCH": "master",
+      "BITBUCKET_BUILD_NUMBER": "bitbucket-build-num",
+      "BITBUCKET_CLONE_DIR": "foo/bar",
+      "BITBUCKET_COMMIT": "bitbucket-commit",
+      "BITBUCKET_GIT_SSH_ORIGIN": "bitbucket-repo-url",
+      "BITBUCKET_PIPELINE_UUID": "{bitbucket-uuid}",
+      "BITBUCKET_REPO_FULL_NAME": "bitbucket-repo"
+    },
+    {
+      "ci.job.url": "https://bitbucket.org/bitbucket-repo/addon/pipelines/home#!/results/bitbucket-build-num",
+      "ci.pipeline.id": "bitbucket-uuid",
+      "ci.pipeline.name": "bitbucket-repo",
+      "ci.pipeline.number": "bitbucket-build-num",
+      "ci.pipeline.url": "https://bitbucket.org/bitbucket-repo/addon/pipelines/home#!/results/bitbucket-build-num",
+      "ci.provider.name": "bitbucket",
+      "ci.workspace_path": "foo/bar",
+      "git.branch": "master",
+      "git.commit.sha": "bitbucket-commit",
+      "git.repository_url": "bitbucket-repo-url"
+    }
+  ],
+  [
+    {
+      "BITBUCKET_BRANCH": "master",
+      "BITBUCKET_BUILD_NUMBER": "bitbucket-build-num",
+      "BITBUCKET_CLONE_DIR": "/foo/bar~",
+      "BITBUCKET_COMMIT": "bitbucket-commit",
+      "BITBUCKET_GIT_SSH_ORIGIN": "bitbucket-repo-url",
+      "BITBUCKET_PIPELINE_UUID": "{bitbucket-uuid}",
+      "BITBUCKET_REPO_FULL_NAME": "bitbucket-repo"
+    },
+    {
+      "ci.job.url": "https://bitbucket.org/bitbucket-repo/addon/pipelines/home#!/results/bitbucket-build-num",
+      "ci.pipeline.id": "bitbucket-uuid",
+      "ci.pipeline.name": "bitbucket-repo",
+      "ci.pipeline.number": "bitbucket-build-num",
+      "ci.pipeline.url": "https://bitbucket.org/bitbucket-repo/addon/pipelines/home#!/results/bitbucket-build-num",
+      "ci.provider.name": "bitbucket",
+      "ci.workspace_path": "/foo/bar~",
+      "git.branch": "master",
+      "git.commit.sha": "bitbucket-commit",
+      "git.repository_url": "bitbucket-repo-url"
+    }
+  ],
+  [
+    {
+      "BITBUCKET_BRANCH": "master",
+      "BITBUCKET_BUILD_NUMBER": "bitbucket-build-num",
+      "BITBUCKET_CLONE_DIR": "/foo/~/bar",
+      "BITBUCKET_COMMIT": "bitbucket-commit",
+      "BITBUCKET_GIT_SSH_ORIGIN": "bitbucket-repo-url",
+      "BITBUCKET_PIPELINE_UUID": "{bitbucket-uuid}",
+      "BITBUCKET_REPO_FULL_NAME": "bitbucket-repo"
+    },
+    {
+      "ci.job.url": "https://bitbucket.org/bitbucket-repo/addon/pipelines/home#!/results/bitbucket-build-num",
+      "ci.pipeline.id": "bitbucket-uuid",
+      "ci.pipeline.name": "bitbucket-repo",
+      "ci.pipeline.number": "bitbucket-build-num",
+      "ci.pipeline.url": "https://bitbucket.org/bitbucket-repo/addon/pipelines/home#!/results/bitbucket-build-num",
+      "ci.provider.name": "bitbucket",
+      "ci.workspace_path": "/foo/~/bar",
+      "git.branch": "master",
+      "git.commit.sha": "bitbucket-commit",
+      "git.repository_url": "bitbucket-repo-url"
+    }
+  ],
+  [
+    {
+      "BITBUCKET_BRANCH": "master",
+      "BITBUCKET_BUILD_NUMBER": "bitbucket-build-num",
+      "BITBUCKET_CLONE_DIR": "~/foo/bar",
+      "BITBUCKET_COMMIT": "bitbucket-commit",
+      "BITBUCKET_GIT_SSH_ORIGIN": "bitbucket-repo-url",
+      "BITBUCKET_PIPELINE_UUID": "{bitbucket-uuid}",
+      "BITBUCKET_REPO_FULL_NAME": "bitbucket-repo",
+      "HOME": "/not-my-home",
+      "USERPROFILE": "/not-my-home"
+    },
+    {
+      "ci.job.url": "https://bitbucket.org/bitbucket-repo/addon/pipelines/home#!/results/bitbucket-build-num",
+      "ci.pipeline.id": "bitbucket-uuid",
+      "ci.pipeline.name": "bitbucket-repo",
+      "ci.pipeline.number": "bitbucket-build-num",
+      "ci.pipeline.url": "https://bitbucket.org/bitbucket-repo/addon/pipelines/home#!/results/bitbucket-build-num",
+      "ci.provider.name": "bitbucket",
+      "ci.workspace_path": "/not-my-home/foo/bar",
+      "git.branch": "master",
+      "git.commit.sha": "bitbucket-commit",
+      "git.repository_url": "bitbucket-repo-url"
+    }
+  ],
+  [
+    {
+      "BITBUCKET_BRANCH": "master",
+      "BITBUCKET_BUILD_NUMBER": "bitbucket-build-num",
+      "BITBUCKET_CLONE_DIR": "~foo/bar",
+      "BITBUCKET_COMMIT": "bitbucket-commit",
+      "BITBUCKET_GIT_SSH_ORIGIN": "bitbucket-repo-url",
+      "BITBUCKET_PIPELINE_UUID": "{bitbucket-uuid}",
+      "BITBUCKET_REPO_FULL_NAME": "bitbucket-repo"
+    },
+    {
+      "ci.job.url": "https://bitbucket.org/bitbucket-repo/addon/pipelines/home#!/results/bitbucket-build-num",
+      "ci.pipeline.id": "bitbucket-uuid",
+      "ci.pipeline.name": "bitbucket-repo",
+      "ci.pipeline.number": "bitbucket-build-num",
+      "ci.pipeline.url": "https://bitbucket.org/bitbucket-repo/addon/pipelines/home#!/results/bitbucket-build-num",
+      "ci.provider.name": "bitbucket",
+      "ci.workspace_path": "~foo/bar",
+      "git.branch": "master",
+      "git.commit.sha": "bitbucket-commit",
+      "git.repository_url": "bitbucket-repo-url"
+    }
+  ],
+  [
+    {
+      "BITBUCKET_BRANCH": "master",
+      "BITBUCKET_BUILD_NUMBER": "bitbucket-build-num",
+      "BITBUCKET_CLONE_DIR": "~",
+      "BITBUCKET_COMMIT": "bitbucket-commit",
+      "BITBUCKET_GIT_SSH_ORIGIN": "bitbucket-repo-url",
+      "BITBUCKET_PIPELINE_UUID": "{bitbucket-uuid}",
+      "BITBUCKET_REPO_FULL_NAME": "bitbucket-repo",
+      "HOME": "/not-my-home",
+      "USERPROFILE": "/not-my-home"
+    },
+    {
+      "ci.job.url": "https://bitbucket.org/bitbucket-repo/addon/pipelines/home#!/results/bitbucket-build-num",
+      "ci.pipeline.id": "bitbucket-uuid",
+      "ci.pipeline.name": "bitbucket-repo",
+      "ci.pipeline.number": "bitbucket-build-num",
+      "ci.pipeline.url": "https://bitbucket.org/bitbucket-repo/addon/pipelines/home#!/results/bitbucket-build-num",
+      "ci.provider.name": "bitbucket",
+      "ci.workspace_path": "/not-my-home",
+      "git.branch": "master",
+      "git.commit.sha": "bitbucket-commit",
+      "git.repository_url": "bitbucket-repo-url"
+    }
+  ],
+  [
+    {
+      "BITBUCKET_BRANCH": "master",
+      "BITBUCKET_BUILD_NUMBER": "bitbucket-build-num",
+      "BITBUCKET_CLONE_DIR": "/foo/bar",
+      "BITBUCKET_COMMIT": "bitbucket-commit",
+      "BITBUCKET_GIT_SSH_ORIGIN": "bitbucket-repo-url",
+      "BITBUCKET_PIPELINE_UUID": "{bitbucket-uuid}",
+      "BITBUCKET_REPO_FULL_NAME": "bitbucket-repo"
+    },
+    {
+      "ci.job.url": "https://bitbucket.org/bitbucket-repo/addon/pipelines/home#!/results/bitbucket-build-num",
+      "ci.pipeline.id": "bitbucket-uuid",
+      "ci.pipeline.name": "bitbucket-repo",
+      "ci.pipeline.number": "bitbucket-build-num",
+      "ci.pipeline.url": "https://bitbucket.org/bitbucket-repo/addon/pipelines/home#!/results/bitbucket-build-num",
+      "ci.provider.name": "bitbucket",
+      "ci.workspace_path": "/foo/bar",
+      "git.branch": "master",
+      "git.commit.sha": "bitbucket-commit",
+      "git.repository_url": "bitbucket-repo-url"
+    }
+  ],
+  [
+    {
+      "BITBUCKET_BRANCH": "origin/master",
+      "BITBUCKET_BUILD_NUMBER": "bitbucket-build-num",
+      "BITBUCKET_CLONE_DIR": "/foo/bar",
+      "BITBUCKET_COMMIT": "bitbucket-commit",
+      "BITBUCKET_GIT_SSH_ORIGIN": "bitbucket-repo-url",
+      "BITBUCKET_PIPELINE_UUID": "{bitbucket-uuid}",
+      "BITBUCKET_REPO_FULL_NAME": "bitbucket-repo"
+    },
+    {
+      "ci.job.url": "https://bitbucket.org/bitbucket-repo/addon/pipelines/home#!/results/bitbucket-build-num",
+      "ci.pipeline.id": "bitbucket-uuid",
+      "ci.pipeline.name": "bitbucket-repo",
+      "ci.pipeline.number": "bitbucket-build-num",
+      "ci.pipeline.url": "https://bitbucket.org/bitbucket-repo/addon/pipelines/home#!/results/bitbucket-build-num",
+      "ci.provider.name": "bitbucket",
+      "ci.workspace_path": "/foo/bar",
+      "git.branch": "master",
+      "git.commit.sha": "bitbucket-commit",
+      "git.repository_url": "bitbucket-repo-url"
+    }
+  ],
+  [
+    {
+      "BITBUCKET_BRANCH": "refs/heads/master",
+      "BITBUCKET_BUILD_NUMBER": "bitbucket-build-num",
+      "BITBUCKET_CLONE_DIR": "/foo/bar",
+      "BITBUCKET_COMMIT": "bitbucket-commit",
+      "BITBUCKET_GIT_SSH_ORIGIN": "bitbucket-repo-url",
+      "BITBUCKET_PIPELINE_UUID": "{bitbucket-uuid}",
+      "BITBUCKET_REPO_FULL_NAME": "bitbucket-repo"
+    },
+    {
+      "ci.job.url": "https://bitbucket.org/bitbucket-repo/addon/pipelines/home#!/results/bitbucket-build-num",
+      "ci.pipeline.id": "bitbucket-uuid",
+      "ci.pipeline.name": "bitbucket-repo",
+      "ci.pipeline.number": "bitbucket-build-num",
+      "ci.pipeline.url": "https://bitbucket.org/bitbucket-repo/addon/pipelines/home#!/results/bitbucket-build-num",
+      "ci.provider.name": "bitbucket",
+      "ci.workspace_path": "/foo/bar",
+      "git.branch": "master",
+      "git.commit.sha": "bitbucket-commit",
+      "git.repository_url": "bitbucket-repo-url"
+    }
+  ],
+  [
+    {
+      "BITBUCKET_BRANCH": "refs/heads/feature/one",
+      "BITBUCKET_BUILD_NUMBER": "bitbucket-build-num",
+      "BITBUCKET_CLONE_DIR": "/foo/bar",
+      "BITBUCKET_COMMIT": "bitbucket-commit",
+      "BITBUCKET_GIT_SSH_ORIGIN": "bitbucket-repo-url",
+      "BITBUCKET_PIPELINE_UUID": "{bitbucket-uuid}",
+      "BITBUCKET_REPO_FULL_NAME": "bitbucket-repo"
+    },
+    {
+      "ci.job.url": "https://bitbucket.org/bitbucket-repo/addon/pipelines/home#!/results/bitbucket-build-num",
+      "ci.pipeline.id": "bitbucket-uuid",
+      "ci.pipeline.name": "bitbucket-repo",
+      "ci.pipeline.number": "bitbucket-build-num",
+      "ci.pipeline.url": "https://bitbucket.org/bitbucket-repo/addon/pipelines/home#!/results/bitbucket-build-num",
+      "ci.provider.name": "bitbucket",
+      "ci.workspace_path": "/foo/bar",
+      "git.branch": "feature/one",
+      "git.commit.sha": "bitbucket-commit",
+      "git.repository_url": "bitbucket-repo-url"
+    }
+  ],
+  [
+    {
+      "BITBUCKET_BRANCH": "origin/master",
+      "BITBUCKET_BUILD_NUMBER": "bitbucket-build-num",
+      "BITBUCKET_CLONE_DIR": "/foo/bar",
+      "BITBUCKET_COMMIT": "bitbucket-commit",
+      "BITBUCKET_GIT_SSH_ORIGIN": "bitbucket-repo-url",
+      "BITBUCKET_PIPELINE_UUID": "{bitbucket-uuid}",
+      "BITBUCKET_REPO_FULL_NAME": "bitbucket-repo"
+    },
+    {
+      "ci.job.url": "https://bitbucket.org/bitbucket-repo/addon/pipelines/home#!/results/bitbucket-build-num",
+      "ci.pipeline.id": "bitbucket-uuid",
+      "ci.pipeline.name": "bitbucket-repo",
+      "ci.pipeline.number": "bitbucket-build-num",
+      "ci.pipeline.url": "https://bitbucket.org/bitbucket-repo/addon/pipelines/home#!/results/bitbucket-build-num",
+      "ci.provider.name": "bitbucket",
+      "ci.workspace_path": "/foo/bar",
+      "git.branch": "master",
+      "git.commit.sha": "bitbucket-commit",
+      "git.repository_url": "bitbucket-repo-url"
+    }
+  ],
+  [
+    {
+      "BITBUCKET_BRANCH": "refs/heads/master",
+      "BITBUCKET_BUILD_NUMBER": "bitbucket-build-num",
+      "BITBUCKET_CLONE_DIR": "/foo/bar",
+      "BITBUCKET_COMMIT": "bitbucket-commit",
+      "BITBUCKET_GIT_SSH_ORIGIN": "bitbucket-repo-url",
+      "BITBUCKET_PIPELINE_UUID": "{bitbucket-uuid}",
+      "BITBUCKET_REPO_FULL_NAME": "bitbucket-repo"
+    },
+    {
+      "ci.job.url": "https://bitbucket.org/bitbucket-repo/addon/pipelines/home#!/results/bitbucket-build-num",
+      "ci.pipeline.id": "bitbucket-uuid",
+      "ci.pipeline.name": "bitbucket-repo",
+      "ci.pipeline.number": "bitbucket-build-num",
+      "ci.pipeline.url": "https://bitbucket.org/bitbucket-repo/addon/pipelines/home#!/results/bitbucket-build-num",
+      "ci.provider.name": "bitbucket",
+      "ci.workspace_path": "/foo/bar",
+      "git.branch": "master",
+      "git.commit.sha": "bitbucket-commit",
+      "git.repository_url": "bitbucket-repo-url"
+    }
+  ],
+  [
+    {
+      "BITBUCKET_BUILD_NUMBER": "bitbucket-build-num",
+      "BITBUCKET_CLONE_DIR": "/foo/bar",
+      "BITBUCKET_COMMIT": "bitbucket-commit",
+      "BITBUCKET_GIT_SSH_ORIGIN": "bitbucket-repo-url",
+      "BITBUCKET_PIPELINE_UUID": "{bitbucket-uuid}",
+      "BITBUCKET_REPO_FULL_NAME": "bitbucket-repo",
+      "BITBUCKET_TAG": "origin/tags/0.1.0"
+    },
+    {
+      "ci.job.url": "https://bitbucket.org/bitbucket-repo/addon/pipelines/home#!/results/bitbucket-build-num",
+      "ci.pipeline.id": "bitbucket-uuid",
+      "ci.pipeline.name": "bitbucket-repo",
+      "ci.pipeline.number": "bitbucket-build-num",
+      "ci.pipeline.url": "https://bitbucket.org/bitbucket-repo/addon/pipelines/home#!/results/bitbucket-build-num",
+      "ci.provider.name": "bitbucket",
+      "ci.workspace_path": "/foo/bar",
+      "git.commit.sha": "bitbucket-commit",
+      "git.repository_url": "bitbucket-repo-url",
+      "git.tag": "0.1.0"
+    }
+  ],
+  [
+    {
+      "BITBUCKET_BUILD_NUMBER": "bitbucket-build-num",
+      "BITBUCKET_CLONE_DIR": "/foo/bar",
+      "BITBUCKET_COMMIT": "bitbucket-commit",
+      "BITBUCKET_GIT_SSH_ORIGIN": "bitbucket-repo-url",
+      "BITBUCKET_PIPELINE_UUID": "{bitbucket-uuid}",
+      "BITBUCKET_REPO_FULL_NAME": "bitbucket-repo",
+      "BITBUCKET_TAG": "refs/heads/tags/0.1.0"
+    },
+    {
+      "ci.job.url": "https://bitbucket.org/bitbucket-repo/addon/pipelines/home#!/results/bitbucket-build-num",
+      "ci.pipeline.id": "bitbucket-uuid",
+      "ci.pipeline.name": "bitbucket-repo",
+      "ci.pipeline.number": "bitbucket-build-num",
+      "ci.pipeline.url": "https://bitbucket.org/bitbucket-repo/addon/pipelines/home#!/results/bitbucket-build-num",
+      "ci.provider.name": "bitbucket",
+      "ci.workspace_path": "/foo/bar",
+      "git.commit.sha": "bitbucket-commit",
+      "git.repository_url": "bitbucket-repo-url",
+      "git.tag": "0.1.0"
+    }
+  ]
+]

--- a/src/helpers/__tests__/ci-env/bitrise.json
+++ b/src/helpers/__tests__/ci-env/bitrise.json
@@ -1,0 +1,493 @@
+[
+  [
+    {
+      "BITRISE_APP_TITLE": "bitrise-pipeline-name",
+      "BITRISE_BUILD_NUMBER": "bitrise-pipeline-number",
+      "BITRISE_BUILD_SLUG": "bitrise-pipeline-id",
+      "BITRISE_BUILD_URL": "bitrise-build-url",
+      "BITRISE_GIT_COMMIT": "gitcommit",
+      "BITRISE_SOURCE_DIR": "/foo/bar",
+      "GIT_CLONE_COMMIT_HASH": "bitrise-git-commit",
+      "GIT_REPOSITORY_URL": "sample"
+    },
+    {
+      "ci.pipeline.id": "bitrise-pipeline-id",
+      "ci.pipeline.name": "bitrise-pipeline-name",
+      "ci.pipeline.number": "bitrise-pipeline-number",
+      "ci.pipeline.url": "bitrise-build-url",
+      "ci.provider.name": "bitrise",
+      "ci.workspace_path": "/foo/bar",
+      "git.commit.sha": "gitcommit",
+      "git.repository_url": "sample"
+    }
+  ],
+  [
+    {
+      "BITRISE_APP_TITLE": "bitrise-pipeline-name",
+      "BITRISE_BUILD_NUMBER": "bitrise-pipeline-number",
+      "BITRISE_BUILD_SLUG": "bitrise-pipeline-id",
+      "BITRISE_BUILD_URL": "bitrise-build-url",
+      "BITRISE_GIT_BRANCH": "origin/master",
+      "BITRISE_SOURCE_DIR": "/foo/bar",
+      "GIT_CLONE_COMMIT_HASH": "bitrise-git-commit",
+      "GIT_REPOSITORY_URL": "sample"
+    },
+    {
+      "ci.pipeline.id": "bitrise-pipeline-id",
+      "ci.pipeline.name": "bitrise-pipeline-name",
+      "ci.pipeline.number": "bitrise-pipeline-number",
+      "ci.pipeline.url": "bitrise-build-url",
+      "ci.provider.name": "bitrise",
+      "ci.workspace_path": "/foo/bar",
+      "git.branch": "master",
+      "git.commit.sha": "bitrise-git-commit",
+      "git.repository_url": "sample"
+    }
+  ],
+  [
+    {
+      "BITRISE_APP_TITLE": "bitrise-pipeline-name",
+      "BITRISE_BUILD_NUMBER": "bitrise-pipeline-number",
+      "BITRISE_BUILD_SLUG": "bitrise-pipeline-id",
+      "BITRISE_BUILD_URL": "bitrise-build-url",
+      "BITRISE_GIT_BRANCH": "origin/master",
+      "BITRISE_SOURCE_DIR": "/foo/bar",
+      "GIT_CLONE_COMMIT_HASH": "bitrise-git-commit",
+      "GIT_REPOSITORY_URL": "sample"
+    },
+    {
+      "ci.pipeline.id": "bitrise-pipeline-id",
+      "ci.pipeline.name": "bitrise-pipeline-name",
+      "ci.pipeline.number": "bitrise-pipeline-number",
+      "ci.pipeline.url": "bitrise-build-url",
+      "ci.provider.name": "bitrise",
+      "ci.workspace_path": "/foo/bar",
+      "git.branch": "master",
+      "git.commit.sha": "bitrise-git-commit",
+      "git.repository_url": "sample"
+    }
+  ],
+  [
+    {
+      "BITRISE_APP_TITLE": "bitrise-pipeline-name",
+      "BITRISE_BUILD_NUMBER": "bitrise-pipeline-number",
+      "BITRISE_BUILD_SLUG": "bitrise-pipeline-id",
+      "BITRISE_BUILD_URL": "bitrise-build-url",
+      "BITRISE_GIT_BRANCH": "origin/master",
+      "BITRISE_SOURCE_DIR": "/foo/bar",
+      "GIT_CLONE_COMMIT_HASH": "bitrise-git-commit",
+      "GIT_REPOSITORY_URL": "sample"
+    },
+    {
+      "ci.pipeline.id": "bitrise-pipeline-id",
+      "ci.pipeline.name": "bitrise-pipeline-name",
+      "ci.pipeline.number": "bitrise-pipeline-number",
+      "ci.pipeline.url": "bitrise-build-url",
+      "ci.provider.name": "bitrise",
+      "ci.workspace_path": "/foo/bar",
+      "git.branch": "master",
+      "git.commit.sha": "bitrise-git-commit",
+      "git.repository_url": "sample"
+    }
+  ],
+  [
+    {
+      "BITRISE_APP_TITLE": "bitrise-pipeline-name",
+      "BITRISE_BUILD_NUMBER": "bitrise-pipeline-number",
+      "BITRISE_BUILD_SLUG": "bitrise-pipeline-id",
+      "BITRISE_BUILD_URL": "bitrise-build-url",
+      "BITRISE_GIT_BRANCH": "origin/master",
+      "BITRISE_SOURCE_DIR": "/foo/bar",
+      "GIT_CLONE_COMMIT_HASH": "bitrise-git-commit",
+      "GIT_REPOSITORY_URL": "sample"
+    },
+    {
+      "ci.pipeline.id": "bitrise-pipeline-id",
+      "ci.pipeline.name": "bitrise-pipeline-name",
+      "ci.pipeline.number": "bitrise-pipeline-number",
+      "ci.pipeline.url": "bitrise-build-url",
+      "ci.provider.name": "bitrise",
+      "ci.workspace_path": "/foo/bar",
+      "git.branch": "master",
+      "git.commit.sha": "bitrise-git-commit",
+      "git.repository_url": "sample"
+    }
+  ],
+  [
+    {
+      "BITRISE_APP_TITLE": "bitrise-pipeline-name",
+      "BITRISE_BUILD_NUMBER": "bitrise-pipeline-number",
+      "BITRISE_BUILD_SLUG": "bitrise-pipeline-id",
+      "BITRISE_BUILD_URL": "bitrise-build-url",
+      "BITRISE_GIT_BRANCH": "origin/master",
+      "BITRISE_SOURCE_DIR": "foo/bar",
+      "GIT_CLONE_COMMIT_HASH": "bitrise-git-commit",
+      "GIT_REPOSITORY_URL": "sample"
+    },
+    {
+      "ci.pipeline.id": "bitrise-pipeline-id",
+      "ci.pipeline.name": "bitrise-pipeline-name",
+      "ci.pipeline.number": "bitrise-pipeline-number",
+      "ci.pipeline.url": "bitrise-build-url",
+      "ci.provider.name": "bitrise",
+      "ci.workspace_path": "foo/bar",
+      "git.branch": "master",
+      "git.commit.sha": "bitrise-git-commit",
+      "git.repository_url": "sample"
+    }
+  ],
+  [
+    {
+      "BITRISE_APP_TITLE": "bitrise-pipeline-name",
+      "BITRISE_BUILD_NUMBER": "bitrise-pipeline-number",
+      "BITRISE_BUILD_SLUG": "bitrise-pipeline-id",
+      "BITRISE_BUILD_URL": "bitrise-build-url",
+      "BITRISE_GIT_BRANCH": "origin/master",
+      "BITRISE_SOURCE_DIR": "/foo/bar~",
+      "GIT_CLONE_COMMIT_HASH": "bitrise-git-commit",
+      "GIT_REPOSITORY_URL": "sample"
+    },
+    {
+      "ci.pipeline.id": "bitrise-pipeline-id",
+      "ci.pipeline.name": "bitrise-pipeline-name",
+      "ci.pipeline.number": "bitrise-pipeline-number",
+      "ci.pipeline.url": "bitrise-build-url",
+      "ci.provider.name": "bitrise",
+      "ci.workspace_path": "/foo/bar~",
+      "git.branch": "master",
+      "git.commit.sha": "bitrise-git-commit",
+      "git.repository_url": "sample"
+    }
+  ],
+  [
+    {
+      "BITRISE_APP_TITLE": "bitrise-pipeline-name",
+      "BITRISE_BUILD_NUMBER": "bitrise-pipeline-number",
+      "BITRISE_BUILD_SLUG": "bitrise-pipeline-id",
+      "BITRISE_BUILD_URL": "bitrise-build-url",
+      "BITRISE_GIT_BRANCH": "origin/master",
+      "BITRISE_SOURCE_DIR": "/foo/~/bar",
+      "GIT_CLONE_COMMIT_HASH": "bitrise-git-commit",
+      "GIT_REPOSITORY_URL": "sample"
+    },
+    {
+      "ci.pipeline.id": "bitrise-pipeline-id",
+      "ci.pipeline.name": "bitrise-pipeline-name",
+      "ci.pipeline.number": "bitrise-pipeline-number",
+      "ci.pipeline.url": "bitrise-build-url",
+      "ci.provider.name": "bitrise",
+      "ci.workspace_path": "/foo/~/bar",
+      "git.branch": "master",
+      "git.commit.sha": "bitrise-git-commit",
+      "git.repository_url": "sample"
+    }
+  ],
+  [
+    {
+      "BITRISE_APP_TITLE": "bitrise-pipeline-name",
+      "BITRISE_BUILD_NUMBER": "bitrise-pipeline-number",
+      "BITRISE_BUILD_SLUG": "bitrise-pipeline-id",
+      "BITRISE_BUILD_URL": "bitrise-build-url",
+      "BITRISE_GIT_BRANCH": "origin/master",
+      "BITRISE_SOURCE_DIR": "~/foo/bar",
+      "GIT_CLONE_COMMIT_HASH": "bitrise-git-commit",
+      "GIT_REPOSITORY_URL": "sample",
+      "HOME": "/not-my-home",
+      "USERPROFILE": "/not-my-home"
+    },
+    {
+      "ci.pipeline.id": "bitrise-pipeline-id",
+      "ci.pipeline.name": "bitrise-pipeline-name",
+      "ci.pipeline.number": "bitrise-pipeline-number",
+      "ci.pipeline.url": "bitrise-build-url",
+      "ci.provider.name": "bitrise",
+      "ci.workspace_path": "/not-my-home/foo/bar",
+      "git.branch": "master",
+      "git.commit.sha": "bitrise-git-commit",
+      "git.repository_url": "sample"
+    }
+  ],
+  [
+    {
+      "BITRISE_APP_TITLE": "bitrise-pipeline-name",
+      "BITRISE_BUILD_NUMBER": "bitrise-pipeline-number",
+      "BITRISE_BUILD_SLUG": "bitrise-pipeline-id",
+      "BITRISE_BUILD_URL": "bitrise-build-url",
+      "BITRISE_GIT_BRANCH": "origin/master",
+      "BITRISE_SOURCE_DIR": "~foo/bar",
+      "GIT_CLONE_COMMIT_HASH": "bitrise-git-commit",
+      "GIT_REPOSITORY_URL": "sample",
+      "HOME": "/not-my-home",
+      "USERPROFILE": "/not-my-home"
+    },
+    {
+      "ci.pipeline.id": "bitrise-pipeline-id",
+      "ci.pipeline.name": "bitrise-pipeline-name",
+      "ci.pipeline.number": "bitrise-pipeline-number",
+      "ci.pipeline.url": "bitrise-build-url",
+      "ci.provider.name": "bitrise",
+      "ci.workspace_path": "~foo/bar",
+      "git.branch": "master",
+      "git.commit.sha": "bitrise-git-commit",
+      "git.repository_url": "sample"
+    }
+  ],
+  [
+    {
+      "BITRISE_APP_TITLE": "bitrise-pipeline-name",
+      "BITRISE_BUILD_NUMBER": "bitrise-pipeline-number",
+      "BITRISE_BUILD_SLUG": "bitrise-pipeline-id",
+      "BITRISE_BUILD_URL": "bitrise-build-url",
+      "BITRISE_GIT_BRANCH": "origin/master",
+      "BITRISE_SOURCE_DIR": "~",
+      "GIT_CLONE_COMMIT_HASH": "bitrise-git-commit",
+      "GIT_REPOSITORY_URL": "sample",
+      "HOME": "/not-my-home",
+      "USERPROFILE": "/not-my-home"
+    },
+    {
+      "ci.pipeline.id": "bitrise-pipeline-id",
+      "ci.pipeline.name": "bitrise-pipeline-name",
+      "ci.pipeline.number": "bitrise-pipeline-number",
+      "ci.pipeline.url": "bitrise-build-url",
+      "ci.provider.name": "bitrise",
+      "ci.workspace_path": "/not-my-home",
+      "git.branch": "master",
+      "git.commit.sha": "bitrise-git-commit",
+      "git.repository_url": "sample"
+    }
+  ],
+  [
+    {
+      "BITRISE_APP_TITLE": "bitrise-pipeline-name",
+      "BITRISE_BUILD_NUMBER": "bitrise-pipeline-number",
+      "BITRISE_BUILD_SLUG": "bitrise-pipeline-id",
+      "BITRISE_BUILD_URL": "bitrise-build-url",
+      "BITRISE_GIT_BRANCH": "refs/heads/master",
+      "BITRISE_SOURCE_DIR": "/foo/bar",
+      "GIT_CLONE_COMMIT_HASH": "bitrise-git-commit",
+      "GIT_REPOSITORY_URL": "sample"
+    },
+    {
+      "ci.pipeline.id": "bitrise-pipeline-id",
+      "ci.pipeline.name": "bitrise-pipeline-name",
+      "ci.pipeline.number": "bitrise-pipeline-number",
+      "ci.pipeline.url": "bitrise-build-url",
+      "ci.provider.name": "bitrise",
+      "ci.workspace_path": "/foo/bar",
+      "git.branch": "master",
+      "git.commit.sha": "bitrise-git-commit",
+      "git.repository_url": "sample"
+    }
+  ],
+  [
+    {
+      "BITRISE_APP_TITLE": "bitrise-pipeline-name",
+      "BITRISE_BUILD_NUMBER": "bitrise-pipeline-number",
+      "BITRISE_BUILD_SLUG": "bitrise-pipeline-id",
+      "BITRISE_BUILD_URL": "bitrise-build-url",
+      "BITRISE_GIT_BRANCH": "refs/heads/feature/one",
+      "BITRISE_SOURCE_DIR": "/foo/bar",
+      "GIT_CLONE_COMMIT_HASH": "bitrise-git-commit",
+      "GIT_REPOSITORY_URL": "sample"
+    },
+    {
+      "ci.pipeline.id": "bitrise-pipeline-id",
+      "ci.pipeline.name": "bitrise-pipeline-name",
+      "ci.pipeline.number": "bitrise-pipeline-number",
+      "ci.pipeline.url": "bitrise-build-url",
+      "ci.provider.name": "bitrise",
+      "ci.workspace_path": "/foo/bar",
+      "git.branch": "feature/one",
+      "git.commit.sha": "bitrise-git-commit",
+      "git.repository_url": "sample"
+    }
+  ],
+  [
+    {
+      "BITRISE_APP_TITLE": "bitrise-pipeline-name",
+      "BITRISE_BUILD_NUMBER": "bitrise-pipeline-number",
+      "BITRISE_BUILD_SLUG": "bitrise-pipeline-id",
+      "BITRISE_BUILD_URL": "bitrise-build-url",
+      "BITRISE_GIT_BRANCH": "origin/tags/0.1.0",
+      "BITRISE_GIT_TAG": "origin/tags/0.1.0",
+      "BITRISE_SOURCE_DIR": "/foo/bar",
+      "GIT_CLONE_COMMIT_HASH": "bitrise-git-commit",
+      "GIT_REPOSITORY_URL": "sample"
+    },
+    {
+      "ci.pipeline.id": "bitrise-pipeline-id",
+      "ci.pipeline.name": "bitrise-pipeline-name",
+      "ci.pipeline.number": "bitrise-pipeline-number",
+      "ci.pipeline.url": "bitrise-build-url",
+      "ci.provider.name": "bitrise",
+      "ci.workspace_path": "/foo/bar",
+      "git.commit.sha": "bitrise-git-commit",
+      "git.repository_url": "sample",
+      "git.tag": "0.1.0"
+    }
+  ],
+  [
+    {
+      "BITRISE_APP_TITLE": "bitrise-pipeline-name",
+      "BITRISE_BUILD_NUMBER": "bitrise-pipeline-number",
+      "BITRISE_BUILD_SLUG": "bitrise-pipeline-id",
+      "BITRISE_BUILD_URL": "bitrise-build-url",
+      "BITRISE_GIT_BRANCH": "refs/heads/tags/0.1.0",
+      "BITRISE_GIT_TAG": "refs/heads/tags/0.1.0",
+      "BITRISE_SOURCE_DIR": "/foo/bar",
+      "GIT_CLONE_COMMIT_HASH": "bitrise-git-commit",
+      "GIT_REPOSITORY_URL": "sample"
+    },
+    {
+      "ci.pipeline.id": "bitrise-pipeline-id",
+      "ci.pipeline.name": "bitrise-pipeline-name",
+      "ci.pipeline.number": "bitrise-pipeline-number",
+      "ci.pipeline.url": "bitrise-build-url",
+      "ci.provider.name": "bitrise",
+      "ci.workspace_path": "/foo/bar",
+      "git.commit.sha": "bitrise-git-commit",
+      "git.repository_url": "sample",
+      "git.tag": "0.1.0"
+    }
+  ],
+  [
+    {
+      "BITRISE_APP_TITLE": "bitrise-pipeline-name",
+      "BITRISE_BUILD_NUMBER": "bitrise-pipeline-number",
+      "BITRISE_BUILD_SLUG": "bitrise-pipeline-id",
+      "BITRISE_BUILD_URL": "bitrise-build-url",
+      "BITRISE_GIT_BRANCH": "origin/master",
+      "BITRISE_SOURCE_DIR": "/foo/bar",
+      "GIT_CLONE_COMMIT_HASH": "bitrise-git-commit",
+      "GIT_REPOSITORY_URL": "sample"
+    },
+    {
+      "ci.pipeline.id": "bitrise-pipeline-id",
+      "ci.pipeline.name": "bitrise-pipeline-name",
+      "ci.pipeline.number": "bitrise-pipeline-number",
+      "ci.pipeline.url": "bitrise-build-url",
+      "ci.provider.name": "bitrise",
+      "ci.workspace_path": "/foo/bar",
+      "git.branch": "master",
+      "git.commit.sha": "bitrise-git-commit",
+      "git.repository_url": "sample"
+    }
+  ],
+  [
+    {
+      "BITRISE_APP_TITLE": "bitrise-pipeline-name",
+      "BITRISE_BUILD_NUMBER": "bitrise-pipeline-number",
+      "BITRISE_BUILD_SLUG": "bitrise-pipeline-id",
+      "BITRISE_BUILD_URL": "bitrise-build-url",
+      "BITRISE_GIT_BRANCH": "origin/master",
+      "BITRISE_SOURCE_DIR": "/foo/bar",
+      "GIT_CLONE_COMMIT_HASH": "bitrise-git-commit",
+      "GIT_REPOSITORY_URL": "sample"
+    },
+    {
+      "ci.pipeline.id": "bitrise-pipeline-id",
+      "ci.pipeline.name": "bitrise-pipeline-name",
+      "ci.pipeline.number": "bitrise-pipeline-number",
+      "ci.pipeline.url": "bitrise-build-url",
+      "ci.provider.name": "bitrise",
+      "ci.workspace_path": "/foo/bar",
+      "git.branch": "master",
+      "git.commit.sha": "bitrise-git-commit",
+      "git.repository_url": "sample"
+    }
+  ],
+  [
+    {
+      "BITRISE_APP_TITLE": "bitrise-pipeline-name",
+      "BITRISE_BUILD_NUMBER": "bitrise-pipeline-number",
+      "BITRISE_BUILD_SLUG": "bitrise-pipeline-id",
+      "BITRISE_BUILD_URL": "bitrise-build-url",
+      "BITRISE_GIT_BRANCH": "origin/master",
+      "BITRISE_SOURCE_DIR": "/foo/bar",
+      "GIT_CLONE_COMMIT_HASH": "bitrise-git-commit",
+      "GIT_REPOSITORY_URL": "http://hostname.com/repo.git"
+    },
+    {
+      "ci.pipeline.id": "bitrise-pipeline-id",
+      "ci.pipeline.name": "bitrise-pipeline-name",
+      "ci.pipeline.number": "bitrise-pipeline-number",
+      "ci.pipeline.url": "bitrise-build-url",
+      "ci.provider.name": "bitrise",
+      "ci.workspace_path": "/foo/bar",
+      "git.branch": "master",
+      "git.commit.sha": "bitrise-git-commit",
+      "git.repository_url": "http://hostname.com/repo.git"
+    }
+  ],
+  [
+    {
+      "BITRISE_APP_TITLE": "bitrise-pipeline-name",
+      "BITRISE_BUILD_NUMBER": "bitrise-pipeline-number",
+      "BITRISE_BUILD_SLUG": "bitrise-pipeline-id",
+      "BITRISE_BUILD_URL": "bitrise-build-url",
+      "BITRISE_GIT_BRANCH": "origin/master",
+      "BITRISE_SOURCE_DIR": "/foo/bar",
+      "GIT_CLONE_COMMIT_HASH": "bitrise-git-commit",
+      "GIT_REPOSITORY_URL": "git@hostname.com:org/repo.git"
+    },
+    {
+      "ci.pipeline.id": "bitrise-pipeline-id",
+      "ci.pipeline.name": "bitrise-pipeline-name",
+      "ci.pipeline.number": "bitrise-pipeline-number",
+      "ci.pipeline.url": "bitrise-build-url",
+      "ci.provider.name": "bitrise",
+      "ci.workspace_path": "/foo/bar",
+      "git.branch": "master",
+      "git.commit.sha": "bitrise-git-commit",
+      "git.repository_url": "git@hostname.com:org/repo.git"
+    }
+  ],
+  [
+    {
+      "BITRISEIO_GIT_BRANCH_DEST": "origin/master",
+      "BITRISE_APP_TITLE": "bitrise-pipeline-name",
+      "BITRISE_BUILD_NUMBER": "bitrise-pipeline-number",
+      "BITRISE_BUILD_SLUG": "bitrise-pipeline-id",
+      "BITRISE_BUILD_URL": "bitrise-build-url",
+      "BITRISE_SOURCE_DIR": "/foo/bar",
+      "GIT_CLONE_COMMIT_HASH": "bitrise-git-commit",
+      "GIT_REPOSITORY_URL": "git@hostname.com:org/repo.git"
+    },
+    {
+      "ci.pipeline.id": "bitrise-pipeline-id",
+      "ci.pipeline.name": "bitrise-pipeline-name",
+      "ci.pipeline.number": "bitrise-pipeline-number",
+      "ci.pipeline.url": "bitrise-build-url",
+      "ci.provider.name": "bitrise",
+      "ci.workspace_path": "/foo/bar",
+      "git.branch": "master",
+      "git.commit.sha": "bitrise-git-commit",
+      "git.repository_url": "git@hostname.com:org/repo.git"
+    }
+  ],
+  [
+    {
+      "BITRISEIO_GIT_BRANCH_DEST": "origin/notmaster",
+      "BITRISE_APP_TITLE": "bitrise-pipeline-name",
+      "BITRISE_BUILD_NUMBER": "bitrise-pipeline-number",
+      "BITRISE_BUILD_SLUG": "bitrise-pipeline-id",
+      "BITRISE_BUILD_URL": "bitrise-build-url",
+      "BITRISE_GIT_BRANCH": "origin/master",
+      "BITRISE_SOURCE_DIR": "/foo/bar",
+      "GIT_CLONE_COMMIT_HASH": "bitrise-git-commit",
+      "GIT_REPOSITORY_URL": "git@hostname.com:org/repo.git"
+    },
+    {
+      "ci.pipeline.id": "bitrise-pipeline-id",
+      "ci.pipeline.name": "bitrise-pipeline-name",
+      "ci.pipeline.number": "bitrise-pipeline-number",
+      "ci.pipeline.url": "bitrise-build-url",
+      "ci.provider.name": "bitrise",
+      "ci.workspace_path": "/foo/bar",
+      "git.branch": "notmaster",
+      "git.commit.sha": "bitrise-git-commit",
+      "git.repository_url": "git@hostname.com:org/repo.git"
+    }
+  ]
+]

--- a/src/helpers/__tests__/ci-env/buildkite.json
+++ b/src/helpers/__tests__/ci-env/buildkite.json
@@ -1,0 +1,450 @@
+[
+  [
+    {
+      "BUILDKITE": "true",
+      "BUILDKITE_BRANCH": "master",
+      "BUILDKITE_BUILD_CHECKOUT_PATH": "/foo/bar",
+      "BUILDKITE_BUILD_ID": "buildkite-pipeline-id",
+      "BUILDKITE_BUILD_NUMBER": "buildkite-pipeline-number",
+      "BUILDKITE_BUILD_URL": "buildkite-build-url",
+      "BUILDKITE_COMMIT": "buildkite-git-commit",
+      "BUILDKITE_JOB_ID": "buildkite-job-id",
+      "BUILDKITE_PIPELINE_SLUG": "buildkite-pipeline-name",
+      "BUILDKITE_REPO": "http://hostname.com/repo.git"
+    },
+    {
+      "ci.job.url": "buildkite-build-url#buildkite-job-id",
+      "ci.pipeline.id": "buildkite-pipeline-id",
+      "ci.pipeline.name": "buildkite-pipeline-name",
+      "ci.pipeline.number": "buildkite-pipeline-number",
+      "ci.pipeline.url": "buildkite-build-url",
+      "ci.provider.name": "buildkite",
+      "ci.workspace_path": "/foo/bar",
+      "git.branch": "master",
+      "git.commit.sha": "buildkite-git-commit",
+      "git.repository_url": "http://hostname.com/repo.git"
+    }
+  ],
+  [
+    {
+      "BUILDKITE": "true",
+      "BUILDKITE_BRANCH": "master",
+      "BUILDKITE_BUILD_CHECKOUT_PATH": "foo/bar",
+      "BUILDKITE_BUILD_ID": "buildkite-pipeline-id",
+      "BUILDKITE_BUILD_NUMBER": "buildkite-pipeline-number",
+      "BUILDKITE_BUILD_URL": "buildkite-build-url",
+      "BUILDKITE_COMMIT": "buildkite-git-commit",
+      "BUILDKITE_JOB_ID": "buildkite-job-id",
+      "BUILDKITE_PIPELINE_SLUG": "buildkite-pipeline-name",
+      "BUILDKITE_REPO": "http://hostname.com/repo.git"
+    },
+    {
+      "ci.job.url": "buildkite-build-url#buildkite-job-id",
+      "ci.pipeline.id": "buildkite-pipeline-id",
+      "ci.pipeline.name": "buildkite-pipeline-name",
+      "ci.pipeline.number": "buildkite-pipeline-number",
+      "ci.pipeline.url": "buildkite-build-url",
+      "ci.provider.name": "buildkite",
+      "ci.workspace_path": "foo/bar",
+      "git.branch": "master",
+      "git.commit.sha": "buildkite-git-commit",
+      "git.repository_url": "http://hostname.com/repo.git"
+    }
+  ],
+  [
+    {
+      "BUILDKITE": "true",
+      "BUILDKITE_BRANCH": "master",
+      "BUILDKITE_BUILD_CHECKOUT_PATH": "/foo/bar~",
+      "BUILDKITE_BUILD_ID": "buildkite-pipeline-id",
+      "BUILDKITE_BUILD_NUMBER": "buildkite-pipeline-number",
+      "BUILDKITE_BUILD_URL": "buildkite-build-url",
+      "BUILDKITE_COMMIT": "buildkite-git-commit",
+      "BUILDKITE_JOB_ID": "buildkite-job-id",
+      "BUILDKITE_PIPELINE_SLUG": "buildkite-pipeline-name",
+      "BUILDKITE_REPO": "http://hostname.com/repo.git"
+    },
+    {
+      "ci.job.url": "buildkite-build-url#buildkite-job-id",
+      "ci.pipeline.id": "buildkite-pipeline-id",
+      "ci.pipeline.name": "buildkite-pipeline-name",
+      "ci.pipeline.number": "buildkite-pipeline-number",
+      "ci.pipeline.url": "buildkite-build-url",
+      "ci.provider.name": "buildkite",
+      "ci.workspace_path": "/foo/bar~",
+      "git.branch": "master",
+      "git.commit.sha": "buildkite-git-commit",
+      "git.repository_url": "http://hostname.com/repo.git"
+    }
+  ],
+  [
+    {
+      "BUILDKITE": "true",
+      "BUILDKITE_BRANCH": "master",
+      "BUILDKITE_BUILD_CHECKOUT_PATH": "/foo/~/bar",
+      "BUILDKITE_BUILD_ID": "buildkite-pipeline-id",
+      "BUILDKITE_BUILD_NUMBER": "buildkite-pipeline-number",
+      "BUILDKITE_BUILD_URL": "buildkite-build-url",
+      "BUILDKITE_COMMIT": "buildkite-git-commit",
+      "BUILDKITE_JOB_ID": "buildkite-job-id",
+      "BUILDKITE_PIPELINE_SLUG": "buildkite-pipeline-name",
+      "BUILDKITE_REPO": "http://hostname.com/repo.git"
+    },
+    {
+      "ci.job.url": "buildkite-build-url#buildkite-job-id",
+      "ci.pipeline.id": "buildkite-pipeline-id",
+      "ci.pipeline.name": "buildkite-pipeline-name",
+      "ci.pipeline.number": "buildkite-pipeline-number",
+      "ci.pipeline.url": "buildkite-build-url",
+      "ci.provider.name": "buildkite",
+      "ci.workspace_path": "/foo/~/bar",
+      "git.branch": "master",
+      "git.commit.sha": "buildkite-git-commit",
+      "git.repository_url": "http://hostname.com/repo.git"
+    }
+  ],
+  [
+    {
+      "BUILDKITE": "true",
+      "BUILDKITE_BRANCH": "master",
+      "BUILDKITE_BUILD_CHECKOUT_PATH": "~/foo/bar",
+      "BUILDKITE_BUILD_ID": "buildkite-pipeline-id",
+      "BUILDKITE_BUILD_NUMBER": "buildkite-pipeline-number",
+      "BUILDKITE_BUILD_URL": "buildkite-build-url",
+      "BUILDKITE_COMMIT": "buildkite-git-commit",
+      "BUILDKITE_JOB_ID": "buildkite-job-id",
+      "BUILDKITE_PIPELINE_SLUG": "buildkite-pipeline-name",
+      "BUILDKITE_REPO": "http://hostname.com/repo.git",
+      "HOME": "/not-my-home",
+      "USERPROFILE": "/not-my-home"
+    },
+    {
+      "ci.job.url": "buildkite-build-url#buildkite-job-id",
+      "ci.pipeline.id": "buildkite-pipeline-id",
+      "ci.pipeline.name": "buildkite-pipeline-name",
+      "ci.pipeline.number": "buildkite-pipeline-number",
+      "ci.pipeline.url": "buildkite-build-url",
+      "ci.provider.name": "buildkite",
+      "ci.workspace_path": "/not-my-home/foo/bar",
+      "git.branch": "master",
+      "git.commit.sha": "buildkite-git-commit",
+      "git.repository_url": "http://hostname.com/repo.git"
+    }
+  ],
+  [
+    {
+      "BUILDKITE": "true",
+      "BUILDKITE_BRANCH": "master",
+      "BUILDKITE_BUILD_CHECKOUT_PATH": "~foo/bar",
+      "BUILDKITE_BUILD_ID": "buildkite-pipeline-id",
+      "BUILDKITE_BUILD_NUMBER": "buildkite-pipeline-number",
+      "BUILDKITE_BUILD_URL": "buildkite-build-url",
+      "BUILDKITE_COMMIT": "buildkite-git-commit",
+      "BUILDKITE_JOB_ID": "buildkite-job-id",
+      "BUILDKITE_PIPELINE_SLUG": "buildkite-pipeline-name",
+      "BUILDKITE_REPO": "http://hostname.com/repo.git",
+      "HOME": "/not-my-home",
+      "USERPROFILE": "/not-my-home"
+    },
+    {
+      "ci.job.url": "buildkite-build-url#buildkite-job-id",
+      "ci.pipeline.id": "buildkite-pipeline-id",
+      "ci.pipeline.name": "buildkite-pipeline-name",
+      "ci.pipeline.number": "buildkite-pipeline-number",
+      "ci.pipeline.url": "buildkite-build-url",
+      "ci.provider.name": "buildkite",
+      "ci.workspace_path": "~foo/bar",
+      "git.branch": "master",
+      "git.commit.sha": "buildkite-git-commit",
+      "git.repository_url": "http://hostname.com/repo.git"
+    }
+  ],
+  [
+    {
+      "BUILDKITE": "true",
+      "BUILDKITE_BRANCH": "master",
+      "BUILDKITE_BUILD_CHECKOUT_PATH": "~",
+      "BUILDKITE_BUILD_ID": "buildkite-pipeline-id",
+      "BUILDKITE_BUILD_NUMBER": "buildkite-pipeline-number",
+      "BUILDKITE_BUILD_URL": "buildkite-build-url",
+      "BUILDKITE_COMMIT": "buildkite-git-commit",
+      "BUILDKITE_JOB_ID": "buildkite-job-id",
+      "BUILDKITE_PIPELINE_SLUG": "buildkite-pipeline-name",
+      "BUILDKITE_REPO": "http://hostname.com/repo.git",
+      "HOME": "/not-my-home",
+      "USERPROFILE": "/not-my-home"
+    },
+    {
+      "ci.job.url": "buildkite-build-url#buildkite-job-id",
+      "ci.pipeline.id": "buildkite-pipeline-id",
+      "ci.pipeline.name": "buildkite-pipeline-name",
+      "ci.pipeline.number": "buildkite-pipeline-number",
+      "ci.pipeline.url": "buildkite-build-url",
+      "ci.provider.name": "buildkite",
+      "ci.workspace_path": "/not-my-home",
+      "git.branch": "master",
+      "git.commit.sha": "buildkite-git-commit",
+      "git.repository_url": "http://hostname.com/repo.git"
+    }
+  ],
+  [
+    {
+      "BUILDKITE": "true",
+      "BUILDKITE_BRANCH": "master",
+      "BUILDKITE_BUILD_CHECKOUT_PATH": "/foo/bar",
+      "BUILDKITE_BUILD_ID": "buildkite-pipeline-id",
+      "BUILDKITE_BUILD_NUMBER": "buildkite-pipeline-number",
+      "BUILDKITE_BUILD_URL": "buildkite-build-url",
+      "BUILDKITE_COMMIT": "buildkite-git-commit",
+      "BUILDKITE_JOB_ID": "buildkite-job-id",
+      "BUILDKITE_PIPELINE_SLUG": "buildkite-pipeline-name",
+      "BUILDKITE_REPO": "http://user@hostname.com/repo.git"
+    },
+    {
+      "ci.job.url": "buildkite-build-url#buildkite-job-id",
+      "ci.pipeline.id": "buildkite-pipeline-id",
+      "ci.pipeline.name": "buildkite-pipeline-name",
+      "ci.pipeline.number": "buildkite-pipeline-number",
+      "ci.pipeline.url": "buildkite-build-url",
+      "ci.provider.name": "buildkite",
+      "ci.workspace_path": "/foo/bar",
+      "git.branch": "master",
+      "git.commit.sha": "buildkite-git-commit",
+      "git.repository_url": "http://hostname.com/repo.git"
+    }
+  ],
+  [
+    {
+      "BUILDKITE": "true",
+      "BUILDKITE_BRANCH": "master",
+      "BUILDKITE_BUILD_CHECKOUT_PATH": "/foo/bar",
+      "BUILDKITE_BUILD_ID": "buildkite-pipeline-id",
+      "BUILDKITE_BUILD_NUMBER": "buildkite-pipeline-number",
+      "BUILDKITE_BUILD_URL": "buildkite-build-url",
+      "BUILDKITE_COMMIT": "buildkite-git-commit",
+      "BUILDKITE_JOB_ID": "buildkite-job-id",
+      "BUILDKITE_PIPELINE_SLUG": "buildkite-pipeline-name",
+      "BUILDKITE_REPO": "http://user%E2%82%AC@hostname.com/repo.git"
+    },
+    {
+      "ci.job.url": "buildkite-build-url#buildkite-job-id",
+      "ci.pipeline.id": "buildkite-pipeline-id",
+      "ci.pipeline.name": "buildkite-pipeline-name",
+      "ci.pipeline.number": "buildkite-pipeline-number",
+      "ci.pipeline.url": "buildkite-build-url",
+      "ci.provider.name": "buildkite",
+      "ci.workspace_path": "/foo/bar",
+      "git.branch": "master",
+      "git.commit.sha": "buildkite-git-commit",
+      "git.repository_url": "http://hostname.com/repo.git"
+    }
+  ],
+  [
+    {
+      "BUILDKITE": "true",
+      "BUILDKITE_BRANCH": "master",
+      "BUILDKITE_BUILD_CHECKOUT_PATH": "/foo/bar",
+      "BUILDKITE_BUILD_ID": "buildkite-pipeline-id",
+      "BUILDKITE_BUILD_NUMBER": "buildkite-pipeline-number",
+      "BUILDKITE_BUILD_URL": "buildkite-build-url",
+      "BUILDKITE_COMMIT": "buildkite-git-commit",
+      "BUILDKITE_JOB_ID": "buildkite-job-id",
+      "BUILDKITE_PIPELINE_SLUG": "buildkite-pipeline-name",
+      "BUILDKITE_REPO": "http://user:pwd@hostname.com/repo.git"
+    },
+    {
+      "ci.job.url": "buildkite-build-url#buildkite-job-id",
+      "ci.pipeline.id": "buildkite-pipeline-id",
+      "ci.pipeline.name": "buildkite-pipeline-name",
+      "ci.pipeline.number": "buildkite-pipeline-number",
+      "ci.pipeline.url": "buildkite-build-url",
+      "ci.provider.name": "buildkite",
+      "ci.workspace_path": "/foo/bar",
+      "git.branch": "master",
+      "git.commit.sha": "buildkite-git-commit",
+      "git.repository_url": "http://hostname.com/repo.git"
+    }
+  ],
+  [
+    {
+      "BUILDKITE": "true",
+      "BUILDKITE_BRANCH": "master",
+      "BUILDKITE_BUILD_CHECKOUT_PATH": "/foo/bar",
+      "BUILDKITE_BUILD_ID": "buildkite-pipeline-id",
+      "BUILDKITE_BUILD_NUMBER": "buildkite-pipeline-number",
+      "BUILDKITE_BUILD_URL": "buildkite-build-url",
+      "BUILDKITE_COMMIT": "buildkite-git-commit",
+      "BUILDKITE_JOB_ID": "buildkite-job-id",
+      "BUILDKITE_PIPELINE_SLUG": "buildkite-pipeline-name",
+      "BUILDKITE_REPO": "git@hostname.com:org/repo.git"
+    },
+    {
+      "ci.job.url": "buildkite-build-url#buildkite-job-id",
+      "ci.pipeline.id": "buildkite-pipeline-id",
+      "ci.pipeline.name": "buildkite-pipeline-name",
+      "ci.pipeline.number": "buildkite-pipeline-number",
+      "ci.pipeline.url": "buildkite-build-url",
+      "ci.provider.name": "buildkite",
+      "ci.workspace_path": "/foo/bar",
+      "git.branch": "master",
+      "git.commit.sha": "buildkite-git-commit",
+      "git.repository_url": "git@hostname.com:org/repo.git"
+    }
+  ],
+  [
+    {
+      "BUILDKITE": "true",
+      "BUILDKITE_BRANCH": "origin/master",
+      "BUILDKITE_BUILD_CHECKOUT_PATH": "/foo/bar",
+      "BUILDKITE_BUILD_ID": "buildkite-pipeline-id",
+      "BUILDKITE_BUILD_NUMBER": "buildkite-pipeline-number",
+      "BUILDKITE_BUILD_URL": "buildkite-build-url",
+      "BUILDKITE_COMMIT": "buildkite-git-commit",
+      "BUILDKITE_JOB_ID": "buildkite-job-id",
+      "BUILDKITE_PIPELINE_SLUG": "buildkite-pipeline-name",
+      "BUILDKITE_REPO": "http://hostname.com/repo.git"
+    },
+    {
+      "ci.job.url": "buildkite-build-url#buildkite-job-id",
+      "ci.pipeline.id": "buildkite-pipeline-id",
+      "ci.pipeline.name": "buildkite-pipeline-name",
+      "ci.pipeline.number": "buildkite-pipeline-number",
+      "ci.pipeline.url": "buildkite-build-url",
+      "ci.provider.name": "buildkite",
+      "ci.workspace_path": "/foo/bar",
+      "git.branch": "master",
+      "git.commit.sha": "buildkite-git-commit",
+      "git.repository_url": "http://hostname.com/repo.git"
+    }
+  ],
+  [
+    {
+      "BUILDKITE": "true",
+      "BUILDKITE_BRANCH": "refs/heads/master",
+      "BUILDKITE_BUILD_CHECKOUT_PATH": "/foo/bar",
+      "BUILDKITE_BUILD_ID": "buildkite-pipeline-id",
+      "BUILDKITE_BUILD_NUMBER": "buildkite-pipeline-number",
+      "BUILDKITE_BUILD_URL": "buildkite-build-url",
+      "BUILDKITE_COMMIT": "buildkite-git-commit",
+      "BUILDKITE_JOB_ID": "buildkite-job-id",
+      "BUILDKITE_PIPELINE_SLUG": "buildkite-pipeline-name",
+      "BUILDKITE_REPO": "http://hostname.com/repo.git"
+    },
+    {
+      "ci.job.url": "buildkite-build-url#buildkite-job-id",
+      "ci.pipeline.id": "buildkite-pipeline-id",
+      "ci.pipeline.name": "buildkite-pipeline-name",
+      "ci.pipeline.number": "buildkite-pipeline-number",
+      "ci.pipeline.url": "buildkite-build-url",
+      "ci.provider.name": "buildkite",
+      "ci.workspace_path": "/foo/bar",
+      "git.branch": "master",
+      "git.commit.sha": "buildkite-git-commit",
+      "git.repository_url": "http://hostname.com/repo.git"
+    }
+  ],
+  [
+    {
+      "BUILDKITE": "true",
+      "BUILDKITE_BRANCH": "refs/heads/feature/one",
+      "BUILDKITE_BUILD_CHECKOUT_PATH": "/foo/bar",
+      "BUILDKITE_BUILD_ID": "buildkite-pipeline-id",
+      "BUILDKITE_BUILD_NUMBER": "buildkite-pipeline-number",
+      "BUILDKITE_BUILD_URL": "buildkite-build-url",
+      "BUILDKITE_COMMIT": "buildkite-git-commit",
+      "BUILDKITE_JOB_ID": "buildkite-job-id",
+      "BUILDKITE_PIPELINE_SLUG": "buildkite-pipeline-name",
+      "BUILDKITE_REPO": "http://hostname.com/repo.git"
+    },
+    {
+      "ci.job.url": "buildkite-build-url#buildkite-job-id",
+      "ci.pipeline.id": "buildkite-pipeline-id",
+      "ci.pipeline.name": "buildkite-pipeline-name",
+      "ci.pipeline.number": "buildkite-pipeline-number",
+      "ci.pipeline.url": "buildkite-build-url",
+      "ci.provider.name": "buildkite",
+      "ci.workspace_path": "/foo/bar",
+      "git.branch": "feature/one",
+      "git.commit.sha": "buildkite-git-commit",
+      "git.repository_url": "http://hostname.com/repo.git"
+    }
+  ],
+  [
+    {
+      "BUILDKITE": "true",
+      "BUILDKITE_BUILD_CHECKOUT_PATH": "/foo/bar",
+      "BUILDKITE_BUILD_ID": "buildkite-pipeline-id",
+      "BUILDKITE_BUILD_NUMBER": "buildkite-pipeline-number",
+      "BUILDKITE_BUILD_URL": "buildkite-build-url",
+      "BUILDKITE_COMMIT": "buildkite-git-commit",
+      "BUILDKITE_JOB_ID": "buildkite-job-id",
+      "BUILDKITE_PIPELINE_SLUG": "buildkite-pipeline-name",
+      "BUILDKITE_REPO": "http://hostname.com/repo.git",
+      "BUILDKITE_TAG": "0.1.0"
+    },
+    {
+      "ci.job.url": "buildkite-build-url#buildkite-job-id",
+      "ci.pipeline.id": "buildkite-pipeline-id",
+      "ci.pipeline.name": "buildkite-pipeline-name",
+      "ci.pipeline.number": "buildkite-pipeline-number",
+      "ci.pipeline.url": "buildkite-build-url",
+      "ci.provider.name": "buildkite",
+      "ci.workspace_path": "/foo/bar",
+      "git.commit.sha": "buildkite-git-commit",
+      "git.repository_url": "http://hostname.com/repo.git",
+      "git.tag": "0.1.0"
+    }
+  ],
+  [
+    {
+      "BUILDKITE": "true",
+      "BUILDKITE_BUILD_CHECKOUT_PATH": "/foo/bar",
+      "BUILDKITE_BUILD_ID": "buildkite-pipeline-id",
+      "BUILDKITE_BUILD_NUMBER": "buildkite-pipeline-number",
+      "BUILDKITE_BUILD_URL": "buildkite-build-url",
+      "BUILDKITE_COMMIT": "buildkite-git-commit",
+      "BUILDKITE_JOB_ID": "buildkite-job-id",
+      "BUILDKITE_PIPELINE_SLUG": "buildkite-pipeline-name",
+      "BUILDKITE_REPO": "http://hostname.com/repo.git",
+      "BUILDKITE_TAG": "origin/tags/0.1.0"
+    },
+    {
+      "ci.job.url": "buildkite-build-url#buildkite-job-id",
+      "ci.pipeline.id": "buildkite-pipeline-id",
+      "ci.pipeline.name": "buildkite-pipeline-name",
+      "ci.pipeline.number": "buildkite-pipeline-number",
+      "ci.pipeline.url": "buildkite-build-url",
+      "ci.provider.name": "buildkite",
+      "ci.workspace_path": "/foo/bar",
+      "git.commit.sha": "buildkite-git-commit",
+      "git.repository_url": "http://hostname.com/repo.git",
+      "git.tag": "0.1.0"
+    }
+  ],
+  [
+    {
+      "BUILDKITE": "true",
+      "BUILDKITE_BUILD_CHECKOUT_PATH": "/foo/bar",
+      "BUILDKITE_BUILD_ID": "buildkite-pipeline-id",
+      "BUILDKITE_BUILD_NUMBER": "buildkite-pipeline-number",
+      "BUILDKITE_BUILD_URL": "buildkite-build-url",
+      "BUILDKITE_COMMIT": "buildkite-git-commit",
+      "BUILDKITE_JOB_ID": "buildkite-job-id",
+      "BUILDKITE_PIPELINE_SLUG": "buildkite-pipeline-name",
+      "BUILDKITE_REPO": "http://hostname.com/repo.git",
+      "BUILDKITE_TAG": "refs/heads/tags/0.1.0"
+    },
+    {
+      "ci.job.url": "buildkite-build-url#buildkite-job-id",
+      "ci.pipeline.id": "buildkite-pipeline-id",
+      "ci.pipeline.name": "buildkite-pipeline-name",
+      "ci.pipeline.number": "buildkite-pipeline-number",
+      "ci.pipeline.url": "buildkite-build-url",
+      "ci.provider.name": "buildkite",
+      "ci.workspace_path": "/foo/bar",
+      "git.commit.sha": "buildkite-git-commit",
+      "git.repository_url": "http://hostname.com/repo.git",
+      "git.tag": "0.1.0"
+    }
+  ]
+]

--- a/src/helpers/__tests__/ci-env/circleci.json
+++ b/src/helpers/__tests__/ci-env/circleci.json
@@ -1,0 +1,535 @@
+[
+  [
+    {
+      "CIRCLECI": "circleCI",
+      "CIRCLE_BRANCH": "origin/master",
+      "CIRCLE_BUILD_NUM": "circleci-pipeline-number",
+      "CIRCLE_BUILD_URL": "circleci-build-url",
+      "CIRCLE_PROJECT_REPONAME": "circleci-pipeline-name",
+      "CIRCLE_REPOSITORY_URL": "sample",
+      "CIRCLE_SHA1": "circleci-git-commit",
+      "CIRCLE_WORKFLOW_ID": "circleci-pipeline-id",
+      "CIRCLE_WORKING_DIRECTORY": "/foo/bar"
+    },
+    {
+      "ci.job.url": "circleci-build-url",
+      "ci.pipeline.id": "circleci-pipeline-id",
+      "ci.pipeline.name": "circleci-pipeline-name",
+      "ci.pipeline.number": "circleci-pipeline-number",
+      "ci.pipeline.url": "circleci-build-url",
+      "ci.provider.name": "circleci",
+      "ci.workspace_path": "/foo/bar",
+      "git.branch": "master",
+      "git.commit.sha": "circleci-git-commit",
+      "git.repository_url": "sample"
+    }
+  ],
+  [
+    {
+      "CIRCLECI": "circleCI",
+      "CIRCLE_BRANCH": "origin/master",
+      "CIRCLE_BUILD_NUM": "circleci-pipeline-number",
+      "CIRCLE_BUILD_URL": "circleci-build-url",
+      "CIRCLE_PROJECT_REPONAME": "circleci-pipeline-name",
+      "CIRCLE_REPOSITORY_URL": "sample",
+      "CIRCLE_SHA1": "circleci-git-commit",
+      "CIRCLE_WORKFLOW_ID": "circleci-pipeline-id",
+      "CIRCLE_WORKING_DIRECTORY": "/foo/bar"
+    },
+    {
+      "ci.job.url": "circleci-build-url",
+      "ci.pipeline.id": "circleci-pipeline-id",
+      "ci.pipeline.name": "circleci-pipeline-name",
+      "ci.pipeline.number": "circleci-pipeline-number",
+      "ci.pipeline.url": "circleci-build-url",
+      "ci.provider.name": "circleci",
+      "ci.workspace_path": "/foo/bar",
+      "git.branch": "master",
+      "git.commit.sha": "circleci-git-commit",
+      "git.repository_url": "sample"
+    }
+  ],
+  [
+    {
+      "CIRCLECI": "circleCI",
+      "CIRCLE_BRANCH": "origin/master",
+      "CIRCLE_BUILD_NUM": "circleci-pipeline-number",
+      "CIRCLE_BUILD_URL": "circleci-build-url",
+      "CIRCLE_PROJECT_REPONAME": "circleci-pipeline-name",
+      "CIRCLE_REPOSITORY_URL": "sample",
+      "CIRCLE_SHA1": "circleci-git-commit",
+      "CIRCLE_WORKFLOW_ID": "circleci-pipeline-id",
+      "CIRCLE_WORKING_DIRECTORY": "/foo/bar"
+    },
+    {
+      "ci.job.url": "circleci-build-url",
+      "ci.pipeline.id": "circleci-pipeline-id",
+      "ci.pipeline.name": "circleci-pipeline-name",
+      "ci.pipeline.number": "circleci-pipeline-number",
+      "ci.pipeline.url": "circleci-build-url",
+      "ci.provider.name": "circleci",
+      "ci.workspace_path": "/foo/bar",
+      "git.branch": "master",
+      "git.commit.sha": "circleci-git-commit",
+      "git.repository_url": "sample"
+    }
+  ],
+  [
+    {
+      "CIRCLECI": "circleCI",
+      "CIRCLE_BRANCH": "origin/master",
+      "CIRCLE_BUILD_NUM": "circleci-pipeline-number",
+      "CIRCLE_BUILD_URL": "circleci-build-url",
+      "CIRCLE_PROJECT_REPONAME": "circleci-pipeline-name",
+      "CIRCLE_REPOSITORY_URL": "sample",
+      "CIRCLE_SHA1": "circleci-git-commit",
+      "CIRCLE_WORKFLOW_ID": "circleci-pipeline-id",
+      "CIRCLE_WORKING_DIRECTORY": "/foo/bar"
+    },
+    {
+      "ci.job.url": "circleci-build-url",
+      "ci.pipeline.id": "circleci-pipeline-id",
+      "ci.pipeline.name": "circleci-pipeline-name",
+      "ci.pipeline.number": "circleci-pipeline-number",
+      "ci.pipeline.url": "circleci-build-url",
+      "ci.provider.name": "circleci",
+      "ci.workspace_path": "/foo/bar",
+      "git.branch": "master",
+      "git.commit.sha": "circleci-git-commit",
+      "git.repository_url": "sample"
+    }
+  ],
+  [
+    {
+      "CIRCLECI": "circleCI",
+      "CIRCLE_BRANCH": "origin/master",
+      "CIRCLE_BUILD_NUM": "circleci-pipeline-number",
+      "CIRCLE_BUILD_URL": "circleci-build-url",
+      "CIRCLE_PROJECT_REPONAME": "circleci-pipeline-name",
+      "CIRCLE_REPOSITORY_URL": "sample",
+      "CIRCLE_SHA1": "circleci-git-commit",
+      "CIRCLE_WORKFLOW_ID": "circleci-pipeline-id",
+      "CIRCLE_WORKING_DIRECTORY": "foo/bar"
+    },
+    {
+      "ci.job.url": "circleci-build-url",
+      "ci.pipeline.id": "circleci-pipeline-id",
+      "ci.pipeline.name": "circleci-pipeline-name",
+      "ci.pipeline.number": "circleci-pipeline-number",
+      "ci.pipeline.url": "circleci-build-url",
+      "ci.provider.name": "circleci",
+      "ci.workspace_path": "foo/bar",
+      "git.branch": "master",
+      "git.commit.sha": "circleci-git-commit",
+      "git.repository_url": "sample"
+    }
+  ],
+  [
+    {
+      "CIRCLECI": "circleCI",
+      "CIRCLE_BRANCH": "origin/master",
+      "CIRCLE_BUILD_NUM": "circleci-pipeline-number",
+      "CIRCLE_BUILD_URL": "circleci-build-url",
+      "CIRCLE_PROJECT_REPONAME": "circleci-pipeline-name",
+      "CIRCLE_REPOSITORY_URL": "sample",
+      "CIRCLE_SHA1": "circleci-git-commit",
+      "CIRCLE_WORKFLOW_ID": "circleci-pipeline-id",
+      "CIRCLE_WORKING_DIRECTORY": "/foo/bar~"
+    },
+    {
+      "ci.job.url": "circleci-build-url",
+      "ci.pipeline.id": "circleci-pipeline-id",
+      "ci.pipeline.name": "circleci-pipeline-name",
+      "ci.pipeline.number": "circleci-pipeline-number",
+      "ci.pipeline.url": "circleci-build-url",
+      "ci.provider.name": "circleci",
+      "ci.workspace_path": "/foo/bar~",
+      "git.branch": "master",
+      "git.commit.sha": "circleci-git-commit",
+      "git.repository_url": "sample"
+    }
+  ],
+  [
+    {
+      "CIRCLECI": "circleCI",
+      "CIRCLE_BRANCH": "origin/master",
+      "CIRCLE_BUILD_NUM": "circleci-pipeline-number",
+      "CIRCLE_BUILD_URL": "circleci-build-url",
+      "CIRCLE_PROJECT_REPONAME": "circleci-pipeline-name",
+      "CIRCLE_REPOSITORY_URL": "sample",
+      "CIRCLE_SHA1": "circleci-git-commit",
+      "CIRCLE_WORKFLOW_ID": "circleci-pipeline-id",
+      "CIRCLE_WORKING_DIRECTORY": "/foo/~/bar"
+    },
+    {
+      "ci.job.url": "circleci-build-url",
+      "ci.pipeline.id": "circleci-pipeline-id",
+      "ci.pipeline.name": "circleci-pipeline-name",
+      "ci.pipeline.number": "circleci-pipeline-number",
+      "ci.pipeline.url": "circleci-build-url",
+      "ci.provider.name": "circleci",
+      "ci.workspace_path": "/foo/~/bar",
+      "git.branch": "master",
+      "git.commit.sha": "circleci-git-commit",
+      "git.repository_url": "sample"
+    }
+  ],
+  [
+    {
+      "CIRCLECI": "circleCI",
+      "CIRCLE_BRANCH": "origin/master",
+      "CIRCLE_BUILD_NUM": "circleci-pipeline-number",
+      "CIRCLE_BUILD_URL": "circleci-build-url",
+      "CIRCLE_PROJECT_REPONAME": "circleci-pipeline-name",
+      "CIRCLE_REPOSITORY_URL": "sample",
+      "CIRCLE_SHA1": "circleci-git-commit",
+      "CIRCLE_WORKFLOW_ID": "circleci-pipeline-id",
+      "CIRCLE_WORKING_DIRECTORY": "~/foo/bar",
+      "HOME": "/not-my-home",
+      "USERPROFILE": "/not-my-home"
+    },
+    {
+      "ci.job.url": "circleci-build-url",
+      "ci.pipeline.id": "circleci-pipeline-id",
+      "ci.pipeline.name": "circleci-pipeline-name",
+      "ci.pipeline.number": "circleci-pipeline-number",
+      "ci.pipeline.url": "circleci-build-url",
+      "ci.provider.name": "circleci",
+      "ci.workspace_path": "/not-my-home/foo/bar",
+      "git.branch": "master",
+      "git.commit.sha": "circleci-git-commit",
+      "git.repository_url": "sample"
+    }
+  ],
+  [
+    {
+      "CIRCLECI": "circleCI",
+      "CIRCLE_BRANCH": "origin/master",
+      "CIRCLE_BUILD_NUM": "circleci-pipeline-number",
+      "CIRCLE_BUILD_URL": "circleci-build-url",
+      "CIRCLE_PROJECT_REPONAME": "circleci-pipeline-name",
+      "CIRCLE_REPOSITORY_URL": "sample",
+      "CIRCLE_SHA1": "circleci-git-commit",
+      "CIRCLE_WORKFLOW_ID": "circleci-pipeline-id",
+      "CIRCLE_WORKING_DIRECTORY": "~foo/bar",
+      "HOME": "/not-my-home",
+      "USERPROFILE": "/not-my-home"
+    },
+    {
+      "ci.job.url": "circleci-build-url",
+      "ci.pipeline.id": "circleci-pipeline-id",
+      "ci.pipeline.name": "circleci-pipeline-name",
+      "ci.pipeline.number": "circleci-pipeline-number",
+      "ci.pipeline.url": "circleci-build-url",
+      "ci.provider.name": "circleci",
+      "ci.workspace_path": "~foo/bar",
+      "git.branch": "master",
+      "git.commit.sha": "circleci-git-commit",
+      "git.repository_url": "sample"
+    }
+  ],
+  [
+    {
+      "CIRCLECI": "circleCI",
+      "CIRCLE_BRANCH": "origin/master",
+      "CIRCLE_BUILD_NUM": "circleci-pipeline-number",
+      "CIRCLE_BUILD_URL": "circleci-build-url",
+      "CIRCLE_PROJECT_REPONAME": "circleci-pipeline-name",
+      "CIRCLE_REPOSITORY_URL": "sample",
+      "CIRCLE_SHA1": "circleci-git-commit",
+      "CIRCLE_WORKFLOW_ID": "circleci-pipeline-id",
+      "CIRCLE_WORKING_DIRECTORY": "~",
+      "HOME": "/not-my-home",
+      "USERPROFILE": "/not-my-home"
+    },
+    {
+      "ci.job.url": "circleci-build-url",
+      "ci.pipeline.id": "circleci-pipeline-id",
+      "ci.pipeline.name": "circleci-pipeline-name",
+      "ci.pipeline.number": "circleci-pipeline-number",
+      "ci.pipeline.url": "circleci-build-url",
+      "ci.provider.name": "circleci",
+      "ci.workspace_path": "/not-my-home",
+      "git.branch": "master",
+      "git.commit.sha": "circleci-git-commit",
+      "git.repository_url": "sample"
+    }
+  ],
+  [
+    {
+      "CIRCLECI": "circleCI",
+      "CIRCLE_BRANCH": "refs/heads/master",
+      "CIRCLE_BUILD_NUM": "circleci-pipeline-number",
+      "CIRCLE_BUILD_URL": "circleci-build-url",
+      "CIRCLE_PROJECT_REPONAME": "circleci-pipeline-name",
+      "CIRCLE_REPOSITORY_URL": "sample",
+      "CIRCLE_SHA1": "circleci-git-commit",
+      "CIRCLE_WORKFLOW_ID": "circleci-pipeline-id",
+      "CIRCLE_WORKING_DIRECTORY": "/foo/bar"
+    },
+    {
+      "ci.job.url": "circleci-build-url",
+      "ci.pipeline.id": "circleci-pipeline-id",
+      "ci.pipeline.name": "circleci-pipeline-name",
+      "ci.pipeline.number": "circleci-pipeline-number",
+      "ci.pipeline.url": "circleci-build-url",
+      "ci.provider.name": "circleci",
+      "ci.workspace_path": "/foo/bar",
+      "git.branch": "master",
+      "git.commit.sha": "circleci-git-commit",
+      "git.repository_url": "sample"
+    }
+  ],
+  [
+    {
+      "CIRCLECI": "circleCI",
+      "CIRCLE_BRANCH": "refs/heads/feature/one",
+      "CIRCLE_BUILD_NUM": "circleci-pipeline-number",
+      "CIRCLE_BUILD_URL": "circleci-build-url",
+      "CIRCLE_PROJECT_REPONAME": "circleci-pipeline-name",
+      "CIRCLE_REPOSITORY_URL": "sample",
+      "CIRCLE_SHA1": "circleci-git-commit",
+      "CIRCLE_WORKFLOW_ID": "circleci-pipeline-id",
+      "CIRCLE_WORKING_DIRECTORY": "/foo/bar"
+    },
+    {
+      "ci.job.url": "circleci-build-url",
+      "ci.pipeline.id": "circleci-pipeline-id",
+      "ci.pipeline.name": "circleci-pipeline-name",
+      "ci.pipeline.number": "circleci-pipeline-number",
+      "ci.pipeline.url": "circleci-build-url",
+      "ci.provider.name": "circleci",
+      "ci.workspace_path": "/foo/bar",
+      "git.branch": "feature/one",
+      "git.commit.sha": "circleci-git-commit",
+      "git.repository_url": "sample"
+    }
+  ],
+  [
+    {
+      "CIRCLECI": "circleCI",
+      "CIRCLE_BRANCH": "origin/tags/0.1.0",
+      "CIRCLE_BUILD_NUM": "circleci-pipeline-number",
+      "CIRCLE_BUILD_URL": "circleci-build-url",
+      "CIRCLE_PROJECT_REPONAME": "circleci-pipeline-name",
+      "CIRCLE_REPOSITORY_URL": "sample",
+      "CIRCLE_SHA1": "circleci-git-commit",
+      "CIRCLE_TAG": "origin/tags/0.1.0",
+      "CIRCLE_WORKFLOW_ID": "circleci-pipeline-id",
+      "CIRCLE_WORKING_DIRECTORY": "/foo/bar"
+    },
+    {
+      "ci.job.url": "circleci-build-url",
+      "ci.pipeline.id": "circleci-pipeline-id",
+      "ci.pipeline.name": "circleci-pipeline-name",
+      "ci.pipeline.number": "circleci-pipeline-number",
+      "ci.pipeline.url": "circleci-build-url",
+      "ci.provider.name": "circleci",
+      "ci.workspace_path": "/foo/bar",
+      "git.commit.sha": "circleci-git-commit",
+      "git.repository_url": "sample",
+      "git.tag": "0.1.0"
+    }
+  ],
+  [
+    {
+      "CIRCLECI": "circleCI",
+      "CIRCLE_BRANCH": "refs/heads/tags/0.1.0",
+      "CIRCLE_BUILD_NUM": "circleci-pipeline-number",
+      "CIRCLE_BUILD_URL": "circleci-build-url",
+      "CIRCLE_PROJECT_REPONAME": "circleci-pipeline-name",
+      "CIRCLE_REPOSITORY_URL": "sample",
+      "CIRCLE_SHA1": "circleci-git-commit",
+      "CIRCLE_TAG": "refs/heads/tags/0.1.0",
+      "CIRCLE_WORKFLOW_ID": "circleci-pipeline-id",
+      "CIRCLE_WORKING_DIRECTORY": "/foo/bar"
+    },
+    {
+      "ci.job.url": "circleci-build-url",
+      "ci.pipeline.id": "circleci-pipeline-id",
+      "ci.pipeline.name": "circleci-pipeline-name",
+      "ci.pipeline.number": "circleci-pipeline-number",
+      "ci.pipeline.url": "circleci-build-url",
+      "ci.provider.name": "circleci",
+      "ci.workspace_path": "/foo/bar",
+      "git.commit.sha": "circleci-git-commit",
+      "git.repository_url": "sample",
+      "git.tag": "0.1.0"
+    }
+  ],
+  [
+    {
+      "CIRCLECI": "circleCI",
+      "CIRCLE_BRANCH": "origin/master",
+      "CIRCLE_BUILD_NUM": "circleci-pipeline-number",
+      "CIRCLE_BUILD_URL": "circleci-build-url",
+      "CIRCLE_PROJECT_REPONAME": "circleci-pipeline-name",
+      "CIRCLE_REPOSITORY_URL": "sample",
+      "CIRCLE_SHA1": "circleci-git-commit",
+      "CIRCLE_WORKFLOW_ID": "circleci-pipeline-id",
+      "CIRCLE_WORKING_DIRECTORY": "/foo/bar"
+    },
+    {
+      "ci.job.url": "circleci-build-url",
+      "ci.pipeline.id": "circleci-pipeline-id",
+      "ci.pipeline.name": "circleci-pipeline-name",
+      "ci.pipeline.number": "circleci-pipeline-number",
+      "ci.pipeline.url": "circleci-build-url",
+      "ci.provider.name": "circleci",
+      "ci.workspace_path": "/foo/bar",
+      "git.branch": "master",
+      "git.commit.sha": "circleci-git-commit",
+      "git.repository_url": "sample"
+    }
+  ],
+  [
+    {
+      "CIRCLECI": "circleCI",
+      "CIRCLE_BRANCH": "origin/master",
+      "CIRCLE_BUILD_NUM": "circleci-pipeline-number",
+      "CIRCLE_BUILD_URL": "circleci-build-url",
+      "CIRCLE_PROJECT_REPONAME": "circleci-pipeline-name",
+      "CIRCLE_REPOSITORY_URL": "sample",
+      "CIRCLE_SHA1": "circleci-git-commit",
+      "CIRCLE_WORKFLOW_ID": "circleci-pipeline-id",
+      "CIRCLE_WORKING_DIRECTORY": "/foo/bar"
+    },
+    {
+      "ci.job.url": "circleci-build-url",
+      "ci.pipeline.id": "circleci-pipeline-id",
+      "ci.pipeline.name": "circleci-pipeline-name",
+      "ci.pipeline.number": "circleci-pipeline-number",
+      "ci.pipeline.url": "circleci-build-url",
+      "ci.provider.name": "circleci",
+      "ci.workspace_path": "/foo/bar",
+      "git.branch": "master",
+      "git.commit.sha": "circleci-git-commit",
+      "git.repository_url": "sample"
+    }
+  ],
+  [
+    {
+      "CIRCLECI": "circleCI",
+      "CIRCLE_BRANCH": "origin/master",
+      "CIRCLE_BUILD_NUM": "circleci-pipeline-number",
+      "CIRCLE_BUILD_URL": "circleci-build-url",
+      "CIRCLE_PROJECT_REPONAME": "circleci-pipeline-name",
+      "CIRCLE_REPOSITORY_URL": "http://hostname.com/repo.git",
+      "CIRCLE_SHA1": "circleci-git-commit",
+      "CIRCLE_WORKFLOW_ID": "circleci-pipeline-id",
+      "CIRCLE_WORKING_DIRECTORY": "/foo/bar"
+    },
+    {
+      "ci.job.url": "circleci-build-url",
+      "ci.pipeline.id": "circleci-pipeline-id",
+      "ci.pipeline.name": "circleci-pipeline-name",
+      "ci.pipeline.number": "circleci-pipeline-number",
+      "ci.pipeline.url": "circleci-build-url",
+      "ci.provider.name": "circleci",
+      "ci.workspace_path": "/foo/bar",
+      "git.branch": "master",
+      "git.commit.sha": "circleci-git-commit",
+      "git.repository_url": "http://hostname.com/repo.git"
+    }
+  ],
+  [
+    {
+      "CIRCLECI": "circleCI",
+      "CIRCLE_BRANCH": "origin/master",
+      "CIRCLE_BUILD_NUM": "circleci-pipeline-number",
+      "CIRCLE_BUILD_URL": "circleci-build-url",
+      "CIRCLE_PROJECT_REPONAME": "circleci-pipeline-name",
+      "CIRCLE_REPOSITORY_URL": "http://user@hostname.com/repo.git",
+      "CIRCLE_SHA1": "circleci-git-commit",
+      "CIRCLE_WORKFLOW_ID": "circleci-pipeline-id",
+      "CIRCLE_WORKING_DIRECTORY": "/foo/bar"
+    },
+    {
+      "ci.job.url": "circleci-build-url",
+      "ci.pipeline.id": "circleci-pipeline-id",
+      "ci.pipeline.name": "circleci-pipeline-name",
+      "ci.pipeline.number": "circleci-pipeline-number",
+      "ci.pipeline.url": "circleci-build-url",
+      "ci.provider.name": "circleci",
+      "ci.workspace_path": "/foo/bar",
+      "git.branch": "master",
+      "git.commit.sha": "circleci-git-commit",
+      "git.repository_url": "http://hostname.com/repo.git"
+    }
+  ],
+  [
+    {
+      "CIRCLECI": "circleCI",
+      "CIRCLE_BRANCH": "origin/master",
+      "CIRCLE_BUILD_NUM": "circleci-pipeline-number",
+      "CIRCLE_BUILD_URL": "circleci-build-url",
+      "CIRCLE_PROJECT_REPONAME": "circleci-pipeline-name",
+      "CIRCLE_REPOSITORY_URL": "http://user%E2%82%AC@hostname.com/repo.git",
+      "CIRCLE_SHA1": "circleci-git-commit",
+      "CIRCLE_WORKFLOW_ID": "circleci-pipeline-id",
+      "CIRCLE_WORKING_DIRECTORY": "/foo/bar"
+    },
+    {
+      "ci.job.url": "circleci-build-url",
+      "ci.pipeline.id": "circleci-pipeline-id",
+      "ci.pipeline.name": "circleci-pipeline-name",
+      "ci.pipeline.number": "circleci-pipeline-number",
+      "ci.pipeline.url": "circleci-build-url",
+      "ci.provider.name": "circleci",
+      "ci.workspace_path": "/foo/bar",
+      "git.branch": "master",
+      "git.commit.sha": "circleci-git-commit",
+      "git.repository_url": "http://hostname.com/repo.git"
+    }
+  ],
+  [
+    {
+      "CIRCLECI": "circleCI",
+      "CIRCLE_BRANCH": "origin/master",
+      "CIRCLE_BUILD_NUM": "circleci-pipeline-number",
+      "CIRCLE_BUILD_URL": "circleci-build-url",
+      "CIRCLE_PROJECT_REPONAME": "circleci-pipeline-name",
+      "CIRCLE_REPOSITORY_URL": "http://user:pwd@hostname.com/repo.git",
+      "CIRCLE_SHA1": "circleci-git-commit",
+      "CIRCLE_WORKFLOW_ID": "circleci-pipeline-id",
+      "CIRCLE_WORKING_DIRECTORY": "/foo/bar"
+    },
+    {
+      "ci.job.url": "circleci-build-url",
+      "ci.pipeline.id": "circleci-pipeline-id",
+      "ci.pipeline.name": "circleci-pipeline-name",
+      "ci.pipeline.number": "circleci-pipeline-number",
+      "ci.pipeline.url": "circleci-build-url",
+      "ci.provider.name": "circleci",
+      "ci.workspace_path": "/foo/bar",
+      "git.branch": "master",
+      "git.commit.sha": "circleci-git-commit",
+      "git.repository_url": "http://hostname.com/repo.git"
+    }
+  ],
+  [
+    {
+      "CIRCLECI": "circleCI",
+      "CIRCLE_BRANCH": "origin/master",
+      "CIRCLE_BUILD_NUM": "circleci-pipeline-number",
+      "CIRCLE_BUILD_URL": "circleci-build-url",
+      "CIRCLE_PROJECT_REPONAME": "circleci-pipeline-name",
+      "CIRCLE_REPOSITORY_URL": "git@hostname.com:org/repo.git",
+      "CIRCLE_SHA1": "circleci-git-commit",
+      "CIRCLE_WORKFLOW_ID": "circleci-pipeline-id",
+      "CIRCLE_WORKING_DIRECTORY": "/foo/bar"
+    },
+    {
+      "ci.job.url": "circleci-build-url",
+      "ci.pipeline.id": "circleci-pipeline-id",
+      "ci.pipeline.name": "circleci-pipeline-name",
+      "ci.pipeline.number": "circleci-pipeline-number",
+      "ci.pipeline.url": "circleci-build-url",
+      "ci.provider.name": "circleci",
+      "ci.workspace_path": "/foo/bar",
+      "git.branch": "master",
+      "git.commit.sha": "circleci-git-commit",
+      "git.repository_url": "git@hostname.com:org/repo.git"
+    }
+  ]
+]

--- a/src/helpers/__tests__/ci-env/github.json
+++ b/src/helpers/__tests__/ci-env/github.json
@@ -1,0 +1,395 @@
+[
+  [
+    {
+      "GITHUB_ACTION": "run",
+      "GITHUB_REF": "master",
+      "GITHUB_REPOSITORY": "ghactions-repo",
+      "GITHUB_RUN_ID": "ghactions-pipeline-id",
+      "GITHUB_RUN_NUMBER": "ghactions-pipeline-number",
+      "GITHUB_SHA": "ghactions-commit",
+      "GITHUB_WORKFLOW": "ghactions-pipeline-name",
+      "GITHUB_WORKSPACE": "/foo/bar"
+    },
+    {
+      "ci.job.url": "https://github.com/ghactions-repo/commit/ghactions-commit/checks",
+      "ci.pipeline.id": "ghactions-pipeline-id",
+      "ci.pipeline.name": "ghactions-pipeline-name",
+      "ci.pipeline.number": "ghactions-pipeline-number",
+      "ci.pipeline.url": "https://github.com/ghactions-repo/commit/ghactions-commit/checks",
+      "ci.provider.name": "github",
+      "ci.workspace_path": "/foo/bar",
+      "git.branch": "master",
+      "git.commit.sha": "ghactions-commit",
+      "git.repository_url": "https://github.com/ghactions-repo.git"
+    }
+  ],
+  [
+    {
+      "GITHUB_ACTION": "run",
+      "GITHUB_REF": "master",
+      "GITHUB_REPOSITORY": "ghactions-repo",
+      "GITHUB_RUN_ID": "ghactions-pipeline-id",
+      "GITHUB_RUN_NUMBER": "ghactions-pipeline-number",
+      "GITHUB_SHA": "ghactions-commit",
+      "GITHUB_WORKFLOW": "ghactions-pipeline-name",
+      "GITHUB_WORKSPACE": "/foo/bar"
+    },
+    {
+      "ci.job.url": "https://github.com/ghactions-repo/commit/ghactions-commit/checks",
+      "ci.pipeline.id": "ghactions-pipeline-id",
+      "ci.pipeline.name": "ghactions-pipeline-name",
+      "ci.pipeline.number": "ghactions-pipeline-number",
+      "ci.pipeline.url": "https://github.com/ghactions-repo/commit/ghactions-commit/checks",
+      "ci.provider.name": "github",
+      "ci.workspace_path": "/foo/bar",
+      "git.branch": "master",
+      "git.commit.sha": "ghactions-commit",
+      "git.repository_url": "https://github.com/ghactions-repo.git"
+    }
+  ],
+  [
+    {
+      "GITHUB_ACTION": "run",
+      "GITHUB_REF": "master",
+      "GITHUB_REPOSITORY": "ghactions-repo",
+      "GITHUB_RUN_ID": "ghactions-pipeline-id",
+      "GITHUB_RUN_NUMBER": "ghactions-pipeline-number",
+      "GITHUB_SHA": "ghactions-commit",
+      "GITHUB_WORKFLOW": "ghactions-pipeline-name",
+      "GITHUB_WORKSPACE": "foo/bar"
+    },
+    {
+      "ci.job.url": "https://github.com/ghactions-repo/commit/ghactions-commit/checks",
+      "ci.pipeline.id": "ghactions-pipeline-id",
+      "ci.pipeline.name": "ghactions-pipeline-name",
+      "ci.pipeline.number": "ghactions-pipeline-number",
+      "ci.pipeline.url": "https://github.com/ghactions-repo/commit/ghactions-commit/checks",
+      "ci.provider.name": "github",
+      "ci.workspace_path": "foo/bar",
+      "git.branch": "master",
+      "git.commit.sha": "ghactions-commit",
+      "git.repository_url": "https://github.com/ghactions-repo.git"
+    }
+  ],
+  [
+    {
+      "GITHUB_ACTION": "run",
+      "GITHUB_REF": "master",
+      "GITHUB_REPOSITORY": "ghactions-repo",
+      "GITHUB_RUN_ID": "ghactions-pipeline-id",
+      "GITHUB_RUN_NUMBER": "ghactions-pipeline-number",
+      "GITHUB_SHA": "ghactions-commit",
+      "GITHUB_WORKFLOW": "ghactions-pipeline-name",
+      "GITHUB_WORKSPACE": "/foo/bar~"
+    },
+    {
+      "ci.job.url": "https://github.com/ghactions-repo/commit/ghactions-commit/checks",
+      "ci.pipeline.id": "ghactions-pipeline-id",
+      "ci.pipeline.name": "ghactions-pipeline-name",
+      "ci.pipeline.number": "ghactions-pipeline-number",
+      "ci.pipeline.url": "https://github.com/ghactions-repo/commit/ghactions-commit/checks",
+      "ci.provider.name": "github",
+      "ci.workspace_path": "/foo/bar~",
+      "git.branch": "master",
+      "git.commit.sha": "ghactions-commit",
+      "git.repository_url": "https://github.com/ghactions-repo.git"
+    }
+  ],
+  [
+    {
+      "GITHUB_ACTION": "run",
+      "GITHUB_REF": "master",
+      "GITHUB_REPOSITORY": "ghactions-repo",
+      "GITHUB_RUN_ID": "ghactions-pipeline-id",
+      "GITHUB_RUN_NUMBER": "ghactions-pipeline-number",
+      "GITHUB_SHA": "ghactions-commit",
+      "GITHUB_WORKFLOW": "ghactions-pipeline-name",
+      "GITHUB_WORKSPACE": "/foo/~/bar"
+    },
+    {
+      "ci.job.url": "https://github.com/ghactions-repo/commit/ghactions-commit/checks",
+      "ci.pipeline.id": "ghactions-pipeline-id",
+      "ci.pipeline.name": "ghactions-pipeline-name",
+      "ci.pipeline.number": "ghactions-pipeline-number",
+      "ci.pipeline.url": "https://github.com/ghactions-repo/commit/ghactions-commit/checks",
+      "ci.provider.name": "github",
+      "ci.workspace_path": "/foo/~/bar",
+      "git.branch": "master",
+      "git.commit.sha": "ghactions-commit",
+      "git.repository_url": "https://github.com/ghactions-repo.git"
+    }
+  ],
+  [
+    {
+      "GITHUB_ACTION": "run",
+      "GITHUB_REF": "master",
+      "GITHUB_REPOSITORY": "ghactions-repo",
+      "GITHUB_RUN_ID": "ghactions-pipeline-id",
+      "GITHUB_RUN_NUMBER": "ghactions-pipeline-number",
+      "GITHUB_SHA": "ghactions-commit",
+      "GITHUB_WORKFLOW": "ghactions-pipeline-name",
+      "GITHUB_WORKSPACE": "~/foo/bar",
+      "HOME": "/not-my-home",
+      "USERPROFILE": "/not-my-home"
+    },
+    {
+      "ci.job.url": "https://github.com/ghactions-repo/commit/ghactions-commit/checks",
+      "ci.pipeline.id": "ghactions-pipeline-id",
+      "ci.pipeline.name": "ghactions-pipeline-name",
+      "ci.pipeline.number": "ghactions-pipeline-number",
+      "ci.pipeline.url": "https://github.com/ghactions-repo/commit/ghactions-commit/checks",
+      "ci.provider.name": "github",
+      "ci.workspace_path": "/not-my-home/foo/bar",
+      "git.branch": "master",
+      "git.commit.sha": "ghactions-commit",
+      "git.repository_url": "https://github.com/ghactions-repo.git"
+    }
+  ],
+  [
+    {
+      "GITHUB_ACTION": "run",
+      "GITHUB_REF": "master",
+      "GITHUB_REPOSITORY": "ghactions-repo",
+      "GITHUB_RUN_ID": "ghactions-pipeline-id",
+      "GITHUB_RUN_NUMBER": "ghactions-pipeline-number",
+      "GITHUB_SHA": "ghactions-commit",
+      "GITHUB_WORKFLOW": "ghactions-pipeline-name",
+      "GITHUB_WORKSPACE": "~foo/bar",
+      "HOME": "/not-my-home",
+      "USERPROFILE": "/not-my-home"
+    },
+    {
+      "ci.job.url": "https://github.com/ghactions-repo/commit/ghactions-commit/checks",
+      "ci.pipeline.id": "ghactions-pipeline-id",
+      "ci.pipeline.name": "ghactions-pipeline-name",
+      "ci.pipeline.number": "ghactions-pipeline-number",
+      "ci.pipeline.url": "https://github.com/ghactions-repo/commit/ghactions-commit/checks",
+      "ci.provider.name": "github",
+      "ci.workspace_path": "~foo/bar",
+      "git.branch": "master",
+      "git.commit.sha": "ghactions-commit",
+      "git.repository_url": "https://github.com/ghactions-repo.git"
+    }
+  ],
+  [
+    {
+      "GITHUB_ACTION": "run",
+      "GITHUB_REF": "master",
+      "GITHUB_REPOSITORY": "ghactions-repo",
+      "GITHUB_RUN_ID": "ghactions-pipeline-id",
+      "GITHUB_RUN_NUMBER": "ghactions-pipeline-number",
+      "GITHUB_SHA": "ghactions-commit",
+      "GITHUB_WORKFLOW": "ghactions-pipeline-name",
+      "GITHUB_WORKSPACE": "~",
+      "HOME": "/not-my-home",
+      "USERPROFILE": "/not-my-home"
+    },
+    {
+      "ci.job.url": "https://github.com/ghactions-repo/commit/ghactions-commit/checks",
+      "ci.pipeline.id": "ghactions-pipeline-id",
+      "ci.pipeline.name": "ghactions-pipeline-name",
+      "ci.pipeline.number": "ghactions-pipeline-number",
+      "ci.pipeline.url": "https://github.com/ghactions-repo/commit/ghactions-commit/checks",
+      "ci.provider.name": "github",
+      "ci.workspace_path": "/not-my-home",
+      "git.branch": "master",
+      "git.commit.sha": "ghactions-commit",
+      "git.repository_url": "https://github.com/ghactions-repo.git"
+    }
+  ],
+  [
+    {
+      "GITHUB_ACTION": "run",
+      "GITHUB_REF": "origin/master",
+      "GITHUB_REPOSITORY": "ghactions-repo",
+      "GITHUB_RUN_ID": "ghactions-pipeline-id",
+      "GITHUB_RUN_NUMBER": "ghactions-pipeline-number",
+      "GITHUB_SHA": "ghactions-commit",
+      "GITHUB_WORKFLOW": "ghactions-pipeline-name",
+      "GITHUB_WORKSPACE": "/foo/bar"
+    },
+    {
+      "ci.job.url": "https://github.com/ghactions-repo/commit/ghactions-commit/checks",
+      "ci.pipeline.id": "ghactions-pipeline-id",
+      "ci.pipeline.name": "ghactions-pipeline-name",
+      "ci.pipeline.number": "ghactions-pipeline-number",
+      "ci.pipeline.url": "https://github.com/ghactions-repo/commit/ghactions-commit/checks",
+      "ci.provider.name": "github",
+      "ci.workspace_path": "/foo/bar",
+      "git.branch": "master",
+      "git.commit.sha": "ghactions-commit",
+      "git.repository_url": "https://github.com/ghactions-repo.git"
+    }
+  ],
+  [
+    {
+      "GITHUB_ACTION": "run",
+      "GITHUB_REF": "refs/heads/master",
+      "GITHUB_REPOSITORY": "ghactions-repo",
+      "GITHUB_RUN_ID": "ghactions-pipeline-id",
+      "GITHUB_RUN_NUMBER": "ghactions-pipeline-number",
+      "GITHUB_SHA": "ghactions-commit",
+      "GITHUB_WORKFLOW": "ghactions-pipeline-name",
+      "GITHUB_WORKSPACE": "/foo/bar"
+    },
+    {
+      "ci.job.url": "https://github.com/ghactions-repo/commit/ghactions-commit/checks",
+      "ci.pipeline.id": "ghactions-pipeline-id",
+      "ci.pipeline.name": "ghactions-pipeline-name",
+      "ci.pipeline.number": "ghactions-pipeline-number",
+      "ci.pipeline.url": "https://github.com/ghactions-repo/commit/ghactions-commit/checks",
+      "ci.provider.name": "github",
+      "ci.workspace_path": "/foo/bar",
+      "git.branch": "master",
+      "git.commit.sha": "ghactions-commit",
+      "git.repository_url": "https://github.com/ghactions-repo.git"
+    }
+  ],
+  [
+    {
+      "GITHUB_ACTION": "run",
+      "GITHUB_REF": "refs/heads/feature/one",
+      "GITHUB_REPOSITORY": "ghactions-repo",
+      "GITHUB_RUN_ID": "ghactions-pipeline-id",
+      "GITHUB_RUN_NUMBER": "ghactions-pipeline-number",
+      "GITHUB_SHA": "ghactions-commit",
+      "GITHUB_WORKFLOW": "ghactions-pipeline-name",
+      "GITHUB_WORKSPACE": "/foo/bar"
+    },
+    {
+      "ci.job.url": "https://github.com/ghactions-repo/commit/ghactions-commit/checks",
+      "ci.pipeline.id": "ghactions-pipeline-id",
+      "ci.pipeline.name": "ghactions-pipeline-name",
+      "ci.pipeline.number": "ghactions-pipeline-number",
+      "ci.pipeline.url": "https://github.com/ghactions-repo/commit/ghactions-commit/checks",
+      "ci.provider.name": "github",
+      "ci.workspace_path": "/foo/bar",
+      "git.branch": "feature/one",
+      "git.commit.sha": "ghactions-commit",
+      "git.repository_url": "https://github.com/ghactions-repo.git"
+    }
+  ],
+  [
+    {
+      "GITHUB_ACTION": "run",
+      "GITHUB_REF": "origin/tags/0.1.0",
+      "GITHUB_REPOSITORY": "ghactions-repo",
+      "GITHUB_RUN_ID": "ghactions-pipeline-id",
+      "GITHUB_RUN_NUMBER": "ghactions-pipeline-number",
+      "GITHUB_SHA": "ghactions-commit",
+      "GITHUB_WORKFLOW": "ghactions-pipeline-name",
+      "GITHUB_WORKSPACE": "/foo/bar"
+    },
+    {
+      "ci.job.url": "https://github.com/ghactions-repo/commit/ghactions-commit/checks",
+      "ci.pipeline.id": "ghactions-pipeline-id",
+      "ci.pipeline.name": "ghactions-pipeline-name",
+      "ci.pipeline.number": "ghactions-pipeline-number",
+      "ci.pipeline.url": "https://github.com/ghactions-repo/commit/ghactions-commit/checks",
+      "ci.provider.name": "github",
+      "ci.workspace_path": "/foo/bar",
+      "git.commit.sha": "ghactions-commit",
+      "git.repository_url": "https://github.com/ghactions-repo.git",
+      "git.tag": "0.1.0"
+    }
+  ],
+  [
+    {
+      "GITHUB_ACTION": "run",
+      "GITHUB_REF": "refs/heads/tags/0.1.0",
+      "GITHUB_REPOSITORY": "ghactions-repo",
+      "GITHUB_RUN_ID": "ghactions-pipeline-id",
+      "GITHUB_RUN_NUMBER": "ghactions-pipeline-number",
+      "GITHUB_SHA": "ghactions-commit",
+      "GITHUB_WORKFLOW": "ghactions-pipeline-name",
+      "GITHUB_WORKSPACE": "/foo/bar"
+    },
+    {
+      "ci.job.url": "https://github.com/ghactions-repo/commit/ghactions-commit/checks",
+      "ci.pipeline.id": "ghactions-pipeline-id",
+      "ci.pipeline.name": "ghactions-pipeline-name",
+      "ci.pipeline.number": "ghactions-pipeline-number",
+      "ci.pipeline.url": "https://github.com/ghactions-repo/commit/ghactions-commit/checks",
+      "ci.provider.name": "github",
+      "ci.workspace_path": "/foo/bar",
+      "git.commit.sha": "ghactions-commit",
+      "git.repository_url": "https://github.com/ghactions-repo.git",
+      "git.tag": "0.1.0"
+    }
+  ],
+  [
+    {
+      "GITHUB_ACTION": "run",
+      "GITHUB_HEAD_REF": "origin/other",
+      "GITHUB_REF": "origin/master",
+      "GITHUB_REPOSITORY": "ghactions-repo",
+      "GITHUB_RUN_ID": "ghactions-pipeline-id",
+      "GITHUB_RUN_NUMBER": "ghactions-pipeline-number",
+      "GITHUB_SHA": "ghactions-commit",
+      "GITHUB_WORKFLOW": "ghactions-pipeline-name",
+      "GITHUB_WORKSPACE": "/foo/bar"
+    },
+    {
+      "ci.job.url": "https://github.com/ghactions-repo/commit/ghactions-commit/checks",
+      "ci.pipeline.id": "ghactions-pipeline-id",
+      "ci.pipeline.name": "ghactions-pipeline-name",
+      "ci.pipeline.number": "ghactions-pipeline-number",
+      "ci.pipeline.url": "https://github.com/ghactions-repo/commit/ghactions-commit/checks",
+      "ci.provider.name": "github",
+      "ci.workspace_path": "/foo/bar",
+      "git.branch": "other",
+      "git.commit.sha": "ghactions-commit",
+      "git.repository_url": "https://github.com/ghactions-repo.git"
+    }
+  ],
+  [
+    {
+      "GITHUB_ACTION": "run",
+      "GITHUB_HEAD_REF": "refs/heads/other",
+      "GITHUB_REF": "refs/heads/master",
+      "GITHUB_REPOSITORY": "ghactions-repo",
+      "GITHUB_RUN_ID": "ghactions-pipeline-id",
+      "GITHUB_RUN_NUMBER": "ghactions-pipeline-number",
+      "GITHUB_SHA": "ghactions-commit",
+      "GITHUB_WORKFLOW": "ghactions-pipeline-name",
+      "GITHUB_WORKSPACE": "/foo/bar"
+    },
+    {
+      "ci.job.url": "https://github.com/ghactions-repo/commit/ghactions-commit/checks",
+      "ci.pipeline.id": "ghactions-pipeline-id",
+      "ci.pipeline.name": "ghactions-pipeline-name",
+      "ci.pipeline.number": "ghactions-pipeline-number",
+      "ci.pipeline.url": "https://github.com/ghactions-repo/commit/ghactions-commit/checks",
+      "ci.provider.name": "github",
+      "ci.workspace_path": "/foo/bar",
+      "git.branch": "other",
+      "git.commit.sha": "ghactions-commit",
+      "git.repository_url": "https://github.com/ghactions-repo.git"
+    }
+  ],
+  [
+    {
+      "GITHUB_ACTION": "run",
+      "GITHUB_HEAD_REF": "refs/heads/feature/other",
+      "GITHUB_REF": "refs/heads/feature/one",
+      "GITHUB_REPOSITORY": "ghactions-repo",
+      "GITHUB_RUN_ID": "ghactions-pipeline-id",
+      "GITHUB_RUN_NUMBER": "ghactions-pipeline-number",
+      "GITHUB_SHA": "ghactions-commit",
+      "GITHUB_WORKFLOW": "ghactions-pipeline-name",
+      "GITHUB_WORKSPACE": "/foo/bar"
+    },
+    {
+      "ci.job.url": "https://github.com/ghactions-repo/commit/ghactions-commit/checks",
+      "ci.pipeline.id": "ghactions-pipeline-id",
+      "ci.pipeline.name": "ghactions-pipeline-name",
+      "ci.pipeline.number": "ghactions-pipeline-number",
+      "ci.pipeline.url": "https://github.com/ghactions-repo/commit/ghactions-commit/checks",
+      "ci.provider.name": "github",
+      "ci.workspace_path": "/foo/bar",
+      "git.branch": "feature/other",
+      "git.commit.sha": "ghactions-commit",
+      "git.repository_url": "https://github.com/ghactions-repo.git"
+    }
+  ]
+]

--- a/src/helpers/__tests__/ci-env/gitlab.json
+++ b/src/helpers/__tests__/ci-env/gitlab.json
@@ -1,0 +1,630 @@
+[
+  [
+    {
+      "CI_COMMIT_BRANCH": "origin/master",
+      "CI_COMMIT_SHA": "gitlab-git-commit",
+      "CI_JOB_NAME": "gitlab-job-name",
+      "CI_JOB_STAGE": "gitlab-stage-name",
+      "CI_JOB_URL": "gitlab-job-url",
+      "CI_PIPELINE_ID": "gitlab-pipeline-id",
+      "CI_PIPELINE_IID": "gitlab-pipeline-number",
+      "CI_PIPELINE_URL": "https://foo/repo/-/pipelines/1234",
+      "CI_PROJECT_PATH": "gitlab-pipeline-name",
+      "CI_REPOSITORY_URL": "sample",
+      "GITLAB_CI": "gitlab"
+    },
+    {
+      "ci.job.name": "gitlab-job-name",
+      "ci.job.url": "gitlab-job-url",
+      "ci.pipeline.id": "gitlab-pipeline-id",
+      "ci.pipeline.name": "gitlab-pipeline-name",
+      "ci.pipeline.number": "gitlab-pipeline-number",
+      "ci.pipeline.url": "https://foo/repo/pipelines/1234",
+      "ci.provider.name": "gitlab",
+      "ci.stage.name": "gitlab-stage-name",
+      "git.branch": "master",
+      "git.commit.sha": "gitlab-git-commit",
+      "git.repository_url": "sample"
+    }
+  ],
+  [
+    {
+      "CI_COMMIT_BRANCH": "origin/master",
+      "CI_COMMIT_SHA": "gitlab-git-commit",
+      "CI_JOB_NAME": "gitlab-job-name",
+      "CI_JOB_STAGE": "gitlab-stage-name",
+      "CI_JOB_URL": "gitlab-job-url",
+      "CI_PIPELINE_ID": "gitlab-pipeline-id",
+      "CI_PIPELINE_IID": "gitlab-pipeline-number",
+      "CI_PIPELINE_URL": "https://foo/repo/-/pipelines/1234",
+      "CI_PROJECT_PATH": "gitlab-pipeline-name",
+      "CI_REPOSITORY_URL": "sample",
+      "GITLAB_CI": "gitlab"
+    },
+    {
+      "ci.job.name": "gitlab-job-name",
+      "ci.job.url": "gitlab-job-url",
+      "ci.pipeline.id": "gitlab-pipeline-id",
+      "ci.pipeline.name": "gitlab-pipeline-name",
+      "ci.pipeline.number": "gitlab-pipeline-number",
+      "ci.pipeline.url": "https://foo/repo/pipelines/1234",
+      "ci.provider.name": "gitlab",
+      "ci.stage.name": "gitlab-stage-name",
+      "git.branch": "master",
+      "git.commit.sha": "gitlab-git-commit",
+      "git.repository_url": "sample"
+    }
+  ],
+  [
+    {
+      "CI_COMMIT_BRANCH": "origin/master",
+      "CI_COMMIT_SHA": "gitlab-git-commit",
+      "CI_JOB_NAME": "gitlab-job-name",
+      "CI_JOB_STAGE": "gitlab-stage-name",
+      "CI_JOB_URL": "gitlab-job-url",
+      "CI_PIPELINE_ID": "gitlab-pipeline-id",
+      "CI_PIPELINE_IID": "gitlab-pipeline-number",
+      "CI_PIPELINE_URL": "https://foo/repo/-/pipelines/1234",
+      "CI_PROJECT_DIR": "foo/bar",
+      "CI_PROJECT_PATH": "gitlab-pipeline-name",
+      "CI_REPOSITORY_URL": "sample",
+      "GITLAB_CI": "gitlab"
+    },
+    {
+      "ci.job.name": "gitlab-job-name",
+      "ci.job.url": "gitlab-job-url",
+      "ci.pipeline.id": "gitlab-pipeline-id",
+      "ci.pipeline.name": "gitlab-pipeline-name",
+      "ci.pipeline.number": "gitlab-pipeline-number",
+      "ci.pipeline.url": "https://foo/repo/pipelines/1234",
+      "ci.provider.name": "gitlab",
+      "ci.stage.name": "gitlab-stage-name",
+      "ci.workspace_path": "foo/bar",
+      "git.branch": "master",
+      "git.commit.sha": "gitlab-git-commit",
+      "git.repository_url": "sample"
+    }
+  ],
+  [
+    {
+      "CI_COMMIT_BRANCH": "origin/master",
+      "CI_COMMIT_SHA": "gitlab-git-commit",
+      "CI_JOB_NAME": "gitlab-job-name",
+      "CI_JOB_STAGE": "gitlab-stage-name",
+      "CI_JOB_URL": "gitlab-job-url",
+      "CI_PIPELINE_ID": "gitlab-pipeline-id",
+      "CI_PIPELINE_IID": "gitlab-pipeline-number",
+      "CI_PIPELINE_URL": "https://foo/repo/-/pipelines/1234",
+      "CI_PROJECT_DIR": "/foo/bar~",
+      "CI_PROJECT_PATH": "gitlab-pipeline-name",
+      "CI_REPOSITORY_URL": "sample",
+      "GITLAB_CI": "gitlab"
+    },
+    {
+      "ci.job.name": "gitlab-job-name",
+      "ci.job.url": "gitlab-job-url",
+      "ci.pipeline.id": "gitlab-pipeline-id",
+      "ci.pipeline.name": "gitlab-pipeline-name",
+      "ci.pipeline.number": "gitlab-pipeline-number",
+      "ci.pipeline.url": "https://foo/repo/pipelines/1234",
+      "ci.provider.name": "gitlab",
+      "ci.stage.name": "gitlab-stage-name",
+      "ci.workspace_path": "/foo/bar~",
+      "git.branch": "master",
+      "git.commit.sha": "gitlab-git-commit",
+      "git.repository_url": "sample"
+    }
+  ],
+  [
+    {
+      "CI_COMMIT_BRANCH": "origin/master",
+      "CI_COMMIT_SHA": "gitlab-git-commit",
+      "CI_JOB_NAME": "gitlab-job-name",
+      "CI_JOB_STAGE": "gitlab-stage-name",
+      "CI_JOB_URL": "gitlab-job-url",
+      "CI_PIPELINE_ID": "gitlab-pipeline-id",
+      "CI_PIPELINE_IID": "gitlab-pipeline-number",
+      "CI_PIPELINE_URL": "https://foo/repo/-/pipelines/1234",
+      "CI_PROJECT_DIR": "/foo/~/bar",
+      "CI_PROJECT_PATH": "gitlab-pipeline-name",
+      "CI_REPOSITORY_URL": "sample",
+      "GITLAB_CI": "gitlab"
+    },
+    {
+      "ci.job.name": "gitlab-job-name",
+      "ci.job.url": "gitlab-job-url",
+      "ci.pipeline.id": "gitlab-pipeline-id",
+      "ci.pipeline.name": "gitlab-pipeline-name",
+      "ci.pipeline.number": "gitlab-pipeline-number",
+      "ci.pipeline.url": "https://foo/repo/pipelines/1234",
+      "ci.provider.name": "gitlab",
+      "ci.stage.name": "gitlab-stage-name",
+      "ci.workspace_path": "/foo/~/bar",
+      "git.branch": "master",
+      "git.commit.sha": "gitlab-git-commit",
+      "git.repository_url": "sample"
+    }
+  ],
+  [
+    {
+      "CI_COMMIT_BRANCH": "origin/master",
+      "CI_COMMIT_SHA": "gitlab-git-commit",
+      "CI_JOB_NAME": "gitlab-job-name",
+      "CI_JOB_STAGE": "gitlab-stage-name",
+      "CI_JOB_URL": "gitlab-job-url",
+      "CI_PIPELINE_ID": "gitlab-pipeline-id",
+      "CI_PIPELINE_IID": "gitlab-pipeline-number",
+      "CI_PIPELINE_URL": "https://foo/repo/-/pipelines/1234",
+      "CI_PROJECT_DIR": "~/foo/bar",
+      "CI_PROJECT_PATH": "gitlab-pipeline-name",
+      "CI_REPOSITORY_URL": "sample",
+      "GITLAB_CI": "gitlab",
+      "HOME": "/not-my-home",
+      "USERPROFILE": "/not-my-home"
+    },
+    {
+      "ci.job.name": "gitlab-job-name",
+      "ci.job.url": "gitlab-job-url",
+      "ci.pipeline.id": "gitlab-pipeline-id",
+      "ci.pipeline.name": "gitlab-pipeline-name",
+      "ci.pipeline.number": "gitlab-pipeline-number",
+      "ci.pipeline.url": "https://foo/repo/pipelines/1234",
+      "ci.provider.name": "gitlab",
+      "ci.stage.name": "gitlab-stage-name",
+      "ci.workspace_path": "/not-my-home/foo/bar",
+      "git.branch": "master",
+      "git.commit.sha": "gitlab-git-commit",
+      "git.repository_url": "sample"
+    }
+  ],
+  [
+    {
+      "CI_COMMIT_BRANCH": "origin/master",
+      "CI_COMMIT_SHA": "gitlab-git-commit",
+      "CI_JOB_NAME": "gitlab-job-name",
+      "CI_JOB_STAGE": "gitlab-stage-name",
+      "CI_JOB_URL": "gitlab-job-url",
+      "CI_PIPELINE_ID": "gitlab-pipeline-id",
+      "CI_PIPELINE_IID": "gitlab-pipeline-number",
+      "CI_PIPELINE_URL": "https://foo/repo/-/pipelines/1234",
+      "CI_PROJECT_DIR": "~foo/bar",
+      "CI_PROJECT_PATH": "gitlab-pipeline-name",
+      "CI_REPOSITORY_URL": "sample",
+      "GITLAB_CI": "gitlab",
+      "HOME": "/not-my-home",
+      "USERPROFILE": "/not-my-home"
+    },
+    {
+      "ci.job.name": "gitlab-job-name",
+      "ci.job.url": "gitlab-job-url",
+      "ci.pipeline.id": "gitlab-pipeline-id",
+      "ci.pipeline.name": "gitlab-pipeline-name",
+      "ci.pipeline.number": "gitlab-pipeline-number",
+      "ci.pipeline.url": "https://foo/repo/pipelines/1234",
+      "ci.provider.name": "gitlab",
+      "ci.stage.name": "gitlab-stage-name",
+      "ci.workspace_path": "~foo/bar",
+      "git.branch": "master",
+      "git.commit.sha": "gitlab-git-commit",
+      "git.repository_url": "sample"
+    }
+  ],
+  [
+    {
+      "CI_COMMIT_BRANCH": "origin/master",
+      "CI_COMMIT_SHA": "gitlab-git-commit",
+      "CI_JOB_NAME": "gitlab-job-name",
+      "CI_JOB_STAGE": "gitlab-stage-name",
+      "CI_JOB_URL": "gitlab-job-url",
+      "CI_PIPELINE_ID": "gitlab-pipeline-id",
+      "CI_PIPELINE_IID": "gitlab-pipeline-number",
+      "CI_PIPELINE_URL": "https://foo/repo/-/pipelines/1234",
+      "CI_PROJECT_DIR": "~",
+      "CI_PROJECT_PATH": "gitlab-pipeline-name",
+      "CI_REPOSITORY_URL": "sample",
+      "GITLAB_CI": "gitlab",
+      "HOME": "/not-my-home",
+      "USERPROFILE": "/not-my-home"
+    },
+    {
+      "ci.job.name": "gitlab-job-name",
+      "ci.job.url": "gitlab-job-url",
+      "ci.pipeline.id": "gitlab-pipeline-id",
+      "ci.pipeline.name": "gitlab-pipeline-name",
+      "ci.pipeline.number": "gitlab-pipeline-number",
+      "ci.pipeline.url": "https://foo/repo/pipelines/1234",
+      "ci.provider.name": "gitlab",
+      "ci.stage.name": "gitlab-stage-name",
+      "ci.workspace_path": "/not-my-home",
+      "git.branch": "master",
+      "git.commit.sha": "gitlab-git-commit",
+      "git.repository_url": "sample"
+    }
+  ],
+  [
+    {
+      "CI_COMMIT_BRANCH": "origin/master",
+      "CI_COMMIT_SHA": "gitlab-git-commit",
+      "CI_JOB_NAME": "gitlab-job-name",
+      "CI_JOB_STAGE": "gitlab-stage-name",
+      "CI_JOB_URL": "gitlab-job-url",
+      "CI_PIPELINE_ID": "gitlab-pipeline-id",
+      "CI_PIPELINE_IID": "gitlab-pipeline-number",
+      "CI_PIPELINE_URL": "https://foo/repo/-/pipelines/1234",
+      "CI_PROJECT_DIR": "/foo/bar",
+      "CI_PROJECT_PATH": "gitlab-pipeline-name",
+      "CI_REPOSITORY_URL": "sample",
+      "GITLAB_CI": "gitlab"
+    },
+    {
+      "ci.job.name": "gitlab-job-name",
+      "ci.job.url": "gitlab-job-url",
+      "ci.pipeline.id": "gitlab-pipeline-id",
+      "ci.pipeline.name": "gitlab-pipeline-name",
+      "ci.pipeline.number": "gitlab-pipeline-number",
+      "ci.pipeline.url": "https://foo/repo/pipelines/1234",
+      "ci.provider.name": "gitlab",
+      "ci.stage.name": "gitlab-stage-name",
+      "ci.workspace_path": "/foo/bar",
+      "git.branch": "master",
+      "git.commit.sha": "gitlab-git-commit",
+      "git.repository_url": "sample"
+    }
+  ],
+  [
+    {
+      "CI_COMMIT_BRANCH": "origin/master",
+      "CI_COMMIT_SHA": "gitlab-git-commit",
+      "CI_JOB_NAME": "gitlab-job-name",
+      "CI_JOB_STAGE": "gitlab-stage-name",
+      "CI_JOB_URL": "gitlab-job-url",
+      "CI_PIPELINE_ID": "gitlab-pipeline-id",
+      "CI_PIPELINE_IID": "gitlab-pipeline-number",
+      "CI_PROJECT_DIR": "/foo/bar",
+      "CI_PROJECT_PATH": "gitlab-pipeline-name",
+      "CI_REPOSITORY_URL": "sample",
+      "GITLAB_CI": "gitlab"
+    },
+    {
+      "ci.job.name": "gitlab-job-name",
+      "ci.job.url": "gitlab-job-url",
+      "ci.pipeline.id": "gitlab-pipeline-id",
+      "ci.pipeline.name": "gitlab-pipeline-name",
+      "ci.pipeline.number": "gitlab-pipeline-number",
+      "ci.provider.name": "gitlab",
+      "ci.stage.name": "gitlab-stage-name",
+      "ci.workspace_path": "/foo/bar",
+      "git.branch": "master",
+      "git.commit.sha": "gitlab-git-commit",
+      "git.repository_url": "sample"
+    }
+  ],
+  [
+    {
+      "CI_COMMIT_BRANCH": "origin/master",
+      "CI_COMMIT_SHA": "gitlab-git-commit",
+      "CI_JOB_NAME": "gitlab-job-name",
+      "CI_JOB_STAGE": "gitlab-stage-name",
+      "CI_JOB_URL": "gitlab-job-url",
+      "CI_PIPELINE_ID": "gitlab-pipeline-id",
+      "CI_PIPELINE_IID": "gitlab-pipeline-number",
+      "CI_PROJECT_DIR": "/foo/bar",
+      "CI_PROJECT_PATH": "gitlab-pipeline-name",
+      "CI_REPOSITORY_URL": "sample",
+      "GITLAB_CI": "gitlab"
+    },
+    {
+      "ci.job.name": "gitlab-job-name",
+      "ci.job.url": "gitlab-job-url",
+      "ci.pipeline.id": "gitlab-pipeline-id",
+      "ci.pipeline.name": "gitlab-pipeline-name",
+      "ci.pipeline.number": "gitlab-pipeline-number",
+      "ci.provider.name": "gitlab",
+      "ci.stage.name": "gitlab-stage-name",
+      "ci.workspace_path": "/foo/bar",
+      "git.branch": "master",
+      "git.commit.sha": "gitlab-git-commit",
+      "git.repository_url": "sample"
+    }
+  ],
+  [
+    {
+      "CI_COMMIT_BRANCH": "refs/heads/master",
+      "CI_COMMIT_SHA": "gitlab-git-commit",
+      "CI_JOB_NAME": "gitlab-job-name",
+      "CI_JOB_STAGE": "gitlab-stage-name",
+      "CI_JOB_URL": "gitlab-job-url",
+      "CI_PIPELINE_ID": "gitlab-pipeline-id",
+      "CI_PIPELINE_IID": "gitlab-pipeline-number",
+      "CI_PIPELINE_URL": "https://foo/repo/-/pipelines/1234",
+      "CI_PROJECT_DIR": "/foo/bar",
+      "CI_PROJECT_PATH": "gitlab-pipeline-name",
+      "CI_REPOSITORY_URL": "sample",
+      "GITLAB_CI": "gitlab"
+    },
+    {
+      "ci.job.name": "gitlab-job-name",
+      "ci.job.url": "gitlab-job-url",
+      "ci.pipeline.id": "gitlab-pipeline-id",
+      "ci.pipeline.name": "gitlab-pipeline-name",
+      "ci.pipeline.number": "gitlab-pipeline-number",
+      "ci.pipeline.url": "https://foo/repo/pipelines/1234",
+      "ci.provider.name": "gitlab",
+      "ci.stage.name": "gitlab-stage-name",
+      "ci.workspace_path": "/foo/bar",
+      "git.branch": "master",
+      "git.commit.sha": "gitlab-git-commit",
+      "git.repository_url": "sample"
+    }
+  ],
+  [
+    {
+      "CI_COMMIT_BRANCH": "refs/heads/feature/one",
+      "CI_COMMIT_SHA": "gitlab-git-commit",
+      "CI_JOB_NAME": "gitlab-job-name",
+      "CI_JOB_STAGE": "gitlab-stage-name",
+      "CI_JOB_URL": "gitlab-job-url",
+      "CI_PIPELINE_ID": "gitlab-pipeline-id",
+      "CI_PIPELINE_IID": "gitlab-pipeline-number",
+      "CI_PIPELINE_URL": "https://foo/repo/-/pipelines/1234",
+      "CI_PROJECT_DIR": "/foo/bar",
+      "CI_PROJECT_PATH": "gitlab-pipeline-name",
+      "CI_REPOSITORY_URL": "sample",
+      "GITLAB_CI": "gitlab"
+    },
+    {
+      "ci.job.name": "gitlab-job-name",
+      "ci.job.url": "gitlab-job-url",
+      "ci.pipeline.id": "gitlab-pipeline-id",
+      "ci.pipeline.name": "gitlab-pipeline-name",
+      "ci.pipeline.number": "gitlab-pipeline-number",
+      "ci.pipeline.url": "https://foo/repo/pipelines/1234",
+      "ci.provider.name": "gitlab",
+      "ci.stage.name": "gitlab-stage-name",
+      "ci.workspace_path": "/foo/bar",
+      "git.branch": "feature/one",
+      "git.commit.sha": "gitlab-git-commit",
+      "git.repository_url": "sample"
+    }
+  ],
+  [
+    {
+      "CI_COMMIT_SHA": "gitlab-git-commit",
+      "CI_COMMIT_TAG": "origin/tags/0.1.0",
+      "CI_JOB_NAME": "gitlab-job-name",
+      "CI_JOB_STAGE": "gitlab-stage-name",
+      "CI_JOB_URL": "gitlab-job-url",
+      "CI_PIPELINE_ID": "gitlab-pipeline-id",
+      "CI_PIPELINE_IID": "gitlab-pipeline-number",
+      "CI_PIPELINE_URL": "https://foo/repo/-/pipelines/1234",
+      "CI_PROJECT_DIR": "/foo/bar",
+      "CI_PROJECT_PATH": "gitlab-pipeline-name",
+      "CI_REPOSITORY_URL": "sample",
+      "GITLAB_CI": "gitlab"
+    },
+    {
+      "ci.job.name": "gitlab-job-name",
+      "ci.job.url": "gitlab-job-url",
+      "ci.pipeline.id": "gitlab-pipeline-id",
+      "ci.pipeline.name": "gitlab-pipeline-name",
+      "ci.pipeline.number": "gitlab-pipeline-number",
+      "ci.pipeline.url": "https://foo/repo/pipelines/1234",
+      "ci.provider.name": "gitlab",
+      "ci.stage.name": "gitlab-stage-name",
+      "ci.workspace_path": "/foo/bar",
+      "git.commit.sha": "gitlab-git-commit",
+      "git.repository_url": "sample",
+      "git.tag": "0.1.0"
+    }
+  ],
+  [
+    {
+      "CI_COMMIT_SHA": "gitlab-git-commit",
+      "CI_COMMIT_TAG": "refs/heads/tags/0.1.0",
+      "CI_JOB_NAME": "gitlab-job-name",
+      "CI_JOB_STAGE": "gitlab-stage-name",
+      "CI_JOB_URL": "gitlab-job-url",
+      "CI_PIPELINE_ID": "gitlab-pipeline-id",
+      "CI_PIPELINE_IID": "gitlab-pipeline-number",
+      "CI_PIPELINE_URL": "https://foo/repo/-/pipelines/1234",
+      "CI_PROJECT_DIR": "/foo/bar",
+      "CI_PROJECT_PATH": "gitlab-pipeline-name",
+      "CI_REPOSITORY_URL": "sample",
+      "GITLAB_CI": "gitlab"
+    },
+    {
+      "ci.job.name": "gitlab-job-name",
+      "ci.job.url": "gitlab-job-url",
+      "ci.pipeline.id": "gitlab-pipeline-id",
+      "ci.pipeline.name": "gitlab-pipeline-name",
+      "ci.pipeline.number": "gitlab-pipeline-number",
+      "ci.pipeline.url": "https://foo/repo/pipelines/1234",
+      "ci.provider.name": "gitlab",
+      "ci.stage.name": "gitlab-stage-name",
+      "ci.workspace_path": "/foo/bar",
+      "git.commit.sha": "gitlab-git-commit",
+      "git.repository_url": "sample",
+      "git.tag": "0.1.0"
+    }
+  ],
+  [
+    {
+      "CI_COMMIT_SHA": "gitlab-git-commit",
+      "CI_COMMIT_TAG": "0.1.0",
+      "CI_JOB_NAME": "gitlab-job-name",
+      "CI_JOB_STAGE": "gitlab-stage-name",
+      "CI_JOB_URL": "gitlab-job-url",
+      "CI_PIPELINE_ID": "gitlab-pipeline-id",
+      "CI_PIPELINE_IID": "gitlab-pipeline-number",
+      "CI_PIPELINE_URL": "https://foo/repo/-/pipelines/1234",
+      "CI_PROJECT_DIR": "/foo/bar",
+      "CI_PROJECT_PATH": "gitlab-pipeline-name",
+      "CI_REPOSITORY_URL": "sample",
+      "GITLAB_CI": "gitlab"
+    },
+    {
+      "ci.job.name": "gitlab-job-name",
+      "ci.job.url": "gitlab-job-url",
+      "ci.pipeline.id": "gitlab-pipeline-id",
+      "ci.pipeline.name": "gitlab-pipeline-name",
+      "ci.pipeline.number": "gitlab-pipeline-number",
+      "ci.pipeline.url": "https://foo/repo/pipelines/1234",
+      "ci.provider.name": "gitlab",
+      "ci.stage.name": "gitlab-stage-name",
+      "ci.workspace_path": "/foo/bar",
+      "git.commit.sha": "gitlab-git-commit",
+      "git.repository_url": "sample",
+      "git.tag": "0.1.0"
+    }
+  ],
+  [
+    {
+      "CI_COMMIT_BRANCH": "origin/master",
+      "CI_COMMIT_SHA": "gitlab-git-commit",
+      "CI_JOB_NAME": "gitlab-job-name",
+      "CI_JOB_STAGE": "gitlab-stage-name",
+      "CI_JOB_URL": "gitlab-job-url",
+      "CI_PIPELINE_ID": "gitlab-pipeline-id",
+      "CI_PIPELINE_IID": "gitlab-pipeline-number",
+      "CI_PIPELINE_URL": "https://foo/repo/-/pipelines/1234",
+      "CI_PROJECT_DIR": "/foo/bar",
+      "CI_PROJECT_PATH": "gitlab-pipeline-name",
+      "CI_REPOSITORY_URL": "http://hostname.com/repo.git",
+      "GITLAB_CI": "gitlab"
+    },
+    {
+      "ci.job.name": "gitlab-job-name",
+      "ci.job.url": "gitlab-job-url",
+      "ci.pipeline.id": "gitlab-pipeline-id",
+      "ci.pipeline.name": "gitlab-pipeline-name",
+      "ci.pipeline.number": "gitlab-pipeline-number",
+      "ci.pipeline.url": "https://foo/repo/pipelines/1234",
+      "ci.provider.name": "gitlab",
+      "ci.stage.name": "gitlab-stage-name",
+      "ci.workspace_path": "/foo/bar",
+      "git.branch": "master",
+      "git.commit.sha": "gitlab-git-commit",
+      "git.repository_url": "http://hostname.com/repo.git"
+    }
+  ],
+  [
+    {
+      "CI_COMMIT_BRANCH": "origin/master",
+      "CI_COMMIT_SHA": "gitlab-git-commit",
+      "CI_JOB_NAME": "gitlab-job-name",
+      "CI_JOB_STAGE": "gitlab-stage-name",
+      "CI_JOB_URL": "gitlab-job-url",
+      "CI_PIPELINE_ID": "gitlab-pipeline-id",
+      "CI_PIPELINE_IID": "gitlab-pipeline-number",
+      "CI_PIPELINE_URL": "https://foo/repo/-/pipelines/1234",
+      "CI_PROJECT_DIR": "/foo/bar",
+      "CI_PROJECT_PATH": "gitlab-pipeline-name",
+      "CI_REPOSITORY_URL": "http://user@hostname.com/repo.git",
+      "GITLAB_CI": "gitlab"
+    },
+    {
+      "ci.job.name": "gitlab-job-name",
+      "ci.job.url": "gitlab-job-url",
+      "ci.pipeline.id": "gitlab-pipeline-id",
+      "ci.pipeline.name": "gitlab-pipeline-name",
+      "ci.pipeline.number": "gitlab-pipeline-number",
+      "ci.pipeline.url": "https://foo/repo/pipelines/1234",
+      "ci.provider.name": "gitlab",
+      "ci.stage.name": "gitlab-stage-name",
+      "ci.workspace_path": "/foo/bar",
+      "git.branch": "master",
+      "git.commit.sha": "gitlab-git-commit",
+      "git.repository_url": "http://hostname.com/repo.git"
+    }
+  ],
+  [
+    {
+      "CI_COMMIT_BRANCH": "origin/master",
+      "CI_COMMIT_SHA": "gitlab-git-commit",
+      "CI_JOB_NAME": "gitlab-job-name",
+      "CI_JOB_STAGE": "gitlab-stage-name",
+      "CI_JOB_URL": "gitlab-job-url",
+      "CI_PIPELINE_ID": "gitlab-pipeline-id",
+      "CI_PIPELINE_IID": "gitlab-pipeline-number",
+      "CI_PIPELINE_URL": "https://foo/repo/-/pipelines/1234",
+      "CI_PROJECT_DIR": "/foo/bar",
+      "CI_PROJECT_PATH": "gitlab-pipeline-name",
+      "CI_REPOSITORY_URL": "http://user%E2%82%AC@hostname.com/repo.git",
+      "GITLAB_CI": "gitlab"
+    },
+    {
+      "ci.job.name": "gitlab-job-name",
+      "ci.job.url": "gitlab-job-url",
+      "ci.pipeline.id": "gitlab-pipeline-id",
+      "ci.pipeline.name": "gitlab-pipeline-name",
+      "ci.pipeline.number": "gitlab-pipeline-number",
+      "ci.pipeline.url": "https://foo/repo/pipelines/1234",
+      "ci.provider.name": "gitlab",
+      "ci.stage.name": "gitlab-stage-name",
+      "ci.workspace_path": "/foo/bar",
+      "git.branch": "master",
+      "git.commit.sha": "gitlab-git-commit",
+      "git.repository_url": "http://hostname.com/repo.git"
+    }
+  ],
+  [
+    {
+      "CI_COMMIT_BRANCH": "origin/master",
+      "CI_COMMIT_SHA": "gitlab-git-commit",
+      "CI_JOB_NAME": "gitlab-job-name",
+      "CI_JOB_STAGE": "gitlab-stage-name",
+      "CI_JOB_URL": "gitlab-job-url",
+      "CI_PIPELINE_ID": "gitlab-pipeline-id",
+      "CI_PIPELINE_IID": "gitlab-pipeline-number",
+      "CI_PIPELINE_URL": "https://foo/repo/-/pipelines/1234",
+      "CI_PROJECT_DIR": "/foo/bar",
+      "CI_PROJECT_PATH": "gitlab-pipeline-name",
+      "CI_REPOSITORY_URL": "http://user:pwd@hostname.com/repo.git",
+      "GITLAB_CI": "gitlab"
+    },
+    {
+      "ci.job.name": "gitlab-job-name",
+      "ci.job.url": "gitlab-job-url",
+      "ci.pipeline.id": "gitlab-pipeline-id",
+      "ci.pipeline.name": "gitlab-pipeline-name",
+      "ci.pipeline.number": "gitlab-pipeline-number",
+      "ci.pipeline.url": "https://foo/repo/pipelines/1234",
+      "ci.provider.name": "gitlab",
+      "ci.stage.name": "gitlab-stage-name",
+      "ci.workspace_path": "/foo/bar",
+      "git.branch": "master",
+      "git.commit.sha": "gitlab-git-commit",
+      "git.repository_url": "http://hostname.com/repo.git"
+    }
+  ],
+  [
+    {
+      "CI_COMMIT_BRANCH": "origin/master",
+      "CI_COMMIT_SHA": "gitlab-git-commit",
+      "CI_JOB_NAME": "gitlab-job-name",
+      "CI_JOB_STAGE": "gitlab-stage-name",
+      "CI_JOB_URL": "gitlab-job-url",
+      "CI_PIPELINE_ID": "gitlab-pipeline-id",
+      "CI_PIPELINE_IID": "gitlab-pipeline-number",
+      "CI_PIPELINE_URL": "https://foo/repo/-/pipelines/1234",
+      "CI_PROJECT_DIR": "/foo/bar",
+      "CI_PROJECT_PATH": "gitlab-pipeline-name",
+      "CI_REPOSITORY_URL": "git@hostname.com:org/repo.git",
+      "GITLAB_CI": "gitlab"
+    },
+    {
+      "ci.job.name": "gitlab-job-name",
+      "ci.job.url": "gitlab-job-url",
+      "ci.pipeline.id": "gitlab-pipeline-id",
+      "ci.pipeline.name": "gitlab-pipeline-name",
+      "ci.pipeline.number": "gitlab-pipeline-number",
+      "ci.pipeline.url": "https://foo/repo/pipelines/1234",
+      "ci.provider.name": "gitlab",
+      "ci.stage.name": "gitlab-stage-name",
+      "ci.workspace_path": "/foo/bar",
+      "git.branch": "master",
+      "git.commit.sha": "gitlab-git-commit",
+      "git.repository_url": "git@hostname.com:org/repo.git"
+    }
+  ]
+]

--- a/src/helpers/__tests__/ci-env/jenkins.json
+++ b/src/helpers/__tests__/ci-env/jenkins.json
@@ -1,0 +1,525 @@
+[
+  [
+    {
+      "BUILD_NUMBER": "jenkins-pipeline-number",
+      "BUILD_TAG": "jenkins-pipeline-id",
+      "BUILD_URL": "jenkins-pipeline-url",
+      "GIT_BRANCH": "origin/master",
+      "GIT_COMMIT": "jenkins-git-commit",
+      "GIT_URL": "sample",
+      "JENKINS_URL": "jenkins",
+      "JOB_NAME": "jobName",
+      "JOB_URL": "jenkins-job-url"
+    },
+    {
+      "ci.pipeline.id": "jenkins-pipeline-id",
+      "ci.pipeline.name": "jobName",
+      "ci.pipeline.number": "jenkins-pipeline-number",
+      "ci.pipeline.url": "jenkins-pipeline-url",
+      "ci.provider.name": "jenkins",
+      "git.branch": "master",
+      "git.commit.sha": "jenkins-git-commit",
+      "git.repository_url": "sample"
+    }
+  ],
+  [
+    {
+      "BUILD_NUMBER": "jenkins-pipeline-number",
+      "BUILD_TAG": "jenkins-pipeline-id",
+      "BUILD_URL": "jenkins-pipeline-url",
+      "GIT_BRANCH": "origin/master",
+      "GIT_COMMIT": "jenkins-git-commit",
+      "GIT_URL": "sample",
+      "JENKINS_URL": "jenkins",
+      "JOB_NAME": "jobName",
+      "JOB_URL": "jenkins-job-url"
+    },
+    {
+      "ci.pipeline.id": "jenkins-pipeline-id",
+      "ci.pipeline.name": "jobName",
+      "ci.pipeline.number": "jenkins-pipeline-number",
+      "ci.pipeline.url": "jenkins-pipeline-url",
+      "ci.provider.name": "jenkins",
+      "git.branch": "master",
+      "git.commit.sha": "jenkins-git-commit",
+      "git.repository_url": "sample"
+    }
+  ],
+  [
+    {
+      "BUILD_NUMBER": "jenkins-pipeline-number",
+      "BUILD_TAG": "jenkins-pipeline-id",
+      "BUILD_URL": "jenkins-pipeline-url",
+      "GIT_BRANCH": "origin/master",
+      "GIT_COMMIT": "jenkins-git-commit",
+      "GIT_URL": "sample",
+      "JENKINS_URL": "jenkins",
+      "JOB_NAME": "jobName",
+      "JOB_URL": "jenkins-job-url",
+      "WORKSPACE": "foo/bar"
+    },
+    {
+      "ci.pipeline.id": "jenkins-pipeline-id",
+      "ci.pipeline.name": "jobName",
+      "ci.pipeline.number": "jenkins-pipeline-number",
+      "ci.pipeline.url": "jenkins-pipeline-url",
+      "ci.provider.name": "jenkins",
+      "ci.workspace_path": "foo/bar",
+      "git.branch": "master",
+      "git.commit.sha": "jenkins-git-commit",
+      "git.repository_url": "sample"
+    }
+  ],
+  [
+    {
+      "BUILD_NUMBER": "jenkins-pipeline-number",
+      "BUILD_TAG": "jenkins-pipeline-id",
+      "BUILD_URL": "jenkins-pipeline-url",
+      "GIT_BRANCH": "origin/master",
+      "GIT_COMMIT": "jenkins-git-commit",
+      "GIT_URL": "sample",
+      "JENKINS_URL": "jenkins",
+      "JOB_NAME": "jobName",
+      "JOB_URL": "jenkins-job-url",
+      "WORKSPACE": "/foo/bar~"
+    },
+    {
+      "ci.pipeline.id": "jenkins-pipeline-id",
+      "ci.pipeline.name": "jobName",
+      "ci.pipeline.number": "jenkins-pipeline-number",
+      "ci.pipeline.url": "jenkins-pipeline-url",
+      "ci.provider.name": "jenkins",
+      "ci.workspace_path": "/foo/bar~",
+      "git.branch": "master",
+      "git.commit.sha": "jenkins-git-commit",
+      "git.repository_url": "sample"
+    }
+  ],
+  [
+    {
+      "BUILD_NUMBER": "jenkins-pipeline-number",
+      "BUILD_TAG": "jenkins-pipeline-id",
+      "BUILD_URL": "jenkins-pipeline-url",
+      "GIT_BRANCH": "origin/master",
+      "GIT_COMMIT": "jenkins-git-commit",
+      "GIT_URL": "sample",
+      "JENKINS_URL": "jenkins",
+      "JOB_NAME": "jobName",
+      "JOB_URL": "jenkins-job-url",
+      "WORKSPACE": "/foo/~/bar"
+    },
+    {
+      "ci.pipeline.id": "jenkins-pipeline-id",
+      "ci.pipeline.name": "jobName",
+      "ci.pipeline.number": "jenkins-pipeline-number",
+      "ci.pipeline.url": "jenkins-pipeline-url",
+      "ci.provider.name": "jenkins",
+      "ci.workspace_path": "/foo/~/bar",
+      "git.branch": "master",
+      "git.commit.sha": "jenkins-git-commit",
+      "git.repository_url": "sample"
+    }
+  ],
+  [
+    {
+      "BUILD_NUMBER": "jenkins-pipeline-number",
+      "BUILD_TAG": "jenkins-pipeline-id",
+      "BUILD_URL": "jenkins-pipeline-url",
+      "GIT_BRANCH": "origin/master",
+      "GIT_COMMIT": "jenkins-git-commit",
+      "GIT_URL": "sample",
+      "HOME": "/not-my-home",
+      "JENKINS_URL": "jenkins",
+      "JOB_NAME": "jobName",
+      "JOB_URL": "jenkins-job-url",
+      "USERPROFILE": "/not-my-home",
+      "WORKSPACE": "~/foo/bar"
+    },
+    {
+      "ci.pipeline.id": "jenkins-pipeline-id",
+      "ci.pipeline.name": "jobName",
+      "ci.pipeline.number": "jenkins-pipeline-number",
+      "ci.pipeline.url": "jenkins-pipeline-url",
+      "ci.provider.name": "jenkins",
+      "ci.workspace_path": "/not-my-home/foo/bar",
+      "git.branch": "master",
+      "git.commit.sha": "jenkins-git-commit",
+      "git.repository_url": "sample"
+    }
+  ],
+  [
+    {
+      "BUILD_NUMBER": "jenkins-pipeline-number",
+      "BUILD_TAG": "jenkins-pipeline-id",
+      "BUILD_URL": "jenkins-pipeline-url",
+      "GIT_BRANCH": "origin/master",
+      "GIT_COMMIT": "jenkins-git-commit",
+      "GIT_URL": "sample",
+      "HOME": "/not-my-home",
+      "JENKINS_URL": "jenkins",
+      "JOB_NAME": "jobName",
+      "JOB_URL": "jenkins-job-url",
+      "USERPROFILE": "/not-my-home",
+      "WORKSPACE": "~foo/bar"
+    },
+    {
+      "ci.pipeline.id": "jenkins-pipeline-id",
+      "ci.pipeline.name": "jobName",
+      "ci.pipeline.number": "jenkins-pipeline-number",
+      "ci.pipeline.url": "jenkins-pipeline-url",
+      "ci.provider.name": "jenkins",
+      "ci.workspace_path": "~foo/bar",
+      "git.branch": "master",
+      "git.commit.sha": "jenkins-git-commit",
+      "git.repository_url": "sample"
+    }
+  ],
+  [
+    {
+      "BUILD_NUMBER": "jenkins-pipeline-number",
+      "BUILD_TAG": "jenkins-pipeline-id",
+      "BUILD_URL": "jenkins-pipeline-url",
+      "GIT_BRANCH": "origin/master",
+      "GIT_COMMIT": "jenkins-git-commit",
+      "GIT_URL": "sample",
+      "HOME": "/not-my-home",
+      "JENKINS_URL": "jenkins",
+      "JOB_NAME": "jobName",
+      "JOB_URL": "jenkins-job-url",
+      "USERPROFILE": "/not-my-home",
+      "WORKSPACE": "~"
+    },
+    {
+      "ci.pipeline.id": "jenkins-pipeline-id",
+      "ci.pipeline.name": "jobName",
+      "ci.pipeline.number": "jenkins-pipeline-number",
+      "ci.pipeline.url": "jenkins-pipeline-url",
+      "ci.provider.name": "jenkins",
+      "ci.workspace_path": "/not-my-home",
+      "git.branch": "master",
+      "git.commit.sha": "jenkins-git-commit",
+      "git.repository_url": "sample"
+    }
+  ],
+  [
+    {
+      "BUILD_NUMBER": "jenkins-pipeline-number",
+      "BUILD_TAG": "jenkins-pipeline-id",
+      "BUILD_URL": "jenkins-pipeline-url",
+      "GIT_BRANCH": "origin/master",
+      "GIT_COMMIT": "jenkins-git-commit",
+      "GIT_URL": "sample",
+      "JENKINS_URL": "jenkins",
+      "JOB_NAME": "jobName",
+      "JOB_URL": "jenkins-job-url",
+      "WORKSPACE": "/foo/bar"
+    },
+    {
+      "ci.pipeline.id": "jenkins-pipeline-id",
+      "ci.pipeline.name": "jobName",
+      "ci.pipeline.number": "jenkins-pipeline-number",
+      "ci.pipeline.url": "jenkins-pipeline-url",
+      "ci.provider.name": "jenkins",
+      "ci.workspace_path": "/foo/bar",
+      "git.branch": "master",
+      "git.commit.sha": "jenkins-git-commit",
+      "git.repository_url": "sample"
+    }
+  ],
+  [
+    {
+      "BUILD_NUMBER": "jenkins-pipeline-number",
+      "BUILD_TAG": "jenkins-pipeline-id",
+      "BUILD_URL": "jenkins-pipeline-url",
+      "GIT_BRANCH": "refs/heads/master",
+      "GIT_COMMIT": "jenkins-git-commit",
+      "GIT_URL": "sample",
+      "JENKINS_URL": "jenkins",
+      "JOB_NAME": "jobName/master",
+      "JOB_URL": "jenkins-job-url",
+      "WORKSPACE": "/foo/bar"
+    },
+    {
+      "ci.pipeline.id": "jenkins-pipeline-id",
+      "ci.pipeline.name": "jobName",
+      "ci.pipeline.number": "jenkins-pipeline-number",
+      "ci.pipeline.url": "jenkins-pipeline-url",
+      "ci.provider.name": "jenkins",
+      "ci.workspace_path": "/foo/bar",
+      "git.branch": "master",
+      "git.commit.sha": "jenkins-git-commit",
+      "git.repository_url": "sample"
+    }
+  ],
+  [
+    {
+      "BUILD_NUMBER": "jenkins-pipeline-number",
+      "BUILD_TAG": "jenkins-pipeline-id",
+      "BUILD_URL": "jenkins-pipeline-url",
+      "GIT_BRANCH": "refs/heads/master",
+      "GIT_COMMIT": "jenkins-git-commit",
+      "GIT_URL": "sample",
+      "JENKINS_URL": "jenkins",
+      "JOB_NAME": "jobName/another",
+      "JOB_URL": "jenkins-job-url",
+      "WORKSPACE": "/foo/bar"
+    },
+    {
+      "ci.pipeline.id": "jenkins-pipeline-id",
+      "ci.pipeline.name": "jobName/another",
+      "ci.pipeline.number": "jenkins-pipeline-number",
+      "ci.pipeline.url": "jenkins-pipeline-url",
+      "ci.provider.name": "jenkins",
+      "ci.workspace_path": "/foo/bar",
+      "git.branch": "master",
+      "git.commit.sha": "jenkins-git-commit",
+      "git.repository_url": "sample"
+    }
+  ],
+  [
+    {
+      "BUILD_NUMBER": "jenkins-pipeline-number",
+      "BUILD_TAG": "jenkins-pipeline-id",
+      "BUILD_URL": "jenkins-pipeline-url",
+      "GIT_BRANCH": "refs/heads/feature/one",
+      "GIT_COMMIT": "jenkins-git-commit",
+      "GIT_URL": "sample",
+      "JENKINS_URL": "jenkins",
+      "JOB_NAME": "jobName/feature/one",
+      "JOB_URL": "jenkins-job-url",
+      "WORKSPACE": "/foo/bar"
+    },
+    {
+      "ci.pipeline.id": "jenkins-pipeline-id",
+      "ci.pipeline.name": "jobName",
+      "ci.pipeline.number": "jenkins-pipeline-number",
+      "ci.pipeline.url": "jenkins-pipeline-url",
+      "ci.provider.name": "jenkins",
+      "ci.workspace_path": "/foo/bar",
+      "git.branch": "feature/one",
+      "git.commit.sha": "jenkins-git-commit",
+      "git.repository_url": "sample"
+    }
+  ],
+  [
+    {
+      "BUILD_NUMBER": "jenkins-pipeline-number",
+      "BUILD_TAG": "jenkins-pipeline-id",
+      "BUILD_URL": "jenkins-pipeline-url",
+      "GIT_BRANCH": "refs/heads/master",
+      "GIT_COMMIT": "jenkins-git-commit",
+      "GIT_URL": "sample",
+      "JENKINS_URL": "jenkins",
+      "JOB_NAME": "jobName/KEY1=VALUE1,KEY2=VALUE2",
+      "JOB_URL": "jenkins-job-url",
+      "WORKSPACE": "/foo/bar"
+    },
+    {
+      "ci.pipeline.id": "jenkins-pipeline-id",
+      "ci.pipeline.name": "jobName",
+      "ci.pipeline.number": "jenkins-pipeline-number",
+      "ci.pipeline.url": "jenkins-pipeline-url",
+      "ci.provider.name": "jenkins",
+      "ci.workspace_path": "/foo/bar",
+      "git.branch": "master",
+      "git.commit.sha": "jenkins-git-commit",
+      "git.repository_url": "sample"
+    }
+  ],
+  [
+    {
+      "BUILD_NUMBER": "jenkins-pipeline-number",
+      "BUILD_TAG": "jenkins-pipeline-id",
+      "BUILD_URL": "jenkins-pipeline-url",
+      "GIT_BRANCH": "refs/heads/master",
+      "GIT_COMMIT": "jenkins-git-commit",
+      "GIT_URL": "sample",
+      "JENKINS_URL": "jenkins",
+      "JOB_NAME": "jobName/KEY1=VALUE1,KEY2=VALUE2/master",
+      "JOB_URL": "jenkins-job-url",
+      "WORKSPACE": "/foo/bar"
+    },
+    {
+      "ci.pipeline.id": "jenkins-pipeline-id",
+      "ci.pipeline.name": "jobName",
+      "ci.pipeline.number": "jenkins-pipeline-number",
+      "ci.pipeline.url": "jenkins-pipeline-url",
+      "ci.provider.name": "jenkins",
+      "ci.workspace_path": "/foo/bar",
+      "git.branch": "master",
+      "git.commit.sha": "jenkins-git-commit",
+      "git.repository_url": "sample"
+    }
+  ],
+  [
+    {
+      "BUILD_NUMBER": "jenkins-pipeline-number",
+      "BUILD_TAG": "jenkins-pipeline-id",
+      "BUILD_URL": "jenkins-pipeline-url",
+      "GIT_BRANCH": "origin/tags/0.1.0",
+      "GIT_COMMIT": "jenkins-git-commit",
+      "GIT_URL": "sample",
+      "JENKINS_URL": "jenkins",
+      "JOB_URL": "jenkins-job-url",
+      "WORKSPACE": "/foo/bar"
+    },
+    {
+      "ci.pipeline.id": "jenkins-pipeline-id",
+      "ci.pipeline.number": "jenkins-pipeline-number",
+      "ci.pipeline.url": "jenkins-pipeline-url",
+      "ci.provider.name": "jenkins",
+      "ci.workspace_path": "/foo/bar",
+      "git.commit.sha": "jenkins-git-commit",
+      "git.repository_url": "sample",
+      "git.tag": "0.1.0"
+    }
+  ],
+  [
+    {
+      "BUILD_NUMBER": "jenkins-pipeline-number",
+      "BUILD_TAG": "jenkins-pipeline-id",
+      "BUILD_URL": "jenkins-pipeline-url",
+      "GIT_BRANCH": "refs/heads/tags/0.1.0",
+      "GIT_COMMIT": "jenkins-git-commit",
+      "GIT_URL": "sample",
+      "JENKINS_URL": "jenkins",
+      "JOB_URL": "jenkins-job-url",
+      "WORKSPACE": "/foo/bar"
+    },
+    {
+      "ci.pipeline.id": "jenkins-pipeline-id",
+      "ci.pipeline.number": "jenkins-pipeline-number",
+      "ci.pipeline.url": "jenkins-pipeline-url",
+      "ci.provider.name": "jenkins",
+      "ci.workspace_path": "/foo/bar",
+      "git.commit.sha": "jenkins-git-commit",
+      "git.repository_url": "sample",
+      "git.tag": "0.1.0"
+    }
+  ],
+  [
+    {
+      "BUILD_NUMBER": "jenkins-pipeline-number",
+      "BUILD_TAG": "jenkins-pipeline-id",
+      "BUILD_URL": "jenkins-pipeline-url",
+      "GIT_BRANCH": "origin/master",
+      "GIT_COMMIT": "jenkins-git-commit",
+      "GIT_URL": "http://hostname.com/repo.git",
+      "JENKINS_URL": "jenkins",
+      "JOB_NAME": "jobName",
+      "JOB_URL": "jenkins-job-url",
+      "WORKSPACE": "/foo/bar"
+    },
+    {
+      "ci.pipeline.id": "jenkins-pipeline-id",
+      "ci.pipeline.name": "jobName",
+      "ci.pipeline.number": "jenkins-pipeline-number",
+      "ci.pipeline.url": "jenkins-pipeline-url",
+      "ci.provider.name": "jenkins",
+      "ci.workspace_path": "/foo/bar",
+      "git.branch": "master",
+      "git.commit.sha": "jenkins-git-commit",
+      "git.repository_url": "http://hostname.com/repo.git"
+    }
+  ],
+  [
+    {
+      "BUILD_NUMBER": "jenkins-pipeline-number",
+      "BUILD_TAG": "jenkins-pipeline-id",
+      "BUILD_URL": "jenkins-pipeline-url",
+      "GIT_BRANCH": "origin/master",
+      "GIT_COMMIT": "jenkins-git-commit",
+      "GIT_URL": "http://user@hostname.com/repo.git",
+      "JENKINS_URL": "jenkins",
+      "JOB_NAME": "jobName",
+      "JOB_URL": "jenkins-job-url",
+      "WORKSPACE": "/foo/bar"
+    },
+    {
+      "ci.pipeline.id": "jenkins-pipeline-id",
+      "ci.pipeline.name": "jobName",
+      "ci.pipeline.number": "jenkins-pipeline-number",
+      "ci.pipeline.url": "jenkins-pipeline-url",
+      "ci.provider.name": "jenkins",
+      "ci.workspace_path": "/foo/bar",
+      "git.branch": "master",
+      "git.commit.sha": "jenkins-git-commit",
+      "git.repository_url": "http://hostname.com/repo.git"
+    }
+  ],
+  [
+    {
+      "BUILD_NUMBER": "jenkins-pipeline-number",
+      "BUILD_TAG": "jenkins-pipeline-id",
+      "BUILD_URL": "jenkins-pipeline-url",
+      "GIT_BRANCH": "origin/master",
+      "GIT_COMMIT": "jenkins-git-commit",
+      "GIT_URL": "http://user%E2%82%AC@hostname.com/repo.git",
+      "JENKINS_URL": "jenkins",
+      "JOB_NAME": "jobName",
+      "JOB_URL": "jenkins-job-url",
+      "WORKSPACE": "/foo/bar"
+    },
+    {
+      "ci.pipeline.id": "jenkins-pipeline-id",
+      "ci.pipeline.name": "jobName",
+      "ci.pipeline.number": "jenkins-pipeline-number",
+      "ci.pipeline.url": "jenkins-pipeline-url",
+      "ci.provider.name": "jenkins",
+      "ci.workspace_path": "/foo/bar",
+      "git.branch": "master",
+      "git.commit.sha": "jenkins-git-commit",
+      "git.repository_url": "http://hostname.com/repo.git"
+    }
+  ],
+  [
+    {
+      "BUILD_NUMBER": "jenkins-pipeline-number",
+      "BUILD_TAG": "jenkins-pipeline-id",
+      "BUILD_URL": "jenkins-pipeline-url",
+      "GIT_BRANCH": "origin/master",
+      "GIT_COMMIT": "jenkins-git-commit",
+      "GIT_URL": "http://user:pwd@hostname.com/repo.git",
+      "JENKINS_URL": "jenkins",
+      "JOB_NAME": "jobName",
+      "JOB_URL": "jenkins-job-url",
+      "WORKSPACE": "/foo/bar"
+    },
+    {
+      "ci.pipeline.id": "jenkins-pipeline-id",
+      "ci.pipeline.name": "jobName",
+      "ci.pipeline.number": "jenkins-pipeline-number",
+      "ci.pipeline.url": "jenkins-pipeline-url",
+      "ci.provider.name": "jenkins",
+      "ci.workspace_path": "/foo/bar",
+      "git.branch": "master",
+      "git.commit.sha": "jenkins-git-commit",
+      "git.repository_url": "http://hostname.com/repo.git"
+    }
+  ],
+  [
+    {
+      "BUILD_NUMBER": "jenkins-pipeline-number",
+      "BUILD_TAG": "jenkins-pipeline-id",
+      "BUILD_URL": "jenkins-pipeline-url",
+      "GIT_BRANCH": "origin/master",
+      "GIT_COMMIT": "jenkins-git-commit",
+      "GIT_URL": "git@hostname.com:org/repo.git",
+      "JENKINS_URL": "jenkins",
+      "JOB_NAME": "jobName",
+      "JOB_URL": "jenkins-job-url",
+      "WORKSPACE": "/foo/bar"
+    },
+    {
+      "ci.pipeline.id": "jenkins-pipeline-id",
+      "ci.pipeline.name": "jobName",
+      "ci.pipeline.number": "jenkins-pipeline-number",
+      "ci.pipeline.url": "jenkins-pipeline-url",
+      "ci.provider.name": "jenkins",
+      "ci.workspace_path": "/foo/bar",
+      "git.branch": "master",
+      "git.commit.sha": "jenkins-git-commit",
+      "git.repository_url": "git@hostname.com:org/repo.git"
+    }
+  ]
+]

--- a/src/helpers/__tests__/ci-env/travisci.json
+++ b/src/helpers/__tests__/ci-env/travisci.json
@@ -1,0 +1,460 @@
+[
+  [
+    {
+      "TRAVIS": "travisCI",
+      "TRAVIS_BRANCH": "origin/tags/0.1.0",
+      "TRAVIS_BUILD_DIR": "/foo/bar",
+      "TRAVIS_BUILD_ID": "travis-pipeline-id",
+      "TRAVIS_BUILD_NUMBER": "travis-pipeline-number",
+      "TRAVIS_BUILD_WEB_URL": "travis-pipeline-url",
+      "TRAVIS_COMMIT": "travis-git-commit",
+      "TRAVIS_JOB_WEB_URL": "travis-job-url",
+      "TRAVIS_REPO_SLUG": "user/repo",
+      "TRAVIS_TAG": "origin/tags/0.1.0"
+    },
+    {
+      "ci.job.url": "travis-job-url",
+      "ci.pipeline.id": "travis-pipeline-id",
+      "ci.pipeline.name": "user/repo",
+      "ci.pipeline.number": "travis-pipeline-number",
+      "ci.pipeline.url": "travis-pipeline-url",
+      "ci.provider.name": "travisci",
+      "ci.workspace_path": "/foo/bar",
+      "git.commit.sha": "travis-git-commit",
+      "git.repository_url": "https://github.com/user/repo.git",
+      "git.tag": "0.1.0"
+    }
+  ],
+  [
+    {
+      "TRAVIS": "travisCI",
+      "TRAVIS_BRANCH": "refs/heads/tags/0.1.0",
+      "TRAVIS_BUILD_DIR": "/foo/bar",
+      "TRAVIS_BUILD_ID": "travis-pipeline-id",
+      "TRAVIS_BUILD_NUMBER": "travis-pipeline-number",
+      "TRAVIS_BUILD_WEB_URL": "travis-pipeline-url",
+      "TRAVIS_COMMIT": "travis-git-commit",
+      "TRAVIS_JOB_WEB_URL": "travis-job-url",
+      "TRAVIS_REPO_SLUG": "user/repo",
+      "TRAVIS_TAG": "refs/heads/tags/0.1.0"
+    },
+    {
+      "ci.job.url": "travis-job-url",
+      "ci.pipeline.id": "travis-pipeline-id",
+      "ci.pipeline.name": "user/repo",
+      "ci.pipeline.number": "travis-pipeline-number",
+      "ci.pipeline.url": "travis-pipeline-url",
+      "ci.provider.name": "travisci",
+      "ci.workspace_path": "/foo/bar",
+      "git.commit.sha": "travis-git-commit",
+      "git.repository_url": "https://github.com/user/repo.git",
+      "git.tag": "0.1.0"
+    }
+  ],
+  [
+    {
+      "TRAVIS": "travisCI",
+      "TRAVIS_BRANCH": "origin/master",
+      "TRAVIS_BUILD_ID": "travis-pipeline-id",
+      "TRAVIS_BUILD_NUMBER": "travis-pipeline-number",
+      "TRAVIS_BUILD_WEB_URL": "travis-pipeline-url",
+      "TRAVIS_COMMIT": "travis-git-commit",
+      "TRAVIS_JOB_WEB_URL": "travis-job-url",
+      "TRAVIS_REPO_SLUG": "user/repo"
+    },
+    {
+      "ci.job.url": "travis-job-url",
+      "ci.pipeline.id": "travis-pipeline-id",
+      "ci.pipeline.name": "user/repo",
+      "ci.pipeline.number": "travis-pipeline-number",
+      "ci.pipeline.url": "travis-pipeline-url",
+      "ci.provider.name": "travisci",
+      "git.branch": "master",
+      "git.commit.sha": "travis-git-commit",
+      "git.repository_url": "https://github.com/user/repo.git"
+    }
+  ],
+  [
+    {
+      "TRAVIS": "travisCI",
+      "TRAVIS_BRANCH": "origin/master",
+      "TRAVIS_BUILD_ID": "travis-pipeline-id",
+      "TRAVIS_BUILD_NUMBER": "travis-pipeline-number",
+      "TRAVIS_BUILD_WEB_URL": "travis-pipeline-url",
+      "TRAVIS_COMMIT": "travis-git-commit",
+      "TRAVIS_JOB_WEB_URL": "travis-job-url",
+      "TRAVIS_REPO_SLUG": "user/repo"
+    },
+    {
+      "ci.job.url": "travis-job-url",
+      "ci.pipeline.id": "travis-pipeline-id",
+      "ci.pipeline.name": "user/repo",
+      "ci.pipeline.number": "travis-pipeline-number",
+      "ci.pipeline.url": "travis-pipeline-url",
+      "ci.provider.name": "travisci",
+      "git.branch": "master",
+      "git.commit.sha": "travis-git-commit",
+      "git.repository_url": "https://github.com/user/repo.git"
+    }
+  ],
+  [
+    {
+      "TRAVIS": "travisCI",
+      "TRAVIS_BRANCH": "origin/master",
+      "TRAVIS_BUILD_DIR": "foo/bar",
+      "TRAVIS_BUILD_ID": "travis-pipeline-id",
+      "TRAVIS_BUILD_NUMBER": "travis-pipeline-number",
+      "TRAVIS_BUILD_WEB_URL": "travis-pipeline-url",
+      "TRAVIS_COMMIT": "travis-git-commit",
+      "TRAVIS_JOB_WEB_URL": "travis-job-url",
+      "TRAVIS_REPO_SLUG": "user/repo"
+    },
+    {
+      "ci.job.url": "travis-job-url",
+      "ci.pipeline.id": "travis-pipeline-id",
+      "ci.pipeline.name": "user/repo",
+      "ci.pipeline.number": "travis-pipeline-number",
+      "ci.pipeline.url": "travis-pipeline-url",
+      "ci.provider.name": "travisci",
+      "ci.workspace_path": "foo/bar",
+      "git.branch": "master",
+      "git.commit.sha": "travis-git-commit",
+      "git.repository_url": "https://github.com/user/repo.git"
+    }
+  ],
+  [
+    {
+      "TRAVIS": "travisCI",
+      "TRAVIS_BRANCH": "origin/master",
+      "TRAVIS_BUILD_DIR": "foo/bar",
+      "TRAVIS_BUILD_ID": "travis-pipeline-id",
+      "TRAVIS_BUILD_NUMBER": "travis-pipeline-number",
+      "TRAVIS_BUILD_WEB_URL": "travis-pipeline-url",
+      "TRAVIS_COMMIT": "travis-git-commit",
+      "TRAVIS_JOB_WEB_URL": "travis-job-url",
+      "TRAVIS_REPO_SLUG": "user/repo"
+    },
+    {
+      "ci.job.url": "travis-job-url",
+      "ci.pipeline.id": "travis-pipeline-id",
+      "ci.pipeline.name": "user/repo",
+      "ci.pipeline.number": "travis-pipeline-number",
+      "ci.pipeline.url": "travis-pipeline-url",
+      "ci.provider.name": "travisci",
+      "ci.workspace_path": "foo/bar",
+      "git.branch": "master",
+      "git.commit.sha": "travis-git-commit",
+      "git.repository_url": "https://github.com/user/repo.git"
+    }
+  ],
+  [
+    {
+      "TRAVIS": "travisCI",
+      "TRAVIS_BRANCH": "origin/master",
+      "TRAVIS_BUILD_DIR": "foo/bar",
+      "TRAVIS_BUILD_ID": "travis-pipeline-id",
+      "TRAVIS_BUILD_NUMBER": "travis-pipeline-number",
+      "TRAVIS_BUILD_WEB_URL": "travis-pipeline-url",
+      "TRAVIS_COMMIT": "travis-git-commit",
+      "TRAVIS_JOB_WEB_URL": "travis-job-url",
+      "TRAVIS_REPO_SLUG": "user/repo"
+    },
+    {
+      "ci.job.url": "travis-job-url",
+      "ci.pipeline.id": "travis-pipeline-id",
+      "ci.pipeline.name": "user/repo",
+      "ci.pipeline.number": "travis-pipeline-number",
+      "ci.pipeline.url": "travis-pipeline-url",
+      "ci.provider.name": "travisci",
+      "ci.workspace_path": "foo/bar",
+      "git.branch": "master",
+      "git.commit.sha": "travis-git-commit",
+      "git.repository_url": "https://github.com/user/repo.git"
+    }
+  ],
+  [
+    {
+      "TRAVIS": "travisCI",
+      "TRAVIS_BRANCH": "origin/master",
+      "TRAVIS_BUILD_DIR": "/foo/bar~",
+      "TRAVIS_BUILD_ID": "travis-pipeline-id",
+      "TRAVIS_BUILD_NUMBER": "travis-pipeline-number",
+      "TRAVIS_BUILD_WEB_URL": "travis-pipeline-url",
+      "TRAVIS_COMMIT": "travis-git-commit",
+      "TRAVIS_JOB_WEB_URL": "travis-job-url",
+      "TRAVIS_REPO_SLUG": "user/repo"
+    },
+    {
+      "ci.job.url": "travis-job-url",
+      "ci.pipeline.id": "travis-pipeline-id",
+      "ci.pipeline.name": "user/repo",
+      "ci.pipeline.number": "travis-pipeline-number",
+      "ci.pipeline.url": "travis-pipeline-url",
+      "ci.provider.name": "travisci",
+      "ci.workspace_path": "/foo/bar~",
+      "git.branch": "master",
+      "git.commit.sha": "travis-git-commit",
+      "git.repository_url": "https://github.com/user/repo.git"
+    }
+  ],
+  [
+    {
+      "TRAVIS": "travisCI",
+      "TRAVIS_BRANCH": "origin/master",
+      "TRAVIS_BUILD_DIR": "/foo/~/bar",
+      "TRAVIS_BUILD_ID": "travis-pipeline-id",
+      "TRAVIS_BUILD_NUMBER": "travis-pipeline-number",
+      "TRAVIS_BUILD_WEB_URL": "travis-pipeline-url",
+      "TRAVIS_COMMIT": "travis-git-commit",
+      "TRAVIS_JOB_WEB_URL": "travis-job-url",
+      "TRAVIS_REPO_SLUG": "user/repo"
+    },
+    {
+      "ci.job.url": "travis-job-url",
+      "ci.pipeline.id": "travis-pipeline-id",
+      "ci.pipeline.name": "user/repo",
+      "ci.pipeline.number": "travis-pipeline-number",
+      "ci.pipeline.url": "travis-pipeline-url",
+      "ci.provider.name": "travisci",
+      "ci.workspace_path": "/foo/~/bar",
+      "git.branch": "master",
+      "git.commit.sha": "travis-git-commit",
+      "git.repository_url": "https://github.com/user/repo.git"
+    }
+  ],
+  [
+    {
+      "HOME": "/not-my-home",
+      "TRAVIS": "travisCI",
+      "TRAVIS_BRANCH": "origin/master",
+      "TRAVIS_BUILD_DIR": "~/foo/bar",
+      "TRAVIS_BUILD_ID": "travis-pipeline-id",
+      "TRAVIS_BUILD_NUMBER": "travis-pipeline-number",
+      "TRAVIS_BUILD_WEB_URL": "travis-pipeline-url",
+      "TRAVIS_COMMIT": "travis-git-commit",
+      "TRAVIS_JOB_WEB_URL": "travis-job-url",
+      "TRAVIS_REPO_SLUG": "user/repo",
+      "USERPROFILE": "/not-my-home"
+    },
+    {
+      "ci.job.url": "travis-job-url",
+      "ci.pipeline.id": "travis-pipeline-id",
+      "ci.pipeline.name": "user/repo",
+      "ci.pipeline.number": "travis-pipeline-number",
+      "ci.pipeline.url": "travis-pipeline-url",
+      "ci.provider.name": "travisci",
+      "ci.workspace_path": "/not-my-home/foo/bar",
+      "git.branch": "master",
+      "git.commit.sha": "travis-git-commit",
+      "git.repository_url": "https://github.com/user/repo.git"
+    }
+  ],
+  [
+    {
+      "TRAVIS": "travisCI",
+      "TRAVIS_BRANCH": "origin/master",
+      "TRAVIS_BUILD_DIR": "~foo/bar",
+      "TRAVIS_BUILD_ID": "travis-pipeline-id",
+      "TRAVIS_BUILD_NUMBER": "travis-pipeline-number",
+      "TRAVIS_BUILD_WEB_URL": "travis-pipeline-url",
+      "TRAVIS_COMMIT": "travis-git-commit",
+      "TRAVIS_JOB_WEB_URL": "travis-job-url",
+      "TRAVIS_REPO_SLUG": "user/repo"
+    },
+    {
+      "ci.job.url": "travis-job-url",
+      "ci.pipeline.id": "travis-pipeline-id",
+      "ci.pipeline.name": "user/repo",
+      "ci.pipeline.number": "travis-pipeline-number",
+      "ci.pipeline.url": "travis-pipeline-url",
+      "ci.provider.name": "travisci",
+      "ci.workspace_path": "~foo/bar",
+      "git.branch": "master",
+      "git.commit.sha": "travis-git-commit",
+      "git.repository_url": "https://github.com/user/repo.git"
+    }
+  ],
+  [
+    {
+      "HOME": "/not-my-home",
+      "TRAVIS": "travisCI",
+      "TRAVIS_BRANCH": "origin/master",
+      "TRAVIS_BUILD_DIR": "~",
+      "TRAVIS_BUILD_ID": "travis-pipeline-id",
+      "TRAVIS_BUILD_NUMBER": "travis-pipeline-number",
+      "TRAVIS_BUILD_WEB_URL": "travis-pipeline-url",
+      "TRAVIS_COMMIT": "travis-git-commit",
+      "TRAVIS_JOB_WEB_URL": "travis-job-url",
+      "TRAVIS_REPO_SLUG": "user/repo",
+      "USERPROFILE": "/not-my-home"
+    },
+    {
+      "ci.job.url": "travis-job-url",
+      "ci.pipeline.id": "travis-pipeline-id",
+      "ci.pipeline.name": "user/repo",
+      "ci.pipeline.number": "travis-pipeline-number",
+      "ci.pipeline.url": "travis-pipeline-url",
+      "ci.provider.name": "travisci",
+      "ci.workspace_path": "/not-my-home",
+      "git.branch": "master",
+      "git.commit.sha": "travis-git-commit",
+      "git.repository_url": "https://github.com/user/repo.git"
+    }
+  ],
+  [
+    {
+      "TRAVIS": "travisCI",
+      "TRAVIS_BRANCH": "origin/master",
+      "TRAVIS_BUILD_DIR": "/foo/bar",
+      "TRAVIS_BUILD_ID": "travis-pipeline-id",
+      "TRAVIS_BUILD_NUMBER": "travis-pipeline-number",
+      "TRAVIS_BUILD_WEB_URL": "travis-pipeline-url",
+      "TRAVIS_COMMIT": "travis-git-commit",
+      "TRAVIS_JOB_WEB_URL": "travis-job-url",
+      "TRAVIS_REPO_SLUG": "user/repo"
+    },
+    {
+      "ci.job.url": "travis-job-url",
+      "ci.pipeline.id": "travis-pipeline-id",
+      "ci.pipeline.name": "user/repo",
+      "ci.pipeline.number": "travis-pipeline-number",
+      "ci.pipeline.url": "travis-pipeline-url",
+      "ci.provider.name": "travisci",
+      "ci.workspace_path": "/foo/bar",
+      "git.branch": "master",
+      "git.commit.sha": "travis-git-commit",
+      "git.repository_url": "https://github.com/user/repo.git"
+    }
+  ],
+  [
+    {
+      "TRAVIS": "travisCI",
+      "TRAVIS_BRANCH": "refs/heads/master",
+      "TRAVIS_BUILD_DIR": "/foo/bar",
+      "TRAVIS_BUILD_ID": "travis-pipeline-id",
+      "TRAVIS_BUILD_NUMBER": "travis-pipeline-number",
+      "TRAVIS_BUILD_WEB_URL": "travis-pipeline-url",
+      "TRAVIS_COMMIT": "travis-git-commit",
+      "TRAVIS_JOB_WEB_URL": "travis-job-url",
+      "TRAVIS_REPO_SLUG": "user/repo"
+    },
+    {
+      "ci.job.url": "travis-job-url",
+      "ci.pipeline.id": "travis-pipeline-id",
+      "ci.pipeline.name": "user/repo",
+      "ci.pipeline.number": "travis-pipeline-number",
+      "ci.pipeline.url": "travis-pipeline-url",
+      "ci.provider.name": "travisci",
+      "ci.workspace_path": "/foo/bar",
+      "git.branch": "master",
+      "git.commit.sha": "travis-git-commit",
+      "git.repository_url": "https://github.com/user/repo.git"
+    }
+  ],
+  [
+    {
+      "TRAVIS": "travisCI",
+      "TRAVIS_BRANCH": "refs/heads/feature/one",
+      "TRAVIS_BUILD_DIR": "/foo/bar",
+      "TRAVIS_BUILD_ID": "travis-pipeline-id",
+      "TRAVIS_BUILD_NUMBER": "travis-pipeline-number",
+      "TRAVIS_BUILD_WEB_URL": "travis-pipeline-url",
+      "TRAVIS_COMMIT": "travis-git-commit",
+      "TRAVIS_JOB_WEB_URL": "travis-job-url",
+      "TRAVIS_REPO_SLUG": "user/repo"
+    },
+    {
+      "ci.job.url": "travis-job-url",
+      "ci.pipeline.id": "travis-pipeline-id",
+      "ci.pipeline.name": "user/repo",
+      "ci.pipeline.number": "travis-pipeline-number",
+      "ci.pipeline.url": "travis-pipeline-url",
+      "ci.provider.name": "travisci",
+      "ci.workspace_path": "/foo/bar",
+      "git.branch": "feature/one",
+      "git.commit.sha": "travis-git-commit",
+      "git.repository_url": "https://github.com/user/repo.git"
+    }
+  ],
+  [
+    {
+      "TRAVIS": "travisCI",
+      "TRAVIS_BRANCH": "origin/other",
+      "TRAVIS_BUILD_DIR": "/foo/bar",
+      "TRAVIS_BUILD_ID": "travis-pipeline-id",
+      "TRAVIS_BUILD_NUMBER": "travis-pipeline-number",
+      "TRAVIS_BUILD_WEB_URL": "travis-pipeline-url",
+      "TRAVIS_COMMIT": "travis-git-commit",
+      "TRAVIS_JOB_WEB_URL": "travis-job-url",
+      "TRAVIS_PULL_REQUEST_BRANCH": "origin/master",
+      "TRAVIS_PULL_REQUEST_SLUG": "user/repo",
+      "TRAVIS_REPO_SLUG": "user/repo"
+    },
+    {
+      "ci.job.url": "travis-job-url",
+      "ci.pipeline.id": "travis-pipeline-id",
+      "ci.pipeline.name": "user/repo",
+      "ci.pipeline.number": "travis-pipeline-number",
+      "ci.pipeline.url": "travis-pipeline-url",
+      "ci.provider.name": "travisci",
+      "ci.workspace_path": "/foo/bar",
+      "git.branch": "master",
+      "git.commit.sha": "travis-git-commit",
+      "git.repository_url": "https://github.com/user/repo.git"
+    }
+  ],
+  [
+    {
+      "TRAVIS": "travisCI",
+      "TRAVIS_BRANCH": "origin/other",
+      "TRAVIS_BUILD_DIR": "/foo/bar",
+      "TRAVIS_BUILD_ID": "travis-pipeline-id",
+      "TRAVIS_BUILD_NUMBER": "travis-pipeline-number",
+      "TRAVIS_BUILD_WEB_URL": "travis-pipeline-url",
+      "TRAVIS_COMMIT": "travis-git-commit",
+      "TRAVIS_JOB_WEB_URL": "travis-job-url",
+      "TRAVIS_PULL_REQUEST_BRANCH": "refs/heads/master",
+      "TRAVIS_PULL_REQUEST_SLUG": "user/repo",
+      "TRAVIS_REPO_SLUG": "user/repo"
+    },
+    {
+      "ci.job.url": "travis-job-url",
+      "ci.pipeline.id": "travis-pipeline-id",
+      "ci.pipeline.name": "user/repo",
+      "ci.pipeline.number": "travis-pipeline-number",
+      "ci.pipeline.url": "travis-pipeline-url",
+      "ci.provider.name": "travisci",
+      "ci.workspace_path": "/foo/bar",
+      "git.branch": "master",
+      "git.commit.sha": "travis-git-commit",
+      "git.repository_url": "https://github.com/user/repo.git"
+    }
+  ],
+  [
+    {
+      "TRAVIS": "travisCI",
+      "TRAVIS_BRANCH": "origin/other",
+      "TRAVIS_BUILD_DIR": "/foo/bar",
+      "TRAVIS_BUILD_ID": "travis-pipeline-id",
+      "TRAVIS_BUILD_NUMBER": "travis-pipeline-number",
+      "TRAVIS_BUILD_WEB_URL": "travis-pipeline-url",
+      "TRAVIS_COMMIT": "travis-git-commit",
+      "TRAVIS_JOB_WEB_URL": "travis-job-url",
+      "TRAVIS_PULL_REQUEST_BRANCH": "refs/heads/feature/one",
+      "TRAVIS_PULL_REQUEST_SLUG": "user/repo",
+      "TRAVIS_REPO_SLUG": "user/repo"
+    },
+    {
+      "ci.job.url": "travis-job-url",
+      "ci.pipeline.id": "travis-pipeline-id",
+      "ci.pipeline.name": "user/repo",
+      "ci.pipeline.number": "travis-pipeline-number",
+      "ci.pipeline.url": "travis-pipeline-url",
+      "ci.provider.name": "travisci",
+      "ci.workspace_path": "/foo/bar",
+      "git.branch": "feature/one",
+      "git.commit.sha": "travis-git-commit",
+      "git.repository_url": "https://github.com/user/repo.git"
+    }
+  ]
+]

--- a/src/helpers/__tests__/ci.test.ts
+++ b/src/helpers/__tests__/ci.test.ts
@@ -1,19 +1,7 @@
 import {CI_ENGINES, getCIMetadata, getCISpanTags} from '../ci'
-import {
-  CI_JOB_NAME,
-  CI_JOB_URL,
-  CI_PIPELINE_ID,
-  CI_PIPELINE_NAME,
-  CI_PIPELINE_NUMBER,
-  CI_PIPELINE_URL,
-  CI_PROVIDER_NAME,
-  CI_STAGE_NAME,
-  CI_WORKSPACE_PATH,
-  GIT_BRANCH,
-  GIT_REPOSITORY_URL,
-  GIT_SHA,
-  GIT_TAG,
-} from '../tags'
+
+import fs from 'fs'
+import path from 'path'
 
 describe('getCIMetadata', () => {
   const branch = 'fakeBranch'
@@ -143,163 +131,21 @@ describe('getCIMetadata', () => {
   })
 })
 
-describe('getCISpanTags', () => {
-  const branch = 'fakeBranch'
-  const tag = 'fakeTag'
-  const commit = 'fakeCommitSha'
-  const pipelineURL = 'fakePipelineUrl'
-  const pipelineId = 'fakePipelineId'
-  const pipelineName = 'fakePipelineName'
-  const pipelineNumber = 'fakePipelineNumber'
-  const workspacePath = 'fakeWorkspacePath'
-  const repositoryUrl = 'fakeRepositoryUrl'
-  const jobUrl = 'fakeJobUrl'
-  const stageName = 'fakeStageName'
-  const jobName = 'fakeJobName'
-
-  test('non-recognized CI returns empty dictionary', () => {
+describe('ci tags', () => {
+  test('returns an empty object if the CI is not supported', () => {
     process.env = {}
     expect(getCISpanTags()).toEqual({})
   })
 
-  test('circle CI is recognized', () => {
-    process.env = {
-      CIRCLECI: 'true',
-      CIRCLE_BRANCH: branch,
-      CIRCLE_BUILD_NUM: pipelineNumber,
-      CIRCLE_BUILD_URL: pipelineURL,
-      CIRCLE_PROJECT_REPONAME: pipelineName,
-      CIRCLE_REPOSITORY_URL: repositoryUrl,
-      CIRCLE_SHA1: commit,
-      CIRCLE_TAG: tag,
-      CIRCLE_WORKFLOW_ID: pipelineId,
-      CIRCLE_WORKING_DIRECTORY: workspacePath,
-    }
-    expect(getCISpanTags()).toEqual({
-      [CI_JOB_URL]: pipelineURL,
-      [CI_PIPELINE_ID]: pipelineId,
-      [CI_PIPELINE_NAME]: pipelineName,
-      [CI_PIPELINE_NUMBER]: pipelineNumber,
-      [CI_PIPELINE_URL]: pipelineURL,
-      [CI_PROVIDER_NAME]: CI_ENGINES.CIRCLECI,
-      [CI_WORKSPACE_PATH]: workspacePath,
-      [GIT_BRANCH]: branch,
-      [GIT_SHA]: commit,
-      [GIT_REPOSITORY_URL]: repositoryUrl,
-      [GIT_TAG]: tag,
-    })
-  })
+  const ciProviders = fs.readdirSync(path.join(__dirname, 'ci-env'))
+  ciProviders.forEach((ciProvider) => {
+    const assertions = require(path.join(__dirname, 'ci-env', ciProvider))
 
-  test('travis CI is recognized', () => {
-    process.env = {
-      TRAVIS: 'true',
-      TRAVIS_BRANCH: branch,
-      TRAVIS_BUILD_DIR: workspacePath,
-      TRAVIS_BUILD_ID: pipelineId,
-      TRAVIS_BUILD_NUMBER: pipelineNumber,
-      TRAVIS_BUILD_WEB_URL: pipelineURL,
-      TRAVIS_COMMIT: commit,
-      TRAVIS_JOB_WEB_URL: jobUrl,
-      TRAVIS_REPO_SLUG: pipelineName,
-      TRAVIS_TAG: tag,
-    }
-    expect(getCISpanTags()).toEqual({
-      [CI_JOB_URL]: jobUrl,
-      [CI_PIPELINE_ID]: pipelineId,
-      [CI_PIPELINE_NAME]: pipelineName,
-      [CI_PIPELINE_NUMBER]: pipelineNumber,
-      [CI_PIPELINE_URL]: pipelineURL,
-      [CI_PROVIDER_NAME]: CI_ENGINES.TRAVIS,
-      [CI_WORKSPACE_PATH]: workspacePath,
-      [GIT_BRANCH]: branch,
-      [GIT_SHA]: commit,
-      [GIT_REPOSITORY_URL]: `https://github.com/${pipelineName}.git`,
-      [GIT_TAG]: tag,
-    })
-  })
-
-  test('gitlab CI is recognized', () => {
-    process.env = {
-      CI_COMMIT_BRANCH: branch,
-      CI_COMMIT_SHA: commit,
-      CI_COMMIT_TAG: tag,
-      CI_JOB_NAME: jobName,
-      CI_JOB_STAGE: stageName,
-      CI_JOB_URL: jobUrl,
-      CI_PIPELINE_ID: pipelineId,
-      CI_PIPELINE_IID: pipelineNumber,
-      CI_PIPELINE_URL: pipelineURL,
-      CI_PROJECT_DIR: workspacePath,
-      CI_PROJECT_PATH: pipelineName,
-      CI_REPOSITORY_URL: repositoryUrl,
-      GITLAB_CI: 'true',
-    }
-    expect(getCISpanTags()).toEqual({
-      [CI_JOB_NAME]: jobName,
-      [CI_JOB_URL]: jobUrl,
-      [CI_PIPELINE_ID]: pipelineId,
-      [CI_PIPELINE_NAME]: pipelineName,
-      [CI_PIPELINE_NUMBER]: pipelineNumber,
-      [CI_PIPELINE_URL]: pipelineURL,
-      [CI_PROVIDER_NAME]: CI_ENGINES.GITLAB,
-      [CI_STAGE_NAME]: stageName,
-      [CI_WORKSPACE_PATH]: workspacePath,
-      [GIT_BRANCH]: branch,
-      [GIT_SHA]: commit,
-      [GIT_REPOSITORY_URL]: repositoryUrl,
-      [GIT_TAG]: tag,
-    })
-  })
-
-  test('github actions is recognized', () => {
-    process.env = {
-      GITHUB_ACTIONS: 'true',
-      GITHUB_REF: branch,
-      GITHUB_REPOSITORY: 'DataDog/datadog-ci',
-      GITHUB_RUN_ID: pipelineId,
-      GITHUB_RUN_NUMBER: pipelineNumber,
-      GITHUB_SHA: commit,
-      GITHUB_WORKFLOW: pipelineName,
-      GITHUB_WORKSPACE: workspacePath,
-    }
-    const expectedRepositoryUrl = 'https://github.com/DataDog/datadog-ci.git'
-    const expectedPipelineUrl = `https://github.com/DataDog/datadog-ci/commit/${commit}/checks`
-    expect(getCISpanTags()).toEqual({
-      [CI_JOB_URL]: expectedPipelineUrl,
-      [CI_PIPELINE_ID]: pipelineId,
-      [CI_PIPELINE_NAME]: pipelineName,
-      [CI_PIPELINE_NUMBER]: pipelineNumber,
-      [CI_PIPELINE_URL]: expectedPipelineUrl,
-      [CI_PROVIDER_NAME]: CI_ENGINES.GITHUB,
-      [CI_WORKSPACE_PATH]: workspacePath,
-      [GIT_BRANCH]: branch,
-      [GIT_SHA]: commit,
-      [GIT_REPOSITORY_URL]: expectedRepositoryUrl,
-    })
-  })
-
-  test('jenkins is recognized', () => {
-    process.env = {
-      BUILD_NUMBER: pipelineNumber,
-      BUILD_TAG: pipelineId,
-      BUILD_URL: pipelineURL,
-      GIT_BRANCH: branch,
-      GIT_COMMIT: commit,
-      GIT_URL: repositoryUrl,
-      JENKINS_URL: 'https://fakebuildserver.url/',
-      JOB_NAME: pipelineName,
-      WORKSPACE: workspacePath,
-    }
-    expect(getCISpanTags()).toEqual({
-      [CI_PIPELINE_ID]: pipelineId,
-      [CI_PIPELINE_NAME]: pipelineName,
-      [CI_PIPELINE_NUMBER]: pipelineNumber,
-      [CI_PIPELINE_URL]: pipelineURL,
-      [CI_PROVIDER_NAME]: CI_ENGINES.JENKINS,
-      [CI_WORKSPACE_PATH]: workspacePath,
-      [GIT_BRANCH]: branch,
-      [GIT_SHA]: commit,
-      [GIT_REPOSITORY_URL]: repositoryUrl,
+    assertions.forEach(([env, expectedSpanTags]: [{[key: string]: string}, {[key: string]: string}], index: number) => {
+      test(`reads env info for spec ${index} from ${ciProvider}`, () => {
+        process.env = env
+        expect(getCISpanTags()).toEqual(expectedSpanTags)
+      })
     })
   })
 })

--- a/src/helpers/__tests__/ci.test.ts
+++ b/src/helpers/__tests__/ci.test.ts
@@ -131,7 +131,7 @@ describe('getCIMetadata', () => {
   })
 })
 
-describe('ci tags', () => {
+describe('getCISpanTags', () => {
   test('returns an empty object if the CI is not supported', () => {
     process.env = {}
     expect(getCISpanTags()).toEqual({})

--- a/src/helpers/ci.ts
+++ b/src/helpers/ci.ts
@@ -18,11 +18,16 @@ import {
 } from './tags'
 
 export const CI_ENGINES = {
+  APPVEYOR: 'appveyor',
+  AZURE: 'azurepipelines',
+  BITBUCKET: 'bitbucket',
+  BITRISE: 'bitrise',
+  BUILDKITE: 'buildkite',
   CIRCLECI: 'circleci',
   GITHUB: 'github',
   GITLAB: 'gitlab',
   JENKINS: 'jenkins',
-  TRAVIS: 'travis',
+  TRAVIS: 'travisci',
 }
 
 const removeEmptyValues = (tags: SpanTags) =>
@@ -65,7 +70,7 @@ const filterSensitiveInfoFromRepository = (repositoryUrl: string) => {
   }
 }
 
-const normalizeRef = (ref: string) => {
+const normalizeRef = (ref: string | undefined) => {
   if (!ref) {
     return ref
   }
@@ -97,15 +102,15 @@ export const getCISpanTags = (): SpanTags | undefined => {
       [CI_PIPELINE_URL]: CIRCLE_BUILD_URL,
       [CI_PROVIDER_NAME]: CI_ENGINES.CIRCLECI,
       [CI_WORKSPACE_PATH]: CIRCLE_WORKING_DIRECTORY,
-      [GIT_BRANCH]: CIRCLE_BRANCH,
       [GIT_SHA]: CIRCLE_SHA1,
       [GIT_REPOSITORY_URL]: CIRCLE_REPOSITORY_URL,
-      [GIT_TAG]: CIRCLE_TAG,
+      [CIRCLE_TAG ? GIT_TAG : GIT_BRANCH]: CIRCLE_TAG || CIRCLE_BRANCH,
     }
   }
 
   if (env.TRAVIS) {
     const {
+      TRAVIS_PULL_REQUEST_BRANCH,
       TRAVIS_BRANCH,
       TRAVIS_COMMIT,
       TRAVIS_REPO_SLUG,
@@ -124,11 +129,13 @@ export const getCISpanTags = (): SpanTags | undefined => {
       [CI_PIPELINE_URL]: TRAVIS_BUILD_WEB_URL,
       [CI_PROVIDER_NAME]: CI_ENGINES.TRAVIS,
       [CI_WORKSPACE_PATH]: TRAVIS_BUILD_DIR,
-      [GIT_BRANCH]: TRAVIS_BRANCH,
       [GIT_SHA]: TRAVIS_COMMIT,
       [GIT_REPOSITORY_URL]: `https://github.com/${TRAVIS_REPO_SLUG}.git`,
-      [GIT_TAG]: TRAVIS_TAG,
     }
+    const isTag = !!TRAVIS_TAG
+    const ref = TRAVIS_TAG || TRAVIS_PULL_REQUEST_BRANCH || TRAVIS_BRANCH
+    const refKey = isTag ? GIT_TAG : GIT_BRANCH
+    tags[refKey] = ref
   }
 
   if (env.GITLAB_CI) {
@@ -169,12 +176,16 @@ export const getCISpanTags = (): SpanTags | undefined => {
       GITHUB_WORKFLOW,
       GITHUB_RUN_NUMBER,
       GITHUB_WORKSPACE,
+      GITHUB_HEAD_REF,
       GITHUB_REF,
       GITHUB_SHA,
       GITHUB_REPOSITORY,
     } = env
     const repositoryUrl = `https://github.com/${GITHUB_REPOSITORY}.git`
     const pipelineURL = `https://github.com/${GITHUB_REPOSITORY}/commit/${GITHUB_SHA}/checks`
+
+    const ref = GITHUB_HEAD_REF || GITHUB_REF || ''
+    const refKey = ref.includes('tags') ? GIT_TAG : GIT_BRANCH
 
     tags = {
       [CI_JOB_URL]: pipelineURL,
@@ -184,9 +195,9 @@ export const getCISpanTags = (): SpanTags | undefined => {
       [CI_PIPELINE_URL]: pipelineURL,
       [CI_PROVIDER_NAME]: CI_ENGINES.GITHUB,
       [CI_WORKSPACE_PATH]: GITHUB_WORKSPACE,
-      [GIT_BRANCH]: GITHUB_REF,
       [GIT_SHA]: GITHUB_SHA,
       [GIT_REPOSITORY_URL]: repositoryUrl,
+      [refKey]: ref,
     }
   }
 
@@ -204,16 +215,206 @@ export const getCISpanTags = (): SpanTags | undefined => {
 
     tags = {
       [CI_PIPELINE_ID]: BUILD_TAG,
-      [CI_PIPELINE_NAME]: JOB_NAME,
       [CI_PIPELINE_NUMBER]: BUILD_NUMBER,
       [CI_PIPELINE_URL]: BUILD_URL,
       [CI_PROVIDER_NAME]: CI_ENGINES.JENKINS,
       [CI_WORKSPACE_PATH]: WORKSPACE,
-      [GIT_BRANCH]: JENKINS_GIT_BRANCH,
       [GIT_SHA]: GIT_COMMIT,
       [GIT_REPOSITORY_URL]: GIT_URL,
     }
+    const isTag = JENKINS_GIT_BRANCH && JENKINS_GIT_BRANCH.includes('tags')
+    const refKey = isTag ? GIT_TAG : GIT_BRANCH
+    const ref = normalizeRef(JENKINS_GIT_BRANCH)
+
+    tags[refKey] = ref
+
+    let finalPipelineName = ''
+    if (JOB_NAME) {
+      // Job names can contain parameters, e.g. jobName/KEY1=VALUE1,KEY2=VALUE2/branchName
+      const jobNameAndParams = JOB_NAME.split('/')
+      if (jobNameAndParams.length > 1 && jobNameAndParams[1].includes('=')) {
+        finalPipelineName = jobNameAndParams[0]
+      } else {
+        finalPipelineName = JOB_NAME.replace(`/${ref}`, '')
+      }
+      tags[CI_PIPELINE_NAME] = finalPipelineName
+    }
   }
+
+  if (env.BUILDKITE) {
+    const {
+      BUILDKITE_BRANCH,
+      BUILDKITE_COMMIT,
+      BUILDKITE_REPO,
+      BUILDKITE_TAG,
+      BUILDKITE_BUILD_ID,
+      BUILDKITE_PIPELINE_SLUG,
+      BUILDKITE_BUILD_NUMBER,
+      BUILDKITE_BUILD_URL,
+      BUILDKITE_JOB_ID,
+      BUILDKITE_BUILD_CHECKOUT_PATH,
+    } = env
+
+    const ref = BUILDKITE_TAG || BUILDKITE_BRANCH
+    const refKey = BUILDKITE_TAG ? GIT_TAG : GIT_BRANCH
+
+    tags = {
+      [CI_PROVIDER_NAME]: CI_ENGINES.BUILDKITE,
+      [CI_PIPELINE_ID]: BUILDKITE_BUILD_ID,
+      [CI_PIPELINE_NAME]: BUILDKITE_PIPELINE_SLUG,
+      [CI_PIPELINE_NUMBER]: BUILDKITE_BUILD_NUMBER,
+      [CI_PIPELINE_URL]: BUILDKITE_BUILD_URL,
+      [CI_JOB_URL]: `${BUILDKITE_BUILD_URL}#${BUILDKITE_JOB_ID}`,
+      [GIT_SHA]: BUILDKITE_COMMIT,
+      [CI_WORKSPACE_PATH]: BUILDKITE_BUILD_CHECKOUT_PATH,
+      [GIT_REPOSITORY_URL]: BUILDKITE_REPO,
+      [refKey]: ref,
+    }
+  }
+
+  if (env.BITRISE_BUILD_SLUG) {
+    const {
+      BITRISE_GIT_COMMIT,
+      GIT_CLONE_COMMIT_HASH,
+      BITRISEIO_GIT_BRANCH_DEST,
+      BITRISE_GIT_BRANCH,
+      BITRISE_BUILD_SLUG,
+      BITRISE_APP_TITLE,
+      BITRISE_BUILD_NUMBER,
+      BITRISE_BUILD_URL,
+      BITRISE_SOURCE_DIR,
+      GIT_REPOSITORY_URL: BITRISE_GIT_REPOSITORY_URL,
+      BITRISE_GIT_TAG,
+    } = env
+
+    const isTag = !!BITRISE_GIT_TAG
+    const refKey = isTag ? GIT_TAG : GIT_BRANCH
+    const ref = BITRISE_GIT_TAG || BITRISEIO_GIT_BRANCH_DEST || BITRISE_GIT_BRANCH
+
+    tags = {
+      [CI_PROVIDER_NAME]: CI_ENGINES.BITRISE,
+      [CI_PIPELINE_ID]: BITRISE_BUILD_SLUG,
+      [CI_PIPELINE_NAME]: BITRISE_APP_TITLE,
+      [CI_PIPELINE_NUMBER]: BITRISE_BUILD_NUMBER,
+      [CI_PIPELINE_URL]: BITRISE_BUILD_URL,
+      [GIT_SHA]: BITRISE_GIT_COMMIT || GIT_CLONE_COMMIT_HASH,
+      [GIT_REPOSITORY_URL]: BITRISE_GIT_REPOSITORY_URL,
+      [CI_WORKSPACE_PATH]: BITRISE_SOURCE_DIR,
+      [refKey]: ref,
+    }
+  }
+
+  if (env.BITBUCKET_COMMIT) {
+    const {
+      BITBUCKET_REPO_FULL_NAME,
+      BITBUCKET_BUILD_NUMBER,
+      BITBUCKET_BRANCH,
+      BITBUCKET_COMMIT,
+      BITBUCKET_GIT_SSH_ORIGIN,
+      BITBUCKET_TAG,
+      BITBUCKET_PIPELINE_UUID,
+      BITBUCKET_CLONE_DIR,
+    } = env
+
+    const url = `https://bitbucket.org/${BITBUCKET_REPO_FULL_NAME}/addon/pipelines/home#!/results/${BITBUCKET_BUILD_NUMBER}`
+
+    tags = {
+      [CI_PROVIDER_NAME]: CI_ENGINES.BITBUCKET,
+      [GIT_SHA]: BITBUCKET_COMMIT,
+      [CI_PIPELINE_NUMBER]: BITBUCKET_BUILD_NUMBER,
+      [CI_PIPELINE_NAME]: BITBUCKET_REPO_FULL_NAME,
+      [CI_JOB_URL]: url,
+      [CI_PIPELINE_URL]: url,
+      [GIT_BRANCH]: BITBUCKET_BRANCH,
+      [GIT_TAG]: BITBUCKET_TAG,
+      [GIT_REPOSITORY_URL]: BITBUCKET_GIT_SSH_ORIGIN,
+      [CI_WORKSPACE_PATH]: BITBUCKET_CLONE_DIR,
+      [CI_PIPELINE_ID]: BITBUCKET_PIPELINE_UUID && BITBUCKET_PIPELINE_UUID.replace(/{|}/gm, ''),
+    }
+  }
+
+  if (env.TF_BUILD) {
+    const {
+      BUILD_SOURCESDIRECTORY,
+      BUILD_BUILDID,
+      BUILD_DEFINITIONNAME,
+      SYSTEM_TEAMFOUNDATIONSERVERURI,
+      SYSTEM_TEAMPROJECTID,
+      SYSTEM_JOBID,
+      SYSTEM_TASKINSTANCEID,
+      SYSTEM_PULLREQUEST_SOURCEBRANCH,
+      BUILD_SOURCEBRANCH,
+      BUILD_SOURCEBRANCHNAME,
+      SYSTEM_PULLREQUEST_SOURCECOMMITID,
+      SYSTEM_PULLREQUEST_SOURCEREPOSITORYURI,
+      BUILD_REPOSITORY_URI,
+      BUILD_SOURCEVERSION,
+    } = env
+
+    const ref = SYSTEM_PULLREQUEST_SOURCEBRANCH || BUILD_SOURCEBRANCH || BUILD_SOURCEBRANCHNAME
+    const refKey = (ref || '').includes('tags') ? GIT_TAG : GIT_BRANCH
+
+    tags = {
+      [CI_PROVIDER_NAME]: CI_ENGINES.AZURE,
+      [CI_PIPELINE_ID]: BUILD_BUILDID,
+      [CI_PIPELINE_NAME]: BUILD_DEFINITIONNAME,
+      [CI_PIPELINE_NUMBER]: BUILD_BUILDID,
+      [GIT_SHA]: SYSTEM_PULLREQUEST_SOURCECOMMITID || BUILD_SOURCEVERSION,
+      [CI_WORKSPACE_PATH]: BUILD_SOURCESDIRECTORY,
+      [GIT_REPOSITORY_URL]: SYSTEM_PULLREQUEST_SOURCEREPOSITORYURI || BUILD_REPOSITORY_URI,
+      [refKey]: ref,
+    }
+
+    if (SYSTEM_TEAMFOUNDATIONSERVERURI && SYSTEM_TEAMPROJECTID && BUILD_BUILDID) {
+      const baseUrl = `${SYSTEM_TEAMFOUNDATIONSERVERURI}${SYSTEM_TEAMPROJECTID}/_build/results?buildId=${BUILD_BUILDID}`
+      const pipelineUrl = baseUrl
+      const jobUrl = `${baseUrl}&view=logs&j=${SYSTEM_JOBID}&t=${SYSTEM_TASKINSTANCEID}`
+
+      tags = {
+        ...tags,
+        [CI_PIPELINE_URL]: pipelineUrl,
+        [CI_JOB_URL]: jobUrl,
+      }
+    }
+  }
+
+  if (env.APPVEYOR) {
+    const {
+      APPVEYOR_REPO_NAME,
+      APPVEYOR_REPO_PROVIDER,
+      APPVEYOR_BUILD_FOLDER,
+      APPVEYOR_BUILD_ID,
+      APPVEYOR_BUILD_NUMBER,
+      APPVEYOR_REPO_COMMIT,
+      APPVEYOR_PULL_REQUEST_HEAD_REPO_BRANCH,
+      APPVEYOR_REPO_BRANCH,
+      APPVEYOR_REPO_TAG_NAME,
+    } = env
+
+    const pipelineUrl = `https://ci.appveyor.com/project/${APPVEYOR_REPO_NAME}/builds/${APPVEYOR_BUILD_ID}`
+
+    tags = {
+      [CI_PROVIDER_NAME]: CI_ENGINES.APPVEYOR,
+      [CI_PIPELINE_URL]: pipelineUrl,
+      [CI_PIPELINE_ID]: APPVEYOR_BUILD_ID,
+      [CI_PIPELINE_NAME]: APPVEYOR_REPO_NAME,
+      [CI_PIPELINE_NUMBER]: APPVEYOR_BUILD_NUMBER,
+      [CI_JOB_URL]: pipelineUrl,
+      [CI_WORKSPACE_PATH]: APPVEYOR_BUILD_FOLDER,
+    }
+
+    if (APPVEYOR_REPO_PROVIDER === 'github') {
+      const refKey = APPVEYOR_REPO_TAG_NAME ? GIT_TAG : GIT_BRANCH
+      const ref = APPVEYOR_REPO_TAG_NAME || APPVEYOR_PULL_REQUEST_HEAD_REPO_BRANCH || APPVEYOR_REPO_BRANCH
+      tags = {
+        ...tags,
+        [GIT_REPOSITORY_URL]: `https://github.com/${APPVEYOR_REPO_NAME}.git`,
+        [GIT_SHA]: APPVEYOR_REPO_COMMIT,
+        [refKey]: ref,
+      }
+    }
+  }
+
   if (tags[CI_WORKSPACE_PATH]) {
     tags[CI_WORKSPACE_PATH] = resolveTilde(tags[CI_WORKSPACE_PATH]!)
   }


### PR DESCRIPTION
### What and why?

Improve support for CI providers and make sure we follow the spec.

### How?

* Add JSON files for each CI provider to assert we are extracting metadata correctly. This is based on the CI Spec in https://github.com/DataDog/datadog-ci-spec/tree/main/spec_tests. 
* Create tests for each file: https://github.com/DataDog/datadog-ci/pull/219/files#diff-bdab68b0d54fe06587bd7486f7b20e4da6d3ec0127f20806fa0096546de554e6R144-R148 
* Add support for remaining CI providers in `src/helpers/ci.ts`.

Additionally I've added this repository to our spec tests in https://github.com/DataDog/datadog-ci-spec/pull/95. 

The GHA in https://github.com/DataDog/datadog-ci-spec/blob/main/.github/workflows/spec_tests.yml checks whether the projects that are reading from CI providers' environment are homogeneous. 

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)

