### PR TITLE
[sourcemaps] Display human-readable error message for http errors.

### DIFF
--- a/src/commands/sourcemaps/upload.ts
+++ b/src/commands/sourcemaps/upload.ts
@@ -305,7 +305,13 @@ export class UploadCommand extends Command {
         )
       }
       metricsLogger.increment('failed', 1)
-      this.context.stdout.write(renderFailedUpload(sourcemap, error))
+      if (error.response && error.response.statusText) {
+        // Display human readable info about the status code
+        this.context.stdout.write(renderFailedUpload(sourcemap, `${error.message} (${error.response.statusText})`))
+      } else {
+        // Default error handling
+        this.context.stdout.write(renderFailedUpload(sourcemap, error))
+      }
 
       return UploadStatus.Failure
     }


### PR DESCRIPTION
### What and why?

Include the human-readable message for the http error in the console, like this:
```
❌ Failed upload sourcemap for [src/commands/sourcemaps/__tests__/fixtures/too-big/file.js.map]: Request failed with status code 413 (Request Entity Too Large)

Command summary:
❌ Some sourcemaps have not been uploaded correctly.
Details about the 1 found sourcemap:
  * 1 sourcemap failed to upload
```

### How?

A brief description of implementation details of this PR.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)

