### PR TITLE
[sourcemaps] Avoid command crash when sourcemap is empty. 

### DIFF
--- a/src/commands/sourcemaps/renderer.ts
+++ b/src/commands/sourcemaps/renderer.ts
@@ -14,6 +14,9 @@ export const renderGitWarning = (errorMessage: string) =>
 Make sure the command is running within your git repository to fully leverage Datadog's git integration.
 To ignore this warning use the --disable-git flag.\n`)
 
+export const renderGitDataNotAttachedWarning = (sourcemap: string, errorMessage: string) =>
+  chalk.yellow(`${ICONS.WARNING} Could not attach git data for sourcemap ${sourcemap}: ${errorMessage}\n`)
+
 export const renderSourcesNotFoundWarning = (sourcemap: string) =>
   chalk.yellow(`${ICONS.WARNING} No tracked files found for sources contained in ${sourcemap}\n`)
 


### PR DESCRIPTION
Before that, command crashed because of git repository data attachment.

An improvement to this PR could be to fail the sourcemap if we cannot
decode it for git attachment, since it means it will be useless anyway.
