### PR TITLE
[Synthetics] Tunnel: Fix socket error forwarding and buffer/backlog sizes

### DIFF
--- a/src/commands/synthetics/tunnel.ts
+++ b/src/commands/synthetics/tunnel.ts
@@ -198,6 +198,9 @@ export class Tunnel {
 
     // Set up multiplexing
     const multiplexerConfig: MultiplexerConfig = {
+      // Increase maximum backlog size to more easily handle
+      // running multiple large browser tests in parallel.
+      acceptBacklog: 2048,
       enableKeepAlive: false,
     }
     this.multiplexer = new Multiplexer((stream) => {

--- a/src/commands/synthetics/tunnel.ts
+++ b/src/commands/synthetics/tunnel.ts
@@ -171,11 +171,20 @@ export class Tunnel {
           })
         })
         dest.on('error', (error) => {
-          console.error('Forwarding error', error.message)
+          if (!src) {
+            if ((error as any).code === 'ENOTFOUND') {
+              this.logError(`Unable to resolve host ${(error as any).hostname}`)
+            } else {
+              this.logError(`Forwarding channel error: "${error.message}"`)
+            }
+            reject()
+          }
         })
         dest.on('close', () => {
           if (src) {
             src.close()
+          } else {
+            reject()
           }
         })
         dest.connect(info.destPort, info.destIP)

--- a/src/commands/synthetics/tunnel.ts
+++ b/src/commands/synthetics/tunnel.ts
@@ -170,9 +170,9 @@ export class Tunnel {
             dest.destroy()
           })
         })
-        dest.on('error', (error) => {
+        dest.on('error', (error: NodeJS.ErrnoException) => {
           if (!src) {
-            if ((error as any).code === 'ENOTFOUND') {
+            if ('code' in error && error.code === 'ENOTFOUND') {
               this.logError(`Unable to resolve host ${(error as any).hostname}`)
             } else {
               this.logError(`Forwarding channel error: "${error.message}"`)

--- a/src/commands/synthetics/tunnel.ts
+++ b/src/commands/synthetics/tunnel.ts
@@ -49,6 +49,9 @@ export class Tunnel {
       algorithms: {
         serverHostKey: [parsedHostPrivateKey.type],
       },
+      // Greatly increase highWaterMark (32kb -> 255kb) to avoid hanging with large requests
+      // SW-1182, https://github.com/mscdex/ssh2/issues/908
+      highWaterMark: 255 * 1024,
       hostKeys: {
         // Typings are wrong for host keys
         [parsedHostPrivateKey.type]: parsedHostPrivateKey as any,


### PR DESCRIPTION
Merge tunnel fixes from `alpha` branch:
- https://github.com/DataDog/datadog-ci/pull/257: Increase SSH stream `highWaterMark`
- https://github.com/DataDog/datadog-ci/pull/261: Reject SSH forwarding on socket error
- https://github.com/DataDog/datadog-ci/pull/268: Increase yamux backlog size 
