### PR TITLE
[Synthetics] Tunnel: Reduce `Proxy opened` log verbosity

### DIFF
--- a/src/commands/synthetics/tunnel.ts
+++ b/src/commands/synthetics/tunnel.ts
@@ -23,11 +23,11 @@ export interface TunnelInfo {
 }
 
 export class Tunnel {
+  private connected = false
   private forwardSockets: Socket[] = []
   private log: (message: string) => void
   private logError: (message: string) => void
   private multiplexer?: Multiplexer
-  private openedTunnels: Set<string> = new Set()
   private privateKey: string
   private publicKey: ParsedKey
   private sshStreamConfig: SSH2StreamConfig
@@ -140,10 +140,10 @@ export class Tunnel {
     }
 
     // Username is allowed and key authentication was successful
-    if (!this.openedTunnels.has(ctx.username)) {
-      // Limit to one log per test
-      this.openedTunnels.add(ctx.username)
-      this.log(`Proxy opened for test ${ctx.username}`)
+    if (!this.connected) {
+      // Limit to one log per tunnel
+      this.connected = true
+      this.log(`Successfully connected for test ${ctx.username}`)
     }
     ctx.accept()
   }

--- a/src/commands/synthetics/tunnel.ts
+++ b/src/commands/synthetics/tunnel.ts
@@ -27,6 +27,7 @@ export class Tunnel {
   private log: (message: string) => void
   private logError: (message: string) => void
   private multiplexer?: Multiplexer
+  private openedTunnels: Set<string> = new Set()
   private privateKey: string
   private publicKey: ParsedKey
   private sshStreamConfig: SSH2StreamConfig
@@ -139,7 +140,11 @@ export class Tunnel {
     }
 
     // Username is allowed and key authentication was successful
-    this.log(`Proxy opened for test ${user}`)
+    if (!this.openedTunnels.has(ctx.username)) {
+      // Limit to one log per test
+      this.openedTunnels.add(ctx.username)
+      this.log(`Proxy opened for test ${ctx.username}`)
+    }
     ctx.accept()
   }
 


### PR DESCRIPTION
### What and why?

Only display `[Tunnel] Proxy opened for test ...` log once per test instead on every proxy connection to reduce output spam for browser tests.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)

