### PR TITLE
Fix standalone binary darwin release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,8 +83,8 @@ jobs:
         run: yarn dist-standalone -t node14-macos-x64 -o datadog-ci_darwin-x64
       - name: Remove dist folder to check that binary can stand alone
         run: |
-          rm dist -r
-          rm src -r
+          rm -rf dist
+          rm -rf src
       - name: Test generated standalone binary
         run: yarn dist-standalone:test
       - name: Upload binaries to GitHub release


### PR DESCRIPTION
### What and why?

Macos release is broken in the latest release: https://github.com/DataDog/datadog-ci/runs/5641538045?check_suite_focus=true. There was a typo in the release script.

I uploaded the binary manually to fix this specific release, but this PR should make fix it permanently. 

### How?

Fix release script.
