### PR TITLE
Standalone binary for `datadog-ci`: Remove from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,12 +29,6 @@ npm install -g @datadog/datadog-ci
 yarn global add @datadog/datadog-ci
 ```
 
-If installing nodejs in the CI is an issue, standalone binaries are provided with [releases](https://github.com/DataDog/datadog-ci/releases). There is also a one line install script for the latest version:
-
-```sh
-curl https://raw.githubusercontent.com/DataDog/datadog-ci/master/quick-install.sh | bash
-```
-
 ## Usage
 
 ```bash


### PR DESCRIPTION
### What and why?

We still need to release and test this internally before promoting it to customers.

### How?

Remove note about standalone binary from README.

