### PR TITLE
[Synthetics] Use `result.failure` field, Fix run errors reporting

### DIFF
--- a/src/commands/synthetics/interfaces.ts
+++ b/src/commands/synthetics/interfaces.ts
@@ -40,6 +40,10 @@ export interface Result {
   errorCode?: string
   errorMessage?: string
   eventType: string
+  failure?: {
+    code: string
+    message: string
+  }
   passed: boolean
   stepDetails: Step[]
   timings?: Timings

--- a/src/commands/synthetics/reporters/default.ts
+++ b/src/commands/synthetics/reporters/default.ts
@@ -112,8 +112,8 @@ const renderResultOutcome = (
   }
 
   if (result.unhealthy) {
-    const errorName =
-      result.errorMessage && result.errorMessage !== 'Unknown error' ? result.errorMessage : 'General Error'
+    const errorMessage = result.failure ? result.failure.message : result.errorMessage
+    const errorName = errorMessage && errorMessage !== 'Unknown error' ? errorMessage : 'General Error'
 
     return [
       `    ${chalk.yellow(` ${ICONS.SKIPPED} | ${errorName}`)}`,
@@ -124,11 +124,11 @@ const renderResultOutcome = (
   if (test.type === 'api') {
     const requestDescription = renderApiRequestDescription(test.subtype, test.config)
 
-    if (result.errorCode && result.errorMessage) {
-      return [
-        `    ${icon} ${color(requestDescription)}`,
-        renderApiError(result.errorCode!, result.errorMessage!, color),
-      ].join('\n')
+    if (result.failure || (result.errorCode && result.errorMessage)) {
+      const errorCode = result.failure ? result.failure.code : result.errorCode
+      const errorMessage = result.failure ? result.failure.message : result.errorMessage
+
+      return [`    ${icon} ${color(requestDescription)}`, renderApiError(errorCode!, errorMessage!, color)].join('\n')
     }
 
     return `    ${icon} ${color(requestDescription)}`

--- a/src/commands/synthetics/reporters/default.ts
+++ b/src/commands/synthetics/reporters/default.ts
@@ -107,7 +107,8 @@ const renderResultOutcome = (
   failOnCriticalErrors: boolean,
   failOnTimeout: boolean
 ) => {
-  if (result.error) {
+  // Only display critical errors if failure is not filled.
+  if (result.error && !(result.failure || result.errorMessage)) {
     return `    ${chalk.bold(`${ICONS.FAILED} | ${result.error}`)}`
   }
 


### PR DESCRIPTION
### What and why?

- Fix assertion failure and unhealthy runs render
- Update result rendering to support `failure` field in results, or fallback to deprecated `errorMessage` and `errorCode`

### How?

Only render `result.error` if `result.failure` and `result.errorMessage` are not defined.
Read errors from `result.failure` before falling back to `result.errorMessage`

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)

