### PR TITLE
[synthetics] Allow spaces between variable brackets

### DIFF
--- a/src/commands/synthetics/__tests__/utils.test.ts
+++ b/src/commands/synthetics/__tests__/utils.test.ts
@@ -202,7 +202,7 @@ describe('utils', () => {
         type: 'browser',
       } as Test
       const configOverride = {
-        startUrl: 'https://{{DOMAIN}}/newPath?oldPath={{PATHNAME}}{{HASH}}',
+        startUrl: 'https://{{DOMAIN}}/newPath?oldPath={{ PATHNAME   }}{{HASH}}',
       }
       const expectedUrl = 'https://example.org/newPath?oldPath=/path#target'
 

--- a/src/commands/synthetics/utils.ts
+++ b/src/commands/synthetics/utils.ts
@@ -34,9 +34,10 @@ import {Tunnel} from './tunnel'
 const POLLING_INTERVAL = 5000 // In ms
 const PUBLIC_ID_REGEX = /^[\d\w]{3}-[\d\w]{3}-[\d\w]{3}$/
 const SUBDOMAIN_REGEX = /(.*?)\.(?=[^\/]*\..{2,5})/
+const TEMPLATE_REGEX = /{{\s*([^{}]*?)\s*}}/g
 
 const template = (st: string, context: any): string =>
-  st.replace(/{{\s*([A-Z_]+)\s*}}/g, (match: string, p1: string) => (p1 in context ? context[p1] : match))
+  st.replace(TEMPLATE_REGEX, (match: string, p1: string) => (p1 in context ? context[p1] : match))
 
 export const handleConfig = (
   test: Test,

--- a/src/commands/synthetics/utils.ts
+++ b/src/commands/synthetics/utils.ts
@@ -36,7 +36,7 @@ const PUBLIC_ID_REGEX = /^[\d\w]{3}-[\d\w]{3}-[\d\w]{3}$/
 const SUBDOMAIN_REGEX = /(.*?)\.(?=[^\/]*\..{2,5})/
 
 const template = (st: string, context: any): string =>
-  st.replace(/{{([A-Z_]+)}}/g, (match: string, p1: string) => (p1 in context ? context[p1] : match))
+  st.replace(/{{\s*([A-Z_]+)\s*}}/g, (match: string, p1: string) => (p1 in context ? context[p1] : match))
 
 export const handleConfig = (
   test: Test,


### PR DESCRIPTION
### What and why?

Match tests variables definition rule to allow whitespace between variable name and brackets.

### How?

Update variable template regex.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)

