### PR TITLE
[s8s] Create junit report even in directory

### DIFF
--- a/src/commands/synthetics/__tests__/fixtures.ts
+++ b/src/commands/synthetics/__tests__/fixtures.ts
@@ -5,7 +5,18 @@ import WebSocket, {Server as WebSocketServer} from 'ws'
 
 import {ProxyConfiguration} from '../../../helpers/utils'
 
-import {MainReporter, PollResult, Result, Step, Test, User} from '../interfaces'
+import {
+  ApiTestResult,
+  BrowserTestResult,
+  MainReporter,
+  MultiStep,
+  MultiStepsTestResult,
+  PollResult,
+  Step,
+  Test,
+  TestResult,
+  User,
+} from '../interfaces'
 
 const mockUser: User = {
   email: '',
@@ -80,26 +91,70 @@ export const getStep = (): Step => ({
   warnings: [],
 })
 
-export const getResult = (): PollResult => ({
+export const getMultiStep = (): MultiStep => ({
+  allowFailure: false,
+  assertionResults: [],
+  name: 'name',
+  passed: true,
+  skipped: false,
+  subtype: 'subtype',
+  timings: {
+    total: 123,
+  },
+})
+
+const getPollResult = () => ({
   dc_id: 1,
-  result: getBrowserResult(),
   resultID: '123',
   timestamp: 1,
 })
 
-export const getBrowserResult = (opts: any = {}): Result => ({
+export const getBrowserPollResult = (): PollResult => ({
+  ...getPollResult(),
+  result: getBrowserResult(),
+})
+
+export const getApiPollResult = (): PollResult => ({
+  ...getPollResult(),
+  result: getApiResult(),
+})
+
+const getResult = (): TestResult => ({
+  eventType: 'finished',
+  passed: true,
+})
+
+export const getBrowserResult = (opts: any = {}): BrowserTestResult => ({
+  ...getResult(),
   device: {
     height: 1,
     id: 'laptop_large',
     width: 1,
   },
   duration: 0,
-  eventType: 'finished',
-  passed: true,
   startUrl: '',
   stepDetails: [],
   tunnel: false,
   ...opts,
+})
+
+export const getApiResult = (): ApiTestResult => ({
+  ...getResult(),
+  assertionResults: [
+    {
+      actual: 'actual',
+      valid: true,
+    },
+  ],
+  timings: {
+    total: 123,
+  },
+})
+
+export const getMultiStepsResult = (): MultiStepsTestResult => ({
+  ...getResult(),
+  duration: 123,
+  steps: [],
 })
 
 const mockResult = {

--- a/src/commands/synthetics/__tests__/reporters/junit.test.ts
+++ b/src/commands/synthetics/__tests__/reporters/junit.test.ts
@@ -40,8 +40,7 @@ describe('Junit reporter', () => {
   describe('runEnd', () => {
     beforeEach(() => {
       reporter = new JUnitReporter(commandMock as RunTestCommand)
-      // Also mock implementation so it doesn't write the file during the test
-      jest.spyOn(fs, 'writeFile').mockImplementation(jest.fn())
+      jest.spyOn(fs, 'writeFile')
       jest.spyOn(reporter['builder'], 'buildObject')
     })
 
@@ -50,6 +49,9 @@ describe('Junit reporter', () => {
       expect(reporter['builder'].buildObject).toHaveBeenCalledWith(reporter['json'])
       expect(fs.writeFile).toHaveBeenCalledWith('junit.xml', expect.any(String), 'utf8')
       expect(writeMock).toHaveBeenCalledTimes(1)
+
+      // Cleaning
+      await fs.unlink(reporter['destination'])
     })
 
     it('should gracefully fail', async () => {
@@ -61,6 +63,17 @@ describe('Junit reporter', () => {
 
       expect(fs.writeFile).not.toHaveBeenCalled()
       expect(writeMock).toHaveBeenCalledTimes(1)
+    })
+
+    it('should create the file', async () => {
+      reporter['destination'] = 'junit/report.xml'
+      await reporter.runEnd()
+      const stat = await fs.stat(reporter['destination'])
+      expect(stat).toBeDefined()
+
+      // Cleaning
+      await fs.unlink(reporter['destination'])
+      await fs.rmdir('junit')
     })
   })
 

--- a/src/commands/synthetics/__tests__/reporters/junit.test.ts
+++ b/src/commands/synthetics/__tests__/reporters/junit.test.ts
@@ -83,6 +83,16 @@ describe('Junit reporter', () => {
       await fs.unlink(reporter['destination'])
       await fs.rmdir('junit')
     })
+
+    it('should not throw on existing directory', async () => {
+      await fs.mkdir('junit')
+      reporter['destination'] = 'junit/report.xml'
+      await reporter.runEnd()
+
+      // Cleaning
+      await fs.unlink(reporter['destination'])
+      await fs.rmdir('junit')
+    })
   })
 
   describe('testEnd', () => {

--- a/src/commands/synthetics/__tests__/reporters/junit.test.ts
+++ b/src/commands/synthetics/__tests__/reporters/junit.test.ts
@@ -5,14 +5,13 @@ import {Writable} from 'stream'
 import {getDefaultStats, JUnitReporter, XMLTestCase} from '../../reporters/junit'
 import {RunTestCommand} from '../../run-test'
 import {
-  getApiTest,
-  getBrowserResult,
-  getBrowserPollResult,
-  getStep,
   getApiPollResult,
-  getApiResult,
-  getMultiStepsResult,
+  getApiTest,
+  getBrowserPollResult,
+  getBrowserResult,
   getMultiStep,
+  getMultiStepsResult,
+  getStep,
 } from '../fixtures'
 
 const globalTestMock = getApiTest('123')
@@ -123,21 +122,21 @@ describe('Junit reporter', () => {
               ...getStep(),
               browserErrors: [
                 {
-                  type: 'error type',
-                  name: 'error name',
                   description: 'error description',
+                  name: 'error name',
+                  type: 'error type',
                 },
                 {
-                  type: 'error type',
-                  name: 'error name',
                   description: 'error description',
+                  name: 'error name',
+                  type: 'error type',
                 },
               ],
               error: 'error',
               warnings: [
                 {
-                  type: 'warning type',
                   message: 'warning message',
+                  type: 'warning type',
                 },
               ],
             },

--- a/src/commands/synthetics/reporters/junit.ts
+++ b/src/commands/synthetics/reporters/junit.ts
@@ -41,16 +41,16 @@ interface XMLTestCaseProperties extends Stats {
   timestamp: string
 }
 
-interface XMLTestCase {
+export interface XMLTestCase {
   $: XMLTestCaseProperties
   // These are singular for a better display in the XML format of the report.
-  browser_error?: XMLError[]
+  browser_error: XMLError[]
   error: XMLError[]
   properties: {
     property: {$: {name: string; value: any}}[]
   }
   testcase: XMLStep[]
-  warning?: XMLError[]
+  warning: XMLError[]
 }
 
 interface XMLStepProperties extends Stats {
@@ -165,15 +165,15 @@ export class JUnitReporter implements Reporter {
         // It's a browser test.
         for (const stepDetail of result.result.stepDetails) {
           const {browser_error, error, warning} = this.getBrowserTestStep(stepDetail)
-          testCase.browser_error = browser_error
-          testCase.error = error
-          testCase.warning = warning
+          testCase.browser_error.push(...browser_error)
+          testCase.error.push(...error)
+          testCase.warning.push(...warning)
         }
       } else if ('steps' in result.result) {
         // It's a multistep test.
         for (const step of result.result.steps) {
           const {error} = this.getApiTestStep(step)
-          testCase.error = error
+          testCase.error.push(...error)
         }
       }
 

--- a/src/commands/synthetics/reporters/junit.ts
+++ b/src/commands/synthetics/reporters/junit.ts
@@ -1,6 +1,7 @@
 import c from 'chalk'
 import {BaseContext} from 'clipanion'
 import {promises as fs} from 'fs'
+import path from 'path'
 import {Writable} from 'stream'
 import {Builder} from 'xml2js'
 
@@ -131,6 +132,7 @@ export class JUnitReporter implements Reporter {
     // Write the file
     try {
       const xml = this.builder.buildObject(this.json)
+      await fs.mkdir(path.dirname(this.destination), {recursive: true})
       await fs.writeFile(this.destination, xml, 'utf8')
       this.write(`✅ Created a jUnit report at ${c.bold.green(this.destination)}\n`)
     } catch (e) {


### PR DESCRIPTION
### What and why?

When trying to create a jUnit report in a directory, it's not working if the directory in question doesn't exist.

![image](https://user-images.githubusercontent.com/597828/135045052-4c698495-81ca-47c7-a562-51d84c7ffc35.png)

Also, when reporting errors, new steps where overwriting over previous steps.


### How?

- First create the directory.
- Push errors instead of overwriting the full array.


### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)

Published in `0.17.2-alpha`