### PR TITLE
Add `--logLevel` option to `lambda instrument`

### DIFF
--- a/src/commands/lambda/README.md
+++ b/src/commands/lambda/README.md
@@ -17,8 +17,8 @@ export AWS_SECRET_ACCESS_KEY="<ACCESS KEY>"
 Download [Datadog CI][2].
 
 ### Configuration
-
-Configuration is done using a JSON file. Specify the `datadog-ci.json` using the `--config` argument, and this configuration file structure:
+#### Configuration file
+Configuration can be done using command-line arguments or a JSON configuration file. If you use a configuration file, specify the `datadog-ci.json` using the `--config` argument, and use this configuration file structure:
 
 ```json
 {
@@ -55,7 +55,9 @@ datadog-ci lambda instrument -f functionname -f another-functionname -r us-east-
 datadog-ci lambda instrument -f functionname -r us-east-1 -v 10 --dry
 ```
 
-#### All arguments:
+#### All arguments
+
+You can pass arguments to `instrument` to specify its behavior. These arguments will override the values set in the configuration file, if any.
 
 | Argument | Shorthand | Description | Default |
 | --- | --- | --- | --- |
@@ -72,7 +74,7 @@ datadog-ci lambda instrument -f functionname -r us-east-1 -v 10 --dry
 
 <br />
 
-#### Additional Environment Variables:
+#### Additional environment variables
 
 You may configure the `lambda instrument` command with environment variables:
 *You must expose these environment variables in the environment where you are running `datadog-ci lambda instrument`*

--- a/src/commands/lambda/README.md
+++ b/src/commands/lambda/README.md
@@ -6,7 +6,7 @@ You can use the CLI to instrument your AWS Lambda functions with Datadog. Only P
 
 ### Before you begin
 
-Make your AWS credentials `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` available in your environment using the following cmd, or use any of the authentication methods supported by the [AWS JS sdk][1].
+Make your AWS credentials `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` available in your environment using the following command, or use any of the authentication methods supported by the [AWS JS SDK][1].
 
 ```bash
 # Environment setup
@@ -14,7 +14,7 @@ export AWS_ACCESS_KEY_ID="<ACCESS KEY ID>"
 export AWS_SECRET_ACCESS_KEY="<ACCESS KEY>"
 ```
 
-Download the [Datadog CI][2].
+Download [Datadog CI][2].
 
 ### Configuration
 
