### PR TITLE
v0.18.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci",
-  "version": "0.17.13",
+  "version": "0.18.0",
   "description": "Run datadog actions from the CI.",
   "repository": "https://github.com/DataDog/datadog-ci",
   "license": "Apache-2.0",


### PR DESCRIPTION
### What and why?

This PR bumps the package to version v0.18.0, releasing:
- https://github.com/DataDog/datadog-ci/pull/474
- https://github.com/DataDog/datadog-ci/pull/457
- https://github.com/DataDog/datadog-ci/pull/483
- https://github.com/DataDog/datadog-ci/pull/478
- https://github.com/DataDog/datadog-ci/pull/477
