### PR TITLE
[s8s] : Refactor message creation logic in CiError class

### DIFF
--- a/src/commands/synthetics/__tests__/run-test.test.ts
+++ b/src/commands/synthetics/__tests__/run-test.test.ts
@@ -129,7 +129,7 @@ describe('run-test', () => {
       jest.spyOn(runTests, 'getApiHelper').mockImplementation(() => apiHelper as any)
       await expect(
         runTests.executeTests(mockReporter, {...ciConfig, testSearchQuery: 'a-search-query', tunnel: true})
-      ).rejects.toMatchError(new CriticalError('UNAVAILABLE_TEST_CONFIG'))
+      ).rejects.toMatchError(new CriticalError('UNAVAILABLE_TEST_CONFIG', serverError.message))
     })
 
     test('getTestsToTrigger throws', async () => {
@@ -144,7 +144,7 @@ describe('run-test', () => {
       jest.spyOn(runTests, 'getApiHelper').mockImplementation(() => apiHelper as any)
       await expect(
         runTests.executeTests(mockReporter, {...ciConfig, publicIds: ['public-id-1'], tunnel: true})
-      ).rejects.toMatchError(new CriticalError('UNAVAILABLE_TEST_CONFIG'))
+      ).rejects.toMatchError(new CriticalError('UNAVAILABLE_TEST_CONFIG', serverError.message))
     })
 
     test('getPresignedURL throws', async () => {
@@ -168,7 +168,7 @@ describe('run-test', () => {
       jest.spyOn(runTests, 'getApiHelper').mockImplementation(() => apiHelper as any)
       await expect(
         runTests.executeTests(mockReporter, {...ciConfig, publicIds: ['public-id-1', 'public-id-2'], tunnel: true})
-      ).rejects.toMatchError(new CriticalError('UNAVAILABLE_TUNNEL_CONFIG'))
+      ).rejects.toMatchError(new CriticalError('UNAVAILABLE_TUNNEL_CONFIG', serverError.message))
     })
 
     test('runTests throws', async () => {
@@ -192,7 +192,12 @@ describe('run-test', () => {
       jest.spyOn(runTests, 'getApiHelper').mockImplementation(() => apiHelper as any)
       await expect(
         runTests.executeTests(mockReporter, {...ciConfig, publicIds: ['public-id-1', 'public-id-2']})
-      ).rejects.toMatchError(new CriticalError('TRIGGER_TESTS_FAILED'))
+      ).rejects.toMatchError(
+        new CriticalError(
+          'TRIGGER_TESTS_FAILED',
+          '[] Failed to trigger tests: query on baseURLurl returned: "Bad Gateway"\n'
+        )
+      )
     })
 
     test('waitForResults throws', async () => {
@@ -236,7 +241,7 @@ describe('run-test', () => {
           failOnCriticalErrors: true,
           publicIds: ['public-id-1', 'public-id-2'],
         })
-      ).rejects.toMatchError(new CriticalError('POLL_RESULTS_FAILED'))
+      ).rejects.toMatchError(new CriticalError('POLL_RESULTS_FAILED', serverError.message))
     })
   })
 

--- a/src/commands/synthetics/cli.ts
+++ b/src/commands/synthetics/cli.ts
@@ -1,4 +1,3 @@
-import chalk from 'chalk'
 import {Command} from 'clipanion'
 import deepExtend from 'deep-extend'
 
