### PR TITLE
add checklist to update dependencies of datadog-ci

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,4 +9,4 @@ A brief description of implementation details of this PR.
 ### Review checklist
 
 - [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
-
+- [ ] A new release of `datadog-ci` MUST be updated in the [synthetics-ci-github-action](https://github.com/DataDog/synthetics-ci-github-action)


### PR DESCRIPTION
This PR adds an item in the checklist to make sure a new release of `datadog-ci` is followed by an update in the [`synthetics-ci-github-action`](https://github.com/DataDog/synthetics-ci-github-action).
