### PR TITLE
added a ci query param to the result url of tests

### DIFF
--- a/src/commands/synthetics/reporters/default.ts
+++ b/src/commands/synthetics/reporters/default.ts
@@ -184,12 +184,13 @@ const renderApiRequestDescription = (subType: string, config: Test['config']): s
 }
 
 const getResultUrl = (baseUrl: string, test: Test, resultId: string) => {
+  const ciQueryParam = 'from_ci=true'
   const testDetailUrl = `${baseUrl}synthetics/details/${test.public_id}`
   if (test.type === 'browser') {
-    return `${testDetailUrl}/result/${resultId}`
+    return `${testDetailUrl}/result/${resultId}?${ciQueryParam}`
   }
 
-  return `${testDetailUrl}?resultId=${resultId}`
+  return `${testDetailUrl}?resultId=${resultId}&${ciQueryParam}`
 }
 
 const renderExecutionResult = (


### PR DESCRIPTION
[SW-1456](https://datadoghq.atlassian.net/browse/SW-1456)

- added ci query parameter to the result URL of a healthy test result to link to the result page
