### PR TITLE
[lambda] Replace static version in tests inline snapshots

### DIFF
--- a/src/commands/lambda/__tests__/instrument.test.ts
+++ b/src/commands/lambda/__tests__/instrument.test.ts
@@ -1318,7 +1318,7 @@ UpdateFunctionConfiguration -> arn:aws:lambda:sa-east-1:123456789012:function:la
 }
 TagResource -> arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world
 {
-  \\"dd_sls_ci\\": \\"v1.3.0\\"
+  \\"dd_sls_ci\\": \\"v${version}\\"
 }
 ${yellow('[!]')} Confirmation needed.
 ${yellow('[!]')} Instrumenting functions.
@@ -1425,7 +1425,7 @@ UpdateFunctionConfiguration -> arn:aws:lambda:sa-east-1:123456789012:function:la
 }
 TagResource -> arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world
 {
-  \\"dd_sls_ci\\": \\"v1.3.0\\"
+  \\"dd_sls_ci\\": \\"v${version}\\"
 }
 ${yellow('[!]')} Confirmation needed.
 ${yellow('[!]')} Instrumenting functions.


### PR DESCRIPTION
### What and why?

Replace the static version in inline snapshot with the `package.json` to avoid manually updating it on each package release https://github.com/DataDog/datadog-ci/pull/519#discussion_r854054687.
