### PR TITLE
[Synthetics] Tunnel: Increase yamux backlog size

### DIFF
--- a/src/commands/synthetics/tunnel.ts
+++ b/src/commands/synthetics/tunnel.ts
@@ -205,6 +205,9 @@ export class Tunnel {
 
     // Set up multiplexing
     const multiplexerConfig: MultiplexerConfig = {
+      // Increase maximum backlog size to more easily handle
+      // running multiple large browser tests in parallel.
+      acceptBacklog: 2048,
       enableKeepAlive: false,
     }
     this.multiplexer = new Multiplexer((stream) => {


### PR DESCRIPTION
### What and why?

Running a dozen tunneled browser tests can easily exceed the default backlog size of 256 streams, resetting connections.
This PR increase the maximum size of the backlog.

### How?

Increase yamux backlog size from default of `256` to `2048`.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)

