### PR TITLE
[Synthetics] Add `trigger_app` property to batch metadata

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,8 +9,4 @@ A brief description of implementation details of this PR.
 ### Review checklist
 
 - [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
-
-<!--
-[TODO MROUSSE Nov 15th 2021: the repository is not public/published yet so this should not be done for now]
-- [ ] A new release of `datadog-ci` MUST be updated in the [synthetics-ci-github-action](https://github.com/DataDog/synthetics-ci-github-action)
--->
+- [ ] \[_Synthetics_\] New releases of `datadog-ci` MUST be followed by a [synthetics-ci-github-action](https://github.com/DataDog/synthetics-ci-github-action) release

--- a/src/commands/synthetics/__tests__/utils.test.ts
+++ b/src/commands/synthetics/__tests__/utils.test.ts
@@ -72,11 +72,7 @@ describe('utils', () => {
     })
 
     test('runTests sends batch metadata', async () => {
-      const metadata: Metadata = {
-        ci: {job: {name: 'job'}, pipeline: {}, provider: {name: 'jest'}, stage: {}},
-        git: {commit: {author: {}, committer: {}, message: 'test'}},
-      }
-      jest.spyOn(ciHelpers, 'getCIMetadata').mockImplementation(() => metadata)
+      jest.spyOn(ciHelpers, 'getCIMetadata').mockImplementation(() => undefined)
 
       const payloadMetadataSpy = jest.fn()
       const axiosMock = jest.spyOn(axios, 'create')
@@ -88,11 +84,21 @@ describe('utils', () => {
       }) as any)
 
       await utils.runTests(api, [{public_id: fakeId, executionRule: ExecutionRule.NON_BLOCKING}])
-      expect(payloadMetadataSpy).toHaveBeenCalledWith({...metadata, trigger_source: 'npm_package'})
+      expect(payloadMetadataSpy).toHaveBeenCalledWith({
+        ci: {job: {}, pipeline: {}, provider: {}, stage: {}},
+        git: {commit: {author: {}, committer: {}}},
+        trigger_app: 'npm_package',
+      })
 
-      utils.setCiTriggerSource('unit_test')
+      const metadata: Metadata = {
+        ci: {job: {name: 'job'}, pipeline: {}, provider: {name: 'jest'}, stage: {}},
+        git: {commit: {author: {}, committer: {}, message: 'test'}},
+      }
+      jest.spyOn(ciHelpers, 'getCIMetadata').mockImplementation(() => metadata)
+
+      utils.setCiTriggerApp('unit_test')
       await utils.runTests(api, [{public_id: fakeId, executionRule: ExecutionRule.NON_BLOCKING}])
-      expect(payloadMetadataSpy).toHaveBeenCalledWith({...metadata, trigger_source: 'unit_test'})
+      expect(payloadMetadataSpy).toHaveBeenCalledWith({...metadata, trigger_app: 'unit_test'})
     })
 
     test('should run test with publicId from url', async () => {

--- a/src/commands/synthetics/__tests__/utils.test.ts
+++ b/src/commands/synthetics/__tests__/utils.test.ts
@@ -6,6 +6,8 @@ import * as fs from 'fs'
 import {AxiosError, AxiosRequestConfig, AxiosResponse, default as axios} from 'axios'
 import glob from 'glob'
 
+import * as ciHelpers from '../../../helpers/ci'
+import {Metadata} from '../../../helpers/interfaces'
 import {ProxyConfiguration} from '../../../helpers/utils'
 
 import {apiConstructor} from '../api'
@@ -67,6 +69,30 @@ describe('utils', () => {
 
       const output = await utils.runTests(api, [{public_id: fakeId, executionRule: ExecutionRule.NON_BLOCKING}])
       expect(output).toEqual(fakeTrigger)
+    })
+
+    test('runTests sends batch metadata', async () => {
+      const metadata: Metadata = {
+        ci: {job: {name: 'job'}, pipeline: {}, provider: {name: 'jest'}, stage: {}},
+        git: {commit: {author: {}, committer: {}, message: 'test'}},
+      }
+      jest.spyOn(ciHelpers, 'getCIMetadata').mockImplementation(() => metadata)
+
+      const payloadMetadataSpy = jest.fn()
+      const axiosMock = jest.spyOn(axios, 'create')
+      axiosMock.mockImplementation((() => (e: any) => {
+        payloadMetadataSpy(e.data.metadata)
+        if (e.url === '/synthetics/tests/trigger/ci') {
+          return {data: fakeTrigger}
+        }
+      }) as any)
+
+      await utils.runTests(api, [{public_id: fakeId, executionRule: ExecutionRule.NON_BLOCKING}])
+      expect(payloadMetadataSpy).toHaveBeenCalledWith({...metadata, trigger_source: 'npm_package'})
+
+      utils.setCiTriggerSource('unit_test')
+      await utils.runTests(api, [{public_id: fakeId, executionRule: ExecutionRule.NON_BLOCKING}])
+      expect(payloadMetadataSpy).toHaveBeenCalledWith({...metadata, trigger_source: 'unit_test'})
     })
 
     test('should run test with publicId from url', async () => {

--- a/src/commands/synthetics/interfaces.ts
+++ b/src/commands/synthetics/interfaces.ts
@@ -272,7 +272,7 @@ export interface Payload {
 }
 
 export type SyntheticsMetadata = Metadata & {
-  trigger_source: string
+  trigger_app: string
 }
 
 export interface TestPayload extends ConfigOverride {

--- a/src/commands/synthetics/interfaces.ts
+++ b/src/commands/synthetics/interfaces.ts
@@ -267,8 +267,12 @@ export interface ConfigOverride {
 }
 
 export interface Payload {
-  metadata?: Metadata
+  metadata?: SyntheticsMetadata
   tests: TestPayload[]
+}
+
+export type SyntheticsMetadata = Metadata & {
+  trigger_source: string
 }
 
 export interface TestPayload extends ConfigOverride {

--- a/src/commands/synthetics/utils.ts
+++ b/src/commands/synthetics/utils.ts
@@ -41,6 +41,8 @@ const TEMPLATE_REGEX = /{{\s*([^{}]*?)\s*}}/g
 const template = (st: string, context: any): string =>
   st.replace(TEMPLATE_REGEX, (match: string, p1: string) => (p1 in context ? context[p1] : match))
 
+let ciTriggerSource = 'npm_package'
+
 export const handleConfig = (
   test: InternalTest,
   publicId: string,
@@ -83,6 +85,10 @@ export const handleConfig = (
   }
 
   return handledConfig
+}
+
+export const setCiTriggerSource = (source: string): void => {
+  ciTriggerSource = source
 }
 
 const parseUrlVariables = (url: string, reporter: MainReporter) => {
@@ -499,7 +505,7 @@ export const runTests = async (api: APIHelper, testsToTrigger: TestPayload[]): P
   const payload: Payload = {tests: testsToTrigger}
   const ciMetadata = getCIMetadata()
   if (ciMetadata) {
-    payload.metadata = ciMetadata
+    payload.metadata = {...ciMetadata, trigger_source: ciTriggerSource}
   }
 
   try {


### PR DESCRIPTION
### What and why?

Provide new `trigger_app` metadata to Synthetics test batches.

### How?

- Add a new `trigger_app` to Synthetics tests batch Metadata only, defaulting to `npm_package`
- Expose `setCiTriggerApp()` to allow integrations to provide custom values
- Update `PULL_REQUEST_TEMPLATE.md` with reminder check for Github Action releases (↓)
### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] \[_Synthetics_\] New releases of `datadog-ci` MUST be followed by a [synthetics-ci-github-action](https://github.com/DataDog/synthetics-ci-github-action) release
