### PR TITLE
[alpha][Synthetics] Tunnel: increase SSH stream `highWaterMark`

### DIFF
--- a/src/commands/synthetics/tunnel.ts
+++ b/src/commands/synthetics/tunnel.ts
@@ -48,6 +48,9 @@ export class Tunnel {
       algorithms: {
         serverHostKey: [parsedHostPrivateKey.type],
       },
+      // Greatly increase highWaterMark (32kb -> 255kb) to avoid hanging with large requests
+      // SW-1182, https://github.com/mscdex/ssh2/issues/908
+      highWaterMark: 255 * 1024,
       hostKeys: {
         // Typings are wrong for host keys
         [parsedHostPrivateKey.type]: parsedHostPrivateKey as any,


### PR DESCRIPTION
### What and why?

The default value of `highWaterMark` used for tunneled  SSH stream buffers causes large network requests (> 2MB) to hang, increasing the stream buffer capacity prevent tunneled tests from failing due to never loading resources.

Relevant end-to-end tunnel tests will be present in datadog-ci tunneled Synthetics tests for the worker.

### How?

Increase the stream buffer size through  `highWaterMark` from the 32kb default to 255kb. 

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)

