### PR TITLE
[Synthetics] Pass `trigger_app` as request header

### DIFF
--- a/src/commands/synthetics/__tests__/utils.test.ts
+++ b/src/commands/synthetics/__tests__/utils.test.ts
@@ -77,14 +77,14 @@ describe('utils', () => {
 
       const payloadMetadataSpy = jest.fn()
       jest.spyOn(axios, 'create').mockImplementation((() => (request: any) => {
-        payloadMetadataSpy(request.data)
+        payloadMetadataSpy(request.data.metadata)
         if (request.url === '/synthetics/tests/trigger/ci') {
           return {data: fakeTrigger}
         }
       }) as any)
 
       await utils.runTests(api, [{public_id: fakeId, executionRule: ExecutionRule.NON_BLOCKING}])
-      expect(payloadMetadataSpy).not.toHaveBeenCalledWith(expect.objectContaining({metadata: expect.anything()}))
+      expect(payloadMetadataSpy).toHaveBeenCalledWith(undefined)
 
       const metadata: Metadata = {
         ci: {job: {name: 'job'}, pipeline: {}, provider: {name: 'jest'}, stage: {}},
@@ -93,7 +93,7 @@ describe('utils', () => {
       jest.spyOn(ciHelpers, 'getCIMetadata').mockImplementation(() => metadata)
 
       await utils.runTests(api, [{public_id: fakeId, executionRule: ExecutionRule.NON_BLOCKING}])
-      expect(payloadMetadataSpy).toHaveBeenCalledWith(expect.objectContaining({metadata}))
+      expect(payloadMetadataSpy).toHaveBeenCalledWith(metadata)
     })
 
     test('runTests api call includes trigger app header', async () => {

--- a/src/commands/synthetics/__tests__/utils.test.ts
+++ b/src/commands/synthetics/__tests__/utils.test.ts
@@ -76,20 +76,15 @@ describe('utils', () => {
       jest.spyOn(ciHelpers, 'getCIMetadata').mockImplementation(() => undefined)
 
       const payloadMetadataSpy = jest.fn()
-      const axiosMock = jest.spyOn(axios, 'create')
-      axiosMock.mockImplementation((() => (e: any) => {
-        payloadMetadataSpy(e.data.metadata)
-        if (e.url === '/synthetics/tests/trigger/ci') {
+      jest.spyOn(axios, 'create').mockImplementation((() => (request: any) => {
+        payloadMetadataSpy(request.data)
+        if (request.url === '/synthetics/tests/trigger/ci') {
           return {data: fakeTrigger}
         }
       }) as any)
 
       await utils.runTests(api, [{public_id: fakeId, executionRule: ExecutionRule.NON_BLOCKING}])
-      expect(payloadMetadataSpy).toHaveBeenCalledWith({
-        ci: {job: {}, pipeline: {}, provider: {}, stage: {}},
-        git: {commit: {author: {}, committer: {}}},
-        trigger_app: 'npm_package',
-      })
+      expect(payloadMetadataSpy).not.toHaveBeenCalledWith(expect.objectContaining({metadata: expect.anything()}))
 
       const metadata: Metadata = {
         ci: {job: {name: 'job'}, pipeline: {}, provider: {name: 'jest'}, stage: {}},
@@ -97,9 +92,27 @@ describe('utils', () => {
       }
       jest.spyOn(ciHelpers, 'getCIMetadata').mockImplementation(() => metadata)
 
+      await utils.runTests(api, [{public_id: fakeId, executionRule: ExecutionRule.NON_BLOCKING}])
+      expect(payloadMetadataSpy).toHaveBeenCalledWith(expect.objectContaining({metadata}))
+    })
+
+    test('runTests api call includes trigger app header', async () => {
+      jest.spyOn(ciHelpers, 'getCIMetadata').mockImplementation(() => undefined)
+
+      const headersMetadataSpy = jest.fn()
+      jest.spyOn(axios, 'create').mockImplementation((() => (request: any) => {
+        headersMetadataSpy(request.headers)
+        if (request.url === '/synthetics/tests/trigger/ci') {
+          return {data: fakeTrigger}
+        }
+      }) as any)
+
+      await utils.runTests(api, [{public_id: fakeId, executionRule: ExecutionRule.NON_BLOCKING}])
+      expect(headersMetadataSpy).toHaveBeenCalledWith(expect.objectContaining({'X-Trigger-App': 'npm_package'}))
+
       utils.setCiTriggerApp('unit_test')
       await utils.runTests(api, [{public_id: fakeId, executionRule: ExecutionRule.NON_BLOCKING}])
-      expect(payloadMetadataSpy).toHaveBeenCalledWith({...metadata, trigger_app: 'unit_test'})
+      expect(headersMetadataSpy).toHaveBeenCalledWith(expect.objectContaining({'X-Trigger-App': 'unit_test'}))
     })
 
     test('should run test with publicId from url', async () => {

--- a/src/commands/synthetics/api.ts
+++ b/src/commands/synthetics/api.ts
@@ -4,8 +4,8 @@ import {AxiosError, AxiosPromise, AxiosRequestConfig} from 'axios'
 
 import {getRequestBuilder} from '../../helpers/utils'
 
-import {APIConfiguration, Payload, PollResult, Test, TestSearchResult, Trigger} from './interfaces'
-import {retry} from './utils'
+import {APIConfiguration, APIHelper, Payload, PollResult, Test, TestSearchResult, Trigger} from './interfaces'
+import {ciTriggerApp, retry} from './utils'
 
 interface BackendError {
   errors: string[]
@@ -40,6 +40,7 @@ const triggerTests = (request: (args: AxiosRequestConfig) => AxiosPromise<Trigge
   const resp = await retryRequest(
     {
       data,
+      headers: {'X-Trigger-App': ciTriggerApp},
       method: 'POST',
       url: '/synthetics/tests/trigger/ci',
     },
@@ -129,7 +130,7 @@ export const is5xxError = (error: AxiosError | EndpointError) => {
 const retryRequest = <T>(args: AxiosRequestConfig, request: (args: AxiosRequestConfig) => AxiosPromise<T>) =>
   retry(() => request(args), retryOn5xxErrors)
 
-export const apiConstructor = (configuration: APIConfiguration) => {
+export const apiConstructor = (configuration: APIConfiguration): APIHelper => {
   const {baseUrl, baseIntakeUrl, apiKey, appKey, proxyOpts} = configuration
   const baseOptions = {apiKey, appKey, proxyOpts}
   const request = getRequestBuilder({...baseOptions, baseUrl})

--- a/src/commands/synthetics/interfaces.ts
+++ b/src/commands/synthetics/interfaces.ts
@@ -269,12 +269,8 @@ export interface ConfigOverride {
 }
 
 export interface Payload {
-  metadata?: SyntheticsMetadata
+  metadata?: Metadata
   tests: TestPayload[]
-}
-
-export type SyntheticsMetadata = Metadata & {
-  trigger_app: string
 }
 
 export interface TestPayload extends ConfigOverride {

--- a/src/commands/synthetics/reporters/default.ts
+++ b/src/commands/synthetics/reporters/default.ts
@@ -279,7 +279,7 @@ export class DefaultReporter implements MainReporter {
   }
 
   public initErrors(errors: string[]) {
-    this.write(errors.join('\n') + '\n')
+    this.write(errors.join('\n') + '\n\n')
   }
 
   public log(log: string) {
@@ -356,7 +356,7 @@ export class DefaultReporter implements MainReporter {
     const testsDisplay = chalk.gray(`(${testsList.join(', ')})`)
 
     this.write(
-      `\nWaiting for ${chalk.bold.cyan(tests.length)} test result${tests.length > 1 ? 's' : ''} ${testsDisplay}…\n`
+      `Waiting for ${chalk.bold.cyan(tests.length)} test result${tests.length > 1 ? 's' : ''} ${testsDisplay}…\n`
     )
   }
 

--- a/src/commands/synthetics/utils.ts
+++ b/src/commands/synthetics/utils.ts
@@ -24,7 +24,6 @@ import {
   Result,
   Suite,
   Summary,
-  SyntheticsMetadata,
   TemplateContext,
   TemplateVariables,
   TestPayload,
@@ -43,7 +42,7 @@ const TEMPLATE_REGEX = /{{\s*([^{}]*?)\s*}}/g
 const template = (st: string, context: any): string =>
   st.replace(TEMPLATE_REGEX, (match: string, p1: string) => (p1 in context ? context[p1] : match))
 
-let ciTriggerApp = 'npm_package'
+export let ciTriggerApp = 'npm_package'
 
 export const handleConfig = (
   test: InternalTest,
@@ -525,13 +524,9 @@ export const runTests = async (api: APIHelper, testsToTrigger: TestPayload[]): P
   const payload: Payload = {tests: testsToTrigger}
   const ciMetadata = getCIMetadata()
 
-  const syntheticsMetadata: SyntheticsMetadata = {
-    ci: {job: {}, pipeline: {}, provider: {}, stage: {}},
-    git: {commit: {author: {}, committer: {}}},
-    ...ciMetadata,
-    trigger_app: ciTriggerApp,
+  if (ciMetadata) {
+    payload.metadata = ciMetadata
   }
-  payload.metadata = syntheticsMetadata
 
   try {
     return await api.triggerTests(payload)


### PR DESCRIPTION
### What and why?

Move trigger app from metadata to request headers.

Also fixes the extra line break before `Waiting for results` if no tests are skipped.

### How?

Deprecate passing `trigger_app` through a batch `metadata` property in favor of passing it as a request `X-Trigger-App` header (trigger endpoint only).

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] \[_Synthetics_\] New releases of `datadog-ci` MUST be followed by a [synthetics-ci-github-action](https://github.com/DataDog/synthetics-ci-github-action) release
