### PR TITLE
[git-metadata] Upload returns 1 when no git metadata available.

### DIFF
--- a/src/commands/git-metadata/upload.ts
+++ b/src/commands/git-metadata/upload.ts
@@ -61,7 +61,7 @@ export class UploadCommand extends Command {
     })
     const payload = await getCommitInfo(await newSimpleGit(), this.context.stdout, this.repositoryURL)
     if (payload === undefined) {
-      return 0
+      return 1
     }
     this.context.stdout.write(renderCommandInfo(payload))
     try {


### PR DESCRIPTION
### What and why?

If no git metadata is available we should consider the command run as a
failure.

Fixes #426

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
