### PR TITLE
[Synthetics] Update `failOnCriticalErrors`, Improve command output

### DIFF
--- a/src/commands/synthetics/README.md
+++ b/src/commands/synthetics/README.md
@@ -17,7 +17,7 @@ export DATADOG_APP_KEY="<APPLICATION KEY>"
 yarn datadog-ci synthetics <command> --apiKey "<API KEY>" --appKey "<APPLICATION KEY>"
 ```
 
-It is possible to configure the tool to use Datadog EU by defining the `DATADOG_SITE` environment variable to `datadoghq.eu`. By defaut the requests are sent to Datadog US.
+It is possible to configure the tool to use Datadog EU by defining the `DATADOG_SITE` environment variable to `datadoghq.eu`. By default the requests are sent to Datadog US.
 
 If the org uses a custom sub-domain to access Datadog app, it needs to be set in the `DATADOG_SUBDOMAIN` environment variable or in the global configuration file under the `subdomain` key to properly display the test results URL. As an example, if the URL used to access Datadog is `myorg.datadoghq.com` then set the environment variable to `myorg`, ie:
 
@@ -37,7 +37,7 @@ By default it runs at the root of the working directory and finds `{,!(node_modu
 
 #### Configuration
 
-Configuration is done via a json file, by default the tool load `datadog-ci.json` which can be overriden through the `--config` argument.
+Configuration is done via a json file, by default the tool load `datadog-ci.json` which can be overridden through the `--config` argument.
 
 The configuration file structure is the following:
 
@@ -106,7 +106,7 @@ yarn datadog-ci synthetics run-tests -s 'tag:e2e-tests' --config global.config.j
 ```
 
 You can use `--files` (shorthand `-f`) to override the global file selector.
-It's particularely useful when you want to run multiple suites in parallel with a single global configuration file.
+It's particularly useful when you want to run multiple suites in parallel with a single global configuration file.
 
 ```bash
 yarn datadog-ci synthetics run-tests -f ./component-1/**/*.synthetics.json -f ./component-2/**/*.synthetics.json
@@ -139,6 +139,7 @@ Your test files must be named with a `.synthetics.json` suffix.
         "defaultStepTimeout": 15,
         "deviceIds": ["laptop_large"],
         "executionRule": "skipped",
+        "failOnCriticalErrors": true,
         "followRedirects": true,
         "headers": {"NEW_HEADER": "NEW VALUE"},
         "locations": ["aws:us-east-1"],
@@ -172,6 +173,7 @@ All options under the `config` key are optional and allow overriding the configu
   - `blocking`: the CLI returns an error if the test fails.
   - `non_blocking`: the CLI only prints a warning if the test fails.
   - `skipped`: the test is not executed at all.
+- `failOnCriticalErrors`: (boolean) exit with an error code 1 if tests were not triggered or results could not be fetched.
 - `followRedirects`: (boolean) indicates whether to follow or not HTTP redirections in API tests.
 - `headers`: (object) headers to replace in the test. This object should contain as keys the name of the header to replace and as values the new value of the header.
 - `locations`: (array) list of locations from which the test should be run.
@@ -261,3 +263,4 @@ Reporters can hook themselves into the `MainReporter` of the command.
 | `testEnd`     | `(test: Test, results: PollResult[], baseUrl: string, locationNames: LocationsMapping)` | called when a test receives its results.                        |
 | `testTrigger` | `(test: Test, testId: string, executionRule: ExecutionRule, config: ConfigOverride)`    | called when a test is triggered.                                |
 | `testWait`    | `(test: Test)`                                                                          | called when a test is waiting to receive its results.           |
+| `testsWait`   | `(tests: Test[])`                                                                       | called when all tests are waiting to receive their results.     |

--- a/src/commands/synthetics/__tests__/cli.test.ts
+++ b/src/commands/synthetics/__tests__/cli.test.ts
@@ -337,7 +337,7 @@ describe('run-test', () => {
             }),
           }
           jest.spyOn(runTests, 'getApiHelper').mockImplementation(() => apiHelper as any)
-          jest.spyOn(ciUtils, 'parseConfigFile').mockImplementation(async (config, _) => config)
+          jest.spyOn(ciUtils, 'parseConfigFile').mockImplementation(async (config, __) => config)
 
           expect(await command.execute()).toBe(expectedExit)
           expect(apiHelper.searchTests).toHaveBeenCalledTimes(1)
@@ -354,7 +354,7 @@ describe('run-test', () => {
             }),
           }
           jest.spyOn(runTests, 'getApiHelper').mockImplementation(() => apiHelper as any)
-          jest.spyOn(ciUtils, 'parseConfigFile').mockImplementation(async (config, _) => config)
+          jest.spyOn(ciUtils, 'parseConfigFile').mockImplementation(async (config, __) => config)
           jest.spyOn(utils, 'getSuites').mockImplementation((() => [getTestSuite()]) as any)
 
           expect(await command.execute()).toBe(expectedExit)
@@ -373,7 +373,7 @@ describe('run-test', () => {
             }),
           }
           jest.spyOn(runTests, 'getApiHelper').mockImplementation(() => apiHelper as any)
