### PR TITLE
[synthetics] truncate git commit message length to 500 chars

### DIFF
--- a/src/commands/synthetics/utils.ts
+++ b/src/commands/synthetics/utils.ts
@@ -7,6 +7,7 @@ import chalk from 'chalk'
 import glob from 'glob'
 
 import {getCIMetadata} from '../../helpers/ci'
+import {GIT_COMMIT_MESSAGE} from '../../helpers/tags'
 import {pick} from '../../helpers/utils'
 
 import {EndpointError, formatBackendErrors, is5xxError, isNotFoundError} from './api'
@@ -539,7 +540,10 @@ export const getTestsToTrigger = async (api: APIHelper, triggerConfigs: TriggerC
 
 export const runTests = async (api: APIHelper, testsToTrigger: TestPayload[]): Promise<Trigger> => {
   const payload: Payload = {tests: testsToTrigger}
-  const ciMetadata = getCIMetadata()
+  const tagsToLimit = {
+    [GIT_COMMIT_MESSAGE]: 500,
+  }
+  const ciMetadata = getCIMetadata(tagsToLimit)
 
   if (ciMetadata) {
     payload.metadata = ciMetadata

--- a/src/helpers/__tests__/ci.test.ts
+++ b/src/helpers/__tests__/ci.test.ts
@@ -79,6 +79,22 @@ describe('getCIMetadata', () => {
     expect(getCIMetadata()?.ci.pipeline.number).toBeUndefined()
   })
 
+  test('tags are properly truncated when required', () => {
+    const bigString = ''.padEnd(1600, 'a')
+    process.env = {GITLAB_CI: 'gitlab'}
+
+    process.env.CI_COMMIT_MESSAGE = bigString
+    process.env.CI_COMMIT_TAG = bigString
+    expect(getCIMetadata()?.git.commit.message).toBe(bigString)
+    expect(getCIMetadata()?.git.tag).toBe(bigString)
+
+    const tagSizeLimits = {
+      'git.commit.message': 500,
+    }
+    expect(getCIMetadata(tagSizeLimits)?.git.commit.message).toBe(bigString.substring(0, 500))
+    expect(getCIMetadata(tagSizeLimits)?.git.tag).toBe(bigString)
+  })
+
   describe.each(CI_PROVIDERS)('%s', (ciProvider) => {
     const assertions = require(path.join(__dirname, 'ci-env', ciProvider))
 

--- a/src/helpers/ci.ts
+++ b/src/helpers/ci.ts
@@ -1,6 +1,6 @@
 import {URL} from 'url'
 
-import {Metadata, SpanTags} from './interfaces'
+import {Metadata, SpanTag, SpanTags} from './interfaces'
 import {
   CI_JOB_NAME,
   CI_JOB_URL,
@@ -483,7 +483,7 @@ export const getCISpanTags = (): SpanTags | undefined => {
   return removeEmptyValues(tags)
 }
 
-export const getCIMetadata = (): Metadata | undefined => {
+export const getCIMetadata = (tagSizeLimits?: {[key in keyof SpanTags]?: number}): Metadata | undefined => {
   const tags = {
     ...getCISpanTags(),
     ...getUserCISpanTags(),
@@ -492,6 +492,16 @@ export const getCIMetadata = (): Metadata | undefined => {
 
   if (!tags || !Object.keys(tags).length) {
     return
+  }
+
+  if (tagSizeLimits) {
+    for (const key of Object.keys(tagSizeLimits)) {
+      const tagToLimit = key as SpanTag
+      const originalTag = tags[tagToLimit]
+      if (!!originalTag) {
+        tags[tagToLimit] = originalTag.substring(0, tagSizeLimits[tagToLimit])
+      }
+    }
   }
 
   const metadata: Metadata = {


### PR DESCRIPTION
### What and why?

This PR adds truncation of the git commit message that is retrieved when triggering synthetics tests through datadog-ci.

This fixes an issue where CI invocations of the command when done with a git commit message of over 1500 chars could make the API call fail with a 400 error.

### How?

This PR adds an optional argument to the helper used to retrieve CI metadata to pass per-tag size limit.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] \[_Synthetics_\] New releases of `datadog-ci` MUST be followed by a [synthetics-ci-github-action](https://github.com/DataDog/synthetics-ci-github-action) release
