### PR TITLE
v0.13.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "Run datadog actions from the CI.",
   "main": "dist/index.js",
   "repository": "https://github.com/DataDog/datadog-ci",


### PR DESCRIPTION
### What and why?
Releases changes from #251 and #249  

I incremented the minor version because I added a new feature to the lambda instrument command while keeping backwards compatibility