@@ -162,37 +161,10 @@ export class RunTestCommand extends Command {
   }
 
   private reportCiError(error: CiError, reporter: MainReporter) {
-    switch (error.code) {
-      case 'NO_RESULTS_TO_POLL':
-        reporter.log('No results to poll.\n')
-        break
-      case 'NO_TESTS_TO_RUN':
-        reporter.log('No test to run.\n')
-        break
-      case 'MISSING_APP_KEY':
-        reporter.error(`Missing ${chalk.red.bold('DATADOG_APP_KEY')} in your environment.\n`)
-        break
-      case 'MISSING_API_KEY':
-        reporter.error(`Missing ${chalk.red.bold('DATADOG_API_KEY')} in your environment.\n`)
-        break
-      case 'POLL_RESULTS_FAILED':
-        reporter.error(`\n${chalk.bgRed.bold(' ERROR: unable to poll test results ')}\n${error.message}\n\n`)
-        break
-      case 'TUNNEL_START_FAILED':
-        reporter.error(`\n${chalk.bgRed.bold(' ERROR: unable to start tunnel')}\n${error.message}\n\n`)
-        break
-      case 'TRIGGER_TESTS_FAILED':
-        reporter.error(`\n${chalk.bgRed.bold(' ERROR: unable to trigger tests')}\n${error.message}\n\n`)
-        break
-      case 'UNAVAILABLE_TEST_CONFIG':
-        reporter.error(
-          `\n${chalk.bgRed.bold(' ERROR: unable to obtain test configurations with search query ')}\n${
-            error.message
-          }\n\n`
-        )
-        break
-      case 'UNAVAILABLE_TUNNEL_CONFIG':
-        reporter.error(`\n${chalk.bgRed.bold(' ERROR: unable to get tunnel configuration')}\n${error.message}\n\n`)
+    if (error.code === 'NO_RESULTS_TO_POLL' || error.code === 'NO_TESTS_TO_RUN') {
+      reporter.log(error.message)
+    } else {
+      reporter.error(error.message)
     }
   }
 

--- a/src/commands/synthetics/errors.ts
+++ b/src/commands/synthetics/errors.ts
@@ -1,3 +1,5 @@
+import chalk from 'chalk'
+
 /* tslint:disable:max-classes-per-file */
 const ciErrorCodes = [
   'UNAVAILABLE_TEST_CONFIG',
@@ -13,8 +15,38 @@ const ciErrorCodes = [
 type CiErrorCode = typeof ciErrorCodes[number]
 
 export class CiError extends Error {
-  constructor(public code: CiErrorCode) {
-    super()
+  constructor(public code: CiErrorCode, message?: string) {
+    super(message)
+    switch (code) {
+      case 'NO_RESULTS_TO_POLL':
+        this.message = 'No results to poll.'
+        break
+      case 'NO_TESTS_TO_RUN':
+        this.message = 'No test to run.'
+        break
+      case 'MISSING_APP_KEY':
+        this.message = `Missing ${chalk.red.bold('DATADOG_APP_KEY')} in your environment.\n`
+        break
+      case 'MISSING_API_KEY':
+        this.message = `Missing ${chalk.red.bold('DATADOG_API_KEY')} in your environment.\n`
+        break
+      case 'POLL_RESULTS_FAILED':
+        this.message = `\n${chalk.bgRed.bold(' ERROR: unable to poll test results ')}\n${message}\n\n`
+        break
+      case 'TUNNEL_START_FAILED':
+        this.message = `\n${chalk.bgRed.bold(' ERROR: unable to start tunnel')}\n${message}\n\n`
+        break
+      case 'TRIGGER_TESTS_FAILED':
+        this.message = `\n${chalk.bgRed.bold(' ERROR: unable to trigger tests')}\n${message}\n\n`
+        break
+      case 'UNAVAILABLE_TEST_CONFIG':
+        this.message = `\n${chalk.bgRed.bold(
+          ' ERROR: unable to obtain test configurations with search query '
+        )}\n${message}\n\n`
+        break
+      case 'UNAVAILABLE_TUNNEL_CONFIG':
+        this.message = `\n${chalk.bgRed.bold(' ERROR: unable to get tunnel configuration')}\n${message}\n\n`
+    }
   }
 }
 


### PR DESCRIPTION
### What and why?

Currently an error message for each CiError code is  set at the level of the error handler in the `cli.ts` [file](https://github.com/DataDog/datadog-ci/blob/master/src/commands/synthetics/cli.ts#L173)

In order to avoid having to re-write this logic every time, we've moved the logic within the `CiError` class.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] A new release of `datadog-ci` MUST be updated in the [synthetics-ci-github-action](https://github.com/DataDog/synthetics-ci-github-action)
