### PR TITLE
[ci-app] Remove `ci.job.id` from CircleCI Env Var Extraction

### DIFF
--- a/src/helpers/__tests__/ci-env/circleci.json
+++ b/src/helpers/__tests__/ci-env/circleci.json
@@ -13,7 +13,6 @@
       "CIRCLECI": "circleCI"
     },
     {
-      "ci.job.id": "circleci-pipeline-number",
       "ci.job.name": "circleci-job-name",
       "ci.job.url": "circleci-build-url",
       "ci.pipeline.id": "circleci-pipeline-id",
@@ -40,7 +39,6 @@
       "CIRCLECI": "circleCI"
     },
     {
-      "ci.job.id": "circleci-pipeline-number",
       "ci.job.name": "circleci-job-name",
       "ci.job.url": "circleci-build-url",
       "ci.pipeline.id": "circleci-pipeline-id",
@@ -67,7 +65,6 @@
       "CIRCLECI": "circleCI"
     },
     {
-      "ci.job.id": "circleci-pipeline-number",
       "ci.job.name": "circleci-job-name",
       "ci.job.url": "circleci-build-url",
       "ci.pipeline.id": "circleci-pipeline-id",
@@ -94,7 +91,6 @@
       "CIRCLECI": "circleCI"
     },
     {
-      "ci.job.id": "circleci-pipeline-number",
       "ci.job.name": "circleci-job-name",
       "ci.job.url": "circleci-build-url",
       "ci.pipeline.id": "circleci-pipeline-id",
@@ -121,7 +117,6 @@
       "CIRCLECI": "circleCI"
     },
     {
-      "ci.job.id": "circleci-pipeline-number",
       "ci.job.name": "circleci-job-name",
       "ci.job.url": "circleci-build-url",
       "ci.pipeline.id": "circleci-pipeline-id",
@@ -148,7 +143,6 @@
       "CIRCLECI": "circleCI"
     },
     {
-      "ci.job.id": "circleci-pipeline-number",
       "ci.job.name": "circleci-job-name",
       "ci.job.url": "circleci-build-url",
       "ci.pipeline.id": "circleci-pipeline-id",
@@ -175,7 +169,6 @@
       "CIRCLECI": "circleCI"
     },
     {
-      "ci.job.id": "circleci-pipeline-number",
       "ci.job.name": "circleci-job-name",
       "ci.job.url": "circleci-build-url",
       "ci.pipeline.id": "circleci-pipeline-id",
@@ -204,7 +197,6 @@
       "USERPROFILE": "/not-my-home"
     },
     {
-      "ci.job.id": "circleci-pipeline-number",
       "ci.job.name": "circleci-job-name",
       "ci.job.url": "circleci-build-url",
       "ci.pipeline.id": "circleci-pipeline-id",
@@ -233,7 +225,6 @@
       "USERPROFILE": "/not-my-home"
     },
     {
-      "ci.job.id": "circleci-pipeline-number",
       "ci.job.name": "circleci-job-name",
       "ci.job.url": "circleci-build-url",
       "ci.pipeline.id": "circleci-pipeline-id",
@@ -262,7 +253,6 @@
       "USERPROFILE": "/not-my-home"
     },
     {
-      "ci.job.id": "circleci-pipeline-number",
       "ci.job.name": "circleci-job-name",
       "ci.job.url": "circleci-build-url",
       "ci.pipeline.id": "circleci-pipeline-id",
@@ -289,7 +279,6 @@
       "CIRCLECI": "circleCI"
     },
     {
-      "ci.job.id": "circleci-pipeline-number",
       "ci.job.name": "circleci-job-name",
       "ci.job.url": "circleci-build-url",
       "ci.pipeline.id": "circleci-pipeline-id",
@@ -316,7 +305,6 @@
       "CIRCLECI": "circleCI"
     },
     {
-      "ci.job.id": "circleci-pipeline-number",
       "ci.job.name": "circleci-job-name",
       "ci.job.url": "circleci-build-url",
       "ci.pipeline.id": "circleci-pipeline-id",
@@ -344,7 +332,6 @@
       "CIRCLECI": "circleCI"
     },
     {
-      "ci.job.id": "circleci-pipeline-number",
       "ci.job.name": "circleci-job-name",
       "ci.job.url": "circleci-build-url",
       "ci.pipeline.id": "circleci-pipeline-id",
@@ -372,7 +359,6 @@
       "CIRCLECI": "circleCI"
     },
     {
-      "ci.job.id": "circleci-pipeline-number",
       "ci.job.name": "circleci-job-name",
       "ci.job.url": "circleci-build-url",
       "ci.pipeline.id": "circleci-pipeline-id",
@@ -399,7 +385,6 @@
       "CIRCLECI": "circleCI"
     },
     {
-      "ci.job.id": "circleci-pipeline-number",
       "ci.job.name": "circleci-job-name",
       "ci.job.url": "circleci-build-url",
       "ci.pipeline.id": "circleci-pipeline-id",
@@ -426,7 +411,6 @@
       "CIRCLECI": "circleCI"
     },
     {
-      "ci.job.id": "circleci-pipeline-number",
       "ci.job.name": "circleci-job-name",
       "ci.job.url": "circleci-build-url",
       "ci.pipeline.id": "circleci-pipeline-id",
@@ -453,7 +437,6 @@
       "CIRCLECI": "circleCI"
     },
     {
-      "ci.job.id": "circleci-pipeline-number",
       "ci.job.name": "circleci-job-name",
       "ci.job.url": "circleci-build-url",
       "ci.pipeline.id": "circleci-pipeline-id",
@@ -480,7 +463,6 @@
       "CIRCLECI": "circleCI"
     },
     {
-      "ci.job.id": "circleci-pipeline-number",
       "ci.job.name": "circleci-job-name",
       "ci.job.url": "circleci-build-url",
       "ci.pipeline.id": "circleci-pipeline-id",
@@ -507,7 +489,6 @@
       "CIRCLECI": "circleCI"
     },
     {
-      "ci.job.id": "circleci-pipeline-number",
       "ci.job.name": "circleci-job-name",
       "ci.job.url": "circleci-build-url",
       "ci.pipeline.id": "circleci-pipeline-id",
@@ -534,7 +515,6 @@
       "CIRCLECI": "circleCI"
     },
     {
-      "ci.job.id": "circleci-pipeline-number",
       "ci.job.name": "circleci-job-name",
       "ci.job.url": "circleci-build-url",
       "ci.pipeline.id": "circleci-pipeline-id",
@@ -561,7 +541,6 @@
       "CIRCLECI": "circleCI"
     },
     {
-      "ci.job.id": "circleci-pipeline-number",
       "ci.job.name": "circleci-job-name",
       "ci.job.url": "circleci-build-url",
       "ci.pipeline.id": "circleci-pipeline-id",

--- a/src/helpers/ci.ts
+++ b/src/helpers/ci.ts
@@ -2,7 +2,6 @@ import {URL} from 'url'
 
 import {Metadata, SpanTag, SpanTags} from './interfaces'
 import {
-  CI_JOB_ID,
   CI_JOB_NAME,
   CI_JOB_URL,
   CI_PIPELINE_ID,
@@ -87,7 +86,6 @@ export const getCISpanTags = (): SpanTags | undefined => {
     const {
       CIRCLE_WORKFLOW_ID,
       CIRCLE_PROJECT_REPONAME,
-      CIRCLE_BUILD_NUM,
       CIRCLE_BUILD_URL,
       CIRCLE_WORKING_DIRECTORY,
       CIRCLE_BRANCH,
@@ -105,7 +103,6 @@ export const getCISpanTags = (): SpanTags | undefined => {
       [CI_PIPELINE_NAME]: CIRCLE_PROJECT_REPONAME,
       [CI_PIPELINE_URL]: pipelineUrl,
       [CI_JOB_NAME]: CIRCLE_JOB,
-      [CI_JOB_ID]: CIRCLE_BUILD_NUM,
       [CI_PROVIDER_NAME]: CI_ENGINES.CIRCLECI,
       [CI_WORKSPACE_PATH]: CIRCLE_WORKING_DIRECTORY,
       [GIT_SHA]: CIRCLE_SHA1,

--- a/src/helpers/interfaces.ts
+++ b/src/helpers/interfaces.ts
@@ -1,5 +1,4 @@
 import {
-  CI_JOB_ID,
   CI_JOB_NAME,
   CI_JOB_URL,
   CI_PIPELINE_ID,
@@ -31,7 +30,6 @@ export interface Metadata {
 }
 
 export type SpanTag =
-  | typeof CI_JOB_ID
   | typeof CI_JOB_NAME
   | typeof CI_JOB_URL
   | typeof CI_PIPELINE_ID

--- a/src/helpers/tags.ts
+++ b/src/helpers/tags.ts
@@ -8,7 +8,6 @@ export const CI_WORKSPACE_PATH = 'ci.workspace_path'
 export const GIT_REPOSITORY_URL = 'git.repository_url'
 export const CI_JOB_URL = 'ci.job.url'
 export const CI_JOB_NAME = 'ci.job.name'
-export const CI_JOB_ID = 'ci.job.id'
 export const CI_STAGE_NAME = 'ci.stage.name'
 export const CI_LEVEL = '_dd.ci.level'
 // @deprecated TODO: remove this once backend is updated


### PR DESCRIPTION
### What and why?

In https://github.com/DataDog/datadog-ci/pull/253 I added ci.job.id, but we didn't want it: it is only available in CircleCI and we are not using it anywhere, so it makes no sense to keep it.

### How?

* Remove `ci.job.id`

