### PR TITLE
[CIAPP-3830] Add internal tag to junit upload to enable logs collection

### DIFF
--- a/src/commands/junit/README.md
+++ b/src/commands/junit/README.md
@@ -27,6 +27,7 @@ datadog-ci junit upload --service my-service --tags key1:value1 --tags key2:valu
 - `--env` (default: `DD_ENV` env var) is a string that represents the environment where you want your tests to appear in.
 - `--max-concurrency` (default: `20`): number of concurrent uploads to the API.
 - `--dry-run` (default: `false`): it will run the command without the final upload step. All other checks are performed.
+- `--logs` (default: `false`): it will enable collecting logs from the content in the XML reports.
 
 #### Environment variables
 
@@ -38,6 +39,7 @@ Additionally you might configure the `junit` command with environment variables:
 - `DD_TAGS`: set global tags applied to all spans. The format must be `key1:value1,key2:value2`.
   - The resulting dictionary will be merged with whatever is in the `--tags` parameter. If a `key` appears both in `--tags` and `DD_TAGS`, whatever value is in `DD_TAGS` will take precedence.
 - `DATADOG_SITE`: choose your Datadog site, e.g. datadoghq.com or datadoghq.eu.
+- `DD_CIVISIBILITY_LOGS_ENABLED`: it will enable collecting logs from the content in the XML reports.
 
 ### Optional dependencies
 

--- a/src/commands/junit/__tests__/upload.test.ts
+++ b/src/commands/junit/__tests__/upload.test.ts
@@ -188,7 +188,7 @@ describe('upload', () => {
         basePaths: ['./src/commands/junit/__tests__/fixtures'],
         config: {},
         context,
-        logsEnabled: true,
+        logs: true,
         service: 'service',
       })
       expect(firstFile.logsEnabled).toBe(true)

--- a/src/commands/junit/__tests__/upload.test.ts
+++ b/src/commands/junit/__tests__/upload.test.ts
@@ -180,6 +180,20 @@ describe('upload', () => {
         key2: 'value2',
       })
     })
+    test('should set logsEnabled for each file', async () => {
+      process.env.DD_CIVISIBILITY_LOGS_ENABLED = 'true'
+      const context = createMockContext()
+      const command = new UploadJUnitXMLCommand()
+      const [firstFile, secondFile] = await command['getMatchingJUnitXMLFiles'].call({
+        basePaths: ['./src/commands/junit/__tests__/fixtures'],
+        config: {},
+        context,
+        logsEnabled: true,
+        service: 'service',
+      })
+      expect(firstFile.logsEnabled).toBe(true)
+      expect(secondFile.logsEnabled).toBe(true)
+    })
   })
 })
 
