### PR TITLE
[codeowners] remove m-rousse from codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,7 @@
 * @DataDog/datadog-ci
 
 src/commands
-src/commands/synthetics  @m-rousse @DataDog/synthetics-worker
+src/commands/synthetics @DataDog/synthetics-worker
 src/commands/lambda @DataDog/serverless
 src/commands/sourcemaps @DataDog/source-code-integration
 src/commands/git-metadata @DataDog/source-code-integration


### PR DESCRIPTION
### What and why?

The `synthetics` command is owned by Synthetics Worker, no need to have me specifically notified.