### PR TITLE
[ci] rename getXXXMetadata to getXXXSpanTags

### DIFF
--- a/src/commands/junit/upload.ts
+++ b/src/commands/junit/upload.ts
@@ -22,7 +22,7 @@ import {getCISpanTags} from '../../helpers/ci'
 import {getGitMetadata} from '../../helpers/git'
 import {retryRequest} from '../../helpers/retry'
 import {parseTags} from '../../helpers/tags'
-import {getUserGitMetadata} from '../../helpers/user-provided-git'
+import {getUserGitSpanTags} from '../../helpers/user-provided-git'
 import {buildPath} from '../../helpers/utils'
 
 const errorCodesStopUpload = [400, 403]
@@ -137,7 +137,7 @@ export class UploadJUnitXMLCommand extends Command {
 
     const ciSpanTags = getCISpanTags()
     const gitSpanTags = await getGitMetadata()
-    const userGitSpanTags = getUserGitMetadata()
+    const userGitSpanTags = getUserGitSpanTags()
 
     const envVarTags = this.config.envVarTags ? parseTags(this.config.envVarTags.split(',')) : {}
     const cliTags = this.tags ? parseTags(this.tags) : {}

--- a/src/commands/trace/api.ts
+++ b/src/commands/trace/api.ts
@@ -1,7 +1,7 @@
 import type {AxiosPromise, AxiosRequestConfig, AxiosResponse} from 'axios'
 
 import {getGitMetadata} from '../../helpers/git'
-import {getUserGitMetadata} from '../../helpers/user-provided-git'
+import {getUserGitSpanTags} from '../../helpers/user-provided-git'
 import {getRequestBuilder} from '../../helpers/utils'
 import {Payload} from './interfaces'
 
@@ -14,7 +14,7 @@ export const reportCustomSpan = (request: (args: AxiosRequestConfig) => AxiosPro
   provider: string
 ) => {
   const gitSpanTags = await getGitMetadata()
-  const userGitSpanTags = getUserGitMetadata()
+  const userGitSpanTags = getUserGitSpanTags()
 
   return request({
     data: {

--- a/src/helpers/__tests__/ci.test.ts
+++ b/src/helpers/__tests__/ci.test.ts
@@ -3,7 +3,7 @@ import path from 'path'
 
 import {getCIMetadata, getCISpanTags} from '../ci'
 import {Metadata, SpanTags} from '../interfaces'
-import {getUserCIMetadata, getUserGitMetadata} from '../user-provided-git'
+import {getUserCISpanTags, getUserGitSpanTags} from '../user-provided-git'
 
 const CI_PROVIDERS = fs.readdirSync(path.join(__dirname, 'ci-env'))
 
@@ -133,8 +133,8 @@ describe('ci spec', () => {
     process.env = {}
     const tags = {
       ...getCISpanTags(),
-      ...getUserCIMetadata(),
-      ...getUserGitMetadata(),
+      ...getUserCISpanTags(),
+      ...getUserGitSpanTags(),
     }
     expect(tags).toEqual({})
   })
@@ -147,7 +147,7 @@ describe('ci spec', () => {
         process.env = env
         const tags = {
           ...getCISpanTags(),
-          ...getUserGitMetadata(),
+          ...getUserGitSpanTags(),
         }
         expect(tags).toEqual(expectedSpanTags)
       })

--- a/src/helpers/__tests__/user-provided-git.test.ts
+++ b/src/helpers/__tests__/user-provided-git.test.ts
@@ -21,9 +21,9 @@ import {
   GIT_TAG,
 } from '../tags'
 
-import {getUserCIMetadata, getUserGitMetadata} from '../user-provided-git'
+import {getUserCISpanTags, getUserGitSpanTags} from '../user-provided-git'
 
-describe('getUserGitMetadata', () => {
+describe('getUserGitSpanTags', () => {
   const DD_GIT_METADATA = {
     DD_GIT_BRANCH: 'DD_GIT_BRANCH',
     DD_GIT_COMMIT_AUTHOR_DATE: 'DD_GIT_COMMIT_AUTHOR_DATE',
@@ -39,7 +39,7 @@ describe('getUserGitMetadata', () => {
 
   it('reads user defined git metadata successfully', () => {
     process.env = {...DD_GIT_METADATA}
-    const result = getUserGitMetadata()
+    const result = getUserGitSpanTags()
     expect(result).toEqual({
       [GIT_REPOSITORY_URL]: 'DD_GIT_REPOSITORY_URL',
       [GIT_BRANCH]: 'DD_GIT_BRANCH',
@@ -55,7 +55,7 @@ describe('getUserGitMetadata', () => {
   })
   it('does not include empty values', () => {
     process.env = {...DD_GIT_METADATA, DD_GIT_COMMIT_SHA: undefined}
-    const result = getUserGitMetadata()
+    const result = getUserGitSpanTags()
     expect(result).toEqual({
       [GIT_REPOSITORY_URL]: 'DD_GIT_REPOSITORY_URL',
       [GIT_BRANCH]: 'DD_GIT_BRANCH',
@@ -70,7 +70,7 @@ describe('getUserGitMetadata', () => {
   })
   it('overwrites branch when tag is available', () => {
     process.env = {...DD_GIT_METADATA, DD_GIT_TAG: 'DD_GIT_TAG'}
-    const result = getUserGitMetadata()
+    const result = getUserGitSpanTags()
     expect(result).toEqual({
       [GIT_TAG]: 'DD_GIT_TAG',
       [GIT_REPOSITORY_URL]: 'DD_GIT_REPOSITORY_URL',
@@ -86,12 +86,12 @@ describe('getUserGitMetadata', () => {
   })
   it('returns an empty object if no user git is defined', () => {
     process.env = {}
-    const result = getUserGitMetadata()
+    const result = getUserGitSpanTags()
     expect(result).toEqual({})
   })
 })
 
-describe('getUserCIMetadata', () => {
+describe('getUserCISpanTags', () => {
   const DD_CI_METADATA = {
     DD_CI_JOB_NAME: 'DD_CI_JOB_NAME',
     DD_CI_JOB_URL: 'DD_CI_JOB_URL',
@@ -106,7 +106,7 @@ describe('getUserCIMetadata', () => {
 
   it('reads user defined CI metadata successfully', () => {
     process.env = {...DD_CI_METADATA}
-    const result = getUserCIMetadata()
+    const result = getUserCISpanTags()
     expect(result).toEqual({
       [CI_JOB_NAME]: 'DD_CI_JOB_NAME',
       [CI_JOB_URL]: 'DD_CI_JOB_URL',
@@ -121,7 +121,7 @@ describe('getUserCIMetadata', () => {
   })
   it('does not include empty values', () => {
     process.env = {...DD_CI_METADATA, DD_CI_PIPELINE_ID: undefined}
-    const result = getUserCIMetadata()
+    const result = getUserCISpanTags()
     expect(result).toEqual({
       [CI_JOB_NAME]: 'DD_CI_JOB_NAME',
       [CI_JOB_URL]: 'DD_CI_JOB_URL',
@@ -135,7 +135,7 @@ describe('getUserCIMetadata', () => {
   })
   it('returns an empty object if no user CI is defined', () => {
     process.env = {}
-    const result = getUserCIMetadata()
+    const result = getUserCISpanTags()
     expect(result).toEqual({})
   })
 })

--- a/src/helpers/ci.ts
+++ b/src/helpers/ci.ts
@@ -23,7 +23,7 @@ import {
   GIT_SHA,
   GIT_TAG,
 } from './tags'
-import {getUserCIMetadata, getUserGitMetadata} from './user-provided-git'
+import {getUserCISpanTags, getUserGitSpanTags} from './user-provided-git'
 import {normalizeRef, removeEmptyValues, removeUndefinedValues} from './utils'
 
 export const CI_ENGINES = {
@@ -486,8 +486,8 @@ export const getCISpanTags = (): SpanTags | undefined => {
 export const getCIMetadata = (): Metadata | undefined => {
   const tags = {
     ...getCISpanTags(),
-    ...getUserCIMetadata(),
-    ...getUserGitMetadata(),
+    ...getUserCISpanTags(),
+    ...getUserGitSpanTags(),
   }
 
   if (!tags || !Object.keys(tags).length) {

--- a/src/helpers/user-provided-git.ts
+++ b/src/helpers/user-provided-git.ts
@@ -22,7 +22,7 @@ import {
 } from './tags'
 import {normalizeRef, removeEmptyValues} from './utils'
 
-export const getUserGitMetadata = () => {
+export const getUserGitSpanTags = () => {
   const {
     DD_GIT_REPOSITORY_URL,
     DD_GIT_COMMIT_SHA,
@@ -64,7 +64,7 @@ export const getUserGitMetadata = () => {
   })
 }
 
-export const getUserCIMetadata = () => {
+export const getUserCISpanTags = () => {
   const {
     DD_CI_JOB_NAME,
     DD_CI_JOB_URL,


### PR DESCRIPTION
### What and why?

Rename `getXXXMetadata` to `getXXXSpanTags` to enhance readability because we mixed Metadata (structured) and SpanTags (unstructured) .
