### PR TITLE
[ci-app] Add `--env` Input to `junit` Command.

### DIFF
--- a/src/commands/junit/README.md
+++ b/src/commands/junit/README.md
@@ -23,7 +23,7 @@ datadog-ci junit upload --service my-service --tags key1:value1 --tags key2:valu
 ```
 
 - The positional arguments are the directories or file paths in which the jUnit XML reports are located. If you pass a folder, the CLI will look for all `.xml` files in it.
-- `--apiKey` (default: `DATADOG_API_KEY` env var) is the API Key used to authenticate the requests. **Important**: the API key needs to be available either through this parameter or `DATADOG_API_KEY` env var.
+- `--api-key` (default: `DATADOG_API_KEY` env var) is the API Key used to authenticate the requests. **Important**: the API key needs to be available either through this parameter or `DATADOG_API_KEY` env var.
 - `--service` (default: `DD_SERVICE` env var) should be set as the name of the service you're uploading jUnit XML reports for.
 - `--tags` is a array of key value pairs of the shape `key:value`. This will set global tags applied to all spans.
   - The resulting dictionary will be merged with whatever is in the `DD_TAGS` environment variable. If a `key` appears both in `--tags` and `DD_TAGS`, whatever value is in `DD_TAGS` will take precedence.

--- a/src/commands/junit/README.md
+++ b/src/commands/junit/README.md
@@ -35,7 +35,7 @@ datadog-ci junit upload --service my-service --tags key1:value1 --tags key2:valu
 
 Additionally you might configure the `junit` command with environment variables:
 
-- `DATADOG_API_KEY`: API key used to authenticate the requests. **Important**: the API key needs to be available either through this env var or through `--apiKey` parameter.
+- `DATADOG_API_KEY`: API key used to authenticate the requests. **Important**: the API key needs to be available either through this env var or through `--api-key` parameter.
 - `DD_ENV`: you may choose the environment you want your test results to appear in.
 - `DD_SERVICE`: if you haven't specified a service through `--service` you might do it with this env var.
 - `DD_TAGS`: set global tags applied to all spans. The format must be `key1:value1,key2:value2`.

--- a/src/commands/junit/README.md
+++ b/src/commands/junit/README.md
@@ -23,6 +23,7 @@ datadog-ci junit upload --service my-service --tags key1:value1 --tags key2:valu
 ```
 
 - The positional arguments are the directories or file paths in which the jUnit XML reports are located. If you pass a folder, the CLI will look for all `.xml` files in it.
+- `--service` (default: `DD_SERVICE` env var) should be set as the name of the service you're uploading jUnit XML reports for.
 - `--tags` is a array of key value pairs of the shape `key:value`. This will set global tags applied to all spans.
   - The resulting dictionary will be merged with whatever is in the `DD_TAGS` environment variable. If a `key` appears both in `--tags` and `DD_TAGS`, whatever value is in `DD_TAGS` will take precedence.
 - `--env` (default: `DD_ENV` env var) is a string that represents the environment where you want your tests to appear in.

