### PR TITLE
[s8s] Fix jUnit report with Timeout errors

### DIFF
--- a/src/commands/synthetics/__tests__/reporters/junit.test.ts
+++ b/src/commands/synthetics/__tests__/reporters/junit.test.ts
@@ -1,6 +1,7 @@
 // tslint:disable: no-string-literal
 import {promises as fs} from 'fs'
 import {Writable} from 'stream'
+import {ERRORS} from '../../interfaces'
 
 import {getDefaultStats, JUnitReporter, XMLTestCase} from '../../reporters/junit'
 import {RunTestCommand} from '../../run-test'
@@ -158,6 +159,10 @@ describe('Junit reporter', () => {
         ...globalResultMock,
         result: getBrowserResult(),
       }
+      const browserResult3 = {
+        ...globalResultMock,
+        result: {...getBrowserResult(), error: ERRORS.TIMEOUT},
+      }
       const apiResult = {
         ...getApiPollResult(),
         result: {
@@ -173,11 +178,12 @@ describe('Junit reporter', () => {
           ],
         },
       }
-      reporter.testEnd(globalTestMock, [browserResult1, browserResult2, apiResult], '', {})
+      reporter.testEnd(globalTestMock, [browserResult1, browserResult2, browserResult3, apiResult], '', {})
       const testsuite = reporter['json'].testsuites.testsuite[0]
       const results = [
         [2, 1, 1],
         [0, 0, 0],
+        [0, 1, 0],
         [0, 1, 0],
       ]
       const entries: [any, XMLTestCase][] = Object.entries(testsuite.testcase)

--- a/src/commands/synthetics/__tests__/utils.test.ts
+++ b/src/commands/synthetics/__tests__/utils.test.ts
@@ -9,7 +9,7 @@ import glob from 'glob'
 import {ProxyConfiguration} from '../../../helpers/utils'
 
 import {apiConstructor} from '../api'
-import {ConfigOverride, ExecutionRule, InternalTest, PollResult, Result} from '../interfaces'
+import {ConfigOverride, ERRORS, ExecutionRule, InternalTest, PollResult, Result} from '../interfaces'
 import {Tunnel} from '../tunnel'
 import * as utils from '../utils'
 
@@ -374,7 +374,7 @@ describe('utils', () => {
       const result: Result = {
         device: {height: 0, id: 'laptop_large', width: 0},
         duration: 0,
-        error: 'Timeout',
+        error: ERRORS.TIMEOUT,
         eventType: 'finished',
         passed: false,
         startUrl: '',
@@ -389,7 +389,7 @@ describe('utils', () => {
     const result: Result = {
       device: {height: 0, id: 'laptop_large', width: 0},
       duration: 0,
-      error: 'Endpoint Failure',
+      error: ERRORS.ENDPOINT,
       eventType: 'finished',
       passed: false,
       startUrl: '',
@@ -427,14 +427,14 @@ describe('utils', () => {
     const endpointFailurePollResult = {
       check: testConfiguration,
       dc_id: 42,
-      result: {...passingResult, passed: false, error: 'Endpoint Failure'},
+      result: {...passingResult, passed: false, error: ERRORS.ENDPOINT},
       resultID: '0123456789',
       timestamp: 0,
     }
     const timeoutPollResult = {
       check: testConfiguration,
       dc_id: 42,
-      result: {...passingResult, passed: false, error: 'Timeout'},
+      result: {...passingResult, passed: false, error: ERRORS.TIMEOUT},
       resultID: '0123456789',
       timestamp: 0,
     }
@@ -471,7 +471,7 @@ describe('utils', () => {
     const getPassingPollResult = (resultId: string) => ({
       check: getTestConfig(),
       dc_id: 42,
-      result: getBrowserResult({error: 'Timeout', passed: false}),
+      result: getBrowserResult({error: ERRORS.TIMEOUT, passed: false}),
       resultID: resultId,
       timestamp: 0,
     })
@@ -515,7 +515,7 @@ describe('utils', () => {
           dc_id: triggerResult.location,
           result: getBrowserResult({
             device: {height: 0, id: triggerResult.device, width: 0},
-            error: 'Timeout',
+            error: ERRORS.TIMEOUT,
             passed: false,
           }),
           resultID: triggerResult.result_id,
@@ -533,7 +533,7 @@ describe('utils', () => {
           dc_id: triggerResult.location,
           result: getBrowserResult({
             device: {height: 0, id: triggerResult.device, width: 0},
-            error: 'Timeout',
+            error: ERRORS.TIMEOUT,
             passed: false,
           }),
           resultID: triggerResult.result_id,
@@ -568,7 +568,7 @@ describe('utils', () => {
           dc_id: triggerResultTimeOut.location,
           result: getBrowserResult({
             device: {height: 0, id: triggerResultTimeOut.device, width: 0},
-            error: 'Timeout',
+            error: ERRORS.TIMEOUT,
             passed: false,
           }),
           resultID: triggerResultTimeOut.result_id,
@@ -601,7 +601,7 @@ describe('utils', () => {
             dc_id: triggerResult.location,
             result: getBrowserResult({
               device: {height: 0, id: triggerResult.device, width: 0},
-              error: 'Tunnel Failure',
+              error: ERRORS.TUNNEL,
               passed: false,
               tunnel: true,
             }),
@@ -633,7 +633,7 @@ describe('utils', () => {
             dc_id: triggerResult.location,
             result: getBrowserResult({
               device: {height: 0, id: triggerResult.device, width: 0},
-              error: 'Endpoint Failure',
+              error: ERRORS.ENDPOINT,
               passed: false,
               tunnel: true,
             }),

--- a/src/commands/synthetics/interfaces.ts
+++ b/src/commands/synthetics/interfaces.ts
@@ -20,6 +20,12 @@ export interface MainReporter {
   testWait(test: Test): void
 }
 
+export enum ERRORS {
+  TIMEOUT = 'Timeout',
+  ENDPOINT = 'Endpoint Failure',
+  TUNNEL = 'Tunnel Failure',
+}
+
 export type Reporter = Partial<MainReporter>
 
 export interface TestResult {
@@ -43,7 +49,7 @@ export interface BrowserTestResult extends TestResult {
     width: number
   }
   duration: number
-  error?: string | 'Endpoint Failure' | 'Timeout' | 'Tunnel Failure'
+  error?: string | ERRORS
   startUrl: string
   stepDetails: Step[]
 }

--- a/src/commands/synthetics/reporters/default.ts
+++ b/src/commands/synthetics/reporters/default.ts
@@ -5,6 +5,7 @@ import {Writable} from 'stream'
 import {
   Assertion,
   ConfigOverride,
+  ERRORS,
   ExecutionRule,
   LocationsMapping,
   Operator,
@@ -218,7 +219,7 @@ const renderExecutionResult = (
     const durationText = duration ? `  total duration: ${duration} ms -` : ''
 
     const resultUrl = getResultUrl(baseUrl, test, resultID)
-    const resultUrlStatus = result.error === 'Timeout' ? '(not yet received)' : ''
+    const resultUrlStatus = result.error === ERRORS.TIMEOUT ? '(not yet received)' : ''
 
     const resultInfo = `    ⎋${durationText} result url: ${chalk.dim.cyan(resultUrl)} ${resultUrlStatus}`
     outputLines.push(resultInfo)

--- a/src/commands/synthetics/reporters/junit.ts
+++ b/src/commands/synthetics/reporters/junit.ts
@@ -7,6 +7,7 @@ import {Builder} from 'xml2js'
 
 import {
   ApiTestResult,
+  ERRORS,
   InternalTest,
   LocationsMapping,
   MultiStep,
@@ -160,7 +161,13 @@ export class JUnitReporter implements Reporter {
 
     for (const result of results) {
       const testCase: XMLTestCase = this.getTestCase(test, result, locations)
-
+      // Timeout errors are only reported at the top level.
+      if (result.result.error === ERRORS.TIMEOUT) {
+        testCase.error.push({
+          $: {type: 'timeout'},
+          _: result.result.error,
+        })
+      }
       if ('stepDetails' in result.result) {
         // It's a browser test.
         for (const stepDetail of result.result.stepDetails) {

--- a/src/commands/synthetics/run-test.ts
+++ b/src/commands/synthetics/run-test.ts
@@ -7,6 +7,7 @@ import {apiConstructor, is5xxError} from './api'
 import {
   APIHelper,
   CommandConfig,
+  ERRORS,
   ExecutionRule,
   LocationsMapping,
   MainReporter,
@@ -237,7 +238,7 @@ export class RunTestCommand extends Command {
           summary.timedOut = 0
         }
 
-        const hasTimeout = testResults.some((pollResult) => pollResult.result.error === 'Timeout')
+        const hasTimeout = testResults.some((pollResult) => pollResult.result.error === ERRORS.TIMEOUT)
         if (hasTimeout) {
           summary.timedOut++
         }

--- a/src/commands/synthetics/utils.ts
+++ b/src/commands/synthetics/utils.ts
@@ -13,6 +13,7 @@ import {EndpointError, formatBackendErrors, is5xxError} from './api'
 import {
   APIHelper,
   ConfigOverride,
+  ERRORS,
   ExecutionRule,
   InternalTest,
   MainReporter,
@@ -169,14 +170,14 @@ export const getStrictestExecutionRule = (configRule: ExecutionRule, testRule?: 
   return ExecutionRule.BLOCKING
 }
 
-export const isCriticalError = (result: Result): boolean => result.unhealthy || result.error === 'Endpoint Failure'
+export const isCriticalError = (result: Result): boolean => result.unhealthy || result.error === ERRORS.ENDPOINT
 
 export const hasResultPassed = (result: Result, failOnCriticalErrors: boolean, failOnTimeout: boolean): boolean => {
   if (isCriticalError(result) && !failOnCriticalErrors) {
     return true
   }
 
-  if (result.error === 'Timeout' && !failOnTimeout) {
+  if (result.error === ERRORS.TIMEOUT && !failOnTimeout) {
     return true
   }
 
@@ -251,7 +252,7 @@ export const waitForResults = async (
     for (const triggerResult of triggerResults.filter((tr) => !tr.result)) {
       if (pollingDuration >= triggerResult.pollingTimeout) {
         triggerResult.result = createFailingResult(
-          'Timeout',
+          ERRORS.TIMEOUT,
           triggerResult.result_id,
           triggerResult.device,
           triggerResult.location,
@@ -263,7 +264,7 @@ export const waitForResults = async (
     if (tunnel && !isTunnelConnected) {
       for (const triggerResult of triggerResults.filter((tr) => !tr.result)) {
         triggerResult.result = createFailingResult(
-          'Tunnel Failure',
+          ERRORS.TUNNEL,
           triggerResult.result_id,
           triggerResult.device,
           triggerResult.location,
@@ -285,7 +286,7 @@ export const waitForResults = async (
         polledResults = []
         for (const triggerResult of triggerResultsSucceed) {
           triggerResult.result = createFailingResult(
-            'Endpoint Failure',
+            ERRORS.ENDPOINT,
             triggerResult.result_id,
             triggerResult.device,
             triggerResult.location,
@@ -344,7 +345,7 @@ export const createTriggerResultMap = (
 }
 
 const createFailingResult = (
-  errorMessage: 'Endpoint Failure' | 'Timeout' | 'Tunnel Failure',
+  errorMessage: ERRORS,
   resultId: string,
   deviceId: string,
   dcId: number,


### PR DESCRIPTION
### What and why?

Currently, the jUnit report doesn't consider timeouts as errors in its reporting.

### How?

- Type errors
- Catch timeouts as errors in the reporting

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)

