### PR TITLE
Publish v0.11.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci",
-  "version": "0.11.10",
+  "version": "0.11.11",
   "description": "Run datadog actions from the CI.",
   "main": "dist/index.js",
   "repository": "https://github.com/DataDog/datadog-ci",


### PR DESCRIPTION
### What and why?

This PR publishes the `datadog-ci` packet in version v0.11.11

### How?

🔖 

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)

