### PR TITLE
[codeowners] @m-rousse from commands codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,6 @@
 * @yoannmoinet @m-rousse
 
-src/commands  @m-rousse
+src/commands
 src/commands/synthetics  @m-rousse @DataDog/synthetics-worker
 src/commands/lambda @DataDog/serverless
 src/commands/sourcemaps/ @DataDog/source-code-integration


### PR DESCRIPTION
### What and why?

It removes `@m-rousse` from the `src/commands` folder CODEOWNERS as it is not relevant anymore to be notified for all commands PRs.