### PR TITLE
Check for aws credentials in ~/.aws/credentials as well as environment variables in interactive mode

### DIFF
--- a/src/commands/lambda/__tests__/functions/commons.test.ts
+++ b/src/commands/lambda/__tests__/functions/commons.test.ts
@@ -1,6 +1,6 @@
 /* tslint:disable:no-string-literal */
-import {config, Credentials} from "aws-sdk"
-jest.mock("aws-sdk")
+import {config as aws_sdk_config, Credentials} from 'aws-sdk'
+jest.mock('aws-sdk')
 import {Lambda} from 'aws-sdk'
 import {
   AWS_ACCESS_KEY_ID_ENV_VAR,
@@ -290,31 +290,30 @@ describe('commons', () => {
     })
     test('returns true when only AWS_SECRET_ACCESS_KEY env var is set and `~/.aws/credentials` are missing', () => {
       process.env[AWS_SECRET_ACCESS_KEY_ENV_VAR] = 'SOME-AWS-SECRET-ACCESS-KEY'
-      config.credentials = null
+      aws_sdk_config.credentials = undefined
       expect(isMissingAWSCredentials()).toBe(true) // We return true since AWS_ACCESS_KEY_ID_ENV_VAR is missing
-
     })
 
     test('returns true when only AWS_ACCESS_KEY_ID environment variable is set and `~/.aws/credentials` are missing', () => {
       process.env[AWS_ACCESS_KEY_ID_ENV_VAR] = 'SOME-AWS-ACCESS-KEY-ID'
-      config.credentials = null
+      aws_sdk_config.credentials = undefined
       expect(isMissingAWSCredentials()).toBe(true) // We return true since AWS_SECRET_ACCESS_KEY_ENV_VAR is missing
     })
 
     test('returns false when AWS credentials via environment variabiables are set', () => {
       process.env[AWS_ACCESS_KEY_ID_ENV_VAR] = 'SOME-AWS-ACCESS-KEY-ID'
       process.env[AWS_SECRET_ACCESS_KEY_ENV_VAR] = 'SOME-AWS-SECRET-ACCESS-KEY'
-      config.credentials = {foo:"bar"} as unknown as Credentials
+      aws_sdk_config.credentials = ({foo: 'bar'} as unknown) as Credentials
       expect(isMissingAWSCredentials()).toBe(false)
     })
 
     test('returns true when both environment variables and `~/.aws/credentials` are missing', () => {
-      config.credentials = null
+      aws_sdk_config.credentials = undefined
       expect(isMissingAWSCredentials()).toBe(true)
     })
 
     test('returns false when AWS credentials via `~/.aws/credentials` are set', () => {
-      config.credentials = {foo:"bar"} as unknown as Credentials
+      aws_sdk_config.credentials = ({foo: 'bar'} as unknown) as Credentials
       expect(isMissingAWSCredentials()).toBe(false)
     })
   })

--- a/src/commands/lambda/__tests__/functions/commons.test.ts
+++ b/src/commands/lambda/__tests__/functions/commons.test.ts
@@ -300,7 +300,7 @@ describe('commons', () => {
       expect(isMissingAWSCredentials()).toBe(true) // We return true since AWS_SECRET_ACCESS_KEY_ENV_VAR is missing
     })
 
