### PR TITLE
Datadog CLI sets default for unified service tagging

### DIFF
--- a/src/commands/lambda/__tests__/function.test.ts
+++ b/src/commands/lambda/__tests__/function.test.ts
@@ -2,13 +2,16 @@ jest.mock('../loggroup')
 
 import {Lambda} from 'aws-sdk'
 import {
+  ENVIRONMENT_ENV_VAR,
   FLUSH_TO_LOG_ENV_VAR,
   GOVCLOUD_LAYER_AWS_ACCOUNT,
   LAMBDA_HANDLER_ENV_VAR,
   LOG_LEVEL_ENV_VAR,
   MERGE_XRAY_TRACES_ENV_VAR,
+  SERVICE_ENV_VAR,
   SITE_ENV_VAR,
   TRACE_ENABLED_ENV_VAR,
+  VERSION_ENV_VAR,
 } from '../constants'
 import {calculateUpdateRequest, getExtensionArn, getLambdaConfigs, getLayerArn, updateLambdaConfigs} from '../function'
 import * as loggroup from '../loggroup'
@@ -45,11 +48,14 @@ describe('function', () => {
       })
       const cloudWatch = makeMockCloudWatchLogs()
       const settings = {
+        environment: 'staging',
         flushMetricsToLogs: false,
         layerVersion: 22,
         logLevel: 'debug',
         mergeXrayTraces: false,
+        service: 'middletier',
         tracingEnabled: false,
+        version: '0.2',
       }
       const result = await getLambdaConfigs(
         lambda as any,
@@ -63,12 +69,15 @@ describe('function', () => {
         Object {
           "Environment": Object {
             "Variables": Object {
+              "DD_ENV": "staging",
               "DD_FLUSH_TO_LOG": "false",
               "DD_LAMBDA_HANDLER": "index.handler",
               "DD_LOG_LEVEL": "debug",
               "DD_MERGE_XRAY_TRACES": "false",
+              "DD_SERVICE": "middletier",
               "DD_SITE": "datadoghq.com",
               "DD_TRACE_ENABLED": "false",
+              "DD_VERSION": "0.2",
             },
           },
           "FunctionName": "arn:aws:lambda:us-east-1:000000000000:function:autoinstrument",
@@ -91,6 +100,9 @@ describe('function', () => {
               [MERGE_XRAY_TRACES_ENV_VAR]: 'false',
               [SITE_ENV_VAR]: 'datadoghq.com',
               [TRACE_ENABLED_ENV_VAR]: 'false',
+              [SERVICE_ENV_VAR]: 'middletier',
+              [ENVIRONMENT_ENV_VAR]: 'staging',
+              [VERSION_ENV_VAR]: '0.2',
             },
           },
           FunctionArn: 'arn:aws:lambda:us-east-1:000000000000:function:autoinstrument',
@@ -102,11 +114,14 @@ describe('function', () => {
       const cloudWatch = makeMockCloudWatchLogs()
 
       const settings = {
+        environment: 'staging',
         flushMetricsToLogs: false,
         layerVersion: 22,
         logLevel: 'debug',
         mergeXrayTraces: false,
+        service: 'middletier',
         tracingEnabled: false,
+        version: '0.2',
       }
       const result = await getLambdaConfigs(
         lambda as any,

--- a/src/commands/lambda/__tests__/instrument.test.ts
+++ b/src/commands/lambda/__tests__/instrument.test.ts
@@ -105,13 +105,13 @@ describe('lambda', () => {
               \\"Variables\\": {
                 \\"DD_LAMBDA_HANDLER\\": \\"index.handler\\",
                 \\"DD_SITE\\": \\"datadoghq.com\\",
-                \\"DD_TRACE_ENABLED\\": \\"true\\",
-                \\"DD_MERGE_XRAY_TRACES\\": \\"false\\",
-                \\"DD_FLUSH_TO_LOG\\": \\"true\\",
                 \\"DD_ENV\\": \\"staging\\",
-                \\"DD_SERVICE\\": \\"middletier\\",
-                \\"DD_VERSION\\": \\"0.2\\",
                 \\"DD_TAGS\\": \\"layer:api,team:intake\\",
+                \\"DD_FLUSH_TO_LOG\\": \\"true\\",
+                \\"DD_MERGE_XRAY_TRACES\\": \\"false\\",
+                \\"DD_SERVICE\\": \\"middletier\\",
+                \\"DD_TRACE_ENABLED\\": \\"true\\",
+                \\"DD_VERSION\\": \\"0.2\\",
                 \\"DD_LOG_LEVEL\\": \\"debug\\"
               }
             },
@@ -175,13 +175,13 @@ describe('lambda', () => {
                 \\"DD_LAMBDA_HANDLER\\": \\"index.handler\\",
                 \\"DD_API_KEY\\": \\"1234\\",
                 \\"DD_SITE\\": \\"datadoghq.com\\",
-                \\"DD_TRACE_ENABLED\\": \\"true\\",
-                \\"DD_MERGE_XRAY_TRACES\\": \\"false\\",
-                \\"DD_FLUSH_TO_LOG\\": \\"true\\",
                 \\"DD_ENV\\": \\"staging\\",
+                \\"DD_TAGS\\": \\"layer:api,team:intake\\",
+                \\"DD_FLUSH_TO_LOG\\": \\"true\\",
+                \\"DD_MERGE_XRAY_TRACES\\": \\"false\\",
                 \\"DD_SERVICE\\": \\"middletier\\",
-                \\"DD_VERSION\\": \\"0.2\\",
-                \\"DD_TAGS\\": \\"layer:api,team:intake\\"
+                \\"DD_TRACE_ENABLED\\": \\"true\\",
+                \\"DD_VERSION\\": \\"0.2\\"
               }
             },
             \\"Layers\\": [

--- a/src/commands/lambda/__tests__/instrument.test.ts
+++ b/src/commands/lambda/__tests__/instrument.test.ts
@@ -6,8 +6,9 @@ import * as fs from 'fs'
 
 import {Cli} from 'clipanion/lib/advanced'
 import path from 'path'
+import {EXTRA_TAGS_REG_EXP} from '../constants'
 import {InstrumentationSettings} from '../function'
-import {InstrumentCommand} from '../instrument'
+import {InstrumentCommand, sentenceMatchesRegEx} from '../instrument'
 import {LambdaConfigOptions} from '../interfaces'
 // tslint:disable-next-line
 const {version} = require(path.join(__dirname, '../../../../package.json'))
@@ -709,6 +710,24 @@ describe('lambda', () => {
                     }
                     "
                 `)
+      })
+    })
+    describe('sentenceMatchesRegEx', () => {
+      const tags: [string, boolean][] = [
+        ['not-complying:regex-should-fail', false],
+        ['1first-char-is-number:should-fail', false],
+        ['_also-not-complying:should-fail', false],
+        ['complying_tag:accepted/with/slashes.and.dots,but-empty-tag', false],
+        ['also_complying:success,1but_is_illegal:should-fail', false],
+        ['this:complies,also_this_one:yes,numb3r_in_name:should-succeed,dots:al.lo.wed', true],
+        ['complying_ip_address_4:192.342.3134.231', true],
+        ['complying:alone', true],
+        ['one_divided_by_two:1/2,one_divided_by_four:0.25,three_minus_one_half:3-1/2', true],
+        ['this_is_a_valid_t4g:yes/it.is-42', true],
+      ]
+      test.each(tags)('check if the tags match the expected result from the regex', (tag, expectedResult) => {
+        const result = !!sentenceMatchesRegEx(tag, EXTRA_TAGS_REG_EXP)
+        expect(result).toEqual(expectedResult)
       })
     })
   })

--- a/src/commands/lambda/__tests__/instrument.test.ts
+++ b/src/commands/lambda/__tests__/instrument.test.ts
@@ -571,7 +571,7 @@ describe('lambda', () => {
         await command['getSettings']()
         const output = command.context.stdout.toString()
         expect(output).toMatch(
-          'No value found for the environment tag.\nNo value found for the service tag.\nNo value found for the version tag.\nIt is recommended to set tags, try to do it later.\n'
+          'Warning: The environment, service and version tags have not been configured. Learn more about Datadog unified service tagging: https://docs.datadoghq.com/getting_started/tagging/unified_service_tagging/#serverless-environment.\n'
         )
       })
 

--- a/src/commands/lambda/__tests__/instrument.test.ts
+++ b/src/commands/lambda/__tests__/instrument.test.ts
@@ -561,17 +561,28 @@ describe('lambda', () => {
         }
       })
 
-      test('warns if any of environment, service or version tags is not set', async () => {
+      test('warns if any of environment, service or version tags are not set', async () => {
         ;(fs.readFile as any).mockImplementation((a: any, b: any, callback: any) => callback({}))
 
         process.env = {}
-        const command = createCommand()
+        let command = createCommand()
         command['config']['region'] = 'ap-southeast-1'
         command['config']['functions'] = ['arn:aws:lambda:ap-southeast-1:123456789012:function:lambda-hello-world']
         await command['getSettings']()
-        const output = command.context.stdout.toString()
+        let output = command.context.stdout.toString()
         expect(output).toMatch(
           'Warning: The environment, service and version tags have not been configured. Learn more about Datadog unified service tagging: https://docs.datadoghq.com/getting_started/tagging/unified_service_tagging/#serverless-environment.\n'
+        )
+
+        command = createCommand()
+        command['config']['region'] = 'ap-southeast-1'
+        command['config']['functions'] = ['arn:aws:lambda:ap-southeast-1:123456789012:function:lambda-hello-world']
+        command['config']['environment'] = 'b'
+        command['config']['service'] = 'middletier'
+        await command['getSettings']()
+        output = command.context.stdout.toString()
+        expect(output).toMatch(
+          'Warning: The version tag has not been configured. Learn more about Datadog unified service tagging: https://docs.datadoghq.com/getting_started/tagging/unified_service_tagging/#serverless-environment.\n'
         )
       })
 

--- a/src/commands/lambda/constants.ts
+++ b/src/commands/lambda/constants.ts
@@ -52,4 +52,4 @@ export const CI_KMS_API_KEY_ENV_VAR = 'DATADOG_KMS_API_KEY'
 // This RegExp ensures that the --extra-tags string
 // matches a list of <key>:<value> separated by commas
 // such as: layer:api,team:intake
-export const EXTRA_TAGS_REG_EXP: RegExp = /^(([a-zA-Z_]+)\w+:[\w\-]+)+((\,)([a-zA-Z_]+)\w+:[\w\-]+)*$/g
+export const EXTRA_TAGS_REG_EXP: RegExp = /^(([a-zA-Z]+)\w+:[\w\-/\.]+)+((\,)([a-zA-Z]+)\w+:[\w\-/\.]+)*$/g

--- a/src/commands/lambda/constants.ts
+++ b/src/commands/lambda/constants.ts
@@ -38,8 +38,18 @@ export const MERGE_XRAY_TRACES_ENV_VAR = 'DD_MERGE_XRAY_TRACES'
 export const FLUSH_TO_LOG_ENV_VAR = 'DD_FLUSH_TO_LOG'
 export const LOG_LEVEL_ENV_VAR = 'DD_LOG_LEVEL'
 export const LAMBDA_HANDLER_ENV_VAR = 'DD_LAMBDA_HANDLER'
+export const SERVICE_ENV_VAR = 'DD_SERVICE'
+export const VERSION_ENV_VAR = 'DD_VERSION'
+export const ENVIRONMENT_ENV_VAR = 'DD_ENV'
+export const EXTRA_TAGS_ENV_VAR = 'DD_TAGS'
 
 // Environment variables used by Datadog CI
 export const CI_SITE_ENV_VAR = 'DATADOG_SITE'
 export const CI_API_KEY_ENV_VAR = 'DATADOG_API_KEY'
 export const CI_KMS_API_KEY_ENV_VAR = 'DATADOG_KMS_API_KEY'
+
+// DD_TAGS Regular Expression
+// This RegExp ensures that the --extra-tags string
+// matches a list of <key>:<value> separated by commas
+// such as: layer:api,team:intake
+export const EXTRA_TAGS_REG_EXP: RegExp = /^(([a-zA-Z_]+)\w+:\w+)+((\,)([a-zA-Z_]+)\w+:\w+)*$/g

--- a/src/commands/lambda/constants.ts
+++ b/src/commands/lambda/constants.ts
@@ -52,4 +52,4 @@ export const CI_KMS_API_KEY_ENV_VAR = 'DATADOG_KMS_API_KEY'
 // This RegExp ensures that the --extra-tags string
 // matches a list of <key>:<value> separated by commas
 // such as: layer:api,team:intake
-export const EXTRA_TAGS_REG_EXP: RegExp = /^(([a-zA-Z_]+)\w+:\w+)+((\,)([a-zA-Z_]+)\w+:\w+)*$/g
+export const EXTRA_TAGS_REG_EXP: RegExp = /^(([a-zA-Z_]+)\w+:[\w\-]+)+((\,)([a-zA-Z_]+)\w+:[\w\-]+)*$/g

--- a/src/commands/lambda/function.ts
+++ b/src/commands/lambda/function.ts
@@ -6,6 +6,8 @@ import {
   CI_SITE_ENV_VAR,
   DD_LAMBDA_EXTENSION_LAYER_NAME,
   DEFAULT_LAYER_AWS_ACCOUNT,
+  ENVIRONMENT_ENV_VAR,
+  EXTRA_TAGS_ENV_VAR,
   FLUSH_TO_LOG_ENV_VAR,
   GOVCLOUD_LAYER_AWS_ACCOUNT,
   HANDLER_LOCATION,
@@ -15,8 +17,10 @@ import {
   MERGE_XRAY_TRACES_ENV_VAR,
   Runtime,
   RUNTIME_LAYER_LOOKUP,
+  SERVICE_ENV_VAR,
   SITE_ENV_VAR,
   TRACE_ENABLED_ENV_VAR,
+  VERSION_ENV_VAR,
 } from './constants'
 import {applyLogGroupConfig, calculateLogGroupUpdateRequest, LogGroupConfiguration} from './loggroup'
 import {applyTagConfig, calculateTagUpdateRequest, TagConfiguration} from './tags'
@@ -30,14 +34,18 @@ export interface FunctionConfiguration {
 }
 
 export interface InstrumentationSettings {
+  environment?: string
   extensionVersion?: number
+  extraTags?: string
   flushMetricsToLogs: boolean
   forwarderARN?: string
   layerAWSAccount?: string
   layerVersion?: number
   logLevel?: string
   mergeXrayTraces: boolean
+  service?: string
   tracingEnabled: boolean
+  version?: string
 }
 
 const MAX_LAMBDA_STATE_CHECKS = 3
@@ -249,6 +257,23 @@ export const calculateUpdateRequest = (
   if (oldEnvVars[FLUSH_TO_LOG_ENV_VAR] !== settings.flushMetricsToLogs.toString()) {
     needsUpdate = true
     changedEnvVars[FLUSH_TO_LOG_ENV_VAR] = settings.flushMetricsToLogs.toString()
+  }
+
+  if (settings.environment && oldEnvVars[ENVIRONMENT_ENV_VAR] !== settings.environment.toString()) {
+    needsUpdate = true
+    changedEnvVars[ENVIRONMENT_ENV_VAR] = settings.environment.toString()
+  }
+  if (settings.service && oldEnvVars[SERVICE_ENV_VAR] !== settings.service.toString()) {
+    needsUpdate = true
+    changedEnvVars[SERVICE_ENV_VAR] = settings.service.toString()
+  }
+  if (settings.version && oldEnvVars[VERSION_ENV_VAR] !== settings.version.toString()) {
+    needsUpdate = true
+    changedEnvVars[VERSION_ENV_VAR] = settings.version.toString()
+  }
+  if (settings.extraTags && oldEnvVars[EXTRA_TAGS_ENV_VAR] !== settings.extraTags.toString()) {
+    needsUpdate = true
+    changedEnvVars[EXTRA_TAGS_ENV_VAR] = settings.extraTags.toString()
   }
 
   const newEnvVars = {...oldEnvVars, ...changedEnvVars}

--- a/src/commands/lambda/instrument.ts
+++ b/src/commands/lambda/instrument.ts
@@ -191,15 +191,17 @@ export class InstrumentCommand extends Command {
       service,
       version,
     }
-    let tagMissing = false
+    const tagsMissing = []
     for (const [tag, value] of Object.entries(tagsMap)) {
       if (!value) {
-        tagMissing = true
-        this.context.stdout.write(`No value found for the ${tag} tag.\n`)
+        tagsMissing.push(tag)
       }
     }
-    if (tagMissing) {
-      this.context.stdout.write('It is recommended to set tags, try to do it later.\n')
+    if (tagsMissing.length > 0) {
+      const tags = tagsMissing.join(', ').replace(/, ([^,]*)$/, ' and $1')
+      this.context.stdout.write(
+        `Warning: The ${tags} tags have not been configured. Learn more about Datadog unified service tagging: https://docs.datadoghq.com/getting_started/tagging/unified_service_tagging/#serverless-environment.\n`
+      )
     }
 
     const extraTags = this.extraTags?.toLowerCase() ?? this.config.extraTags?.toLowerCase()

--- a/src/commands/lambda/instrument.ts
+++ b/src/commands/lambda/instrument.ts
@@ -1,6 +1,7 @@
 import {CloudWatchLogs, Lambda} from 'aws-sdk'
 import {Command} from 'clipanion'
 import {parseConfigFile} from '../../helpers/utils'
+import {EXTRA_TAGS_REG_EXP} from './constants'
 import {FunctionConfiguration, getLambdaConfigs, InstrumentationSettings, updateLambdaConfigs} from './function'
 import {LambdaConfigOptions} from './interfaces'
 
@@ -12,7 +13,9 @@ export class InstrumentCommand extends Command {
   }
   private configPath?: string
   private dryRun = false
+  private environment?: string
   private extensionVersion?: string
+  private extraTags?: string
   private flushMetricsToLogs?: string
   private forwarder?: string
   private functions: string[] = []
@@ -21,7 +24,9 @@ export class InstrumentCommand extends Command {
   private logLevel?: string
   private mergeXrayTraces?: string
   private region?: string
+  private service?: string
   private tracing?: string
+  private version?: string
 
   public async execute() {
     const lambdaConfig = {lambda: this.config}
@@ -154,13 +159,13 @@ export class InstrumentCommand extends Command {
       return
     }
 
-    const stringBooleans: {[key: string]: string | undefined} = {
+    const stringBooleansMap: {[key: string]: string | undefined} = {
       flushMetricsToLogs: this.flushMetricsToLogs?.toLowerCase() ?? this.config.flushMetricsToLogs?.toLowerCase(),
       mergeXrayTraces: this.mergeXrayTraces?.toLowerCase() ?? this.config.mergeXrayTraces?.toLowerCase(),
       tracing: this.tracing?.toLowerCase() ?? this.config.tracing?.toLowerCase(),
     }
 
-    for (const [stringBoolean, value] of Object.entries(stringBooleans)) {
+    for (const [stringBoolean, value] of Object.entries(stringBooleansMap)) {
       if (!['true', 'false', undefined].includes(value)) {
         this.context.stdout.write(`Invalid boolean specified for ${stringBoolean}.\n`)
 
@@ -177,15 +182,46 @@ export class InstrumentCommand extends Command {
     const tracingEnabled = this.convertStringBooleanToBoolean(true, this.tracing, this.config.tracing)
     const logLevel = this.logLevel ?? this.config.logLevel
 
+    const service = this.service ?? this.config.service
+    const environment = this.environment ?? this.config.environment
+    const version = this.version ?? this.config.version
+
+    const tagsMap: {[key: string]: string | undefined} = {
+      environment,
+      service,
+      version,
+    }
+    let tagMissing = false
+    for (const [tag, value] of Object.entries(tagsMap)) {
+      if (!value) {
+        tagMissing = true
+        this.context.stdout.write(`No value found for the ${tag} tag.\n`)
+      }
+    }
+    if (tagMissing) {
+      this.context.stdout.write('It is recommended to set tags, try to do it later.\n')
+    }
+
+    const extraTags = this.extraTags ?? this.config.extraTags
+    if (extraTags && !extraTags.match(EXTRA_TAGS_REG_EXP)) {
+      this.context.stdout.write('Extra tags do not comply with the <key>:<value> array.\n')
+
+      return
+    }
+
     return {
+      environment,
       extensionVersion,
+      extraTags,
       flushMetricsToLogs,
       forwarderARN,
       layerAWSAccount,
       layerVersion,
       logLevel,
       mergeXrayTraces,
+      service,
       tracingEnabled,
+      version,
     }
   }
 
@@ -275,3 +311,8 @@ InstrumentCommand.addOption('dryRun', Command.Boolean('-d,--dry'))
 InstrumentCommand.addOption('configPath', Command.String('--config'))
 InstrumentCommand.addOption('forwarder', Command.String('--forwarder'))
 InstrumentCommand.addOption('logLevel', Command.String('--logLevel'))
+
+InstrumentCommand.addOption('service', Command.String('--service'))
+InstrumentCommand.addOption('environment', Command.String('--env'))
+InstrumentCommand.addOption('version', Command.String('--version'))
+InstrumentCommand.addOption('extraTags', Command.String('--extra-tags'))

--- a/src/commands/lambda/instrument.ts
+++ b/src/commands/lambda/instrument.ts
@@ -199,8 +199,11 @@ export class InstrumentCommand extends Command {
     }
     if (tagsMissing.length > 0) {
       const tags = tagsMissing.join(', ').replace(/, ([^,]*)$/, ' and $1')
+      const plural = tagsMissing.length > 1
       this.context.stdout.write(
-        `Warning: The ${tags} tags have not been configured. Learn more about Datadog unified service tagging: https://docs.datadoghq.com/getting_started/tagging/unified_service_tagging/#serverless-environment.\n`
+        `Warning: The ${tags} tag${
+          plural ? 's have' : ' has'
+        } not been configured. Learn more about Datadog unified service tagging: https://docs.datadoghq.com/getting_started/tagging/unified_service_tagging/#serverless-environment.\n`
       )
     }
 

--- a/src/commands/lambda/instrument.ts
+++ b/src/commands/lambda/instrument.ts
@@ -203,7 +203,7 @@ export class InstrumentCommand extends Command {
     }
 
     const extraTags = this.extraTags ?? this.config.extraTags
-    if (extraTags && !extraTags.match(EXTRA_TAGS_REG_EXP)) {
+    if (extraTags && !this.sentenceMatchesRegEx(extraTags, EXTRA_TAGS_REG_EXP)) {
       this.context.stdout.write('Extra tags do not comply with the <key>:<value> array.\n')
 
       return
@@ -295,6 +295,10 @@ export class InstrumentCommand extends Command {
         )
       }
     }
+  }
+
+  private sentenceMatchesRegEx(sentence: string, regex: RegExp) {
+    return sentence.match(regex)
   }
 }
 

--- a/src/commands/lambda/instrument.ts
+++ b/src/commands/lambda/instrument.ts
@@ -202,7 +202,7 @@ export class InstrumentCommand extends Command {
       this.context.stdout.write('It is recommended to set tags, try to do it later.\n')
     }
 
-    const extraTags = this.extraTags ?? this.config.extraTags
+    const extraTags = this.extraTags?.toLowerCase() ?? this.config.extraTags?.toLowerCase()
     if (extraTags && !this.sentenceMatchesRegEx(extraTags, EXTRA_TAGS_REG_EXP)) {
       this.context.stdout.write('Extra tags do not comply with the <key>:<value> array.\n')
 

--- a/src/commands/lambda/instrument.ts
+++ b/src/commands/lambda/instrument.ts
@@ -203,7 +203,7 @@ export class InstrumentCommand extends Command {
     }
 
     const extraTags = this.extraTags?.toLowerCase() ?? this.config.extraTags?.toLowerCase()
-    if (extraTags && !this.sentenceMatchesRegEx(extraTags, EXTRA_TAGS_REG_EXP)) {
+    if (extraTags && !sentenceMatchesRegEx(extraTags, EXTRA_TAGS_REG_EXP)) {
       this.context.stdout.write('Extra tags do not comply with the <key>:<value> array.\n')
 
       return
@@ -296,11 +296,9 @@ export class InstrumentCommand extends Command {
       }
     }
   }
-
-  private sentenceMatchesRegEx(sentence: string, regex: RegExp) {
-    return sentence.match(regex)
-  }
 }
+
+export const sentenceMatchesRegEx = (sentence: string, regex: RegExp) => sentence.match(regex)
 
 InstrumentCommand.addPath('lambda', 'instrument')
 InstrumentCommand.addOption('functions', Command.Array('-f,--function'))

--- a/src/commands/lambda/interfaces.ts
+++ b/src/commands/lambda/interfaces.ts
@@ -1,5 +1,7 @@
 export interface LambdaConfigOptions {
+  environment?: string
   extensionVersion?: string
+  extraTags?: string
   flushMetricsToLogs?: string
   forwarder?: string
   functions: string[]
@@ -8,5 +10,7 @@ export interface LambdaConfigOptions {
   logLevel?: string
   mergeXrayTraces?: string
   region?: string
+  service?: string
   tracing?: string
+  version?: string
 }


### PR DESCRIPTION
### What and why?

To demonstrate the full capabilities of Datadog serverless monitoring, we should provide options for customers to easily tag their applications, like --service, --env, --version and --extra-tags.

If the customer misses one of --service, --env, --version tags, we should print out a message to encourage users to set them up.

### How?

Add four commands as described above, modified some tests to comply with new feature, and created unit tests for the feature.

### Review checklist

- [x] Modified existing unit tests
- [x] Created unit test
