### PR TITLE
Fix datadog-ci not working with configuration file

### DIFF
--- a/src/commands/lambda/__tests__/instrument.test.ts
+++ b/src/commands/lambda/__tests__/instrument.test.ts
@@ -220,18 +220,7 @@ describe('lambda', () => {
       })
 
       test('aborts early when no functions are specified while using config file', async () => {
-        ;(fs.readFile as any).mockImplementation((a: any, b: any, callback: any) =>
-          callback(
-            JSON.stringify({
-              lambda: {
-                extensionVersion: '10',
-                functions: [],
-                layerVersion: '60',
-                region: 'ap-southeast-1',
-              },
-            })
-          )
-        )
+        ;(fs.readFile as any).mockImplementation((a: any, b: any, callback: any) => callback({}))
 
         process.env = {}
         const command = createCommand()
@@ -325,6 +314,20 @@ describe('lambda', () => {
           "\\"extensionVersion\\" and \\"forwarder\\" should not be used at the same time.
           "
         `)
+      })
+
+      test('check if functions are not empty while using config file', async () => {
+        ;(fs.readFile as any).mockImplementation((a: any, b: any, callback: any) => callback({}))
+
+        process.env = {}
+        const command = createCommand()
+        command['configPath'] = 'someConfigPath.json'
+        command['config']['layerVersion'] = '60'
+        command['config']['extensionVersion'] = '10'
+        command['config']['region'] = 'ap-southeast-1'
+        command['config']['functions'] = ['arn:aws:lambda:ap-southeast-1:123456789012:function:lambda-hello-world']
+        await command['execute']()
+        expect(command['config']['functions']).toHaveLength(1)
       })
     })
 

--- a/src/commands/lambda/__tests__/instrument.test.ts
+++ b/src/commands/lambda/__tests__/instrument.test.ts
@@ -220,10 +220,26 @@ describe('lambda', () => {
       })
 
       test('aborts early when no functions are specified while using config file', async () => {
+        ;(fs.readFile as any).mockImplementation((a: any, b: any, callback: any) =>
+          callback(
+            JSON.stringify({
+              lambda: {
+                extensionVersion: '10',
+                functions: [],
+                layerVersion: '60',
+                region: 'ap-southeast-1',
+              },
+            })
+          )
+        )
+
         process.env = {}
         const command = createCommand()
         command['configPath'] = path.join(__dirname, './mock-configs/no-functions.json')
-        command['execute']()
+        command['config']['layerVersion'] = '60'
+        command['config']['extensionVersion'] = '10'
+        command['config']['region'] = 'ap-southeast-1'
+        await command['execute']()
         const output = command.context.stdout.toString()
         expect(output).toMatchInlineSnapshot(`
                                                             "No functions specified for instrumentation.

--- a/src/commands/lambda/__tests__/instrument.test.ts
+++ b/src/commands/lambda/__tests__/instrument.test.ts
@@ -219,6 +219,18 @@ describe('lambda', () => {
                                                 `)
       })
 
+      test('aborts early when no functions are specified while using config file', async () => {
+        process.env = {}
+        const command = createCommand()
+        command['configPath'] = path.join(__dirname, './mock-configs/no-functions.json')
+        command['execute']()
+        const output = command.context.stdout.toString()
+        expect(output).toMatchInlineSnapshot(`
+                                                            "No functions specified for instrumentation.
+                                                            "
+                                                `)
+      })
+
       test("aborts early when function regions can't be found", async () => {
         ;(fs.readFile as any).mockImplementation((a: any, b: any, callback: any) => callback({code: 'ENOENT'}))
         ;(Lambda as any).mockImplementation(() => makeMockLambda({}))

--- a/src/commands/lambda/__tests__/instrument.test.ts
+++ b/src/commands/lambda/__tests__/instrument.test.ts
@@ -235,7 +235,7 @@ describe('lambda', () => {
 
         process.env = {}
         const command = createCommand()
-        command['configPath'] = path.join(__dirname, './mock-configs/no-functions.json')
+        command['configPath'] = 'someConfigPath.json'
         command['config']['layerVersion'] = '60'
         command['config']['extensionVersion'] = '10'
         command['config']['region'] = 'ap-southeast-1'

--- a/src/commands/lambda/__tests__/mock-configs/no-functions.json
+++ b/src/commands/lambda/__tests__/mock-configs/no-functions.json
@@ -1,8 +1,8 @@
 {
-    "lambda": {
-        "layerVersion": 60,
-        "extensionVersion": 10,
-        "functions": [],
-        "region": "ap-southeast-1"
-    }
+  "lambda": {
+    "layerVersion": 60,
+    "extensionVersion": 10,
+    "functions": [],
+    "region": "ap-southeast-1"
+  }
 }

--- a/src/commands/lambda/__tests__/mock-configs/no-functions.json
+++ b/src/commands/lambda/__tests__/mock-configs/no-functions.json
@@ -1,0 +1,8 @@
+{
+    "lambda": {
+        "layerVersion": 60,
+        "extensionVersion": 10,
+        "functions": [],
+        "region": "ap-southeast-1"
+    }
+}

--- a/src/commands/lambda/__tests__/mock-configs/no-functions.json
+++ b/src/commands/lambda/__tests__/mock-configs/no-functions.json
@@ -1,8 +1,0 @@
-{
-  "lambda": {
-    "layerVersion": 60,
-    "extensionVersion": 10,
-    "functions": [],
-    "region": "ap-southeast-1"
-  }
-}

--- a/src/commands/lambda/instrument.ts
+++ b/src/commands/lambda/instrument.ts
@@ -26,17 +26,18 @@ export class InstrumentCommand extends Command {
   public async execute() {
     const lambdaConfig = {lambda: this.config}
     this.config = (await parseConfigFile(lambdaConfig, this.configPath)).lambda
-
     const settings = this.getSettings()
     if (settings === undefined) {
       return 1
     }
 
-    if (this.functions.length === 0) {
+    const functions = this.configPath ? this.config.functions : this.functions
+    if (functions.length === 0) {
       this.context.stdout.write('No functions specified for instrumentation.\n')
 
       return 1
     }
+    
     const functionGroups = this.collectFunctionsByRegion()
     if (functionGroups === undefined) {
       return 1

--- a/src/commands/lambda/instrument.ts
+++ b/src/commands/lambda/instrument.ts
@@ -37,7 +37,7 @@ export class InstrumentCommand extends Command {
 
       return 1
     }
-    
+
     const functionGroups = this.collectFunctionsByRegion()
     if (functionGroups === undefined) {
       return 1


### PR DESCRIPTION
### What and why?

CLI not working with the following configuration file.
```
{
    "lambda": {
        "layerVersion": 60,
        "extensionVersion": 10,
        "functions": ["arn:aws:lambda:ap-southeast-1:601427279990:function:tian-test-ci-extension"],
        "region": "ap-southeast-1"
    }
}
```
There was a condition that checked if the functions array was empty, but if you specified a config file, it won't bother to check the config functions array.

### How?

Adding a ternary conditional to specify the functions array.

### Review checklist

- [x] Created unit test that mocks a case where config file is used but no functions are provided