-    test('returns false when AWS credentials via environment variabiables are set', () => {
+    test('returns false when AWS credentials via environment variables are set', () => {
       process.env[AWS_ACCESS_KEY_ID_ENV_VAR] = 'SOME-AWS-ACCESS-KEY-ID'
       process.env[AWS_SECRET_ACCESS_KEY_ENV_VAR] = 'SOME-AWS-SECRET-ACCESS-KEY'
       aws_sdk_config.credentials = ({foo: 'bar'} as unknown) as Credentials

--- a/src/commands/lambda/functions/commons.ts
+++ b/src/commands/lambda/functions/commons.ts
@@ -1,4 +1,4 @@
-import {CloudWatchLogs, Lambda} from 'aws-sdk'
+import {AWSError, CloudWatchLogs, Lambda, STS, config, Credentials} from 'aws-sdk'
 import {GetFunctionRequest} from 'aws-sdk/clients/lambda'
 import {
   ARM64_ARCHITECTURE,
@@ -171,9 +171,20 @@ export const findLatestLayerVersion = async (layer: LayerKey, region: string) =>
   return latestVersion
 }
 
-export const isMissingAWSCredentials = () =>
-  process.env[AWS_ACCESS_KEY_ID_ENV_VAR] === undefined || process.env[AWS_SECRET_ACCESS_KEY_ENV_VAR] === undefined
-
+export const isMissingAWSCredentials = () => {
+  // If env vars and config.credentials are not set return true otherwise return false
+  if (process.env[AWS_ACCESS_KEY_ID_ENV_VAR] === undefined || process.env[AWS_SECRET_ACCESS_KEY_ENV_VAR] === undefined){
+    if (config.credentials){
+      return false
+    }
+    else{
+      return true
+    }
+  }
+  else{
+    return false
+  }
+}
 export const isMissingDatadogSiteEnvVar = () => {
   const site = process.env[CI_SITE_ENV_VAR]
   if (site !== undefined) {

--- a/src/commands/lambda/functions/commons.ts
+++ b/src/commands/lambda/functions/commons.ts
@@ -1,4 +1,4 @@
-import {AWSError, CloudWatchLogs, Lambda, STS, config, Credentials} from 'aws-sdk'
+import {CloudWatchLogs, config as aws_sdk_config, Lambda} from 'aws-sdk'
 import {GetFunctionRequest} from 'aws-sdk/clients/lambda'
 import {
   ARM64_ARCHITECTURE,
@@ -172,16 +172,17 @@ export const findLatestLayerVersion = async (layer: LayerKey, region: string) =>
 }
 
 export const isMissingAWSCredentials = () => {
-  // If env vars and config.credentials are not set return true otherwise return false
-  if (process.env[AWS_ACCESS_KEY_ID_ENV_VAR] === undefined || process.env[AWS_SECRET_ACCESS_KEY_ENV_VAR] === undefined){
-    if (config.credentials){
+  // If env vars and aws_sdk_config.credentials are not set return true otherwise return false
+  if (
+    process.env[AWS_ACCESS_KEY_ID_ENV_VAR] === undefined ||
+    process.env[AWS_SECRET_ACCESS_KEY_ENV_VAR] === undefined
+  ) {
+    if (aws_sdk_config.credentials) {
       return false
-    }
-    else{
+    } else {
       return true
     }
-  }
-  else{
+  } else {
     return false
   }
 }

--- a/src/commands/lambda/functions/commons.ts
+++ b/src/commands/lambda/functions/commons.ts
@@ -171,21 +171,10 @@ export const findLatestLayerVersion = async (layer: LayerKey, region: string) =>
   return latestVersion
 }
 
-export const isMissingAWSCredentials = () => {
+export const isMissingAWSCredentials = () =>
   // If env vars and aws_sdk_config.credentials are not set return true otherwise return false
-  if (
-    process.env[AWS_ACCESS_KEY_ID_ENV_VAR] === undefined ||
-    process.env[AWS_SECRET_ACCESS_KEY_ENV_VAR] === undefined
-  ) {
-    if (aws_sdk_config.credentials) {
-      return false
-    } else {
-      return true
-    }
-  } else {
-    return false
-  }
-}
+  (process.env[AWS_ACCESS_KEY_ID_ENV_VAR] === undefined || process.env[AWS_SECRET_ACCESS_KEY_ENV_VAR] === undefined) &&
+  !aws_sdk_config.credentials
 export const isMissingDatadogSiteEnvVar = () => {
   const site = process.env[CI_SITE_ENV_VAR]
   if (site !== undefined) {


### PR DESCRIPTION

### What and why?
https://datadoghq.atlassian.net/browse/SLS-2109
`datadog-ci lambda instrument -i` didnt check for aws credentials in `~/.aws/credentials` and only looked for [environment variables](https://docs.datadoghq.com/serverless/installation/python/?tab=datadogcli#:~:text=gov.com%0Aexport-,AWS_ACCESS_KEY_ID,-%3D%22%3CACCESS%20KEY%20ID) before prompting the user to enter their credentials.
### How?
Add some functionality to check for aws creds in `~/.aws/credentials` by calling aws-sdk's config.credentials. One downside is config.credentials returns an object like: 
<img width="390" alt="Screen Shot 2022-04-01 at 3 04 27 PM" src="https://user-images.githubusercontent.com/49878080/161326163-2338dd0c-ee9c-4d76-bbc4-466e95b8be4b.png">
As you can see it exposes aws_access_key_id but the secret key is never returned in an object. I don't think this is a security concern since the secret key isn't the one being returned to that object but I figured I would bring it up if there are any suggestions

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] \[_Synthetics_\] New releases of `datadog-ci` MUST be followed by a [synthetics-ci-github-action](https://github.com/DataDog/synthetics-ci-github-action) release
