### PR TITLE
[command-synthetics] add defaultConfig and resolveConfig

### DIFF
--- a/src/commands/synthetics/__tests__/run-test.test.ts
+++ b/src/commands/synthetics/__tests__/run-test.test.ts
@@ -1,10 +1,9 @@
 // tslint:disable: no-string-literal
-
 import * as ciUtils from '../../../helpers/utils'
 
 import {ExecutionRule} from '../interfaces'
 import {DefaultReporter} from '../reporters/default'
-import {DEFAULT_COMMAND_CONFIG, RunTestCommand} from '../run-test'
+import {DEFAULT_COMMAND_CONFIG, removeUndefinedValues, RunTestCommand} from '../run-test'
 import * as utils from '../utils'
 import {mockReporter} from './fixtures'
 
@@ -374,5 +373,10 @@ describe('run-test', () => {
         datadogSite: 'datadog.config.file',
       })
     })
+  })
+
+  test('removeUndefinedValues', () => {
+    // tslint:disable-next-line: no-null-keyword
+    expect(removeUndefinedValues({a: 'b', c: 'd', e: undefined, g: null})).toEqual({a: 'b', c: 'd', g: null})
   })
 })

--- a/src/commands/synthetics/__tests__/run-test.test.ts
+++ b/src/commands/synthetics/__tests__/run-test.test.ts
@@ -1,11 +1,10 @@
 // tslint:disable: no-string-literal
-jest.mock('fs')
 
 import * as ciUtils from '../../../helpers/utils'
 
 import {ExecutionRule} from '../interfaces'
 import {DefaultReporter} from '../reporters/default'
-import {RunTestCommand} from '../run-test'
+import {DEFAULT_COMMAND_CONFIG, RunTestCommand} from '../run-test'
 import * as utils from '../utils'
 import {mockReporter} from './fixtures'
 
