### PR TITLE
[lambda] support ARM layers

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   },
   "dependencies": {
     "async-retry": "1.3.1",
-    "aws-sdk": "2.903.0",
+    "aws-sdk": "2.1012.0",
     "axios": "0.21.2",
     "chalk": "3.0.0",
     "clipanion": "2.2.2",

--- a/src/commands/lambda/__tests__/functions/commons.test.ts
+++ b/src/commands/lambda/__tests__/functions/commons.test.ts
@@ -117,7 +117,22 @@ describe('commons', () => {
       expect(layerArn).toEqual(`arn:aws:lambda:${region}:${mockAwsAccount}:layer:Datadog-Extension`)
     })
 
-    test('gets sa-east-1 gov cloud Lambda Extension layer ARN', async () => {
+    test('gets sa-east-1 arm64 Lambda Extension layer ARN', async () => {
+      const config = {
+        Architectures: ['arm64'],
+      }
+      const settings = {
+        flushMetricsToLogs: false,
+        layerAWSAccount: mockAwsAccount,
+        mergeXrayTraces: false,
+        tracingEnabled: false,
+      }
+      const region = 'sa-east-1'
+      const layerArn = getExtensionArn(config, region, settings)
+      expect(layerArn).toEqual(`arn:aws:lambda:${region}:${mockAwsAccount}:layer:Datadog-Extension-ARM`)
+    })
+
+    test('gets us-gov-1 gov cloud Lambda Extension layer ARN', async () => {
       const settings = {
         flushMetricsToLogs: false,
         layerAWSAccount: mockAwsAccount,
@@ -127,6 +142,23 @@ describe('commons', () => {
       const region = 'us-gov-1'
       const layerArn = getExtensionArn({}, region, settings)
       expect(layerArn).toEqual(`arn:aws-us-gov:lambda:${region}:${GOVCLOUD_LAYER_AWS_ACCOUNT}:layer:Datadog-Extension`)
+    })
+
+    test('gets us-gov-1 gov cloud arm64 Lambda Extension layer ARN', async () => {
+      const config = {
+        Architectures: ['arm64'],
+      }
+      const settings = {
+        flushMetricsToLogs: false,
+        layerAWSAccount: mockAwsAccount,
+        mergeXrayTraces: false,
+        tracingEnabled: false,
+      }
+      const region = 'us-gov-1'
+      const layerArn = getExtensionArn(config, region, settings)
+      expect(layerArn).toEqual(
+        `arn:aws-us-gov:lambda:${region}:${GOVCLOUD_LAYER_AWS_ACCOUNT}:layer:Datadog-Extension-ARM`
+      )
     })
   })
   describe('getLayerArn', () => {
@@ -155,7 +187,23 @@ describe('commons', () => {
       expect(layerArn).toEqual(`arn:aws:lambda:${region}:${mockAwsAccount}:layer:Datadog-Node12-x`)
     })
 
-    test('gets sa-east-1 Python37 gov cloud Lambda Library layer ARN', async () => {
+    test('gets sa-east-1 Python3.9 arm64 Lambda Library layer ARN', async () => {
+      const runtime = 'python3.9'
+      const config = {
+        Architectures: ['arm64'],
+        Runtime: runtime,
+      }
+      const settings = {
+        flushMetricsToLogs: false,
+        layerAWSAccount: mockAwsAccount,
+        mergeXrayTraces: false,
+        tracingEnabled: false,
+      }
+      const region = 'sa-east-1'
+      const layerArn = getLayerArn(config, region, settings)
+      expect(layerArn).toEqual(`arn:aws:lambda:${region}:${mockAwsAccount}:layer:Datadog-Python39-ARM`)
+    })
+    test('gets us-gov-1 Python37 gov cloud Lambda Library layer ARN', async () => {
       const runtime = 'python3.7'
       const config = {
         Runtime: runtime,
@@ -169,6 +217,24 @@ describe('commons', () => {
       const region = 'us-gov-1'
       const layerArn = getLayerArn(config, region, settings)
       expect(layerArn).toEqual(`arn:aws-us-gov:lambda:${region}:${GOVCLOUD_LAYER_AWS_ACCOUNT}:layer:Datadog-Python37`)
+    })
+    test('gets us-gov-1 Python39 gov cloud arm64 Lambda Library layer ARN', async () => {
+      const runtime = 'python3.9'
+      const config = {
+        Architectures: ['arm64'],
+        Runtime: runtime,
+      }
+      const settings = {
+        flushMetricsToLogs: false,
+        layerAWSAccount: mockAwsAccount,
+        mergeXrayTraces: false,
+        tracingEnabled: false,
+      }
+      const region = 'us-gov-1'
+      const layerArn = getLayerArn(config, region, settings)
+      expect(layerArn).toEqual(
+        `arn:aws-us-gov:lambda:${region}:${GOVCLOUD_LAYER_AWS_ACCOUNT}:layer:Datadog-Python39-ARM`
+      )
     })
   })
   describe('getRegion', () => {

--- a/src/commands/lambda/__tests__/functions/commons.test.ts
+++ b/src/commands/lambda/__tests__/functions/commons.test.ts
@@ -1,6 +1,7 @@
 /* tslint:disable:no-string-literal */
 import {
   DD_LAMBDA_EXTENSION_LAYER_NAME,
+  EXTENSION_LAYER_KEY,
   EXTRA_TAGS_REG_EXP,
   GOVCLOUD_LAYER_AWS_ACCOUNT,
   LAMBDA_HANDLER_ENV_VAR,
@@ -12,7 +13,6 @@ import {
 import {
   addLayerArn,
   collectFunctionsByRegion,
-  getExtensionArn,
   getLayerArn,
   getRegion,
   sentenceMatchesRegEx,
@@ -34,8 +34,8 @@ describe('commons', () => {
       ]
       const region = 'sa-east-1'
       const lambdaLibraryLayerName = RUNTIME_LAYER_LOOKUP[runtime]
-      const fullLambdaLibraryLayerArn = getLayerArn(config, region) + ':49'
-      const fullExtensionLayerArn = getExtensionArn(config, region) + ':11'
+      const fullLambdaLibraryLayerArn = getLayerArn(config, config.Runtime, region) + ':49'
+      const fullExtensionLayerArn = getLayerArn(config, EXTENSION_LAYER_KEY as Runtime, region) + ':11'
       layerARNs = addLayerArn(fullLambdaLibraryLayerArn, lambdaLibraryLayerName, layerARNs)
       layerARNs = addLayerArn(fullExtensionLayerArn, DD_LAMBDA_EXTENSION_LAYER_NAME, layerARNs)
 
@@ -57,8 +57,8 @@ describe('commons', () => {
       ]
       const region = 'sa-east-1'
       const lambdaLibraryLayerName = RUNTIME_LAYER_LOOKUP[runtime]
-      const fullLambdaLibraryLayerArn = getLayerArn(config, region) + ':49'
-      const fullExtensionLayerArn = getExtensionArn(config, region) + ':11'
+      const fullLambdaLibraryLayerArn = getLayerArn(config, config.Runtime, region) + ':49'
+      const fullExtensionLayerArn = getLayerArn(config, EXTENSION_LAYER_KEY as Runtime, region) + ':11'
       layerARNs = addLayerArn(fullLambdaLibraryLayerArn, lambdaLibraryLayerName, layerARNs)
       layerARNs = addLayerArn(fullExtensionLayerArn, DD_LAMBDA_EXTENSION_LAYER_NAME, layerARNs)
 
@@ -145,7 +145,7 @@ describe('commons', () => {
       expect(functionsGroup).toBeUndefined()
     })
   })
-  describe('getExtensionArn', () => {
+  describe('getLayerArn', () => {
     const OLD_ENV = process.env
     beforeEach(() => {
       jest.resetModules()
@@ -163,7 +163,7 @@ describe('commons', () => {
         tracingEnabled: false,
       }
       const region = 'sa-east-1'
-      const layerArn = getExtensionArn({}, region, settings)
+      const layerArn = getLayerArn({}, EXTENSION_LAYER_KEY as Runtime, region, settings)
       expect(layerArn).toEqual(`arn:aws:lambda:${region}:${mockAwsAccount}:layer:Datadog-Extension`)
     })
 
@@ -178,7 +178,7 @@ describe('commons', () => {
         tracingEnabled: false,
       }
       const region = 'sa-east-1'
-      const layerArn = getExtensionArn(config, region, settings)
+      const layerArn = getLayerArn(config, EXTENSION_LAYER_KEY as Runtime, region, settings)
       expect(layerArn).toEqual(`arn:aws:lambda:${region}:${mockAwsAccount}:layer:Datadog-Extension-ARM`)
     })
 
@@ -190,7 +190,7 @@ describe('commons', () => {
         tracingEnabled: false,
       }
       const region = 'us-gov-1'
-      const layerArn = getExtensionArn({}, region, settings)
+      const layerArn = getLayerArn({}, EXTENSION_LAYER_KEY as Runtime, region, settings)
       expect(layerArn).toEqual(`arn:aws-us-gov:lambda:${region}:${GOVCLOUD_LAYER_AWS_ACCOUNT}:layer:Datadog-Extension`)
     })
 
@@ -205,20 +205,10 @@ describe('commons', () => {
         tracingEnabled: false,
       }
       const region = 'us-gov-1'
-      const layerArn = getExtensionArn(config, region, settings)
+      const layerArn = getLayerArn(config, EXTENSION_LAYER_KEY as Runtime, region, settings)
       expect(layerArn).toEqual(
         `arn:aws-us-gov:lambda:${region}:${GOVCLOUD_LAYER_AWS_ACCOUNT}:layer:Datadog-Extension-ARM`
       )
-    })
-  })
-  describe('getLayerArn', () => {
-    const OLD_ENV = process.env
-    beforeEach(() => {
-      jest.resetModules()
-      process.env = {}
-    })
-    afterAll(() => {
-      process.env = OLD_ENV
     })
 
     test('gets sa-east-1 Node12 Lambda Library layer ARN', async () => {
@@ -233,7 +223,7 @@ describe('commons', () => {
         tracingEnabled: false,
       }
       const region = 'sa-east-1'
-      const layerArn = getLayerArn(config, region, settings)
+      const layerArn = getLayerArn(config, config.Runtime as Runtime, region, settings)
       expect(layerArn).toEqual(`arn:aws:lambda:${region}:${mockAwsAccount}:layer:Datadog-Node12-x`)
     })
 
@@ -250,7 +240,7 @@ describe('commons', () => {
         tracingEnabled: false,
       }
       const region = 'sa-east-1'
-      const layerArn = getLayerArn(config, region, settings)
+      const layerArn = getLayerArn(config, config.Runtime as Runtime, region, settings)
       expect(layerArn).toEqual(`arn:aws:lambda:${region}:${mockAwsAccount}:layer:Datadog-Python39-ARM`)
     })
     test('gets us-gov-1 Python37 gov cloud Lambda Library layer ARN', async () => {
@@ -265,7 +255,7 @@ describe('commons', () => {
         tracingEnabled: false,
       }
       const region = 'us-gov-1'
-      const layerArn = getLayerArn(config, region, settings)
+      const layerArn = getLayerArn(config, config.Runtime as Runtime, region, settings)
       expect(layerArn).toEqual(`arn:aws-us-gov:lambda:${region}:${GOVCLOUD_LAYER_AWS_ACCOUNT}:layer:Datadog-Python37`)
     })
     test('gets us-gov-1 Python39 gov cloud arm64 Lambda Library layer ARN', async () => {
@@ -281,7 +271,7 @@ describe('commons', () => {
         tracingEnabled: false,
       }
       const region = 'us-gov-1'
-      const layerArn = getLayerArn(config, region, settings)
+      const layerArn = getLayerArn(config, config.Runtime as Runtime, region, settings)
       expect(layerArn).toEqual(
         `arn:aws-us-gov:lambda:${region}:${GOVCLOUD_LAYER_AWS_ACCOUNT}:layer:Datadog-Python39-ARM`
       )

--- a/src/commands/lambda/__tests__/functions/instrument.test.ts
+++ b/src/commands/lambda/__tests__/functions/instrument.test.ts
@@ -33,10 +33,12 @@ describe('instrument', () => {
     })
 
     test('calculates an update request with just lambda library layers', () => {
+      const runtime = 'nodejs12.x'
       const config = {
         FunctionArn: 'arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world',
         Handler: 'index.handler',
         Layers: [],
+        Runtime: runtime,
       }
       const settings = {
         flushMetricsToLogs: false,
@@ -45,17 +47,9 @@ describe('instrument', () => {
         mergeXrayTraces: false,
         tracingEnabled: false,
       }
-      const lambdaLibraryLayerArn = `arn:aws:lambda:sa-east-1:${mockAwsAccount}:layer:Datadog-Node12-x`
-      const lambdaExtensionLayerArn = `arn:aws:lambda:sa-east-1:${mockAwsAccount}:layer:Datadog-Extension`
-      const runtime = 'nodejs12.x'
+      const region = 'sa-east-1'
 
-      const updateRequest = calculateUpdateRequest(
-        config,
-        settings,
-        lambdaLibraryLayerArn,
-        lambdaExtensionLayerArn,
-        runtime
-      )
+      const updateRequest = calculateUpdateRequest(config, settings, region, runtime)
       expect(updateRequest).toMatchInlineSnapshot(`
         Object {
           "Environment": Object {
@@ -76,12 +70,53 @@ describe('instrument', () => {
       `)
     })
 
+    test('calculates an update request with just lambda library layers in arm architecture', () => {
+      const runtime = 'python3.9'
+      const config = {
+        Architectures: ['arm64'],
+        FunctionArn: 'arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world',
+        Handler: 'handler.hello',
+        Layers: [],
+        Runtime: runtime,
+      }
+      const settings = {
+        flushMetricsToLogs: false,
+        layerAWSAccount: mockAwsAccount,
+        layerVersion: 11,
+        mergeXrayTraces: false,
+        tracingEnabled: false,
+      }
+      const region = 'sa-east-1'
+
+      const updateRequest = calculateUpdateRequest(config, settings, region, runtime)
+      expect(updateRequest).toMatchInlineSnapshot(`
+        Object {
+          "Environment": Object {
+            "Variables": Object {
+              "DD_FLUSH_TO_LOG": "false",
+              "DD_LAMBDA_HANDLER": "handler.hello",
+              "DD_MERGE_XRAY_TRACES": "false",
+              "DD_SITE": "datadoghq.com",
+              "DD_TRACE_ENABLED": "false",
+            },
+          },
+          "FunctionName": "arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world",
+          "Handler": "datadog_lambda.handler.handler",
+          "Layers": Array [
+            "arn:aws:lambda:sa-east-1:123456789012:layer:Datadog-Python39-ARM:11",
+          ],
+        }
+      `)
+    })
+
     test('calculates an update request with a lambda library, extension, and DATADOG_API_KEY', () => {
       process.env.DATADOG_API_KEY = '1234'
+      const runtime = 'nodejs12.x'
       const config = {
         FunctionArn: 'arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world',
         Handler: 'index.handler',
         Layers: [],
+        Runtime: runtime,
       }
       const settings = {
         extensionVersion: 6,
@@ -91,17 +126,9 @@ describe('instrument', () => {
         mergeXrayTraces: false,
         tracingEnabled: false,
       }
-      const lambdaLibraryLayerArn = `arn:aws:lambda:sa-east-1:${mockAwsAccount}:layer:Datadog-Node12-x`
-      const lambdaExtensionLayerArn = `arn:aws:lambda:sa-east-1:${mockAwsAccount}:layer:Datadog-Extension`
-      const runtime = 'nodejs12.x'
+      const region = 'sa-east-1'
 
-      const updateRequest = calculateUpdateRequest(
-        config,
-        settings,
-        lambdaLibraryLayerArn,
-        lambdaExtensionLayerArn,
-        runtime
-      )
+      const updateRequest = calculateUpdateRequest(config, settings, region, runtime)
       expect(updateRequest).toMatchInlineSnapshot(`
         Object {
           "Environment": Object {
@@ -126,10 +153,12 @@ describe('instrument', () => {
 
     test('calculates an update request with a lambda library, extension, and DATADOG_KMS_API_KEY', () => {
       process.env.DATADOG_KMS_API_KEY = '5678'
+      const runtime = 'python3.6'
       const config = {
         FunctionArn: 'arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world',
         Handler: 'index.handler',
         Layers: [],
+        Runtime: runtime,
       }
       const settings = {
         extensionVersion: 6,
@@ -139,17 +168,9 @@ describe('instrument', () => {
         mergeXrayTraces: false,
         tracingEnabled: false,
       }
-      const lambdaLibraryLayerArn = `arn:aws:lambda:sa-east-1:${mockAwsAccount}:layer:Datadog-Python36`
-      const lambdaExtensionLayerArn = `arn:aws:lambda:sa-east-1:${mockAwsAccount}:layer:Datadog-Extension`
-      const runtime = 'python3.6'
+      const region = 'sa-east-1'
 
-      const updateRequest = calculateUpdateRequest(
-        config,
-        settings,
-        lambdaLibraryLayerArn,
-        lambdaExtensionLayerArn,
-        runtime
-      )
+      const updateRequest = calculateUpdateRequest(config, settings, region, runtime)
       expect(updateRequest).toMatchInlineSnapshot(`
         Object {
           "Environment": Object {
@@ -173,10 +194,12 @@ describe('instrument', () => {
     })
 
     test('by default calculates an update request with DATADOG_SITE being set to datadoghq.com', () => {
+      const runtime = 'python3.6'
       const config = {
         FunctionArn: 'arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world',
         Handler: 'index.handler',
         Layers: [],
+        Runtime: runtime,
       }
       const settings = {
         flushMetricsToLogs: false,
@@ -184,17 +207,9 @@ describe('instrument', () => {
         mergeXrayTraces: false,
         tracingEnabled: false,
       }
-      const lambdaLibraryLayerArn = `arn:aws:lambda:sa-east-1:${mockAwsAccount}:layer:Datadog-Python36`
-      const lambdaExtensionLayerArn = `arn:aws:lambda:sa-east-1:${mockAwsAccount}:layer:Datadog-Extension`
-      const runtime = 'python3.6'
+      const region = 'sa-east-1'
 
-      const updateRequest = calculateUpdateRequest(
-        config,
-        settings,
-        lambdaLibraryLayerArn,
-        lambdaExtensionLayerArn,
-        runtime
-      )
+      const updateRequest = calculateUpdateRequest(config, settings, region, runtime)
       expect(updateRequest).toMatchInlineSnapshot(`
         Object {
           "Environment": Object {
@@ -225,17 +240,10 @@ describe('instrument', () => {
         mergeXrayTraces: false,
         tracingEnabled: false,
       }
-      const lambdaLibraryLayerArn = `arn:aws:lambda:sa-east-1:${mockAwsAccount}:layer:Datadog-Python36`
-      const lambdaExtensionLayerArn = `arn:aws:lambda:sa-east-1:${mockAwsAccount}:layer:Datadog-Extension`
+      const region = 'sa-east-1'
       const runtime = 'python3.6'
 
-      const updateRequest = calculateUpdateRequest(
-        config,
-        settings,
-        lambdaLibraryLayerArn,
-        lambdaExtensionLayerArn,
-        runtime
-      )
+      const updateRequest = calculateUpdateRequest(config, settings, region, runtime)
       expect(updateRequest).toMatchInlineSnapshot(`
         Object {
           "Environment": Object {
@@ -267,12 +275,11 @@ describe('instrument', () => {
         mergeXrayTraces: false,
         tracingEnabled: false,
       }
-      const lambdaLibraryLayerArn = `arn:aws:lambda:sa-east-1:${mockAwsAccount}:layer:Datadog-Python36`
-      const lambdaExtensionLayerArn = `arn:aws:lambda:sa-east-1:${mockAwsAccount}:layer:Datadog-Extension`
+      const region = 'us-east-1'
       const runtime = 'python3.6'
 
       expect(() => {
-        calculateUpdateRequest(config, settings, lambdaLibraryLayerArn, lambdaExtensionLayerArn, runtime)
+        calculateUpdateRequest(config, settings, region, runtime)
       }).toThrowError(
         'Warning: Invalid site URL. Must be either datadoghq.com, datadoghq.eu, us3.datadoghq.com, or ddog-gov.com.'
       )
@@ -292,12 +299,11 @@ describe('instrument', () => {
         mergeXrayTraces: false,
         tracingEnabled: false,
       }
-      const lambdaLibraryLayerArn = `arn:aws:lambda:sa-east-1:${mockAwsAccount}:layer:Datadog-Python36`
-      const lambdaExtensionLayerArn = `arn:aws:lambda:sa-east-1:${mockAwsAccount}:layer:Datadog-Extension`
+      const region = 'us-east-1'
       const runtime = 'python3.6'
 
       expect(() => {
-        calculateUpdateRequest(config, settings, lambdaLibraryLayerArn, lambdaExtensionLayerArn, runtime)
+        calculateUpdateRequest(config, settings, region, runtime)
       }).toThrowError("When 'extensionLayer' is set, DATADOG_API_KEY or DATADOG_KMS_API_KEY must also be set")
     })
   })

--- a/src/commands/lambda/__tests__/functions/instrument.test.ts
+++ b/src/commands/lambda/__tests__/functions/instrument.test.ts
@@ -3,7 +3,6 @@ jest.mock('../../loggroup')
 import {
   ENVIRONMENT_ENV_VAR,
   FLUSH_TO_LOG_ENV_VAR,
-  GOVCLOUD_LAYER_AWS_ACCOUNT,
   LAMBDA_HANDLER_ENV_VAR,
   LOG_LEVEL_ENV_VAR,
   MERGE_XRAY_TRACES_ENV_VAR,
@@ -14,11 +13,9 @@ import {
 } from '../../constants'
 import {
   calculateUpdateRequest,
-  getExtensionArn,
   getFunctionConfig,
   getFunctionConfigs,
   getLambdaConfigsFromRegEx,
-  getLayerArn,
 } from '../../functions/instrument'
 
 import * as loggroup from '../../loggroup'
@@ -302,40 +299,6 @@ describe('instrument', () => {
       expect(() => {
         calculateUpdateRequest(config, settings, lambdaLibraryLayerArn, lambdaExtensionLayerArn, runtime)
       }).toThrowError("When 'extensionLayer' is set, DATADOG_API_KEY or DATADOG_KMS_API_KEY must also be set")
-    })
-  })
-  describe('getExtensionArn', () => {
-    const OLD_ENV = process.env
-    beforeEach(() => {
-      jest.resetModules()
-      process.env = {}
-    })
-    afterAll(() => {
-      process.env = OLD_ENV
-    })
-
-    test('gets sa-east-1 Lambda Extension layer ARN', async () => {
-      const settings = {
-        flushMetricsToLogs: false,
-        layerAWSAccount: mockAwsAccount,
-        mergeXrayTraces: false,
-        tracingEnabled: false,
-      }
-      const region = 'sa-east-1'
-      const layerArn = getExtensionArn(settings, region)
-      expect(layerArn).toEqual(`arn:aws:lambda:${region}:${mockAwsAccount}:layer:Datadog-Extension`)
-    })
-
-    test('gets sa-east-1 gov cloud Lambda Extension layer ARN', async () => {
-      const settings = {
-        flushMetricsToLogs: false,
-        layerAWSAccount: mockAwsAccount,
-        mergeXrayTraces: false,
-        tracingEnabled: false,
-      }
-      const region = 'us-gov-1'
-      const layerArn = getExtensionArn(settings, region)
-      expect(layerArn).toEqual(`arn:aws-us-gov:lambda:${region}:${GOVCLOUD_LAYER_AWS_ACCOUNT}:layer:Datadog-Extension`)
     })
   })
   describe('getFunctionConfig', () => {
@@ -690,42 +653,6 @@ describe('instrument', () => {
       await expect(
         getLambdaConfigsFromRegEx(lambda as any, cloudWatch as any, 'us-east-1', 'fake-pattern', settings)
       ).rejects.toStrictEqual(new Error('Max retry count exceeded.'))
-    })
-  })
-  describe('getLayerArn', () => {
-    const OLD_ENV = process.env
-    beforeEach(() => {
-      jest.resetModules()
-      process.env = {}
-    })
-    afterAll(() => {
-      process.env = OLD_ENV
-    })
-
-    test('gets sa-east-1 Node12 Lambda Library layer ARN', async () => {
-      const runtime = 'nodejs12.x'
-      const settings = {
-        flushMetricsToLogs: false,
-        layerAWSAccount: mockAwsAccount,
-        mergeXrayTraces: false,
-        tracingEnabled: false,
-      }
-      const region = 'sa-east-1'
-      const layerArn = getLayerArn(runtime, settings, region)
-      expect(layerArn).toEqual(`arn:aws:lambda:${region}:${mockAwsAccount}:layer:Datadog-Node12-x`)
-    })
-
-    test('gets sa-east-1 Python37 gov cloud Lambda Library layer ARN', async () => {
-      const runtime = 'python3.7'
-      const settings = {
-        flushMetricsToLogs: false,
-        layerAWSAccount: mockAwsAccount,
-        mergeXrayTraces: false,
-        tracingEnabled: false,
-      }
-      const region = 'us-gov-1'
-      const layerArn = getLayerArn(runtime, settings, region)
-      expect(layerArn).toEqual(`arn:aws-us-gov:lambda:${region}:${GOVCLOUD_LAYER_AWS_ACCOUNT}:layer:Datadog-Python37`)
     })
   })
 })

--- a/src/commands/lambda/__tests__/uninstrument.test.ts
+++ b/src/commands/lambda/__tests__/uninstrument.test.ts
@@ -35,6 +35,7 @@ describe('uninstrument', () => {
       ;(Lambda as any).mockImplementation(() =>
         makeMockLambda({
           'arn:aws:lambda:us-east-1:000000000000:function:uninstrument': {
+            Architectures: ['x86_64'],
             Environment: {
               Variables: {
                 [ENVIRONMENT_ENV_VAR]: 'staging',

--- a/src/commands/lambda/constants.ts
+++ b/src/commands/lambda/constants.ts
@@ -10,6 +10,13 @@ export const RUNTIME_LAYER_LOOKUP = {
 } as const
 export type Runtime = keyof typeof RUNTIME_LAYER_LOOKUP
 
+export const ARM_RUNTIMES = ['python3.8', 'python3.9']
+export const X86_64_ARCHITECTURE = 'x86_64'
+export const ARM64_ARCHITECTURE = 'arm64'
+export const DEFAULT_ARCHITECTURE = X86_64_ARCHITECTURE
+export const LAMBDA_ARCHITECTURES = [ARM64_ARCHITECTURE, X86_64_ARCHITECTURE]
+export const ARM_LAYER_SUFFIX = '-ARM'
+
 const PYTHON_HANDLER_LOCATION = 'datadog_lambda.handler.handler'
 const NODE_HANDLER_LOCATION = '/opt/nodejs/node_modules/datadog-lambda-js/handler.handler'
 export const HANDLER_LOCATION = {

--- a/src/commands/lambda/constants.ts
+++ b/src/commands/lambda/constants.ts
@@ -11,10 +11,7 @@ export const RUNTIME_LAYER_LOOKUP = {
 export type Runtime = keyof typeof RUNTIME_LAYER_LOOKUP
 
 export const ARM_RUNTIMES = ['python3.8', 'python3.9']
-export const X86_64_ARCHITECTURE = 'x86_64'
 export const ARM64_ARCHITECTURE = 'arm64'
-export const DEFAULT_ARCHITECTURE = X86_64_ARCHITECTURE
-export const LAMBDA_ARCHITECTURES = [ARM64_ARCHITECTURE, X86_64_ARCHITECTURE]
 export const ARM_LAYER_SUFFIX = '-ARM'
 
 const PYTHON_HANDLER_LOCATION = 'datadog_lambda.handler.handler'

--- a/src/commands/lambda/constants.ts
+++ b/src/commands/lambda/constants.ts
@@ -1,4 +1,7 @@
+export const DD_LAMBDA_EXTENSION_LAYER_NAME = 'Datadog-Extension'
+export const EXTENSION_LAYER_KEY = 'extension'
 export const RUNTIME_LAYER_LOOKUP = {
+  [EXTENSION_LAYER_KEY]: DD_LAMBDA_EXTENSION_LAYER_NAME,
   'nodejs10.x': 'Datadog-Node10-x',
   'nodejs12.x': 'Datadog-Node12-x',
   'nodejs14.x': 'Datadog-Node14-x',
@@ -8,9 +11,11 @@ export const RUNTIME_LAYER_LOOKUP = {
   'python3.8': 'Datadog-Python38',
   'python3.9': 'Datadog-Python39',
 } as const
-export type Runtime = keyof typeof RUNTIME_LAYER_LOOKUP
+// We exclude the Extension Layer Key in order for the runtime
+// to be used directly in HANDLER_LOCATION.
+export type Runtime = Exclude<keyof typeof RUNTIME_LAYER_LOOKUP, typeof EXTENSION_LAYER_KEY>
 
-export const ARM_RUNTIMES = ['python3.8', 'python3.9']
+export const ARM_RUNTIMES = [EXTENSION_LAYER_KEY, 'python3.8', 'python3.9']
 export const ARM64_ARCHITECTURE = 'arm64'
 export const ARM_LAYER_SUFFIX = '-ARM'
 
@@ -31,7 +36,6 @@ export const DEFAULT_LAYER_AWS_ACCOUNT = '464622532012'
 export const GOVCLOUD_LAYER_AWS_ACCOUNT = '002406178527'
 export const SUBSCRIPTION_FILTER_NAME = 'datadog-ci-filter'
 export const TAG_VERSION_NAME = 'dd_sls_ci'
-export const DD_LAMBDA_EXTENSION_LAYER_NAME = 'Datadog-Extension'
 
 // Environment variables used in the Lambda environment
 export const API_KEY_ENV_VAR = 'DD_API_KEY'

--- a/src/commands/lambda/functions/commons.ts
+++ b/src/commands/lambda/functions/commons.ts
@@ -4,7 +4,6 @@ import {
   ARM64_ARCHITECTURE,
   ARM_LAYER_SUFFIX,
   ARM_RUNTIMES,
-  DD_LAMBDA_EXTENSION_LAYER_NAME,
   DEFAULT_LAYER_AWS_ACCOUNT,
   GOVCLOUD_LAYER_AWS_ACCOUNT,
   MAX_LAMBDA_STATE_CHECK_ATTEMPTS,
@@ -67,32 +66,6 @@ export const collectFunctionsByRegion = (functions: string[], defaultRegion: str
 
   return groups
 }
-/**
- * Returns the correct ARN of the **Extension Layer** given its configuration, region,
- * and settings (optional).
- *
- * @param config a Lambda FunctionConfiguration.
- * @param region a region where the layer is hosted.
- * @param settings instrumentation settings, mainly used to change the AWS account that contains the Layer.
- * @returns the ARN of the **Extension Layer** with the correct region, account, architecture, and name.
- */
-export const getExtensionArn = (
-  config: Lambda.FunctionConfiguration,
-  region: string,
-  settings?: InstrumentationSettings
-) => {
-  let layerName = DD_LAMBDA_EXTENSION_LAYER_NAME
-  if (config.Architectures?.includes(ARM64_ARCHITECTURE)) {
-    layerName += ARM_LAYER_SUFFIX
-  }
-  const account = settings?.layerAWSAccount ?? DEFAULT_LAYER_AWS_ACCOUNT
-  const isGovCloud = region.startsWith('us-gov')
-  if (isGovCloud) {
-    return `arn:aws-us-gov:lambda:${region}:${GOVCLOUD_LAYER_AWS_ACCOUNT}:layer:${layerName}`
-  }
-
-  return `arn:aws:lambda:${region}:${account}:layer:${layerName}`
-}
 
 /**
  * Given a Lambda instance and an array of Lambda names,
@@ -123,10 +96,10 @@ export const getLambdaFunctionConfigs = (
  */
 export const getLayerArn = (
   config: Lambda.FunctionConfiguration,
+  runtime: Runtime,
   region: string,
   settings?: InstrumentationSettings
 ) => {
-  const runtime = config.Runtime as Runtime
   let layerName = RUNTIME_LAYER_LOOKUP[runtime]
   if (ARM_RUNTIMES.includes(runtime) && config.Architectures?.includes(ARM64_ARCHITECTURE)) {
     layerName += ARM_LAYER_SUFFIX

--- a/src/commands/lambda/functions/commons.ts
+++ b/src/commands/lambda/functions/commons.ts
@@ -36,7 +36,7 @@ export const addLayerARN = (fullLayerARN: string | undefined, partialLayerARN: s
 }
 
 /**
- * Returns an arrayed grouped functions by its region, it
+ * Returns an array of functions grouped by its region, it
  * throws an error if there are functions without a region.
  *
  * @param functions an array of strings comprised by
@@ -67,7 +67,15 @@ export const collectFunctionsByRegion = (functions: string[], defaultRegion: str
 
   return groups
 }
-
+/**
+ * Returns the correct ARN of the **Extension Layer** given its configuration, region,
+ * and settings (optional).
+ *
+ * @param config a Lambda FunctionConfiguration.
+ * @param region a region where the layer is hosted.
+ * @param settings instrumentation settings, mainly used to change the AWS account that contains the Layer.
+ * @returns the ARN of the **Extension Layer** with the correct region, account, architecture, and name.
+ */
 export const getExtensionArn = (
   config: Lambda.FunctionConfiguration,
   region: string,
@@ -104,6 +112,15 @@ export const getLambdaFunctionConfigs = (
   return Promise.all(promises)
 }
 
+/**
+ * Returns the correct ARN of a **Specific Runtime Layer** given its configuration, region,
+ * and settings (optional).
+ *
+ * @param config a Lambda FunctionConfiguration.
+ * @param region a region where the layer is hosted.
+ * @param settings instrumentation settings, mainly used to change the AWS account that contains the Layer.
+ * @returns the ARN of a **Specific Runtime Layer** with the correct region, account, architecture, and name.
+ */
 export const getLayerArn = (
   config: Lambda.FunctionConfiguration,
   region: string,
@@ -111,7 +128,7 @@ export const getLayerArn = (
 ) => {
   const runtime = config.Runtime as Runtime
   let layerName = RUNTIME_LAYER_LOOKUP[runtime]
-  if (runtime in ARM_RUNTIMES && config.Architectures?.includes(ARM64_ARCHITECTURE)) {
+  if (ARM_RUNTIMES.includes(runtime) && config.Architectures?.includes(ARM64_ARCHITECTURE)) {
     layerName += ARM_LAYER_SUFFIX
   }
   const account = settings?.layerAWSAccount ?? DEFAULT_LAYER_AWS_ACCOUNT

--- a/src/commands/lambda/functions/commons.ts
+++ b/src/commands/lambda/functions/commons.ts
@@ -24,11 +24,11 @@ import {applyTagConfig} from '../tags'
  * @param layerARNs an array of layer ARNs.
  * @returns an array of layer ARNs.
  */
-export const addLayerARN = (fullLayerARN: string | undefined, partialLayerARN: string, layerARNs: string[]) => {
-  if (fullLayerARN) {
-    if (!layerARNs.includes(fullLayerARN)) {
+export const addLayerArn = (fullLayerArn: string | undefined, previousLayerName: string, layerARNs: string[]) => {
+  if (fullLayerArn) {
+    if (!layerARNs.includes(fullLayerArn)) {
       // Remove any other versions of the layer
-      layerARNs = [...layerARNs.filter((l) => !l.startsWith(partialLayerARN)), fullLayerARN]
+      layerARNs = [...layerARNs.filter((layer) => !layer.includes(previousLayerName)), fullLayerArn]
     }
   }
 
@@ -139,6 +139,8 @@ export const getLayerArn = (
 
   return `arn:aws:lambda:${region}:${account}:layer:${layerName}`
 }
+
+export const getLayers = (config: Lambda.FunctionConfiguration) => (config.Layers ?? []).map((layer) => layer.Arn ?? '')
 
 /**
  * Call the aws-sdk Lambda api to get a Function given

--- a/src/commands/lambda/functions/instrument.ts
+++ b/src/commands/lambda/functions/instrument.ts
@@ -149,10 +149,10 @@ export const calculateUpdateRequest = (
   let needsUpdate = false
 
   // Update Handler
-  const expectedHandler = HANDLER_LOCATION[runtime as Runtime]
+  const expectedHandler = HANDLER_LOCATION[runtime]
   if (config.Handler !== expectedHandler) {
     needsUpdate = true
-    updateRequest.Handler = HANDLER_LOCATION[runtime as Runtime]
+    updateRequest.Handler = HANDLER_LOCATION[runtime]
   }
 
   // Update Env Vars

--- a/src/commands/lambda/functions/instrument.ts
+++ b/src/commands/lambda/functions/instrument.ts
@@ -6,6 +6,7 @@ import {
   CI_SITE_ENV_VAR,
   DD_LAMBDA_EXTENSION_LAYER_NAME,
   ENVIRONMENT_ENV_VAR,
+  EXTENSION_LAYER_KEY,
   EXTRA_TAGS_ENV_VAR,
   FLUSH_TO_LOG_ENV_VAR,
   HANDLER_LOCATION,
@@ -26,7 +27,6 @@ import {calculateLogGroupUpdateRequest} from '../loggroup'
 import {calculateTagUpdateRequest} from '../tags'
 import {
   addLayerArn,
-  getExtensionArn,
   getLambdaFunctionConfigs,
   getLayerArn,
   getLayers,
@@ -149,10 +149,10 @@ export const calculateUpdateRequest = (
   let needsUpdate = false
 
   // Update Handler
-  const expectedHandler = HANDLER_LOCATION[runtime]
+  const expectedHandler = HANDLER_LOCATION[runtime as Runtime]
   if (config.Handler !== expectedHandler) {
     needsUpdate = true
-    updateRequest.Handler = HANDLER_LOCATION[runtime]
+    updateRequest.Handler = HANDLER_LOCATION[runtime as Runtime]
   }
 
   // Update Env Vars
@@ -217,13 +217,13 @@ export const calculateUpdateRequest = (
   }
 
   // Update Layers
-  const lambdaLibraryLayerArn = getLayerArn(config, region, settings)
+  const lambdaLibraryLayerArn = getLayerArn(config, config.Runtime as Runtime, region, settings)
   const lambraLibraryLayerName = RUNTIME_LAYER_LOOKUP[runtime]
   let fullLambdaLibraryLayerARN: string | undefined
   if (settings.layerVersion !== undefined) {
     fullLambdaLibraryLayerARN = `${lambdaLibraryLayerArn}:${settings.layerVersion}`
   }
-  const lambdaExtensionLayerArn = getExtensionArn(config, region, settings)
+  const lambdaExtensionLayerArn = getLayerArn(config, EXTENSION_LAYER_KEY as Runtime, region, settings)
   let fullExtensionLayerARN: string | undefined
   if (settings.extensionVersion !== undefined) {
     fullExtensionLayerARN = `${lambdaExtensionLayerArn}:${settings.extensionVersion}`

--- a/src/commands/lambda/functions/instrument.ts
+++ b/src/commands/lambda/functions/instrument.ts
@@ -29,6 +29,7 @@ import {
   getExtensionArn,
   getLambdaFunctionConfigs,
   getLayerArn,
+  getLayers,
   isLambdaActive,
   isSupportedRuntime,
 } from './commons'
@@ -227,8 +228,8 @@ export const calculateUpdateRequest = (
   if (settings.extensionVersion !== undefined) {
     fullExtensionLayerARN = `${lambdaExtensionLayerArn}:${settings.extensionVersion}`
   }
-  let layerARNs = (config.Layers ?? []).map((layer) => layer.Arn ?? '')
-  const originalLayerARNs = (config.Layers ?? []).map((layer) => layer.Arn ?? '')
+  let layerARNs = getLayers(config)
+  const originalLayerARNs = layerARNs
   let needsLayerUpdate = false
   layerARNs = addLayerArn(fullLambdaLibraryLayerARN, lambraLibraryLayerName, layerARNs)
   layerARNs = addLayerArn(fullExtensionLayerARN, DD_LAMBDA_EXTENSION_LAYER_NAME, layerARNs)

--- a/src/commands/lambda/functions/uninstrument.ts
+++ b/src/commands/lambda/functions/uninstrument.ts
@@ -20,7 +20,7 @@ import {
 import {FunctionConfiguration, LogGroupConfiguration, TagConfiguration} from '../interfaces'
 import {calculateLogGroupRemoveRequest} from '../loggroup'
 import {calculateTagRemoveRequest} from '../tags'
-import {getLambdaFunctionConfigs, isSupportedRuntime} from './commons'
+import {getLambdaFunctionConfigs, getLayers, isSupportedRuntime} from './commons'
 
 export const getFunctionConfigs = async (
   lambda: Lambda,
@@ -123,7 +123,7 @@ export const calculateUpdateRequest = (config: Lambda.FunctionConfiguration, run
   // Remove Layers
   let needsLayerRemoval = false
   const lambdaLibraryLayerName = RUNTIME_LAYER_LOOKUP[runtime]
-  const originalLayerARNs = (config.Layers ?? []).map((layer) => layer.Arn ?? '')
+  const originalLayerARNs = getLayers(config)
   const layerARNs = (config.Layers ?? [])
     .filter(
       (layer) => !layer.Arn?.includes(lambdaLibraryLayerName) && !layer.Arn?.includes(DD_LAMBDA_EXTENSION_LAYER_NAME)

--- a/yarn.lock
+++ b/yarn.lock
@@ -1785,10 +1785,10 @@ atob@^2.1.2:
   resolved "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz"
   integrity sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
 
-aws-sdk@2.903.0:
-  version "2.903.0"
-  resolved "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.903.0.tgz"
-  integrity sha512-BP/giYLP8QJ63Jta59kph1F76oPITxRt/wNr3BdoEs9BtshWlGKk149UaseDB4wJtI+0TER5jtzBIUBcP6E+wA==
+aws-sdk@2.1012.0:
+  version "2.1012.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.1012.0.tgz#93618320cf1ff274389d8fcc563d62974545e1f9"
+  integrity sha512-5F/tC+mOJSTq4BTWqg6DepDIC7h+OeUycCYsFU6fMblQCUEBuI11o8z/+2DxGt4c40f52OstalYNiSlP2RuZvw==
   dependencies:
     buffer "4.9.2"
     events "1.1.1"


### PR DESCRIPTION
### What and why?

Refer to [SLS-1390](https://datadoghq.atlassian.net/browse/SLS-1390)

### How?

Refactor `getLayerArn` and `getExtensionArn` to support this feature, and move them into `commons.ts`.
Moved tests to their corresponding file, and added some more according to the feature.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] A new release of `datadog-ci` MUST be updated in the [synthetics-ci-github-action](https://github.com/DataDog/synthetics-ci-github-action)
