### PR TITLE
allow overriding junit intake url with env

### DIFF
--- a/src/commands/junit/README.md
+++ b/src/commands/junit/README.md
@@ -40,6 +40,7 @@ Additionally you might configure the `junit` command with environment variables:
 - `DD_TAGS`: set global tags applied to all spans. The format must be `key1:value1,key2:value2`.
   - The resulting dictionary will be merged with whatever is in the `--tags` parameter. If a `key` appears both in `--tags` and `DD_TAGS`, whatever value is in `DD_TAGS` will take precedence.
 - `DATADOG_SITE`: choose your Datadog site, e.g. datadoghq.com or datadoghq.eu.
+- `DATADOG_JUNIT_INTAKE_URL`: override the full URL for the intake endpoint.
 
 ### Optional dependencies
 

--- a/src/commands/junit/utils.ts
+++ b/src/commands/junit/utils.ts
@@ -1,5 +1,7 @@
 export const getBaseIntakeUrl = () => {
-  if (process.env.DATADOG_SITE || process.env.DD_SITE) {
+  if (process.env.DATADOG_JUNIT_INTAKE_URL) {
+    return process.env.DATADOG_JUNIT_INTAKE_URL
+  } else if (process.env.DATADOG_SITE || process.env.DD_SITE) {
     return `https://cireport-intake.${process.env.DATADOG_SITE || process.env.DD_SITE}`
   }
 


### PR DESCRIPTION
Allow setting a custom junit intake url with `DATADOG_JUNIT_INTAKE_URL` environment variable
