### PR TITLE
v0.11.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci",
-  "version": "0.11.8",
+  "version": "0.11.9",
   "description": "Run datadog actions from the CI.",
   "main": "dist/index.js",
   "repository": "https://github.com/DataDog/datadog-ci",


### PR DESCRIPTION
### What and why?

Release version 0.11.9 of the package with updated dependencies to fix vulnerabilities:
- #237 Bump hosted-git-info from 2.7.1 to 2.8.9
- #236 Bump aws-sdk, datadog-metrics and dd-trace