### PR TITLE
[lambda] Add `us5.datadoghq.com` support

### DIFF
--- a/src/commands/lambda/__tests__/functions/instrument.test.ts
+++ b/src/commands/lambda/__tests__/functions/instrument.test.ts
@@ -355,7 +355,7 @@ describe('instrument', () => {
       expect(() => {
         calculateUpdateRequest(config, settings, region, runtime)
       }).toThrowError(
-        'Warning: Invalid site URL. Must be either datadoghq.com, datadoghq.eu, us3.datadoghq.com, or ddog-gov.com.'
+        'Warning: Invalid site URL. Must be either datadoghq.com, datadoghq.eu, us3.datadoghq.com, us5.datadoghq.com, or ddog-gov.com.'
       )
     })
 

--- a/src/commands/lambda/constants.ts
+++ b/src/commands/lambda/constants.ts
@@ -42,6 +42,14 @@ export const HANDLER_LOCATION = {
   'python3.9': PYTHON_HANDLER_LOCATION,
 }
 
+export const SITES: string[] = [
+  'datadoghq.com',
+  'datadoghq.eu',
+  'us3.datadoghq.com',
+  'us5.datadoghq.com',
+  'ddog-gov.,com',
+]
+
 export const DEFAULT_LAYER_AWS_ACCOUNT = '464622532012'
 export const GOVCLOUD_LAYER_AWS_ACCOUNT = '002406178527'
 export const SUBSCRIPTION_FILTER_NAME = 'datadog-ci-filter'

--- a/src/commands/lambda/functions/instrument.ts
+++ b/src/commands/lambda/functions/instrument.ts
@@ -23,6 +23,7 @@ import {
   RuntimeType,
   SERVICE_ENV_VAR,
   SITE_ENV_VAR,
+  SITES,
   TRACE_ENABLED_ENV_VAR,
   VERSION_ENV_VAR,
 } from '../constants'
@@ -186,13 +187,12 @@ export const calculateUpdateRequest = (
   }
 
   if (site !== undefined && oldEnvVars[SITE_ENV_VAR] !== site) {
-    const siteList: string[] = ['datadoghq.com', 'datadoghq.eu', 'us3.datadoghq.com', 'ddog-gov.com']
-    if (siteList.includes(site.toLowerCase())) {
+    if (SITES.includes(site.toLowerCase())) {
       needsUpdate = true
       changedEnvVars[SITE_ENV_VAR] = site
     } else {
       throw new Error(
-        'Warning: Invalid site URL. Must be either datadoghq.com, datadoghq.eu, us3.datadoghq.com, or ddog-gov.com.'
+        'Warning: Invalid site URL. Must be either datadoghq.com, datadoghq.eu, us3.datadoghq.com, us5.datadoghq.com, or ddog-gov.com.'
       )
     }
   }


### PR DESCRIPTION
### What and why?

Add `us5.datadoghq.com` to the supported sites array.  Since it wasn't there.

### How?

Moving the sites' array to `constants.ts` and add `us5.datadoghq.com`. 
Also fixed test to comply with the supported sites.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)

<!--
[TODO MROUSSE Nov 15th 2021: the repository is not public/published yet so this should not be done for now]
- [ ] A new release of `datadog-ci` MUST be updated in the [synthetics-ci-github-action](https://github.com/DataDog/synthetics-ci-github-action)
-->
