### PR TITLE
[ci-app] Improve help for non-US1 use cases

### DIFF
--- a/src/commands/junit/upload.ts
+++ b/src/commands/junit/upload.ts
@@ -41,6 +41,10 @@ export class UploadJUnitXMLCommand extends Command {
         'Upload all jUnit XML test report files in current directory and add extra tags',
         'datadog-ci junit upload --service my-service --tags key1:value1 --tags key2:value2 .',
       ],
+      [
+        'Upload all jUnit XML test report files in current directory to the datadoghq.eu site',
+        'DATADOG_SITE=datadoghq.eu datadog-ci junit upload --service my-service --tags key1:value1 --tags key2:value2 .',
+      ],
     ],
   })
 

--- a/src/commands/junit/upload.ts
+++ b/src/commands/junit/upload.ts
@@ -43,7 +43,7 @@ export class UploadJUnitXMLCommand extends Command {
       ],
       [
         'Upload all jUnit XML test report files in current directory to the datadoghq.eu site',
-        'DATADOG_SITE=datadoghq.eu datadog-ci junit upload --service my-service --tags key1:value1 --tags key2:value2 .',
+        'DATADOG_SITE=datadoghq.eu datadog-ci junit upload --service my-service .',
       ],
     ],
   })


### PR DESCRIPTION
### What and why?

Using the junit command with a non-US1 endpoint isn't straightforward: the command will fail with a 403 error without any more context, and the CLI help doesn't mention anything about the DATADOG_SITE env var.

### How?

Added a new example that shows how to send data to EU1

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)

