### PR TITLE
Honor lambda states (optional now, rolled out everywhere in September)

### DIFF
--- a/src/commands/lambda/__tests__/instrument.test.ts
+++ b/src/commands/lambda/__tests__/instrument.test.ts
@@ -235,6 +235,30 @@ describe('lambda', () => {
                                         `)
       })
 
+      test("aborts if a function is not in an Active state with LastUpdateStatus Successful", async () => {
+        ;(fs.readFile as any).mockImplementation((a: any, b: any, callback: any) => callback({code: 'ENOENT'}))
+        ;(Lambda as any).mockImplementation(() => makeMockLambda({
+          'arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world': {
+            FunctionArn: 'arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world',
+            Handler: 'index.handler',
+            Runtime: 'nodejs12.x',
+            State: 'Failed',
+            LastUpdateStatus: 'Unsuccessful'
+          }
+        }))
+
+        const cli = makeCli()
+        const context = createMockContext() as any
+        const code = await cli.run(['lambda', 'instrument', '--function', 'arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world', '--layerVersion', '10'], context)
+
+        const output = context.stdout.toString()
+        expect(code).toBe(1)
+        expect(output).toMatchInlineSnapshot(`
+                                                  "Couldn't fetch lambda functions. Error: Can't instrument arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world, as current State is Failed (must be "Active") and Last Update Status is Unsuccessful (must be "Successful")
+                                                  "
+                                        `)
+      })
+
       test('aborts early when extensionVersion and forwarder are set', async () => {
         ;(fs.readFile as any).mockImplementation((a: any, b: any, callback: any) => callback({code: 'ENOENT'}))
         ;(Lambda as any).mockImplementation(() => makeMockLambda({}))

--- a/src/commands/lambda/__tests__/instrument.test.ts
+++ b/src/commands/lambda/__tests__/instrument.test.ts
@@ -235,21 +235,33 @@ describe('lambda', () => {
                                         `)
       })
 
