### PR TITLE
Sourcemaps Upload: use strip credentials on remote

### DIFF
--- a/src/commands/sourcemaps/git.ts
+++ b/src/commands/sourcemaps/git.ts
@@ -35,12 +35,12 @@ export const gitRemote = async (git: simpleGit.SimpleGit): Promise<string> => {
   for (const remote of remotes) {
     // We're trying to pick the remote called with the default git name 'origin'.
     if (remote.name === 'origin') {
-      return remote.refs.push
+      return stripCredentials(remote.refs.push)
     }
   }
 
   // Falling back to picking the first remote in the list if 'origin' is not found.
-  return remotes[0].refs.push
+  return stripCredentials(remotes[0].refs.push)
 }
 
 // StripCredentials removes credentials from a remote HTTP url.


### PR DESCRIPTION
### What and why?

The function `stripCredentials` which removes eventual HTTP auth credentials within URLs was not called.
It now is applied on the remote URL gathered.

### How?

A brief description of implementation details of this PR.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)