--- a/src/commands/junit/README.md
+++ b/src/commands/junit/README.md
@@ -23,9 +23,11 @@ datadog-ci junit upload --service my-service --tags key1:value1 --tags key2:valu
 ```
 
 - The positional arguments are the directories or file paths in which the jUnit XML reports are located. If you pass a folder, the CLI will look for all `.xml` files in it.
+- `--apiKey` (default: `DATADOG_API_KEY` env var) is the API Key used to authenticate the requests. **Important**: the API key needs to be available either through this parameter or `DATADOG_API_KEY` env var.
 - `--service` (default: `DD_SERVICE` env var) should be set as the name of the service you're uploading jUnit XML reports for.
 - `--tags` is a array of key value pairs of the shape `key:value`. This will set global tags applied to all spans.
   - The resulting dictionary will be merged with whatever is in the `DD_TAGS` environment variable. If a `key` appears both in `--tags` and `DD_TAGS`, whatever value is in `DD_TAGS` will take precedence.
+- `--env` (default: `DD_ENV` env var) is a string that represents the environment where you want your tests to appear in.
 - `--max-concurrency` (default: `20`): number of concurrent uploads to the API.
 - `--dry-run` (default: `false`): it will run the command without the final upload step. All other checks are performed.
 
@@ -33,7 +35,7 @@ datadog-ci junit upload --service my-service --tags key1:value1 --tags key2:valu
 
 Additionally you might configure the `junit` command with environment variables:
 
-- `DATADOG_API_KEY` (**required**): API key used to authenticate the requests.
+- `DATADOG_API_KEY`: API key used to authenticate the requests. **Important**: the API key needs to be available either through this env var or through `--apiKey` parameter.
 - `DD_ENV`: you may choose the environment you want your test results to appear in.
 - `DD_SERVICE`: if you haven't specified a service through `--service` you might do it with this env var.
 - `DD_TAGS`: set global tags applied to all spans. The format must be `key1:value1,key2:value2`.

--- a/src/commands/junit/README.md
+++ b/src/commands/junit/README.md
@@ -23,8 +23,6 @@ datadog-ci junit upload --service my-service --tags key1:value1 --tags key2:valu
 ```
 
 - The positional arguments are the directories or file paths in which the jUnit XML reports are located. If you pass a folder, the CLI will look for all `.xml` files in it.
-- `--api-key` (default: `DATADOG_API_KEY` env var) is the API Key used to authenticate the requests. **Important**: the API key needs to be available either through this parameter or `DATADOG_API_KEY` env var.
-- `--service` (default: `DD_SERVICE` env var) should be set as the name of the service you're uploading jUnit XML reports for.
 - `--tags` is a array of key value pairs of the shape `key:value`. This will set global tags applied to all spans.
   - The resulting dictionary will be merged with whatever is in the `DD_TAGS` environment variable. If a `key` appears both in `--tags` and `DD_TAGS`, whatever value is in `DD_TAGS` will take precedence.
 - `--env` (default: `DD_ENV` env var) is a string that represents the environment where you want your tests to appear in.
@@ -35,7 +33,7 @@ datadog-ci junit upload --service my-service --tags key1:value1 --tags key2:valu
 
 Additionally you might configure the `junit` command with environment variables:
 
-- `DATADOG_API_KEY`: API key used to authenticate the requests. **Important**: the API key needs to be available either through this env var or through `--api-key` parameter.
+- `DATADOG_API_KEY` (**required**): API key used to authenticate the requests.
 - `DD_ENV`: you may choose the environment you want your test results to appear in.
 - `DD_SERVICE`: if you haven't specified a service through `--service` you might do it with this env var.
 - `DD_TAGS`: set global tags applied to all spans. The format must be `key1:value1,key2:value2`.