-      test("aborts if a function is not in an Active state with LastUpdateStatus Successful", async () => {
+      test('aborts if a function is not in an Active state with LastUpdateStatus Successful', async () => {
         ;(fs.readFile as any).mockImplementation((a: any, b: any, callback: any) => callback({code: 'ENOENT'}))
-        ;(Lambda as any).mockImplementation(() => makeMockLambda({
-          'arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world': {
-            FunctionArn: 'arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world',
-            Handler: 'index.handler',
-            Runtime: 'nodejs12.x',
-            State: 'Failed',
-            LastUpdateStatus: 'Unsuccessful'
-          }
-        }))
+        ;(Lambda as any).mockImplementation(() =>
+          makeMockLambda({
+            'arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world': {
+              FunctionArn: 'arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world',
+              Handler: 'index.handler',
+              LastUpdateStatus: 'Unsuccessful',
+              Runtime: 'nodejs12.x',
+              State: 'Failed',
+            },
+          })
+        )
 
         const cli = makeCli()
         const context = createMockContext() as any
-        const code = await cli.run(['lambda', 'instrument', '--function', 'arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world', '--layerVersion', '10'], context)
+        const code = await cli.run(
+          [
+            'lambda',
+            'instrument',
+            '--function',
+            'arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world',
+            '--layerVersion',
+            '10',
+          ],
+          context
+        )
 
         const output = context.stdout.toString()
         expect(code).toBe(1)

--- a/src/commands/lambda/__tests__/instrument.test.ts
+++ b/src/commands/lambda/__tests__/instrument.test.ts
@@ -254,7 +254,7 @@ describe('lambda', () => {
         const output = context.stdout.toString()
         expect(code).toBe(1)
         expect(output).toMatchInlineSnapshot(`
-                                                  "Couldn't fetch lambda functions. Error: Can't instrument arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world, as current State is Failed (must be "Active") and Last Update Status is Unsuccessful (must be "Successful")
+                                                  "Couldn't fetch lambda functions. Error: Can't instrument arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world, as current State is Failed (must be \\"Active\\") and Last Update Status is Unsuccessful (must be \\"Successful\\")
                                                   "
                                         `)
       })

--- a/src/commands/lambda/function.ts
+++ b/src/commands/lambda/function.ts
@@ -62,6 +62,7 @@ const checkLambdaState = async (
   functionArn: string,
   attempts = 0
 ): Promise<boolean> => {
+  // TODO remove 1 Oct 2021 https://aws.amazon.com/blogs/compute/tracking-the-state-of-lambda-functions/
   if (!config.State || !config.LastUpdateStatus) {
     return true
   }

--- a/src/commands/lambda/function.ts
+++ b/src/commands/lambda/function.ts
@@ -47,7 +47,7 @@ const MAX_LAMBDA_STATE_CHECKS = 3
  * @param ms
  * @returns
  */
-const wait = (ms: number): Promise<void> => new Promise((res) => setTimeout(res, ms));
+const wait = (ms: number): Promise<void> => new Promise((res) => setTimeout(res, ms))
 
 /**
  *
@@ -56,7 +56,12 @@ const wait = (ms: number): Promise<void> => new Promise((res) => setTimeout(res,
  * @param attempts
  * @returns bool
  */
-const checkLambdaState = async (lambda: Lambda, config: Lambda.FunctionConfiguration, functionArn: string, attempts: number = 0): Promise<Boolean> => {
+const checkLambdaState = async (
+  lambda: Lambda,
+  config: Lambda.FunctionConfiguration,
+  functionArn: string,
+  attempts = 0
+): Promise<boolean> => {
   if (!config.State || !config.LastUpdateStatus) {
     return true
   }
@@ -64,11 +69,14 @@ const checkLambdaState = async (lambda: Lambda, config: Lambda.FunctionConfigura
     return true
   }
   if (config.State === 'Pending' && attempts <= MAX_LAMBDA_STATE_CHECKS) {
-    await wait(2 ** attempts * 1000 )
+    await wait(2 ** attempts * 1000)
     const refetchedConfig = await getLambdaConfig(lambda, functionArn)
-    return checkLambdaState(lambda, refetchedConfig.config, functionArn, attempts += 1)
+
+    return checkLambdaState(lambda, refetchedConfig.config, functionArn, (attempts += 1))
   }
-  throw Error(`Can't instrument ${functionArn}, as current State is ${config.State} (must be "Active") and Last Update Status is ${config.LastUpdateStatus} (must be "Successful")`)
+  throw Error(
+    `Can't instrument ${functionArn}, as current State is ${config.State} (must be "Active") and Last Update Status is ${config.LastUpdateStatus} (must be "Successful")`
+  )
 }
 
 export const getLambdaConfigs = async (
@@ -83,7 +91,7 @@ export const getLambdaConfigs = async (
 
   const functionsToUpdate: FunctionConfiguration[] = []
 
-  for (let {config, functionARN} of results) {
+  for (const {config, functionARN} of results) {
     const runtime = config.Runtime
     if (!isSupportedRuntime(runtime)) {
       throw Error(`Can't instrument ${functionARN}, runtime ${runtime} not supported`)


### PR DESCRIPTION
- feat: Honor lambda state in instrument method
- feat: double escape quotes to pass snapshots

### What and why?

This PR verifies that the function can be updated, which according to this [post](https://aws.amazon.com/blogs/compute/coming-soon-expansion-of-aws-lambda-states-to-all-functions/) is when the `State` is `Active` and `LastUpdateStatus` is `Successful.

### How?

When we fetch the function configuration, this is attribute is returned. Because this command is likely ran in CI, immediately after updating a function, we will try 3 extra times if the first state is not valid, with exponential backoff between attempts.

I believe _all_ function configurations return `State` and `LastUpdateStatus`, but I've included a guard clause in cause. To be removed 1 Oct 2021, as per comment and schedule.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)

