### PR TITLE
v0.17.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci",
-  "version": "0.17.5",
+  "version": "0.17.6",
   "description": "Run datadog actions from the CI.",
   "main": "dist/index.js",
   "repository": "https://github.com/DataDog/datadog-ci",


### PR DESCRIPTION
### What and why?

This PR bumps the package to version 0.17.6 with the following changes : 

- [#376](https://github.com/DataDog/datadog-ci/pull/376): [s8s] Separate run-test logic from cli
- [#394](https://github.com/DataDog/datadog-ci/pull/394): [s8s] Add allowed_error to the report
- [#395](https://github.com/DataDog/datadog-ci/pull/395): [ci-app] Capture error message
- [#396](https://github.com/DataDog/datadog-ci/pull/396): [sourcemaps] Fix sourcemap README.md
- [#397](https://github.com/DataDog/datadog-ci/pull/397): [lambda] Add documentation for unified service tagging

