### PR TITLE
[synthetics-command] Add DATADOG_LOCATIONS env variable to override locations

### DIFF
--- a/src/commands/synthetics/README.md
+++ b/src/commands/synthetics/README.md
@@ -25,7 +25,7 @@ If the org uses a custom sub-domain to access Datadog app, it needs to be set in
 export DATADOG_SUBDOMAIN="myorg"
 ```
 
-You can use the `DATADOG_SYNTHETICS_LOCATIONS` to override the locations where your tests run. Locations should be separated with `;`. Note that the configuration of the test will always the precedent over others overrides.  
+You can use the `DATADOG_SYNTHETICS_LOCATIONS` to override the locations where your tests run. Locations should be separated with `;`. Note that the configuration in test files takes precedence over others overrides.  
 
 ```bash
 export DATADOG_SYNTHETICS_LOCATIONS="aws:us-east-1;aws:us-east-2"

--- a/src/commands/synthetics/README.md
+++ b/src/commands/synthetics/README.md
@@ -25,6 +25,12 @@ If the org uses a custom sub-domain to access Datadog app, it needs to be set in
 export DATADOG_SUBDOMAIN="myorg"
 ```
 
+You can use the `DATADOG_SYNTHETICS_LOCATIONS` to override the locations where your tests run. Locations should be separated with `;`.
+
+```bash
+export DATADOG_SYNTHETICS_LOCATIONS="aws:us-east-1;aws:us-east-2"
+```
+
 ### API
 
 By default it runs at the root of the working directory and finds `{,!(node_modules)/**/}*.synthetics.json` files (every files ending with `.synthetics.json` except those in the `node_modules` folder).

--- a/src/commands/synthetics/README.md
+++ b/src/commands/synthetics/README.md
@@ -25,7 +25,7 @@ If the org uses a custom sub-domain to access Datadog app, it needs to be set in
 export DATADOG_SUBDOMAIN="myorg"
 ```
 
