### PR TITLE
[CIAPP] Move tag and metric command to beta

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ Available commands:
   - git-metadata
   - junit
   - trace
+  - tag
+  - metric
 ```
 
 Each command allows interacting with a product of the Datadog platform. The commands are defined in the [src/commands](/src/commands) folder.
@@ -83,6 +85,8 @@ Further documentation for each command can be found in its folder, ie:
 - [Git metadata](src/commands/git-metadata)
 - [JUnit XML](src/commands/junit)
 - [Trace](src/commands/trace)
+- [Tag](src/commands/tag)
+- [Metric](src/commands/metric)
 
 ## Contributing
 

--- a/src/commands/metric/README.md
+++ b/src/commands/metric/README.md
@@ -1,6 +1,6 @@
 # metric command
 
-:warning: This command is in alpha stage.
+:warning: This command is in beta stage.
 
 Add numeric tags to CI Visibility pipeline and job spans.
 

--- a/src/commands/tag/README.md
+++ b/src/commands/tag/README.md
@@ -1,6 +1,6 @@
 # tag command
 
-:warning: This command is in alpha stage.
+:warning: This command is in beta stage.
 
 Tag CI Visibility pipeline and job spans.
 


### PR DESCRIPTION
### What and why?

The underlaying functionality has now been activated for all customers to try, as such this PR adds the commands to the readme and marks them as beta.

### How?



### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] \[_Synthetics_\] New releases of `datadog-ci` MUST be followed by a [synthetics-ci-github-action](https://github.com/DataDog/synthetics-ci-github-action) release
