### PR TITLE
[s8s] Add allowed_error to the report

### DIFF
--- a/src/commands/synthetics/__tests__/reporters/junit.test.ts
+++ b/src/commands/synthetics/__tests__/reporters/junit.test.ts
@@ -132,6 +132,7 @@ describe('Junit reporter', () => {
           stepDetails: [
             {
               ...getStep(),
+              allowFailure: true,
               browserErrors: [
                 {
                   description: 'error description',
@@ -182,17 +183,18 @@ describe('Junit reporter', () => {
       reporter.testEnd(globalTestMock, [browserResult1, browserResult2, browserResult3, apiResult], '', {}, true, true)
       const testsuite = reporter['json'].testsuites.testsuite[0]
       const results = [
-        [2, 1, 1],
-        [0, 0, 0],
-        [0, 1, 0],
-        [0, 1, 0],
+        [1, 2, 0, 1],
+        [0, 0, 0, 0],
+        [0, 0, 1, 0],
+        [0, 0, 1, 0],
       ]
       const entries: [any, XMLTestCase][] = Object.entries(testsuite.testcase)
       for (const [i, testcase] of entries) {
         const result = results[i]
-        expect(testcase.browser_error.length).toBe(result[0])
-        expect(testcase.error.length).toBe(result[1])
-        expect(testcase.warning.length).toBe(result[2])
+        expect(testcase.allowed_error.length).toBe(result[0])
+        expect(testcase.browser_error.length).toBe(result[1])
+        expect(testcase.error.length).toBe(result[2])
+        expect(testcase.warning.length).toBe(result[3])
       }
     })
   })


### PR DESCRIPTION
### What and why?

We should not report step's error as an `<error>` if the step is `allowFailure=true` because, the test may be reported as failing, when it's not.

### How?

Add a new `<allowed_error>` to the report, so we keep reporting them, without marking the test as failing.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)

