### PR TITLE
Fixes support of proxies through HTTPS_PROXY env var.

### DIFF
--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -68,7 +68,7 @@ export interface ProxyConfiguration {
 }
 
 export const getProxyUrl = (options?: ProxyConfiguration): string => {
-  if (options === undefined) {
+  if (!options) {
     return ''
   }
 
@@ -110,7 +110,7 @@ export const getRequestBuilder = (options: RequestOptions) => {
     }
 
     const proxyAgent = getProxyAgent(proxyOpts, disableEnvironmentVariables)
-    if (proxyAgent !== undefined) {
+    if (proxyAgent) {
       newArguments.httpAgent = proxyAgent
       newArguments.httpsAgent = proxyAgent
     }
@@ -135,12 +135,12 @@ export const getRequestBuilder = (options: RequestOptions) => {
 }
 
 const getProxyAgent = (proxyOpts?: ProxyConfiguration, disableProxyFromEnvVar?: boolean) => {
-  const proxyUrl = getProxyUrl(proxyOpts)
-  if (disableProxyFromEnvVar && proxyUrl === '') {
+  const proxyUrlFromConfiguration = getProxyUrl(proxyOpts)
+  if (disableProxyFromEnvVar && proxyUrlFromConfiguration === '') {
     return
   }
 
-  return new ProxyAgent(proxyUrl)
+  return new ProxyAgent(proxyUrlFromConfiguration)
 }
 
 export const getApiHostForSite = (site: string) => {

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -67,7 +67,11 @@ export interface ProxyConfiguration {
   protocol: ProxyType
 }
 
-export const getProxyUrl = (options: ProxyConfiguration) => {
+export const getProxyUrl = (options?: ProxyConfiguration): string => {
+  if (options === undefined) {
+    return ''
+  }
+
   const {auth, host, port, protocol} = options
 
   if (!host || !port) {
@@ -105,9 +109,10 @@ export const getRequestBuilder = (options: RequestOptions) => {
       newArguments.url = overrideUrl
     }
 
-    if (proxyOpts && proxyOpts.host && proxyOpts.port) {
-      const proxyUrl = getProxyUrl(proxyOpts)
-      newArguments.httpsAgent = new ProxyAgent(proxyUrl)
+    const proxyAgent = getProxyAgent(proxyOpts, disableEnvironmentVariables)
+    if (proxyAgent !== undefined) {
+      newArguments.httpAgent = proxyAgent
+      newArguments.httpsAgent = proxyAgent
     }
 
     if (options.headers !== undefined) {
@@ -121,13 +126,21 @@ export const getRequestBuilder = (options: RequestOptions) => {
 
   const baseConfiguration: AxiosRequestConfig = {
     baseURL: baseUrl,
-  }
-
-  if (disableEnvironmentVariables) {
-    baseConfiguration.proxy = false
+    // Disabling proxy in Axios config as it's not working properly
+    // the passed httpAgent/httpsAgent are handling the proxy instead.
+    proxy: false,
   }
 
   return (args: AxiosRequestConfig) => axios.create(baseConfiguration)(overrideArgs(args))
+}
+
+const getProxyAgent = (proxyOpts?: ProxyConfiguration, disableProxyFromEnvVar?: boolean) => {
+  const proxyUrl = getProxyUrl(proxyOpts)
+  if (disableProxyFromEnvVar && proxyUrl === '') {
+    return
+  }
+
+  return new ProxyAgent(proxyUrl)
 }
 
 export const getApiHostForSite = (site: string) => {


### PR DESCRIPTION
### What and why?

With this change, proxy conf set by HTTPS_PROXY should be handled correctly for any call sent through getRequestBuilder(), unless support of env var is explicitly disabled in the options of getRequestBuilder.

In that sense, the semantic of the option disableEnvironmentVariables has slightly changed. Before this commit, `disableEnvironmentVariables:true` meant HTTPS_PROXY support was disabled, and `disableEnvironmentVariables:false` meant HTTPS_PROXY support was enabled but bugged.

Now the option disableEnvironmentVariables is still used to disable HTTPS_PROXY support, except that when HTTPS_PROXY support is enabled, it works as expected, leveraging the proxy-from-env library (through proxy-agent library).

### How?

We always set an httpsAgent and an httpAgent to proxy-agent's `ProxyAgent`.
The `new ProxyAgent(proxyUrl)` has the following effect:
- proxies request through `proxyUrl` if `proxyUrl` is defined
- proxies requests respecting the `HTTPS_PROXY/HTTP_PROXY/NO_PROXY` env vars if `proxyUrl` is undefined

**Note:** I didn't find a way to properly write end-to-end test for the behavior with env vars, without replicating `proxy-agent` unit test suite. I assumed that relying on `proxy-agent` to work correctly was enough, but as a result we don't have any end-to-end test of this behavior in the test suite.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)

