### PR TITLE
[lambda instrument] Always ask for region in interactive mode

### DIFF
--- a/src/commands/lambda/__tests__/functions/instrument.test.ts
+++ b/src/commands/lambda/__tests__/functions/instrument.test.ts
@@ -816,7 +816,7 @@ describe('instrument', () => {
     test('fails when retry count is exceeded', async () => {
       const makeMockLambdaListFunctionsError = () => ({
         listFunctions: jest.fn().mockImplementation((args) => ({
-          promise: () => Promise.reject(),
+          promise: () => Promise.reject('ListFunctionsError'),
         })),
       })
       const lambda = makeMockLambdaListFunctionsError()
@@ -831,7 +831,7 @@ describe('instrument', () => {
 
       await expect(
         getInstrumentedFunctionConfigsFromRegEx(lambda as any, cloudWatch as any, 'us-east-1', 'fake-pattern', settings)
-      ).rejects.toStrictEqual(new Error('Max retry count exceeded.'))
+      ).rejects.toStrictEqual(new Error('Max retry count exceeded. ListFunctionsError'))
     })
   })
 })

--- a/src/commands/lambda/__tests__/functions/uninstrument.test.ts
+++ b/src/commands/lambda/__tests__/functions/uninstrument.test.ts
@@ -451,7 +451,7 @@ describe('uninstrument', () => {
     test('fails when retry count is exceeded', async () => {
       const makeMockLambdaListFunctionsError = () => ({
         listFunctions: jest.fn().mockImplementation((args) => ({
-          promise: () => Promise.reject("ListFunctionsError"),
+          promise: () => Promise.reject('ListFunctionsError'),
         })),
       })
       const lambda = makeMockLambdaListFunctionsError()

--- a/src/commands/lambda/__tests__/functions/uninstrument.test.ts
+++ b/src/commands/lambda/__tests__/functions/uninstrument.test.ts
@@ -451,7 +451,7 @@ describe('uninstrument', () => {
     test('fails when retry count is exceeded', async () => {
       const makeMockLambdaListFunctionsError = () => ({
         listFunctions: jest.fn().mockImplementation((args) => ({
-          promise: () => Promise.reject(),
+          promise: () => Promise.reject("ListFunctionsError"),
         })),
       })
       const lambda = makeMockLambdaListFunctionsError()
@@ -459,7 +459,7 @@ describe('uninstrument', () => {
 
       await expect(
         getUninstrumentedFunctionConfigsFromRegEx(lambda as any, cloudWatch as any, 'fake-pattern', undefined)
-      ).rejects.toStrictEqual(new Error('Max retry count exceeded.'))
+      ).rejects.toStrictEqual(new Error('Max retry count exceeded. ListFunctionsError'))
     })
   })
 })

--- a/src/commands/lambda/__tests__/instrument.test.ts
+++ b/src/commands/lambda/__tests__/instrument.test.ts
@@ -949,7 +949,9 @@ TagResource -> arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world
         const output = context.stdout.toString()
         expect(code).toBe(0)
         expect(output).toMatchInlineSnapshot(`
-"${bold(yellow('[!]'))} No AWS credentials found, let's set them up! Or you can re-run the command and supply the AWS credentials in the same way when you invoke the AWS CLI.
+"${bold(
+          yellow('[!]')
+        )} No AWS credentials found, let's set them up! Or you can re-run the command and supply the AWS credentials in the same way when you invoke the AWS CLI.
 ${bold(yellow('[!]'))} Configure AWS region.
 ${bold(yellow('[!]'))} Configure Datadog settings.
 Fetching Lambda functions, this might take a while.
@@ -1095,7 +1097,9 @@ ${yellow('[!]')} Instrumenting functions.
         const output = context.stdout.toString()
         expect(code).toBe(0)
         expect(output).toMatchInlineSnapshot(`
-"${bold(yellow('[!]'))} No AWS credentials found, let's set them up! Or you can re-run the command and supply the AWS credentials in the same way when you invoke the AWS CLI.
+"${bold(
+          yellow('[!]')
+        )} No AWS credentials found, let's set them up! Or you can re-run the command and supply the AWS credentials in the same way when you invoke the AWS CLI.
 ${bold(yellow('[!]'))} Configure AWS region.
 ${bold(yellow('[!]'))} Configure Datadog settings.
 ${bold(
@@ -1183,7 +1187,9 @@ ${yellow('[!]')} Instrumenting functions.
         const output = context.stdout.toString()
         expect(code).toBe(1)
         expect(output).toMatchInlineSnapshot(`
-"${bold(yellow('[!]'))} No AWS credentials found, let's set them up! Or you can re-run the command and supply the AWS credentials in the same way when you invoke the AWS CLI.
+"${bold(
+          yellow('[!]')
+        )} No AWS credentials found, let's set them up! Or you can re-run the command and supply the AWS credentials in the same way when you invoke the AWS CLI.
 ${red('[Error]')} Unexpected error
 "
 `)

--- a/src/commands/lambda/__tests__/instrument.test.ts
+++ b/src/commands/lambda/__tests__/instrument.test.ts
@@ -949,7 +949,8 @@ TagResource -> arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world
         const output = context.stdout.toString()
         expect(code).toBe(0)
         expect(output).toMatchInlineSnapshot(`
-"${bold(yellow('[!]'))} No existing AWS credentials found, let's set them up!
+"${bold(yellow('[!]'))} No AWS credentials found, let's set them up! Or you can re-run the command and supply the AWS credentials in the same way when you invoke the AWS CLI.
+${bold(yellow('[!]'))} Configure AWS region.
 ${bold(yellow('[!]'))} Configure Datadog settings.
 Fetching Lambda functions, this might take a while.
 ${bold(
@@ -1094,7 +1095,8 @@ ${yellow('[!]')} Instrumenting functions.
         const output = context.stdout.toString()
         expect(code).toBe(0)
         expect(output).toMatchInlineSnapshot(`
-"${bold(yellow('[!]'))} No existing AWS credentials found, let's set them up!
+"${bold(yellow('[!]'))} No AWS credentials found, let's set them up! Or you can re-run the command and supply the AWS credentials in the same way when you invoke the AWS CLI.
+${bold(yellow('[!]'))} Configure AWS region.
 ${bold(yellow('[!]'))} Configure Datadog settings.
 ${bold(
   yellow('[Warning]')
@@ -1181,7 +1183,7 @@ ${yellow('[!]')} Instrumenting functions.
         const output = context.stdout.toString()
         expect(code).toBe(1)
         expect(output).toMatchInlineSnapshot(`
-"${bold(yellow('[!]'))} No existing AWS credentials found, let's set them up!
+"${bold(yellow('[!]'))} No AWS credentials found, let's set them up! Or you can re-run the command and supply the AWS credentials in the same way when you invoke the AWS CLI.
 ${red('[Error]')} Unexpected error
 "
 `)
@@ -1201,7 +1203,8 @@ ${red('[Error]')} Unexpected error
         const output = context.stdout.toString()
         expect(code).toBe(1)
         expect(output).toMatchInlineSnapshot(`
-"${bold(yellow('[!]'))} Configure Datadog settings.
+"${bold(yellow('[!]'))} Configure AWS region.
+${bold(yellow('[!]'))} Configure Datadog settings.
 ${red('[Error]')} Unexpected error
 "
 `)
@@ -1223,7 +1226,8 @@ ${red('[Error]')} Unexpected error
         const output = context.stdout.toString()
         expect(code).toBe(1)
         expect(output).toMatchInlineSnapshot(`
-"Fetching Lambda functions, this might take a while.
+"${bold(yellow('[!]'))} Configure AWS region.
+Fetching Lambda functions, this might take a while.
 ${red('[Error]')} Couldn't find any Lambda functions in the specified region.
 "
 `)
@@ -1239,7 +1243,7 @@ ${red('[Error]')} Couldn't find any Lambda functions in the specified region.
         }
         ;(fs.readFile as any).mockImplementation((a: any, b: any, callback: any) => callback({code: 'ENOENT'}))
         ;(Lambda as any).mockImplementation(() => ({
-          listFunctions: jest.fn().mockImplementation(() => ({promise: () => Promise.reject('Lambda failed')})),
+          listFunctions: jest.fn().mockImplementation(() => ({promise: () => Promise.reject('ListFunctionsError')})),
         }))
 
         const cli = makeCli()
@@ -1248,8 +1252,9 @@ ${red('[Error]')} Couldn't find any Lambda functions in the specified region.
         const output = context.stdout.toString()
         expect(code).toBe(1)
         expect(output).toMatchInlineSnapshot(`
-"Fetching Lambda functions, this might take a while.
-${red('[Error]')} Couldn't fetch Lambda functions. Error: Max retry count exceeded.
+"${bold(yellow('[!]'))} Configure AWS region.
+Fetching Lambda functions, this might take a while.
+${red('[Error]')} Couldn't fetch Lambda functions. Error: Max retry count exceeded. ListFunctionsError
 "
 `)
       })

--- a/src/commands/lambda/__tests__/prompt.test.ts
+++ b/src/commands/lambda/__tests__/prompt.test.ts
@@ -98,7 +98,6 @@ describe('prompt', () => {
         Promise.resolve({
           [AWS_ACCESS_KEY_ID_ENV_VAR]: mockAwsAccessKeyId,
           [AWS_SECRET_ACCESS_KEY_ENV_VAR]: mockAwsSecretAccessKey,
-          [AWS_DEFAULT_REGION_ENV_VAR]: 'sa-east-1',
         })
       )
 
@@ -106,7 +105,6 @@ describe('prompt', () => {
 
       expect(process.env[AWS_ACCESS_KEY_ID_ENV_VAR]).toBe(mockAwsAccessKeyId)
       expect(process.env[AWS_SECRET_ACCESS_KEY_ENV_VAR]).toBe(mockAwsSecretAccessKey)
-      expect(process.env[AWS_DEFAULT_REGION_ENV_VAR]).toBe('sa-east-1')
     })
 
     test('sets the AWS credentials with session token as environment variables', async () => {
@@ -114,7 +112,6 @@ describe('prompt', () => {
         Promise.resolve({
           [AWS_ACCESS_KEY_ID_ENV_VAR]: mockAwsAccessKeyId,
           [AWS_SECRET_ACCESS_KEY_ENV_VAR]: mockAwsSecretAccessKey,
-          [AWS_DEFAULT_REGION_ENV_VAR]: 'sa-east-1',
           [AWS_SESSION_TOKEN_ENV_VAR]: 'some-session-token',
         })
       )
@@ -123,7 +120,6 @@ describe('prompt', () => {
 
       expect(process.env[AWS_ACCESS_KEY_ID_ENV_VAR]).toBe(mockAwsAccessKeyId)
       expect(process.env[AWS_SECRET_ACCESS_KEY_ENV_VAR]).toBe(mockAwsSecretAccessKey)
-      expect(process.env[AWS_DEFAULT_REGION_ENV_VAR]).toBe('sa-east-1')
       expect(process.env[AWS_SESSION_TOKEN_ENV_VAR]).toBe('some-session-token')
     })
 

--- a/src/commands/lambda/__tests__/prompt.test.ts
+++ b/src/commands/lambda/__tests__/prompt.test.ts
@@ -3,7 +3,6 @@ import {blueBright} from 'chalk'
 import {prompt} from 'inquirer'
 import {
   AWS_ACCESS_KEY_ID_ENV_VAR,
-  AWS_DEFAULT_REGION_ENV_VAR,
   AWS_SECRET_ACCESS_KEY_ENV_VAR,
   AWS_SESSION_TOKEN_ENV_VAR,
   CI_API_KEY_ENV_VAR,

--- a/src/commands/lambda/__tests__/uninstrument.test.ts
+++ b/src/commands/lambda/__tests__/uninstrument.test.ts
@@ -254,8 +254,14 @@ UpdateFunctionConfiguration -> arn:aws:lambda:us-east-1:000000000000:function:un
 
     test('aborts if the the aws-sdk fails', async () => {
       ;(fs.readFile as any).mockImplementation((a: any, b: any, callback: any) => callback({}))
-      ;(Lambda as any).mockImplementation(() => ({promise: Promise.reject()}))
+      ;(Lambda as any).mockImplementation(() => ({
+        listFunctions: jest.fn().mockImplementation(() => ({promise: () => Promise.reject('ListFunctionsError')})),
+      }))
       process.env = {}
+
+      ;(Lambda as any).mockImplementation(() => ({
+        listFunctions: jest.fn().mockImplementation(() => ({promise: () => Promise.reject('ListFunctionsError')})),
+      }))
       const command = createCommand(UninstrumentCommand)
       command['region'] = 'ap-southeast-1'
       command['regExPattern'] = 'my-function'
@@ -265,7 +271,7 @@ UpdateFunctionConfiguration -> arn:aws:lambda:us-east-1:000000000000:function:un
       expect(output).toMatch(
         `Fetching Lambda functions, this might take a while.\n${red(
           '[Error]'
-        )} Couldn't fetch Lambda functions. Error: Max retry count exceeded.\n`
+        )} Couldn't fetch Lambda functions. Error: Max retry count exceeded. ListFunctionsError\n`
       )
     })
 
@@ -361,7 +367,7 @@ UpdateFunctionConfiguration -> arn:aws:lambda:us-east-1:000000000000:function:un
       const output = context.stdout.toString()
       expect(code).toBe(0)
       expect(output).toMatchInlineSnapshot(`
-"${bold(yellow('[!]'))} No existing AWS credentials found, let's set them up!
+"${bold(yellow('[!]'))} No AWS credentials found, let's set them up! Or you can re-run the command and supply the AWS credentials in the same way when you invoke the AWS CLI.
 Fetching Lambda functions, this might take a while.\n
 ${bold(yellow('[!]'))} Functions to be updated:
 \t- ${bold('arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world')}
@@ -496,7 +502,7 @@ ${yellow('[!]')} Uninstrumenting functions.
       const output = context.stdout.toString()
       expect(code).toBe(0)
       expect(output).toMatchInlineSnapshot(`
-"${bold(yellow('[!]'))} No existing AWS credentials found, let's set them up!\n
+"${bold(yellow('[!]'))} No AWS credentials found, let's set them up! Or you can re-run the command and supply the AWS credentials in the same way when you invoke the AWS CLI.\n
 ${bold(yellow('[!]'))} Functions to be updated:
 \t- ${bold('arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world')}
 \t- ${bold('arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world-2')}\n
@@ -536,7 +542,7 @@ ${yellow('[!]')} Uninstrumenting functions.
       const output = context.stdout.toString()
       expect(code).toBe(1)
       expect(output).toMatchInlineSnapshot(`
-"${bold(yellow('[!]'))} No existing AWS credentials found, let's set them up!
+"${bold(yellow('[!]'))} No AWS credentials found, let's set them up! Or you can re-run the command and supply the AWS credentials in the same way when you invoke the AWS CLI.
 ${red('[Error]')} Unexpected error
 "
 `)
@@ -570,7 +576,7 @@ ${red('[Error]')} Couldn't find any Lambda functions in the specified region.
       }
       ;(fs.readFile as any).mockImplementation((a: any, b: any, callback: any) => callback({code: 'ENOENT'}))
       ;(Lambda as any).mockImplementation(() => ({
-        listFunctions: jest.fn().mockImplementation(() => ({promise: () => Promise.reject('Lambda failed')})),
+        listFunctions: jest.fn().mockImplementation(() => ({promise: () => Promise.reject('ListFunctionsError')})),
       }))
 
       const cli = makeCli()
@@ -580,7 +586,7 @@ ${red('[Error]')} Couldn't find any Lambda functions in the specified region.
       expect(code).toBe(1)
       expect(output).toMatchInlineSnapshot(`
 "Fetching Lambda functions, this might take a while.
-${red('[Error]')} Couldn't fetch Lambda functions. Error: Max retry count exceeded.
+${red('[Error]')} Couldn't fetch Lambda functions. Error: Max retry count exceeded. ListFunctionsError
 "
 `)
     })

--- a/src/commands/lambda/__tests__/uninstrument.test.ts
+++ b/src/commands/lambda/__tests__/uninstrument.test.ts
@@ -258,7 +258,6 @@ UpdateFunctionConfiguration -> arn:aws:lambda:us-east-1:000000000000:function:un
         listFunctions: jest.fn().mockImplementation(() => ({promise: () => Promise.reject('ListFunctionsError')})),
       }))
       process.env = {}
-
       ;(Lambda as any).mockImplementation(() => ({
         listFunctions: jest.fn().mockImplementation(() => ({promise: () => Promise.reject('ListFunctionsError')})),
       }))
@@ -367,7 +366,9 @@ UpdateFunctionConfiguration -> arn:aws:lambda:us-east-1:000000000000:function:un
       const output = context.stdout.toString()
       expect(code).toBe(0)
       expect(output).toMatchInlineSnapshot(`
-"${bold(yellow('[!]'))} No AWS credentials found, let's set them up! Or you can re-run the command and supply the AWS credentials in the same way when you invoke the AWS CLI.
+"${bold(
+        yellow('[!]')
+      )} No AWS credentials found, let's set them up! Or you can re-run the command and supply the AWS credentials in the same way when you invoke the AWS CLI.
 Fetching Lambda functions, this might take a while.\n
 ${bold(yellow('[!]'))} Functions to be updated:
 \t- ${bold('arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world')}
@@ -502,7 +503,9 @@ ${yellow('[!]')} Uninstrumenting functions.
       const output = context.stdout.toString()
       expect(code).toBe(0)
       expect(output).toMatchInlineSnapshot(`
-"${bold(yellow('[!]'))} No AWS credentials found, let's set them up! Or you can re-run the command and supply the AWS credentials in the same way when you invoke the AWS CLI.\n
+"${bold(
+        yellow('[!]')
+      )} No AWS credentials found, let's set them up! Or you can re-run the command and supply the AWS credentials in the same way when you invoke the AWS CLI.\n
 ${bold(yellow('[!]'))} Functions to be updated:
 \t- ${bold('arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world')}
 \t- ${bold('arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world-2')}\n
@@ -542,7 +545,9 @@ ${yellow('[!]')} Uninstrumenting functions.
       const output = context.stdout.toString()
       expect(code).toBe(1)
       expect(output).toMatchInlineSnapshot(`
-"${bold(yellow('[!]'))} No AWS credentials found, let's set them up! Or you can re-run the command and supply the AWS credentials in the same way when you invoke the AWS CLI.
+"${bold(
+        yellow('[!]')
+      )} No AWS credentials found, let's set them up! Or you can re-run the command and supply the AWS credentials in the same way when you invoke the AWS CLI.
 ${red('[Error]')} Unexpected error
 "
 `)

--- a/src/commands/lambda/constants.ts
+++ b/src/commands/lambda/constants.ts
@@ -53,32 +53,6 @@ export const SITES: string[] = [
   'ddog-gov.com',
 ]
 
-export const AWS_REGIONS: string[] = [
-  'us-east-1',
-  'us-east-2',
-  'us-west-1',
-  'us-west-2',
-  'af-south-1',
-  'ap-east-1',
-  'ap-south-1',
-  'ap-northeast-3',
-  'ap-northeast-2',
-  'ap-southeast-1',
-  'ap-southeast-2',
-  'ap-northeast-1',
-  'ca-central-1',
-  'eu-central-1',
-  'eu-west-1',
-  'eu-west-2',
-  'eu-south-1',
-  'eu-west-3',
-  'eu-north-1',
-  'me-south-1',
-  'sa-east-1',
-  'us-gov-east-1',
-  'us-gov-west-1',
-]
-
 export const DEFAULT_LAYER_AWS_ACCOUNT = '464622532012'
 export const GOVCLOUD_LAYER_AWS_ACCOUNT = '002406178527'
 export const SUBSCRIPTION_FILTER_NAME = 'datadog-ci-filter'

--- a/src/commands/lambda/functions/commons.ts
+++ b/src/commands/lambda/functions/commons.ts
@@ -231,7 +231,7 @@ export const getLambdaFunctionConfigsFromRegex = async (
     } catch (e) {
       retryCount++
       if (retryCount > LIST_FUNCTIONS_MAX_RETRY_COUNT) {
-        throw Error('Max retry count exceeded.')
+        throw Error(`Max retry count exceeded. ${e}`)
       }
     }
   }