@@ -24,18 +24,20 @@ Configuration is done using a JSON file. Specify the `datadog-ci.json` using the
 {
     "lambda": {
         "layerVersion": 10,
+        "extensionVersion": 8,
         "functions": ["arn:aws:lambda:us-east-1:000000000000:function:autoinstrument"],
         "region": "us-east-1",
         "tracing": true,
         "mergeXrayTraces": true,
-        "forwarder": "arn:aws:lambda:us-east-1:000000000000:function:datadog-forwarder"
+        "forwarder": "arn:aws:lambda:us-east-1:000000000000:function:datadog-forwarder",
+        "logLevel": "debug"
     }
 }
 ```
 
 #### Commands
 
-Use `instrument` to apply Datadog instrumentation to a Lambda. This command automatically adds the Datadog Lambda library (as a Lambda Layer) to the instrumented Lambda functions and modifies their configurations. 
+Use `instrument` to apply Datadog instrumentation to a Lambda. This command automatically adds the Datadog Lambda Library and/or the Datadog Lambda Extension as Lambda Layers to the instrumented Lambda functions and modifies their configurations. 
 
 This command is the quickest way to try out Datadog instrumentation on an existing Lambda function. To use in the production environment, run this command in your CI/CD pipelines to ensure your Lambda functions are always updated for instrumentation.
 
@@ -56,7 +58,7 @@ datadog-ci lambda instrument -f functionname -r us-east-1 -v 10 --dry
 #### All arguments:
 
 | Argument | Shorthand | Description | Default |
-| -------- | --------- | ----------- | ------- |
+| --- | --- | --- | --- |
 | --function | -f | The ARN of the Lambda function to be instrumented, or the name of the Lambda function (--region must be defined) | |
 | --region | -r | Default region to use, when `--function` is specified by the function name instead of the ARN | |
 | --layerVersion | -v | Version of the Datadog Lambda Library layer to apply. This varies between runtimes. To see the latest layer version check the [JS][3] or [python][4] datadog-lambda-layer repo release notes | |
@@ -66,6 +68,7 @@ datadog-ci lambda instrument -f functionname -r us-east-1 -v 10 --dry
 | --flushMetricsToLogs | | Whether to send metrics via the Datadog Forwarder [asynchronously](https://docs.datadoghq.com/serverless/custom_metrics?tab=python#enabling-asynchronous-custom-metrics) | true |
 | --forwarder | | The ARN of the [datadog forwarder](https://docs.datadoghq.com/serverless/forwarder/) to attach this function's LogGroup to. | |
 | --dry | -d | Preview changes running command would apply. | false |
+| --logLevel | | Set to `debug` to see additional output from the Datadog Lambda Library and/or Lambda Extension for troubleshooting purposes. | |
 
 <br />
 
@@ -74,11 +77,11 @@ datadog-ci lambda instrument -f functionname -r us-east-1 -v 10 --dry
 You may configure the `lambda instrument` command with environment variables:
 *You must expose these environment variables in the environment where you are running `datadog-ci lambda instrument`*
 
-| Environment Variable | Description                                                                                                                                                                                                                                                                                               | Example                             |
-|----------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------|
-| DATADOG_API_KEY      | Datadog API Key. Sets the `DD_API_KEY` environment variable on your Lambda function configuration. For more information about getting a Datadog API key, see the [API key documentation][6]                                                                                                               | export DATADOG_API_KEY="1234"       |
-| DATADOG_KMS_API_KEY  | Datadog API Key encrypted using KMS. Sets the `DD_KMS_API_KEY` environment variable on your Lambda function  configuration.                                                                                                                                                                               | export DATADOG_KMS_API_KEY="5678"   |
-| DATADOG_SITE         | Set which Datadog site to send data. Only needed when using the Datadog Lambda Extension. Possible values are  `datadoghq.com` , `datadoghq.eu` , `us3.datadoghq.com` and `ddog-gov.com`. The default is `datadoghq.com`. Sets the `DD_SITE` environment variable on your Lambda function configurations. | export DATADOG_SITE="datadoghq.com" |
+| Environment Variable | Description | Example |
+| --- | --- | --- |
+| DATADOG_API_KEY | Datadog API Key. Sets the `DD_API_KEY` environment variable on your Lambda function configuration. For more information about getting a Datadog API key, see the [API key documentation][6] | export DATADOG_API_KEY="1234" |
+| DATADOG_KMS_API_KEY | Datadog API Key encrypted using KMS. Sets the `DD_KMS_API_KEY` environment variable on your Lambda function  configuration. | export DATADOG_KMS_API_KEY="5678" |
+| DATADOG_SITE | Set which Datadog site to send data. Only needed when using the Datadog Lambda Extension. Possible values are  `datadoghq.com` , `datadoghq.eu` , `us3.datadoghq.com` and `ddog-gov.com`. The default is `datadoghq.com`. Sets the `DD_SITE` environment variable on your Lambda function configurations. | export DATADOG_SITE="datadoghq.com" |
 
 ## Community
 

--- a/src/commands/lambda/__tests__/function.test.ts
+++ b/src/commands/lambda/__tests__/function.test.ts
@@ -57,7 +57,7 @@ describe('function', () => {
             "Variables": Object {
               "DD_FLUSH_TO_LOG": "false",
               "DD_LAMBDA_HANDLER": "index.handler",
-              "DD_LOG_LEVEL", "debug",
+              "DD_LOG_LEVEL": "debug",
               "DD_MERGE_XRAY_TRACES": "false",
               "DD_SITE": "datadoghq.com",
               "DD_TRACE_ENABLED": "false",

--- a/src/commands/lambda/__tests__/function.test.ts
+++ b/src/commands/lambda/__tests__/function.test.ts
@@ -1,7 +1,15 @@
 jest.mock('../loggroup')
 
 import {Lambda} from 'aws-sdk'
-import {FLUSH_TO_LOG_ENV_VAR, GOVCLOUD_LAYER_AWS_ACCOUNT, LAMBDA_HANDLER_ENV_VAR, LOG_LEVEL_ENV_VAR, MERGE_XRAY_TRACES_ENV_VAR, SITE_ENV_VAR, TRACE_ENABLED_ENV_VAR} from '../constants'
+import {
+  FLUSH_TO_LOG_ENV_VAR,
+  GOVCLOUD_LAYER_AWS_ACCOUNT,
+  LAMBDA_HANDLER_ENV_VAR,
+  LOG_LEVEL_ENV_VAR,
+  MERGE_XRAY_TRACES_ENV_VAR,
+  SITE_ENV_VAR,
+  TRACE_ENABLED_ENV_VAR,
+} from '../constants'
 import {calculateUpdateRequest, getExtensionArn, getLambdaConfigs, getLayerArn, updateLambdaConfigs} from '../function'
 import * as loggroup from '../loggroup'
 

--- a/src/commands/lambda/__tests__/function.test.ts
+++ b/src/commands/lambda/__tests__/function.test.ts
@@ -638,7 +638,6 @@ describe('function', () => {
         Layers: [],
       }
       const settings = {
-        extensionVersion: 6,
         flushMetricsToLogs: false,
         layerAWSAccount: mockAwsAccount,
         layerVersion: 5,

--- a/src/commands/lambda/__tests__/function.test.ts
+++ b/src/commands/lambda/__tests__/function.test.ts
@@ -590,7 +590,7 @@ describe('function', () => {
     })
 
     test('calculates an update request with DATADOG_SITE being set to datadoghq.eu', () => {
-      process.env[SITE_ENV_VAR] = 'datadoghq.eu'
+      process.env.DATADOG_SITE = 'datadoghq.eu'
       const config = {
         FunctionArn: 'arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world',
         Handler: 'index.handler',
@@ -631,7 +631,7 @@ describe('function', () => {
     })
 
     test('throws an error when an invalid DATADOG_SITE url is given', () => {
-      process.env[SITE_ENV_VAR] = 'datacathq.eu'
+      process.env.DATADOG_SITE = 'datacathq.eu'
       const config = {
         FunctionArn: 'arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world',
         Handler: 'index.handler',

--- a/src/commands/lambda/__tests__/function.test.ts
+++ b/src/commands/lambda/__tests__/function.test.ts
@@ -26,6 +26,7 @@ describe('function', () => {
     afterAll(() => {
       process.env = OLD_ENV
     })
+
     test('returns the update request for each function', async () => {
       const lambda = makeMockLambda({
         'arn:aws:lambda:us-east-1:000000000000:function:autoinstrument': {
@@ -40,6 +41,7 @@ describe('function', () => {
         layerVersion: 22,
         mergeXrayTraces: false,
         tracingEnabled: false,
+        logLevel: 'debug',
       }
       const result = await getLambdaConfigs(
         lambda as any,
@@ -55,6 +57,7 @@ describe('function', () => {
             "Variables": Object {
               "DD_FLUSH_TO_LOG": "false",
               "DD_LAMBDA_HANDLER": "index.handler",
+              "DD_LOG_LEVEL", "debug",
               "DD_MERGE_XRAY_TRACES": "false",
               "DD_SITE": "datadoghq.com",
               "DD_TRACE_ENABLED": "false",
@@ -79,6 +82,7 @@ describe('function', () => {
               DD_MERGE_XRAY_TRACES: 'false',
               DD_SITE: 'datadoghq.com',
               DD_TRACE_ENABLED: 'false',
+              DD_LOG_LEVEL: 'debug',
             },
           },
           FunctionArn: 'arn:aws:lambda:us-east-1:000000000000:function:autoinstrument',
@@ -92,9 +96,9 @@ describe('function', () => {
       const settings = {
         flushMetricsToLogs: false,
         layerVersion: 22,
-
         mergeXrayTraces: false,
         tracingEnabled: false,
+        logLevel: 'debug',
       }
       const result = await getLambdaConfigs(
         lambda as any,
@@ -139,6 +143,7 @@ describe('function', () => {
                       ]
                 `)
     })
