### PR TITLE
[synthetics-command] display critical errors and timedout in summary

### DIFF
--- a/src/commands/synthetics/__tests__/run-test.test.ts
+++ b/src/commands/synthetics/__tests__/run-test.test.ts
@@ -24,7 +24,7 @@ describe('run-test', () => {
       const getTestsToTriggersMock = jest.spyOn(utils, 'getTestsToTrigger').mockReturnValue(
         Promise.resolve({
           overriddenTestsToTrigger: [],
-          summary: {passed: 0, failed: 0, skipped: 0, notFound: 0},
+          summary: {criticalErrors: 0, passed: 0, failed: 0, skipped: 0, notFound: 0, timedOut: 0},
           tests: [],
         })
       )
@@ -58,7 +58,7 @@ describe('run-test', () => {
       const getTestsToTriggersMock = jest.spyOn(utils, 'getTestsToTrigger').mockReturnValue(
         Promise.resolve({
           overriddenTestsToTrigger: [],
-          summary: {passed: 0, failed: 0, skipped: 0, notFound: 0},
+          summary: {criticalErrors: 0, passed: 0, failed: 0, skipped: 0, notFound: 0, timedOut: 0},
           tests: [],
         })
       )
@@ -90,7 +90,7 @@ describe('run-test', () => {
       const getTestsToTriggersMock = jest.spyOn(utils, 'getTestsToTrigger').mockReturnValue(
         Promise.resolve({
           overriddenTestsToTrigger: [],
-          summary: {passed: 0, failed: 0, skipped: 0, notFound: 0},
+          summary: {criticalErrors: 0, passed: 0, failed: 0, skipped: 0, notFound: 0, timedOut: 0},
           tests: [],
         })
       )
@@ -177,7 +177,7 @@ describe('run-test', () => {
       jest.spyOn(utils, 'getTestsToTrigger').mockReturnValue(
         Promise.resolve({
           overriddenTestsToTrigger: [],
-          summary: {passed: 0, failed: 0, skipped: 0, notFound: 0},
+          summary: {criticalErrors: 0, passed: 0, failed: 0, skipped: 0, notFound: 0, timedOut: 0},
           tests: [{options: {ci: {executionRule: ExecutionRule.BLOCKING}}, public_id: 'publicId'} as any],
         })
       )
@@ -209,7 +209,7 @@ describe('run-test', () => {
       jest.spyOn(utils, 'getTestsToTrigger').mockReturnValue(
         Promise.resolve({
           overriddenTestsToTrigger: [],
-          summary: {passed: 0, failed: 0, skipped: 0, notFound: 0},
+          summary: {criticalErrors: 0, passed: 0, failed: 0, skipped: 0, notFound: 0, timedOut: 0},
           tests: [{options: {ci: {executionRule: ExecutionRule.BLOCKING}}, public_id: 'publicId'} as any],
         })
       )
@@ -247,7 +247,7 @@ describe('run-test', () => {
       jest.spyOn(utils, 'getTestsToTrigger').mockReturnValue(
         Promise.resolve({
           overriddenTestsToTrigger: [],
-          summary: {passed: 0, failed: 0, skipped: 0, notFound: 0},
+          summary: {criticalErrors: 0, passed: 0, failed: 0, skipped: 0, notFound: 0, timedOut: 0},
           tests: [{options: {ci: {executionRule: ExecutionRule.BLOCKING}}, public_id: 'publicId'} as any],
         })
       )

--- a/src/commands/synthetics/__tests__/utils.test.ts
+++ b/src/commands/synthetics/__tests__/utils.test.ts
@@ -151,7 +151,7 @@ describe('utils', () => {
         {executionRule: ExecutionRule.BLOCKING, public_id: '123-456-789'},
         {executionRule: ExecutionRule.SKIPPED, public_id: 'ski-ppe-d01'},
       ])
-      
+
       expect(summary).toEqual({criticalErrors: 0, failed: 0, notFound: 1, passed: 0, skipped: 1, timedOut: 0})
     })
 

--- a/src/commands/synthetics/__tests__/utils.test.ts
+++ b/src/commands/synthetics/__tests__/utils.test.ts
@@ -151,7 +151,8 @@ describe('utils', () => {
         {executionRule: ExecutionRule.BLOCKING, public_id: '123-456-789'},
         {executionRule: ExecutionRule.SKIPPED, public_id: 'ski-ppe-d01'},
       ])
-      expect(summary).toEqual({passed: 0, failed: 0, skipped: 1, notFound: 1})
+      
+      expect(summary).toEqual({criticalErrors: 0, failed: 0, notFound: 1, passed: 0, skipped: 1, timedOut: 0})
     })
 
     test('no tests triggered throws an error', async () => {

--- a/src/commands/synthetics/interfaces.ts
+++ b/src/commands/synthetics/interfaces.ts
@@ -250,12 +250,12 @@ export interface Suite {
 }
 
 export interface Summary {
-  criticalErrors?: number
+  criticalErrors: number
   failed: number
   notFound: number
   passed: number
   skipped: number
-  timedOut?: number
+  timedOut: number
 }
 
 export interface TestSearchResult {

--- a/src/commands/synthetics/interfaces.ts
+++ b/src/commands/synthetics/interfaces.ts
@@ -250,10 +250,12 @@ export interface Suite {
 }
 
 export interface Summary {
+  criticalErrors?: number
   failed: number
   notFound: number
   passed: number
   skipped: number
+  timedOut?: number
 }
 
 export interface TestSearchResult {

--- a/src/commands/synthetics/reporters/default.ts
+++ b/src/commands/synthetics/reporters/default.ts
@@ -296,14 +296,20 @@ export class DefaultReporter implements Reporter {
     if (summary.notFound) {
       summaries.push(chalk.yellow(`${chalk.bold(summary.notFound)} not found`))
     }
+
+    const extraInfo = []
     if (summary.timedOut) {
-      summaries.push(chalk.yellow(`${chalk.bold(summary.timedOut)} timed out`))
+      extraInfo.push(chalk.yellow(`${chalk.bold(summary.timedOut)} timed out`))
     }
     if (summary.criticalErrors) {
-      summaries.push(chalk.red(`${chalk.bold(summary.criticalErrors)} critical errors`))
+      extraInfo.push(chalk.red(`${chalk.bold(summary.criticalErrors)} critical errors`))
     }
 
-    this.write(`${chalk.bold('Tests execution summary:')} ${summaries.join(', ')}\n`)
+    this.write(
+      `${chalk.bold('Tests execution summary:')} ${summaries.join(', ')}${
+        extraInfo.length ? ' (' + extraInfo.join(', ') + ')' : ''
+      }\n`
+    )
   }
 
   public testEnd(

--- a/src/commands/synthetics/reporters/default.ts
+++ b/src/commands/synthetics/reporters/default.ts
@@ -296,6 +296,12 @@ export class DefaultReporter implements Reporter {
     if (summary.notFound) {
       summaries.push(chalk.yellow(`${chalk.bold(summary.notFound)} not found`))
     }
+    if (summary.timedOut) {
+      summaries.push(chalk.yellow(`${chalk.bold(summary.timedOut)} timed out`))
+    }
+    if (summary.criticalErrors) {
+      summaries.push(chalk.red(`${chalk.bold(summary.criticalErrors)} critical errors`))
+    }
 
     this.write(`${chalk.bold('Tests execution summary:')} ${summaries.join(', ')}\n`)
   }

--- a/src/commands/synthetics/utils.ts
+++ b/src/commands/synthetics/utils.ts
@@ -424,7 +424,7 @@ export const getReporter = (reporters: Reporter[]): MainReporter => ({
 export const getTestsToTrigger = async (api: APIHelper, triggerConfigs: TriggerConfig[], reporter: MainReporter) => {
   const overriddenTestsToTrigger: TestPayload[] = []
   const errorMessages: string[] = []
-  const summary: Summary = {failed: 0, notFound: 0, passed: 0, skipped: 0}
+  const summary: Summary = {criticalErrors: 0, failed: 0, notFound: 0, passed: 0, skipped: 0, timedOut: 0}
 
   const tests = await Promise.all(
     triggerConfigs.map(async ({config, id}) => {

--- a/src/commands/synthetics/utils.ts
+++ b/src/commands/synthetics/utils.ts
@@ -169,12 +169,10 @@ export const getStrictestExecutionRule = (configRule: ExecutionRule, testRule?: 
   return ExecutionRule.BLOCKING
 }
 
-export const hasResultPassed = (result: Result, failOnCriticalErrors: boolean, failOnTimeout: boolean): boolean => {
-  if (result.unhealthy && !failOnCriticalErrors) {
-    return true
-  }
+export const isCriticalError = (result: Result): boolean => result.unhealthy || result.error === 'Endpoint Failure'
 
-  if (result.error === 'Endpoint Failure' && !failOnCriticalErrors) {
+export const hasResultPassed = (result: Result, failOnCriticalErrors: boolean, failOnTimeout: boolean): boolean => {
+  if (isCriticalError(result) && !failOnCriticalErrors) {
     return true
   }
 


### PR DESCRIPTION
### What and why?

- Display critical errors and timedout in summary to improve readability



