### PR TITLE
Revert "[lambda] Fix bug that won't allow users to use config file while uninstrumenting"

### DIFF
--- a/src/commands/lambda/__tests__/uninstrument.test.ts
+++ b/src/commands/lambda/__tests__/uninstrument.test.ts
@@ -184,7 +184,7 @@ describe('uninstrument', () => {
 
       process.env = {}
       const command = createCommand(UninstrumentCommand)
-      command['config']['region'] = 'ap-southeast-1'
+
       await command['execute']()
       const output = command.context.stdout.toString()
       expect(output).toMatchInlineSnapshot(`

--- a/src/commands/lambda/uninstrument.ts
+++ b/src/commands/lambda/uninstrument.ts
@@ -137,7 +137,7 @@ export class UninstrumentCommand extends Command {
 UninstrumentCommand.addPath('lambda', 'uninstrument')
 UninstrumentCommand.addOption('functions', Command.Array('-f,--function'))
 UninstrumentCommand.addOption('region', Command.String('-r,--region'))
-UninstrumentCommand.addOption('configPath', Command.String('--config'))
+UninstrumentCommand.addOption('configPath', Command.Array('--config'))
 UninstrumentCommand.addOption('dryRun', Command.Boolean('-d,--dry'))
 UninstrumentCommand.addOption('forwarder', Command.String('--forwarder'))
 


### PR DESCRIPTION
Reverts DataDog/datadog-ci#416