### PR TITLE
Fix Release Script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,8 +79,8 @@ jobs:
           node-version: '14.18.3'
       - run: yarn install --immutable
       - run: yarn build
-      - name: Bundle standalone binary
-        run: yarn dist-standalone -t node14-linux-x64 -o datadog-ci-linux
+      - name: Create standalone binary
+        run: yarn dist-standalone -t node14-linux-x64 -o datadog-ci_linux-x64
       - name: Remove dist and src folder to check that binary can stand alone
         run: |
           rm -rf dist
@@ -99,8 +99,8 @@ jobs:
           node-version: '14.18.3'
       - run: yarn install --immutable
       - run: yarn build:win
-      - name: Bundle standalone binary
-        run: yarn dist-standalone -t node14-win-x64 -o datadog-ci-win
+      - name: Create standalone binary
+        run: yarn dist-standalone -t node14-win-x64 -o datadog-ci_win-x64
       - name: Remove dist and src folder to check that binary can stand alone
         run: |
           rm dist -r
@@ -119,8 +119,8 @@ jobs:
           node-version: '14.18.3'
       - run: yarn install --immutable
       - run: yarn build
-      - name: Bundle standalone binary
-        run: yarn dist-standalone -t node14-macos-x64 -o datadog-ci-macos
+      - name: Create standalone binary
+        run: yarn dist-standalone -t node14-macos-x64 -o datadog-ci_darwin-x64
       - name: Remove dist and src folder to check that binary can stand alone
         run: |
           rm -rf dist

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,7 +65,7 @@ jobs:
         uses: shogo82148/actions-upload-release-asset@v1
         with:
           upload_url: ${{ github.event.release.upload_url }}
-          asset_path: ./datadog-ci_win-x64
+          asset_path: ./datadog-ci_win-x64.exe
 
   build-binary-macos:
     runs-on: macos-latest

--- a/standalone-e2e/standalone-binary.test.ts
+++ b/standalone-e2e/standalone-binary.test.ts
@@ -7,9 +7,9 @@ const execPromise = promisify(exec)
 
 const isWin = process.platform === 'win32'
 
-const os = isWin ? 'win' : process.platform === 'darwin' ? 'macos' : 'linux'
+const os = isWin ? 'win' : process.platform === 'darwin' ? 'darwin' : 'linux'
 
-const STANDALONE_BINARY = `datadog-ci-${os}`
+const STANDALONE_BINARY = `datadog-ci_${os}-x64`
 
 const STANDALONE_BINARY_PATH = `${isWin ? '.\\' : './'}${STANDALONE_BINARY}${isWin ? '.exe' : ''}`
 


### PR DESCRIPTION
### What and why?

Jobs in https://github.com/DataDog/datadog-ci/actions/runs/1997744883 are failing because the path of the executable for the standalone binary tests is wrong. I fix it with this PR.

### How?

Change `STANDALONE_BINARY` so that it is actually the correct name. 

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] \[_Synthetics_\] New releases of `datadog-ci` MUST be followed by a [synthetics-ci-github-action](https://github.com/DataDog/synthetics-ci-github-action) release