@@ -188,7 +202,10 @@ describe('execute', () => {
     const cli = makeCli()
     const context = createMockContext() as any
     process.env = {DATADOG_API_KEY: 'PLACEHOLDER'}
-    const code = await cli.run(['junit', 'upload', '--service', 'test-service', '--dry-run', ...paths], context)
+    const code = await cli.run(
+      ['junit', 'upload', '--service', 'test-service', '--dry-run', '--logs', ...paths],
+      context
+    )
 
     return {context, code}
   }

--- a/src/commands/junit/api.ts
+++ b/src/commands/junit/api.ts
@@ -34,14 +34,16 @@ export const uploadJUnitXML = (request: (args: AxiosRequestConfig) => AxiosPromi
     fileName = 'default_file_name'
   }
 
-  let spanTags = {
+  const spanTags: Record<string, string | undefined> = {
     service: jUnitXML.service,
     ...jUnitXML.spanTags,
     '_dd.cireport_version': '2',
   }
+
   if (jUnitXML.logsEnabled) {
     spanTags['_dd.junitxml_logs'] = 'true'
   }
+
   form.append('event', JSON.stringify(spanTags), {filename: 'event.json'})
 
   let uniqueFileName = `${fileName}-${jUnitXML.service}-${spanTags[GIT_SHA]}`

--- a/src/commands/junit/api.ts
+++ b/src/commands/junit/api.ts
@@ -34,10 +34,13 @@ export const uploadJUnitXML = (request: (args: AxiosRequestConfig) => AxiosPromi
     fileName = 'default_file_name'
   }
 
-  const spanTags = {
+  let spanTags = {
     service: jUnitXML.service,
     ...jUnitXML.spanTags,
     '_dd.cireport_version': '2',
+  }
+  if (jUnitXML.logsEnabled) {
+    spanTags['_dd.junitxml_logs'] = 'true'
   }
   form.append('event', JSON.stringify(spanTags), {filename: 'event.json'})
 

--- a/src/commands/junit/interfaces.ts
+++ b/src/commands/junit/interfaces.ts
@@ -7,6 +7,7 @@ export interface Payload {
   service: string
   spanTags: SpanTags
   xmlPath: string
+  logsEnabled: boolean
 }
 
 export interface APIHelper {

--- a/src/commands/junit/interfaces.ts
+++ b/src/commands/junit/interfaces.ts
@@ -4,10 +4,10 @@ import {Writable} from 'stream'
 import {SpanTags} from '../../helpers/interfaces'
 
 export interface Payload {
+  logsEnabled: boolean
   service: string
   spanTags: SpanTags
   xmlPath: string
-  logsEnabled: boolean
 }
 
 export interface APIHelper {

--- a/src/commands/junit/upload.ts
+++ b/src/commands/junit/upload.ts
@@ -77,10 +77,10 @@ export class UploadJUnitXMLCommand extends Command {
   }
   private dryRun = false
   private env?: string
+  private logsEnabled = false
   private maxConcurrency = 20
   private service?: string
   private tags?: string[]
-  private logsEnabled = false
 
   public async execute() {
     if (!this.service) {
@@ -102,8 +102,11 @@ export class UploadJUnitXMLCommand extends Command {
       this.config.env = this.env
     }
 
-    if(!this.logsEnabled && process.env.DD_CIVISIBILITY_LOGS_ENABLED &&
-      !['false', '0'].includes(process.env.DD_CIVISIBILITY_LOGS_ENABLED.toLowerCase())) {
+    if (
+      !this.logsEnabled &&
+      process.env.DD_CIVISIBILITY_LOGS_ENABLED &&
+      !['false', '0'].includes(process.env.DD_CIVISIBILITY_LOGS_ENABLED.toLowerCase())
+    ) {
       this.logsEnabled = true
     }
 
@@ -173,10 +176,10 @@ export class UploadJUnitXMLCommand extends Command {
     })
 
     return validUniqueFiles.map((jUnitXMLFilePath) => ({
+      logsEnabled: this.logsEnabled,
       service: this.service!,
       spanTags,
       xmlPath: jUnitXMLFilePath,
-      logsEnabled: this.logsEnabled,
     }))
   }
 

--- a/src/commands/junit/upload.ts
+++ b/src/commands/junit/upload.ts
@@ -77,7 +77,7 @@ export class UploadJUnitXMLCommand extends Command {
   }
   private dryRun = false
   private env?: string
-  private logsEnabled = false
+  private logs = false
   private maxConcurrency = 20
   private service?: string
   private tags?: string[]
@@ -103,11 +103,11 @@ export class UploadJUnitXMLCommand extends Command {
     }
 
     if (
-      !this.logsEnabled &&
+      !this.logs &&
       process.env.DD_CIVISIBILITY_LOGS_ENABLED &&
       !['false', '0'].includes(process.env.DD_CIVISIBILITY_LOGS_ENABLED.toLowerCase())
     ) {
-      this.logsEnabled = true
+      this.logs = true
     }
 
     const api = this.getApiHelper()
@@ -176,7 +176,7 @@ export class UploadJUnitXMLCommand extends Command {
     })
 
     return validUniqueFiles.map((jUnitXMLFilePath) => ({
-      logsEnabled: this.logsEnabled,
+      logsEnabled: this.logs,
       service: this.service!,
       spanTags,
       xmlPath: jUnitXMLFilePath,

--- a/src/commands/junit/upload.ts
+++ b/src/commands/junit/upload.ts
@@ -62,6 +62,10 @@ export class UploadJUnitXMLCommand extends Command {
         'Upload all jUnit XML test report files in current directory to the datadoghq.eu site',
         'DATADOG_SITE=datadoghq.eu datadog-ci junit upload --service my-service .',
       ],
+      [
+        'Upload all jUnit XML test report files in current directory while also collecting logs',
+        'datadog-ci junit upload --service my-service --logs .',
+      ],
     ],
   })
 
@@ -76,6 +80,7 @@ export class UploadJUnitXMLCommand extends Command {
   private maxConcurrency = 20
   private service?: string
   private tags?: string[]
+  private logsEnabled = false
 
   public async execute() {
     if (!this.service) {
@@ -95,6 +100,11 @@ export class UploadJUnitXMLCommand extends Command {
 
     if (!this.config.env) {
       this.config.env = this.env
+    }
+
+    if(!this.logsEnabled && process.env.DD_CIVISIBILITY_LOGS_ENABLED &&
+      !['false', '0'].includes(process.env.DD_CIVISIBILITY_LOGS_ENABLED.toLowerCase())) {
+      this.logsEnabled = true
     }
 
     const api = this.getApiHelper()
@@ -166,6 +176,7 @@ export class UploadJUnitXMLCommand extends Command {
       service: this.service!,
       spanTags,
       xmlPath: jUnitXMLFilePath,
+      logsEnabled: this.logsEnabled,
     }))
   }
 
@@ -203,3 +214,4 @@ UploadJUnitXMLCommand.addOption('dryRun', Command.Boolean('--dry-run'))
 UploadJUnitXMLCommand.addOption('tags', Command.Array('--tags'))
 UploadJUnitXMLCommand.addOption('basePaths', Command.Rest({required: 1}))
 UploadJUnitXMLCommand.addOption('maxConcurrency', Command.String('--max-concurrency'))
+UploadJUnitXMLCommand.addOption('logs', Command.Boolean('--logs'))


### PR DESCRIPTION
### What and why?
This is a new flag to opt in to send logs from junit XML imports. We need a way to opt in as logs have an additional cost.

### How?
There is a new internal tag `_dd.junitxml_logs` that is already being read in the backend.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] \[_Synthetics_\] New releases of `datadog-ci` MUST be followed by a [synthetics-ci-github-action](https://github.com/DataDog/synthetics-ci-github-action) release
