### PR TITLE
[Synthetics] Use environment variable value for `trigger_app` when present

### DIFF
--- a/src/commands/synthetics/__tests__/utils.test.ts
+++ b/src/commands/synthetics/__tests__/utils.test.ts
@@ -6,6 +6,8 @@ import * as fs from 'fs'
 import {AxiosError, AxiosRequestConfig, AxiosResponse, default as axios} from 'axios'
 import glob from 'glob'
 
+process.env.DATADOG_SYNTHETICS_CI_TRIGGER_APP = 'env_default'
+
 import * as ciHelpers from '../../../helpers/ci'
 import {Metadata} from '../../../helpers/interfaces'
 import {ProxyConfiguration} from '../../../helpers/utils'
@@ -108,7 +110,7 @@ describe('utils', () => {
       }) as any)
 
       await utils.runTests(api, [{public_id: fakeId, executionRule: ExecutionRule.NON_BLOCKING}])
-      expect(headersMetadataSpy).toHaveBeenCalledWith(expect.objectContaining({'X-Trigger-App': 'npm_package'}))
+      expect(headersMetadataSpy).toHaveBeenCalledWith(expect.objectContaining({'X-Trigger-App': 'env_default'}))
 
       utils.setCiTriggerApp('unit_test')
       await utils.runTests(api, [{public_id: fakeId, executionRule: ExecutionRule.NON_BLOCKING}])

--- a/src/commands/synthetics/utils.ts
+++ b/src/commands/synthetics/utils.ts
@@ -42,7 +42,7 @@ const TEMPLATE_REGEX = /{{\s*([^{}]*?)\s*}}/g
 const template = (st: string, context: any): string =>
   st.replace(TEMPLATE_REGEX, (match: string, p1: string) => (p1 in context ? context[p1] : match))
 
-export let ciTriggerApp = 'npm_package'
+export let ciTriggerApp = process.env.DATADOG_SYNTHETICS_CI_TRIGGER_APP || 'npm_package'
 
 export const handleConfig = (
   test: InternalTest,


### PR DESCRIPTION
### What and why?

Use `DATADOG_SYNTHETICS_CI_TRIGGER_APP` env var for `trigger_app` to allow third party integrations to specify it when not using the datadog-ci API.

### How?

Default `triggerApp` to `DATADOG_SYNTHETICS_CI_TRIGGER_APP`, can still be overridden through `setCiTriggerApp()`.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] \[_Synthetics_\] New releases of `datadog-ci` MUST be followed by a [synthetics-ci-github-action](https://github.com/DataDog/synthetics-ci-github-action) release
