### PR TITLE
Enable linktogit in the stable channel

### DIFF
--- a/src/commands/sourcemaps/README.md
+++ b/src/commands/sourcemaps/README.md
@@ -45,8 +45,10 @@ Example: if you're uploading `dist/file.js` to `https://example.com/static/file.
 In addition, some optional parameters are available:
 
 * `--concurrency` (default: `20`): number of concurrent upload to the API.
+* `--disable-git` (default: false): prevents the command from sending any repository related data to Datadog (hash, remote URL and the paths within the repository of the sources referenced in the sourcemap).
 * `--dry-run` (default: `false`): it will run the command without the final step of upload. All other checks are performed.
-* `--project-path` (default: empty): the path of the project where the sourcemaps were built. This will be stripped off from the file name in the displayed stack traces.
+* `--project-path` (default: empty): the path of the project where the sourcemaps were built. This will be stripped off from sources paths referenced in the sourcemap so they can be properly matched against tracked files paths.
+* `--repository-url` (default: empty): overrides the repository remote with a custom URL. For example: https://github.com/my-company/my-project
 
 ### End-to-end testing process
 

--- a/src/commands/sourcemaps/upload.ts
+++ b/src/commands/sourcemaps/upload.ts
@@ -55,8 +55,8 @@ export class UploadCommand extends Command {
     apiKey: process.env.DATADOG_API_KEY,
     datadogSite: process.env.DATADOG_SITE || 'datadoghq.com',
   }
+  private disableGit?: boolean
   private dryRun = false
-  private enableGit?: boolean
   private maxConcurrency = 20
   private minifiedPathPrefix?: string
   private projectPath = ''
@@ -111,7 +111,7 @@ export class UploadCommand extends Command {
     )
     const cliVersion = require('../../../package.json').version
     const metricsLogger = getMetricsLogger(this.releaseVersion, this.service, cliVersion)
-    const useGit = this.enableGit !== undefined && this.enableGit
+    const useGit = this.disableGit === undefined || !this.disableGit
     const initialTime = Date.now()
     const payloads = await this.getPayloadsToUpload(useGit, cliVersion)
     const upload = (p: Payload) => this.uploadSourcemap(api, metricsLogger.logger, p)
@@ -342,4 +342,4 @@ UploadCommand.addOption('projectPath', Command.String('--project-path'))
 UploadCommand.addOption('maxConcurrency', Command.String('--max-concurrency'))
 UploadCommand.addOption('dryRun', Command.Boolean('--dry-run'))
 UploadCommand.addOption('repositoryURL', Command.String('--repository-url'))
-UploadCommand.addOption('enableGit', Command.Boolean('--enable-git-experimental'))
+UploadCommand.addOption('disableGit', Command.Boolean('--disable-git'))


### PR DESCRIPTION
### What and why?

This PR enables linktogit by default in the stable channel. It is already enabled in the alpha channel.

### How?

A brief description of implementation details of this PR.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)

