### PR TITLE
[Synthetics] Detect authentication errors on fetch/trigger test endpoints

### DIFF
--- a/src/commands/synthetics/__tests__/run-test.test.ts
+++ b/src/commands/synthetics/__tests__/run-test.test.ts
@@ -168,10 +168,10 @@ describe('run-test', () => {
     })
 
     const cases: [number, CriticalCiErrorCode][] = [
-      [403, 'AUTHENTICATION_ERROR'],
+      [403, 'AUTHORIZATION_ERROR'],
       [502, 'UNAVAILABLE_TEST_CONFIG'],
     ]
-    describe.each(cases)('%s trigger %s', (status, error) => {
+    describe.each(cases)('%s triggers %s', (status, error) => {
       test(`getTestsList throws - ${status}`, async () => {
         const serverError = new Error('Server Error') as AxiosError
         serverError.response = {data: {errors: ['Error']}, status} as AxiosResponse

--- a/src/commands/synthetics/api.ts
+++ b/src/commands/synthetics/api.ts
@@ -118,7 +118,7 @@ const retryOn5xxErrors = (retries: number, error: AxiosError) => {
 const getErrorHttpStatus = (error: AxiosError | EndpointError) =>
   'status' in error ? error.status : error.response?.status
 
-export const isRefusedError = (error: AxiosError | EndpointError) => getErrorHttpStatus(error) === 403
+export const isForbiddenError = (error: AxiosError | EndpointError) => getErrorHttpStatus(error) === 403
 
 export const isNotFoundError = (error: AxiosError | EndpointError) => getErrorHttpStatus(error) === 404
 

--- a/src/commands/synthetics/api.ts
+++ b/src/commands/synthetics/api.ts
@@ -118,6 +118,8 @@ const retryOn5xxErrors = (retries: number, error: AxiosError) => {
 const getErrorHttpStatus = (error: AxiosError | EndpointError) =>
   'status' in error ? error.status : error.response?.status
 
+export const isRefusedError = (error: AxiosError | EndpointError) => getErrorHttpStatus(error) === 403
+
 export const isNotFoundError = (error: AxiosError | EndpointError) => getErrorHttpStatus(error) === 404
 
 export const is5xxError = (error: AxiosError | EndpointError) => {

--- a/src/commands/synthetics/command.ts
+++ b/src/commands/synthetics/command.ts
@@ -184,6 +184,10 @@ export class RunTestCommand extends Command {
         break
 
       // Critical command errors
+      case 'AUTHENTICATION_ERROR':
+        reporter.error(`\n${chalk.bgRed.bold(' ERROR: authentication error ')}\n${error.message}\n\n`)
+        reporter.log('Invalid credentials, make sure `apiKey`, `appKey` and `datadogSite` are correct.\n')
+        break
       case 'MISSING_APP_KEY':
         reporter.error(`Missing ${chalk.red.bold('DATADOG_APP_KEY')} in your environment.\n`)
         break

--- a/src/commands/synthetics/command.ts
+++ b/src/commands/synthetics/command.ts
@@ -184,9 +184,9 @@ export class RunTestCommand extends Command {
         break
 
       // Critical command errors
-      case 'AUTHENTICATION_ERROR':
-        reporter.error(`\n${chalk.bgRed.bold(' ERROR: authentication error ')}\n${error.message}\n\n`)
-        reporter.log('Invalid credentials, make sure `apiKey`, `appKey` and `datadogSite` are correct.\n')
+      case 'AUTHORIZATION_ERROR':
+        reporter.error(`\n${chalk.bgRed.bold(' ERROR: authorization error ')}\n${error.message}\n\n`)
+        reporter.log('Credentials refused, make sure `apiKey`, `appKey` and `datadogSite` are correct.\n')
         break
       case 'MISSING_APP_KEY':
         reporter.error(`Missing ${chalk.red.bold('DATADOG_APP_KEY')} in your environment.\n`)

--- a/src/commands/synthetics/errors.ts
+++ b/src/commands/synthetics/errors.ts
@@ -3,7 +3,7 @@ const nonCriticalErrorCodes = ['NO_TESTS_TO_RUN', 'NO_RESULTS_TO_POLL'] as const
 export type NonCriticalCiErrorCode = typeof nonCriticalErrorCodes[number]
 
 const criticalErrorCodes = [
-  'AUTHENTICATION_ERROR',
+  'AUTHORIZATION_ERROR',
   'MISSING_API_KEY',
   'MISSING_APP_KEY',
   'POLL_RESULTS_FAILED',

--- a/src/commands/synthetics/errors.ts
+++ b/src/commands/synthetics/errors.ts
@@ -3,13 +3,14 @@ const nonCriticalErrorCodes = ['NO_TESTS_TO_RUN', 'NO_RESULTS_TO_POLL'] as const
 type NonCriticalCiErrorCode = typeof nonCriticalErrorCodes[number]
 
 const criticalErrorCodes = [
-  'UNAVAILABLE_TEST_CONFIG',
+  'AUTHENTICATION_ERROR',
   'MISSING_API_KEY',
   'MISSING_APP_KEY',
-  'UNAVAILABLE_TUNNEL_CONFIG',
-  'TUNNEL_START_FAILED',
-  'TRIGGER_TESTS_FAILED',
   'POLL_RESULTS_FAILED',
+  'TRIGGER_TESTS_FAILED',
+  'TUNNEL_START_FAILED',
+  'UNAVAILABLE_TEST_CONFIG',
+  'UNAVAILABLE_TUNNEL_CONFIG',
 ] as const
 type CriticalCiErrorCode = typeof criticalErrorCodes[number]
 

--- a/src/commands/synthetics/errors.ts
+++ b/src/commands/synthetics/errors.ts
@@ -1,6 +1,6 @@
 /* tslint:disable:max-classes-per-file */
 const nonCriticalErrorCodes = ['NO_TESTS_TO_RUN', 'NO_RESULTS_TO_POLL'] as const
-type NonCriticalCiErrorCode = typeof nonCriticalErrorCodes[number]
+export type NonCriticalCiErrorCode = typeof nonCriticalErrorCodes[number]
 
 const criticalErrorCodes = [
   'AUTHENTICATION_ERROR',
@@ -12,9 +12,9 @@ const criticalErrorCodes = [
   'UNAVAILABLE_TEST_CONFIG',
   'UNAVAILABLE_TUNNEL_CONFIG',
 ] as const
-type CriticalCiErrorCode = typeof criticalErrorCodes[number]
+export type CriticalCiErrorCode = typeof criticalErrorCodes[number]
 
-type CiErrorCode = NonCriticalCiErrorCode | CriticalCiErrorCode
+export type CiErrorCode = NonCriticalCiErrorCode | CriticalCiErrorCode
 
 export class CiError extends Error {
   constructor(public code: CiErrorCode) {

--- a/src/commands/synthetics/run-test.ts
+++ b/src/commands/synthetics/run-test.ts
@@ -1,4 +1,4 @@
-import {apiConstructor, isRefusedError} from './api'
+import {apiConstructor, isForbiddenError} from './api'
 import {CiError, CriticalError} from './errors'
 import {
   APIHelper,
@@ -33,7 +33,7 @@ export const executeTests = async (reporter: MainReporter, config: SyntheticsCIC
     try {
       testsToTrigger = await getTestsList(api, config, reporter)
     } catch (error) {
-      throw new CriticalError(isRefusedError(error) ? 'AUTHENTICATION_ERROR' : 'UNAVAILABLE_TEST_CONFIG')
+      throw new CriticalError(isForbiddenError(error) ? 'AUTHORIZATION_ERROR' : 'UNAVAILABLE_TEST_CONFIG')
     }
   }
 
@@ -54,7 +54,7 @@ export const executeTests = async (reporter: MainReporter, config: SyntheticsCIC
       throw error
     }
 
-    throw new CriticalError(isRefusedError(error) ? 'AUTHENTICATION_ERROR' : 'UNAVAILABLE_TEST_CONFIG')
+    throw new CriticalError(isForbiddenError(error) ? 'AUTHORIZATION_ERROR' : 'UNAVAILABLE_TEST_CONFIG')
   }
 
   const {tests, overriddenTestsToTrigger, summary} = testsToTriggerResult

--- a/src/commands/synthetics/run-test.ts
+++ b/src/commands/synthetics/run-test.ts
@@ -1,4 +1,4 @@
-import {apiConstructor} from './api'
+import {apiConstructor, isRefusedError} from './api'
 import {CiError, CriticalError} from './errors'
 import {
   APIHelper,
@@ -33,7 +33,7 @@ export const executeTests = async (reporter: MainReporter, config: SyntheticsCIC
     try {
       testsToTrigger = await getTestsList(api, config, reporter)
     } catch (error) {
-      throw new CriticalError('UNAVAILABLE_TEST_CONFIG')
+      throw new CriticalError(isRefusedError(error) ? 'AUTHENTICATION_ERROR' : 'UNAVAILABLE_TEST_CONFIG')
     }
   }
 
@@ -50,7 +50,11 @@ export const executeTests = async (reporter: MainReporter, config: SyntheticsCIC
   try {
     testsToTriggerResult = await getTestsToTrigger(api, testsToTrigger, reporter)
   } catch (error) {
-    throw error instanceof CiError ? error : new CriticalError('UNAVAILABLE_TEST_CONFIG')
+    if (error instanceof CiError) {
+      throw error
+    }
+
+    throw new CriticalError(isRefusedError(error) ? 'AUTHENTICATION_ERROR' : 'UNAVAILABLE_TEST_CONFIG')
   }
 
   const {tests, overriddenTestsToTrigger, summary} = testsToTriggerResult


### PR DESCRIPTION
### What and why?

Display a specific error message for invalid credential on fetch/trigger test endpoints.


```
 ERROR: authorization error

Credentials refused, make sure `apiKey`, `appKey` and `datadogSite` are correct.
```

### How?

Throw new `AUTHENTICATION_ERROR` critical error on 403 responses with appropriate message.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] \[_Synthetics_\] New releases of `datadog-ci` MUST be followed by a [synthetics-ci-github-action](https://github.com/DataDog/synthetics-ci-github-action) release
