### PR TITLE
[ci-app] Capture error message

### DIFF
--- a/src/commands/junit/upload.ts
+++ b/src/commands/junit/upload.ts
@@ -189,21 +189,22 @@ export class UploadJUnitXMLCommand extends Command {
                 throw error
               }
             }
-            // If it's another error or an axios error we don't want to retry, bail
-            bail(error)
+            // If it's another error or an axios error let us retry just in case
+            // This will catch DNS resolution errors and connection timeouts
+            throw error
 
             return
           }
         },
         {
           onRetry: (e, attempt) => {
-            this.context.stdout.write(renderRetriedUpload(jUnitXML, e.message, attempt))
+            this.context.stderr.write(renderRetriedUpload(jUnitXML, e.message, attempt))
           },
           retries: 5,
         }
       )
     } catch (error) {
-      this.context.stdout.write(renderFailedUpload(jUnitXML, error))
+      this.context.stderr.write(renderFailedUpload(jUnitXML, error))
       if (error.response) {
         // If it's an axios error
         if (!errorCodesStopUpload.includes(error.response.status)) {

--- a/src/commands/trace/interfaces.ts
+++ b/src/commands/trace/interfaces.ts
@@ -15,6 +15,8 @@ export interface Payload {
   // Data is a map of CI-provider-specific environment variables
   data: Record<string, string>
   end_time: string
+  error_message: string
+  exit_code: number
   is_error: boolean
   name: string
   start_time: string

--- a/src/commands/trace/trace.ts
+++ b/src/commands/trace/trace.ts
@@ -59,7 +59,8 @@ export class TraceCommand extends Command {
       stdio: ['inherit', 'inherit', 'pipe'],
     })
     const chunks: Buffer[] = []
-    const strerrCatcher: Promise<string> = new Promise((resolve, reject) => {
+    childProcess.stderr.pipe(this.context.stderr)
+    const stderrCatcher: Promise<string> = new Promise((resolve, reject) => {
       childProcess.stderr.on('data', (chunk) => chunks.push(Buffer.from(chunk)))
       childProcess.stderr.on('error', (err) => reject(err))
       childProcess.stderr.on('end', () => resolve(Buffer.concat(chunks).toString('utf8')))
@@ -74,8 +75,7 @@ export class TraceCommand extends Command {
       })
     })
 
-    const stderr: string = await strerrCatcher
-    this.context.stderr.write(stderr)
+    const stderr: string = await stderrCatcher
     const endTime = new Date().toISOString()
     const exitCode: number = status ?? this.signalToNumber(signal) ?? BAD_COMMAND_EXIT_CODE
     const [ciEnvVars, provider] = this.getCIEnvVars()

--- a/src/commands/trace/trace.ts
+++ b/src/commands/trace/trace.ts
@@ -1,3 +1,4 @@
+import retry from 'async-retry'
 import chalk from 'chalk'
 import {spawn} from 'child_process'
 import {Command} from 'clipanion'
@@ -5,7 +6,9 @@ import crypto from 'crypto'
 import os from 'os'
 import {parseTags} from '../../helpers/tags'
 import {apiConstructor} from './api'
-import {APIHelper, CIRCLECI, JENKINS, Provider, SUPPORTED_PROVIDERS} from './interfaces'
+import {APIHelper, CIRCLECI, JENKINS, Payload, Provider, SUPPORTED_PROVIDERS} from './interfaces'
+
+const errorCodesNoRetry = [400, 403, 413]
 
 // We use 127 as exit code for invalid commands since that is what *sh terminals return
 const BAD_COMMAND_EXIT_CODE = 127
@@ -53,7 +56,16 @@ export class TraceCommand extends Command {
     const [command, ...args] = this.command
     const id = crypto.randomBytes(5).toString('hex')
     const startTime = new Date().toISOString()
-    const childProcess = spawn(command, args, {env: {...process.env, DD_CUSTOM_PARENT_ID: id}, stdio: 'inherit'})
+    const childProcess = spawn(command, args, {
+      env: {...process.env, DD_CUSTOM_PARENT_ID: id},
+      stdio: ['inherit', 'inherit', 'pipe'],
+    })
+    const chunks: Buffer[] = []
+    const strerrCatcher: Promise<string> = new Promise((resolve, reject) => {
+      childProcess.stderr.on('data', (chunk) => chunks.push(Buffer.from(chunk)))
+      childProcess.stderr.on('error', (err) => reject(err))
+      childProcess.stderr.on('end', () => resolve(Buffer.concat(chunks).toString('utf8')))
+    })
     const [status, signal] = await new Promise((resolve, reject) => {
       childProcess.on('error', (error: Error) => {
         reject(error)
@@ -63,15 +75,17 @@ export class TraceCommand extends Command {
         resolve([exitStatus, exitSignal])
       })
     })
+
+    const stderr: string = await strerrCatcher
+    this.context.stderr.write(stderr)
     const endTime = new Date().toISOString()
-    const exitCode = status ?? this.signalToNumber(signal) ?? BAD_COMMAND_EXIT_CODE
+    const exitCode: number = status ?? this.signalToNumber(signal) ?? BAD_COMMAND_EXIT_CODE
     const [ciEnvVars, provider] = this.getCIEnvVars()
     if (provider) {
-      const api = this.getApiHelper()
       const commandStr = this.command.join(' ')
       const envVarTags = this.config.envVarTags ? parseTags(this.config.envVarTags.split(',')) : {}
       const cliTags = this.tags ? parseTags(this.tags) : {}
-      await api.reportCustomSpan(
+      await this.reportCustomSpan(
         {
           command: commandStr,
           custom: {
@@ -80,6 +94,8 @@ export class TraceCommand extends Command {
           },
           data: ciEnvVars,
           end_time: endTime,
+          error_message: stderr,
+          exit_code: exitCode,
           is_error: exitCode !== 0,
           name: this.name ?? commandStr,
           start_time: startTime,
@@ -93,6 +109,39 @@ export class TraceCommand extends Command {
     }
 
     return exitCode
+  }
+
+  private async reportCustomSpan(payload: Payload, provider: Provider) {
+    const api = this.getApiHelper()
+    try {
+      await retry(
+        async (bail) => {
+          try {
+            await api.reportCustomSpan(payload, provider)
+          } catch (error) {
+            const util = require('util')
+            if (error.response) {
+              // If it's an axios error
+              if (!errorCodesNoRetry.includes(error.response.status)) {
+                // And a status code that is not excluded from retries, throw the error to retry
+                throw error
+              }
+            }
+            // If it's another error or an axios error let us retry just in case
+            // This will catch DNS resolution errors and connection timeouts
+            throw error
+          }
+        },
+        {
+          onRetry: (e, attempt) => {
+            this.context.stderr.write(chalk.yellow(`[attempt ${attempt}] Could not report custom span. Retrying...: ${e.message}\n`))
+          },
+          retries: 5,
+        }
+      )
+    } catch (error) {
+      this.context.stderr.write(chalk.red(`Failed to report custom span: ${error.message}\n`))
+    }
   }
 
   public getCIEnvVars(): [Record<string, string>, Provider?] {

--- a/src/helpers/__tests__/retry.test.ts
+++ b/src/helpers/__tests__/retry.test.ts
@@ -34,6 +34,8 @@ describe('retry', () => {
 
   test('should retry retriable failed requests', async () => {
     await retryRequest(createResultWithErrors([buildHttpError(500), undefined]), {
+      maxTimeout: 50,
+      minTimeout: 10,
       onRetry: retryCallback,
       retries: 5,
     })
@@ -42,6 +44,8 @@ describe('retry', () => {
 
   test('should retry non-http errors', async () => {
     await retryRequest(createResultWithErrors([{message: 'Connection timeout'}, undefined]), {
+      maxTimeout: 50,
+      minTimeout: 10,
       onRetry: retryCallback,
       retries: 5,
     })
@@ -52,6 +56,8 @@ describe('retry', () => {
     let threwError = false
     try {
       await retryRequest(createResultWithErrors([buildHttpError(413)]), {
+        maxTimeout: 50,
+        minTimeout: 10,
         onRetry: retryCallback,
         retries: 5,
       })
@@ -65,21 +71,28 @@ describe('retry', () => {
   test('should retry only a given amount of times', async () => {
     let threwError = false
     try {
-      await retryRequest(createResultWithErrors([buildHttpError(413), buildHttpError(413)]), {
-        onRetry: retryCallback,
-        retries: 1,
-      })
+      await retryRequest(
+        createResultWithErrors([buildHttpError(500), buildHttpError(500), buildHttpError(500), buildHttpError(500)]),
+        {
+          maxTimeout: 20,
+          minTimeout: 10,
+          onRetry: retryCallback,
+          retries: 3,
+        }
+      )
     } catch (error) {
       threwError = true
     }
     expect(threwError).toBeTruthy()
-    expect(retryCallback).toBeCalledTimes(0)
+    expect(retryCallback).toBeCalledTimes(3)
   })
 
   test('should not retry if the call was successful', async () => {
     await retryRequest(createResultWithErrors([undefined]), {
+      maxTimeout: 50,
+      minTimeout: 10,
       onRetry: retryCallback,
-      retries: 1,
+      retries: 5,
     })
     expect(retryCallback).toBeCalledTimes(0)
   })

--- a/src/helpers/__tests__/retry.test.ts
+++ b/src/helpers/__tests__/retry.test.ts
@@ -1,0 +1,86 @@
+import {AxiosPromise} from 'axios'
+import {retryRequest} from '../retry'
+
+describe('retry', () => {
+  const retryCallback = jest.fn()
+  const createResultWithErrors = (errors: any[]): (() => AxiosPromise) => {
+    let i = -1
+
+    return () => {
+      i = i + 1
+      if (errors[i] === undefined) {
+        return Promise.resolve({
+          config: {},
+          data: {},
+          headers: undefined,
+          status: 200,
+          statusText: '',
+        })
+      } else {
+        return Promise.reject(errors[i])
+      }
+    }
+  }
+
+  beforeEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  const buildHttpError = (statusCode: number) => ({
+    response: {
+      status: statusCode,
+    },
+  })
+
+  test('should retry retriable failed requests', async () => {
+    await retryRequest(createResultWithErrors([buildHttpError(500), undefined]), {
+      onRetry: retryCallback,
+      retries: 5,
+    })
+    expect(retryCallback).toBeCalledTimes(1)
+  })
+
+  test('should retry non-http errors', async () => {
+    await retryRequest(createResultWithErrors([{message: 'Connection timeout'}, undefined]), {
+      onRetry: retryCallback,
+      retries: 5,
+    })
+    expect(retryCallback).toBeCalledTimes(1)
+  })
+
+  test('should not retry some clients failures', async () => {
+    let threwError = false
+    try {
+      await retryRequest(createResultWithErrors([buildHttpError(413)]), {
+        onRetry: retryCallback,
+        retries: 5,
+      })
+    } catch (error) {
+      threwError = true
+    }
+    expect(threwError).toBeTruthy()
+    expect(retryCallback).toBeCalledTimes(0)
+  })
+
+  test('should retry only a given amount of times', async () => {
+    let threwError = false
+    try {
+      await retryRequest(createResultWithErrors([buildHttpError(413), buildHttpError(413)]), {
+        onRetry: retryCallback,
+        retries: 1,
+      })
+    } catch (error) {
+      threwError = true
+    }
+    expect(threwError).toBeTruthy()
+    expect(retryCallback).toBeCalledTimes(0)
+  })
+
+  test('should not retry if the call was successful', async () => {
+    await retryRequest(createResultWithErrors([undefined]), {
+      onRetry: retryCallback,
+      retries: 1,
+    })
+    expect(retryCallback).toBeCalledTimes(0)
+  })
+})

--- a/src/helpers/__tests__/retry.test.ts
+++ b/src/helpers/__tests__/retry.test.ts
@@ -16,9 +16,9 @@ describe('retry', () => {
           status: 200,
           statusText: '',
         })
-      } else {
-        return Promise.reject(errors[i])
       }
+
+      return Promise.reject(errors[i])
     }
   }
 

--- a/src/helpers/retry.ts
+++ b/src/helpers/retry.ts
@@ -8,18 +8,15 @@ export const retryRequest = async (requestBuilder: () => Promise<any>, retryOpts
     try {
       await requestBuilder()
     } catch (error) {
-      if (error.response) {
-        // If it's an axios error
-        if (!errorCodesNoRetry.includes(error.response.status)) {
-          // And a status code that is not excluded from retries, throw the error so that upload is retried
-          throw error
-        }
-      } else {
-        // If it's another error or an axios error let us retry just in case
-        // This will catch DNS resolution errors and connection timeouts
-        throw error
+      if (error.response && errorCodesNoRetry.includes(error.response.status)) {
+        // If it's an axios error with a status code that is excluded from retries, we bail to avoid retrying
+        bail(error)
+
+        return
       }
-      bail(error)
+      // Other cases are retried: other axios HTTP errors as well as
+      // non-axios errors such as DNS resolution errors and connection timeouts
+      throw error
     }
   }
 

--- a/src/helpers/retry.ts
+++ b/src/helpers/retry.ts
@@ -2,11 +2,11 @@ import retry from 'async-retry'
 
 const errorCodesNoRetry = [400, 403, 413]
 
-export const retryRequest = async (requestBuilder: () => Promise<any>, retryOpts: retry.Options): Promise<void> => {
+export const retryRequest = async (requestPerformer: () => Promise<any>, retryOpts: retry.Options): Promise<void> => {
   // Request function, passed to async-retry
   const doRequest = async (bail: (e: Error) => void) => {
     try {
-      await requestBuilder()
+      await requestPerformer()
     } catch (error) {
       if (error.response && errorCodesNoRetry.includes(error.response.status)) {
         // If it's an axios error with a status code that is excluded from retries, we bail to avoid retrying

--- a/src/helpers/retry.ts
+++ b/src/helpers/retry.ts
@@ -1,0 +1,28 @@
+import retry from 'async-retry'
+
+const errorCodesNoRetry = [400, 403, 413]
+
+export const retryRequest = async (requestBuilder: () => Promise<any>, retryOpts: retry.Options): Promise<void> => {
+  // Request function, passed to async-retry
+  const doRequest = async (bail: (e: Error) => void) => {
+    try {
+      await requestBuilder()
+    } catch (error) {
+      if (error.response) {
+        // If it's an axios error
+        if (!errorCodesNoRetry.includes(error.response.status)) {
+          // And a status code that is not excluded from retries, throw the error so that upload is retried
+          throw error
+        }
+      } else {
+        // If it's another error or an axios error let us retry just in case
+        // This will catch DNS resolution errors and connection timeouts
+        throw error
+      }
+      bail(error)
+    }
+  }
+
+  // Do the actual call
+  return retry(doRequest, retryOpts)
+}


### PR DESCRIPTION
### What and why?

- Adds error messages and exit code to the payload for custom spans
- Adds retries to HTTP intake for the trace command

### How?

The upload code in the utils package has been refactored into a retry package to have a common retry policy among commands. The trace command as well as the source code integration commands and the junit commands are now using this common retry logic.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)

