### PR TITLE
Update README for ci-visibility Commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ npm install -g @datadog/datadog-ci
 # Yarn v1 add globally
 yarn global add @datadog/datadog-ci
 ```
+
 ## Usage
 
 ```bash
@@ -40,6 +41,8 @@ Available commands:
   - synthetics
   - dsyms
   - git-metadata
+  - junit
+  - trace
 ```
 
 Each command allows interacting with a product of the Datadog platform. The commands are defined in the [src/commands](/src/commands) folder.
@@ -52,6 +55,8 @@ Further documentation for each command can be found in its folder, ie:
 - [Synthetics CI/CD Testing](src/commands/synthetics/)
 - [iOS dSYM Files](src/commands/dsyms/)
 - [Git metadata](src/commands/git-metadata)
+- [JUnit XML](src/commands/junit)
+- [Trace](src/commands/trace)
 
 ## Contributing
 

--- a/src/commands/junit/README.md
+++ b/src/commands/junit/README.md
@@ -2,8 +2,6 @@
 
 Upload your jUnit XML files.
 
-**Warning**: this command is still in alpha and should not be used in production environments.
-
 ## Usage
 
 #### Commands
@@ -47,21 +45,21 @@ Additionally you might configure the `junit` command with environment variables:
 
 ### End-to-end testing process
 
-To verify this command works as expected, you can send some mock data and validate the command returns 0:
+To verify this command works as expected, you can use `--dry-run`:
 
 ```bash
 export DATADOG_API_KEY='<API key>'
 
-yarn launch junit upload /src/commands/junit/__tests__/fixtures --service example-upload
+yarn launch junit upload ./src/commands/junit/__tests__/fixtures/java-report.xml --service example-upload --dry-run
 ```
 
 Successful output should look like this:
 
 ```bash
+⚠️ DRY-RUN MODE ENABLED. WILL NOT UPLOAD JUNIT XML
 Starting upload with concurrency 20.
-Will look for jUnit XML files in src/commands/junit/__tests__/fixtures
+Will upload jUnit XML file src/commands/junit/__tests__/fixtures/java-report.xml
 service: example-upload
-Uploading jUnit XML test report file in src/commands/junit/__tests__/fixtures/go-report.xml
-Uploading jUnit XML test report file in src/commands/junit/__tests__/fixtures/java-report.xml
-✅ Uploaded 2 files in ? seconds.
+[DRYRUN] Uploading jUnit XML test report file in src/commands/junit/__tests__/fixtures/java-report.xml
+✅ Uploaded 1 files in 0 seconds.
 ```

--- a/src/commands/trace/README.md
+++ b/src/commands/trace/README.md
@@ -2,8 +2,6 @@
 
 Trace a command with a custom span and report it to Datadog.
 
-**Warning**: this command is still in alpha and should not be used in production environments.
-
 ## Usage
 
 ```bash


### PR DESCRIPTION
### What and why?

Link to `trace` and `junit` commands from the main README. They were hidden but they are production ready now, so they shouldn't be.

