### PR TITLE
[synthetics] Add warning on reserved environment variable names

### DIFF
--- a/src/commands/synthetics/interfaces.ts
+++ b/src/commands/synthetics/interfaces.ts
@@ -211,8 +211,9 @@ interface BasicAuthCredentials {
   username: string
 }
 
-export interface TemplateContext extends NodeJS.ProcessEnv {
+export interface TemplateVariables {
   DOMAIN?: string
+  HASH?: string
   HOST?: string
   HOSTNAME?: string
   ORIGIN?: string
@@ -223,6 +224,8 @@ export interface TemplateContext extends NodeJS.ProcessEnv {
   SUBDOMAIN?: string
   URL: string
 }
+
+export interface TemplateContext extends TemplateVariables, NodeJS.ProcessEnv {}
 
 export interface TriggerConfig {
   config: ConfigOverride


### PR DESCRIPTION
### What and why?

Add a log to warn when reserved namespace for `startUrl` template variables are present in environment variables. 
This is to explicitly communicate the behavior of overriding them with parsed URL parts.

### How?

Log this message when reserved names are detected in environment variables:
```
Detected HASH, DOMAIN environment variables. HASH, DOMAIN are Datadog reserved variables used to parse your original test URL, read more about it on our documentation https://docs.datadoghq.com/synthetics/ci/?tab=apitest#start-url. If you want to override your startUrl parameter using environment variables, use different namespaces.
```

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)

