### PR TITLE
[ci-app] Update CircleCI Env Var Tests

### DIFF
--- a/src/helpers/__tests__/ci-env/circleci.json
+++ b/src/helpers/__tests__/ci-env/circleci.json
@@ -1,22 +1,24 @@
 [
   [
     {
-      "CIRCLECI": "circleCI",
       "CIRCLE_BRANCH": "origin/master",
       "CIRCLE_BUILD_NUM": "circleci-pipeline-number",
       "CIRCLE_BUILD_URL": "circleci-build-url",
+      "CIRCLE_JOB": "circleci-job-name",
       "CIRCLE_PROJECT_REPONAME": "circleci-pipeline-name",
       "CIRCLE_REPOSITORY_URL": "sample",
       "CIRCLE_SHA1": "circleci-git-commit",
       "CIRCLE_WORKFLOW_ID": "circleci-pipeline-id",
-      "CIRCLE_WORKING_DIRECTORY": "/foo/bar"
+      "CIRCLE_WORKING_DIRECTORY": "/foo/bar",
+      "CIRCLECI": "circleCI"
     },
     {
+      "ci.job.id": "circleci-pipeline-number",
+      "ci.job.name": "circleci-job-name",
       "ci.job.url": "circleci-build-url",
       "ci.pipeline.id": "circleci-pipeline-id",
       "ci.pipeline.name": "circleci-pipeline-name",
-      "ci.pipeline.number": "circleci-pipeline-number",
-      "ci.pipeline.url": "circleci-build-url",
+      "ci.pipeline.url": "https://app.circle.com/pipelines/workflows/circleci-pipeline-id",
       "ci.provider.name": "circleci",
       "ci.workspace_path": "/foo/bar",
       "git.branch": "master",
@@ -26,22 +28,24 @@
   ],
   [
     {
-      "CIRCLECI": "circleCI",
       "CIRCLE_BRANCH": "origin/master",
       "CIRCLE_BUILD_NUM": "circleci-pipeline-number",
       "CIRCLE_BUILD_URL": "circleci-build-url",
+      "CIRCLE_JOB": "circleci-job-name",
       "CIRCLE_PROJECT_REPONAME": "circleci-pipeline-name",
       "CIRCLE_REPOSITORY_URL": "sample",
       "CIRCLE_SHA1": "circleci-git-commit",
       "CIRCLE_WORKFLOW_ID": "circleci-pipeline-id",
-      "CIRCLE_WORKING_DIRECTORY": "/foo/bar"
+      "CIRCLE_WORKING_DIRECTORY": "/foo/bar",
+      "CIRCLECI": "circleCI"
     },
     {
+      "ci.job.id": "circleci-pipeline-number",
+      "ci.job.name": "circleci-job-name",
       "ci.job.url": "circleci-build-url",
       "ci.pipeline.id": "circleci-pipeline-id",
       "ci.pipeline.name": "circleci-pipeline-name",
-      "ci.pipeline.number": "circleci-pipeline-number",
-      "ci.pipeline.url": "circleci-build-url",
+      "ci.pipeline.url": "https://app.circle.com/pipelines/workflows/circleci-pipeline-id",
       "ci.provider.name": "circleci",
       "ci.workspace_path": "/foo/bar",
       "git.branch": "master",
@@ -51,22 +55,24 @@
   ],
   [
     {
-      "CIRCLECI": "circleCI",
       "CIRCLE_BRANCH": "origin/master",
       "CIRCLE_BUILD_NUM": "circleci-pipeline-number",
       "CIRCLE_BUILD_URL": "circleci-build-url",
+      "CIRCLE_JOB": "circleci-job-name",
       "CIRCLE_PROJECT_REPONAME": "circleci-pipeline-name",
       "CIRCLE_REPOSITORY_URL": "sample",
       "CIRCLE_SHA1": "circleci-git-commit",
       "CIRCLE_WORKFLOW_ID": "circleci-pipeline-id",
-      "CIRCLE_WORKING_DIRECTORY": "/foo/bar"
+      "CIRCLE_WORKING_DIRECTORY": "/foo/bar",
+      "CIRCLECI": "circleCI"
     },
     {
+      "ci.job.id": "circleci-pipeline-number",
+      "ci.job.name": "circleci-job-name",
       "ci.job.url": "circleci-build-url",
       "ci.pipeline.id": "circleci-pipeline-id",
       "ci.pipeline.name": "circleci-pipeline-name",
-      "ci.pipeline.number": "circleci-pipeline-number",
-      "ci.pipeline.url": "circleci-build-url",
+      "ci.pipeline.url": "https://app.circle.com/pipelines/workflows/circleci-pipeline-id",
       "ci.provider.name": "circleci",
       "ci.workspace_path": "/foo/bar",
       "git.branch": "master",
@@ -76,22 +82,24 @@
   ],
   [
     {
-      "CIRCLECI": "circleCI",
       "CIRCLE_BRANCH": "origin/master",
       "CIRCLE_BUILD_NUM": "circleci-pipeline-number",
       "CIRCLE_BUILD_URL": "circleci-build-url",
+      "CIRCLE_JOB": "circleci-job-name",
       "CIRCLE_PROJECT_REPONAME": "circleci-pipeline-name",
       "CIRCLE_REPOSITORY_URL": "sample",
       "CIRCLE_SHA1": "circleci-git-commit",
       "CIRCLE_WORKFLOW_ID": "circleci-pipeline-id",
-      "CIRCLE_WORKING_DIRECTORY": "/foo/bar"
+      "CIRCLE_WORKING_DIRECTORY": "/foo/bar",
+      "CIRCLECI": "circleCI"
     },
     {
+      "ci.job.id": "circleci-pipeline-number",
+      "ci.job.name": "circleci-job-name",
       "ci.job.url": "circleci-build-url",
       "ci.pipeline.id": "circleci-pipeline-id",
       "ci.pipeline.name": "circleci-pipeline-name",
-      "ci.pipeline.number": "circleci-pipeline-number",
-      "ci.pipeline.url": "circleci-build-url",
+      "ci.pipeline.url": "https://app.circle.com/pipelines/workflows/circleci-pipeline-id",
       "ci.provider.name": "circleci",
       "ci.workspace_path": "/foo/bar",
       "git.branch": "master",
@@ -101,22 +109,24 @@
   ],
   [
     {
-      "CIRCLECI": "circleCI",
       "CIRCLE_BRANCH": "origin/master",
       "CIRCLE_BUILD_NUM": "circleci-pipeline-number",
       "CIRCLE_BUILD_URL": "circleci-build-url",
+      "CIRCLE_JOB": "circleci-job-name",
       "CIRCLE_PROJECT_REPONAME": "circleci-pipeline-name",
       "CIRCLE_REPOSITORY_URL": "sample",
       "CIRCLE_SHA1": "circleci-git-commit",
       "CIRCLE_WORKFLOW_ID": "circleci-pipeline-id",
-      "CIRCLE_WORKING_DIRECTORY": "foo/bar"
+      "CIRCLE_WORKING_DIRECTORY": "foo/bar",
+      "CIRCLECI": "circleCI"
     },
     {
+      "ci.job.id": "circleci-pipeline-number",
+      "ci.job.name": "circleci-job-name",
       "ci.job.url": "circleci-build-url",
       "ci.pipeline.id": "circleci-pipeline-id",
       "ci.pipeline.name": "circleci-pipeline-name",
-      "ci.pipeline.number": "circleci-pipeline-number",
-      "ci.pipeline.url": "circleci-build-url",
+      "ci.pipeline.url": "https://app.circle.com/pipelines/workflows/circleci-pipeline-id",
       "ci.provider.name": "circleci",
       "ci.workspace_path": "foo/bar",
       "git.branch": "master",
@@ -126,22 +136,24 @@
   ],
   [
     {
-      "CIRCLECI": "circleCI",
       "CIRCLE_BRANCH": "origin/master",
       "CIRCLE_BUILD_NUM": "circleci-pipeline-number",
       "CIRCLE_BUILD_URL": "circleci-build-url",
+      "CIRCLE_JOB": "circleci-job-name",
       "CIRCLE_PROJECT_REPONAME": "circleci-pipeline-name",
       "CIRCLE_REPOSITORY_URL": "sample",
       "CIRCLE_SHA1": "circleci-git-commit",
       "CIRCLE_WORKFLOW_ID": "circleci-pipeline-id",
-      "CIRCLE_WORKING_DIRECTORY": "/foo/bar~"
+      "CIRCLE_WORKING_DIRECTORY": "/foo/bar~",
+      "CIRCLECI": "circleCI"
     },
     {
+      "ci.job.id": "circleci-pipeline-number",
+      "ci.job.name": "circleci-job-name",
       "ci.job.url": "circleci-build-url",
       "ci.pipeline.id": "circleci-pipeline-id",
       "ci.pipeline.name": "circleci-pipeline-name",
-      "ci.pipeline.number": "circleci-pipeline-number",
-      "ci.pipeline.url": "circleci-build-url",
+      "ci.pipeline.url": "https://app.circle.com/pipelines/workflows/circleci-pipeline-id",
       "ci.provider.name": "circleci",
       "ci.workspace_path": "/foo/bar~",
       "git.branch": "master",
@@ -151,22 +163,24 @@
   ],
   [
     {
-      "CIRCLECI": "circleCI",
       "CIRCLE_BRANCH": "origin/master",
       "CIRCLE_BUILD_NUM": "circleci-pipeline-number",
       "CIRCLE_BUILD_URL": "circleci-build-url",
+      "CIRCLE_JOB": "circleci-job-name",
       "CIRCLE_PROJECT_REPONAME": "circleci-pipeline-name",
       "CIRCLE_REPOSITORY_URL": "sample",
       "CIRCLE_SHA1": "circleci-git-commit",
       "CIRCLE_WORKFLOW_ID": "circleci-pipeline-id",
-      "CIRCLE_WORKING_DIRECTORY": "/foo/~/bar"
+      "CIRCLE_WORKING_DIRECTORY": "/foo/~/bar",
+      "CIRCLECI": "circleCI"
     },
     {
+      "ci.job.id": "circleci-pipeline-number",
+      "ci.job.name": "circleci-job-name",
       "ci.job.url": "circleci-build-url",
       "ci.pipeline.id": "circleci-pipeline-id",
       "ci.pipeline.name": "circleci-pipeline-name",
-      "ci.pipeline.number": "circleci-pipeline-number",
-      "ci.pipeline.url": "circleci-build-url",
+      "ci.pipeline.url": "https://app.circle.com/pipelines/workflows/circleci-pipeline-id",
       "ci.provider.name": "circleci",
       "ci.workspace_path": "/foo/~/bar",
       "git.branch": "master",
@@ -176,24 +190,26 @@
   ],
   [
     {
-      "CIRCLECI": "circleCI",
       "CIRCLE_BRANCH": "origin/master",
       "CIRCLE_BUILD_NUM": "circleci-pipeline-number",
       "CIRCLE_BUILD_URL": "circleci-build-url",
+      "CIRCLE_JOB": "circleci-job-name",
       "CIRCLE_PROJECT_REPONAME": "circleci-pipeline-name",
       "CIRCLE_REPOSITORY_URL": "sample",
       "CIRCLE_SHA1": "circleci-git-commit",
       "CIRCLE_WORKFLOW_ID": "circleci-pipeline-id",
       "CIRCLE_WORKING_DIRECTORY": "~/foo/bar",
+      "CIRCLECI": "circleCI",
       "HOME": "/not-my-home",
       "USERPROFILE": "/not-my-home"
     },
     {
+      "ci.job.id": "circleci-pipeline-number",
+      "ci.job.name": "circleci-job-name",
       "ci.job.url": "circleci-build-url",
       "ci.pipeline.id": "circleci-pipeline-id",
       "ci.pipeline.name": "circleci-pipeline-name",
-      "ci.pipeline.number": "circleci-pipeline-number",
-      "ci.pipeline.url": "circleci-build-url",
+      "ci.pipeline.url": "https://app.circle.com/pipelines/workflows/circleci-pipeline-id",
       "ci.provider.name": "circleci",
       "ci.workspace_path": "/not-my-home/foo/bar",
       "git.branch": "master",
@@ -203,24 +219,26 @@
   ],
   [
     {
-      "CIRCLECI": "circleCI",
       "CIRCLE_BRANCH": "origin/master",
       "CIRCLE_BUILD_NUM": "circleci-pipeline-number",
       "CIRCLE_BUILD_URL": "circleci-build-url",
+      "CIRCLE_JOB": "circleci-job-name",
       "CIRCLE_PROJECT_REPONAME": "circleci-pipeline-name",
       "CIRCLE_REPOSITORY_URL": "sample",
       "CIRCLE_SHA1": "circleci-git-commit",
       "CIRCLE_WORKFLOW_ID": "circleci-pipeline-id",
       "CIRCLE_WORKING_DIRECTORY": "~foo/bar",
+      "CIRCLECI": "circleCI",
       "HOME": "/not-my-home",
       "USERPROFILE": "/not-my-home"
     },
     {
+      "ci.job.id": "circleci-pipeline-number",
+      "ci.job.name": "circleci-job-name",
       "ci.job.url": "circleci-build-url",
       "ci.pipeline.id": "circleci-pipeline-id",
       "ci.pipeline.name": "circleci-pipeline-name",
-      "ci.pipeline.number": "circleci-pipeline-number",
-      "ci.pipeline.url": "circleci-build-url",
+      "ci.pipeline.url": "https://app.circle.com/pipelines/workflows/circleci-pipeline-id",
       "ci.provider.name": "circleci",
       "ci.workspace_path": "~foo/bar",
       "git.branch": "master",
@@ -230,24 +248,26 @@
   ],
   [
     {
-      "CIRCLECI": "circleCI",
       "CIRCLE_BRANCH": "origin/master",
       "CIRCLE_BUILD_NUM": "circleci-pipeline-number",
       "CIRCLE_BUILD_URL": "circleci-build-url",
+      "CIRCLE_JOB": "circleci-job-name",
       "CIRCLE_PROJECT_REPONAME": "circleci-pipeline-name",
       "CIRCLE_REPOSITORY_URL": "sample",
       "CIRCLE_SHA1": "circleci-git-commit",
       "CIRCLE_WORKFLOW_ID": "circleci-pipeline-id",
       "CIRCLE_WORKING_DIRECTORY": "~",
+      "CIRCLECI": "circleCI",
       "HOME": "/not-my-home",
       "USERPROFILE": "/not-my-home"
     },
     {
+      "ci.job.id": "circleci-pipeline-number",
+      "ci.job.name": "circleci-job-name",
       "ci.job.url": "circleci-build-url",
       "ci.pipeline.id": "circleci-pipeline-id",
       "ci.pipeline.name": "circleci-pipeline-name",
-      "ci.pipeline.number": "circleci-pipeline-number",
-      "ci.pipeline.url": "circleci-build-url",
+      "ci.pipeline.url": "https://app.circle.com/pipelines/workflows/circleci-pipeline-id",
       "ci.provider.name": "circleci",
       "ci.workspace_path": "/not-my-home",
       "git.branch": "master",
@@ -257,22 +277,24 @@
   ],
   [
     {
-      "CIRCLECI": "circleCI",
       "CIRCLE_BRANCH": "refs/heads/master",
       "CIRCLE_BUILD_NUM": "circleci-pipeline-number",
       "CIRCLE_BUILD_URL": "circleci-build-url",
+      "CIRCLE_JOB": "circleci-job-name",
       "CIRCLE_PROJECT_REPONAME": "circleci-pipeline-name",
       "CIRCLE_REPOSITORY_URL": "sample",
       "CIRCLE_SHA1": "circleci-git-commit",
       "CIRCLE_WORKFLOW_ID": "circleci-pipeline-id",
-      "CIRCLE_WORKING_DIRECTORY": "/foo/bar"
+      "CIRCLE_WORKING_DIRECTORY": "/foo/bar",
+      "CIRCLECI": "circleCI"
     },
     {
+      "ci.job.id": "circleci-pipeline-number",
+      "ci.job.name": "circleci-job-name",
       "ci.job.url": "circleci-build-url",
       "ci.pipeline.id": "circleci-pipeline-id",
       "ci.pipeline.name": "circleci-pipeline-name",
-      "ci.pipeline.number": "circleci-pipeline-number",
-      "ci.pipeline.url": "circleci-build-url",
+      "ci.pipeline.url": "https://app.circle.com/pipelines/workflows/circleci-pipeline-id",
       "ci.provider.name": "circleci",
       "ci.workspace_path": "/foo/bar",
       "git.branch": "master",
@@ -282,22 +304,24 @@
   ],
   [
     {
-      "CIRCLECI": "circleCI",
       "CIRCLE_BRANCH": "refs/heads/feature/one",
       "CIRCLE_BUILD_NUM": "circleci-pipeline-number",
       "CIRCLE_BUILD_URL": "circleci-build-url",
+      "CIRCLE_JOB": "circleci-job-name",
       "CIRCLE_PROJECT_REPONAME": "circleci-pipeline-name",
       "CIRCLE_REPOSITORY_URL": "sample",
       "CIRCLE_SHA1": "circleci-git-commit",
       "CIRCLE_WORKFLOW_ID": "circleci-pipeline-id",
-      "CIRCLE_WORKING_DIRECTORY": "/foo/bar"
+      "CIRCLE_WORKING_DIRECTORY": "/foo/bar",
+      "CIRCLECI": "circleCI"
     },
     {
+      "ci.job.id": "circleci-pipeline-number",
+      "ci.job.name": "circleci-job-name",
       "ci.job.url": "circleci-build-url",
       "ci.pipeline.id": "circleci-pipeline-id",
       "ci.pipeline.name": "circleci-pipeline-name",
-      "ci.pipeline.number": "circleci-pipeline-number",
-      "ci.pipeline.url": "circleci-build-url",
+      "ci.pipeline.url": "https://app.circle.com/pipelines/workflows/circleci-pipeline-id",
       "ci.provider.name": "circleci",
       "ci.workspace_path": "/foo/bar",
       "git.branch": "feature/one",
@@ -307,23 +331,25 @@
   ],
   [
     {
-      "CIRCLECI": "circleCI",
       "CIRCLE_BRANCH": "origin/tags/0.1.0",
       "CIRCLE_BUILD_NUM": "circleci-pipeline-number",
       "CIRCLE_BUILD_URL": "circleci-build-url",
+      "CIRCLE_JOB": "circleci-job-name",
       "CIRCLE_PROJECT_REPONAME": "circleci-pipeline-name",
       "CIRCLE_REPOSITORY_URL": "sample",
       "CIRCLE_SHA1": "circleci-git-commit",
       "CIRCLE_TAG": "origin/tags/0.1.0",
       "CIRCLE_WORKFLOW_ID": "circleci-pipeline-id",
-      "CIRCLE_WORKING_DIRECTORY": "/foo/bar"
+      "CIRCLE_WORKING_DIRECTORY": "/foo/bar",
+      "CIRCLECI": "circleCI"
     },
     {
+      "ci.job.id": "circleci-pipeline-number",
+      "ci.job.name": "circleci-job-name",
       "ci.job.url": "circleci-build-url",
       "ci.pipeline.id": "circleci-pipeline-id",
       "ci.pipeline.name": "circleci-pipeline-name",
-      "ci.pipeline.number": "circleci-pipeline-number",
-      "ci.pipeline.url": "circleci-build-url",
+      "ci.pipeline.url": "https://app.circle.com/pipelines/workflows/circleci-pipeline-id",
       "ci.provider.name": "circleci",
       "ci.workspace_path": "/foo/bar",
       "git.commit.sha": "circleci-git-commit",
@@ -333,23 +359,25 @@
   ],
   [
     {
-      "CIRCLECI": "circleCI",
       "CIRCLE_BRANCH": "refs/heads/tags/0.1.0",
       "CIRCLE_BUILD_NUM": "circleci-pipeline-number",
       "CIRCLE_BUILD_URL": "circleci-build-url",
+      "CIRCLE_JOB": "circleci-job-name",
       "CIRCLE_PROJECT_REPONAME": "circleci-pipeline-name",
       "CIRCLE_REPOSITORY_URL": "sample",
       "CIRCLE_SHA1": "circleci-git-commit",
       "CIRCLE_TAG": "refs/heads/tags/0.1.0",
       "CIRCLE_WORKFLOW_ID": "circleci-pipeline-id",
-      "CIRCLE_WORKING_DIRECTORY": "/foo/bar"
+      "CIRCLE_WORKING_DIRECTORY": "/foo/bar",
+      "CIRCLECI": "circleCI"
     },
     {
+      "ci.job.id": "circleci-pipeline-number",
+      "ci.job.name": "circleci-job-name",
       "ci.job.url": "circleci-build-url",
       "ci.pipeline.id": "circleci-pipeline-id",
       "ci.pipeline.name": "circleci-pipeline-name",
-      "ci.pipeline.number": "circleci-pipeline-number",
-      "ci.pipeline.url": "circleci-build-url",
+      "ci.pipeline.url": "https://app.circle.com/pipelines/workflows/circleci-pipeline-id",
       "ci.provider.name": "circleci",
       "ci.workspace_path": "/foo/bar",
       "git.commit.sha": "circleci-git-commit",
@@ -359,22 +387,24 @@
   ],
   [
     {
-      "CIRCLECI": "circleCI",
       "CIRCLE_BRANCH": "origin/master",
       "CIRCLE_BUILD_NUM": "circleci-pipeline-number",
       "CIRCLE_BUILD_URL": "circleci-build-url",
+      "CIRCLE_JOB": "circleci-job-name",
       "CIRCLE_PROJECT_REPONAME": "circleci-pipeline-name",
       "CIRCLE_REPOSITORY_URL": "sample",
       "CIRCLE_SHA1": "circleci-git-commit",
       "CIRCLE_WORKFLOW_ID": "circleci-pipeline-id",
-      "CIRCLE_WORKING_DIRECTORY": "/foo/bar"
+      "CIRCLE_WORKING_DIRECTORY": "/foo/bar",
+      "CIRCLECI": "circleCI"
     },
     {
+      "ci.job.id": "circleci-pipeline-number",
+      "ci.job.name": "circleci-job-name",
       "ci.job.url": "circleci-build-url",
       "ci.pipeline.id": "circleci-pipeline-id",
       "ci.pipeline.name": "circleci-pipeline-name",
-      "ci.pipeline.number": "circleci-pipeline-number",
-      "ci.pipeline.url": "circleci-build-url",
+      "ci.pipeline.url": "https://app.circle.com/pipelines/workflows/circleci-pipeline-id",
       "ci.provider.name": "circleci",
       "ci.workspace_path": "/foo/bar",
       "git.branch": "master",
@@ -384,22 +414,24 @@
   ],
   [
     {
-      "CIRCLECI": "circleCI",
       "CIRCLE_BRANCH": "origin/master",
       "CIRCLE_BUILD_NUM": "circleci-pipeline-number",
       "CIRCLE_BUILD_URL": "circleci-build-url",
+      "CIRCLE_JOB": "circleci-job-name",
       "CIRCLE_PROJECT_REPONAME": "circleci-pipeline-name",
       "CIRCLE_REPOSITORY_URL": "sample",
       "CIRCLE_SHA1": "circleci-git-commit",
       "CIRCLE_WORKFLOW_ID": "circleci-pipeline-id",
-      "CIRCLE_WORKING_DIRECTORY": "/foo/bar"
+      "CIRCLE_WORKING_DIRECTORY": "/foo/bar",
+      "CIRCLECI": "circleCI"
     },
     {
+      "ci.job.id": "circleci-pipeline-number",
+      "ci.job.name": "circleci-job-name",
       "ci.job.url": "circleci-build-url",
       "ci.pipeline.id": "circleci-pipeline-id",
       "ci.pipeline.name": "circleci-pipeline-name",
-      "ci.pipeline.number": "circleci-pipeline-number",
-      "ci.pipeline.url": "circleci-build-url",
+      "ci.pipeline.url": "https://app.circle.com/pipelines/workflows/circleci-pipeline-id",
       "ci.provider.name": "circleci",
       "ci.workspace_path": "/foo/bar",
       "git.branch": "master",
@@ -409,22 +441,24 @@
   ],
   [
     {
-      "CIRCLECI": "circleCI",
       "CIRCLE_BRANCH": "origin/master",
       "CIRCLE_BUILD_NUM": "circleci-pipeline-number",
       "CIRCLE_BUILD_URL": "circleci-build-url",
+      "CIRCLE_JOB": "circleci-job-name",
       "CIRCLE_PROJECT_REPONAME": "circleci-pipeline-name",
       "CIRCLE_REPOSITORY_URL": "http://hostname.com/repo.git",
       "CIRCLE_SHA1": "circleci-git-commit",
       "CIRCLE_WORKFLOW_ID": "circleci-pipeline-id",
-      "CIRCLE_WORKING_DIRECTORY": "/foo/bar"
+      "CIRCLE_WORKING_DIRECTORY": "/foo/bar",
+      "CIRCLECI": "circleCI"
     },
     {
+      "ci.job.id": "circleci-pipeline-number",
+      "ci.job.name": "circleci-job-name",
       "ci.job.url": "circleci-build-url",
       "ci.pipeline.id": "circleci-pipeline-id",
       "ci.pipeline.name": "circleci-pipeline-name",
-      "ci.pipeline.number": "circleci-pipeline-number",
-      "ci.pipeline.url": "circleci-build-url",
+      "ci.pipeline.url": "https://app.circle.com/pipelines/workflows/circleci-pipeline-id",
       "ci.provider.name": "circleci",
       "ci.workspace_path": "/foo/bar",
       "git.branch": "master",
@@ -434,22 +468,24 @@
   ],
   [
     {
-      "CIRCLECI": "circleCI",
       "CIRCLE_BRANCH": "origin/master",
       "CIRCLE_BUILD_NUM": "circleci-pipeline-number",
       "CIRCLE_BUILD_URL": "circleci-build-url",
+      "CIRCLE_JOB": "circleci-job-name",
       "CIRCLE_PROJECT_REPONAME": "circleci-pipeline-name",
       "CIRCLE_REPOSITORY_URL": "http://user@hostname.com/repo.git",
       "CIRCLE_SHA1": "circleci-git-commit",
       "CIRCLE_WORKFLOW_ID": "circleci-pipeline-id",
-      "CIRCLE_WORKING_DIRECTORY": "/foo/bar"
+      "CIRCLE_WORKING_DIRECTORY": "/foo/bar",
+      "CIRCLECI": "circleCI"
     },
     {
+      "ci.job.id": "circleci-pipeline-number",
+      "ci.job.name": "circleci-job-name",
       "ci.job.url": "circleci-build-url",
       "ci.pipeline.id": "circleci-pipeline-id",
       "ci.pipeline.name": "circleci-pipeline-name",
-      "ci.pipeline.number": "circleci-pipeline-number",
-      "ci.pipeline.url": "circleci-build-url",
+      "ci.pipeline.url": "https://app.circle.com/pipelines/workflows/circleci-pipeline-id",
       "ci.provider.name": "circleci",
       "ci.workspace_path": "/foo/bar",
       "git.branch": "master",
@@ -459,22 +495,24 @@
   ],
   [
     {
-      "CIRCLECI": "circleCI",
       "CIRCLE_BRANCH": "origin/master",
       "CIRCLE_BUILD_NUM": "circleci-pipeline-number",
       "CIRCLE_BUILD_URL": "circleci-build-url",
+      "CIRCLE_JOB": "circleci-job-name",
       "CIRCLE_PROJECT_REPONAME": "circleci-pipeline-name",
       "CIRCLE_REPOSITORY_URL": "http://user%E2%82%AC@hostname.com/repo.git",
       "CIRCLE_SHA1": "circleci-git-commit",
       "CIRCLE_WORKFLOW_ID": "circleci-pipeline-id",
-      "CIRCLE_WORKING_DIRECTORY": "/foo/bar"
+      "CIRCLE_WORKING_DIRECTORY": "/foo/bar",
+      "CIRCLECI": "circleCI"
     },
     {
+      "ci.job.id": "circleci-pipeline-number",
+      "ci.job.name": "circleci-job-name",
       "ci.job.url": "circleci-build-url",
       "ci.pipeline.id": "circleci-pipeline-id",
       "ci.pipeline.name": "circleci-pipeline-name",
-      "ci.pipeline.number": "circleci-pipeline-number",
-      "ci.pipeline.url": "circleci-build-url",
+      "ci.pipeline.url": "https://app.circle.com/pipelines/workflows/circleci-pipeline-id",
       "ci.provider.name": "circleci",
       "ci.workspace_path": "/foo/bar",
       "git.branch": "master",
@@ -484,22 +522,24 @@
   ],
   [
     {
-      "CIRCLECI": "circleCI",
       "CIRCLE_BRANCH": "origin/master",
       "CIRCLE_BUILD_NUM": "circleci-pipeline-number",
       "CIRCLE_BUILD_URL": "circleci-build-url",
+      "CIRCLE_JOB": "circleci-job-name",
       "CIRCLE_PROJECT_REPONAME": "circleci-pipeline-name",
       "CIRCLE_REPOSITORY_URL": "http://user:pwd@hostname.com/repo.git",
       "CIRCLE_SHA1": "circleci-git-commit",
       "CIRCLE_WORKFLOW_ID": "circleci-pipeline-id",
-      "CIRCLE_WORKING_DIRECTORY": "/foo/bar"
+      "CIRCLE_WORKING_DIRECTORY": "/foo/bar",
+      "CIRCLECI": "circleCI"
     },
     {
+      "ci.job.id": "circleci-pipeline-number",
+      "ci.job.name": "circleci-job-name",
       "ci.job.url": "circleci-build-url",
       "ci.pipeline.id": "circleci-pipeline-id",
       "ci.pipeline.name": "circleci-pipeline-name",
-      "ci.pipeline.number": "circleci-pipeline-number",
-      "ci.pipeline.url": "circleci-build-url",
+      "ci.pipeline.url": "https://app.circle.com/pipelines/workflows/circleci-pipeline-id",
       "ci.provider.name": "circleci",
       "ci.workspace_path": "/foo/bar",
       "git.branch": "master",
@@ -509,22 +549,24 @@
   ],
   [
     {
-      "CIRCLECI": "circleCI",
       "CIRCLE_BRANCH": "origin/master",
       "CIRCLE_BUILD_NUM": "circleci-pipeline-number",
       "CIRCLE_BUILD_URL": "circleci-build-url",
+      "CIRCLE_JOB": "circleci-job-name",
       "CIRCLE_PROJECT_REPONAME": "circleci-pipeline-name",
       "CIRCLE_REPOSITORY_URL": "git@hostname.com:org/repo.git",
       "CIRCLE_SHA1": "circleci-git-commit",
       "CIRCLE_WORKFLOW_ID": "circleci-pipeline-id",
-      "CIRCLE_WORKING_DIRECTORY": "/foo/bar"
+      "CIRCLE_WORKING_DIRECTORY": "/foo/bar",
+      "CIRCLECI": "circleCI"
     },
     {
+      "ci.job.id": "circleci-pipeline-number",
+      "ci.job.name": "circleci-job-name",
       "ci.job.url": "circleci-build-url",
       "ci.pipeline.id": "circleci-pipeline-id",
       "ci.pipeline.name": "circleci-pipeline-name",
-      "ci.pipeline.number": "circleci-pipeline-number",
-      "ci.pipeline.url": "circleci-build-url",
+      "ci.pipeline.url": "https://app.circle.com/pipelines/workflows/circleci-pipeline-id",
       "ci.provider.name": "circleci",
       "ci.workspace_path": "/foo/bar",
       "git.branch": "master",

--- a/src/helpers/ci.ts
+++ b/src/helpers/ci.ts
@@ -2,6 +2,7 @@ import {URL} from 'url'
 
 import {Metadata, SpanTag, SpanTags} from './interfaces'
 import {
+  CI_JOB_ID,
   CI_JOB_NAME,
   CI_JOB_URL,
   CI_PIPELINE_ID,
@@ -93,13 +94,18 @@ export const getCISpanTags = (): SpanTags | undefined => {
       CIRCLE_TAG,
       CIRCLE_SHA1,
       CIRCLE_REPOSITORY_URL,
+      CIRCLE_JOB,
     } = env
+
+    const pipelineUrl = `https://app.circle.com/pipelines/workflows/${CIRCLE_WORKFLOW_ID}`
+
     tags = {
       [CI_JOB_URL]: CIRCLE_BUILD_URL,
       [CI_PIPELINE_ID]: CIRCLE_WORKFLOW_ID,
       [CI_PIPELINE_NAME]: CIRCLE_PROJECT_REPONAME,
-      [CI_PIPELINE_NUMBER]: CIRCLE_BUILD_NUM,
-      [CI_PIPELINE_URL]: CIRCLE_BUILD_URL,
+      [CI_PIPELINE_URL]: pipelineUrl,
+      [CI_JOB_NAME]: CIRCLE_JOB,
+      [CI_JOB_ID]: CIRCLE_BUILD_NUM,
       [CI_PROVIDER_NAME]: CI_ENGINES.CIRCLECI,
       [CI_WORKSPACE_PATH]: CIRCLE_WORKING_DIRECTORY,
       [GIT_SHA]: CIRCLE_SHA1,

--- a/src/helpers/interfaces.ts
+++ b/src/helpers/interfaces.ts
@@ -1,4 +1,5 @@
 import {
+  CI_JOB_ID,
   CI_JOB_NAME,
   CI_JOB_URL,
   CI_PIPELINE_ID,
@@ -30,6 +31,7 @@ export interface Metadata {
 }
 
 export type SpanTag =
+  | typeof CI_JOB_ID
   | typeof CI_JOB_NAME
   | typeof CI_JOB_URL
   | typeof CI_PIPELINE_ID

--- a/src/helpers/tags.ts
+++ b/src/helpers/tags.ts
@@ -8,6 +8,7 @@ export const CI_WORKSPACE_PATH = 'ci.workspace_path'
 export const GIT_REPOSITORY_URL = 'git.repository_url'
 export const CI_JOB_URL = 'ci.job.url'
 export const CI_JOB_NAME = 'ci.job.name'
+export const CI_JOB_ID = 'ci.job.id'
 export const CI_STAGE_NAME = 'ci.stage.name'
 export const CI_LEVEL = '_dd.ci.level'
 // @deprecated TODO: remove this once backend is updated


### PR DESCRIPTION
### What and why?

Update circle ci env vars extraction spec to have unique pipeline urls instead of repeating them in each job within a pipeline. 

### How?

* Update `ci.pipeline.url`
* Add `ci.job.name`
* Add `ci.job.id`
* Remove `ci.pipeline.number`


### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)

