### PR TITLE
[github] Set `@DataDog/datadog-ci` as repo codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
-* @m-rousse
+* @DataDog/datadog-ci
 
 src/commands
 src/commands/synthetics  @m-rousse @DataDog/synthetics-worker


### PR DESCRIPTION
### What and why?

Update repository codeowner to `@DataDog/datadog-ci` team.
