### PR TITLE
Support proxy config from env var in sourcemaps upload.

### DIFF
--- a/src/commands/sourcemaps/upload.ts
+++ b/src/commands/sourcemaps/upload.ts
@@ -52,6 +52,7 @@ export class UploadCommand extends Command {
   private config = {
     apiKey: process.env.DATADOG_API_KEY,
     datadogSite: process.env.DATADOG_SITE || 'datadoghq.com',
+    httpsProxy: process.env.https_proxy || process.env.HTTPS_PROXY,
   }
   private disableGit?: boolean
   private dryRun = false
@@ -228,11 +229,15 @@ export class UploadCommand extends Command {
     return getRequestBuilder({
       apiKey: this.config.apiKey!,
       baseUrl: getBaseIntakeUrl(),
+      disableEnvironmentVariables: true,
       headers: new Map([
         ['DD-EVP-ORIGIN', 'datadog-ci sourcemaps'],
         ['DD-EVP-ORIGIN-VERSION', this.cliVersion],
       ]),
       overrideUrl: 'api/v2/srcmap',
+      proxyOpts: {
+        url: this.config.httpsProxy || undefined,
+      },
     })
   }
 

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -64,7 +64,8 @@ export interface ProxyConfiguration {
   }
   host?: string
   port?: number
-  protocol: ProxyType
+  protocol?: ProxyType
+  url?: string
 }
 
 export const getProxyUrl = (options: ProxyConfiguration) => {
@@ -105,9 +106,11 @@ export const getRequestBuilder = (options: RequestOptions) => {
       newArguments.url = overrideUrl
     }
 
-    if (proxyOpts && proxyOpts.host && proxyOpts.port) {
+    if (proxyOpts && proxyOpts.host && proxyOpts.port && proxyOpts.protocol) {
       const proxyUrl = getProxyUrl(proxyOpts)
       newArguments.httpsAgent = new ProxyAgent(proxyUrl)
+    } else if (proxyOpts && proxyOpts.url !== undefined) {
+      newArguments.httpsAgent = new ProxyAgent(proxyOpts.url!)
     }
 
     if (options.headers !== undefined) {


### PR DESCRIPTION
### What and why?

This PR:
- allow the possibility for commands to configure proxy through an URL instead of host/port/protocol
- allow proxy configuration in sourcemaps upload through `https_proxy` and `HTTPS_PROXY`.

Open questions:
- should we add support for proxy configuration through command-line flags?
- should we support `https_proxy` and `HTTPS_PROXY` by default for all commands?

Still left to do in this PR:
- support proxy in commits upload and dsyms upload commands

What's not addressed in this PR:
- proxy support for reported datadog metrics

### How?

A brief description of implementation details of this PR.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)