@@ -27,9 +26,17 @@ export const assertAsyncThrow = async (func: any, errorRegex?: RegExp) => {
 }
 
 describe('run-test', () => {
+  beforeEach(() => {
+    jest.resetAllMocks()
+    jest.spyOn(ciUtils, 'getConfig').mockImplementation(async () => ({}))
+    process.env = {}
+  })
+
   describe('execute', () => {
+    beforeEach(() => {
+      jest.resetAllMocks()
+    })
     test('should apply config override for tests triggered by public id', async () => {
-      jest.spyOn(ciUtils, 'parseConfigFile').mockImplementation(async (config, _) => config)
       const getTestsToTriggersMock = jest.spyOn(utils, 'getTestsToTrigger').mockReturnValue(
         Promise.resolve({
           overriddenTestsToTrigger: [],
@@ -40,15 +47,17 @@ describe('run-test', () => {
       jest.spyOn(utils, 'runTests').mockImplementation()
 
       const startUrl = '{{PROTOCOL}}//myhost{{PATHNAME}}{{PARAMS}}'
-      const locations = ['location1', 'location2']
+      const locations = ['location1', 'location22']
       const configOverride = {locations, startUrl}
 
       const apiHelper = {}
       const command = new RunTestCommand()
       command.context = {stdout: {write: jest.fn()}} as any
       command['getApiHelper'] = (() => apiHelper) as any
-      command['config'].global = configOverride
-      command['publicIds'] = ['public-id-1', 'public-id-2']
+      // Override with config file
+      jest
+        .spyOn(ciUtils, 'getConfig')
+        .mockImplementation(async () => ({global: configOverride, publicIds: ['public-id-1', 'public-id-2']}))
       await command.execute()
 
       expect(getTestsToTriggersMock).toHaveBeenCalledWith(
@@ -62,7 +71,6 @@ describe('run-test', () => {
     })
 
     test('should not wait for `skipped` only tests batch results', async () => {
-      jest.spyOn(ciUtils, 'parseConfigFile').mockImplementation(async (config, _) => config)
       const getTestsToTriggersMock = jest.spyOn(utils, 'getTestsToTrigger').mockReturnValue(
         Promise.resolve({
           overriddenTestsToTrigger: [],
@@ -81,9 +89,9 @@ describe('run-test', () => {
       const configOverride = {executionRule: ExecutionRule.SKIPPED}
       command.context = {stdout: {write}} as any
       command['getApiHelper'] = (() => apiHelper) as any
-      command['config'].global = configOverride
-      command['publicIds'] = ['public-id-1', 'public-id-2']
-
+      jest
+        .spyOn(ciUtils, 'getConfig')
+        .mockImplementation(async () => ({global: configOverride, publicIds: ['public-id-1', 'public-id-2']}))
       await command.execute()
 
       expect(getTestsToTriggersMock).toHaveBeenCalledWith(
@@ -111,6 +119,7 @@ describe('run-test', () => {
     test('subdomain should be overridable', async () => {
       process.env = {DATADOG_SUBDOMAIN: 'custom'}
       const command = new RunTestCommand()
+      await command['resolveConfig']()
 
       expect(command['getAppBaseURL']()).toBe('https://custom.datadoghq.com/')
     })
@@ -121,6 +130,7 @@ describe('run-test', () => {
         DATADOG_SUBDOMAIN: 'custom',
       }
       const command = new RunTestCommand()
+      await command['resolveConfig']()
 
       expect(command['getAppBaseURL']()).toBe('https://custom.datadoghq.eu/')
     })
@@ -130,6 +140,7 @@ describe('run-test', () => {
     test('should default to datadog us api', async () => {
       process.env = {}
       const command = new RunTestCommand()
+      await command['resolveConfig']()
 
       expect(command['getDatadogHost']()).toBe('https://api.datadoghq.com/api/v1')
       expect(command['getDatadogHost'](true)).toBe('https://intake.synthetics.datadoghq.com/api/v1')
@@ -138,6 +149,7 @@ describe('run-test', () => {
     test('should be tunable through DATADOG_SITE variable', async () => {
       process.env = {DATADOG_SITE: 'datadoghq.eu'}
       const command = new RunTestCommand()
+      await command['resolveConfig']()
 
       expect(command['getDatadogHost']()).toBe('https://api.datadoghq.eu/api/v1')
       expect(command['getDatadogHost'](true)).toBe('https://api.datadoghq.eu/api/v1')
@@ -151,13 +163,14 @@ describe('run-test', () => {
       const command = new RunTestCommand()
       command.context = {stdout: {write}} as any
       command['reporter'] = utils.getReporter([new DefaultReporter(command)])
+      await command['resolveConfig']()
 
       await assertAsyncThrow(command['getApiHelper'].bind(command), /API and\/or Application keys are missing/)
       expect(write.mock.calls[0][0]).toContain('DATADOG_APP_KEY')
       expect(write.mock.calls[1][0]).toContain('DATADOG_API_KEY')
 
       command['appKey'] = 'fakeappkey'
-
+      await command['resolveConfig']()
       write.mockClear()
       await assertAsyncThrow(command['getApiHelper'].bind(command), /API and\/or Application keys are missing/)
       expect(write.mock.calls[0][0]).toContain('DATADOG_API_KEY')
@@ -207,6 +220,7 @@ describe('run-test', () => {
       command['config'].global = {startUrl}
       command['testSearchQuery'] = 'fake search'
 
+      await command['resolveConfig']()
       expect(await command['getTestsList'].bind(command)(fakeApi)).toEqual([
         {
           config: {startUrl},
@@ -216,25 +230,19 @@ describe('run-test', () => {
     })
 
     test('should use given globs to get tests list', async () => {
-      const mockFn = jest.spyOn(utils, 'getSuites').mockImplementation((() => [conf1, conf2]) as any)
+      jest.spyOn(utils, 'getSuites').mockImplementation((() => [conf1, conf2]) as any)
       const command = new RunTestCommand()
       command.context = process
       command['config'].global = {startUrl}
-      command['config'].files = 'random glob'
+      command['config'].fileGlobs = ['random glob']
       command['reporter'] = mockReporter
-
       command['fileGlobs'] = ['new glob', 'another one']
+
+      await command['resolveConfig']()
       await command['getTestsList'].bind(command)(fakeApi)
       expect(utils.getSuites).toHaveBeenCalledTimes(2)
       expect(utils.getSuites).toHaveBeenCalledWith('new glob', command['reporter'])
       expect(utils.getSuites).toHaveBeenCalledWith('another one', command['reporter'])
-
-      mockFn.mockClear()
-
-      command['fileGlobs'] = undefined
-      await command['getTestsList'].bind(command)(fakeApi)
-      expect(utils.getSuites).toHaveBeenCalledTimes(1)
-      expect(utils.getSuites).toHaveBeenCalledWith('random glob', command['reporter'])
     })
   })
 
@@ -258,6 +266,114 @@ describe('run-test', () => {
 
       tests.sort((command['sortTestsByOutcome'] as any)(results))
       expect(tests).toStrictEqual([test3, test1, test2, test5, test4])
+    })
+  })
+
+  describe('resolveConfig', () => {
+    beforeEach(() => {
+      jest.resetAllMocks()
+      process.env = {}
+      jest.spyOn(ciUtils, 'getConfig').mockImplementation(async () => ({}))
+    })
+
+    test('override from ENV', async () => {
+      const overrideEnv = {
+        DATADOG_API_KEY: 'fake_api_key',
+        DATADOG_APP_KEY: 'fake_app_key',
+        DATADOG_SITE: 'datadoghq.eu',
+        DATADOG_SUBDOMAIN: 'custom',
+      }
+
+      process.env = overrideEnv
+      const command = new RunTestCommand()
+
+      await command['resolveConfig']()
+      expect(command['config']).toEqual({
+        ...DEFAULT_COMMAND_CONFIG,
+        apiKey: overrideEnv.DATADOG_API_KEY,
+        appKey: overrideEnv.DATADOG_APP_KEY,
+        datadogSite: overrideEnv.DATADOG_SITE,
+        subdomain: overrideEnv.DATADOG_SUBDOMAIN,
+      })
+    })
+
+    test('override from config file', async () => {
+      const overrideConfigFile = {
+        apiKey: 'fake_api_key',
+        appKey: 'fake_app_key',
+        configPath: 'fake-datadog-ci.json',
+        datadogSite: 'datadoghq.eu',
+        fileGlobs: ['new-file'],
+        global: {locations: []},
+        pollingTimeout: 1,
+        proxy: {protocol: 'https'},
+        publicIds: ['ran-dom-id'],
+        subdomain: 'ppa',
+        tunnel: true,
+      }
+
+      jest.spyOn(ciUtils, 'getConfig').mockImplementation(async () => overrideConfigFile)
+      const command = new RunTestCommand()
+
+      await command['resolveConfig']()
+      expect(command['config']).toEqual(overrideConfigFile)
+    })
+
+    test('override from CLI', async () => {
+      const overrideCLI = {
+        apiKey: 'fake_api_key',
+        appKey: 'fake_app_key',
+        configPath: 'fake-datadog-ci.json',
+        fileGlobs: ['new-file'],
+        publicIds: ['ran-dom-id'],
+        shouldOpenTunnel: true,
+        testSearchQuery: 'a-search-query',
+      }
+
+      const command = new RunTestCommand()
+      command['apiKey'] = overrideCLI.apiKey
+      command['appKey'] = overrideCLI.appKey
+      command['configPath'] = overrideCLI.configPath
+      command['fileGlobs'] = overrideCLI.fileGlobs
+      command['publicIds'] = overrideCLI.publicIds
+      command['shouldOpenTunnel'] = overrideCLI.shouldOpenTunnel
+      command['testSearchQuery'] = overrideCLI.testSearchQuery
+
+      await command['resolveConfig']()
+      expect(command['config']).toEqual({
+        ...DEFAULT_COMMAND_CONFIG,
+        apiKey: 'fake_api_key',
+        appKey: 'fake_app_key',
+        configPath: 'fake-datadog-ci.json',
+        fileGlobs: ['new-file'],
+        publicIds: ['ran-dom-id'],
+        testSearchQuery: 'a-search-query',
+        tunnel: true,
+      })
+    })
+
+    test('override from ENV < config file < CLI', async () => {
+      process.env = {
+        DATADOG_API_KEY: 'api_key_env',
+        DATADOG_APP_KEY: 'app_key_env',
+        DATADOG_SITE: 'datadog.env',
+      }
+
+      jest.spyOn(ciUtils, 'getConfig').mockImplementation(async () => ({
+        apiKey: 'api_key_config_file',
+        appKey: 'app_key_config_file',
+      }))
+
+      const command = new RunTestCommand()
+      command['apiKey'] = 'api_key_cli'
+
+      await command['resolveConfig']()
+      expect(command['config']).toEqual({
+        ...DEFAULT_COMMAND_CONFIG,
+        apiKey: 'api_key_cli',
+        appKey: 'app_key_config_file',
+        datadogSite: 'datadog.env',
+      })
     })
   })
 })

--- a/src/commands/synthetics/__tests__/run-test.test.ts
+++ b/src/commands/synthetics/__tests__/run-test.test.ts
@@ -325,8 +325,8 @@ describe('run-test', () => {
         configPath: 'fake-datadog-ci.json',
         files: ['new-file'],
         publicIds: ['ran-dom-id'],
-        shouldOpenTunnel: true,
         testSearchQuery: 'a-search-query',
+        tunnel: true,
       }
 
       const command = new RunTestCommand()
@@ -335,7 +335,7 @@ describe('run-test', () => {
       command['configPath'] = overrideCLI.configPath
       command['files'] = overrideCLI.files
       command['publicIds'] = overrideCLI.publicIds
-      command['shouldOpenTunnel'] = overrideCLI.shouldOpenTunnel
+      command['tunnel'] = overrideCLI.tunnel
       command['testSearchQuery'] = overrideCLI.testSearchQuery
 
       await command['resolveConfig']()

--- a/src/commands/synthetics/__tests__/run-test.test.ts
+++ b/src/commands/synthetics/__tests__/run-test.test.ts
@@ -47,7 +47,7 @@ describe('run-test', () => {
       jest.spyOn(utils, 'runTests').mockImplementation()
 
       const startUrl = '{{PROTOCOL}}//myhost{{PATHNAME}}{{PARAMS}}'
-      const locations = ['location1', 'location22']
+      const locations = ['location1', 'location2']
       const configOverride = {locations, startUrl}
 
       const apiHelper = {}

--- a/src/commands/synthetics/__tests__/run-test.test.ts
+++ b/src/commands/synthetics/__tests__/run-test.test.ts
@@ -234,25 +234,14 @@ describe('run-test', () => {
       const command = new RunTestCommand()
       command.context = process
       command['config'].global = {startUrl}
-      command['config'].fileGlobs = ['random glob']
       command['reporter'] = mockReporter
-      command['fileGlobs'] = ['new glob', 'another one']
-      command['files'] = 'a last glob'
+      command['files'] = ['new glob', 'another one']
 
       await command['resolveConfig']()
-      // Should take fileGlobs over files
       await command['getTestsList'].bind(command)(fakeApi)
       expect(getSuitesMock).toHaveBeenCalledTimes(2)
       expect(getSuitesMock).toHaveBeenCalledWith('new glob', command['reporter'])
       expect(getSuitesMock).toHaveBeenCalledWith('another one', command['reporter'])
-
-      command['fileGlobs'] = []
-      await command['resolveConfig']()
-      // Should take files over empty fileGlobs
-      getSuitesMock.mockClear()
-      await command['getTestsList'].bind(command)(fakeApi)
-      expect(getSuitesMock).toHaveBeenCalledTimes(1)
-      expect(getSuitesMock).toHaveBeenCalledWith('a last glob', command['reporter'])
     })
   })
 
@@ -313,8 +302,7 @@ describe('run-test', () => {
         appKey: 'fake_app_key',
         configPath: 'fake-datadog-ci.json',
         datadogSite: 'datadoghq.eu',
-        fileGlobs: ['new-file'],
-        files: 'my-new-file',
+        files: ['my-new-file'],
         global: {locations: []},
         pollingTimeout: 1,
         proxy: {protocol: 'https'},
@@ -335,7 +323,7 @@ describe('run-test', () => {
         apiKey: 'fake_api_key',
         appKey: 'fake_app_key',
         configPath: 'fake-datadog-ci.json',
-        fileGlobs: ['new-file'],
+        files: ['new-file'],
         publicIds: ['ran-dom-id'],
         shouldOpenTunnel: true,
         testSearchQuery: 'a-search-query',
@@ -345,7 +333,7 @@ describe('run-test', () => {
       command['apiKey'] = overrideCLI.apiKey
       command['appKey'] = overrideCLI.appKey
       command['configPath'] = overrideCLI.configPath
-      command['fileGlobs'] = overrideCLI.fileGlobs
+      command['files'] = overrideCLI.files
       command['publicIds'] = overrideCLI.publicIds
       command['shouldOpenTunnel'] = overrideCLI.shouldOpenTunnel
       command['testSearchQuery'] = overrideCLI.testSearchQuery
@@ -356,7 +344,7 @@ describe('run-test', () => {
         apiKey: 'fake_api_key',
         appKey: 'fake_app_key',
         configPath: 'fake-datadog-ci.json',
-        fileGlobs: ['new-file'],
+        files: ['new-file'],
         publicIds: ['ran-dom-id'],
         testSearchQuery: 'a-search-query',
         tunnel: true,

--- a/src/commands/synthetics/interfaces.ts
+++ b/src/commands/synthetics/interfaces.ts
@@ -274,6 +274,7 @@ export interface CommandConfig {
   configPath: string
   datadogSite: string
   fileGlobs: string[]
+  files: string
   global: ConfigOverride
   pollingTimeout: number
   proxy: ProxyConfiguration

--- a/src/commands/synthetics/interfaces.ts
+++ b/src/commands/synthetics/interfaces.ts
@@ -273,8 +273,7 @@ export interface CommandConfig {
   appKey: string
   configPath: string
   datadogSite: string
-  fileGlobs: string[]
-  files: string
+  files: string[]
   global: ConfigOverride
   pollingTimeout: number
   proxy: ProxyConfiguration

--- a/src/commands/synthetics/interfaces.ts
+++ b/src/commands/synthetics/interfaces.ts
@@ -267,3 +267,18 @@ export interface APIConfiguration {
   baseUrl: string
   proxyOpts: ProxyConfiguration
 }
+
+export interface CommandConfig {
+  apiKey: string
+  appKey: string
+  configPath: string
+  datadogSite: string
+  fileGlobs: string[]
+  global: ConfigOverride
+  pollingTimeout: number
+  proxy: ProxyConfiguration
+  publicIds: string[]
+  subdomain: string
+  testSearchQuery?: string
+  tunnel: boolean
+}

--- a/src/commands/synthetics/run-test.ts
+++ b/src/commands/synthetics/run-test.ts
@@ -14,8 +14,7 @@ export const DEFAULT_COMMAND_CONFIG: CommandConfig = {
   appKey: '',
   configPath: 'datadog-ci.json',
   datadogSite: 'datadoghq.com',
-  fileGlobs: [],
-  files: '{,!(node_modules)/**/}*.synthetics.json',
+  files: ['{,!(node_modules)/**/}*.synthetics.json'],
   global: {},
   pollingTimeout: 2 * 60 * 1000,
   proxy: {protocol: 'http'},
@@ -29,8 +28,7 @@ export class RunTestCommand extends Command {
   private appKey?: string
   private config: CommandConfig = JSON.parse(JSON.stringify(DEFAULT_COMMAND_CONFIG)) // Deep copy to avoid mutation during unit tests
   private configPath?: string
-  private fileGlobs?: string[]
-  private files?: string
+  private files?: string[]
   private publicIds?: string[]
   private reporter?: MainReporter
   private shouldOpenTunnel?: boolean
@@ -187,8 +185,7 @@ export class RunTestCommand extends Command {
       return testSearchResults.tests.map((test) => ({config: this.config.global, id: test.public_id}))
     }
 
-    const listOfGlobs = this.config.fileGlobs.length ? this.config.fileGlobs : [this.config.files]
-    const suites = (await Promise.all(listOfGlobs.map((glob: string) => getSuites(glob, this.reporter!))))
+    const suites = (await Promise.all(this.config.files.map((glob: string) => getSuites(glob, this.reporter!))))
       .reduce((acc, val) => acc.concat(val), [])
       .map((suite) => suite.tests)
       .filter((suiteTests) => !!suiteTests)
@@ -228,7 +225,6 @@ export class RunTestCommand extends Command {
         apiKey: this.apiKey,
         appKey: this.appKey,
         configPath: this.configPath,
-        fileGlobs: this.fileGlobs,
         files: this.files,
         publicIds: this.publicIds,
         testSearchQuery: this.testSearchQuery,
@@ -268,7 +264,7 @@ RunTestCommand.addPath('synthetics', 'run-tests')
 RunTestCommand.addOption('apiKey', Command.String('--apiKey'))
 RunTestCommand.addOption('appKey', Command.String('--appKey'))
 RunTestCommand.addOption('configPath', Command.String('--config'))
-RunTestCommand.addOption('fileGlobs', Command.Array('-f,--files'))
+RunTestCommand.addOption('files', Command.Array('-f,--files'))
 RunTestCommand.addOption('publicIds', Command.Array('-p,--public-id'))
 RunTestCommand.addOption('shouldOpenTunnel', Command.Boolean('-t,--tunnel'))
 RunTestCommand.addOption('testSearchQuery', Command.String('-s,--search'))

--- a/src/commands/synthetics/run-test.ts
+++ b/src/commands/synthetics/run-test.ts
@@ -231,6 +231,11 @@ export class RunTestCommand extends Command {
         tunnel: this.tunnel,
       })
     )
+
+    if (typeof this.config.files === 'string') {
+      this.reporter!.log('[DEPRECATED] "files" should not be a string, array of string expected. The conversion will be automatic')
+      this.config.files = [this.config.files]
+    }
   }
 
   private sortTestsByOutcome(results: {[key: string]: PollResult[]}) {

--- a/src/commands/synthetics/run-test.ts
+++ b/src/commands/synthetics/run-test.ts
@@ -12,7 +12,7 @@ import {getReporter, getSuites, getTestsToTrigger, hasTestSucceeded, runTests, w
 export const DEFAULT_COMMAND_CONFIG: CommandConfig = {
   apiKey: '',
   appKey: '',
-  configPath: '',
+  configPath: 'datadog-ci.json',
   datadogSite: 'datadoghq.com',
   files: ['{,!(node_modules)/**/}*.synthetics.json'],
   global: {},
@@ -205,9 +205,9 @@ export class RunTestCommand extends Command {
 
     // Override with file config variables
     try {
-      this.config = await parseConfigFile(this.config, this.config.configPath)
+      this.config = await parseConfigFile(this.config, this.configPath ?? this.config.configPath)
     } catch (error) {
-      if (this.config.configPath) {
+      if (this.configPath) {
         throw error
       }
     }

--- a/src/commands/synthetics/run-test.ts
+++ b/src/commands/synthetics/run-test.ts
@@ -41,7 +41,7 @@ export class RunTestCommand extends Command {
     const startTime = Date.now()
 
     const api = this.getApiHelper()
-    const publicIdsFromCli = this.publicIds.map((id) => ({config: this.config.global, id}))
+    const publicIdsFromCli = this.config.publicIds.map((id) => ({config: this.config.global, id}))
     const testsToTrigger = publicIdsFromCli.length ? publicIdsFromCli : await this.getTestsList(api)
 
     if (!testsToTrigger.length) {
@@ -54,7 +54,7 @@ export class RunTestCommand extends Command {
     const publicIdsToTrigger = tests.map(({public_id}) => public_id)
 
     let tunnel: Tunnel | undefined
-    if ((this.shouldOpenTunnel === undefined && this.config.tunnel) || this.shouldOpenTunnel) {
+    if (this.config.tunnel) {
       this.reporter.log(
         'You are using tunnel option, the chosen location(s) will be overridden by a location in your account region.\n'
       )
@@ -138,9 +138,6 @@ export class RunTestCommand extends Command {
   }
 
   private getApiHelper() {
-    this.config.apiKey = this.apiKey || this.config.apiKey
-    this.config.appKey = this.appKey || this.config.appKey
-
     if (!this.config.appKey || !this.config.apiKey) {
       if (!this.config.appKey) {
         this.reporter!.error(`Missing ${chalk.red.bold('DATADOG_APP_KEY')} in your environment.\n`)
@@ -182,8 +179,8 @@ export class RunTestCommand extends Command {
   }
 
   private async getTestsList(api: APIHelper) {
-    if (this.testSearchQuery) {
-      const testSearchResults = await api.searchTests(this.testSearchQuery)
+    if (this.config.testSearchQuery) {
+      const testSearchResults = await api.searchTests(this.config.testSearchQuery)
 
       return testSearchResults.tests.map((test) => ({config: this.config.global, id: test.public_id}))
     }
@@ -196,7 +193,7 @@ export class RunTestCommand extends Command {
     const testsToTrigger = suites
       .reduce((acc, suiteTests) => acc.concat(suiteTests), [])
       .map((test) => ({
-        config: {...this.config!.global, ...test.config},
+        config: {...this.config.global, ...test.config},
         id: test.id,
       }))
 
@@ -261,6 +258,7 @@ export class RunTestCommand extends Command {
 const removeUndefinedValues = <T extends {[key: string]: any}>(object: T): T => {
   const newObject = {...object}
   Object.keys(newObject).forEach((k) => newObject[k] === undefined && delete newObject[k])
+
   return newObject
 }
 

--- a/src/commands/synthetics/run-test.ts
+++ b/src/commands/synthetics/run-test.ts
@@ -209,7 +209,7 @@ export class RunTestCommand extends Command {
       this.config = await parseConfigFile(this.config, configPath)
     } catch (error) {
       if (configPath) {
-        this.reporter!.log(error.message)
+        this.reporter!.log(`${error.message}\n)
       }
     }
 

--- a/src/commands/synthetics/run-test.ts
+++ b/src/commands/synthetics/run-test.ts
@@ -233,7 +233,9 @@ export class RunTestCommand extends Command {
     )
 
     if (typeof this.config.files === 'string') {
-      this.reporter!.log('[DEPRECATED] "files" should be an array of string instead of a string. The conversion will be automatic')
+      this.reporter!.log(
+        '[DEPRECATED] "files" should be an array of string instead of a string. The conversion will be automatic'
+      )
       this.config.files = [this.config.files]
     }
   }
@@ -258,7 +260,7 @@ export class RunTestCommand extends Command {
   }
 }
 
-const removeUndefinedValues = <T extends {[key: string]: any}>(object: T): T => {
+export const removeUndefinedValues = <T extends {[key: string]: any}>(object: T): T => {
   const newObject = {...object}
   Object.keys(newObject).forEach((k) => newObject[k] === undefined && delete newObject[k])
 

--- a/src/commands/synthetics/run-test.ts
+++ b/src/commands/synthetics/run-test.ts
@@ -31,8 +31,8 @@ export class RunTestCommand extends Command {
   private files?: string[]
   private publicIds?: string[]
   private reporter?: MainReporter
-  private shouldOpenTunnel?: boolean
   private testSearchQuery?: string
+  private tunnel?: boolean
 
   public async execute() {
     await this.resolveConfig()
@@ -228,7 +228,7 @@ export class RunTestCommand extends Command {
         files: this.files,
         publicIds: this.publicIds,
         testSearchQuery: this.testSearchQuery,
-        tunnel: this.shouldOpenTunnel,
+        tunnel: this.tunnel,
       })
     )
   }
@@ -266,5 +266,5 @@ RunTestCommand.addOption('appKey', Command.String('--appKey'))
 RunTestCommand.addOption('configPath', Command.String('--config'))
 RunTestCommand.addOption('files', Command.Array('-f,--files'))
 RunTestCommand.addOption('publicIds', Command.Array('-p,--public-id'))
-RunTestCommand.addOption('shouldOpenTunnel', Command.Boolean('-t,--tunnel'))
 RunTestCommand.addOption('testSearchQuery', Command.String('-s,--search'))
+RunTestCommand.addOption('tunnel', Command.Boolean('-t,--tunnel'))

--- a/src/commands/synthetics/run-test.ts
+++ b/src/commands/synthetics/run-test.ts
@@ -205,7 +205,11 @@ export class RunTestCommand extends Command {
 
     // Override with file config variables
     const configPath = this.configPath ?? this.config.configPath
-    this.config = await parseConfigFile(this.config, configPath)
+    try {
+      this.config = await parseConfigFile(this.config, configPath)
+    } catch (error) {
+      this.reporter!.log(error.message)
+    }
 
     // Override with ENV variables
     this.config = deepExtend(
@@ -233,9 +237,7 @@ export class RunTestCommand extends Command {
     )
 
     if (typeof this.config.files === 'string') {
-      this.reporter!.log(
-        '[DEPRECATED] "files" should be an array of string instead of a string. The conversion will be automatic'
-      )
+      this.reporter!.log('[DEPRECATED] "files" should be an array of string instead of a string.\n')
       this.config.files = [this.config.files]
     }
   }

--- a/src/commands/synthetics/run-test.ts
+++ b/src/commands/synthetics/run-test.ts
@@ -12,7 +12,7 @@ import {getReporter, getSuites, getTestsToTrigger, hasTestSucceeded, runTests, w
 export const DEFAULT_COMMAND_CONFIG: CommandConfig = {
   apiKey: '',
   appKey: '',
-  configPath: 'datadog-ci.json',
+  configPath: '',
   datadogSite: 'datadoghq.com',
   files: ['{,!(node_modules)/**/}*.synthetics.json'],
   global: {},
@@ -204,12 +204,11 @@ export class RunTestCommand extends Command {
     // Default < file < ENV < CLI
 
     // Override with file config variables
-    const configPath = this.configPath ?? this.config.configPath
     try {
-      this.config = await parseConfigFile(this.config, configPath)
+      this.config = await parseConfigFile(this.config, this.config.configPath)
     } catch (error) {
-      if (configPath) {
-        this.reporter!.log(`${error.message}\n)
+      if (this.config.configPath) {
+        throw error
       }
     }
 

--- a/src/commands/synthetics/run-test.ts
+++ b/src/commands/synthetics/run-test.ts
@@ -208,7 +208,9 @@ export class RunTestCommand extends Command {
     try {
       this.config = await parseConfigFile(this.config, configPath)
     } catch (error) {
-      this.reporter!.log(error.message)
+      if (configPath) {
+        this.reporter!.log(error.message)
+      }
     }
 
     // Override with ENV variables

--- a/src/commands/synthetics/run-test.ts
+++ b/src/commands/synthetics/run-test.ts
@@ -233,7 +233,7 @@ export class RunTestCommand extends Command {
     )
 
     if (typeof this.config.files === 'string') {
-      this.reporter!.log('[DEPRECATED] "files" should not be a string, array of string expected. The conversion will be automatic')
+      this.reporter!.log('[DEPRECATED] "files" should be an array of string instead of a string. The conversion will be automatic')
       this.config.files = [this.config.files]
     }
   }

--- a/src/commands/synthetics/run-test.ts
+++ b/src/commands/synthetics/run-test.ts
@@ -35,9 +35,9 @@ export class RunTestCommand extends Command {
   private tunnel?: boolean
 
   public async execute() {
-    await this.resolveConfig()
     const reporters = [new DefaultReporter(this)]
     this.reporter = getReporter(reporters)
+    await this.resolveConfig()
     const startTime = Date.now()
 
     const api = this.getApiHelper()

--- a/src/helpers/__tests__/utils.test.ts
+++ b/src/helpers/__tests__/utils.test.ts
@@ -1,18 +1,8 @@
 jest.mock('fs')
-
-import * as fs from 'fs'
-
 import {AxiosPromise, AxiosRequestConfig, default as axios} from 'axios'
+import fs from 'fs'
 
-import {
-  buildPath,
-  getApiHostForSite,
-  getProxyUrl,
-  getRequestBuilder,
-  parseConfigFile,
-  pick,
-  ProxyConfiguration,
-} from '../utils'
+import * as ciUtils from '../utils'
 
 jest.useFakeTimers()
 
@@ -20,48 +10,43 @@ describe('utils', () => {
   test('Test pick', () => {
     const initialHash = {a: 1, b: 2}
 
-    let resultHash = pick(initialHash, ['a'])
+    let resultHash = ciUtils.pick(initialHash, ['a'])
     expect(Object.keys(resultHash).indexOf('b')).toBe(-1)
     expect(resultHash.a).toBe(1)
 
-    resultHash = pick(initialHash, ['c'] as any)
+    resultHash = ciUtils.pick(initialHash, ['c'] as any)
     expect(Object.keys(resultHash).length).toBe(0)
   })
 
   describe('parseConfigFile', () => {
-    afterEach(() => {
-      ;(fs.readFile as any).mockRestore()
+    beforeEach(() => {
+      jest.restoreAllMocks()
     })
-
     test('should read a config file', async () => {
-      ;(fs.readFile as any).mockImplementation((_path: string, _opts: any, callback: any) =>
-        callback(undefined, '{"newconfigkey":"newconfigvalue"}')
-      )
+      jest.spyOn(ciUtils, 'getConfig').mockImplementation(async () => ({newconfigkey: 'newconfigvalue'}))
 
-      const config: any = await parseConfigFile({})
+      const config: any = await ciUtils.parseConfigFile({})
       expect(config.newconfigkey).toBe('newconfigvalue')
     })
 
     test('should throw an error if path is provided and config file is not found', async () => {
-      ;(fs.readFile as any).mockImplementation((a: any, b: any, callback: any) => callback({code: 'ENOENT'}))
-      const config = parseConfigFile({}, '/veryuniqueandabsentfile')
+      jest.spyOn(fs, 'readFile' as any).mockImplementation((a, b, cb: any) => cb({code: 'ENOENT'}))
+      const config = ciUtils.parseConfigFile({}, '/veryuniqueandabsentfile')
 
       await expect(config).rejects.toEqual(Error('Config file not found'))
     })
 
     test('should throw an error if JSON parsing fails', async () => {
-      ;(fs.readFile as any).mockImplementation((p: string, o: any, cb: any) => cb(undefined, 'thisisnoJSON'))
+      jest.spyOn(fs, 'readFile' as any).mockImplementation((a, b, cb: any) => cb(undefined, 'thisisnoJSON'))
 
-      await expect(parseConfigFile({})).rejects.toEqual(Error('Config file is not correct JSON'))
+      await expect(ciUtils.parseConfigFile({})).rejects.toEqual(Error('Config file is not correct JSON'))
     })
 
     test('config file should overwrite default configuration', async () => {
-      ;(fs.readFile as any).mockImplementation((_path: string, _opts: any, callback: any) =>
-        callback(undefined, '{"configKey":"newconfigvalue"}')
-      )
+      jest.spyOn(ciUtils, 'getConfig').mockImplementation(async () => ({configKey: 'newconfigvalue'}))
 
-      const config = await parseConfigFile({configKey: 'configvalue'})
-      await expect(config.configKey).toBe('newconfigvalue')
+      const config = await ciUtils.parseConfigFile({configKey: 'configvalue'})
+      expect(config.configKey).toBe('newconfigvalue')
     })
   })
 
@@ -74,7 +59,7 @@ describe('utils', () => {
         apiKey: 'apiKey',
         baseUrl: 'http://fake-base.url/',
       }
-      const request = getRequestBuilder(requestOptions)
+      const request = ciUtils.getRequestBuilder(requestOptions)
       const fakeEndpoint = fakeEndpointBuilder(request)
       expect(await fakeEndpoint()).toStrictEqual({'DD-API-KEY': 'apiKey'})
     })
@@ -86,21 +71,21 @@ describe('utils', () => {
         appKey: 'applicationKey',
         baseUrl: 'http://fake-base.url/',
       }
-      const request = getRequestBuilder(requestOptions)
+      const request = ciUtils.getRequestBuilder(requestOptions)
       const fakeEndpoint = fakeEndpointBuilder(request)
       expect(await fakeEndpoint()).toStrictEqual({'DD-API-KEY': 'apiKey', 'DD-APPLICATION-KEY': 'applicationKey'})
     })
 
     test('should add proxy configuration', async () => {
       jest.spyOn(axios, 'create').mockImplementation((() => (args: AxiosRequestConfig) => args.httpsAgent) as any)
-      const proxyOpts: ProxyConfiguration = {protocol: 'http', host: '1.2.3.4', port: 1234}
+      const proxyOpts: ciUtils.ProxyConfiguration = {protocol: 'http', host: '1.2.3.4', port: 1234}
       const requestOptions = {
         apiKey: 'apiKey',
         appKey: 'applicationKey',
         baseUrl: 'http://fake-base.url/',
         proxyOpts,
       }
-      const request = getRequestBuilder(requestOptions)
+      const request = ciUtils.getRequestBuilder(requestOptions)
       const fakeEndpoint = fakeEndpointBuilder(request)
       const httpsAgent = await fakeEndpoint()
       expect(httpsAgent).toBeDefined()
@@ -115,7 +100,7 @@ describe('utils', () => {
       ['datadoghq.eu', 'api.datadoghq.eu'],
       ['whitelabel.com', 'api.whitelabel.com'],
     ])('for site = %p, returns api host = %p ', (site, expectedApiHost) => {
-      expect(getApiHostForSite(site)).toEqual(expectedApiHost)
+      expect(ciUtils.getApiHostForSite(site)).toEqual(expectedApiHost)
     })
   })
 
@@ -125,22 +110,22 @@ describe('utils', () => {
       const pathWithTrailingSlash = 'sourcemaps/js/'
       const fileName = 'file1.min.js'
 
-      expect(buildPath(pathWithNoTrailingSlash, fileName)).toBe('sourcemaps/js/file1.min.js')
-      expect(buildPath(pathWithTrailingSlash, fileName)).toBe('sourcemaps/js/file1.min.js')
+      expect(ciUtils.buildPath(pathWithNoTrailingSlash, fileName)).toBe('sourcemaps/js/file1.min.js')
+      expect(ciUtils.buildPath(pathWithTrailingSlash, fileName)).toBe('sourcemaps/js/file1.min.js')
     })
   })
 
   describe('getProxyUrl', () => {
     test('should return correct proxy URI', () => {
-      expect(getProxyUrl({protocol: 'http'})).toBe('')
-      expect(getProxyUrl({host: '127.0.0.1', protocol: 'http'})).toBe('')
-      expect(getProxyUrl({host: '127.0.0.1', port: 1234, protocol: 'http'})).toBe('http://127.0.0.1:1234')
+      expect(ciUtils.getProxyUrl({protocol: 'http'})).toBe('')
+      expect(ciUtils.getProxyUrl({host: '127.0.0.1', protocol: 'http'})).toBe('')
+      expect(ciUtils.getProxyUrl({host: '127.0.0.1', port: 1234, protocol: 'http'})).toBe('http://127.0.0.1:1234')
 
       const auth = {password: 'pwd', username: 'john'}
-      expect(getProxyUrl({auth, host: '127.0.0.1', port: 1234, protocol: 'http'})).toBe(
+      expect(ciUtils.getProxyUrl({auth, host: '127.0.0.1', port: 1234, protocol: 'http'})).toBe(
         'http://john:pwd@127.0.0.1:1234'
       )
-      expect(getProxyUrl({auth, protocol: 'http'})).toBe('')
+      expect(ciUtils.getProxyUrl({auth, protocol: 'http'})).toBe('')
     })
   })
 })

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -16,13 +16,18 @@ export const pick = <T extends object, K extends keyof T>(base: T, keys: K[]) =>
   return pickedObject
 }
 
-export const parseConfigFile = async <T>(baseConfig: T, configPath?: string) => {
+export const getConfig = async (configPath: string) => {
+  const configFile = await promisify(fs.readFile)(configPath, 'utf-8')
+
+  return JSON.parse(configFile)
+}
+
+export const parseConfigFile = async <T>(baseConfig: T, configPath?: string): Promise<T> => {
   try {
     const resolvedConfigPath = configPath ?? 'datadog-ci.json'
-    const configFile = await promisify(fs.readFile)(resolvedConfigPath, 'utf-8')
-    const parsedConfig = JSON.parse(configFile)
+    const parsedConfig = await getConfig(resolvedConfigPath)
 
-    return deepExtend(baseConfig, parsedConfig) as T
+    return deepExtend(baseConfig, parsedConfig)
   } catch (e) {
     if (e.code === 'ENOENT' && configPath) {
       throw new Error('Config file not found')


### PR DESCRIPTION
### What and why?

- Add `defaultConfig` to resolve the config one time and only use one source of truth (`this.config`)  

### How?

-  add `defaultConfig` function

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)

