### PR TITLE
[CIAPP] Trace command support for GitHub Actions

### DIFF
--- a/src/commands/trace/__tests__/trace.test.ts
+++ b/src/commands/trace/__tests__/trace.test.ts
@@ -65,4 +65,19 @@ describe('trace', () => {
       expect(command['getCIEnvVars'].call({context: {stdout: {write: () => undefined}}})).toEqual([{}])
     })
   })
+
+  test('should correctly detect the GitHub environment', () => {
+    process.env = {
+      GITHUB_ACTIONS: 'true',
+      GITHUB_RUN_ID: '10000',
+      NON_GITHUB_ENV: 'bar',
+    }
+    const command = new TraceCommand()
+    expect(command['getCIEnvVars']()).toEqual([
+      {
+        GITHUB_RUN_ID: '1000',
+      },
+      'github',
+    ])
+  })
 })

--- a/src/commands/trace/__tests__/trace.test.ts
+++ b/src/commands/trace/__tests__/trace.test.ts
@@ -69,7 +69,7 @@ describe('trace', () => {
   test('should correctly detect the GitHub environment', () => {
     process.env = {
       GITHUB_ACTIONS: 'true',
-      GITHUB_RUN_ID: '10000',
+      GITHUB_RUN_ID: '1000',
       NON_GITHUB_ENV: 'bar',
     }
     const command = new TraceCommand()

--- a/src/commands/trace/interfaces.ts
+++ b/src/commands/trace/interfaces.ts
@@ -2,8 +2,9 @@ import {AxiosPromise, AxiosResponse} from 'axios'
 
 export const CIRCLECI = 'circleci'
 export const JENKINS = 'jenkins'
+export const GITHUB = 'github'
 
-export const SUPPORTED_PROVIDERS = [CIRCLECI, JENKINS] as const
+export const SUPPORTED_PROVIDERS = [CIRCLECI, JENKINS, GITHUB] as const
 export type Provider = typeof SUPPORTED_PROVIDERS[number]
 
 export interface Payload {

--- a/src/commands/trace/trace.ts
+++ b/src/commands/trace/trace.ts
@@ -170,7 +170,7 @@ export class TraceCommand extends Command {
         JENKINS,
       ]
     }
-    if (process.env.GITHUB_ACTION) {
+    if (process.env.GITHUB_ACTIONS) {
       return [
         this.getEnvironmentVars([
           'GITHUB_WORKFLOW',

--- a/src/commands/trace/trace.ts
+++ b/src/commands/trace/trace.ts
@@ -6,7 +6,7 @@ import os from 'os'
 import {retryRequest} from '../../helpers/retry'
 import {parseTags} from '../../helpers/tags'
 import {apiConstructor} from './api'
-import {APIHelper, CIRCLECI, JENKINS, GITHUB, Payload, Provider, SUPPORTED_PROVIDERS} from './interfaces'
+import {APIHelper, CIRCLECI, GITHUB, JENKINS, Payload, Provider, SUPPORTED_PROVIDERS} from './interfaces'
 
 // We use 127 as exit code for invalid commands since that is what *sh terminals return
 const BAD_COMMAND_EXIT_CODE = 127

--- a/src/commands/trace/trace.ts
+++ b/src/commands/trace/trace.ts
@@ -6,7 +6,7 @@ import os from 'os'
 import {retryRequest} from '../../helpers/retry'
 import {parseTags} from '../../helpers/tags'
 import {apiConstructor} from './api'
-import {APIHelper, CIRCLECI, JENKINS, Payload, Provider, SUPPORTED_PROVIDERS} from './interfaces'
+import {APIHelper, CIRCLECI, JENKINS, GITHUB, Payload, Provider, SUPPORTED_PROVIDERS} from './interfaces'
 
 // We use 127 as exit code for invalid commands since that is what *sh terminals return
 const BAD_COMMAND_EXIT_CODE = 127
@@ -170,6 +170,25 @@ export class TraceCommand extends Command {
         JENKINS,
       ]
     }
+    if (process.env.GITHUB_ACTION) {
+      return [
+        this.getEnvironmentVars([
+          'GITHUB_WORKFLOW',
+          'GITHUB_RUN_ID',
+          'GITHUB_RUN_NUMBER',
+          'GITHUB_JOB',
+          'GITHUB_REPOSITORY',
+          'GITHUB_SHA',
+          'GITHUB_REF',
+          'GITHUB_SERVER_URL',
+          'RUNNER_NAME',
+          'RUNNER_OS',
+          'GITHUB_RUN_ATTEMPT',
+        ]),
+        GITHUB,
+      ];
+    }
+
     const errorMsg = `Cannot detect any supported CI Provider. This command only works if run as part of your CI. Supported providers: ${SUPPORTED_PROVIDERS}.`
     if (this.noFail) {
       this.context.stdout.write(

--- a/src/commands/trace/trace.ts
+++ b/src/commands/trace/trace.ts
@@ -186,7 +186,7 @@ export class TraceCommand extends Command {
           'GITHUB_RUN_ATTEMPT',
         ]),
         GITHUB,
-      ];
+      ]
     }
 
     const errorMsg = `Cannot detect any supported CI Provider. This command only works if run as part of your CI. Supported providers: ${SUPPORTED_PROVIDERS}.`


### PR DESCRIPTION
### What and why?

This PR add support for tracing commands in GitHub Actions so that they show on CI Visibility traces.

### How?

The command will read the [default environmental variables](https://docs.github.com/en/actions/learn-github-actions/environment-variables#default-environment-variables) provided by GitHub to the runner and use that to send custom command payloads to Data Dog.

### Review checklist

- [X] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] A new release of `datadog-ci` MUST be updated in the [synthetics-ci-github-action](https://github.com/DataDog/synthetics-ci-github-action)
