### PR TITLE
Global installation added to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ npm install --save-dev @datadog/datadog-ci
 yarn add --dev @datadog/datadog-ci
 ```
 
-If you need `datadog-ci` as a CLI tool instead of a package, you can run it with `npx` or install globally:
+If you need `datadog-ci` as a CLI tool instead of a package, you can run it with [`npx`](https://www.npmjs.com/package/npx) or install globally:
 
 ```sh
 # npx

--- a/README.md
+++ b/README.md
@@ -16,6 +16,18 @@ npm install --save-dev @datadog/datadog-ci
 yarn add --dev @datadog/datadog-ci
 ```
 
+If you need `datadog-ci` as a CLI tool instead of a package, you can run it with `npx` or install globally:
+
+```sh
+# npx
+npx @datadog/datadog-ci [command]
+
+# NPM install globally
+npm install -g @datadog/datadog-ci
+
+# Yarn add globally
+yarn global add @datadog/datadog-ci
+```
 ## Usage
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ npx @datadog/datadog-ci [command]
 # NPM install globally
 npm install -g @datadog/datadog-ci
 
-# Yarn add globally
+# Yarn v1 add globally
 yarn global add @datadog/datadog-ci
 ```
 ## Usage


### PR DESCRIPTION
### What and why?

Especially in the case of `dsyms upload`, our users won't have `package.json` or an NPM project.
They basically need `datadog-ci` as a CLI tool.

### How?

They can install `datadog-ci` globally via `npm` or `yarn`.
This can be obvious for JS devs but I think mentioning that in Readme can help iOS devs a lot.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)

