### PR TITLE
[alpha][Synthetics] Tunnel: Improve connections timeout handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "glob": "7.1.4",
     "proxy-agent": "4.0.1",
     "simple-git": "2.31.0",
-    "ssh2": "1.1.0",
+    "ssh2": "1.3.0",
     "ssh2-streams": "0.4.10",
     "sshpk": "1.16.1",
     "tiny-async-pool": "1.2.0",

--- a/src/commands/synthetics/tunnel.ts
+++ b/src/commands/synthetics/tunnel.ts
@@ -32,7 +32,7 @@ export interface TunnelInfo {
 export class Tunnel {
   private connected = false
   private forwardedSockets: Set<Socket> = new Set()
-  private FORWARDING_TIMEOUT = 30000 as const
+  private FORWARDING_TIMEOUT = 40000 as const
   private log: (message: string) => void
   private logError: (message: string) => void
   private logWarning: (message: string) => void

--- a/src/commands/synthetics/tunnel.ts
+++ b/src/commands/synthetics/tunnel.ts
@@ -210,12 +210,10 @@ export class Tunnel {
           } else {
             if ('code' in error && error.code === 'ENOTFOUND') {
               this.logWarning(`Unable to resolve host (${destIP})`)
-              // SW-1340: Reject on DNS errors kill requests on the same SSH connection.
-              accept().destroy()
             } else {
               this.logWarning(`Connection error (${destIP}): ${error.code}`)
-              reject()
             }
+            reject()
 
             this.forwardedSockets.delete(dest)
             dest.end()

--- a/yarn.lock
+++ b/yarn.lock
@@ -3630,10 +3630,15 @@ multer@^1.4.2:
     type-is "^1.6.4"
     xtend "^4.0.0"
 
-nan@^2.12.1, nan@^2.14.1, nan@^2.14.2:
+nan@^2.12.1, nan@^2.14.1:
   version "2.14.2"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.2.tgz#f5376400695168f4cc694ac9393d0c9585eeea19"
   integrity sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==
+
+nan@^2.15.0:
+  version "2.15.0"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.15.0.tgz#3f34a473ff18e15c1b5626b62903b5ad6e665fee"
+  integrity sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ==
 
 natural-compare@^1.4.0:
   version "1.4.0"
@@ -4255,16 +4260,16 @@ ssh2-streams@0.4.10:
     bcrypt-pbkdf "^1.0.2"
     streamsearch "~0.1.2"
 
-ssh2@1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/ssh2/-/ssh2-1.1.0.tgz#43dd24930e15e317687f519d6b40270d9cd00d00"
-  integrity sha512-CidQLG2ZacoT0Z7O6dOyisj4JdrOrLVJ4KbHjVNz9yI1vO08FAYQPcnkXY9BP8zeYo+J/nBgY6Gg4R7w4WFWtg==
+ssh2@1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/ssh2/-/ssh2-1.3.0.tgz#bcd42ef7796250268b6ff6b0bbff2697029e91b9"
+  integrity sha512-OjBQ5FR+ClYav3fRnvkhycmd5co5qEfofBaZEqVO3I4tKJLZqu+Ku4LN4nJSckjhqQnomqBqlCdvD3iGV+6isA==
   dependencies:
     asn1 "^0.2.4"
     bcrypt-pbkdf "^1.0.2"
   optionalDependencies:
     cpu-features "0.0.2"
-    nan "^2.14.2"
+    nan "^2.15.0"
 
 sshpk@1.16.1:
   version "1.16.1"


### PR DESCRIPTION
### What and why?

Reduce remote server connections timeout and end associated tunneled connections when they occur to improve remote server timeouts handling.

### How?

- Upgrade `ssh2` to v1.3.0
- Reduce remote socket timeout to 30s
- Replace `pipe` with `pipeline` for packet forwarding and multiplexer
- Revert to rejecting forwarding on DNS errors

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)