### PR TITLE
Remove mention of DATADOG_API_HOST

### DIFF
--- a/src/commands/sourcemaps/README.md
+++ b/src/commands/sourcemaps/README.md
@@ -13,7 +13,7 @@ You need to have `DATADOG_API_KEY` in your environment.
 export DATADOG_API_KEY="<API KEY>"
 ```
 
-It is possible to configure the tool to use Datadog EU by defining the `DATADOG_SITE` environment variable to `datadoghq.eu`. By defaut the requests are sent to Datadog US. In order to send the usage metrics to the correct datacenter, the `DATADOG_API_HOST` must also be set if another instance of Datadog is used. For example, for Datadog EU, it should be set to `api.datadoghq.eu`.
+It is possible to configure the tool to use Datadog EU by defining the `DATADOG_SITE` environment variable to `datadoghq.eu`. By defaut the requests are sent to Datadog US.
 
 It is also possible to override the full URL for the intake endpoint by defining the `DATADOG_SOURCEMAP_INTAKE_URL` environment variable.
 


### PR DESCRIPTION
### What and why?

The api host is inferred from `DATADOG_SITE`.
https://github.com/DataDog/datadog-ci/blob/master/src/commands/sourcemaps/metrics.ts#L11:L11
https://github.com/DataDog/datadog-ci/blob/master/src/commands/sourcemaps/utils.ts#L23:L23

Remove the mention from the unused `DATADOG_API_HOST` from the readme.

### How?

A brief description of implementation details of this PR.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)