-You can use the `DATADOG_SYNTHETICS_LOCATIONS` to override the locations where your tests run. Locations should be separated with `;`.
+You can use the `DATADOG_SYNTHETICS_LOCATIONS` to override the locations where your tests run. Locations should be separated with `;`. Note that the configuration of the test will always the precedent over others overrides.  
 
 ```bash
 export DATADOG_SYNTHETICS_LOCATIONS="aws:us-east-1;aws:us-east-2"

--- a/src/commands/synthetics/__tests__/run-test.test.ts
+++ b/src/commands/synthetics/__tests__/run-test.test.ts
@@ -293,8 +293,8 @@ describe('run-test', () => {
           tests: [{options: {ci: {executionRule: ExecutionRule.BLOCKING}}, public_id: 'publicId'} as any],
         })
       )
-      
-      // throw to stop the test
+
+      // Throw to stop the test
       const serverError = new Error('Server Error') as AxiosError
       serverError.response = {data: {errors: ['Bad Gateway']}, status: 502} as AxiosResponse
       serverError.config = {baseURL: 'baseURL', url: 'url'}
@@ -314,7 +314,7 @@ describe('run-test', () => {
 
       expect(await command.execute()).toBe(0)
       expect(triggerTests).toHaveBeenCalledWith(
-        expect.objectContaining({tests: [{executionRule: 'blocking', locations: [], public_id: 'publicId'}]})
+        expect.objectContaining({tests: [{executionRule: 'blocking', locations: ['edge.us1.prod.dog'], public_id: 'publicId'}]})
       )
 
       process.env = {
@@ -563,6 +563,7 @@ describe('run-test', () => {
         failOnTimeout: false,
         files: ['my-new-file'],
         global: {locations: []},
+        locations: [],
         pollingTimeout: 1,
         proxy: {protocol: 'https'},
         publicIds: ['ran-dom-id'],

--- a/src/commands/synthetics/__tests__/run-test.test.ts
+++ b/src/commands/synthetics/__tests__/run-test.test.ts
@@ -316,7 +316,7 @@ describe('run-test', () => {
         })
       )
 
-      // env > global
+      // Env > global
       process.env = {
         DATADOG_SYNTHETICS_LOCATIONS: 'aws:us-east-3',
       }
@@ -341,7 +341,7 @@ describe('run-test', () => {
         })
       )
 
-      // test > env
+      // Test > env
       const confWithLocation = {
         tests: [{config: {locations: ['aws:us-east-1']}, id: 'publicId'}],
       }

--- a/src/commands/synthetics/__tests__/run-test.test.ts
+++ b/src/commands/synthetics/__tests__/run-test.test.ts
@@ -287,7 +287,7 @@ describe('run-test', () => {
       jest.spyOn(utils, 'getTestsToTrigger').mockReturnValue(
         Promise.resolve({
           overriddenTestsToTrigger: [
-            {public_id: 'publicId', executionRule: ExecutionRule.BLOCKING, locations: ['edge.us1.prod.dog']},
+            {public_id: 'publicId', executionRule: ExecutionRule.BLOCKING, locations: ['aws:us-east-1']},
           ],
           summary: {criticalErrors: 0, passed: 0, failed: 0, skipped: 0, notFound: 0, timedOut: 0},
           tests: [{options: {ci: {executionRule: ExecutionRule.BLOCKING}}, public_id: 'publicId'} as any],
@@ -314,32 +314,32 @@ describe('run-test', () => {
 
       expect(await command.execute()).toBe(0)
       expect(triggerTests).toHaveBeenCalledWith(
-        expect.objectContaining({tests: [{executionRule: 'blocking', locations: ['edge.us1.prod.dog'], public_id: 'publicId'}]})
+        expect.objectContaining({
+          tests: [{executionRule: 'blocking', locations: ['aws:us-east-1'], public_id: 'publicId'}],
+        })
       )
 
       process.env = {
-        DATADOG_LOCATIONS: 'edge.us2.prod.dog',
+        DATADOG_SYNTHETICS_LOCATIONS: 'aws:us-east-2',
       }
       expect(await command.execute()).toBe(0)
       expect(triggerTests).toHaveBeenCalledTimes(2)
       expect(triggerTests).toHaveBeenNthCalledWith(
         2,
         expect.objectContaining({
-          tests: [{executionRule: 'blocking', locations: ['edge.us2.prod.dog'], public_id: 'publicId'}],
+          tests: [{executionRule: 'blocking', locations: ['aws:us-east-2'], public_id: 'publicId'}],
         })
       )
 
       process.env = {
-        DATADOG_LOCATIONS: 'edge.us2.prod.dog;edge.us3.prod.dog',
+        DATADOG_SYNTHETICS_LOCATIONS: 'aws:us-east-2;aws:us-east-3',
       }
       expect(await command.execute()).toBe(0)
       expect(triggerTests).toHaveBeenCalledTimes(3)
       expect(triggerTests).toHaveBeenNthCalledWith(
         3,
         expect.objectContaining({
-          tests: [
-            {executionRule: 'blocking', locations: ['edge.us2.prod.dog', 'edge.us3.prod.dog'], public_id: 'publicId'},
-          ],
+          tests: [{executionRule: 'blocking', locations: ['aws:us-east-2', 'aws:us-east-3'], public_id: 'publicId'}],
         })
       )
     })

--- a/src/commands/synthetics/__tests__/run-test.test.ts
+++ b/src/commands/synthetics/__tests__/run-test.test.ts
@@ -299,8 +299,8 @@ describe('run-test', () => {
       })
 
       const apiHelper = {
-        triggerTests,
         getTest: jest.fn(() => ({...getApiTest('publicId')})),
+        triggerTests,
       }
 
       const write = jest.fn()

--- a/src/commands/synthetics/interfaces.ts
+++ b/src/commands/synthetics/interfaces.ts
@@ -292,8 +292,8 @@ export interface CommandConfig {
   failOnCriticalErrors: boolean
   failOnTimeout: boolean
   files: string[]
-  locations: string[]
   global: ConfigOverride
+  locations: string[]
   pollingTimeout: number
   proxy: ProxyConfiguration
   publicIds: string[]

--- a/src/commands/synthetics/interfaces.ts
+++ b/src/commands/synthetics/interfaces.ts
@@ -292,6 +292,7 @@ export interface CommandConfig {
   failOnCriticalErrors: boolean
   failOnTimeout: boolean
   files: string[]
+  locations: string[]
   global: ConfigOverride
   pollingTimeout: number
   proxy: ProxyConfiguration

--- a/src/commands/synthetics/run-test.ts
+++ b/src/commands/synthetics/run-test.ts
@@ -355,7 +355,7 @@ export class RunTestCommand extends Command {
         apiKey: process.env.DATADOG_API_KEY,
         appKey: process.env.DATADOG_APP_KEY,
         datadogSite: process.env.DATADOG_SITE,
-        locations: process.env.DATADOG_LOCATIONS?.split(';'),
+        locations: process.env.DATADOG_SYNTHETICS_LOCATIONS?.split(';'),
         subdomain: process.env.DATADOG_SUBDOMAIN,
       })
     )

--- a/src/commands/synthetics/run-test.ts
+++ b/src/commands/synthetics/run-test.ts
@@ -322,13 +322,14 @@ export class RunTestCommand extends Command {
       .map((suite) => suite.tests)
       .filter((suiteTests) => !!suiteTests)
 
+    const configFromEnvironment = this.config.locations?.length ? {locations: this.config.locations} : {}
     const testsToTrigger = suites
       .reduce((acc, suiteTests) => acc.concat(suiteTests), [])
       .map((test) => ({
         config: {
           ...this.config.global,
           ...test.config,
-          ...(this.config.locations?.length ? {locations: this.config.locations} : {}),
+          ...configFromEnvironment,
         },
         id: test.id,
       }))

--- a/src/commands/synthetics/run-test.ts
+++ b/src/commands/synthetics/run-test.ts
@@ -124,12 +124,8 @@ export class RunTestCommand extends Command {
 
       return safeExit(1)
     }
+
     const {tests, overriddenTestsToTrigger, summary} = testsToTriggerResult
-    if (this.config.locations.length) {
-      overriddenTestsToTrigger.forEach((overriddenTestToTrigger) => {
-        overriddenTestToTrigger.locations = this.config.locations
-      })
-    }
 
     // All tests have been skipped or are missing.
     if (!tests.length) {
@@ -329,7 +325,11 @@ export class RunTestCommand extends Command {
     const testsToTrigger = suites
       .reduce((acc, suiteTests) => acc.concat(suiteTests), [])
       .map((test) => ({
-        config: {...this.config.global, ...test.config},
+        config: {
+          ...this.config.global,
+          ...test.config,
+          ...(this.config.locations?.length ? {locations: this.config.locations} : {}),
+        },
         id: test.id,
       }))
 

--- a/src/commands/synthetics/run-test.ts
+++ b/src/commands/synthetics/run-test.ts
@@ -37,8 +37,8 @@ export const DEFAULT_COMMAND_CONFIG: CommandConfig = {
   failOnCriticalErrors: false,
   failOnTimeout: true,
   files: ['{,!(node_modules)/**/}*.synthetics.json'],
-  locations: [],
   global: {},
+  locations: [],
   pollingTimeout: 2 * 60 * 1000,
   proxy: {protocol: 'http'},
   publicIds: [],
@@ -125,7 +125,7 @@ export class RunTestCommand extends Command {
       return safeExit(1)
     }
     const {tests, overriddenTestsToTrigger, summary} = testsToTriggerResult
-    if (this.config.locations) {
+    if (this.config.locations.length) {
       overriddenTestsToTrigger.forEach((overriddenTestToTrigger) => {
         overriddenTestToTrigger.locations = this.config.locations
       })

--- a/src/commands/synthetics/run-test.ts
+++ b/src/commands/synthetics/run-test.ts
@@ -328,8 +328,8 @@ export class RunTestCommand extends Command {
       .map((test) => ({
         config: {
           ...this.config.global,
-          ...test.config,
           ...configFromEnvironment,
+          ...test.config,
         },
         id: test.id,
       }))

--- a/src/commands/synthetics/run-test.ts
+++ b/src/commands/synthetics/run-test.ts
@@ -37,6 +37,7 @@ export const DEFAULT_COMMAND_CONFIG: CommandConfig = {
   failOnCriticalErrors: false,
   failOnTimeout: true,
   files: ['{,!(node_modules)/**/}*.synthetics.json'],
+  locations: [],
   global: {},
   pollingTimeout: 2 * 60 * 1000,
   proxy: {protocol: 'http'},
@@ -124,6 +125,11 @@ export class RunTestCommand extends Command {
       return safeExit(1)
     }
     const {tests, overriddenTestsToTrigger, summary} = testsToTriggerResult
+    if (this.config.locations) {
+      overriddenTestsToTrigger.forEach((overriddenTestToTrigger) => {
+        overriddenTestToTrigger.locations = this.config.locations
+      })
+    }
 
     // All tests have been skipped or are missing.
     if (!tests.length) {
@@ -349,6 +355,7 @@ export class RunTestCommand extends Command {
         apiKey: process.env.DATADOG_API_KEY,
         appKey: process.env.DATADOG_APP_KEY,
         datadogSite: process.env.DATADOG_SITE,
+        locations: process.env.DATADOG_LOCATIONS?.split(';'),
         subdomain: process.env.DATADOG_SUBDOMAIN,
       })
     )


### PR DESCRIPTION


### What and why?

This feature was requested by front-end teams to spread tests over DCs 

### How?

- Add `DATADOG_LOCATIONS` env variable (not SYNTHETICS_LOCATIONS because it is not consistent with the rest)

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)

