### PR TITLE
v1.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "Run datadog actions from the CI.",
   "repository": "https://github.com/DataDog/datadog-ci",
   "license": "Apache-2.0",


### PR DESCRIPTION
### What and why?

This PR releases version 1.7.0 of the package, including:
* https://github.com/DataDog/datadog-ci/pull/533 (by [ruizb](https://github.com/ruizb))
* https://github.com/DataDog/datadog-ci/pull/535 (by [Drarig29](https://github.com/Drarig29))
* https://github.com/DataDog/datadog-ci/pull/540 (by [cg14823](https://github.com/cg14823))
* https://github.com/DataDog/datadog-ci/pull/541 (by [DarcyRaynerDD](https://github.com/DarcyRaynerDD))
