### PR TITLE
[synthetics] Export XMLJSON type from junit reporter

### DIFF
--- a/src/commands/synthetics/reporters/junit.ts
+++ b/src/commands/synthetics/reporters/junit.ts
@@ -73,7 +73,7 @@ interface XMLStep {
   warning?: {$: {type: string}; _: string}[]
 }
 
-interface XMLJSON {
+export interface XMLJSON {
   testsuites: {
     $: {name: string}
     testsuite: XMLRun[]


### PR DESCRIPTION
### What and why?

Export junit report TS type. Will be useful to import in web-ui for type safety of report handling


### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration) -> not applicable
- [ ] \[_Synthetics_\] New releases of `datadog-ci` MUST be followed by a [synthetics-ci-github-action](https://github.com/DataDog/synthetics-ci-github-action) release
