### PR TITLE
[alpha] `0.16.2`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci",
-  "version": "0.16.1-alpha",
+  "version": "0.16.2-alpha",
   "description": "Run datadog actions from the CI.",
   "main": "dist/index.js",
   "repository": "https://github.com/DataDog/datadog-ci",


### PR DESCRIPTION
### What and why?

Release `0.16.2-alpha`
- https://github.com/DataDog/datadog-ci/pull/336