--- a/src/commands/junit/__tests__/upload.test.ts
+++ b/src/commands/junit/__tests__/upload.test.ts
@@ -27,7 +27,7 @@ const createMockContext = () => {
 
 describe('upload', () => {
   describe('getApiHelper', () => {
-    test('should throw an error if API key and --apiKey are undefined', () => {
+    test('should throw an error if API key and --api-key are undefined', () => {
       process.env = {}
       const write = jest.fn()
       const command = new UploadJUnitXMLCommand()
@@ -35,7 +35,7 @@ describe('upload', () => {
 
       expect(command['getApiHelper'].bind(command)).toThrow('API key is missing')
       expect(write.mock.calls[0][0]).toEqual(
-        `Missing ${chalk.red.bold('DATADOG_API_KEY')} in your environment and --apiKey was not passed.\n`
+        `Missing ${chalk.red.bold('DATADOG_API_KEY')} in your environment and --api-key was not passed.\n`
       )
     })
   })

--- a/src/commands/junit/__tests__/upload.test.ts
+++ b/src/commands/junit/__tests__/upload.test.ts
@@ -1,5 +1,4 @@
 // tslint:disable: no-string-literal
-import chalk from 'chalk'
 import {Cli} from 'clipanion/lib/advanced'
 import os from 'os'
 
@@ -27,16 +26,14 @@ const createMockContext = () => {
 
 describe('upload', () => {
   describe('getApiHelper', () => {
-    test('should throw an error if API key and --api-key are undefined', () => {
+    test('should throw an error if API key is undefined', () => {
       process.env = {}
       const write = jest.fn()
       const command = new UploadJUnitXMLCommand()
       command.context = {stdout: {write}} as any
 
       expect(command['getApiHelper'].bind(command)).toThrow('API key is missing')
-      expect(write.mock.calls[0][0]).toEqual(
-        `Missing ${chalk.red.bold('DATADOG_API_KEY')} in your environment and --api-key was not passed.\n`
-      )
+      expect(write.mock.calls[0][0]).toContain('DATADOG_API_KEY')
     })
   })
   describe('getMatchingJUnitXMLFiles', () => {

--- a/src/commands/junit/__tests__/upload.test.ts
+++ b/src/commands/junit/__tests__/upload.test.ts
@@ -1,4 +1,5 @@
 // tslint:disable: no-string-literal
+import chalk from 'chalk'
 import {Cli} from 'clipanion/lib/advanced'
 import os from 'os'
 
@@ -26,14 +27,16 @@ const createMockContext = () => {
 
 describe('upload', () => {
   describe('getApiHelper', () => {
-    test('should throw an error if API key is undefined', () => {
+    test('should throw an error if API key and --apiKey are undefined', () => {
       process.env = {}
       const write = jest.fn()
       const command = new UploadJUnitXMLCommand()
       command.context = {stdout: {write}} as any
 
       expect(command['getApiHelper'].bind(command)).toThrow('API key is missing')
-      expect(write.mock.calls[0][0]).toContain('DATADOG_API_KEY')
+      expect(write.mock.calls[0][0]).toEqual(
+        `Missing ${chalk.red.bold('DATADOG_API_KEY')} in your environment and --apiKey was not passed.\n`
+      )
     })
   })
   describe('getMatchingJUnitXMLFiles', () => {

--- a/src/commands/junit/upload.ts
+++ b/src/commands/junit/upload.ts
@@ -44,6 +44,7 @@ export class UploadJUnitXMLCommand extends Command {
     ],
   })
 
+  private apiKey?: string
   private basePaths?: string[]
   private config = {
     apiKey: process.env.DATADOG_API_KEY,
@@ -51,6 +52,7 @@ export class UploadJUnitXMLCommand extends Command {
     envVarTags: process.env.DD_TAGS,
   }
   private dryRun = false
+  private env?: string
   private maxConcurrency = 20
   private service?: string
   private tags?: string[]
@@ -69,6 +71,13 @@ export class UploadJUnitXMLCommand extends Command {
       this.context.stderr.write('Missing basePath\n')
 
       return 1
+    }
+    if (!this.config.apiKey) {
+      this.config.apiKey = this.apiKey
+    }
+
+    if (!this.config.env) {
+      this.config.env = this.env
     }
 
     const api = this.getApiHelper()
@@ -90,7 +99,9 @@ export class UploadJUnitXMLCommand extends Command {
 
   private getApiHelper(): APIHelper {
     if (!this.config.apiKey) {
-      this.context.stdout.write(`Missing ${chalk.red.bold('DATADOG_API_KEY')} in your environment.\n`)
+      this.context.stdout.write(
+        `Missing ${chalk.red.bold('DATADOG_API_KEY')} in your environment and --apiKey was not passed.\n`
+      )
       throw new Error('API key is missing')
     }
 
@@ -175,6 +186,8 @@ export class UploadJUnitXMLCommand extends Command {
 }
 UploadJUnitXMLCommand.addPath('junit', 'upload')
 UploadJUnitXMLCommand.addOption('service', Command.String('--service'))
+UploadJUnitXMLCommand.addOption('env', Command.String('--env'))
+UploadJUnitXMLCommand.addOption('apiKey', Command.String('--apiKey'))
 UploadJUnitXMLCommand.addOption('dryRun', Command.Boolean('--dry-run'))
 UploadJUnitXMLCommand.addOption('tags', Command.Array('--tags'))
 UploadJUnitXMLCommand.addOption('basePaths', Command.Rest({required: 1}))

--- a/src/commands/junit/upload.ts
+++ b/src/commands/junit/upload.ts
@@ -44,7 +44,6 @@ export class UploadJUnitXMLCommand extends Command {
     ],
   })
 
-  private apiKey?: string
   private basePaths?: string[]
   private config = {
     apiKey: process.env.DATADOG_API_KEY,
@@ -72,9 +71,6 @@ export class UploadJUnitXMLCommand extends Command {
 
       return 1
     }
-    if (!this.config.apiKey) {
-      this.config.apiKey = this.apiKey
-    }
 
     if (!this.config.env) {
       this.config.env = this.env
@@ -99,9 +95,7 @@ export class UploadJUnitXMLCommand extends Command {
 
   private getApiHelper(): APIHelper {
     if (!this.config.apiKey) {
-      this.context.stdout.write(
-        `Missing ${chalk.red.bold('DATADOG_API_KEY')} in your environment and --api-key was not passed.\n`
-      )
+      this.context.stdout.write(`Missing ${chalk.red.bold('DATADOG_API_KEY')} in your environment.\n`)
       throw new Error('API key is missing')
     }
 
@@ -187,7 +181,6 @@ export class UploadJUnitXMLCommand extends Command {
 UploadJUnitXMLCommand.addPath('junit', 'upload')
 UploadJUnitXMLCommand.addOption('service', Command.String('--service'))
 UploadJUnitXMLCommand.addOption('env', Command.String('--env'))
-UploadJUnitXMLCommand.addOption('apiKey', Command.String('--api-key'))
 UploadJUnitXMLCommand.addOption('dryRun', Command.Boolean('--dry-run'))
 UploadJUnitXMLCommand.addOption('tags', Command.Array('--tags'))
 UploadJUnitXMLCommand.addOption('basePaths', Command.Rest({required: 1}))

--- a/src/commands/junit/upload.ts
+++ b/src/commands/junit/upload.ts
@@ -100,7 +100,7 @@ export class UploadJUnitXMLCommand extends Command {
   private getApiHelper(): APIHelper {
     if (!this.config.apiKey) {
       this.context.stdout.write(
-        `Missing ${chalk.red.bold('DATADOG_API_KEY')} in your environment and --apiKey was not passed.\n`
+        `Missing ${chalk.red.bold('DATADOG_API_KEY')} in your environment and --api-key was not passed.\n`
       )
       throw new Error('API key is missing')
     }
@@ -187,7 +187,7 @@ export class UploadJUnitXMLCommand extends Command {
 UploadJUnitXMLCommand.addPath('junit', 'upload')
 UploadJUnitXMLCommand.addOption('service', Command.String('--service'))
 UploadJUnitXMLCommand.addOption('env', Command.String('--env'))
-UploadJUnitXMLCommand.addOption('apiKey', Command.String('--apiKey'))
+UploadJUnitXMLCommand.addOption('apiKey', Command.String('--api-key'))
 UploadJUnitXMLCommand.addOption('dryRun', Command.Boolean('--dry-run'))
 UploadJUnitXMLCommand.addOption('tags', Command.Array('--tags'))
 UploadJUnitXMLCommand.addOption('basePaths', Command.Rest({required: 1}))


### PR DESCRIPTION
### What and why?

It seems weird that you can only configure the api key and env through environment variables. This PR changes this.

### How?

* Add `--apiKey` input to `junit`.
* Add `--env` input to `junit`.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)

