### PR TITLE
[s8s] Fix critical error message display

### DIFF
--- a/src/commands/synthetics/__tests__/run-test.test.ts
+++ b/src/commands/synthetics/__tests__/run-test.test.ts
@@ -184,7 +184,7 @@ describe('run-test', () => {
         jest.spyOn(runTests, 'getApiHelper').mockImplementation(() => apiHelper as any)
         await expect(
           runTests.executeTests(mockReporter, {...ciConfig, testSearchQuery: 'a-search-query', tunnel: true})
-        ).rejects.toMatchError(new CriticalError(error))
+        ).rejects.toMatchError(new CriticalError(error, 'Server Error'))
       })
 
       test(`getTestsToTrigger throws - ${status}`, async () => {
@@ -199,7 +199,7 @@ describe('run-test', () => {
         jest.spyOn(runTests, 'getApiHelper').mockImplementation(() => apiHelper as any)
         await expect(
           runTests.executeTests(mockReporter, {...ciConfig, publicIds: ['public-id-1'], tunnel: true})
-        ).rejects.toMatchError(new CriticalError(error))
+        ).rejects.toMatchError(new CriticalError(error, 'Server Error'))
       })
     })
 
@@ -224,7 +224,7 @@ describe('run-test', () => {
       jest.spyOn(runTests, 'getApiHelper').mockImplementation(() => apiHelper as any)
       await expect(
         runTests.executeTests(mockReporter, {...ciConfig, publicIds: ['public-id-1', 'public-id-2'], tunnel: true})
-      ).rejects.toMatchError(new CriticalError('UNAVAILABLE_TUNNEL_CONFIG'))
+      ).rejects.toMatchError(new CriticalError('UNAVAILABLE_TUNNEL_CONFIG', 'Server Error'))
     })
 
     test('runTests throws', async () => {
@@ -254,7 +254,12 @@ describe('run-test', () => {
       jest.spyOn(runTests, 'getApiHelper').mockImplementation(() => apiHelper as any)
       await expect(
         runTests.executeTests(mockReporter, {...ciConfig, publicIds: ['public-id-1', 'public-id-2'], tunnel: true})
-      ).rejects.toMatchError(new CriticalError('TRIGGER_TESTS_FAILED'))
+      ).rejects.toMatchError(
+        new CriticalError(
+          'TRIGGER_TESTS_FAILED',
+          '[] Failed to trigger tests: query on baseURLurl returned: "Bad Gateway"\n'
+        )
+      )
       expect(stopTunnelSpy).toHaveBeenCalledTimes(1)
     })
 
@@ -305,7 +310,7 @@ describe('run-test', () => {
           publicIds: ['public-id-1', 'public-id-2'],
           tunnel: true,
         })
-      ).rejects.toMatchError(new CriticalError('POLL_RESULTS_FAILED'))
+      ).rejects.toMatchError(new CriticalError('POLL_RESULTS_FAILED', 'Server Error'))
       expect(stopTunnelSpy).toHaveBeenCalledTimes(1)
     })
   })

--- a/src/commands/synthetics/errors.ts
+++ b/src/commands/synthetics/errors.ts
@@ -17,13 +17,13 @@ export type CriticalCiErrorCode = typeof criticalErrorCodes[number]
 export type CiErrorCode = NonCriticalCiErrorCode | CriticalCiErrorCode
 
 export class CiError extends Error {
-  constructor(public code: CiErrorCode) {
-    super()
+  constructor(public code: CiErrorCode, message?: string) {
+    super(message)
   }
 }
 
 export class CriticalError extends CiError {
-  constructor(public code: CriticalCiErrorCode) {
-    super(code)
+  constructor(public code: CriticalCiErrorCode, message?: string) {
+    super(code, message)
   }
 }

--- a/src/commands/synthetics/run-test.ts
+++ b/src/commands/synthetics/run-test.ts
@@ -34,7 +34,10 @@ export const executeTests = async (reporter: MainReporter, config: SyntheticsCIC
     try {
       testsToTrigger = await getTestsList(api, config, reporter, suites)
     } catch (error) {
-      throw new CriticalError(isForbiddenError(error) ? 'AUTHORIZATION_ERROR' : 'UNAVAILABLE_TEST_CONFIG')
+      throw new CriticalError(
+        isForbiddenError(error) ? 'AUTHORIZATION_ERROR' : 'UNAVAILABLE_TEST_CONFIG',
+        error.message
+      )
     }
   }
 
@@ -55,7 +58,7 @@ export const executeTests = async (reporter: MainReporter, config: SyntheticsCIC
       throw error
     }
 
-    throw new CriticalError(isForbiddenError(error) ? 'AUTHORIZATION_ERROR' : 'UNAVAILABLE_TEST_CONFIG')
+    throw new CriticalError(isForbiddenError(error) ? 'AUTHORIZATION_ERROR' : 'UNAVAILABLE_TEST_CONFIG', error.message)
   }
 
   const {tests, overriddenTestsToTrigger, summary} = testsToTriggerResult
@@ -73,7 +76,7 @@ export const executeTests = async (reporter: MainReporter, config: SyntheticsCIC
       // Get the pre-signed URL to connect to the tunnel service
       presignedURL = (await api.getPresignedURL(publicIdsToTrigger)).url
     } catch (error) {
-      throw new CriticalError('UNAVAILABLE_TUNNEL_CONFIG')
+      throw new CriticalError('UNAVAILABLE_TUNNEL_CONFIG', error.message)
     }
     // Open a tunnel to Datadog
     try {
@@ -84,7 +87,7 @@ export const executeTests = async (reporter: MainReporter, config: SyntheticsCIC
       })
     } catch (error) {
       await stopTunnel()
-      throw new CriticalError('TUNNEL_START_FAILED')
+      throw new CriticalError('TUNNEL_START_FAILED', error.message)
     }
   }
 
@@ -93,7 +96,7 @@ export const executeTests = async (reporter: MainReporter, config: SyntheticsCIC
     triggers = await runTests(api, overriddenTestsToTrigger)
   } catch (error) {
     await stopTunnel()
-    throw new CriticalError('TRIGGER_TESTS_FAILED')
+    throw new CriticalError('TRIGGER_TESTS_FAILED', error.message)
   }
 
   if (!triggers.results) {
@@ -114,7 +117,7 @@ export const executeTests = async (reporter: MainReporter, config: SyntheticsCIC
     )
     Object.assign(results, resultPolled)
   } catch (error) {
-    throw new CriticalError('POLL_RESULTS_FAILED')
+    throw new CriticalError('POLL_RESULTS_FAILED', error.message)
   } finally {
     await stopTunnel()
   }


### PR DESCRIPTION
### What and why?

This PR improves the display of critical errors by adding the `error.message` into the `CriticalError`.

![image](https://user-images.githubusercontent.com/9317502/168609614-5a221c64-fef1-4d4b-ae6c-c9201b9e77f1.png)

### How?

A new optional message property is added to the `CriticalError` constructor. It is optional because we don't always have an `error.message` to pass to the constructor, and for such errors we [directly log a message in the reporter](https://github.com/DataDog/datadog-ci/blob/67e99c912f525bbd1556fd8ca3d6411674e171a9/src/commands/synthetics/command.ts#L186-L214).

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] \[_Synthetics_\] New releases of `datadog-ci` MUST be followed by a [synthetics-ci-github-action](https://github.com/DataDog/synthetics-ci-github-action) release
