### PR TITLE
[lambda] Coerce boolean for `mergeXrayTraces`, `flushMetricsToLogs`, and `tracing`

### DIFF
--- a/src/commands/lambda/__tests__/functions/commons.test.ts
+++ b/src/commands/lambda/__tests__/functions/commons.test.ts
@@ -80,6 +80,11 @@ describe('commons', () => {
       expect(coerceBoolean(true, 'false', 'true')).toBe(false)
       expect(coerceBoolean(false, 'true', 'False')).toBe(true)
     })
+
+    test('return the first boolean when one of the values provided is boolean', () => {
+      expect(coerceBoolean(true, false, 'truE', true)).toBe(false)
+      expect(coerceBoolean(false, true, 'False', false)).toBe(true)
+    })
   })
   describe('collectFunctionsByRegion', () => {
     test('groups functions with region read from arn', () => {

--- a/src/commands/lambda/__tests__/functions/commons.test.ts
+++ b/src/commands/lambda/__tests__/functions/commons.test.ts
@@ -12,6 +12,7 @@ import {
 } from '../../constants'
 import {
   addLayerArn,
+  coerceBoolean,
   collectFunctionsByRegion,
   getLayerArn,
   getRegion,
@@ -66,6 +67,18 @@ describe('commons', () => {
         'arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Python39-ARM:49',
         'arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Extension-ARM:11',
       ])
+    })
+  })
+
+  describe('coerceBoolean', () => {
+    test('return fallback when none of the values provided can be parsed to boolean', () => {
+      expect(coerceBoolean(true, 'NotBoolean', 123, [], {})).toBe(true)
+      expect(coerceBoolean(false, 'NotBooleanEither', 456, ['An array'], {booleanInObject: true})).toBe(false)
+    })
+
+    test('return the first boolean when one of the values provided can be parsed to boolean', () => {
+      expect(coerceBoolean(true, 'false', 'true')).toBe(false)
+      expect(coerceBoolean(false, 'true', 'False')).toBe(true)
     })
   })
   describe('collectFunctionsByRegion', () => {

--- a/src/commands/lambda/__tests__/instrument.test.ts
+++ b/src/commands/lambda/__tests__/instrument.test.ts
@@ -697,14 +697,18 @@ TagResource -> arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world
         command['config']['logLevel'] = 'debug'
 
         expect(command['getSettings']()).toEqual({
+          environment: undefined,
           extensionVersion: 6,
+          extraTags: undefined,
           flushMetricsToLogs: false,
           forwarderARN: 'my-forwarder',
           layerAWSAccount: 'another-account',
           layerVersion: 2,
           logLevel: 'debug',
           mergeXrayTraces: false,
+          service: undefined,
           tracingEnabled: false,
+          version: undefined,
         })
       })
 

--- a/src/commands/lambda/functions/commons.ts
+++ b/src/commands/lambda/functions/commons.ts
@@ -35,6 +35,14 @@ export const addLayerArn = (fullLayerArn: string | undefined, previousLayerName:
   return layerARNs
 }
 
+/**
+ * Returns a coerced boolean given string booleans or booleans in
+ * an spread array. Every other value will be ignored.
+ *
+ * @param fallback default value if none of the provided `values` comply.
+ * @param values an spread array of string booleans or booleans.
+ * @returns a coerced boolean.
+ */
 export const coerceBoolean = (fallback: boolean, ...values: any[]): boolean => {
   for (const value of values) {
     switch (typeof value) {
@@ -49,6 +57,7 @@ export const coerceBoolean = (fallback: boolean, ...values: any[]): boolean => {
         break
 
       default:
+        continue
     }
   }
 

--- a/src/commands/lambda/functions/commons.ts
+++ b/src/commands/lambda/functions/commons.ts
@@ -35,6 +35,26 @@ export const addLayerArn = (fullLayerArn: string | undefined, previousLayerName:
   return layerARNs
 }
 
+export const coerceBoolean = (fallback: boolean, ...values: any[]): boolean => {
+  for (const value of values) {
+    switch (typeof value) {
+      case 'boolean':
+        return value
+      case 'string':
+        if (value.toString().toLowerCase() === 'true') {
+          return true
+        } else if (value.toString().toLowerCase() === 'false') {
+          return false
+        }
+        break
+
+      default:
+    }
+  }
+
+  return fallback
+}
+
 /**
  * Returns an array of functions grouped by its region, it
  * throws an error if there are functions without a region.


### PR DESCRIPTION
Currently, we were just accepting string booleans for `mergeXrayTraces`, `flushMetricsToLogs`, and `tracing`. If the user specified a boolean in the config file for such fields, it would crash because there is no `.toLowerCase()` method for booleans. 

### What and why?

Coerce booleans to avoid an error when user specifies a value of type `boolean|string` for `mergeXrayTraces`, `flushMetricsToLogs`, and `tracing`.

 
<img width="1091" alt="Screen Shot 2021-11-23 at 3 09 45 PM" src="https://user-images.githubusercontent.com/30836115/143096517-bde7dadd-d84e-453f-a6e5-e35f3e3609b3.png">

### How?

Created a function to coerce booleans: `coerceBoolean`.
Add tests and fix current ones.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)

