### PR TITLE
RUMM-1608 Dsym upload: if dwarfdump throws, error is caught

### DIFF
--- a/src/commands/dsyms/__tests__/utils.test.ts
+++ b/src/commands/dsyms/__tests__/utils.test.ts
@@ -17,7 +17,13 @@ describe('isZipFile', () => {
 })
 
 describe('getMatchingDSYMFiles', () => {
-  test('Should find one dSYM file', async () => {
+  test('Should find no valid dSYM file in Linux', async () => {
+    const folder = './src/commands/dsyms/__tests__/test files/'
+    const foundFiles = await getMatchingDSYMFiles(folder)
+    expect(foundFiles).toEqual([undefined])
+  })
+
+  test('Should find one valid dSYM file with mocking', async () => {
     require('../utils').dwarfdumpUUID = jest.fn().mockResolvedValue(['BD8CE358-D5F3-358B-86DC-CBCF2148097B'])
 
     const folder = './src/commands/dsyms/__tests__/test files/'

--- a/src/commands/dsyms/__tests__/utils.test.ts
+++ b/src/commands/dsyms/__tests__/utils.test.ts
@@ -19,7 +19,7 @@ describe('isZipFile', () => {
 describe('getMatchingDSYMFiles', () => {
   test('Should find no valid dSYM file in Linux', async () => {
     const folder = './src/commands/dsyms/__tests__/test files/'
-    const foundFiles = await getMatchingDSYMFiles(folder)
+    const foundFiles = await getMatchingDSYMFiles(folder, undefined)
     expect(foundFiles).toEqual([undefined])
   })
 
@@ -27,7 +27,7 @@ describe('getMatchingDSYMFiles', () => {
     require('../utils').dwarfdumpUUID = jest.fn().mockResolvedValue(['BD8CE358-D5F3-358B-86DC-CBCF2148097B'])
 
     const folder = './src/commands/dsyms/__tests__/test files/'
-    const foundFiles = await getMatchingDSYMFiles(folder)
+    const foundFiles = await getMatchingDSYMFiles(folder, undefined)
     expect(foundFiles).toEqual([
       new Dsym('./src/commands/dsyms/__tests__/test files/test.dSYM', ['BD8CE358-D5F3-358B-86DC-CBCF2148097B']),
     ])

--- a/src/commands/dsyms/__tests__/utils.test.ts
+++ b/src/commands/dsyms/__tests__/utils.test.ts
@@ -18,16 +18,20 @@ describe('isZipFile', () => {
 
 describe('getMatchingDSYMFiles', () => {
   test('Should find no valid dSYM file in Linux', async () => {
+    const write = jest.fn()
+    const mockContext = {stdout: {write}} as any
     const folder = './src/commands/dsyms/__tests__/test files/'
-    const foundFiles = await getMatchingDSYMFiles(folder, undefined)
+    const foundFiles = await getMatchingDSYMFiles(folder, mockContext)
     expect(foundFiles).toEqual([undefined])
   })
 
   test('Should find one valid dSYM file with mocking', async () => {
     require('../utils').dwarfdumpUUID = jest.fn().mockResolvedValue(['BD8CE358-D5F3-358B-86DC-CBCF2148097B'])
 
+    const write = jest.fn()
+    const mockContext = {stdout: {write}} as any
     const folder = './src/commands/dsyms/__tests__/test files/'
-    const foundFiles = await getMatchingDSYMFiles(folder, undefined)
+    const foundFiles = await getMatchingDSYMFiles(folder, mockContext)
     expect(foundFiles).toEqual([
       new Dsym('./src/commands/dsyms/__tests__/test files/test.dSYM', ['BD8CE358-D5F3-358B-86DC-CBCF2148097B']),
     ])

--- a/src/commands/dsyms/renderer.ts
+++ b/src/commands/dsyms/renderer.ts
@@ -8,6 +8,9 @@ import {UploadStatus} from '../../helpers/upload'
 
 export const renderConfigurationError = (error: Error) => chalk.red(`${ICONS.FAILED} Configuration error: ${error}.\n`)
 
+export const renderInvalidDsymWarning = (path: string) =>
+  chalk.yellow(`${ICONS.WARNING} Invalid dSYM file, will be skipped: ${path}\n`)
+
 export const renderFailedUpload = (dSYM: Dsym, errorMessage: string) => {
   const dSYMPathBold = `[${chalk.bold.dim(dSYM.path)}]`
 

--- a/src/commands/dsyms/upload.ts
+++ b/src/commands/dsyms/upload.ts
@@ -68,10 +68,11 @@ export class UploadCommand extends Command {
       metricsLogger: metricsLogger.logger,
     })
     const payloads = await getMatchingDSYMFiles(searchPath)
+    const validPayloads = payloads.filter((payload) => payload !== undefined) as Dsym[]
     const requestBuilder = this.getRequestBuilder()
     const uploadDSYM = this.uploadDSYM(requestBuilder, metricsLogger, apiKeyValidator)
     try {
-      const results = await asyncPool(this.maxConcurrency, payloads, uploadDSYM)
+      const results = await asyncPool(this.maxConcurrency, validPayloads, uploadDSYM)
       const totalTime = (Date.now() - initialTime) / 1000
       this.context.stdout.write(renderSuccessfulCommand(results, totalTime, this.dryRun))
       metricsLogger.logger.gauge('duration', totalTime)

--- a/src/commands/dsyms/upload.ts
+++ b/src/commands/dsyms/upload.ts
@@ -67,7 +67,7 @@ export class UploadCommand extends Command {
       datadogSite: this.config.datadogSite,
       metricsLogger: metricsLogger.logger,
     })
-    const payloads = await getMatchingDSYMFiles(searchPath)
+    const payloads = await getMatchingDSYMFiles(searchPath, this.context)
     const validPayloads = payloads.filter((payload) => payload !== undefined) as Dsym[]
     const requestBuilder = this.getRequestBuilder()
     const uploadDSYM = this.uploadDSYM(requestBuilder, metricsLogger, apiKeyValidator)

--- a/src/commands/dsyms/utils.ts
+++ b/src/commands/dsyms/utils.ts
@@ -28,7 +28,7 @@ export const isZipFile = async (filepath: string) => {
 
 export const getMatchingDSYMFiles = async (
   absoluteFolderPath: string,
-  context: BaseContext | undefined
+  context: BaseContext
 ): Promise<(Dsym | undefined)[]> => {
   const dSYMFiles = await globAsync(buildPath(absoluteFolderPath, '**/*.dSYM'), {})
 
@@ -38,7 +38,7 @@ export const getMatchingDSYMFiles = async (
 
       return new Dsym(dSYMPath, uuids)
     } catch {
-      context?.stdout.write(renderInvalidDsymWarning(dSYMPath))
+      context.stdout.write(renderInvalidDsymWarning(dSYMPath))
 
       return undefined
     }

--- a/src/commands/dsyms/utils.ts
+++ b/src/commands/dsyms/utils.ts
@@ -1,4 +1,5 @@
 import {exec} from 'child_process'
+import {BaseContext} from 'clipanion'
 import {promises} from 'fs'
 import glob from 'glob'
 import {tmpdir} from 'os'
@@ -8,6 +9,7 @@ import {promisify} from 'util'
 import {Dsym} from './interfaces'
 
 import {buildPath} from '../../helpers/utils'
+import {renderInvalidDsymWarning} from './renderer'
 
 const UUID_REGEX = '[0-9A-F]{8}-([0-9A-F]{4}-){3}[0-9A-F]{12}'
 
@@ -24,7 +26,10 @@ export const isZipFile = async (filepath: string) => {
   }
 }
 
-export const getMatchingDSYMFiles = async (absoluteFolderPath: string): Promise<(Dsym | undefined)[]> => {
+export const getMatchingDSYMFiles = async (
+  absoluteFolderPath: string,
+  context: BaseContext | undefined
+): Promise<(Dsym | undefined)[]> => {
   const dSYMFiles = await globAsync(buildPath(absoluteFolderPath, '**/*.dSYM'), {})
 
   const allDsyms = dSYMFiles.map(async (dSYMPath) => {
@@ -33,6 +38,8 @@ export const getMatchingDSYMFiles = async (absoluteFolderPath: string): Promise<
 
       return new Dsym(dSYMPath, uuids)
     } catch {
+      context?.stdout.write(renderInvalidDsymWarning(dSYMPath))
+
       return undefined
     }
   })

--- a/src/commands/dsyms/utils.ts
+++ b/src/commands/dsyms/utils.ts
@@ -24,16 +24,20 @@ export const isZipFile = async (filepath: string) => {
   }
 }
 
-export const getMatchingDSYMFiles = async (absoluteFolderPath: string): Promise<Dsym[]> => {
-  const dSYMFiles = await globAsync(buildPath(absoluteFolderPath, '**/*.dSYM'))
+export const getMatchingDSYMFiles = async (absoluteFolderPath: string): Promise<(Dsym | undefined)[]> => {
+  const dSYMFiles = await globAsync(buildPath(absoluteFolderPath, '**/*.dSYM'), {})
 
-  return Promise.all(
-    dSYMFiles.map(async (dSYMPath) => {
+  const allDsyms = dSYMFiles.map(async (dSYMPath) => {
+    try {
       const uuids = await dwarfdumpUUID(dSYMPath)
 
       return new Dsym(dSYMPath, uuids)
-    })
-  )
+    } catch {
+      return undefined
+    }
+  })
+
+  return Promise.all(allDsyms)
 }
 
 export const dwarfdumpUUID = async (filePath: string) => {


### PR DESCRIPTION
### What and why?

In the case of invalid dSYM files, dwarfdump can throw.
This resulted in breaking the execution.

### How?

Now we continue running by skipping that particular dsym files.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)

