### PR TITLE
v0.13.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci",
-  "version": "0.13.1",
+  "version": "0.13.2",
   "description": "Run datadog actions from the CI.",
   "main": "dist/index.js",
   "repository": "https://github.com/DataDog/datadog-ci",


### PR DESCRIPTION
### What and why?

Release version 0.13.2 with:
- #262 : [ci-app] Fix ci.pipeline.url in CircleCI Env Var Extraction
- #260 : [ci-app] Remove ci.job.id from CircleCI Env Var Extraction
- #259 : bump `ws`
- #256 : bump `browserslist`

