### PR TITLE
[sourcemaps] Rework wording and add example for --project-path

### DIFF
--- a/src/commands/sourcemaps/README.md
+++ b/src/commands/sourcemaps/README.md
@@ -52,11 +52,11 @@ Errors in Datadog UI can be enriched with links to GitHub/GitLab/Bitbucket if th
 - `git` executable is installed
 - `datadog-ci` is run within the git repository
 
-When these requirements are met, the upload command reports Git information such as the current commit hash, the repository URL, and the list of tracked file paths in the code repository.
-Each sourcemap uploaded gets such information associated with it.
-
-Only tracked file paths that could be related to the sourcemap being uploaded are gathered.
-For example: A sourcemap containing `["webpack:///./src/folder/example.ts"]` inside its `sources` attribute will have associated with it all tracked file paths with `example.ts` as filename.
+When these requirements are met, the upload command reports Git information such as:
+- the current commit hash
+- the repository URL
+- for each sourcemap, the list of file paths that are tracked in the repository. Only tracked file paths that could be related to a sourcemap are gathered.
+For example, for a sourcemap referencing `["webpack:///./src/folder/example.ts"]` inside its `sources` attribute, the command will gather all file paths with `example.ts` as filename.
 
 #### Override repository URL
 
@@ -68,6 +68,14 @@ The value can be overriden with `--repository-url`.
 
 Example: With a remote `git@github.com:Datadog/example.git`, links pointing to `https://github.com/Datadog/example` are generated.
 This behavior can be overriden with links to `https://gitlab.com/Datadog/example` with the flag `--repository-url=https://gitlab.com/Datadog/example`.
+
+#### Setting the project path
+
+If the file paths referenced by your sourcemaps have a prefix before the part relative to the repository root, you need to specify the `--project-path` argument.
+
+For example, if your repository contains a file at `src/foo/example.js`, then:
+  - if the path referenced in the sourcemap is `webpack://src/foo/example.js`, you don't need to use `--project-path`.
+  - if the path referenced in the sourcemap is `webpack://MyProject/src/foo/example.js`, you need to use `--project-path MyProject/` for files to be correctly linked to your repository.
 
 #### Supported repositories
 

--- a/src/commands/sourcemaps/README.md
+++ b/src/commands/sourcemaps/README.md
@@ -43,7 +43,7 @@ In addition, some optional parameters are available:
 * `--max-concurrency` (default: `20`): number of concurrent upload to the API.
 * `--disable-git` (default: false): prevents the command from invoking git in the current working directory and sending repository related data to Datadog (hash, remote URL and the paths within the repository of the sources referenced in the sourcemap).
 * `--dry-run` (default: `false`): it will run the command without the final step of upload. All other checks are performed.
-* `--project-path` (default: empty): the path of the project where the sourcemaps were built. This will be stripped off from sources paths referenced in the sourcemap so they can be properly matched against tracked files paths.
+* `--project-path` (default: empty): the path of the project where the sourcemaps were built. This will be stripped off from sources paths referenced in the sourcemap so they can be properly matched against tracked files paths. See details in the [dedicated section](#setting-the-project-path).
 * `--repository-url` (default: empty): overrides the repository remote with a custom URL. For example: https://github.com/my-company/my-project
 
 ### Link errors with your source code


### PR DESCRIPTION
This is an attempt at improving the documentation, so that it's easier to understand the goal of the `--project-path` argument.
- Rework the wording
- Add a sub-section to the _Link errors with your source code_ section to mention the `--project-path` argument, with an usage example