### PR TITLE
[Synthetics] Add list of tests not found to Test execution summary

### DIFF
--- a/src/commands/synthetics/__tests__/reporters/default.test.ts
+++ b/src/commands/synthetics/__tests__/reporters/default.test.ts
@@ -2,6 +2,7 @@ import {BaseContext} from 'clipanion/lib/advanced'
 
 import {MainReporter} from '../../interfaces'
 import {DefaultReporter} from '../../reporters/default'
+import {createSummary} from '../../utils'
 
 describe('Default reporter', () => {
   const writeMock = jest.fn()
@@ -19,7 +20,7 @@ describe('Default reporter', () => {
       ['initErrors', [['error']]],
       ['log', ['log']],
       ['reportStart', [{startTime: 0}]],
-      ['runEnd', [{passed: 0, failed: 0, skipped: 0}]],
+      ['runEnd', [createSummary()]],
       ['testEnd', [{options: {}}, [], '', []]],
       ['testTrigger', [{}, '', '', {}]],
       ['testWait', [{}]],

--- a/src/commands/synthetics/__tests__/run-test.test.ts
+++ b/src/commands/synthetics/__tests__/run-test.test.ts
@@ -22,7 +22,7 @@ describe('run-test', () => {
       const getTestsToTriggersMock = jest.spyOn(utils, 'getTestsToTrigger').mockReturnValue(
         Promise.resolve({
           overriddenTestsToTrigger: [],
-          summary: {criticalErrors: 0, passed: 0, failed: 0, skipped: 0, notFound: 0, timedOut: 0},
+          summary: utils.createSummary(),
           tests: [],
         })
       )
@@ -57,7 +57,7 @@ describe('run-test', () => {
       const getTestsToTriggersMock = jest.spyOn(utils, 'getTestsToTrigger').mockReturnValue(
         Promise.resolve({
           overriddenTestsToTrigger: [],
-          summary: {criticalErrors: 0, passed: 0, failed: 0, skipped: 0, notFound: 0, timedOut: 0},
+          summary: utils.createSummary(),
           tests: [],
         })
       )
@@ -87,7 +87,7 @@ describe('run-test', () => {
       const getTestsToTriggersMock = jest.spyOn(utils, 'getTestsToTrigger').mockReturnValue(
         Promise.resolve({
           overriddenTestsToTrigger: [],
-          summary: {criticalErrors: 0, passed: 0, failed: 0, skipped: 0, notFound: 0, timedOut: 0},
+          summary: utils.createSummary(),
           tests: [],
         })
       )
@@ -151,7 +151,7 @@ describe('run-test', () => {
       jest.spyOn(utils, 'getTestsToTrigger').mockReturnValue(
         Promise.resolve({
           overriddenTestsToTrigger: [],
-          summary: {criticalErrors: 0, passed: 0, failed: 0, skipped: 0, notFound: 0, timedOut: 0},
+          summary: utils.createSummary(),
           tests: [{options: {ci: {executionRule: ExecutionRule.BLOCKING}}, public_id: 'publicId'} as any],
         })
       )
@@ -175,7 +175,7 @@ describe('run-test', () => {
       jest.spyOn(utils, 'getTestsToTrigger').mockReturnValue(
         Promise.resolve({
           overriddenTestsToTrigger: [],
-          summary: {criticalErrors: 0, passed: 0, failed: 0, skipped: 0, notFound: 0, timedOut: 0},
+          summary: utils.createSummary(),
           tests: [{options: {ci: {executionRule: ExecutionRule.BLOCKING}}, public_id: 'publicId'} as any],
         })
       )
@@ -206,7 +206,7 @@ describe('run-test', () => {
       jest.spyOn(utils, 'getTestsToTrigger').mockReturnValue(
         Promise.resolve({
           overriddenTestsToTrigger: [],
-          summary: {criticalErrors: 0, passed: 0, failed: 0, skipped: 0, notFound: 0, timedOut: 0},
+          summary: utils.createSummary(),
           tests: [{options: {ci: {executionRule: ExecutionRule.BLOCKING}}, public_id: 'publicId'} as any],
         })
       )

--- a/src/commands/synthetics/__tests__/utils.test.ts
+++ b/src/commands/synthetics/__tests__/utils.test.ts
@@ -9,7 +9,7 @@ import glob from 'glob'
 import {ProxyConfiguration} from '../../../helpers/utils'
 
 import {apiConstructor} from '../api'
-import {ConfigOverride, ERRORS, ExecutionRule, InternalTest, PollResult, Result} from '../interfaces'
+import {ConfigOverride, ERRORS, ExecutionRule, InternalTest, PollResult, Result, Summary} from '../interfaces'
 import {Tunnel} from '../tunnel'
 import * as utils from '../utils'
 
@@ -156,7 +156,15 @@ describe('utils', () => {
         {executionRule: ExecutionRule.SKIPPED, public_id: 'ski-ppe-d01'},
       ])
 
-      expect(summary).toEqual({criticalErrors: 0, failed: 0, notFound: 1, passed: 0, skipped: 1, timedOut: 0})
+      const expectedSummary: Summary = {
+        criticalErrors: 0,
+        failed: 0,
+        passed: 0,
+        skipped: 1,
+        testsNotFound: new Set(['987-654-321']),
+        timedOut: 0,
+      }
+      expect(summary).toEqual(expectedSummary)
     })
 
     test('no tests triggered throws an error', async () => {

--- a/src/commands/synthetics/interfaces.ts
+++ b/src/commands/synthetics/interfaces.ts
@@ -315,9 +315,9 @@ export interface Suite {
 export interface Summary {
   criticalErrors: number
   failed: number
-  notFound: number
   passed: number
   skipped: number
+  testsNotFound: Set<string>
   timedOut: number
 }
 

--- a/src/commands/synthetics/reporters/default.ts
+++ b/src/commands/synthetics/reporters/default.ts
@@ -297,8 +297,10 @@ export class DefaultReporter implements MainReporter {
     if (summary.skipped) {
       summaries.push(`${chalk.bold(summary.skipped)} skipped`)
     }
-    if (summary.notFound) {
-      summaries.push(chalk.yellow(`${chalk.bold(summary.notFound)} not found`))
+
+    if (summary.testsNotFound.size > 0) {
+      const testsNotFoundStr = chalk.gray(`(${[...summary.testsNotFound].join(', ')})`)
+      summaries.push(`${chalk.yellow(`${chalk.bold(summary.testsNotFound.size)} not found`)} ${testsNotFoundStr}`)
     }
 
     const extraInfo = []

--- a/src/commands/synthetics/utils.ts
+++ b/src/commands/synthetics/utils.ts
@@ -366,12 +366,21 @@ const createFailingResult = (
   timestamp: 0,
 })
 
+export const createSummary = (): Summary => ({
+  criticalErrors: 0,
+  failed: 0,
+  passed: 0,
+  skipped: 0,
+  testsNotFound: new Set(),
+  timedOut: 0,
+})
+
 export const getResultDuration = (result: Result): number => {
   if ('duration' in result) {
-    return result.duration
+    return Math.round(result.duration)
   }
   if ('timings' in result) {
-    return result.timings.total
+    return Math.round(result.timings.total)
   }
 
   return 0
@@ -439,7 +448,7 @@ export const getReporter = (reporters: Reporter[]): MainReporter => ({
 export const getTestsToTrigger = async (api: APIHelper, triggerConfigs: TriggerConfig[], reporter: MainReporter) => {
   const overriddenTestsToTrigger: TestPayload[] = []
   const errorMessages: string[] = []
-  const summary: Summary = {criticalErrors: 0, failed: 0, notFound: 0, passed: 0, skipped: 0, timedOut: 0}
+  const summary = createSummary()
 
   const tests = await Promise.all(
     triggerConfigs.map(async ({config, id, suite}) => {
@@ -455,7 +464,7 @@ export const getTestsToTrigger = async (api: APIHelper, triggerConfigs: TriggerC
           throw e
         }
 
-        summary.notFound++
+        summary.testsNotFound.add(id)
         const errorMessage = formatBackendErrors(e)
         errorMessages.push(`[${chalk.bold.dim(id)}] ${chalk.yellow.bold('Test not found')}: ${errorMessage}\n`)
 


### PR DESCRIPTION
### What and why?

Output the list of missing tests on the test execution summary.

![image](https://user-images.githubusercontent.com/19409477/137914022-366c2148-9b44-46d9-9be9-c0b34e8b02af.png)

Also rounds total test duration to ms to reduce line width and URL wrapping.

### How?

Store list of missing tests inside `Summary`, add `createSummary()` utility function to instantiate an empty summary.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)

