### PR TITLE
[lambda] Add a warning message to instrument command

### DIFF
--- a/src/commands/lambda/__tests__/instrument.test.ts
+++ b/src/commands/lambda/__tests__/instrument.test.ts
@@ -2,6 +2,7 @@
 jest.mock('fs')
 jest.mock('aws-sdk')
 import {Lambda} from 'aws-sdk'
+import {blueBright, bold, cyan, hex, underline, yellow} from 'chalk'
 import * as fs from 'fs'
 import path from 'path'
 import {InstrumentCommand} from '../instrument'
@@ -61,7 +62,12 @@ describe('lambda', () => {
         const output = context.stdout.toString()
         expect(code).toBe(0)
         expect(output).toMatchInlineSnapshot(`
-          "[Dry Run] Will apply the following updates:
+          "${bold(yellow('[Warning]'))} Instrument your ${hex('#FF9900').bold(
+          'Lambda'
+        )} functions in a dev or staging environment first. Should the instrumentation result be unsatisfactory, run \`${bold(
+          'uninstrument'
+        )}\` with the same arguments to revert the changes.
+          ${bold(cyan('[Dry Run] '))}Will apply the following updates:
           UpdateFunctionConfiguration -> arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world
           {
             \\"FunctionName\\": \\"arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world\\",
@@ -130,7 +136,12 @@ describe('lambda', () => {
         const output = context.stdout.toString()
         expect(code).toBe(0)
         expect(output).toMatchInlineSnapshot(`
-          "[Dry Run] Will apply the following updates:
+          "${bold(yellow('[Warning]'))} Instrument your ${hex('#FF9900').bold(
+          'Lambda'
+        )} functions in a dev or staging environment first. Should the instrumentation result be unsatisfactory, run \`${bold(
+          'uninstrument'
+        )}\` with the same arguments to revert the changes.
+          ${bold(cyan('[Dry Run] '))}Will apply the following updates:
           UpdateFunctionConfiguration -> arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world
           {
             \\"FunctionName\\": \\"arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world\\",
@@ -575,7 +586,13 @@ describe('lambda', () => {
         await command['getSettings']()
         let output = command.context.stdout.toString()
         expect(output).toMatch(
-          'Warning: The environment, service and version tags have not been configured. Learn more about Datadog unified service tagging: https://docs.datadoghq.com/getting_started/tagging/unified_service_tagging/#serverless-environment.\n'
+          `${bold(
+            yellow('[Warning]')
+          )} The environment, service and version tags have not been configured. Learn more about Datadog unified service tagging: ${underline(
+            blueBright(
+              'https://docs.datadoghq.com/getting_started/tagging/unified_service_tagging/#serverless-environment.'
+            )
+          )}\n`
         )
 
         command = createCommand(InstrumentCommand)
@@ -586,7 +603,13 @@ describe('lambda', () => {
         await command['getSettings']()
         output = command.context.stdout.toString()
         expect(output).toMatch(
-          'Warning: The version tag has not been configured. Learn more about Datadog unified service tagging: https://docs.datadoghq.com/getting_started/tagging/unified_service_tagging/#serverless-environment.\n'
+          `${bold(
+            yellow('[Warning]')
+          )} The version tag has not been configured. Learn more about Datadog unified service tagging: ${underline(
+            blueBright(
+              'https://docs.datadoghq.com/getting_started/tagging/unified_service_tagging/#serverless-environment.'
+            )
+          )}\n`
         )
       })
 
@@ -638,7 +661,12 @@ describe('lambda', () => {
         ])
         const output = command.context.stdout.toString()
         expect(output).toMatchInlineSnapshot(`
-                    "Will apply the following updates:
+                    "${bold(yellow('[Warning]'))} Instrument your ${hex('#FF9900').bold(
+          'Lambda'
+        )} functions in a dev or staging environment first. Should the instrumentation result be unsatisfactory, run \`${bold(
+          'uninstrument'
+        )}\` with the same arguments to revert the changes.
+                    Will apply the following updates:
                     CreateLogGroup -> my-log-group
                     {
                       \\"logGroupName\\": \\"my-log-group\\"

--- a/src/commands/lambda/__tests__/uninstrument.test.ts
+++ b/src/commands/lambda/__tests__/uninstrument.test.ts
@@ -2,7 +2,7 @@
 jest.mock('fs')
 jest.mock('aws-sdk')
 import {Lambda} from 'aws-sdk'
-import {cyan, red} from 'chalk'
+import {bold, cyan, red} from 'chalk'
 import * as fs from 'fs'
 
 import {
@@ -77,7 +77,7 @@ describe('uninstrument', () => {
       const output = context.stdout.toString()
       expect(code).toBe(0)
       expect(output).toMatchInlineSnapshot(`
