### PR TITLE
Updating tag split

### DIFF
--- a/src/commands/junit/__tests__/upload.test.ts
+++ b/src/commands/junit/__tests__/upload.test.ts
@@ -135,7 +135,7 @@ describe('upload', () => {
       expect(files.length).toEqual(2)
     })
     test('should parse DD_TAGS and DD_ENV environment variables', async () => {
-      process.env.DD_TAGS = 'key1:value1,key2:value2'
+      process.env.DD_TAGS = 'key1:https://google.com,key2:value2'
       process.env.DD_ENV = 'ci'
       const context = createMockContext()
       const command = new UploadJUnitXMLCommand()
@@ -151,12 +151,12 @@ describe('upload', () => {
 
       expect(firstFile.spanTags).toMatchObject({
         env: 'ci',
-        key1: 'value1',
+        key1: 'https://google.com',
         key2: 'value2',
       })
       expect(secondFile.spanTags).toMatchObject({
         env: 'ci',
-        key1: 'value1',
+        key1: 'https://google.com',
         key2: 'value2',
       })
     })

--- a/src/helpers/tags.ts
+++ b/src/helpers/tags.ts
@@ -38,10 +38,10 @@ export const parseTags = (tags: string[]) => {
       if (!keyValuePair.includes(':')) {
         return acc
       }
-      const firstColon = keyValuePair.indexOf(':');
+      const firstColon = keyValuePair.indexOf(':')
 
-      const key = keyValuePair.substring(0, firstColon);
-      const value = keyValuePair.substring(firstColon+1);
+      const key = keyValuePair.substring(0, firstColon)
+      const value = keyValuePair.substring(firstColon + 1)
 
       return {
         ...acc,

--- a/src/helpers/tags.ts
+++ b/src/helpers/tags.ts
@@ -38,7 +38,10 @@ export const parseTags = (tags: string[]) => {
       if (!keyValuePair.includes(':')) {
         return acc
       }
-      const [key, value] = keyValuePair.split(':')
+      const firstColon = keyValuePair.indexOf(':');
+
+      const key = keyValuePair.substring(0, firstColon);
+      const value = keyValuePair.substring(firstColon+1);
 
       return {
         ...acc,


### PR DESCRIPTION
### What and why?

Fixes #521. Currently tags with values that contain `:` aren't properly split.

### How?

Instead of splitting on `:` which ignores anything after the second occurrence of `:`, we find the first instance of `:` and set the key to be everything before it and the value to be everything after it.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] \[_Synthetics_\] New releases of `datadog-ci` MUST be followed by a [synthetics-ci-github-action](https://github.com/DataDog/synthetics-ci-github-action) release
