### PR TITLE
v0.17.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci",
-  "version": "0.17.6",
+  "version": "0.17.7",
   "description": "Run datadog actions from the CI.",
   "main": "dist/index.js",
   "repository": "https://github.com/DataDog/datadog-ci",


### PR DESCRIPTION
### What and why?

Rename `datadog-ci commits` upload into `datadog-ci git-metadata upload`. Since the command is not publicly documented yet I chose to bump only the patch version number.

### How?

A brief description of implementation details of this PR.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)

