### PR TITLE
[dependencies] metrics flushing fix.

### DIFF
--- a/src/commands/dependencies/__tests__/upload.test.ts
+++ b/src/commands/dependencies/__tests__/upload.test.ts
@@ -244,7 +244,7 @@ describe('execute', () => {
     const stdout = context.stdout.toString()
     const stderr = context.stderr.toString()
 
-    expect(stderr).toEqual('No access granted')
+    expect(stderr).toEqual('No access granted\n')
     expect(stdout).toMatch(new RegExp(`File:[\\s]+${resolvedFilePath}`))
     expect(stdout).toMatch(/Source:[\s]+snyk/)
     expect(stdout).toMatch(/Service:[\s]+my-service/)
@@ -271,7 +271,7 @@ describe('execute', () => {
     const stdout = context.stdout.toString()
     const stderr = context.stderr.toString()
 
-    expect(stderr).toEqual('Forbidden')
+    expect(stderr).toEqual('Forbidden\n')
     expect(stdout).toContain(
       'Failed upload dependencies: Forbidden. Check DATADOG_API_KEY and DATADOG_APP_KEY environment variables.'
     )

--- a/src/commands/dependencies/upload.ts
+++ b/src/commands/dependencies/upload.ts
@@ -113,18 +113,22 @@ export class UploadCommand extends Command {
         source: this.source,
         version: this.releaseVersion,
       }
-      await this.uploadDependencies(payload, metricsLogger)
+      await this.uploadDependencies(payload, metricsLogger.logger)
       const totalTimeSeconds = (Date.now() - initialTime) / 1000
 
       this.context.stdout.write(renderSuccessfulCommand(totalTimeSeconds))
 
-      metricsLogger.gauge('duration', totalTimeSeconds)
+      metricsLogger.logger.gauge('duration', totalTimeSeconds)
     } catch (error) {
-      this.context.stderr.write(error.message)
+      this.context.stderr.write(`${error.message}\n`)
 
       return UploadCommand.UPLOAD_ERROR_EXIT_CODE
     } finally {
-      metricsLogger.flush()
+      try {
+        await metricsLogger.flush()
+      } catch (err) {
+        this.context.stdout.write(`WARN: ${err}\n`)
+      }
     }
   }
 


### PR DESCRIPTION
### What and why?

Port changes from https://github.com/DataDog/datadog-ci/pull/225 to dependencies command.


