### PR TITLE
Fix sourcemap README.md

### DIFF
--- a/src/commands/sourcemaps/README.md
+++ b/src/commands/sourcemaps/README.md
@@ -44,7 +44,7 @@ Example: if you're uploading `dist/file.js` to `https://example.com/static/file.
 
 In addition, some optional parameters are available:
 
-* `--concurrency` (default: `20`): number of concurrent upload to the API.
+* `--max-concurrency` (default: `20`): number of concurrent upload to the API.
 * `--disable-git` (default: false): prevents the command from invoking git in the current working directory and sending repository related data to Datadog (hash, remote URL and the paths within the repository of the sources referenced in the sourcemap).
 * `--dry-run` (default: `false`): it will run the command without the final step of upload. All other checks are performed.
 * `--project-path` (default: empty): the path of the project where the sourcemaps were built. This will be stripped off from sources paths referenced in the sourcemap so they can be properly matched against tracked files paths.


### PR DESCRIPTION
Update the readme to match the flag https://github.com/DataDog/datadog-ci/blob/master/src/commands/sourcemaps/upload.ts#L321
