### PR TITLE
Handle sourcemaps containing backslashes in paths

### DIFF
--- a/src/commands/sourcemaps/__tests__/git.test.ts
+++ b/src/commands/sourcemaps/__tests__/git.test.ts
@@ -117,6 +117,12 @@ describe('git', () => {
         const matcher = new TrackedFilesMatcher(trackedFiles)
         expect(matcher.matchSources(sources)).toStrictEqual(['src/file.ts', 'file.ts'])
       })
+      test('mix of related and not related with backslash separator', () => {
+        const sources = ['folder\\file.ts', 'folder\\other.ts']
+        const trackedFiles = ['src/file.ts', 'file.ts', 'src/other2.ts'] // Git is never expected to output backslashes.
+        const matcher = new TrackedFilesMatcher(trackedFiles)
+        expect(matcher.matchSources(sources)).toStrictEqual(['src/file.ts', 'file.ts'])
+      })
     })
   })
 

--- a/src/commands/sourcemaps/git.ts
+++ b/src/commands/sourcemaps/git.ts
@@ -182,6 +182,10 @@ export class TrackedFilesMatcher {
   // Example: webpack:///./src/folder/ui/select.vue?821e
   private getFilename(s: string): string {
     let start = s.lastIndexOf('/')
+    const backslashStart = s.lastIndexOf('\\')
+    if (backslashStart > start) {
+      start = backslashStart
+    }
     if (start === -1) {
       start = 0
     } else {


### PR DESCRIPTION
### What and why?

Properly handles sourcemaps that contain paths with backslashes (windows).

### How?

A brief description of implementation details of this PR.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)