--- a/src/commands/lambda/instrument.ts
+++ b/src/commands/lambda/instrument.ts
@@ -20,6 +20,7 @@ import {getInstrumentedFunctionConfigs, getInstrumentedFunctionConfigsFromRegEx}
 import {FunctionConfiguration, InstrumentationSettings, LambdaConfigOptions} from './interfaces'
 import {
   requestAWSCredentials,
+  requestAWSRegion,
   requestChangesConfirmation,
   requestDatadogEnvVars,
   requestFunctionSelection,
@@ -60,9 +61,14 @@ export class InstrumentCommand extends Command {
     if (this.interactive) {
       try {
         if (isMissingAWSCredentials()) {
-          this.context.stdout.write(`${bold(yellow('[!]'))} No existing AWS credentials found, let's set them up!\n`)
+          this.context.stdout.write(`${bold(yellow('[!]'))} No AWS credentials found, let's set them up! Or you can re-run the command and supply the AWS credentials in the same way when you invoke the AWS CLI.\n`)
           await requestAWSCredentials()
         }
+
+        // Always ask for region since the user may not want to use the default 
+        this.context.stdout.write(`${bold(yellow('[!]'))} Configure AWS region.\n`)
+        await requestAWSRegion(process.env[AWS_DEFAULT_REGION_ENV_VAR])
+
         if (isMissingDatadogEnvVars()) {
           this.context.stdout.write(`${bold(yellow('[!]'))} Configure Datadog settings.\n`)
           await requestDatadogEnvVars()
@@ -75,6 +81,7 @@ export class InstrumentCommand extends Command {
 
       const region = this.region ?? this.config.region ?? process.env[AWS_DEFAULT_REGION_ENV_VAR]
       this.region = region
+
       // If user doesn't specify functions, allow them
       // to select from all of the functions from the
       // requested region.

--- a/src/commands/lambda/instrument.ts
+++ b/src/commands/lambda/instrument.ts
@@ -61,11 +61,15 @@ export class InstrumentCommand extends Command {
     if (this.interactive) {
       try {
         if (isMissingAWSCredentials()) {
-          this.context.stdout.write(`${bold(yellow('[!]'))} No AWS credentials found, let's set them up! Or you can re-run the command and supply the AWS credentials in the same way when you invoke the AWS CLI.\n`)
+          this.context.stdout.write(
+            `${bold(
+              yellow('[!]')
+            )} No AWS credentials found, let's set them up! Or you can re-run the command and supply the AWS credentials in the same way when you invoke the AWS CLI.\n`
+          )
           await requestAWSCredentials()
         }
 
-        // Always ask for region since the user may not want to use the default 
+        // Always ask for region since the user may not want to use the default
         this.context.stdout.write(`${bold(yellow('[!]'))} Configure AWS region.\n`)
         await requestAWSRegion(process.env[AWS_DEFAULT_REGION_ENV_VAR])
 

--- a/src/commands/lambda/prompt.ts
+++ b/src/commands/lambda/prompt.ts
@@ -61,9 +61,9 @@ const awsCredentialsQuestions: QuestionCollection = [
   },
 ]
 
-const awsRegionQuestion = (defaultRegion?: string) : InputQuestion => ({
+const awsRegionQuestion = (defaultRegion?: string): InputQuestion => ({
   default: defaultRegion,
-  message: `Which AWS region (e.g., us-east-1) your Lambda functions are deployed?`,
+  message: 'Which AWS region (e.g., us-east-1) your Lambda functions are deployed?',
   name: AWS_DEFAULT_REGION_ENV_VAR,
   type: 'input',
 })

--- a/src/commands/lambda/prompt.ts
+++ b/src/commands/lambda/prompt.ts
@@ -12,7 +12,6 @@ import {
   AWS_ACCESS_KEY_ID_ENV_VAR,
   AWS_ACCESS_KEY_ID_REG_EXP,
   AWS_DEFAULT_REGION_ENV_VAR,
-  AWS_REGIONS,
   AWS_SECRET_ACCESS_KEY_ENV_VAR,
   AWS_SECRET_ACCESS_KEY_REG_EXP,
   AWS_SESSION_TOKEN_ENV_VAR,
@@ -60,15 +59,14 @@ const awsCredentialsQuestions: QuestionCollection = [
     name: AWS_SESSION_TOKEN_ENV_VAR,
     type: 'password',
   },
-  {
-    // AWS_DEFAULT_REGION
-    choices: AWS_REGIONS,
-    default: 0,
-    message: 'Select an AWS region:',
-    name: AWS_DEFAULT_REGION_ENV_VAR,
-    type: 'list',
-  },
 ]
+
+const awsRegionQuestion = (defaultRegion?: string) : InputQuestion => ({
+  default: defaultRegion,
+  message: `Which AWS region (e.g., us-east-1) your Lambda functions are deployed?`,
+  name: AWS_DEFAULT_REGION_ENV_VAR,
+  type: 'input',
+})
 
 export const datadogApiKeyTypeQuestion = (datadogSite: string): ListQuestion => ({
   choices: [
@@ -152,13 +150,23 @@ export const requestAWSCredentials = async () => {
     const awsCredentialsAnswers = await prompt(awsCredentialsQuestions)
     process.env[AWS_ACCESS_KEY_ID_ENV_VAR] = awsCredentialsAnswers[AWS_ACCESS_KEY_ID_ENV_VAR]
     process.env[AWS_SECRET_ACCESS_KEY_ENV_VAR] = awsCredentialsAnswers[AWS_SECRET_ACCESS_KEY_ENV_VAR]
-    process.env[AWS_DEFAULT_REGION_ENV_VAR] = awsCredentialsAnswers[AWS_DEFAULT_REGION_ENV_VAR]
     if (awsCredentialsAnswers[AWS_SESSION_TOKEN_ENV_VAR] !== undefined) {
       process.env[AWS_SESSION_TOKEN_ENV_VAR] = awsCredentialsAnswers[AWS_SESSION_TOKEN_ENV_VAR]
     }
   } catch (e) {
     if (e instanceof Error) {
       throw Error(`Couldn't set AWS Credentials. ${e.message}`)
+    }
+  }
+}
+
+export const requestAWSRegion = async (defaultRegion?: string) => {
+  try {
+    const awsRegionAnswer = await prompt(awsRegionQuestion(defaultRegion))
+    process.env[AWS_DEFAULT_REGION_ENV_VAR] = awsRegionAnswer[AWS_DEFAULT_REGION_ENV_VAR]
+  } catch (e) {
+    if (e instanceof Error) {
+      throw Error(`Couldn't set AWS region. ${e.message}`)
     }
   }
 }

--- a/src/commands/lambda/uninstrument.ts
+++ b/src/commands/lambda/uninstrument.ts
@@ -35,7 +35,11 @@ export class UninstrumentCommand extends Command {
     if (this.interactive) {
       try {
         if (isMissingAWSCredentials()) {
-          this.context.stdout.write(`${bold(yellow('[!]'))} No AWS credentials found, let's set them up! Or you can re-run the command and supply the AWS credentials in the same way when you invoke the AWS CLI.\n`)
+          this.context.stdout.write(
+            `${bold(
+              yellow('[!]')
+            )} No AWS credentials found, let's set them up! Or you can re-run the command and supply the AWS credentials in the same way when you invoke the AWS CLI.\n`
+          )
           await requestAWSCredentials()
         }
       } catch (e) {

--- a/src/commands/lambda/uninstrument.ts
+++ b/src/commands/lambda/uninstrument.ts
@@ -35,7 +35,7 @@ export class UninstrumentCommand extends Command {
     if (this.interactive) {
       try {
         if (isMissingAWSCredentials()) {
-          this.context.stdout.write(`${bold(yellow('[!]'))} No existing AWS credentials found, let's set them up!\n`)
+          this.context.stdout.write(`${bold(yellow('[!]'))} No AWS credentials found, let's set them up! Or you can re-run the command and supply the AWS credentials in the same way when you invoke the AWS CLI.\n`)
           await requestAWSCredentials()
         }
       } catch (e) {


### PR DESCRIPTION
### What?

1. Log the actual error when max retries exceeded when pulling the list of Lambda functions
2. Decouple the interactive mode prompt for AWS region and credentials into separate asks. Because it's possible that one is configured while the other not.
3. In the interactive mode, always ask the user to specify (or confirm the default) aws region.

![Image 2022-03-08 at 4 18 07 PM](https://user-images.githubusercontent.com/2373434/157326725-6767d5ff-20dd-43b4-9708-52bfa13d2a1b.jpg)


### Why?

The original issue is that when running the `lambda instrument -i` in interactive mode, the default AWS region configured by the users may not always be correctly detected by the ci. Even when region not detected, the ci continues and throws a max retries error (now it logs the actual error msg). We can fix this by improving the logic to detect the default region, but I realized that a better fix is to **always** ask the user to specify the AWS region or confirm the default:
1. it guarantees that the region is configured (fixing the original error)
2. the user may wants to use a region other than the default one (now it's possible)

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] \[_Synthetics_\] New releases of `datadog-ci` MUST be followed by a [synthetics-ci-github-action](https://github.com/DataDog/synthetics-ci-github-action) release
