### PR TITLE
[ci-app] Fix Gitlab Branch Extraction

### DIFF
--- a/src/helpers/__tests__/ci-env/gitlab.json
+++ b/src/helpers/__tests__/ci-env/gitlab.json
@@ -2,8 +2,8 @@
   [
     {
       "CI_COMMIT_AUTHOR": "John Doe <john@doe.com>",
-      "CI_COMMIT_BRANCH": "origin/master",
       "CI_COMMIT_MESSAGE": "gitlab-git-commit-message",
+      "CI_COMMIT_REF_NAME": "origin/master",
       "CI_COMMIT_SHA": "gitlab-git-commit",
       "CI_COMMIT_TIMESTAMP": "2021-07-21T11:43:07-04:00",
       "CI_JOB_NAME": "gitlab-job-name",
@@ -37,8 +37,8 @@
   [
     {
       "CI_COMMIT_AUTHOR": "John Doe <john@doe.com>",
-      "CI_COMMIT_BRANCH": "origin/master",
       "CI_COMMIT_MESSAGE": "gitlab-git-commit-message",
+      "CI_COMMIT_REF_NAME": "origin/master",
       "CI_COMMIT_SHA": "gitlab-git-commit",
       "CI_COMMIT_TIMESTAMP": "2021-07-21T11:43:07-04:00",
       "CI_JOB_NAME": "gitlab-job-name",
@@ -74,8 +74,8 @@
   [
     {
       "CI_COMMIT_AUTHOR": "John Doe <john@doe.com>",
-      "CI_COMMIT_BRANCH": "origin/master",
       "CI_COMMIT_MESSAGE": "gitlab-git-commit-message",
+      "CI_COMMIT_REF_NAME": "origin/master",
       "CI_COMMIT_SHA": "gitlab-git-commit",
       "CI_COMMIT_TIMESTAMP": "2021-07-21T11:43:07-04:00",
       "CI_JOB_NAME": "gitlab-job-name",
@@ -111,8 +111,8 @@
   [
     {
       "CI_COMMIT_AUTHOR": "John Doe <john@doe.com>",
-      "CI_COMMIT_BRANCH": "origin/master",
       "CI_COMMIT_MESSAGE": "gitlab-git-commit-message",
+      "CI_COMMIT_REF_NAME": "origin/master",
       "CI_COMMIT_SHA": "gitlab-git-commit",
       "CI_COMMIT_TIMESTAMP": "2021-07-21T11:43:07-04:00",
       "CI_JOB_NAME": "gitlab-job-name",
@@ -148,8 +148,8 @@
   [
     {
       "CI_COMMIT_AUTHOR": "John Doe <john@doe.com>",
-      "CI_COMMIT_BRANCH": "origin/master",
       "CI_COMMIT_MESSAGE": "gitlab-git-commit-message",
+      "CI_COMMIT_REF_NAME": "origin/master",
       "CI_COMMIT_SHA": "gitlab-git-commit",
       "CI_COMMIT_TIMESTAMP": "2021-07-21T11:43:07-04:00",
       "CI_JOB_NAME": "gitlab-job-name",
@@ -187,8 +187,8 @@
   [
     {
       "CI_COMMIT_AUTHOR": "John Doe <john@doe.com>",
-      "CI_COMMIT_BRANCH": "origin/master",
       "CI_COMMIT_MESSAGE": "gitlab-git-commit-message",
+      "CI_COMMIT_REF_NAME": "origin/master",
       "CI_COMMIT_SHA": "gitlab-git-commit",
       "CI_COMMIT_TIMESTAMP": "2021-07-21T11:43:07-04:00",
       "CI_JOB_NAME": "gitlab-job-name",
@@ -226,8 +226,8 @@
   [
     {
       "CI_COMMIT_AUTHOR": "John Doe <john@doe.com>",
-      "CI_COMMIT_BRANCH": "origin/master",
       "CI_COMMIT_MESSAGE": "gitlab-git-commit-message",
+      "CI_COMMIT_REF_NAME": "origin/master",
       "CI_COMMIT_SHA": "gitlab-git-commit",
       "CI_COMMIT_TIMESTAMP": "2021-07-21T11:43:07-04:00",
       "CI_JOB_NAME": "gitlab-job-name",
@@ -265,8 +265,8 @@
   [
     {
       "CI_COMMIT_AUTHOR": "John Doe <john@doe.com>",
-      "CI_COMMIT_BRANCH": "origin/master",
       "CI_COMMIT_MESSAGE": "gitlab-git-commit-message",
+      "CI_COMMIT_REF_NAME": "origin/master",
       "CI_COMMIT_SHA": "gitlab-git-commit",
       "CI_COMMIT_TIMESTAMP": "2021-07-21T11:43:07-04:00",
       "CI_JOB_NAME": "gitlab-job-name",
@@ -302,8 +302,8 @@
   [
     {
       "CI_COMMIT_AUTHOR": "John Doe <john@doe.com>",
-      "CI_COMMIT_BRANCH": "origin/master",
       "CI_COMMIT_MESSAGE": "gitlab-git-commit-message",
+      "CI_COMMIT_REF_NAME": "origin/master",
       "CI_COMMIT_SHA": "gitlab-git-commit",
       "CI_COMMIT_TIMESTAMP": "2021-07-21T11:43:07-04:00",
       "CI_JOB_NAME": "gitlab-job-name",
@@ -337,8 +337,8 @@
   [
     {
       "CI_COMMIT_AUTHOR": "John Doe <john@doe.com>",
-      "CI_COMMIT_BRANCH": "refs/heads/master",
       "CI_COMMIT_MESSAGE": "gitlab-git-commit-message",
+      "CI_COMMIT_REF_NAME": "refs/heads/master",
       "CI_COMMIT_SHA": "gitlab-git-commit",
       "CI_COMMIT_TIMESTAMP": "2021-07-21T11:43:07-04:00",
       "CI_JOB_NAME": "gitlab-job-name",
@@ -374,8 +374,8 @@
   [
     {
       "CI_COMMIT_AUTHOR": "John Doe <john@doe.com>",
-      "CI_COMMIT_BRANCH": "refs/heads/feature/one",
       "CI_COMMIT_MESSAGE": "gitlab-git-commit-message",
+      "CI_COMMIT_REF_NAME": "refs/heads/feature/one",
       "CI_COMMIT_SHA": "gitlab-git-commit",
       "CI_COMMIT_TIMESTAMP": "2021-07-21T11:43:07-04:00",
       "CI_JOB_NAME": "gitlab-job-name",
@@ -522,8 +522,8 @@
   [
     {
       "CI_COMMIT_AUTHOR": "John Doe <john@doe.com>",
-      "CI_COMMIT_BRANCH": "origin/master",
       "CI_COMMIT_MESSAGE": "gitlab-git-commit-message",
+      "CI_COMMIT_REF_NAME": "origin/master",
       "CI_COMMIT_SHA": "gitlab-git-commit",
       "CI_COMMIT_TIMESTAMP": "2021-07-21T11:43:07-04:00",
       "CI_JOB_NAME": "gitlab-job-name",
@@ -559,8 +559,8 @@
   [
     {
       "CI_COMMIT_AUTHOR": "John Doe <john@doe.com>",
-      "CI_COMMIT_BRANCH": "origin/master",
       "CI_COMMIT_MESSAGE": "gitlab-git-commit-message",
+      "CI_COMMIT_REF_NAME": "origin/master",
       "CI_COMMIT_SHA": "gitlab-git-commit",
       "CI_COMMIT_TIMESTAMP": "2021-07-21T11:43:07-04:00",
       "CI_JOB_NAME": "gitlab-job-name",
@@ -596,8 +596,8 @@
   [
     {
       "CI_COMMIT_AUTHOR": "John Doe <john@doe.com>",
-      "CI_COMMIT_BRANCH": "origin/master",
       "CI_COMMIT_MESSAGE": "gitlab-git-commit-message",
+      "CI_COMMIT_REF_NAME": "origin/master",
       "CI_COMMIT_SHA": "gitlab-git-commit",
       "CI_COMMIT_TIMESTAMP": "2021-07-21T11:43:07-04:00",
       "CI_JOB_NAME": "gitlab-job-name",
@@ -633,8 +633,8 @@
   [
     {
       "CI_COMMIT_AUTHOR": "John Doe <john@doe.com>",
-      "CI_COMMIT_BRANCH": "origin/master",
       "CI_COMMIT_MESSAGE": "gitlab-git-commit-message",
+      "CI_COMMIT_REF_NAME": "origin/master",
       "CI_COMMIT_SHA": "gitlab-git-commit",
       "CI_COMMIT_TIMESTAMP": "2021-07-21T11:43:07-04:00",
       "CI_JOB_NAME": "gitlab-job-name",
@@ -670,8 +670,8 @@
   [
     {
       "CI_COMMIT_AUTHOR": "John Doe <john@doe.com>",
-      "CI_COMMIT_BRANCH": "origin/master",
       "CI_COMMIT_MESSAGE": "gitlab-git-commit-message",
+      "CI_COMMIT_REF_NAME": "origin/master",
       "CI_COMMIT_SHA": "gitlab-git-commit",
       "CI_COMMIT_TIMESTAMP": "2021-07-21T11:43:07-04:00",
       "CI_JOB_NAME": "gitlab-job-name",

--- a/src/helpers/__tests__/ci.test.ts
+++ b/src/helpers/__tests__/ci.test.ts
@@ -54,7 +54,7 @@ describe('getCIMetadata', () => {
 
   test('gitlab CI is recognized', () => {
     process.env = {
-      CI_COMMIT_BRANCH: branch,
+      CI_COMMIT_REF_NAME: branch,
       CI_COMMIT_SHA: commit,
       CI_JOB_URL: pipelineURL,
       GITLAB_CI: 'true',

--- a/src/helpers/ci.ts
+++ b/src/helpers/ci.ts
@@ -160,7 +160,7 @@ export const getCISpanTags = (): SpanTags | undefined => {
       CI_PIPELINE_IID,
       CI_PIPELINE_URL: GITLAB_CI_PIPELINE_URL,
       CI_PROJECT_DIR,
-      CI_COMMIT_BRANCH,
+      CI_COMMIT_REF_NAME,
       CI_COMMIT_TAG,
       CI_COMMIT_SHA,
       CI_REPOSITORY_URL,
@@ -184,7 +184,7 @@ export const getCISpanTags = (): SpanTags | undefined => {
       [CI_PROVIDER_NAME]: CI_ENGINES.GITLAB,
       [CI_WORKSPACE_PATH]: CI_PROJECT_DIR,
       [CI_STAGE_NAME]: CI_JOB_STAGE,
-      [GIT_BRANCH]: CI_COMMIT_BRANCH,
+      [GIT_BRANCH]: CI_COMMIT_REF_NAME,
       [GIT_SHA]: CI_COMMIT_SHA,
       [GIT_REPOSITORY_URL]: CI_REPOSITORY_URL,
       [GIT_TAG]: CI_COMMIT_TAG,
@@ -529,7 +529,7 @@ export const getCIMetadata = (): Metadata | undefined => {
         },
       },
       git: {
-        branch: env.CI_COMMIT_BRANCH,
+        branch: env.CI_COMMIT_REF_NAME,
         commitSha: env.CI_COMMIT_SHA,
       },
     }


### PR DESCRIPTION
### What and why?

More context in the spec update: https://github.com/DataDog/datadog-ci-spec/pull/144

### How?

* Use `CI_COMMIT_REF_NAME` for branch instead of `CI_COMMIT_BRANCH`

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)

