### PR TITLE
[ci-app] JUnit XML Upload – Use Safe File Names

### DIFF
--- a/src/commands/junit/__tests__/api.test.ts
+++ b/src/commands/junit/__tests__/api.test.ts
@@ -1,0 +1,7 @@
+import {getSafeFileName} from '../api'
+
+describe('getSafeFileName', () => {
+  test('filters unsafe characters out', () => {
+    expect(getSafeFileName('http://gitlab.com/-/pipelines/12345')).toEqual('http___gitlab_com___pipelines_12345')
+  })
+})

--- a/src/commands/junit/__tests__/upload.test.ts
+++ b/src/commands/junit/__tests__/upload.test.ts
@@ -177,6 +177,17 @@ describe('execute', () => {
       service: 'test-service',
     })
   })
+
+  test('single file', async () => {
+    const {context, code} = await runCLI([process.cwd() + '/src/commands/junit/__tests__/fixtures/single_file.xml'])
+    const output = context.stdout.toString().split(os.EOL)
+    const path = `${process.cwd()}/src/commands/junit/__tests__/fixtures/single_file.xml`
+    expect(code).toBe(0)
+    expect(output[0]).toContain('DRY-RUN MODE ENABLED. WILL NOT UPLOAD JUNIT XML')
+    expect(output[1]).toContain('Starting upload with concurrency 20.')
+    expect(output[2]).toContain(`Will upload jUnit XML file ${path}`)
+    expect(output[3]).toContain('service: test-service')
+  })
 })
 
 interface ExpectedOutput {

--- a/src/commands/junit/api.ts
+++ b/src/commands/junit/api.ts
@@ -10,7 +10,10 @@ import {renderUpload} from './renderer'
 
 import {CI_JOB_URL, CI_PIPELINE_URL, GIT_SHA} from '../../helpers/tags'
 
-const getSafeFileName = (unsafeFileName: string) => unsafeFileName.replace(/[^a-z0-9]/gi, '_')
+// We need a unique file name so we use span tags like the pipeline URL,
+// which can contain dots and other unsafe characters for filenames.
+// We filter them out here.
+export const getSafeFileName = (unsafeFileName: string) => unsafeFileName.replace(/[^a-z0-9]/gi, '_')
 
 // Dependency follows-redirects sets a default maxBodyLength of 10 MB https://github.com/follow-redirects/follow-redirects/blob/b774a77e582b97174813b3eaeb86931becba69db/index.js#L391
 // We don't want any hard limit enforced by the CLI, the backend will enforce a max size by returning 413 errors.

--- a/src/commands/junit/api.ts
+++ b/src/commands/junit/api.ts
@@ -10,6 +10,8 @@ import {renderUpload} from './renderer'
 
 import {CI_JOB_URL, CI_PIPELINE_URL, GIT_SHA} from '../../helpers/tags'
 
+const getSafeFileName = (unsafeFileName: string) => unsafeFileName.replace(/[^a-z0-9]/gi, '_')
+
 // Dependency follows-redirects sets a default maxBodyLength of 10 MB https://github.com/follow-redirects/follow-redirects/blob/b774a77e582b97174813b3eaeb86931becba69db/index.js#L391
 // We don't want any hard limit enforced by the CLI, the backend will enforce a max size by returning 413 errors.
 const maxBodyLength = Infinity
@@ -43,7 +45,9 @@ export const uploadJUnitXML = (request: (args: AxiosRequestConfig) => AxiosPromi
     uniqueFileName = `${uniqueFileName}-${spanTags[CI_JOB_URL]}`
   }
 
-  form.append('junit_xml_report_file', fs.createReadStream(jUnitXML.xmlPath), {filename: `${uniqueFileName}.xml`})
+  form.append('junit_xml_report_file', fs.createReadStream(jUnitXML.xmlPath), {
+    filename: `${getSafeFileName(uniqueFileName)}.xml`,
+  })
 
   return request({
     data: form,

--- a/src/commands/junit/renderer.ts
+++ b/src/commands/junit/renderer.ts
@@ -1,4 +1,5 @@
 import chalk from 'chalk'
+import path from 'path'
 
 import {Payload} from './interfaces'
 
@@ -33,7 +34,11 @@ export const renderCommandInfo = (basePaths: string[], service: string, concurre
     fullStr += chalk.yellow(`${ICONS.WARNING} DRY-RUN MODE ENABLED. WILL NOT UPLOAD JUNIT XML\n`)
   }
   fullStr += chalk.green(`Starting upload with concurrency ${concurrency}. \n`)
-  fullStr += chalk.green(`Will look for jUnit XML files in ${basePaths.join(', ')}\n`)
+  if (basePaths.length === 1 && !!path.extname(basePaths[0])) {
+    fullStr += chalk.green(`Will upload jUnit XML file ${basePaths[0]}\n`)
+  } else {
+    fullStr += chalk.green(`Will look for jUnit XML files in ${basePaths.join(', ')}\n`)
+  }
   fullStr += chalk.green(`service: ${service}\n`)
 
   return fullStr


### PR DESCRIPTION
### What and why?

Use a function to make sure the file name we use to be stored in S3 is safe.

Also, improve rendered message when using a single file.

### How?

* Create `getSafeFileName`. 
* Render a slightly different name if the input is a single file.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)

