### PR TITLE
[lambda] Skip DD_FLUSH_TO_LOGS when Extension Layer is being used

### DIFF
--- a/src/commands/lambda/__tests__/instrument.test.ts
+++ b/src/commands/lambda/__tests__/instrument.test.ts
@@ -62,7 +62,6 @@ describe('lambda', () => {
         )
         const output = context.stdout.toString()
         expect(code).toBe(0)
-        console.log(output)
         expect(output).toMatchInlineSnapshot(`
 "${bold(yellow('[Warning]'))} Instrument your ${hex('#FF9900').bold(
           'Lambda'
@@ -82,11 +81,11 @@ UpdateFunctionConfiguration -> arn:aws:lambda:us-east-1:123456789012:function:la
       \\"DD_SITE\\": \\"datadoghq.com\\",
       \\"DD_ENV\\": \\"staging\\",
       \\"DD_TAGS\\": \\"layer:api,team:intake\\",
-      \\"DD_FLUSH_TO_LOG\\": \\"true\\",
       \\"DD_MERGE_XRAY_TRACES\\": \\"false\\",
       \\"DD_SERVICE\\": \\"middletier\\",
       \\"DD_TRACE_ENABLED\\": \\"true\\",
       \\"DD_VERSION\\": \\"0.2\\",
+      \\"DD_FLUSH_TO_LOG\\": \\"true\\",
       \\"DD_LOG_LEVEL\\": \\"debug\\"
     }
   },
@@ -159,7 +158,6 @@ UpdateFunctionConfiguration -> arn:aws:lambda:us-east-1:123456789012:function:la
       \\"DD_SITE\\": \\"datadoghq.com\\",
       \\"DD_ENV\\": \\"staging\\",
       \\"DD_TAGS\\": \\"layer:api,team:intake\\",
-      \\"DD_FLUSH_TO_LOG\\": \\"true\\",
       \\"DD_MERGE_XRAY_TRACES\\": \\"false\\",
       \\"DD_SERVICE\\": \\"middletier\\",
       \\"DD_TRACE_ENABLED\\": \\"true\\",
@@ -357,11 +355,11 @@ UpdateFunctionConfiguration -> arn:aws:lambda:us-east-1:123456789012:function:la
       \\"DD_SITE\\": \\"datadoghq.com\\",
       \\"DD_ENV\\": \\"dummy\\",
       \\"DD_TAGS\\": \\"git.commit.sha:1be168ff837f043bde17c0314341c84271047b31\\",
-      \\"DD_FLUSH_TO_LOG\\": \\"true\\",
       \\"DD_MERGE_XRAY_TRACES\\": \\"false\\",
       \\"DD_SERVICE\\": \\"dummy\\",
       \\"DD_TRACE_ENABLED\\": \\"true\\",
-      \\"DD_VERSION\\": \\"0.1\\"
+      \\"DD_VERSION\\": \\"0.1\\",
+      \\"DD_FLUSH_TO_LOG\\": \\"true\\"
     }
   },
   \\"Layers\\": [

--- a/src/commands/lambda/functions/instrument.ts
+++ b/src/commands/lambda/functions/instrument.ts
@@ -182,7 +182,6 @@ export const calculateUpdateRequest = (
   const environmentVarsTupleArray: [keyof InstrumentationSettings, string][] = [
     ['environment', ENVIRONMENT_ENV_VAR],
     ['extraTags', EXTRA_TAGS_ENV_VAR],
-    ['flushMetricsToLogs', FLUSH_TO_LOG_ENV_VAR],
     ['mergeXrayTraces', MERGE_XRAY_TRACES_ENV_VAR],
     ['service', SERVICE_ENV_VAR],
     ['tracingEnabled', TRACE_ENABLED_ENV_VAR],
@@ -194,6 +193,15 @@ export const calculateUpdateRequest = (
       needsUpdate = true
       changedEnvVars[environmentVar] = settings[key]!.toString()
     }
+  }
+  const isUsingExtension = settings.extensionVersion !== undefined
+  if (
+    !isUsingExtension &&
+    settings.flushMetricsToLogs !== undefined &&
+    oldEnvVars[FLUSH_TO_LOG_ENV_VAR] !== settings.flushMetricsToLogs?.toString()
+  ) {
+    needsUpdate = true
+    changedEnvVars[FLUSH_TO_LOG_ENV_VAR] = settings.flushMetricsToLogs!.toString()
   }
 
   const newEnvVars = {...oldEnvVars, ...changedEnvVars}


### PR DESCRIPTION
The variable `DD_FLUSH_TO_LOGS` was being set to true as fallback, but we didn't skip it if the Extension Layer was being used, this was unexpected behavior.

### What and why?

Skip adding the Environment Variable `DD_FLUSH_TO_LOGS` when the Extension Layer is being used. 

### How?

Remove the variable from the tuple array in which it was set, add a condition to see if the user is adding the Extension Layer.
Added a test and updated existing ones.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)

