### PR TITLE
[dep] Move `@types/datadog-metrics` to project dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "watch": "tsc -w"
   },
   "dependencies": {
+    "@types/datadog-metrics": "0.6.1",
     "async-retry": "1.3.1",
     "aws-sdk": "2.1012.0",
     "axios": "0.21.2",
@@ -68,7 +69,6 @@
     "@babel/preset-env": "7.4.5",
     "@babel/preset-typescript": "7.3.3",
     "@types/async-retry": "1.4.2",
-    "@types/datadog-metrics": "0.6.1",
     "@types/deep-extend": "0.4.31",
     "@types/glob": "7.1.1",
     "@types/inquirer": "8.1.3",


### PR DESCRIPTION
### What and why?

Since https://github.com/DataDog/datadog-ci/pull/476, `@types/datadog-metrics`' `BufferedMetricsLogger` is now indirectly exported by `datadog-ci` ts definitions.

<details>
<summary>Import chain</summary>

https://github.com/DataDog/datadog-ci/blob/bb286e649a8784e5381b0cdba1ff987ad0391115/src/helpers/apikey.ts#L3 https://github.com/DataDog/datadog-ci/blob/bb286e649a8784e5381b0cdba1ff987ad0391115/src/helpers/apikey.ts#L14-L20 https://github.com/DataDog/datadog-ci/blob/1c00c9ea0cb0838fd540ad3e6531ea004f23876d/src/commands/git-metadata/library.ts#L19-L20 https://github.com/DataDog/datadog-ci/blob/0e735fe57eb7a010f1ed3ec9c83bc5d7a9bff5f5/src/index.ts#L1

-----

</details>

However since `@types/datadog-metrics` is not defined in the project `dependencies`, any build of a Typescript project importing `datadog-ci` will fail:
```
node_modules/@datadog/datadog-ci/dist/helpers/apikey.d.ts:2:39 - error TS7016: Could not find a declaration file for module 'datadog-metrics'. '.../node_modules/datadog-metrics/index.js' implicitly has an 'any' type.
  Try `npm i --save-dev @types/datadog-metrics` if it exists or add a new declaration (.d.ts) file containing `declare module 'datadog-metrics';`

2 import { BufferedMetricsLogger } from 'datadog-metrics';
```

### How?

Make `BufferedMetricsLogger` type available in `datadog-ci` imports by moving `@types/datadog-metrics` from `devDependencies` to `dependencies`.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] \[_Synthetics_\] New releases of `datadog-ci` MUST be followed by a [synthetics-ci-github-action](https://github.com/DataDog/synthetics-ci-github-action) release