-          jest.spyOn(ciUtils, 'parseConfigFile').mockImplementation(async (config, _) => config)
+          jest.spyOn(ciUtils, 'parseConfigFile').mockImplementation(async (config, __) => config)
           jest.spyOn(utils, 'getSuites').mockImplementation((() => [getTestSuite()]) as any)
 
           expect(await command.execute()).toBe(expectedExit)
@@ -396,7 +396,7 @@ describe('run-test', () => {
             }),
           }
           jest.spyOn(runTests, 'getApiHelper').mockImplementation(() => apiHelper as any)
-          jest.spyOn(ciUtils, 'parseConfigFile').mockImplementation(async (config, _) => config)
+          jest.spyOn(ciUtils, 'parseConfigFile').mockImplementation(async (config, __) => config)
           jest.spyOn(utils, 'getSuites').mockImplementation((() => [getTestSuite()]) as any)
 
           expect(await command.execute()).toBe(expectedExit)

--- a/src/commands/synthetics/__tests__/cli.test.ts
+++ b/src/commands/synthetics/__tests__/cli.test.ts
@@ -321,9 +321,10 @@ describe('run-test', () => {
     })
 
     describe.each([false, true])('%s', (failOnCriticalErrors: boolean) => {
+      const cases: [string, number?][] = [['HTTP 4xx error', 403], ['HTTP 5xx error', 502], ['Unknown error']]
       const expectedExit = failOnCriticalErrors ? 1 : 0
 
-      describe.each([403, 502])('%i error', (errorCode) => {
+      describe.each(cases)('%s', (_, errorCode) => {
         test('unable to obtain test configurations', async () => {
           const command = new RunTestCommand()
           command.context = {stdout: {write: jest.fn()}} as any
@@ -332,7 +333,7 @@ describe('run-test', () => {
 
           const apiHelper = {
             searchTests: jest.fn(() => {
-              throw getAxiosHttpError(errorCode, 'Error')
+              throw errorCode ? getAxiosHttpError(errorCode, 'Error') : new Error('Unknown error')
             }),
           }
           jest.spyOn(runTests, 'getApiHelper').mockImplementation(() => apiHelper as any)
@@ -349,7 +350,7 @@ describe('run-test', () => {
 
           const apiHelper = {
             getTest: jest.fn(() => {
-              throw getAxiosHttpError(errorCode, 'Error')
+              throw errorCode ? getAxiosHttpError(errorCode, 'Error') : new Error('Unknown error')
             }),
           }
           jest.spyOn(runTests, 'getApiHelper').mockImplementation(() => apiHelper as any)
@@ -368,7 +369,7 @@ describe('run-test', () => {
           const apiHelper = {
             getTest: () => getApiTest('123-456-789'),
             triggerTests: jest.fn(() => {
-              throw getAxiosHttpError(errorCode, 'Error')
+              throw errorCode ? getAxiosHttpError(errorCode, 'Error') : new Error('Unknown error')
             }),
           }
           jest.spyOn(runTests, 'getApiHelper').mockImplementation(() => apiHelper as any)
@@ -387,7 +388,7 @@ describe('run-test', () => {
           const apiHelper = {
             getTest: () => getApiTest('123-456-789'),
             pollResults: jest.fn(() => {
-              throw getAxiosHttpError(errorCode, 'Error')
+              throw errorCode ? getAxiosHttpError(errorCode, 'Error') : new Error('Unknown error')
             }),
             triggerTests: () => ({
               ...mockTestTriggerResponse,

--- a/src/commands/synthetics/__tests__/cli.test.ts
+++ b/src/commands/synthetics/__tests__/cli.test.ts
@@ -6,7 +6,7 @@ import {DEFAULT_COMMAND_CONFIG, RunTestCommand} from '../command'
 import {ExecutionRule} from '../interfaces'
 import * as runTests from '../run-test'
 import * as utils from '../utils'
-import {getApiTest} from './fixtures'
+import {getApiTest, getTestSuite, mockTestTriggerResponse} from './fixtures'
 
 test('all option flags are supported', async () => {
   const options = [
@@ -31,6 +31,14 @@ test('all option flags are supported', async () => {
 
   options.forEach((option) => expect(usage).toContain(`--${option}`))
 })
+
+const getAxiosHttpError = (status: number, error: string) => {
+  const serverError = new Error(error) as AxiosError
+  serverError.response = {data: {errors: [error]}, status} as AxiosResponse
+  serverError.config = {baseURL: 'baseURL', url: 'url'}
+
+  return serverError
+}
 
 describe('run-test', () => {
   beforeEach(() => {
@@ -231,11 +239,8 @@ describe('run-test', () => {
       jest.spyOn(utils, 'getSuites').mockImplementation((() => [conf]) as any)
 
       // Throw to stop the test
-      const serverError = new Error('Server Error') as AxiosError
-      serverError.response = {data: {errors: ['Bad Gateway']}, status: 502} as AxiosResponse
-      serverError.config = {baseURL: 'baseURL', url: 'url'}
       const triggerTests = jest.fn(() => {
-        throw serverError
+        throw getAxiosHttpError(502, 'Bad Gateway')
       })
 
       const apiHelper = {
@@ -293,6 +298,110 @@ describe('run-test', () => {
           tests: [{executionRule: 'blocking', locations: ['aws:us-east-1'], public_id: 'publicId'}],
         })
       )
+    })
+  })
+
+  describe('exit code respects `failOnCriticalErrors`', () => {
+    test('404 test not found never exit with 1', async () => {
+      const command = new RunTestCommand()
+      command.context = {stdout: {write: jest.fn()}} as any
+      command['config'].failOnCriticalErrors = true
+
+      const apiHelper = {
+        getTest: jest.fn(() => {
+          throw getAxiosHttpError(404, 'Test not found')
+        }),
+      }
+      jest.spyOn(runTests, 'getApiHelper').mockImplementation(() => apiHelper as any)
+      jest.spyOn(ciUtils, 'parseConfigFile').mockImplementation(async (config, _) => config)
+      jest.spyOn(utils, 'getSuites').mockImplementation((() => [getTestSuite()]) as any)
+
+      expect(await command.execute()).toBe(0)
+      expect(apiHelper.getTest).toHaveBeenCalledTimes(1)
+    })
+
+    describe.each([false, true])('%s', (failOnCriticalErrors: boolean) => {
+      const expectedExit = failOnCriticalErrors ? 1 : 0
+
+      describe.each([403, 502])('%i error', (errorCode) => {
+        test('unable to obtain test configurations', async () => {
+          const command = new RunTestCommand()
+          command.context = {stdout: {write: jest.fn()}} as any
+          command['config'].failOnCriticalErrors = failOnCriticalErrors
+          command['testSearchQuery'] = 'test:search'
+
+          const apiHelper = {
+            searchTests: jest.fn(() => {
+              throw getAxiosHttpError(errorCode, 'Error')
+            }),
+          }
+          jest.spyOn(runTests, 'getApiHelper').mockImplementation(() => apiHelper as any)
+          jest.spyOn(ciUtils, 'parseConfigFile').mockImplementation(async (config, _) => config)
+
+          expect(await command.execute()).toBe(expectedExit)
+          expect(apiHelper.searchTests).toHaveBeenCalledTimes(1)
+        })
+
+        test('unavailable test config', async () => {
+          const command = new RunTestCommand()
+          command.context = {stdout: {write: jest.fn()}} as any
+          command['config'].failOnCriticalErrors = failOnCriticalErrors
+
+          const apiHelper = {
+            getTest: jest.fn(() => {
+              throw getAxiosHttpError(errorCode, 'Error')
+            }),
+          }
+          jest.spyOn(runTests, 'getApiHelper').mockImplementation(() => apiHelper as any)
+          jest.spyOn(ciUtils, 'parseConfigFile').mockImplementation(async (config, _) => config)
+          jest.spyOn(utils, 'getSuites').mockImplementation((() => [getTestSuite()]) as any)
+
+          expect(await command.execute()).toBe(expectedExit)
+          expect(apiHelper.getTest).toHaveBeenCalledTimes(1)
+        })
+
+        test('unable to trigger tests', async () => {
+          const command = new RunTestCommand()
+          command.context = {stdout: {write: jest.fn()}} as any
+          command['config'].failOnCriticalErrors = failOnCriticalErrors
+
+          const apiHelper = {
+            getTest: () => getApiTest('123-456-789'),
+            triggerTests: jest.fn(() => {
+              throw getAxiosHttpError(errorCode, 'Error')
+            }),
+          }
+          jest.spyOn(runTests, 'getApiHelper').mockImplementation(() => apiHelper as any)
+          jest.spyOn(ciUtils, 'parseConfigFile').mockImplementation(async (config, _) => config)
+          jest.spyOn(utils, 'getSuites').mockImplementation((() => [getTestSuite()]) as any)
+
+          expect(await command.execute()).toBe(expectedExit)
+          expect(apiHelper.triggerTests).toHaveBeenCalledTimes(1)
+        })
+
+        test('unable to poll test results', async () => {
+          const command = new RunTestCommand()
+          command.context = {stdout: {write: jest.fn()}} as any
+          command['config'].failOnCriticalErrors = failOnCriticalErrors
+
+          const apiHelper = {
+            getTest: () => getApiTest('123-456-789'),
+            pollResults: jest.fn(() => {
+              throw getAxiosHttpError(errorCode, 'Error')
+            }),
+            triggerTests: () => ({
+              ...mockTestTriggerResponse,
+              results: [{location: 1, public_id: '123-456-789', result_id: '1'}],
+            }),
+          }
+          jest.spyOn(runTests, 'getApiHelper').mockImplementation(() => apiHelper as any)
+          jest.spyOn(ciUtils, 'parseConfigFile').mockImplementation(async (config, _) => config)
+          jest.spyOn(utils, 'getSuites').mockImplementation((() => [getTestSuite()]) as any)
+
+          expect(await command.execute()).toBe(expectedExit)
+          expect(apiHelper.pollResults).toHaveBeenCalledTimes(1)
+        })
+      })
     })
   })
 })

--- a/src/commands/synthetics/__tests__/fixtures.ts
+++ b/src/commands/synthetics/__tests__/fixtures.ts
@@ -14,6 +14,7 @@ import {
   MultiStepsTestResult,
   PollResult,
   Step,
+  Suite,
   Test,
   TestResult,
   User,
@@ -122,6 +123,8 @@ export const getMultiStep = (): MultiStep => ({
     total: 123,
   },
 })
+
+export const getTestSuite = (): Suite => ({content: {tests: [{config: {}, id: '123-456-789'}]}, name: 'Suite 1'})
 
 const getPollResult = () => ({
   dc_id: 1,

--- a/src/commands/synthetics/__tests__/fixtures.ts
+++ b/src/commands/synthetics/__tests__/fixtures.ts
@@ -35,6 +35,7 @@ export const mockReporter: MainReporter = {
   testEnd: jest.fn(),
   testTrigger: jest.fn(),
   testWait: jest.fn(),
+  testsWait: jest.fn(),
 }
 
 export const ciConfig: CommandConfig = {

--- a/src/commands/synthetics/__tests__/reporters/default.test.ts
+++ b/src/commands/synthetics/__tests__/reporters/default.test.ts
@@ -23,7 +23,7 @@ describe('Default reporter', () => {
       ['runEnd', [createSummary()]],
       ['testEnd', [{options: {}}, [], '', []]],
       ['testTrigger', [{}, '', '', {}]],
-      ['testWait', [{}]],
+      ['testsWait', [[{}]]],
     ]
     for (const [fnName, args] of calls) {
       reporter[fnName](...args)

--- a/src/commands/synthetics/__tests__/reporters/default.test.ts
+++ b/src/commands/synthetics/__tests__/reporters/default.test.ts
@@ -15,6 +15,7 @@ describe('Default reporter', () => {
   }
   const reporter: any = new DefaultReporter(mockContext as {context: BaseContext})
   it('should log for each hook', () => {
+    // `testWait` is skipped as nothing is logged for the default reporter.
     const calls: [keyof MainReporter, any[]][] = [
       ['error', ['error']],
       ['initErrors', [['error']]],

--- a/src/commands/synthetics/__tests__/run-test.test.ts
+++ b/src/commands/synthetics/__tests__/run-test.test.ts
@@ -341,11 +341,15 @@ describe('run-test', () => {
     test('should throw an error if API or Application key are undefined', async () => {
       process.env = {}
 
-      expect(() => runTests.getApiHelper(ciConfig)).toThrow(new CiError('MISSING_APP_KEY'))
-      await expect(runTests.executeTests(mockReporter, ciConfig)).rejects.toMatchError(new CiError('MISSING_APP_KEY'))
-      expect(() => runTests.getApiHelper({...ciConfig, appKey: 'fakeappkey'})).toThrow(new CiError('MISSING_API_KEY'))
+      expect(() => runTests.getApiHelper(ciConfig)).toThrow(new CriticalError('MISSING_APP_KEY'))
+      await expect(runTests.executeTests(mockReporter, ciConfig)).rejects.toMatchError(
+        new CriticalError('MISSING_APP_KEY')
+      )
+      expect(() => runTests.getApiHelper({...ciConfig, appKey: 'fakeappkey'})).toThrow(
+        new CriticalError('MISSING_API_KEY')
+      )
       await expect(runTests.executeTests(mockReporter, {...ciConfig, appKey: 'fakeappkey'})).rejects.toMatchError(
-        new CiError('MISSING_API_KEY')
+        new CriticalError('MISSING_API_KEY')
       )
     })
   })

--- a/src/commands/synthetics/__tests__/utils.test.ts
+++ b/src/commands/synthetics/__tests__/utils.test.ts
@@ -11,12 +11,12 @@ import {Metadata} from '../../../helpers/interfaces'
 import {ProxyConfiguration} from '../../../helpers/utils'
 
 import {apiConstructor} from '../api'
+import {CiError} from '../errors'
 import {ConfigOverride, ERRORS, ExecutionRule, InternalTest, PollResult, Result, Summary} from '../interfaces'
 import {Tunnel} from '../tunnel'
 import * as utils from '../utils'
 
 import {getApiTest, getBrowserResult, mockReporter} from './fixtures'
-import {CiError} from '../errors'
 
 describe('utils', () => {
   const apiConfiguration = {

--- a/src/commands/synthetics/__tests__/utils.test.ts
+++ b/src/commands/synthetics/__tests__/utils.test.ts
@@ -16,6 +16,7 @@ import {Tunnel} from '../tunnel'
 import * as utils from '../utils'
 
 import {getApiTest, getBrowserResult, mockReporter} from './fixtures'
+import {CiError} from '../errors'
 
 describe('utils', () => {
   const apiConfiguration = {
@@ -204,7 +205,7 @@ describe('utils', () => {
     })
 
     test('no tests triggered throws an error', async () => {
-      await expect(utils.getTestsToTrigger(api, [], mockReporter)).rejects.toEqual(new Error('No tests to trigger'))
+      await expect(utils.getTestsToTrigger(api, [], mockReporter)).rejects.toEqual(new CiError('NO_TESTS_TO_RUN'))
     })
   })
 

--- a/src/commands/synthetics/__tests__/utils.test.ts
+++ b/src/commands/synthetics/__tests__/utils.test.ts
@@ -163,6 +163,10 @@ describe('utils', () => {
         if (fakeTests[publicId]) {
           return {data: fakeTests[publicId]}
         }
+
+        const error = new Error('Not found')
+        ;((error as unknown) as {status: number}).status = 404
+        throw error
       }) as any)
     })
 

--- a/src/commands/synthetics/api.ts
+++ b/src/commands/synthetics/api.ts
@@ -126,12 +126,6 @@ export const is5xxError = (error: AxiosError | EndpointError) => {
   return statusCode && statusCode >= 500 && statusCode <= 599
 }
 
-export const isHttpError = (error: AxiosError | EndpointError) => {
-  const statusCode = getErrorHttpStatus(error)
-
-  return statusCode && statusCode >= 400
-}
-
 const retryRequest = <T>(args: AxiosRequestConfig, request: (args: AxiosRequestConfig) => AxiosPromise<T>) =>
   retry(() => request(args), retryOn5xxErrors)
 

--- a/src/commands/synthetics/api.ts
+++ b/src/commands/synthetics/api.ts
@@ -115,10 +115,23 @@ const retryOn5xxErrors = (retries: number, error: AxiosError) => {
   }
 }
 
+const getErrorHttpStatus = (error: AxiosError | EndpointError) =>
+  'status' in error ? error.status : error.response?.status
+
+export const isForbiddenError = (error: AxiosError | EndpointError) => getErrorHttpStatus(error) === 403
+
+export const isNotFoundError = (error: AxiosError | EndpointError) => getErrorHttpStatus(error) === 404
+
 export const is5xxError = (error: AxiosError | EndpointError) => {
-  const statusCode = 'status' in error ? error.status : error.response?.status
+  const statusCode = getErrorHttpStatus(error)
 
   return statusCode && statusCode >= 500 && statusCode <= 599
+}
+
+export const isHttpError = (error: AxiosError | EndpointError) => {
+  const statusCode = getErrorHttpStatus(error)
+
+  return statusCode && statusCode >= 400
 }
 
 const retryRequest = <T>(args: AxiosRequestConfig, request: (args: AxiosRequestConfig) => AxiosPromise<T>) =>

--- a/src/commands/synthetics/api.ts
+++ b/src/commands/synthetics/api.ts
@@ -118,8 +118,6 @@ const retryOn5xxErrors = (retries: number, error: AxiosError) => {
 const getErrorHttpStatus = (error: AxiosError | EndpointError) =>
   'status' in error ? error.status : error.response?.status
 
-export const isForbiddenError = (error: AxiosError | EndpointError) => getErrorHttpStatus(error) === 403
-
 export const isNotFoundError = (error: AxiosError | EndpointError) => getErrorHttpStatus(error) === 404
 
 export const is5xxError = (error: AxiosError | EndpointError) => {

--- a/src/commands/synthetics/command.ts
+++ b/src/commands/synthetics/command.ts
@@ -82,8 +82,16 @@ export class RunTestCommand extends Command {
     } catch (error) {
       if (error instanceof CiError) {
         this.reportCiError(error, this.reporter)
-        if (error instanceof CriticalError && this.config.failOnCriticalErrors) {
-          return 1
+        if (error instanceof CriticalError) {
+          if (this.config.failOnCriticalErrors) {
+            return 1
+          } else {
+            this.reporter.error(
+              chalk.yellow(
+                'Because `failOnCriticalErrors` is not set, the command will exit with an error code 0. Use `failOnCriticalErrors: true` to exit with an error code 1.\n'
+              )
+            )
+          }
         }
       }
 

--- a/src/commands/synthetics/command.ts
+++ b/src/commands/synthetics/command.ts
@@ -82,6 +82,7 @@ export class RunTestCommand extends Command {
     } catch (error) {
       if (error instanceof CiError) {
         this.reportCiError(error, this.reporter)
+
         if (error instanceof CriticalError) {
           if (this.config.failOnCriticalErrors) {
             return 1
@@ -173,12 +174,15 @@ export class RunTestCommand extends Command {
 
   private reportCiError(error: CiError, reporter: MainReporter) {
     switch (error.code) {
+      // Non critical errors
       case 'NO_RESULTS_TO_POLL':
         reporter.log('No results to poll.\n')
         break
       case 'NO_TESTS_TO_RUN':
         reporter.log('No test to run.\n')
         break
+
+      // Critical command errors
       case 'MISSING_APP_KEY':
         reporter.error(`Missing ${chalk.red.bold('DATADOG_APP_KEY')} in your environment.\n`)
         break

--- a/src/commands/synthetics/command.ts
+++ b/src/commands/synthetics/command.ts
@@ -89,7 +89,8 @@ export class RunTestCommand extends Command {
           } else {
             this.reporter.error(
               chalk.yellow(
-                'Because `failOnCriticalErrors` is not set, the command will exit with an error code 0. Use `failOnCriticalErrors: true` to exit with an error code 1.\n'
+                'Because `failOnCriticalErrors` is not set or disabled, the command will exit with an error code 0. ' +
+                  'Use `failOnCriticalErrors: true` to exit with an error code 1.\n'
               )
             )
           }

--- a/src/commands/synthetics/command.ts
+++ b/src/commands/synthetics/command.ts
@@ -181,10 +181,10 @@ export class RunTestCommand extends Command {
         reporter.error(`\n${chalk.bgRed.bold(' ERROR: unable to poll test results ')}\n${error.message}\n\n`)
         break
       case 'TUNNEL_START_FAILED':
-        reporter.error(`\n${chalk.bgRed.bold(' ERROR: unable to start tunnel')}\n${error.message}\n\n`)
+        reporter.error(`\n${chalk.bgRed.bold(' ERROR: unable to start tunnel ')}\n${error.message}\n\n`)
         break
       case 'TRIGGER_TESTS_FAILED':
-        reporter.error(`\n${chalk.bgRed.bold(' ERROR: unable to trigger tests')}\n${error.message}\n\n`)
+        reporter.error(`\n${chalk.bgRed.bold(' ERROR: unable to trigger tests ')}\n${error.message}\n\n`)
         break
       case 'UNAVAILABLE_TEST_CONFIG':
         reporter.error(
@@ -194,7 +194,7 @@ export class RunTestCommand extends Command {
         )
         break
       case 'UNAVAILABLE_TUNNEL_CONFIG':
-        reporter.error(`\n${chalk.bgRed.bold(' ERROR: unable to get tunnel configuration')}\n${error.message}\n\n`)
+        reporter.error(`\n${chalk.bgRed.bold(' ERROR: unable to get tunnel configuration ')}\n${error.message}\n\n`)
     }
   }
 

--- a/src/commands/synthetics/errors.ts
+++ b/src/commands/synthetics/errors.ts
@@ -1,16 +1,19 @@
 /* tslint:disable:max-classes-per-file */
-const ciErrorCodes = [
+const nonCriticalErrorCodes = ['NO_TESTS_TO_RUN', 'NO_RESULTS_TO_POLL'] as const
+type NonCriticalCiErrorCode = typeof nonCriticalErrorCodes[number]
+
+const criticalErrorCodes = [
   'UNAVAILABLE_TEST_CONFIG',
   'MISSING_API_KEY',
   'MISSING_APP_KEY',
-  'NO_RESULTS_TO_POLL',
-  'NO_TESTS_TO_RUN',
   'UNAVAILABLE_TUNNEL_CONFIG',
   'TUNNEL_START_FAILED',
   'TRIGGER_TESTS_FAILED',
   'POLL_RESULTS_FAILED',
 ] as const
-type CiErrorCode = typeof ciErrorCodes[number]
+type CriticalCiErrorCode = typeof criticalErrorCodes[number]
+
+type CiErrorCode = NonCriticalCiErrorCode | CriticalCiErrorCode
 
 export class CiError extends Error {
   constructor(public code: CiErrorCode) {
@@ -18,4 +21,8 @@ export class CiError extends Error {
   }
 }
 
-export class CriticalError extends CiError {}
+export class CriticalError extends CiError {
+  constructor(public code: CriticalCiErrorCode) {
+    super(code)
+  }
+}

--- a/src/commands/synthetics/index.ts
+++ b/src/commands/synthetics/index.ts
@@ -1,4 +1,4 @@
-export {CiError} from './errors'
+export {CiError, CriticalError} from './errors'
 export * from './interfaces'
 export {DefaultReporter} from './reporters/default'
 export {executeTests} from './run-test'

--- a/src/commands/synthetics/interfaces.ts
+++ b/src/commands/synthetics/interfaces.ts
@@ -16,6 +16,7 @@ export interface MainReporter {
     failOnCriticalErrors: boolean,
     failOnTimeout: boolean
   ): void
+  testsWait(tests: Test[]): void
   testTrigger(test: Test, testId: string, executionRule: ExecutionRule, config: ConfigOverride): void
   testWait(test: Test): void
 }

--- a/src/commands/synthetics/reporters/default.ts
+++ b/src/commands/synthetics/reporters/default.ts
@@ -384,5 +384,7 @@ export class DefaultReporter implements MainReporter {
     this.write(`${idDisplay} ${getMessage()}\n`)
   }
 
-  public testWait(test: Test) {}
+  public testWait(test: Test) {
+    return
+  }
 }

--- a/src/commands/synthetics/reporters/default.ts
+++ b/src/commands/synthetics/reporters/default.ts
@@ -347,6 +347,19 @@ export class DefaultReporter implements MainReporter {
     this.write([`${icon} ${idDisplay}${nonBlockingText} | ${nameColor(test.name)}`, testResultsText].join('\n'))
   }
 
+  public testsWait(tests: Test[]) {
+    const count = tests.length
+
+    const testsList = tests.map((t) => t.public_id)
+    if (testsList.length > 10) {
+      testsList.splice(10)
+      testsList.push('…')
+    }
+    const testsDisplay = chalk.gray(`(${testsList.join(', ')})`)
+
+    this.write(`\nWaiting for ${chalk.bold.cyan(count)} test result${count > 1 ? 's' : ''} ${testsDisplay}…\n`)
+  }
+
   public testTrigger(test: Test, testId: string, executionRule: ExecutionRule, config: ConfigOverride) {
     const idDisplay = `[${chalk.bold.dim(testId)}]`
 
@@ -371,9 +384,5 @@ export class DefaultReporter implements MainReporter {
     this.write(`${idDisplay} ${getMessage()}\n`)
   }
 
-  public testWait(test: Test) {
-    const idDisplay = `[${chalk.bold.dim(test.public_id)}]`
-
-    this.write(`${idDisplay} Waiting results for "${chalk.green.bold(test.name)}"\n`)
-  }
+  public testWait(test: Test) {}
 }

--- a/src/commands/synthetics/reporters/default.ts
+++ b/src/commands/synthetics/reporters/default.ts
@@ -279,7 +279,7 @@ export class DefaultReporter implements MainReporter {
   }
 
   public initErrors(errors: string[]) {
-    this.write(errors.join('\n'))
+    this.write(errors.join('\n') + '\n')
   }
 
   public log(log: string) {
@@ -289,7 +289,7 @@ export class DefaultReporter implements MainReporter {
   public reportStart(timings: {startTime: number}) {
     const delay = (Date.now() - timings.startTime).toString()
 
-    this.write(['\n', chalk.bold.cyan('=== REPORT ==='), `Took ${chalk.bold(delay)}ms`, '\n'].join('\n'))
+    this.write(['', chalk.bold.cyan('=== REPORT ==='), `Took ${chalk.bold(delay)}ms`, '\n'].join('\n'))
   }
 
   public runEnd(summary: Summary) {
@@ -368,17 +368,17 @@ export class DefaultReporter implements MainReporter {
         // Test is either skipped from datadog-ci config or from test config
         const isSkippedByCIConfig = config.executionRule === ExecutionRule.SKIPPED
         if (isSkippedByCIConfig) {
-          return `>> Skipped test "${chalk.yellow.dim(test.name)}"`
+          return `Skipped test "${chalk.yellow.dim(test.name)}"`
         } else {
-          return `>> Skipped test "${chalk.yellow.dim(test.name)}" because of execution rule configuration in Datadog`
+          return `Skipped test "${chalk.yellow.dim(test.name)}" because of execution rule configuration in Datadog`
         }
       }
 
       if (executionRule === ExecutionRule.NON_BLOCKING) {
-        return `Trigger test "${chalk.green.bold(test.name)}" (non-blocking)`
+        return `Found test "${chalk.green.bold(test.name)}" (non-blocking)`
       }
 
-      return `Trigger test "${chalk.green.bold(test.name)}"`
+      return `Found test "${chalk.green.bold(test.name)}"`
     }
 
     this.write(`${idDisplay} ${getMessage()}\n`)

--- a/src/commands/synthetics/reporters/default.ts
+++ b/src/commands/synthetics/reporters/default.ts
@@ -348,8 +348,6 @@ export class DefaultReporter implements MainReporter {
   }
 
   public testsWait(tests: Test[]) {
-    const count = tests.length
-
     const testsList = tests.map((t) => t.public_id)
     if (testsList.length > 10) {
       testsList.splice(10)
@@ -357,7 +355,9 @@ export class DefaultReporter implements MainReporter {
     }
     const testsDisplay = chalk.gray(`(${testsList.join(', ')})`)
 
-    this.write(`\nWaiting for ${chalk.bold.cyan(count)} test result${count > 1 ? 's' : ''} ${testsDisplay}…\n`)
+    this.write(
+      `\nWaiting for ${chalk.bold.cyan(tests.length)} test result${tests.length > 1 ? 's' : ''} ${testsDisplay}…\n`
+    )
   }
 
   public testTrigger(test: Test, testId: string, executionRule: ExecutionRule, config: ConfigOverride) {

--- a/src/commands/synthetics/run-test.ts
+++ b/src/commands/synthetics/run-test.ts
@@ -1,4 +1,4 @@
-import {apiConstructor, isHttpError} from './api'
+import {apiConstructor} from './api'
 import {CiError, CriticalError} from './errors'
 import {
   APIHelper,

--- a/src/commands/synthetics/run-test.ts
+++ b/src/commands/synthetics/run-test.ts
@@ -1,4 +1,4 @@
-import {apiConstructor, is5xxError} from './api'
+import {apiConstructor, isHttpError} from './api'
 import {CiError, CriticalError} from './errors'
 import {
   APIHelper,
@@ -33,7 +33,7 @@ export const executeTests = async (reporter: MainReporter, config: SyntheticsCIC
     try {
       testsToTrigger = await getTestsList(api, config, reporter)
     } catch (error) {
-      const isCriticalError = is5xxError(error as any)
+      const isCriticalError = isHttpError(error as any)
       throw new (isCriticalError ? CriticalError : CiError)('UNAVAILABLE_TEST_CONFIG')
     }
   }
@@ -51,7 +51,7 @@ export const executeTests = async (reporter: MainReporter, config: SyntheticsCIC
   try {
     testsToTriggerResult = await getTestsToTrigger(api, testsToTrigger, reporter)
   } catch (error) {
-    const isCriticalError = is5xxError(error as any)
+    const isCriticalError = isHttpError(error as any)
     throw new (isCriticalError ? CriticalError : CiError)('UNAVAILABLE_TEST_CONFIG')
   }
 
@@ -70,7 +70,7 @@ export const executeTests = async (reporter: MainReporter, config: SyntheticsCIC
       // Get the pre-signed URL to connect to the tunnel service
       presignedURL = (await api.getPresignedURL(publicIdsToTrigger)).url
     } catch (error) {
-      const isCriticalError = is5xxError(error as any)
+      const isCriticalError = isHttpError(error as any)
       throw new (isCriticalError ? CriticalError : CiError)('UNAVAILABLE_TUNNEL_CONFIG')
     }
     // Open a tunnel to Datadog
@@ -81,7 +81,7 @@ export const executeTests = async (reporter: MainReporter, config: SyntheticsCIC
         testToTrigger.tunnel = tunnelInfo
       })
     } catch (error) {
-      const isCriticalError = is5xxError(error as any)
+      const isCriticalError = isHttpError(error as any)
       await stopTunnel()
       throw new (isCriticalError ? CriticalError : CiError)('TUNNEL_START_FAILED')
     }
@@ -91,7 +91,7 @@ export const executeTests = async (reporter: MainReporter, config: SyntheticsCIC
   try {
     triggers = await runTests(api, overriddenTestsToTrigger)
   } catch (error) {
-    const isCriticalError = is5xxError(error as any)
+    const isCriticalError = isHttpError(error as any)
     await stopTunnel()
     throw new (isCriticalError ? CriticalError : CiError)('TRIGGER_TESTS_FAILED')
   }
@@ -114,7 +114,7 @@ export const executeTests = async (reporter: MainReporter, config: SyntheticsCIC
     )
     Object.assign(results, resultPolled)
   } catch (error) {
-    const isCriticalError = is5xxError(error as any)
+    const isCriticalError = isHttpError(error as any)
     throw new (isCriticalError ? CriticalError : CiError)('POLL_RESULTS_FAILED')
   } finally {
     await stopTunnel()

--- a/src/commands/synthetics/utils.ts
+++ b/src/commands/synthetics/utils.ts
@@ -513,7 +513,9 @@ export const getTestsToTrigger = async (api: APIHelper, triggerConfigs: TriggerC
   }
 
   const waitedTests = tests.filter(definedTypeGuard)
-  reporter.testsWait(waitedTests)
+  if (waitedTests.length > 0) {
+    reporter.testsWait(waitedTests)
+  }
 
   return {tests: waitedTests, overriddenTestsToTrigger, summary}
 }

--- a/src/commands/synthetics/utils.ts
+++ b/src/commands/synthetics/utils.ts
@@ -9,7 +9,7 @@ import glob from 'glob'
 import {getCIMetadata} from '../../helpers/ci'
 import {pick} from '../../helpers/utils'
 
-import {EndpointError, formatBackendErrors, is5xxError, isForbiddenError, isNotFoundError} from './api'
+import {EndpointError, formatBackendErrors, is5xxError, isNotFoundError} from './api'
 import {
   APIHelper,
   ConfigOverride,
@@ -480,7 +480,7 @@ export const getTestsToTrigger = async (api: APIHelper, triggerConfigs: TriggerC
           suite,
         }
       } catch (error) {
-        if (error instanceof Error && isNotFoundError(error)) {
+        if (isNotFoundError(error)) {
           summary.testsNotFound.add(id)
           const errorMessage = formatBackendErrors(error)
           errorMessages.push(`[${chalk.bold.dim(id)}] ${chalk.yellow.bold('Test not found')}: ${errorMessage}`)

--- a/src/commands/synthetics/utils.ts
+++ b/src/commands/synthetics/utils.ts
@@ -10,6 +10,7 @@ import {getCIMetadata} from '../../helpers/ci'
 import {pick} from '../../helpers/utils'
 
 import {EndpointError, formatBackendErrors, is5xxError, isNotFoundError} from './api'
+import {CiError} from './errors'
 import {
   APIHelper,
   ConfigOverride,
@@ -33,7 +34,6 @@ import {
   TriggerResult,
 } from './interfaces'
 import {Tunnel} from './tunnel'
-import {CiError} from './errors'
 
 const POLLING_INTERVAL = 5000 // In ms
 const PUBLIC_ID_REGEX = /^[\d\w]{3}-[\d\w]{3}-[\d\w]{3}$/

--- a/src/commands/synthetics/utils.ts
+++ b/src/commands/synthetics/utils.ts
@@ -33,6 +33,7 @@ import {
   TriggerResult,
 } from './interfaces'
 import {Tunnel} from './tunnel'
+import {CiError} from './errors'
 
 const POLLING_INTERVAL = 5000 // In ms
 const PUBLIC_ID_REGEX = /^[\d\w]{3}-[\d\w]{3}-[\d\w]{3}$/
@@ -509,7 +510,7 @@ export const getTestsToTrigger = async (api: APIHelper, triggerConfigs: TriggerC
   reporter.initErrors(errorMessages)
 
   if (!overriddenTestsToTrigger.length) {
-    throw new Error('No tests to trigger')
+    throw new CiError('NO_TESTS_TO_RUN')
   }
 
   const waitedTests = tests.filter(definedTypeGuard)


### PR DESCRIPTION
### What and why?

Improve Synthetics command output to make suite of action clearer, update `failOnCriticalErrors` to also fail on any client errors (config/connection errors, and HTTP response errors except "Test not found" which never result in a critical error).


### How?

- Change `CriticalError` scope.
  `CriticalError` are errors triggering a non-0 command exit when `failOnCriticalErrors` is set, they were scoped to `5xx` server responses only and now include all unexpected errors during tests fetch / trigger / result polling / tunnel setup (with the exception of `404` on tests not found, that will never fail the command).
- Add a message when `failOnCriticalErrors` is `false` and a critical error occured to exit command with 1, add option to the readme.
- Replace test fetched messages to make it clearer that the test has not been triggered yet.
- Display message when tests have been triggered with the number of tests waited for, this is done through a new exposed `testsWait` hook.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] \[_Synthetics_\] New releases of `datadog-ci` MUST be followed by a [synthetics-ci-github-action](https://github.com/DataDog/synthetics-ci-github-action) release
