### PR TITLE
[lambda] Minor documentation update

### DIFF
--- a/src/commands/lambda/README.md
+++ b/src/commands/lambda/README.md
@@ -14,13 +14,13 @@ Run `datadog-ci lambda instrument` to apply Datadog instrumentation to a Lambda.
 
 ```bash
 # Instrument multiple functions specified by names
-datadog-ci lambda instrument -f functionname -f another-functionname -r us-east-1 -v 46 -e 10
+datadog-ci lambda instrument -f function-name -f another-function-name -r us-east-1 -v 46 -e 10
 
 # Instrument multiple functions that match a regex pattern
-datadog-ci lambda instrument --functions-regex validregexpattern -r us-east-1 -v 46 -e 10
+datadog-ci lambda instrument --functions-regex valid-regex-pattern -r us-east-1 -v 46 -e 10
 
 # Dry run of all updates
-datadog-ci lambda instrument -f functionname -f another-functionname -r us-east-1 -v 46 -e 10 --dry
+datadog-ci lambda instrument -f function-name -f another-function-name -r us-east-1 -v 46 -e 10 --dry
 ```
 
 See the configuration section for additional settings.
@@ -37,9 +37,9 @@ You must expose these environment variables in the environment where you are run
 
 | Environment Variable | Description | Example |
 | --- | --- | --- |
-| DATADOG_API_KEY | Datadog API Key. Sets the `DD_API_KEY` environment variable on your Lambda function configuration. For more information about getting a Datadog API key, see the [API key documentation][6].  | export DATADOG_API_KEY="1234" |
-| DATADOG_KMS_API_KEY | Datadog API Key encrypted using KMS. Sets the `DD_KMS_API_KEY` environment variable on your Lambda function configuration. Note: `DD_API_KEY` is ignored when `DD_KMS_API_KEY` is set. | export DATADOG_KMS_API_KEY="5678" |
-| DATADOG_SITE | Set which Datadog site to send data. Only needed when using the Datadog Lambda Extension. Possible values are  `datadoghq.com` , `datadoghq.eu` , `us3.datadoghq.com` and `ddog-gov.com`. The default is `datadoghq.com`. Sets the `DD_SITE` environment variable on your Lambda function configurations. | export DATADOG_SITE="datadoghq.com" |
+| `DATADOG_API_KEY` | Datadog API Key. Sets the `DD_API_KEY` environment variable on your Lambda function configuration. For more information about getting a Datadog API key, see the [API key documentation][6].  | `export DATADOG_API_KEY="1234"` |
+| `DATADOG_KMS_API_KEY` | Datadog API Key encrypted using KMS. Sets the `DD_KMS_API_KEY` environment variable on your Lambda function configuration. Note: `DD_API_KEY` is ignored when `DD_KMS_API_KEY` is set. | `export DATADOG_KMS_API_KEY="5678"` |
+| `DATADOG_SITE` | Set which Datadog site to send data. Only needed when using the Datadog Lambda Extension. Possible values are  `datadoghq.com` , `datadoghq.eu` , `us3.datadoghq.com` and `ddog-gov.com`. The default is `datadoghq.com`. Sets the `DD_SITE` environment variable on your Lambda function configurations. | `export DATADOG_SITE="datadoghq.com"` |
 
 
 ### Arguments
@@ -50,17 +50,17 @@ You can pass the following arguments to `instrument` to specify its behavior. Th
 
 | Argument | Shorthand | Description | Default |
 | --- | --- | --- | --- |
-| --function | -f | The ARN of the Lambda function to be instrumented, or the name of the Lambda function (--region must be defined) | |
-| --functions-regex | | A regex pattern to match with the Lambda function name | |
-| --region | -r | Default region to use, when `--function` is specified by the function name instead of the ARN | |
-| --layerVersion | -v | Version of the Datadog Lambda Library layer to apply. This varies between runtimes. To see the latest layer version check the [JS][3] or [python][4] datadog-lambda-layer repo release notes | |
-| --extensionVersion | -e | Version of the Datadog Lambda Extension layer to apply. When `extensionVersion` is set, make sure to export `DATADOG_API_KEY` (or `DATADOG_KMS_API_KEY`) in your environment as well. While using `extensionVersion`, leave out `forwarder` Learn more about the Lambda Extension [here][5]| |
-| --tracing |  | Whether to enable dd-trace tracing on your Lambda | true |
-| --mergeXrayTraces | | Whether to join dd-trace traces to AWS X-Ray traces. Useful for tracing API Gateway spans. | false |
-| --flushMetricsToLogs | | Whether to send metrics via the Datadog Forwarder [asynchronously](https://docs.datadoghq.com/serverless/custom_metrics?tab=python#enabling-asynchronous-custom-metrics) | true |
-| --forwarder | | The ARN of the [datadog forwarder](https://docs.datadoghq.com/serverless/forwarder/) to attach this function's LogGroup to. | |
-| --dry | -d | Preview changes running command would apply. | false |
-| --logLevel | | Set to `debug` to see additional output from the Datadog Lambda Library and/or Lambda Extension for troubleshooting purposes. | |
+| `--function` | `-f` | The ARN of the Lambda function to be instrumented, or the name of the Lambda function (`--region` must be defined) | |
+| `--functions-regex` | | A regex pattern to match with the Lambda function name | |
+| `--region` | `-r` | Default region to use, when `--function` is specified by the function name instead of the ARN | |
+| `--layerVersion` | `-v` | Version of the Datadog Lambda Library layer to apply. This varies between runtimes. To see the latest layer version check the [JS][3] or [python][4] datadog-lambda-layer repo release notes | |
+| `--extensionVersion` | `-e` | Version of the Datadog Lambda Extension layer to apply. When `extensionVersion` is set, make sure to export `DATADOG_API_KEY` (or `DATADOG_KMS_API_KEY`) in your environment as well. While using `extensionVersion`, leave out `forwarder` Learn more about the Lambda Extension [here][5]| |
+| `--tracing` |  | Whether to enable dd-trace tracing on your Lambda | `true` |
+| `--mergeXrayTraces` | | Whether to join dd-trace traces to AWS X-Ray traces. Useful for tracing API Gateway spans. | `false` |
+| `--flushMetricsToLogs` | | Whether to send metrics via the Datadog Forwarder [asynchronously](https://docs.datadoghq.com/serverless/custom_metrics?tab=python#enabling-asynchronous-custom-metrics) | `true` |
+| `--forwarder` | | The ARN of the [datadog forwarder](https://docs.datadoghq.com/serverless/forwarder/) to attach this function's LogGroup to. | |
+| `--dry` | `-d` | Preview changes running command would apply. | `false` |
+| `--logLevel` | | Set to `debug` to see additional output from the Datadog Lambda Library and/or Lambda Extension for troubleshooting purposes. | |
 
 <br />
 


### PR DESCRIPTION
### What and why?

The documentation online parses `--` into its pure form `–`, therefore, users might be prone to understand it as `-`, which could cause problems while using the CLI.

### How?

Update the documentation by adding ``` ` ``` before and after every command.

### Review checklist

No test required.

