### PR TITLE
[SW-1695] explicitely export module required externally

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "publishConfig": {
     "access": "public"
   },
+  "main": "dist/main.js",
   "resolutions": {
     "ini": "1.3.7",
     "kind-of@^6.0.0": "6.0.3"

--- a/src/commands/synthetics/main.ts
+++ b/src/commands/synthetics/main.ts
@@ -1,0 +1,5 @@
+export {CiError} from './errors'
+export * from './interfaces'
+export {DefaultReporter} from './reporters/default'
+export {executeTests} from './run-test'
+export * as utils from './utils'

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,0 +1,4 @@
+import * as Synthetics from './commands/synthetics/main'
+import {parseConfigFile} from './helpers/utils'
+
+export {parseConfigFile, Synthetics}


### PR DESCRIPTION
### What and why?

https://github.com/DataDog/synthetics-ci-github-action depends on some modules from `datadog-ci`. Until now, these dependencies were imported directly from the files, instead of going through a proper export.
Partly because of that, a change in `datadog-ci` led to a bug in the source of https://github.com/DataDog/synthetics-ci-github-action.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] A new release of `datadog-ci` MUST be updated in the [synthetics-ci-github-action](https://github.com/DataDog/synthetics-ci-github-action)
