### PR TITLE
[Synthetics] Tunnel: Reject SSH forwarding on socket error

### DIFF
--- a/src/commands/synthetics/tunnel.ts
+++ b/src/commands/synthetics/tunnel.ts
@@ -169,11 +169,20 @@ export class Tunnel {
           })
         })
         dest.on('error', (error) => {
-          console.error('Forwarding error', error.message)
+          if (!src) {
+            if ((error as any).code === 'ENOTFOUND') {
+              this.logError(`Unable to resolve host ${(error as any).hostname}`)
+            } else {
+              this.logError(`Forwarding channel error: "${error.message}"`)
+            }
+            reject()
+          }
         })
         dest.on('close', () => {
           if (src) {
             src.close()
+          } else {
+            reject()
           }
         })
         dest.connect(info.destPort, info.destIP)

--- a/src/commands/synthetics/tunnel.ts
+++ b/src/commands/synthetics/tunnel.ts
@@ -168,9 +168,9 @@ export class Tunnel {
             dest.destroy()
           })
         })
-        dest.on('error', (error) => {
+        dest.on('error', (error: NodeJS.ErrnoException) => {
           if (!src) {
-            if ((error as any).code === 'ENOTFOUND') {
+            if ('code' in error && error.code === 'ENOTFOUND') {
               this.logError(`Unable to resolve host ${(error as any).hostname}`)
             } else {
               this.logError(`Forwarding channel error: "${error.message}"`)


### PR DESCRIPTION
### What and why?

This PR denies traffic forwarding to the socket when an error occurs and it hasn't been accepted yet, this prevents hanging on DNS errors due to unresolvable hosts.

### How?

Reject forwarding on `error` or `close` when it hasn't been initiated yet and log a custom error message on unresolvable host error.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)

