### PR TITLE
[lambda] Standardize lambda-ci error messages/handling

### DIFF
--- a/src/commands/lambda/__tests__/instrument.test.ts
+++ b/src/commands/lambda/__tests__/instrument.test.ts
@@ -607,7 +607,9 @@ TagResource -> arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world
         const output = context.stdout.toString()
         expect(code).toBe(1)
         expect(output).toMatchInlineSnapshot(`
-                                                            "No functions specified for instrumentation.
+                                                            "${red(
+                                                              '[Error]'
+                                                            )} No functions specified for instrumentation.
                                                             "
                                                 `)
       })
@@ -627,7 +629,9 @@ TagResource -> arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world
         await command['execute']()
         const output = command.context.stdout.toString()
         expect(output).toMatchInlineSnapshot(`
-                                                            "No functions specified for instrumentation.
+                                                            "${red(
+                                                              '[Error]'
+                                                            )} No functions specified for instrumentation.
                                                             "
                                                 `)
       })
@@ -700,7 +704,9 @@ TagResource -> arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world
         const output = context.stdout.toString()
         expect(code).toBe(1)
         expect(output).toMatchInlineSnapshot(`
-                                                  "Couldn't fetch Lambda functions. Error: Can't instrument arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world, as current State is Failed (must be \\"Active\\") and Last Update Status is Unsuccessful (must be \\"Successful\\")
+                                                  "${red(
+                                                    '[Error]'
+                                                  )} Couldn't fetch Lambda functions. Error: Can't instrument arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world, as current State is Failed (must be \\"Active\\") and Last Update Status is Unsuccessful (must be \\"Successful\\")
                                                   "
                                         `)
       })
@@ -734,7 +740,7 @@ TagResource -> arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world
         const output = context.stdout.toString()
         expect(code).toBe(1)
         expect(output).toMatchInlineSnapshot(`
-          "\\"extensionVersion\\" and \\"forwarder\\" should not be used at the same time.
+          "${red('[Error]')} \\"extensionVersion\\" and \\"forwarder\\" should not be used at the same time.
           "
         `)
       })
@@ -778,6 +784,20 @@ TagResource -> arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world
         await command['execute']()
         output = command.context.stdout.toString()
         expect(output).toMatch('"--functions" and "--functions-regex" should not be used at the same time.\n')
+      })
+      test('aborts if pattern is set and no default region is specified', async () => {
+        ;(fs.readFile as any).mockImplementation((a: any, b: any, callback: any) => callback({}))
+
+        process.env = {}
+
+        const command = createCommand(InstrumentCommand)
+        command['environment'] = 'staging'
+        command['service'] = 'middletier'
+        command['version'] = '2'
+        command['regExPattern'] = 'valid-pattern'
+        await command['execute']()
+        const output = command.context.stdout.toString()
+        expect(output).toMatch(`${red('[Error]')} No default region specified. Use \`-r\`, \`--region\`.\n`)
       })
       test('aborts if the regEx pattern is an ARN', async () => {
         ;(fs.readFile as any).mockImplementation((a: any, b: any, callback: any) => callback({}))

--- a/src/commands/lambda/__tests__/uninstrument.test.ts
+++ b/src/commands/lambda/__tests__/uninstrument.test.ts
@@ -190,7 +190,7 @@ UpdateFunctionConfiguration -> arn:aws:lambda:us-east-1:000000000000:function:un
       const output = context.stdout.toString()
       expect(code).toBe(1)
       expect(output).toMatchInlineSnapshot(`
-        "No functions specified for un-instrumentation.
+        "${red('[Error]')} No functions specified for un-instrumentation.
         "
       `)
     })
@@ -203,7 +203,7 @@ UpdateFunctionConfiguration -> arn:aws:lambda:us-east-1:000000000000:function:un
       await command['execute']()
       const output = command.context.stdout.toString()
       expect(output).toMatchInlineSnapshot(`
-        "No functions specified for un-instrumentation.
+        "${red('[Error]')} No functions specified for un-instrumentation.
         "
       `)
     })

