### PR TITLE
v1.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "Run datadog actions from the CI.",
   "repository": "https://github.com/DataDog/datadog-ci",
   "license": "Apache-2.0",


### PR DESCRIPTION
### What and why?

This PR releases version 1.6.0 of the package, including:

PR #538 by mrousse: truncate git commit message
PR #537 by mrousse: update codeowners