-        "${cyan('[Dry Run] ')}Will apply the following updates:
+        "${bold(cyan('[Dry Run] '))}Will apply the following updates:
         UpdateFunctionConfiguration -> arn:aws:lambda:us-east-1:000000000000:function:uninstrument
         {
           \\"FunctionName\\": \\"arn:aws:lambda:us-east-1:000000000000:function:uninstrument\\",

--- a/src/commands/lambda/instrument.ts
+++ b/src/commands/lambda/instrument.ts
@@ -1,4 +1,5 @@
 import {CloudWatchLogs, Lambda} from 'aws-sdk'
+import {blueBright, bold, cyan, hex, underline, yellow} from 'chalk'
 import {Command} from 'clipanion'
 import {parseConfigFile} from '../../helpers/utils'
 import {EXTRA_TAGS_REG_EXP} from './constants'
@@ -210,9 +211,13 @@ export class InstrumentCommand extends Command {
       const tags = tagsMissing.join(', ').replace(/, ([^,]*)$/, ' and $1')
       const plural = tagsMissing.length > 1
       this.context.stdout.write(
-        `Warning: The ${tags} tag${
+        `${bold(yellow('[Warning]'))} The ${tags} tag${
           plural ? 's have' : ' has'
-        } not been configured. Learn more about Datadog unified service tagging: https://docs.datadoghq.com/getting_started/tagging/unified_service_tagging/#serverless-environment.\n`
+        } not been configured. Learn more about Datadog unified service tagging: ${underline(
+          blueBright(
+            'https://docs.datadoghq.com/getting_started/tagging/unified_service_tagging/#serverless-environment.'
+          )
+        )}\n`
       )
     }
 
@@ -240,7 +245,7 @@ export class InstrumentCommand extends Command {
   }
 
   private printPlannedActions(configs: FunctionConfiguration[]) {
-    const prefix = this.dryRun ? '[Dry Run] ' : ''
+    const prefix = this.dryRun ? bold(cyan('[Dry Run] ')) : ''
 
     let anyUpdates = false
     for (const config of configs) {
@@ -260,6 +265,13 @@ export class InstrumentCommand extends Command {
 
       return
     }
+    this.context.stdout.write(
+      `${bold(yellow('[Warning]'))} Instrument your ${hex('#FF9900').bold(
+        'Lambda'
+      )} functions in a dev or staging environment first. Should the instrumentation result be unsatisfactory, run \`${bold(
+        'uninstrument'
+      )}\` with the same arguments to revert the changes.\n`
+    )
     this.context.stdout.write(`${prefix}Will apply the following updates:\n`)
     for (const config of configs) {
       if (config.updateRequest) {

--- a/src/commands/lambda/uninstrument.ts
+++ b/src/commands/lambda/uninstrument.ts
@@ -1,5 +1,5 @@
 import {CloudWatchLogs, Lambda} from 'aws-sdk'
-import {cyan, red} from 'chalk'
+import {bold, cyan, red} from 'chalk'
 import {Command} from 'clipanion'
 import {parseConfigFile} from '../../helpers/utils'
 import {collectFunctionsByRegion, updateLambdaFunctionConfigs} from './functions/commons'
@@ -80,7 +80,7 @@ export class UninstrumentCommand extends Command {
   }
 
   private printPlannedActions(configs: FunctionConfiguration[]) {
-    const prefix = this.dryRun ? cyan('[Dry Run] ') : ''
+    const prefix = this.dryRun ? bold(cyan('[Dry Run] ')) : ''
 
     let anyUpdates = false
     for (const config of configs) {


### PR DESCRIPTION
Let's display a warning message (highlight with a warning color) when the `datadog-ci instrument` command runs. This is important, because in case when the instrument command breaks the customer's function or the customer is not satisfied with the result for whatever reason, they need to know (sometimes in a rush) about how to uninstrument.

### What and why?

Refer to [SLS-1633](https://datadoghq.atlassian.net/browse/SLS-1633)
Documentation to be added in [DataDog/documentation#12055](https://github.com/DataDog/documentation/pull/12055)

### How?

Adding the warning message expected to let the user know what to do if his instrumentation is unsatisfactory. Also add colors to some other commands to have a better user experience.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] A new release of `datadog-ci` MUST be updated in the [synthetics-ci-github-action](https://github.com/DataDog/synthetics-ci-github-action)

### Behavior

<img width="941" alt="Screen Shot 2021-10-26 at 1 57 34 PM" src="https://user-images.githubusercontent.com/30836115/139474512-cec194f0-8e76-4e1b-97dc-8fed66e2f7ba.png">

