### PR TITLE
[ci-app] Compress JUnit XML Report Files

### DIFF
--- a/src/commands/junit/api.ts
+++ b/src/commands/junit/api.ts
@@ -3,6 +3,7 @@ import FormData from 'form-data'
 import fs from 'fs'
 import path from 'path'
 import {Writable} from 'stream'
+import {createGzip} from 'zlib'
 
 import {getRequestBuilder} from '../../helpers/utils'
 import {Payload} from './interfaces'
@@ -48,8 +49,8 @@ export const uploadJUnitXML = (request: (args: AxiosRequestConfig) => AxiosPromi
     uniqueFileName = `${uniqueFileName}-${spanTags[CI_JOB_URL]}`
   }
 
-  form.append('junit_xml_report_file', fs.createReadStream(jUnitXML.xmlPath), {
-    filename: `${getSafeFileName(uniqueFileName)}.xml`,
+  form.append('junit_xml_report_file', fs.createReadStream(jUnitXML.xmlPath).pipe(createGzip()), {
+    filename: `${getSafeFileName(uniqueFileName)}.xml.gz`,
   })
 
   return request({

--- a/src/commands/junit/api.ts
+++ b/src/commands/junit/api.ts
@@ -37,7 +37,7 @@ export const uploadJUnitXML = (request: (args: AxiosRequestConfig) => AxiosPromi
   const spanTags = {
     service: jUnitXML.service,
     ...jUnitXML.spanTags,
-    '_dd.cireport': {type: 'junitxml', version: 2},
+    '_dd.cireport_version': '2',
   }
   form.append('message', JSON.stringify(spanTags))
 

--- a/src/commands/junit/api.ts
+++ b/src/commands/junit/api.ts
@@ -37,6 +37,7 @@ export const uploadJUnitXML = (request: (args: AxiosRequestConfig) => AxiosPromi
   const spanTags = {
     service: jUnitXML.service,
     ...jUnitXML.spanTags,
+    '_dd.cireport': {type: 'junitxml', version: 2},
   }
   form.append('message', JSON.stringify(spanTags))
 


### PR DESCRIPTION
⚠️ **Do not merge**: Backend is not yet ready for this. 

### What and why?

* Compress `.xml` files before uploading them.

### How?

* Pipe file reading stream to `'zlib'`. 

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)

