### PR TITLE
[git-metadata] switch to v2 endpoint

### DIFF
--- a/src/commands/git-metadata/upload.ts
+++ b/src/commands/git-metadata/upload.ts
@@ -119,6 +119,11 @@ export class UploadCommand extends Command {
     return getRequestBuilder({
       apiKey: this.config.apiKey!,
       baseUrl: getBaseIntakeUrl(),
+      headers: new Map([
+        ['DD-EVP-ORIGIN', 'datadog-ci git-metadata'],
+        ['DD-EVP-ORIGIN-VERSION', this.cliVersion],
+      ]),
+      overrideUrl: 'api/v2/srcmap',
     })
   }
 


### PR DESCRIPTION
### What and why?

Switches the `git-metadata` command to the v2 endpoint.
Previously done for the `sourcemaps` command: https://github.com/DataDog/datadog-ci/pull/314/files

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)

<!--
[TODO MROUSSE Nov 15th 2021: the repository is not public/published yet so this should not be done for now]
- [ ] A new release of `datadog-ci` MUST be updated in the [synthetics-ci-github-action](https://github.com/DataDog/synthetics-ci-github-action)
-->
