### PR TITLE
[SW-1103] provide HASH env variable for url override

### DIFF
--- a/src/commands/synthetics/README.md
+++ b/src/commands/synthetics/README.md
@@ -165,25 +165,26 @@ All options under the `config` key allow overriding the configuration of the tes
 
 You can configure on which url your Browser or HTTP test starts by providing a `config.startUrl` to your test object and build your own starting url using any part of your test's original starting url and the following environment variables:
 
-| Environment variable | Description                  | Example                                                |
-| -------------------- | ---------------------------- | ------------------------------------------------------ |
-| `URL`                | Test's original starting url | `https://www.example.org:81/path/to/something?abc=123` |
-| `DOMAIN`             | Test's domain name           | `example.org`                                          |
-| `HOST`               | Test's host                  | `www.example.org:81`                                   |
-| `HOSTNAME`           | Test's hostname              | `www.example.org`                                      |
-| `ORIGIN`             | Test's origin                | `https://www.example.org:81`                           |
-| `PARAMS`             | Test's query parameters      | `?abc=123`                                             |
-| `PATHNAME`           | Test's URl path              | `/path/to/something`                                   |
-| `PORT`               | Test's host port             | `81`                                                   |
-| `PROTOCOL`           | Test's protocol              | `https:`                                               |
-| `SUBDOMAIN`          | Test's sub domain            | `www`                                                  |
+| Environment variable | Description                  | Example                                                       |
+| -------------------- | ---------------------------- | ------------------------------------------------------------- |
+| `URL`                | Test's original starting url | `https://www.example.org:81/path/to/something?abc=123#target` |
+| `DOMAIN`             | Test's domain name           | `example.org`                                                 |
+| `HASH`               | Test's URL hash              | `#target`                                                     |
+| `HOST`               | Test's host                  | `www.example.org:81`                                          |
+| `HOSTNAME`           | Test's hostname              | `www.example.org`                                             |
+| `ORIGIN`             | Test's origin                | `https://www.example.org:81`                                  |
+| `PARAMS`             | Test's query parameters      | `?abc=123`                                                    |
+| `PATHNAME`           | Test's URl path              | `/path/to/something`                                          |
+| `PORT`               | Test's host port             | `81`                                                          |
+| `PROTOCOL`           | Test's protocol              | `https:`                                                      |
+| `SUBDOMAIN`          | Test's sub domain            | `www`                                                         |
 
-For instance, if your test's starting url is `https://www.example.org:81/path/to/something?abc=123`
+For instance, if your test's starting url is `https://www.example.org:81/path/to/something?abc=123#target`
 
 It can be written as :
 
-- `{{PROTOCOL}}//{{SUBDOMAIN}}.{{DOMAIN}}:{{PORT}}{{PATHNAME}}{{PARAMS}}`
-- `{{PROTOCOL}}//{{HOST}}{{PATHNAME}}{{PARAMS}}`
+- `{{PROTOCOL}}//{{SUBDOMAIN}}.{{DOMAIN}}:{{PORT}}{{PATHNAME}}{{PARAMS}}{{HASH}}`
+- `{{PROTOCOL}}//{{HOST}}{{PATHNAME}}{{PARAMS}}{{HASH}}`
 - `{{URL}}`
 
 and so on...

--- a/src/commands/synthetics/__tests__/utils.test.ts
+++ b/src/commands/synthetics/__tests__/utils.test.ts
@@ -197,14 +197,14 @@ describe('utils', () => {
     test('startUrl template is rendered if correct test type or subtype', () => {
       const publicId = 'abc-def-ghi'
       const fakeTest = {
-        config: {request: {url: 'http://example.org/path'}},
+        config: {request: {url: 'http://example.org/path#target'}},
         public_id: publicId,
         type: 'browser',
       } as Test
       const configOverride = {
-        startUrl: 'https://{{DOMAIN}}/newPath?oldPath={{PATHNAME}}',
+        startUrl: 'https://{{DOMAIN}}/newPath?oldPath={{PATHNAME}}{{HASH}}',
       }
-      const expectedUrl = 'https://example.org/newPath?oldPath=/path'
+      const expectedUrl = 'https://example.org/newPath?oldPath=/path#target'
 
       let handledConfig = utils.handleConfig(fakeTest, publicId, mockReporter, configOverride)
       expect(handledConfig.public_id).toBe(publicId)

--- a/src/commands/synthetics/utils.ts
+++ b/src/commands/synthetics/utils.ts
@@ -100,6 +100,7 @@ const parseUrlVariables = (url: string, reporter: MainReporter) => {
   const domain = subdomainMatch ? objUrl.hostname.replace(`${subdomainMatch[1]}.`, '') : objUrl.hostname
 
   context.DOMAIN = domain
+  context.HASH = objUrl.hash
   context.HOST = objUrl.host
   context.HOSTNAME = objUrl.hostname
   context.ORIGIN = objUrl.origin


### PR DESCRIPTION
### What and why?

This PR provide the environment variable `HASH` filled with the hash part of the test url.
easier to review with white-space changes hidden: https://github.com/DataDog/datadog-ci/pull/239/files?diff=split&w=1

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)

