### PR TITLE
[Synthetics] Upgrade `yamux-js` to 0.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "sshpk": "1.16.1",
     "tiny-async-pool": "1.2.0",
     "ws": "7.4.6",
-    "yamux-js": "0.0.6"
+    "yamux-js": "0.1.0"
   },
   "devDependencies": {
     "@babel/core": "7.4.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4842,10 +4842,10 @@ yallist@^4.0.0:
   resolved "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz"
   integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
-yamux-js@0.0.6:
-  version "0.0.6"
-  resolved "https://registry.npmjs.org/yamux-js/-/yamux-js-0.0.6.tgz"
-  integrity sha512-+WeGMUJxaiHeAxLOGDzfRmeEpsEZQ32yG1YpaEmltWF2r/JgcywWeaYoLnHulIdpfu0PPXQjU5OVoZJsLDByKw==
+yamux-js@0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/yamux-js/-/yamux-js-0.1.0.tgz#a0215b8cc315533f6bb3189769febe337ec7440f"
+  integrity sha512-Bg/H2ZIV/FZ2O7LZ4nNYBoE69KPljE6Vo47p5gC7flCxSQQLmbCy1EKYqvq6tLBVBb/ep+6I2niKtPuNlj6hyw==
 
 yargs-parser@20.x:
   version "20.2.4"


### PR DESCRIPTION
### What and why?

Upgrade to latest version of `yamux-js` [updating `on('error')` events](https://github.com/th-ch/yamux-js/blob/cffa837d3f5861d6b5a4bf1f6d9c722e11587448/changelog.md#010) to fix issue with ssh2 error listeners expecting an `Error` object.

### How?

Upgrade `yamux-js` from 0.0.6 to 0.1.0.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)

