### PR TITLE
[lambda][uninstrument] Create uninstrument command

### DIFF
--- a/src/commands/lambda/index.ts
+++ b/src/commands/lambda/index.ts
@@ -1,3 +1,4 @@
 import {InstrumentCommand} from './instrument'
+import { UninstrumentCommand } from './uninstrument'
 
-module.exports = [InstrumentCommand]
+module.exports = [InstrumentCommand, UninstrumentCommand]

--- a/src/commands/lambda/instrument.ts
+++ b/src/commands/lambda/instrument.ts
@@ -230,6 +230,33 @@ export class InstrumentCommand extends Command {
     }
   }
 
+  private getUserFunctions = async (pattern: string) => {
+    const re = new RegExp(pattern);
+    const region = this.region || this.config.region
+    const lambda = new Lambda({ region })
+    const functions: any[] = []
+    let nextMarker
+    try {
+      let results = await lambda.listFunctions().promise()
+      results.Functions?.map(f => f.FunctionName?.match(re) && functions.push(f))
+      
+      nextMarker = results.NextMarker
+      while (nextMarker) {
+        results = await lambda.listFunctions({ Marker: nextMarker }).promise()
+        results.Functions?.map(f => f.FunctionName?.match(re) && functions.push(f))
+        nextMarker = results.NextMarker
+      }
+    } catch (e) {
+      this.context.stdout.write(
+        `An error occurred ${e}. \n`
+      )
+    }
+    this.context.stdout.write(
+      `Found ${functions.length} functions for this user. \n`
+    )
+    return
+  }
+
   private printPlannedActions(configs: FunctionConfiguration[]) {
     const prefix = this.dryRun ? '[Dry Run] ' : ''
 

--- a/src/commands/lambda/uninstrument.ts
+++ b/src/commands/lambda/uninstrument.ts
@@ -1,0 +1,9 @@
+import { Command } from 'clipanion'
+
+export class UninstrumentCommand extends Command {
+    public async execute() {
+        console.log('wow much uninstrument, so serverless!!!!1eleven')
+    }
+}
+
+UninstrumentCommand.addPath('lambda', 'uninstrument')


### PR DESCRIPTION
### What and why?

Customers can use the instrument command to enable instrumentation, but when they are done with the trial or need to disable the instrumentation for some reasons, there is no easy way to revert the changes made by the instrument command.

### How?

Implement the `uninstrument` command which should revert what the `instrument` command does, mostly remove environment variables, layers and probably tags.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)

