### PR TITLE
[ci-app] Support `DD_SITE` and `DD_API_KEY`

### DIFF
--- a/src/commands/junit/README.md
+++ b/src/commands/junit/README.md
@@ -34,7 +34,7 @@ datadog-ci junit upload --service my-service --tags key1:value1 --tags key2:valu
 
 Additionally you might configure the `junit` command with environment variables:
 
-- `DATADOG_API_KEY` (**required**): API key used to authenticate the requests.
+- `DATADOG_API_KEY` or `DD_API_KEY` (**required**): API key used to authenticate the requests.
 - `DD_ENV`: you may choose the environment you want your test results to appear in.
 - `DD_SERVICE`: if you haven't specified a service through `--service` you might do it with this env var.
 - `DD_TAGS`: set global tags applied to all spans. The format must be `key1:value1,key2:value2`.

--- a/src/commands/junit/upload.ts
+++ b/src/commands/junit/upload.ts
@@ -50,7 +50,7 @@ export class UploadJUnitXMLCommand extends Command {
 
   private basePaths?: string[]
   private config = {
-    apiKey: process.env.DATADOG_API_KEY,
+    apiKey: process.env.DATADOG_API_KEY || process.env.DD_API_KEY,
     env: process.env.DD_ENV,
     envVarTags: process.env.DD_TAGS,
   }
@@ -99,7 +99,9 @@ export class UploadJUnitXMLCommand extends Command {
 
   private getApiHelper(): APIHelper {
     if (!this.config.apiKey) {
-      this.context.stdout.write(`Missing ${chalk.red.bold('DATADOG_API_KEY')} in your environment.\n`)
+      this.context.stdout.write(
+        `Neither ${chalk.red.bold('DATADOG_API_KEY')} nor ${chalk.red.bold('DD_API_KEY')} is in your environment.\n`
+      )
       throw new Error('API key is missing')
     }
 

--- a/src/commands/junit/utils.ts
+++ b/src/commands/junit/utils.ts
@@ -1,6 +1,6 @@
 export const getBaseIntakeUrl = () => {
-  if (process.env.DATADOG_SITE) {
-    return 'https://cireport-http-intake.logs.' + process.env.DATADOG_SITE
+  if (process.env.DATADOG_SITE || process.env.DD_SITE) {
+    return `https://cireport-http-intake.logs.${process.env.DATADOG_SITE || process.env.DD_SITE}`
   }
 
   return 'https://cireport-http-intake.logs.datadoghq.com'


### PR DESCRIPTION
### What and why?

It seems the env var used for referring to the datadog site is `DD_SITE` (at least more often than `DATADOG_SITE`, e.g. https://docs.datadoghq.com/getting_started/agent/#configuration).

Same can be said about `DD_API_KEY`.

This PR adds support for `DD_SITE` and `DD_API_KEY`