--- a/src/commands/lambda/instrument.ts
+++ b/src/commands/lambda/instrument.ts
@@ -105,26 +105,28 @@ export class InstrumentCommand extends Command {
     hasSpecifiedFunctions = this.functions.length !== 0 || this.config.functions.length !== 0
     const hasSpecifiedRegExPattern = this.regExPattern !== undefined && this.regExPattern !== ''
     if (!hasSpecifiedFunctions && !hasSpecifiedRegExPattern) {
-      this.context.stdout.write('No functions specified for instrumentation.\n')
+      this.context.stdout.write(`${red('[Error]')} No functions specified for instrumentation.\n`)
 
       return 1
     }
     if (settings.extensionVersion && settings.forwarderARN) {
-      this.context.stdout.write('"extensionVersion" and "forwarder" should not be used at the same time.\n')
+      this.context.stdout.write(
+        `${red('[Error]')} "extensionVersion" and "forwarder" should not be used at the same time.\n`
+      )
 
       return 1
     }
 
     if (this.sourceCodeIntegration) {
       if (!process.env.DATADOG_API_KEY) {
-        this.context.stdout.write('Missing DATADOG_API_KEY in your environment\n')
+        this.context.stdout.write(`${red('[Error]')} Missing DATADOG_API_KEY in your environment\n`)
 
         return 1
       }
       try {
         await this.getGitDataAndUpload(settings)
       } catch (err) {
-        this.context.stdout.write(`${err}\n`)
+        this.context.stdout.write(`${red('[Error]')} ${err}\n`)
 
         return 1
       }
@@ -140,19 +142,21 @@ export class InstrumentCommand extends Command {
     if (hasSpecifiedRegExPattern) {
       if (hasSpecifiedFunctions) {
         const usedCommand = this.functions.length !== 0 ? '"--functions"' : 'Functions in config file'
-        this.context.stdout.write(`${usedCommand} and "--functions-regex" should not be used at the same time.\n`)
+        this.context.stdout.write(
+          `${red('[Error]')} ${usedCommand} and "--functions-regex" should not be used at the same time.\n`
+        )
 
         return 1
       }
       if (this.regExPattern!.match(':')) {
-        this.context.stdout.write(`"--functions-regex" isn't meant to be used with ARNs.\n`)
+        this.context.stdout.write(`${red('[Error]')} "--functions-regex" isn't meant to be used with ARNs.\n`)
 
         return 1
       }
 
       const region = this.region || this.config.region
       if (!region) {
-        this.context.stdout.write('No default region specified. Use `-r`, `--region`.')
+        this.context.stdout.write(`${red('[Error]')} No default region specified. Use \`-r\`, \`--region\`.\n`)
 
         return 1
       }
@@ -171,7 +175,7 @@ export class InstrumentCommand extends Command {
 
         configGroups.push({configs, lambda, cloudWatchLogs, region: region!})
       } catch (err) {
-        this.context.stdout.write(`Couldn't fetch Lambda functions. ${err}\n`)
+        this.context.stdout.write(`${red('[Error]')} Couldn't fetch Lambda functions. ${err}\n`)
 
         return 1
       }
@@ -183,7 +187,7 @@ export class InstrumentCommand extends Command {
           this.region || this.config.region
         )
       } catch (err) {
-        this.context.stdout.write(`Couldn't group functions. ${err}`)
+        this.context.stdout.write(`${red('[Error]')} Couldn't group functions. ${err}`)
 
         return 1
       }
@@ -195,7 +199,7 @@ export class InstrumentCommand extends Command {
           const configs = await getInstrumentedFunctionConfigs(lambda, cloudWatchLogs, region, functionList, settings)
           configGroups.push({configs, lambda, cloudWatchLogs, region})
         } catch (err) {
-          this.context.stdout.write(`Couldn't fetch Lambda functions. ${err}\n`)
+          this.context.stdout.write(`${red('[Error]')} Couldn't fetch Lambda functions. ${err}\n`)
 
           return 1
         }
@@ -224,7 +228,7 @@ export class InstrumentCommand extends Command {
     try {
       await Promise.all(promises)
     } catch (err) {
-      this.context.stdout.write(`Failure during update. ${err}\n`)
+      this.context.stdout.write(`${red('[Error]')} Failure during update. ${err}\n`)
 
       return 1
     }

--- a/src/commands/lambda/uninstrument.ts
+++ b/src/commands/lambda/uninstrument.ts
@@ -71,7 +71,7 @@ export class UninstrumentCommand extends Command {
     hasSpecifiedFunctions = this.functions.length !== 0 || this.config.functions.length !== 0
     const hasSpecifiedRegExPattern = this.regExPattern !== undefined && this.regExPattern !== ''
     if (!hasSpecifiedFunctions && !hasSpecifiedRegExPattern) {
-      this.context.stdout.write('No functions specified for un-instrumentation.\n')
+      this.context.stdout.write(`${red('[Error]')} No functions specified for un-instrumentation.\n`)
 
       return 1
     }
@@ -87,19 +87,21 @@ export class UninstrumentCommand extends Command {
     if (hasSpecifiedRegExPattern) {
       if (hasSpecifiedFunctions) {
         const usedCommand = this.functions.length !== 0 ? '"--functions"' : 'Functions in config file'
-        this.context.stdout.write(`${usedCommand} and "--functions-regex" should not be used at the same time.\n`)
+        this.context.stdout.write(
+          `${red('[Error]')} ${usedCommand} and "--functions-regex" should not be used at the same time.\n`
+        )
 
         return 1
       }
       if (this.regExPattern!.match(':')) {
-        this.context.stdout.write(`"--functions-regex" isn't meant to be used with ARNs.\n`)
+        this.context.stdout.write(`${red('[Error]')} "--functions-regex" isn't meant to be used with ARNs.\n`)
 
         return 1
       }
 
       const region = this.region || this.config.region
       if (!region) {
-        this.context.stdout.write('No default region specified. Use `-r`, `--region`.')
+        this.context.stdout.write(`${red('[Error]')} No default region specified. Use \`-r\`, \`--region\`.`)
 
         return 1
       }
@@ -129,7 +131,7 @@ export class UninstrumentCommand extends Command {
           this.region || this.config.region
         )
       } catch (err) {
-        this.context.stdout.write(`Couldn't group functions. ${err}`)
+        this.context.stdout.write(`${red('[Error]')} Couldn't group functions. ${err}`)
 
         return 1
       }


### PR DESCRIPTION
### What and why?

Standardized how errors are displayed and handled within the lambda-ci commands. 

[SLS-1907](https://datadoghq.atlassian.net/browse/SLS-1907)

### How?

- Previously, Errors were displayed in one of the following two ways:
    - [Error] Error Message (where the [Error] tag is displayed in red)
    - Error Message

- Standardized all error messages in the instrument and uninstrument commands to be a red [Error] tag, followed by the error message itself.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)

<!--
[TODO MROUSSE Nov 15th 2021: the repository is not public/published yet so this should not be done for now]
- [ ] A new release of `datadog-ci` MUST be updated in the [synthetics-ci-github-action](https://github.com/DataDog/synthetics-ci-github-action)
-->
