### PR TITLE
[ci-visibility] Change git Committer/Author Dates format to ISO 8601

### DIFF
--- a/src/helpers/git.ts
+++ b/src/helpers/git.ts
@@ -28,7 +28,7 @@ export const getGitMetadata = async (): Promise<SpanTags> => {
       git.branch(),
       git.listRemote(['--get-url']),
       git.show(['-s', '--format=%s']),
-      git.show(['-s', '--format=%an,%ae,%ad,%cn,%ce,%cd']),
+      git.show(['-s', '--format=%an,%ae,%aI,%cn,%ce,%cI']),
     ])
 
     const [


### PR DESCRIPTION
### What and why?

* Stick with the correct format.

### How?

* Change `git` Committer/Author Dates format to ISO 8601

We simply use `%aI` and `%cI` to get strict ISO 8601 format: 
https://git-scm.com/docs/pretty-formats#Documentation/pretty-formats.txt-emaIem