+
     test('uses the GovCloud lambda layer when a GovCloud region is detected', async () => {
       const lambda = makeMockLambda({
         'arn:aws-us-gov:lambda:us-gov-east-1:000000000000:function:autoinstrument': {
@@ -167,6 +172,7 @@ describe('function', () => {
                       ]
                 `)
     })
+
     test('returns results for multiple functions', async () => {
       const lambda = makeMockLambda({
         'arn:aws:lambda:us-east-1:000000000000:function:another-func': {
@@ -259,6 +265,7 @@ describe('function', () => {
             `)
     })
   })
+
   describe('updateLambdaConfigs', () => {
     const OLD_ENV = process.env
     beforeEach(() => {
@@ -268,6 +275,7 @@ describe('function', () => {
     afterAll(() => {
       process.env = OLD_ENV
     })
+
     test('updates every lambda', async () => {
       const lambda = makeMockLambda({})
       const configs = [
@@ -310,6 +318,7 @@ describe('function', () => {
       })
     })
   })
+
   describe('getLayerArn', () => {
     const OLD_ENV = process.env
     beforeEach(() => {
@@ -319,6 +328,7 @@ describe('function', () => {
     afterAll(() => {
       process.env = OLD_ENV
     })
+
     test('gets sa-east-1 Node12 Lambda Library layer ARN', async () => {
       const runtime = 'nodejs12.x'
       const settings = {
@@ -331,6 +341,7 @@ describe('function', () => {
       const layerArn = getLayerArn(runtime, settings, region)
       expect(layerArn).toEqual(`arn:aws:lambda:${region}:${mockAwsAccount}:layer:Datadog-Node12-x`)
     })
+
     test('gets sa-east-1 Python37 gov cloud Lambda Library layer ARN', async () => {
       const runtime = 'python3.7'
       const settings = {
@@ -344,6 +355,7 @@ describe('function', () => {
       expect(layerArn).toEqual(`arn:aws-us-gov:lambda:${region}:${GOVCLOUD_LAYER_AWS_ACCOUNT}:layer:Datadog-Python37`)
     })
   })
+
   describe('getExtensionArn', () => {
     const OLD_ENV = process.env
     beforeEach(() => {
@@ -353,6 +365,7 @@ describe('function', () => {
     afterAll(() => {
       process.env = OLD_ENV
     })
+
     test('gets sa-east-1 Lambda Extension layer ARN', async () => {
       const settings = {
         flushMetricsToLogs: false,
@@ -364,6 +377,7 @@ describe('function', () => {
       const layerArn = getExtensionArn(settings, region)
       expect(layerArn).toEqual(`arn:aws:lambda:${region}:${mockAwsAccount}:layer:Datadog-Extension`)
     })
+
     test('gets sa-east-1 gov cloud Lambda Extension layer ARN', async () => {
       const settings = {
         flushMetricsToLogs: false,
@@ -376,6 +390,7 @@ describe('function', () => {
       expect(layerArn).toEqual(`arn:aws-us-gov:lambda:${region}:${GOVCLOUD_LAYER_AWS_ACCOUNT}:layer:Datadog-Extension`)
     })
   })
+
   describe('calculateUpdateRequest', () => {
     const OLD_ENV = process.env
     beforeEach(() => {
@@ -385,6 +400,7 @@ describe('function', () => {
     afterAll(() => {
       process.env = OLD_ENV
     })
+
     test('calculates an update request with just lambda library layers', () => {
       const config = {
         FunctionArn: 'arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world',
@@ -564,6 +580,7 @@ describe('function', () => {
         }
       `)
     })
+
     test('calculates an update request with DATADOG_SITE being set to datadoghq.eu', () => {
       process.env.DATADOG_SITE = 'datadoghq.eu'
       const config = {
@@ -604,6 +621,7 @@ describe('function', () => {
         }
       `)
     })
+
     test('throws an error when an invalid DATADOG_SITE url is given', () => {
       process.env.DATADOG_SITE = 'datacathq.eu'
       const config = {
@@ -629,6 +647,7 @@ describe('function', () => {
         'Warning: Invalid site URL. Must be either datadoghq.com, datadoghq.eu, us3.datadoghq.com, or ddog-gov.com.'
       )
     })
+
     test('throws an error when neither DATADOG_API_KEY nor DATADOG_KMS_API_KEY are given through the environment while using extensionVersion', () => {
       const config = {
         FunctionArn: 'arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world',

--- a/src/commands/lambda/__tests__/function.test.ts
+++ b/src/commands/lambda/__tests__/function.test.ts
@@ -1,7 +1,7 @@
 jest.mock('../loggroup')
 
 import {Lambda} from 'aws-sdk'
-import {GOVCLOUD_LAYER_AWS_ACCOUNT} from '../constants'
+import {FLUSH_TO_LOG_ENV_VAR, GOVCLOUD_LAYER_AWS_ACCOUNT, LAMBDA_HANDLER_ENV_VAR, LOG_LEVEL_ENV_VAR, MERGE_XRAY_TRACES_ENV_VAR, SITE_ENV_VAR, TRACE_ENABLED_ENV_VAR} from '../constants'
 import {calculateUpdateRequest, getExtensionArn, getLambdaConfigs, getLayerArn, updateLambdaConfigs} from '../function'
 import * as loggroup from '../loggroup'
 
@@ -77,12 +77,12 @@ describe('function', () => {
         'arn:aws:lambda:us-east-1:000000000000:function:autoinstrument': {
           Environment: {
             Variables: {
-              DD_FLUSH_TO_LOG: 'false',
-              DD_LAMBDA_HANDLER: 'index.handler',
-              DD_LOG_LEVEL: 'debug',
-              DD_MERGE_XRAY_TRACES: 'false',
-              DD_SITE: 'datadoghq.com',
-              DD_TRACE_ENABLED: 'false',
+              [FLUSH_TO_LOG_ENV_VAR]: 'false',
+              [LAMBDA_HANDLER_ENV_VAR]: 'index.handler',
+              [LOG_LEVEL_ENV_VAR]: 'debug',
+              [MERGE_XRAY_TRACES_ENV_VAR]: 'false',
+              [SITE_ENV_VAR]: 'datadoghq.com',
+              [TRACE_ENABLED_ENV_VAR]: 'false',
             },
           },
           FunctionArn: 'arn:aws:lambda:us-east-1:000000000000:function:autoinstrument',
@@ -290,9 +290,9 @@ describe('function', () => {
           updateRequest: {
             Environment: {
               Variables: {
-                DD_LAMBDA_HANDLER: 'index.handler',
-                DD_MERGE_XRAY_TRACES: 'false',
-                DD_TRACE_ENABLED: 'false',
+                [LAMBDA_HANDLER_ENV_VAR]: 'index.handler',
+                [MERGE_XRAY_TRACES_ENV_VAR]: 'false',
+                [TRACE_ENABLED_ENV_VAR]: 'false',
               },
             },
             FunctionName: 'arn:aws:lambda:us-east-1:000000000000:function:autoinstrument',
@@ -307,9 +307,9 @@ describe('function', () => {
       expect(lambda.updateFunctionConfiguration).toHaveBeenCalledWith({
         Environment: {
           Variables: {
-            DD_LAMBDA_HANDLER: 'index.handler',
-            DD_MERGE_XRAY_TRACES: 'false',
-            DD_TRACE_ENABLED: 'false',
+            [LAMBDA_HANDLER_ENV_VAR]: 'index.handler',
+            [MERGE_XRAY_TRACES_ENV_VAR]: 'false',
+            [TRACE_ENABLED_ENV_VAR]: 'false',
           },
         },
         FunctionName: 'arn:aws:lambda:us-east-1:000000000000:function:autoinstrument',
@@ -582,7 +582,7 @@ describe('function', () => {
     })
 
     test('calculates an update request with DATADOG_SITE being set to datadoghq.eu', () => {
-      process.env.DATADOG_SITE = 'datadoghq.eu'
+      process.env[SITE_ENV_VAR] = 'datadoghq.eu'
       const config = {
         FunctionArn: 'arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world',
         Handler: 'index.handler',
@@ -623,7 +623,7 @@ describe('function', () => {
     })
 
     test('throws an error when an invalid DATADOG_SITE url is given', () => {
-      process.env.DATADOG_SITE = 'datacathq.eu'
+      process.env[SITE_ENV_VAR] = 'datacathq.eu'
       const config = {
         FunctionArn: 'arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world',
         Handler: 'index.handler',

--- a/src/commands/lambda/__tests__/function.test.ts
+++ b/src/commands/lambda/__tests__/function.test.ts
@@ -39,9 +39,9 @@ describe('function', () => {
       const settings = {
         flushMetricsToLogs: false,
         layerVersion: 22,
+        logLevel: 'debug',
         mergeXrayTraces: false,
         tracingEnabled: false,
-        logLevel: 'debug',
       }
       const result = await getLambdaConfigs(
         lambda as any,
@@ -79,10 +79,10 @@ describe('function', () => {
             Variables: {
               DD_FLUSH_TO_LOG: 'false',
               DD_LAMBDA_HANDLER: 'index.handler',
+              DD_LOG_LEVEL: 'debug',
               DD_MERGE_XRAY_TRACES: 'false',
               DD_SITE: 'datadoghq.com',
               DD_TRACE_ENABLED: 'false',
-              DD_LOG_LEVEL: 'debug',
             },
           },
           FunctionArn: 'arn:aws:lambda:us-east-1:000000000000:function:autoinstrument',
@@ -96,9 +96,9 @@ describe('function', () => {
       const settings = {
         flushMetricsToLogs: false,
         layerVersion: 22,
+        logLevel: 'debug',
         mergeXrayTraces: false,
         tracingEnabled: false,
-        logLevel: 'debug',
       }
       const result = await getLambdaConfigs(
         lambda as any,

--- a/src/commands/lambda/__tests__/instrument.test.ts
+++ b/src/commands/lambda/__tests__/instrument.test.ts
@@ -81,9 +81,6 @@ describe('lambda', () => {
           {
             \\"FunctionName\\": \\"arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world\\",
             \\"Handler\\": \\"/opt/nodejs/node_modules/datadog-lambda-js/handler.handler\\",
-            \\"Layers\\": [
-              \\"arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Node12-x:10\\"
-            ],
             \\"Environment\\": {
               \\"Variables\\": {
                 \\"DD_LAMBDA_HANDLER\\": \\"index.handler\\",
@@ -93,7 +90,10 @@ describe('lambda', () => {
                 \\"DD_FLUSH_TO_LOG\\": \\"true\\",
                 \\"DD_LOG_LEVEL\\": \\"debug\\"
               }
-            }
+            },
+            \\"Layers\\": [
+              \\"arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Node12-x:10\\"
+            ]
           }
           TagResource -> arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world
           {
@@ -130,9 +130,6 @@ describe('lambda', () => {
           {
             \\"FunctionName\\": \\"arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world\\",
             \\"Handler\\": \\"/opt/nodejs/node_modules/datadog-lambda-js/handler.handler\\",
-            \\"Layers\\": [
-              \\"arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Extension:6\\"
-            ],
             \\"Environment\\": {
               \\"Variables\\": {
                 \\"DD_LAMBDA_HANDLER\\": \\"index.handler\\",
@@ -142,7 +139,10 @@ describe('lambda', () => {
                 \\"DD_MERGE_XRAY_TRACES\\": \\"false\\",
                 \\"DD_FLUSH_TO_LOG\\": \\"true\\"
               }
-            }
+            },
+            \\"Layers\\": [
+              \\"arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Extension:6\\"
+            ]
           }
           TagResource -> arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world
           {

--- a/src/commands/lambda/__tests__/instrument.test.ts
+++ b/src/commands/lambda/__tests__/instrument.test.ts
@@ -54,6 +54,7 @@ describe('lambda', () => {
       afterAll(() => {
         process.env = OLD_ENV
       })
+
       test('prints dry run data for lambda library layer', async () => {
         ;(fs.readFile as any).mockImplementation((a: any, b: any, callback: any) => callback({code: 'ENOENT'}))
         ;(Lambda as any).mockImplementation(() =>
@@ -69,7 +70,7 @@ describe('lambda', () => {
         const context = createMockContext() as any
         const functionARN = 'arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world'
         const code = await cli.run(
-          ['lambda', 'instrument', '-f', functionARN, '--dry', '--layerVersion', '10'],
+          ['lambda', 'instrument', '-f', functionARN, '--dry', '--layerVersion', '10', '--logLevel', 'debug'],
           context
         )
         const output = context.stdout.toString()
@@ -89,7 +90,8 @@ describe('lambda', () => {
                 \\"DD_SITE\\": \\"datadoghq.com\\",
                 \\"DD_TRACE_ENABLED\\": \\"true\\",
                 \\"DD_MERGE_XRAY_TRACES\\": \\"false\\",
-                \\"DD_FLUSH_TO_LOG\\": \\"true\\"
+                \\"DD_FLUSH_TO_LOG\\": \\"true\\",
+                \\"DD_LOG_LEVEL\\": \\"debug\\",
               }
             }
           }
@@ -100,6 +102,7 @@ describe('lambda', () => {
           "
         `)
       })
+
       test('prints dry run data for lambda extension layer', async () => {
         ;(fs.readFile as any).mockImplementation((a: any, b: any, callback: any) => callback({code: 'ENOENT'}))
         ;(Lambda as any).mockImplementation(() =>
@@ -148,6 +151,7 @@ describe('lambda', () => {
           "
         `)
       })
+
       test('runs function update command for lambda library layer', async () => {
         ;(fs.readFile as any).mockImplementation((a: any, b: any, callback: any) => callback({code: 'ENOENT'}))
         const lambda = makeMockLambda({
@@ -173,6 +177,7 @@ describe('lambda', () => {
         )
         expect(lambda.updateFunctionConfiguration).toHaveBeenCalled()
       })
+
       test('runs function update command for lambda extension layer', async () => {
         ;(fs.readFile as any).mockImplementation((a: any, b: any, callback: any) => callback({code: 'ENOENT'}))
         const lambda = makeMockLambda({
@@ -199,6 +204,7 @@ describe('lambda', () => {
         )
         expect(lambda.updateFunctionConfiguration).toHaveBeenCalled()
       })
+
       test('aborts early when no functions are specified', async () => {
         ;(fs.readFile as any).mockImplementation((a: any, b: any, callback: any) => callback({code: 'ENOENT'}))
         ;(Lambda as any).mockImplementation(() => makeMockLambda({}))
@@ -212,6 +218,7 @@ describe('lambda', () => {
                                                             "
                                                 `)
       })
+
       test("aborts early when function regions can't be found", async () => {
         ;(fs.readFile as any).mockImplementation((a: any, b: any, callback: any) => callback({code: 'ENOENT'}))
         ;(Lambda as any).mockImplementation(() => makeMockLambda({}))
@@ -227,7 +234,8 @@ describe('lambda', () => {
                                                   "
                                         `)
       })
-      test('aborts early when no extensionVersion and forwarder are set', async () => {
+
+      test('aborts early when extensionVersion and forwarder are set', async () => {
         ;(fs.readFile as any).mockImplementation((a: any, b: any, callback: any) => callback({code: 'ENOENT'}))
         ;(Lambda as any).mockImplementation(() => makeMockLambda({}))
         const cli = makeCli()
@@ -255,6 +263,7 @@ describe('lambda', () => {
         `)
       })
     })
+
     describe('getSettings', () => {
       test('uses config file settings', () => {
         process.env = {}
@@ -266,6 +275,7 @@ describe('lambda', () => {
         command['config']['layerAWSAccount'] = 'another-account'
         command['config']['mergeXrayTraces'] = false
         command['config']['tracing'] = false
+        command['config']['logLevel'] = 'debug'
 
         expect(command['getSettings']()).toEqual({
           extensionVersion: 6,
@@ -275,6 +285,7 @@ describe('lambda', () => {
           layerVersion: 2,
           mergeXrayTraces: false,
           tracingEnabled: false,
+          logLevel: 'debug',
         })
       })
 
@@ -293,6 +304,8 @@ describe('lambda', () => {
         command['config']['flushMetricsToLogs'] = true
         command['tracing'] = true
         command['config']['tracing'] = false
+        command['logLevel'] = 'debug'
+        command['config']['logLevel'] = 'info'
 
         expect(command['getSettings']()).toEqual({
           flushMetricsToLogs: false,
@@ -301,6 +314,7 @@ describe('lambda', () => {
           layerVersion: 1,
           mergeXrayTraces: true,
           tracingEnabled: true,
+          logLevel: 'debug',
         })
       })
 
@@ -328,6 +342,7 @@ describe('lambda', () => {
         expect(command['getSettings']()).toBeUndefined()
       })
     })
+
     describe('collectFunctionsByRegion', () => {
       test('groups functions with region read from arn', () => {
         process.env = {}
@@ -346,6 +361,7 @@ describe('lambda', () => {
           'us-east-2': ['arn:aws:lambda:us-east-2:123456789012:function:third-func'],
         })
       })
+
       test('groups functions in the config object', () => {
         process.env = {}
         const command = createCommand()
@@ -381,6 +397,7 @@ describe('lambda', () => {
           'us-east-2': ['arn:aws:lambda:us-east-2:123456789012:function:third-func'],
         })
       })
+
       test('fails to collect when there are regionless functions and no default region is set', () => {
         process.env = {}
         const command = createCommand()
@@ -396,6 +413,7 @@ describe('lambda', () => {
         expect(command['collectFunctionsByRegion']()).toBeUndefined()
       })
     })
+
     describe('printPlannedActions', () => {
       test('prints no output when list is empty', () => {
         process.env = {}
@@ -408,6 +426,7 @@ describe('lambda', () => {
                                         "
                                 `)
       })
+
       test('prints log group actions', () => {
         process.env = {}
         const command = createCommand()

--- a/src/commands/lambda/__tests__/instrument.test.ts
+++ b/src/commands/lambda/__tests__/instrument.test.ts
@@ -91,7 +91,7 @@ describe('lambda', () => {
                 \\"DD_TRACE_ENABLED\\": \\"true\\",
                 \\"DD_MERGE_XRAY_TRACES\\": \\"false\\",
                 \\"DD_FLUSH_TO_LOG\\": \\"true\\",
-                \\"DD_LOG_LEVEL\\": \\"debug\\",
+                \\"DD_LOG_LEVEL\\": \\"debug\\"
               }
             }
           }

--- a/src/commands/lambda/__tests__/instrument.test.ts
+++ b/src/commands/lambda/__tests__/instrument.test.ts
@@ -283,9 +283,9 @@ describe('lambda', () => {
           forwarderARN: 'my-forwarder',
           layerAWSAccount: 'another-account',
           layerVersion: 2,
+          logLevel: 'debug',
           mergeXrayTraces: false,
           tracingEnabled: false,
-          logLevel: 'debug',
         })
       })
 
@@ -312,9 +312,9 @@ describe('lambda', () => {
           forwarderARN: 'my-forwarder',
           layerAWSAccount: 'my-account',
           layerVersion: 1,
+          logLevel: 'debug',
           mergeXrayTraces: true,
           tracingEnabled: true,
-          logLevel: 'debug',
         })
       })
 

--- a/src/commands/lambda/constants.ts
+++ b/src/commands/lambda/constants.ts
@@ -24,3 +24,18 @@ export const GOVCLOUD_LAYER_AWS_ACCOUNT = '002406178527'
 export const SUBSCRIPTION_FILTER_NAME = 'datadog-ci-filter'
 export const TAG_VERSION_NAME = 'dd_sls_ci'
 export const DD_LAMBDA_EXTENSION_LAYER_NAME = 'Datadog-Extension'
+
+// Environment variables used in the Lambda environment
+export const API_KEY_ENV_VAR = "DD_API_KEY"
+export const KMS_API_KEY_ENV_VAR = "DD_KMS_API_KEY"
+export const SITE_ENV_VAR = "DD_SITE"
+export const TRACE_ENABLED_ENV_VAR = "DD_TRACE_ENABLED"
+export const MERGE_XRAY_TRACES_ENV_VAR = "DD_MERGE_XRAY_TRACES"
+export const FLUSH_TO_LOG_ENV_VAR = "DD_FLUSH_TO_LOG"
+export const LOG_LEVEL_ENV_VAR = "DD_LOG_LEVEL"
+export const LAMBDA_HANDLER_ENV_VAR = "DD_LAMBDA_HANDLER"
+
+// Environment variables used by Datadog CI
+export const CI_SITE_ENV_VAR = "DATADOG_SITE"
+export const CI_API_KEY_ENV_VAR = "DATADOG_API_KEY"
+export const CI_KMS_API_KEY_ENV_VAR = "DATADOG_KMS_API_KEY"

--- a/src/commands/lambda/constants.ts
+++ b/src/commands/lambda/constants.ts
@@ -26,16 +26,16 @@ export const TAG_VERSION_NAME = 'dd_sls_ci'
 export const DD_LAMBDA_EXTENSION_LAYER_NAME = 'Datadog-Extension'
 
 // Environment variables used in the Lambda environment
-export const API_KEY_ENV_VAR = "DD_API_KEY"
-export const KMS_API_KEY_ENV_VAR = "DD_KMS_API_KEY"
-export const SITE_ENV_VAR = "DD_SITE"
-export const TRACE_ENABLED_ENV_VAR = "DD_TRACE_ENABLED"
-export const MERGE_XRAY_TRACES_ENV_VAR = "DD_MERGE_XRAY_TRACES"
-export const FLUSH_TO_LOG_ENV_VAR = "DD_FLUSH_TO_LOG"
-export const LOG_LEVEL_ENV_VAR = "DD_LOG_LEVEL"
-export const LAMBDA_HANDLER_ENV_VAR = "DD_LAMBDA_HANDLER"
+export const API_KEY_ENV_VAR = 'DD_API_KEY'
+export const KMS_API_KEY_ENV_VAR = 'DD_KMS_API_KEY'
+export const SITE_ENV_VAR = 'DD_SITE'
+export const TRACE_ENABLED_ENV_VAR = 'DD_TRACE_ENABLED'
+export const MERGE_XRAY_TRACES_ENV_VAR = 'DD_MERGE_XRAY_TRACES'
+export const FLUSH_TO_LOG_ENV_VAR = 'DD_FLUSH_TO_LOG'
+export const LOG_LEVEL_ENV_VAR = 'DD_LOG_LEVEL'
+export const LAMBDA_HANDLER_ENV_VAR = 'DD_LAMBDA_HANDLER'
 
 // Environment variables used by Datadog CI
-export const CI_SITE_ENV_VAR = "DATADOG_SITE"
-export const CI_API_KEY_ENV_VAR = "DATADOG_API_KEY"
-export const CI_KMS_API_KEY_ENV_VAR = "DATADOG_KMS_API_KEY"
+export const CI_SITE_ENV_VAR = 'DATADOG_SITE'
+export const CI_API_KEY_ENV_VAR = 'DATADOG_API_KEY'
+export const CI_KMS_API_KEY_ENV_VAR = 'DATADOG_KMS_API_KEY'

--- a/src/commands/lambda/function.ts
+++ b/src/commands/lambda/function.ts
@@ -159,7 +159,7 @@ export const calculateUpdateRequest = (
   const apiKey: string | undefined = process.env[CI_API_KEY_ENV_VAR]
   const apiKmsKey: string | undefined = process.env[CI_KMS_API_KEY_ENV_VAR]
   const site: string | undefined = process.env[CI_SITE_ENV_VAR]
-  
+
   if (functionARN === undefined) {
     return undefined
   }
@@ -261,7 +261,9 @@ export const calculateUpdateRequest = (
       newEnvVars[API_KEY_ENV_VAR] === undefined &&
       newEnvVars[KMS_API_KEY_ENV_VAR] === undefined
     ) {
-      throw new Error(`When 'extensionLayer' is set, ${CI_API_KEY_ENV_VAR} or ${CI_KMS_API_KEY_ENV_VAR} must also be set`)
+      throw new Error(
+        `When 'extensionLayer' is set, ${CI_API_KEY_ENV_VAR} or ${CI_KMS_API_KEY_ENV_VAR} must also be set`
+      )
     }
   })
 

--- a/src/commands/lambda/function.ts
+++ b/src/commands/lambda/function.ts
@@ -1,11 +1,22 @@
 import {CloudWatchLogs, Lambda} from 'aws-sdk'
 import {
+  API_KEY_ENV_VAR,
+  CI_API_KEY_ENV_VAR,
+  CI_KMS_API_KEY_ENV_VAR,
+  CI_SITE_ENV_VAR,
   DD_LAMBDA_EXTENSION_LAYER_NAME,
   DEFAULT_LAYER_AWS_ACCOUNT,
+  FLUSH_TO_LOG_ENV_VAR,
   GOVCLOUD_LAYER_AWS_ACCOUNT,
   HANDLER_LOCATION,
+  KMS_API_KEY_ENV_VAR,
+  LAMBDA_HANDLER_ENV_VAR,
+  LOG_LEVEL_ENV_VAR,
+  MERGE_XRAY_TRACES_ENV_VAR,
   Runtime,
   RUNTIME_LAYER_LOOKUP,
+  SITE_ENV_VAR,
+  TRACE_ENABLED_ENV_VAR,
 } from './constants'
 import {applyLogGroupConfig, calculateLogGroupUpdateRequest, LogGroupConfiguration} from './loggroup'
 import {applyTagConfig, calculateTagUpdateRequest, TagConfiguration} from './tags'
@@ -141,12 +152,14 @@ export const calculateUpdateRequest = (
   lambdaExtensionLayerArn: string,
   runtime: Runtime
 ) => {
-  const env: Record<string, string> = {...config.Environment?.Variables}
-  const newEnvVars: Record<string, string> = {}
+  const oldEnvVars: Record<string, string> = {...config.Environment?.Variables}
+  const changedEnvVars: Record<string, string> = {}
   const functionARN = config.FunctionArn
-  const apiKey: string | undefined = process.env.DATADOG_API_KEY
-  const apiKmsKey: string | undefined = process.env.DATADOG_KMS_API_KEY
-  const site: string | undefined = process.env.DATADOG_SITE
+
+  const apiKey: string | undefined = process.env[CI_API_KEY_ENV_VAR]
+  const apiKmsKey: string | undefined = process.env[CI_KMS_API_KEY_ENV_VAR]
+  const site: string | undefined = process.env[CI_SITE_ENV_VAR]
+  
   if (functionARN === undefined) {
     return undefined
   }
@@ -156,15 +169,70 @@ export const calculateUpdateRequest = (
   }
   let needsUpdate = false
 
-  if (env.DD_LAMBDA_HANDLER === undefined) {
-    needsUpdate = true
-    newEnvVars.DD_LAMBDA_HANDLER = config.Handler ?? ''
-  }
+  // Update Handler
   const expectedHandler = HANDLER_LOCATION[runtime]
   if (config.Handler !== expectedHandler) {
     needsUpdate = true
     updateRequest.Handler = HANDLER_LOCATION[runtime]
   }
+
+  // Update Env Vars
+  if (oldEnvVars[LAMBDA_HANDLER_ENV_VAR] === undefined) {
+    needsUpdate = true
+    changedEnvVars[LAMBDA_HANDLER_ENV_VAR] = config.Handler ?? ''
+  }
+  if (apiKey !== undefined && oldEnvVars[API_KEY_ENV_VAR] !== apiKey) {
+    needsUpdate = true
+    changedEnvVars[API_KEY_ENV_VAR] = apiKey
+  }
+  if (apiKmsKey !== undefined && oldEnvVars[KMS_API_KEY_ENV_VAR] !== apiKmsKey) {
+    needsUpdate = true
+    changedEnvVars[KMS_API_KEY_ENV_VAR] = apiKmsKey
+  }
+  if (site !== undefined && oldEnvVars[SITE_ENV_VAR] !== site) {
+    const siteList: string[] = ['datadoghq.com', 'datadoghq.eu', 'us3.datadoghq.com', 'ddog-gov.com']
+    if (siteList.includes(site.toLowerCase())) {
+      needsUpdate = true
+      changedEnvVars[SITE_ENV_VAR] = site
+    } else {
+      throw new Error(
+        'Warning: Invalid site URL. Must be either datadoghq.com, datadoghq.eu, us3.datadoghq.com, or ddog-gov.com.'
+      )
+    }
+  }
+  if (site === undefined && oldEnvVars[SITE_ENV_VAR] === undefined) {
+    needsUpdate = true
+    changedEnvVars[SITE_ENV_VAR] = 'datadoghq.com'
+  }
+  if (oldEnvVars[TRACE_ENABLED_ENV_VAR] !== settings.tracingEnabled.toString()) {
+    needsUpdate = true
+    changedEnvVars[TRACE_ENABLED_ENV_VAR] = settings.tracingEnabled.toString()
+  }
+  if (oldEnvVars[MERGE_XRAY_TRACES_ENV_VAR] !== settings.mergeXrayTraces.toString()) {
+    needsUpdate = true
+    changedEnvVars[MERGE_XRAY_TRACES_ENV_VAR] = settings.mergeXrayTraces.toString()
+  }
+  if (oldEnvVars[FLUSH_TO_LOG_ENV_VAR] !== settings.flushMetricsToLogs.toString()) {
+    needsUpdate = true
+    changedEnvVars[FLUSH_TO_LOG_ENV_VAR] = settings.flushMetricsToLogs.toString()
+  }
+
+  const newEnvVars = {...oldEnvVars, ...changedEnvVars}
+
+  if (newEnvVars[LOG_LEVEL_ENV_VAR] !== settings.logLevel) {
+    needsUpdate = true
+    if (settings.logLevel) {
+      newEnvVars[LOG_LEVEL_ENV_VAR] = settings.logLevel
+    } else {
+      delete newEnvVars[LOG_LEVEL_ENV_VAR]
+    }
+  }
+
+  updateRequest.Environment = {
+    Variables: newEnvVars,
+  }
+
+  // Update Layers
   let fullLambdaLibraryLayerARN: string | undefined
   if (settings.layerVersion !== undefined) {
     fullLambdaLibraryLayerARN = `${lambdaLibraryLayerArn}:${settings.layerVersion}`
@@ -172,29 +240,6 @@ export const calculateUpdateRequest = (
   let fullExtensionLayerARN: string | undefined
   if (settings.extensionVersion !== undefined) {
     fullExtensionLayerARN = `${lambdaExtensionLayerArn}:${settings.extensionVersion}`
-  }
-  if (apiKey !== undefined && env.DD_API_KEY !== apiKey) {
-    needsUpdate = true
-    newEnvVars.DD_API_KEY = apiKey
-  }
-  if (apiKmsKey !== undefined && env.DD_KMS_API_KEY !== apiKmsKey) {
-    needsUpdate = true
-    newEnvVars.DD_KMS_API_KEY = apiKmsKey
-  }
-  if (site !== undefined && env.DD_SITE !== site) {
-    const siteList: string[] = ['datadoghq.com', 'datadoghq.eu', 'us3.datadoghq.com', 'ddog-gov.com']
-    if (siteList.includes(site.toLowerCase())) {
-      needsUpdate = true
-      newEnvVars.DD_SITE = site
-    } else {
-      throw new Error(
-        'Warning: Invalid site URL. Must be either datadoghq.com, datadoghq.eu, us3.datadoghq.com, or ddog-gov.com.'
-      )
-    }
-  }
-  if (site === undefined && env.DD_SITE === undefined) {
-    needsUpdate = true
-    newEnvVars.DD_SITE = 'datadoghq.com'
   }
   let layerARNs = (config.Layers ?? []).map((layer) => layer.Arn ?? '')
   const originalLayerARNs = (config.Layers ?? []).map((layer) => layer.Arn ?? '')
@@ -209,39 +254,16 @@ export const calculateUpdateRequest = (
     needsUpdate = true
     updateRequest.Layers = layerARNs
   }
-  if (env.DD_TRACE_ENABLED !== settings.tracingEnabled.toString()) {
-    needsUpdate = true
-    newEnvVars.DD_TRACE_ENABLED = settings.tracingEnabled.toString()
-  }
-  if (env.DD_MERGE_XRAY_TRACES !== settings.mergeXrayTraces.toString()) {
-    needsUpdate = true
-    newEnvVars.DD_MERGE_XRAY_TRACES = settings.mergeXrayTraces.toString()
-  }
-  if (env.DD_FLUSH_TO_LOG !== settings.flushMetricsToLogs.toString()) {
-    needsUpdate = true
-    newEnvVars.DD_FLUSH_TO_LOG = settings.flushMetricsToLogs.toString()
-  }
-  if (env.DD_LOG_LEVEL !== settings.logLevel) {
-    needsUpdate = true
-    if (settings.logLevel) {
-      newEnvVars.DD_LOG_LEVEL = settings.logLevel
-    }
-  }
-  const allEnvVariables = {...env, ...newEnvVars}
+
   layerARNs.forEach((layerARN) => {
     if (
       layerARN.includes(DD_LAMBDA_EXTENSION_LAYER_NAME) &&
-      allEnvVariables.DD_API_KEY === undefined &&
-      allEnvVariables.DD_KMS_API_KEY === undefined
+      newEnvVars[API_KEY_ENV_VAR] === undefined &&
+      newEnvVars[KMS_API_KEY_ENV_VAR] === undefined
     ) {
-      throw new Error("When 'extensionLayer' is set, DATADOG_API_KEY or DATADOG_KMS_API_KEY must also be set")
+      throw new Error(`When 'extensionLayer' is set, ${CI_API_KEY_ENV_VAR} or ${CI_KMS_API_KEY_ENV_VAR} must also be set`)
     }
   })
-  if (Object.entries(newEnvVars).length > 0) {
-    updateRequest.Environment = {
-      Variables: allEnvVariables,
-    }
-  }
 
   return needsUpdate ? updateRequest : undefined
 }

--- a/src/commands/lambda/function.ts
+++ b/src/commands/lambda/function.ts
@@ -221,9 +221,11 @@ export const calculateUpdateRequest = (
     needsUpdate = true
     newEnvVars.DD_FLUSH_TO_LOG = settings.flushMetricsToLogs.toString()
   }
-  if (settings.logLevel && env.DD_LOG_LEVEL !== settings.logLevel) {
+  if (env.DD_LOG_LEVEL !== settings.logLevel) {
     needsUpdate = true
-    newEnvVars.DD_LOG_LEVEL = settings.logLevel
+    if (settings.logLevel) {
+      newEnvVars.DD_LOG_LEVEL = settings.logLevel
+    }
   }
   const allEnvVariables = {...env, ...newEnvVars}
   layerARNs.forEach((layerARN) => {

--- a/src/commands/lambda/function.ts
+++ b/src/commands/lambda/function.ts
@@ -24,9 +24,9 @@ export interface InstrumentationSettings {
   forwarderARN?: string
   layerAWSAccount?: string
   layerVersion?: number
+  logLevel?: string
   mergeXrayTraces: boolean
   tracingEnabled: boolean
-  logLevel?: string
 }
 
 export const getLambdaConfigs = async (

--- a/src/commands/lambda/function.ts
+++ b/src/commands/lambda/function.ts
@@ -26,7 +26,9 @@ export interface InstrumentationSettings {
   layerVersion?: number
   mergeXrayTraces: boolean
   tracingEnabled: boolean
+  logLevel?: string
 }
+
 export const getLambdaConfigs = async (
   lambda: Lambda,
   cloudWatch: CloudWatchLogs,
@@ -218,6 +220,10 @@ export const calculateUpdateRequest = (
   if (env.DD_FLUSH_TO_LOG !== settings.flushMetricsToLogs.toString()) {
     needsUpdate = true
     newEnvVars.DD_FLUSH_TO_LOG = settings.flushMetricsToLogs.toString()
+  }
+  if (settings.logLevel && (env.DD_LOG_LEVEL !== settings.logLevel)) {
+    needsUpdate = true
+    newEnvVars.DD_LOG_LEVEL = settings.logLevel
   }
   const allEnvVariables = {...env, ...newEnvVars}
   layerARNs.forEach((layerARN) => {

--- a/src/commands/lambda/function.ts
+++ b/src/commands/lambda/function.ts
@@ -221,7 +221,7 @@ export const calculateUpdateRequest = (
     needsUpdate = true
     newEnvVars.DD_FLUSH_TO_LOG = settings.flushMetricsToLogs.toString()
   }
-  if (settings.logLevel && (env.DD_LOG_LEVEL !== settings.logLevel)) {
+  if (settings.logLevel && env.DD_LOG_LEVEL !== settings.logLevel) {
     needsUpdate = true
     newEnvVars.DD_LOG_LEVEL = settings.logLevel
   }

--- a/src/commands/lambda/instrument.ts
+++ b/src/commands/lambda/instrument.ts
@@ -18,10 +18,10 @@ export class InstrumentCommand extends Command {
   private functions: string[] = []
   private layerAWSAccount?: string
   private layerVersion?: string
+  private logLevel?: string
   private mergeXrayTraces?: boolean
   private region?: string
   private tracing?: boolean
-  private logLevel?: string
 
   public async execute() {
     const lambdaConfig = {lambda: this.config}
@@ -81,6 +81,7 @@ export class InstrumentCommand extends Command {
       await Promise.all(promises)
     } catch (err) {
       this.context.stdout.write(`Failure during update. ${err}\n`)
+
       return 1
     }
 
@@ -158,9 +159,9 @@ export class InstrumentCommand extends Command {
       forwarderARN,
       layerAWSAccount,
       layerVersion,
+      logLevel,
       mergeXrayTraces,
       tracingEnabled,
-      logLevel,
     }
   }
 

--- a/src/commands/lambda/interfaces.ts
+++ b/src/commands/lambda/interfaces.ts
@@ -5,8 +5,8 @@ export interface LambdaConfigOptions {
   functions: string[]
   layerAWSAccount?: string
   layerVersion?: string
+  logLevel?: string
   mergeXrayTraces?: boolean
   region?: string
   tracing?: boolean
-  logLevel?: string
 }

--- a/src/commands/lambda/interfaces.ts
+++ b/src/commands/lambda/interfaces.ts
@@ -8,4 +8,5 @@ export interface LambdaConfigOptions {
   mergeXrayTraces?: boolean
   region?: string
   tracing?: boolean
+  logLevel?: string
 }


### PR DESCRIPTION
### What and why?

Allows users to set the `DD_LOG_LEVEL` environment variable of their Lambda functions by passing `--logLevel debug` to the `lambda instrument` command. This option is useful for seeing extra output from the Datadog Lambda Library and/or Lambda Extension for debugging purposes.

I also made some improvements to the README and reorganized the `calculateUpdateRequest()` function somewhat to be more readable.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)

