### PR TITLE
Code refactoring to prepare batch endpoint

### DIFF
--- a/src/commands/synthetics/__tests__/api.test.ts
+++ b/src/commands/synthetics/__tests__/api.test.ts
@@ -3,7 +3,7 @@ import {AxiosError, AxiosResponse, default as axios} from 'axios'
 import {ProxyConfiguration} from '../../../helpers/utils'
 
 import {apiConstructor} from '../api'
-import {APIConfiguration, ExecutionRule, PollResult, Result, TestPayload, Trigger} from '../interfaces'
+import {APIConfiguration, ExecutionRule, PollResult, ServerResult, TestPayload, Trigger} from '../interfaces'
 
 import {getApiTest, getSyntheticsProxy, mockSearchResponse, mockTestTriggerResponse} from './fixtures'
 
@@ -28,7 +28,7 @@ describe('dd-api', () => {
       {
         check: getApiTest('abc-def-ghi'),
         dc_id: 0,
-        result: {} as Result,
+        result: ({} as unknown) as ServerResult,
         resultID: RESULT_ID,
         timestamp: 0,
       },
@@ -45,7 +45,6 @@ describe('dd-api', () => {
         result_id: RESULT_ID,
       },
     ],
-    triggered_check_ids: [TRIGGERED_TEST_ID],
   }
   const PRESIGNED_URL_PAYLOAD = {
     url: 'wss://presigned.url',
@@ -64,8 +63,7 @@ describe('dd-api', () => {
     const api = apiConstructor(apiConfiguration)
     const {triggerTests} = api
     const tests: TestPayload[] = [{public_id: TRIGGERED_TEST_ID, executionRule: ExecutionRule.BLOCKING}]
-    const {results, triggered_check_ids} = await triggerTests({tests})
-    expect(triggered_check_ids).toEqual([TRIGGERED_TEST_ID])
+    const {results} = await triggerTests({tests})
     expect(results[0].public_id).toBe(TRIGGERED_TEST_ID)
     expect(results[0].result_id).toBe(RESULT_ID)
   })

--- a/src/commands/synthetics/__tests__/fixtures.ts
+++ b/src/commands/synthetics/__tests__/fixtures.ts
@@ -7,21 +7,20 @@ import WebSocket, {Server as WebSocketServer} from 'ws'
 import {ProxyConfiguration} from '../../../helpers/utils'
 
 import {
-  ApiTestResult,
-  BrowserTestResult,
+  ApiServerResult,
+  BrowserServerResult,
   CommandConfig,
   ConfigOverride,
   ExecutionRule,
   Location,
   MainReporter,
   MultiStep,
-  MultiStepsTestResult,
-  PollResult,
+  MultiStepsServerResult,
+  Result,
   Step,
   Suite,
   Summary,
   Test,
-  TestResult,
   Trigger,
   TriggerResponse,
   User,
@@ -69,7 +68,7 @@ export const ciConfig: CommandConfig = {
   variableStrings: [],
 }
 
-export const getApiTest = (publicId: string): Test => ({
+export const getApiTest = (publicId = 'abc-def-ghi'): Test => ({
   config: {
     assertions: [],
     request: {
@@ -138,58 +137,62 @@ export const getMultiStep = (): MultiStep => ({
 
 export const getTestSuite = (): Suite => ({content: {tests: [{config: {}, id: '123-456-789'}]}, name: 'Suite 1'})
 
-const getPollResult = (resultId: string): Omit<PollResult, 'result'> => ({
-  dc_id: 1,
-  resultID: resultId,
+const getBaseResult = (resultId: string, test: Test): Omit<Result, 'result'> => ({
+  dcId: 1,
+  passed: false,
+  resultId,
+  test,
   timestamp: 1,
 })
 
-export const getBrowserPollResult = (resultId: string, resultOpts: Partial<BrowserTestResult> = {}): PollResult => ({
-  ...getPollResult(resultId),
-  result: getBrowserResult(resultOpts),
+export const getBrowserResult = (
+  resultId: string,
+  test: Test,
+  resultOpts: Partial<BrowserServerResult> = {}
+): Result => ({
+  ...getBaseResult(resultId, test),
+  result: getBrowserServerResult(resultOpts),
 })
 
-export const getApiPollResult = (resultId: string, resultOpts: Partial<ApiTestResult> = {}): PollResult => ({
-  ...getPollResult(resultId),
-  result: getApiResult(resultOpts),
+export const getApiResult = (resultId: string, test: Test, resultOpts: Partial<ApiServerResult> = {}): Result => ({
+  ...getBaseResult(resultId, test),
+  result: getApiServerResult(resultOpts),
 })
 
-const getResult = (): TestResult => ({
-  eventType: 'finished',
-  passed: true,
-})
-
-export const getBrowserResult = (opts: Partial<BrowserTestResult> = {}): BrowserTestResult => ({
-  ...getResult(),
+export const getBrowserServerResult = (opts: Partial<BrowserServerResult> = {}): BrowserServerResult => ({
   device: {
     height: 1,
     id: 'laptop_large',
     width: 1,
   },
   duration: 0,
+  eventType: 'finished',
+  passed: true,
   startUrl: '',
   stepDetails: [],
   tunnel: false,
   ...opts,
 })
 
-export const getApiResult = (opts: Partial<ApiTestResult> = {}): ApiTestResult => ({
-  ...getResult(),
+export const getApiServerResult = (opts: Partial<ApiServerResult> = {}): ApiServerResult => ({
   assertionResults: [
     {
       actual: 'actual',
       valid: true,
     },
   ],
+  eventType: 'finished',
+  passed: true,
   timings: {
     total: 123,
   },
   ...opts,
 })
 
-export const getMultiStepsResult = (): MultiStepsTestResult => ({
-  ...getResult(),
+export const getMultiStepsServerResult = (): MultiStepsServerResult => ({
   duration: 123,
+  eventType: 'finished',
+  passed: true,
   steps: [],
 })
 
@@ -219,7 +222,6 @@ export const mockSearchResponse = {tests: [{public_id: '123-456-789'}]}
 export const mockTestTriggerResponse: Trigger = {
   locations: [mockLocation],
   results: [mockTriggerResult],
-  triggered_check_ids: ['123-456-789'],
 }
 
 const mockTunnelConnectionFirstMessage = {host: 'host', id: 'tunnel-id'}
@@ -266,7 +268,7 @@ export const getSyntheticsProxy = () => {
       return mockResponse(calls.presignedUrl, {url: `ws://127.0.0.1:${port}`})
     }
     if (/\/synthetics\/tests\/poll_results/.test(request.url)) {
-      return mockResponse(calls.poll, getApiPollResult('1'))
+      return mockResponse(calls.poll, getApiResult('1', getApiTest()))
     }
     if (/\/synthetics\/tests\//.test(request.url)) {
       return mockResponse(calls.get, getApiTest('123-456-789'))
@@ -301,7 +303,7 @@ export interface RenderResultsTestCase {
   failOnCriticalErrors: boolean
   failOnTimeout: boolean
   fixtures: {
-    results: Record<string, PollResult[]>
+    results: Result[]
     tests: Test[]
     triggers: Trigger
   }
@@ -318,7 +320,7 @@ interface RenderResultsTestFixtureConfigs {
 }
 
 interface RenderResultsTestFixtures {
-  polledResultsByPublicId: Record<string, PollResult[]>
+  results: Result[]
   test: Test
   triggerResult: TriggerResponse
 }
@@ -334,52 +336,37 @@ export class RenderResultsHelper {
   }
 
   private combineTestFixtures(testFixtures: RenderResultsTestFixtures[]): RenderResultsTestCase['fixtures'] {
-    const mergedPolledResults = testFixtures
-      .map(({polledResultsByPublicId}) => polledResultsByPublicId)
-      .reduce((mergedResults, polledResultsByPublicId) => {
-        for (const [testPublicId, polledResults] of Object.entries(polledResultsByPublicId)) {
-          if (!mergedResults[testPublicId]) {
-            mergedResults[testPublicId] = []
-          }
-          mergedResults[testPublicId] = mergedResults[testPublicId].concat(polledResults)
-        }
-
-        return mergedResults
-      }, {})
-
+    const mergedResults = ([] as Result[]).concat(...testFixtures.map(({results}) => results))
     const triggerResults = testFixtures.map(({triggerResult}) => triggerResult)
 
     return {
-      results: mergedPolledResults,
+      results: mergedResults,
       tests: testFixtures.map(({test}) => test),
       triggers: {
         locations: [mockLocation],
         results: triggerResults,
-        triggered_check_ids: triggerResults.map(({public_id}) => public_id),
       },
     }
   }
 
-  private getNextTriggerResultAndPolledResults({
+  private getNextTriggerResultAndResult({
     configOverride,
     publicId,
     resultError,
     resultIsUnhealthy,
     resultPassed,
-  }: Omit<RenderResultsTestFixtureConfigs, 'executionRule'>): [TriggerResponse, Record<string, PollResult[]>] {
+    test,
+  }: Omit<RenderResultsTestFixtureConfigs, 'executionRule'> & {test: Test}): [TriggerResponse, Result] {
     const triggerResult = getTriggerResult(publicId, this.resultIdCounter.toString())
-    const polledResults = {
-      [publicId]: [
-        deepExtend(getApiPollResult(this.resultIdCounter.toString()), {
-          enrichment: {config_override: configOverride},
-          result: {passed: resultPassed, error: resultError, unhealthy: resultIsUnhealthy},
-        }),
-      ],
-    }
+
+    const result = deepExtend(getApiResult(this.resultIdCounter.toString(), test), {
+      enrichment: {config_override: configOverride},
+      result: {passed: resultPassed, error: resultError, unhealthy: resultIsUnhealthy},
+    })
 
     this.resultIdCounter++
 
-    return [triggerResult, polledResults]
+    return [triggerResult, result]
   }
 
   private getTestFixtures({
@@ -394,15 +381,16 @@ export class RenderResultsHelper {
       ? deepExtend(getApiTest(publicId), {options: {ci: {executionRule}}})
       : getApiTest(publicId)
 
-    const [triggerResult, polledResultsByPublicId] = this.getNextTriggerResultAndPolledResults({
+    const [triggerResult, result] = this.getNextTriggerResultAndResult({
       configOverride,
       publicId,
       resultError,
       resultIsUnhealthy,
       resultPassed,
+      test,
     })
 
-    return {test, triggerResult, polledResultsByPublicId}
+    return {test, triggerResult, results: [result]}
   }
 
   private resetResultIdCounter() {

--- a/src/commands/synthetics/__tests__/fixtures.ts
+++ b/src/commands/synthetics/__tests__/fixtures.ts
@@ -139,7 +139,7 @@ export const getTestSuite = (): Suite => ({content: {tests: [{config: {}, id: '1
 
 const getBaseResult = (resultId: string, test: Test): Omit<Result, 'result'> => ({
   dcId: 1,
-  passed: false,
+  passed: true,
   resultId,
   test,
   timestamp: 1,

--- a/src/commands/synthetics/__tests__/reporters/__snapshots__/default.test.ts.snap
+++ b/src/commands/synthetics/__tests__/reporters/__snapshots__/default.test.ts.snap
@@ -21,9 +21,9 @@ exports[`Default reporter runEnd Simple case with 1 test with 1 result (passed) 
 `;
 
 exports[`Default reporter testEnd 1 API test (blocking), 1 location, 3 results: success, failed non-blocking, failed 1`] = `
-"[1m[31m✖[39m[22m [[1m[31mblocking[39m[22m] [[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m - [1m[31mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m
+"[1m[32m✓[39m[22m [[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m - [1m[32mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m
   ⎋ Total duration: 123 ms - Result URL: [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=1&from_ci=true[39m[22m 
-  [1m[31m✖[39m[22m [1m[31m[1mGET[22m[1m - http://fake.url[39m[22m
+  [1m[32m✓[39m[22m [1m[32m[1mGET[22m[1m - http://fake.url[39m[22m
 
 [1m[33m✖[39m[22m [[1m[33mnon-blocking[39m[22m] [[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m - [1m[33mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m
   ⎋ Total duration: 123 ms - Result URL: [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=2&from_ci=true[39m[22m 
@@ -41,9 +41,9 @@ exports[`Default reporter testEnd 1 API test (blocking), 1 location, 3 results: 
 `;
 
 exports[`Default reporter testEnd 1 API test (non-blocking), 1 location, 3 results: success, failed non-blocking, failed 1`] = `
-"[1m[33m✖[39m[22m [[1m[33mnon-blocking[39m[22m] [[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m - [1m[33mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m
+"[1m[32m✓[39m[22m [[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m - [1m[32mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m
   ⎋ Total duration: 123 ms - Result URL: [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=1&from_ci=true[39m[22m 
-  [1m[33m✖[39m[22m [1m[33m[1mGET[22m[1m - http://fake.url[39m[22m
+  [1m[32m✓[39m[22m [1m[32m[1mGET[22m[1m - http://fake.url[39m[22m
 
 [1m[33m✖[39m[22m [[1m[33mnon-blocking[39m[22m] [[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m - [1m[33mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m
   ⎋ Total duration: 123 ms - Result URL: [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=2&from_ci=true[39m[22m 
@@ -61,9 +61,9 @@ exports[`Default reporter testEnd 1 API test (non-blocking), 1 location, 3 resul
 `;
 
 exports[`Default reporter testEnd 1 API test, 1 location, 1 result: success 1`] = `
-"[1m[31m✖[39m[22m [[1m[31mblocking[39m[22m] [[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m - [1m[31mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m
+"[1m[32m✓[39m[22m [[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m - [1m[32mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m
   ⎋ Total duration: 123 ms - Result URL: [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=1&from_ci=true[39m[22m 
-  [1m[31m✖[39m[22m [1m[31m[1mGET[22m[1m - http://fake.url[39m[22m
+  [1m[32m✓[39m[22m [1m[32m[1mGET[22m[1m - http://fake.url[39m[22m
 
 "
 `;

--- a/src/commands/synthetics/__tests__/reporters/__snapshots__/default.test.ts.snap
+++ b/src/commands/synthetics/__tests__/reporters/__snapshots__/default.test.ts.snap
@@ -21,9 +21,9 @@ exports[`Default reporter runEnd Simple case with 1 test with 1 result (passed) 
 `;
 
 exports[`Default reporter testEnd 1 API test (blocking), 1 location, 3 results: success, failed non-blocking, failed 1`] = `
-"[1m[32m✓[39m[22m [[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m - [1m[32mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m
+"[1m[31m✖[39m[22m [[1m[31mblocking[39m[22m] [[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m - [1m[31mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m
   ⎋ Total duration: 123 ms - Result URL: [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=1&from_ci=true[39m[22m 
-  [1m[32m✓[39m[22m [1m[32m[1mGET[22m[1m - http://fake.url[39m[22m
+  [1m[31m✖[39m[22m [1m[31m[1mGET[22m[1m - http://fake.url[39m[22m
 
 [1m[33m✖[39m[22m [[1m[33mnon-blocking[39m[22m] [[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m - [1m[33mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m
   ⎋ Total duration: 123 ms - Result URL: [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=2&from_ci=true[39m[22m 
@@ -41,9 +41,9 @@ exports[`Default reporter testEnd 1 API test (blocking), 1 location, 3 results: 
 `;
 
 exports[`Default reporter testEnd 1 API test (non-blocking), 1 location, 3 results: success, failed non-blocking, failed 1`] = `
-"[1m[32m✓[39m[22m [[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m - [1m[32mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m
+"[1m[33m✖[39m[22m [[1m[33mnon-blocking[39m[22m] [[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m - [1m[33mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m
   ⎋ Total duration: 123 ms - Result URL: [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=1&from_ci=true[39m[22m 
-  [1m[32m✓[39m[22m [1m[32m[1mGET[22m[1m - http://fake.url[39m[22m
+  [1m[33m✖[39m[22m [1m[33m[1mGET[22m[1m - http://fake.url[39m[22m
 
 [1m[33m✖[39m[22m [[1m[33mnon-blocking[39m[22m] [[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m - [1m[33mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m
   ⎋ Total duration: 123 ms - Result URL: [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=2&from_ci=true[39m[22m 
@@ -61,9 +61,9 @@ exports[`Default reporter testEnd 1 API test (non-blocking), 1 location, 3 resul
 `;
 
 exports[`Default reporter testEnd 1 API test, 1 location, 1 result: success 1`] = `
-"[1m[32m✓[39m[22m [[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m - [1m[32mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m
+"[1m[31m✖[39m[22m [[1m[31mblocking[39m[22m] [[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m - [1m[31mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m
   ⎋ Total duration: 123 ms - Result URL: [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=1&from_ci=true[39m[22m 
-  [1m[32m✓[39m[22m [1m[32m[1mGET[22m[1m - http://fake.url[39m[22m
+  [1m[31m✖[39m[22m [1m[31m[1mGET[22m[1m - http://fake.url[39m[22m
 
 "
 `;

--- a/src/commands/synthetics/__tests__/run-test.test.ts
+++ b/src/commands/synthetics/__tests__/run-test.test.ts
@@ -6,7 +6,7 @@ import {ExecutionRule} from '../interfaces'
 import * as runTests from '../run-test'
 import {Tunnel} from '../tunnel'
 import * as utils from '../utils'
-import {ciConfig, getApiPollResult, mockReporter, mockTestTriggerResponse} from './fixtures'
+import {ciConfig, getApiResult, getApiTest, mockReporter, mockTestTriggerResponse} from './fixtures'
 
 describe('run-test', () => {
   beforeEach(() => {
@@ -16,9 +16,6 @@ describe('run-test', () => {
   })
 
   describe('execute', () => {
-    beforeEach(() => {
-      jest.restoreAllMocks()
-    })
     test('should apply config override for tests triggered by public id', async () => {
       const getTestsToTriggersMock = jest.spyOn(utils, 'getTestsToTrigger').mockReturnValue(
         Promise.resolve({
@@ -133,11 +130,11 @@ describe('run-test', () => {
         })
       )
 
-      jest.spyOn(utils, 'runTests').mockResolvedValue({...mockTestTriggerResponse, triggered_check_ids: []})
+      jest.spyOn(utils, 'runTests').mockResolvedValue(mockTestTriggerResponse)
 
       const apiHelper = {
         getPresignedURL: () => ({url: 'url'}),
-        pollResults: () => ({results: [getApiPollResult('1')]}),
+        pollResults: () => ({results: [getApiResult('1', getApiTest())]}),
         triggerTests: () => mockTestTriggerResponse,
       }
 
@@ -273,7 +270,6 @@ describe('run-test', () => {
         Promise.resolve({
           locations: [location],
           results: [{device: 'chrome_laptop.large', location: 1, public_id: 'publicId', result_id: '1111'}],
-          triggered_check_ids: [],
         })
       )
 

--- a/src/commands/synthetics/api.ts
+++ b/src/commands/synthetics/api.ts
@@ -4,7 +4,7 @@ import {AxiosError, AxiosPromise, AxiosRequestConfig} from 'axios'
 
 import {getRequestBuilder} from '../../helpers/utils'
 
-import {APIConfiguration, APIHelper, Payload, PollResult, Test, TestSearchResult, Trigger} from './interfaces'
+import {APIConfiguration, Payload, PollResult, Test, TestSearchResult, Trigger} from './interfaces'
 import {ciTriggerApp, retry} from './utils'
 
 interface BackendError {
@@ -132,7 +132,7 @@ export const is5xxError = (error: AxiosError | EndpointError) => {
 const retryRequest = <T>(args: AxiosRequestConfig, request: (args: AxiosRequestConfig) => AxiosPromise<T>) =>
   retry(() => request(args), retryOn5xxErrors)
 
-export const apiConstructor = (configuration: APIConfiguration): APIHelper => {
+export const apiConstructor = (configuration: APIConfiguration) => {
   const {baseUrl, baseIntakeUrl, apiKey, appKey, proxyOpts} = configuration
   const baseOptions = {apiKey, appKey, proxyOpts}
   const request = getRequestBuilder({...baseOptions, baseUrl})
@@ -146,3 +146,5 @@ export const apiConstructor = (configuration: APIConfiguration): APIHelper => {
     triggerTests: triggerTests(requestIntake),
   }
 }
+
+export type APIHelper = ReturnType<typeof apiConstructor>

--- a/src/commands/synthetics/command.ts
+++ b/src/commands/synthetics/command.ts
@@ -9,8 +9,8 @@ import {
   ERRORS,
   LocationsMapping,
   MainReporter,
-  PollResult,
   Reporter,
+  Result,
   Summary,
   Test,
   Trigger,
@@ -71,7 +71,7 @@ export class RunTestCommand extends Command {
       )
     }
 
-    let results: {[key: string]: PollResult[]}
+    let results: Result[]
     let summary: Summary
     let tests: Test[]
     let triggers: Trigger
@@ -106,22 +106,7 @@ export class RunTestCommand extends Command {
     return `https://${this.config.subdomain}.${this.config.datadogSite}/`
   }
 
-  private renderResults(
-    results: {[key: string]: PollResult[]},
-    summary: Summary,
-    tests: Test[],
-    triggers: Trigger,
-    startTime: number
-  ) {
-    const getTest = (publicId: string) => tests.find((t) => t.public_id === publicId) as Test
-
-    const sortedPollResults = Object.entries(results)
-      .reduce<[Test, PollResult][]>(
-        (accResults, [publicId, pollResults]) => accResults.concat(pollResults.map((r) => [getTest(publicId), r])),
-        []
-      )
-      .sort(this.sortResultsByOutcome())
-
+  private renderResults(results: Result[], summary: Summary, tests: Test[], triggers: Trigger, startTime: number) {
     // Rendering the results.
     this.reporter?.reportStart({startTime})
 
@@ -145,16 +130,18 @@ export class RunTestCommand extends Command {
 
     let hasSucceeded = true // Determine if all the tests have succeeded
 
-    for (const [test, pollResult] of sortedPollResults) {
-      if (!this.config.failOnTimeout && pollResult.result.error === ERRORS.TIMEOUT) {
+    const sortedResults = results.sort(this.sortResultsByOutcome())
+
+    for (const result of sortedResults) {
+      if (!this.config.failOnTimeout && result.result.error === ERRORS.TIMEOUT) {
         summary.timedOut++
       }
 
-      if (!this.config.failOnCriticalErrors && isCriticalError(pollResult.result)) {
+      if (!this.config.failOnCriticalErrors && isCriticalError(result.result)) {
         summary.criticalErrors++
       }
 
-      const resultOutcome = getResultOutcome(test, pollResult)
+      const resultOutcome = getResultOutcome(result)
 
       if ([ResultOutcome.Passed, ResultOutcome.PassedNonBlocking].includes(resultOutcome)) {
         summary.passed++
@@ -165,7 +152,7 @@ export class RunTestCommand extends Command {
         hasSucceeded = false
       }
 
-      this.reporter?.testEnd(test, [pollResult], this.getAppBaseURL(), locationNames)
+      this.reporter?.testEnd(result.test, [result], this.getAppBaseURL(), locationNames)
     }
 
     this.reporter?.runEnd(summary)
@@ -285,12 +272,7 @@ export class RunTestCommand extends Command {
       [ResultOutcome.Failed]: 4,
     }
 
-    return ([t1, r1]: [Test, PollResult], [t2, r2]: [Test, PollResult]) => {
-      const outcome1 = getResultOutcome(t1, r1)
-      const outcome2 = getResultOutcome(t2, r2)
-
-      return outcomeWeight[outcome1] - outcomeWeight[outcome2]
-    }
+    return (r1: Result, r2: Result) => outcomeWeight[getResultOutcome(r1)] - outcomeWeight[getResultOutcome(r2)]
   }
 }
 

--- a/src/commands/synthetics/command.ts
+++ b/src/commands/synthetics/command.ts
@@ -154,12 +154,7 @@ export class RunTestCommand extends Command {
         summary.criticalErrors++
       }
 
-      const resultOutcome = getResultOutcome(
-        test,
-        pollResult,
-        this.config.failOnCriticalErrors,
-        this.config.failOnTimeout
-      )
+      const resultOutcome = getResultOutcome(test, pollResult)
 
       if ([ResultOutcome.Passed, ResultOutcome.PassedNonBlocking].includes(resultOutcome)) {
         summary.passed++
@@ -170,14 +165,7 @@ export class RunTestCommand extends Command {
         hasSucceeded = false
       }
 
-      this.reporter?.testEnd(
-        test,
-        [pollResult],
-        this.getAppBaseURL(),
-        locationNames,
-        this.config.failOnCriticalErrors,
-        this.config.failOnTimeout
-      )
+      this.reporter?.testEnd(test, [pollResult], this.getAppBaseURL(), locationNames)
     }
 
     this.reporter?.runEnd(summary)
@@ -298,8 +286,8 @@ export class RunTestCommand extends Command {
     }
 
     return ([t1, r1]: [Test, PollResult], [t2, r2]: [Test, PollResult]) => {
-      const outcome1 = getResultOutcome(t1, r1, this.config.failOnCriticalErrors, this.config.failOnTimeout)
-      const outcome2 = getResultOutcome(t2, r2, this.config.failOnCriticalErrors, this.config.failOnTimeout)
+      const outcome1 = getResultOutcome(t1, r1)
+      const outcome2 = getResultOutcome(t2, r2)
 
       return outcomeWeight[outcome1] - outcomeWeight[outcome2]
     }

--- a/src/commands/synthetics/interfaces.ts
+++ b/src/commands/synthetics/interfaces.ts
@@ -9,14 +9,7 @@ export interface MainReporter {
   reportStart(timings: {startTime: number}): void
   runEnd(summary: Summary): void
   // `testEnd` is called for each result
-  testEnd(
-    test: Test,
-    results: PollResult[],
-    baseUrl: string,
-    locationNames: LocationsMapping,
-    failOnCriticalErrors: boolean,
-    failOnTimeout: boolean
-  ): void
+  testEnd(test: Test, results: PollResult[], baseUrl: string, locationNames: LocationsMapping): void
   testResult(triggerResponse: TriggerResponse, result: PollResult): void
   testsWait(tests: Test[]): void
   testTrigger(test: Test, testId: string, executionRule: ExecutionRule, config: ConfigOverride): void
@@ -103,6 +96,8 @@ export interface PollResult {
   check_id?: string
   dc_id: number
   enrichment?: Partial<Enrichment>
+  // `.passed` here combines `result.passed` and `failOnCriticalErrors` and `failOnTimeout`
+  passed?: boolean
   result: Result
   resultID: string
   timestamp: number

--- a/src/commands/synthetics/interfaces.ts
+++ b/src/commands/synthetics/interfaces.ts
@@ -342,14 +342,6 @@ export interface TestSearchResult {
   }[]
 }
 
-export interface APIHelper {
-  getPresignedURL(testIds: string[]): Promise<{url: string}>
-  getTest(testId: string): Promise<Test>
-  pollResults(resultIds: string[]): Promise<{results: PollResult[]}>
-  searchTests(query: string): Promise<TestSearchResult>
-  triggerTests(payload: Payload): Promise<Trigger>
-}
-
 export interface APIConfiguration {
   apiKey: string
   appKey: string

--- a/src/commands/synthetics/reporters/junit.ts
+++ b/src/commands/synthetics/reporters/junit.ts
@@ -142,14 +142,7 @@ export class JUnitReporter implements Reporter {
     }
   }
 
-  public testEnd(
-    test: InternalTest,
-    results: PollResult[],
-    baseUrl: string,
-    locations: LocationsMapping,
-    failOnCriticalErrors: boolean,
-    failOnTimeout: boolean
-  ) {
+  public testEnd(test: InternalTest, results: PollResult[], baseUrl: string, locations: LocationsMapping) {
     const suiteRunName = test.suite || 'Undefined suite'
     let suiteRun = this.json.testsuites.testsuite.find((suite: XMLRun) => suite.$.name === suiteRunName)
 
@@ -168,7 +161,7 @@ export class JUnitReporter implements Reporter {
     }
 
     for (const result of results) {
-      const testCase: XMLTestCase = this.getTestCase(test, result, locations, failOnCriticalErrors, failOnTimeout)
+      const testCase: XMLTestCase = this.getTestCase(test, result, locations)
       // Timeout errors are only reported at the top level.
       if (result.result.error === ERRORS.TIMEOUT) {
         testCase.error.push({
@@ -340,15 +333,9 @@ export class JUnitReporter implements Reporter {
     return stats
   }
 
-  private getTestCase(
-    test: InternalTest,
-    result: PollResult,
-    locations: LocationsMapping,
-    failOnCriticalErrors: boolean,
-    failOnTimeout: boolean
-  ): XMLTestCase {
+  private getTestCase(test: InternalTest, result: PollResult, locations: LocationsMapping): XMLTestCase {
     const timeout = result.result.error === ERRORS.TIMEOUT
-    const resultOutcome = getResultOutcome(test, result, failOnCriticalErrors, failOnTimeout)
+    const resultOutcome = getResultOutcome(test, result)
     const passed = [ResultOutcome.Passed, ResultOutcome.PassedNonBlocking].includes(resultOutcome)
 
     return {

--- a/src/commands/synthetics/reporters/junit.ts
+++ b/src/commands/synthetics/reporters/junit.ts
@@ -6,13 +6,13 @@ import {Writable} from 'stream'
 import {Builder} from 'xml2js'
 
 import {
-  ApiTestResult,
+  ApiServerResult,
   ERRORS,
   InternalTest,
   LocationsMapping,
   MultiStep,
-  PollResult,
   Reporter,
+  Result,
   Step,
   Vitals,
 } from '../interfaces'
@@ -142,7 +142,7 @@ export class JUnitReporter implements Reporter {
     }
   }
 
-  public testEnd(test: InternalTest, results: PollResult[], baseUrl: string, locations: LocationsMapping) {
+  public testEnd(test: InternalTest, results: Result[], baseUrl: string, locations: LocationsMapping) {
     const suiteRunName = test.suite || 'Undefined suite'
     let suiteRun = this.json.testsuites.testsuite.find((suite: XMLRun) => suite.$.name === suiteRunName)
 
@@ -191,7 +191,7 @@ export class JUnitReporter implements Reporter {
     }
   }
 
-  private getApiStepStats(step: MultiStep | ApiTestResult): Stats {
+  private getApiStepStats(step: MultiStep | ApiServerResult): Stats {
     // TODO use more granular result based on step.assertionResults
     let allowfailures = 0
     let skipped = 0
@@ -292,7 +292,7 @@ export class JUnitReporter implements Reporter {
     }
   }
 
-  private getResultStats(result: PollResult, stats: Stats | undefined = getDefaultStats()): Stats {
+  private getResultStats(result: Result, stats: Stats | undefined = getDefaultStats()): Stats {
     let stepsStats: Stats[] = []
     if ('stepDetails' in result.result) {
       // It's a browser test.
@@ -325,7 +325,7 @@ export class JUnitReporter implements Reporter {
     return stats
   }
 
-  private getSuiteStats(results: PollResult[], stats: Stats | undefined = getDefaultStats()): Stats {
+  private getSuiteStats(results: Result[], stats: Stats | undefined = getDefaultStats()): Stats {
     for (const result of results) {
       stats = this.getResultStats(result, stats)
     }
@@ -333,9 +333,9 @@ export class JUnitReporter implements Reporter {
     return stats
   }
 
-  private getTestCase(test: InternalTest, result: PollResult, locations: LocationsMapping): XMLTestCase {
+  private getTestCase(test: InternalTest, result: Result, locations: LocationsMapping): XMLTestCase {
     const timeout = result.result.error === ERRORS.TIMEOUT
-    const resultOutcome = getResultOutcome(test, result)
+    const resultOutcome = getResultOutcome(result)
     const passed = [ResultOutcome.Passed, ResultOutcome.PassedNonBlocking].includes(resultOutcome)
 
     return {
@@ -350,7 +350,7 @@ export class JUnitReporter implements Reporter {
       error: [],
       properties: {
         property: [
-          {$: {name: 'check_id', value: result.check_id}},
+          {$: {name: 'check_id', value: result.test.public_id}},
           ...('device' in result.result
             ? [
                 {$: {name: 'device', value: result.result.device.id}},
@@ -359,12 +359,12 @@ export class JUnitReporter implements Reporter {
               ]
             : []),
           {$: {name: 'execution_rule', value: test.options.ci?.executionRule}},
-          {$: {name: 'location', value: locations[result.dc_id]}},
+          {$: {name: 'location', value: locations[result.dcId]}},
           {$: {name: 'message', value: test.message}},
           {$: {name: 'monitor_id', value: test.monitor_id}},
           {$: {name: 'passed', value: `${passed}`}},
           {$: {name: 'public_id', value: test.public_id}},
-          {$: {name: 'result_id', value: result.resultID}},
+          {$: {name: 'result_id', value: result.resultId}},
           ...('startUrl' in result.result ? [{$: {name: 'start_url', value: result.result.startUrl}}] : []),
           {$: {name: 'status', value: test.status}},
           {$: {name: 'tags', value: test.tags.join(',')}},

--- a/src/commands/synthetics/run-test.ts
+++ b/src/commands/synthetics/run-test.ts
@@ -1,6 +1,7 @@
 import {apiConstructor, APIHelper, isForbiddenError} from './api'
 import {CiError, CriticalError} from './errors'
 import {
+  CommandConfig,
   MainReporter,
   PollResult,
   Suite,
@@ -14,7 +15,7 @@ import {
 import {Tunnel} from './tunnel'
 import {getSuites, getTestsToTrigger, runTests, waitForResults} from './utils'
 
-export const executeTests = async (reporter: MainReporter, config: SyntheticsCIConfig, suites?: Suite[]) => {
+export const executeTests = async (reporter: MainReporter, config: CommandConfig, suites?: Suite[]) => {
   const api = getApiHelper(config)
 
   const publicIdsFromCli = config.publicIds.map((id) => ({config: config.global, id}))
@@ -110,7 +111,11 @@ export const executeTests = async (reporter: MainReporter, config: SyntheticsCIC
       api,
       triggers.results,
       testsToTrigger,
-      {defaultTimeout: config.pollingTimeout, failOnCriticalErrors: config.failOnCriticalErrors},
+      {
+        defaultTimeout: config.pollingTimeout,
+        failOnCriticalErrors: config.failOnCriticalErrors,
+        failOnTimeout: config.failOnTimeout,
+      },
       reporter,
       tunnel
     )

--- a/src/commands/synthetics/run-test.ts
+++ b/src/commands/synthetics/run-test.ts
@@ -104,9 +104,8 @@ export const executeTests = async (reporter: MainReporter, config: CommandConfig
     throw new CiError('NO_RESULTS_TO_POLL')
   }
 
-  let results: Result[] = []
   try {
-    results = await waitForResults(
+    const results = await waitForResults(
       api,
       triggers.results,
       testsToTrigger,
@@ -119,13 +118,13 @@ export const executeTests = async (reporter: MainReporter, config: CommandConfig
       reporter,
       tunnel
     )
+
+    return {results, summary, tests, triggers}
   } catch (error) {
     throw new CriticalError('POLL_RESULTS_FAILED', error.message)
   } finally {
     await stopTunnel()
   }
-
-  return {results, summary, tests, triggers}
 }
 
 export const getTestsList = async (

--- a/src/commands/synthetics/run-test.ts
+++ b/src/commands/synthetics/run-test.ts
@@ -1,7 +1,6 @@
-import {apiConstructor, isForbiddenError} from './api'
+import {apiConstructor, APIHelper, isForbiddenError} from './api'
 import {CiError, CriticalError} from './errors'
 import {
-  APIHelper,
   MainReporter,
   PollResult,
   Suite,

--- a/src/commands/synthetics/run-test.ts
+++ b/src/commands/synthetics/run-test.ts
@@ -3,7 +3,7 @@ import {CiError, CriticalError} from './errors'
 import {
   CommandConfig,
   MainReporter,
-  PollResult,
+  Result,
   Suite,
   Summary,
   SyntheticsCIConfig,
@@ -104,13 +104,13 @@ export const executeTests = async (reporter: MainReporter, config: CommandConfig
     throw new CiError('NO_RESULTS_TO_POLL')
   }
 
-  const results: {[key: string]: PollResult[]} = {}
+  let results: Result[] = []
   try {
-    // Poll the results.
-    const resultPolled = await waitForResults(
+    results = await waitForResults(
       api,
       triggers.results,
       testsToTrigger,
+      tests,
       {
         defaultTimeout: config.pollingTimeout,
         failOnCriticalErrors: config.failOnCriticalErrors,
@@ -119,7 +119,6 @@ export const executeTests = async (reporter: MainReporter, config: CommandConfig
       reporter,
       tunnel
     )
-    Object.assign(results, resultPolled)
   } catch (error) {
     throw new CriticalError('POLL_RESULTS_FAILED', error.message)
   } finally {

--- a/src/commands/synthetics/run-test.ts
+++ b/src/commands/synthetics/run-test.ts
@@ -3,7 +3,6 @@ import {CiError, CriticalError} from './errors'
 import {
   CommandConfig,
   MainReporter,
-  Result,
   Suite,
   Summary,
   SyntheticsCIConfig,

--- a/src/commands/synthetics/utils.ts
+++ b/src/commands/synthetics/utils.ts
@@ -1,3 +1,4 @@
+import deepExtend from 'deep-extend'
 import * as fs from 'fs'
 import * as path from 'path'
 import {URL} from 'url'
@@ -22,6 +23,7 @@ import {
   PollResult,
   Reporter,
   Result,
+  ServerResult,
   Suite,
   Summary,
   SyntheticsCIConfig,
@@ -162,12 +164,12 @@ const warnOnReservedEnvVarNames = (context: TemplateContext, reporter: MainRepor
   }
 }
 
-export const getExecutionRule = (test: InternalTest, configOverride?: ConfigOverride): ExecutionRule => {
+export const getExecutionRule = (test?: InternalTest, configOverride?: ConfigOverride): ExecutionRule => {
   if (configOverride && configOverride.executionRule) {
-    return getStrictestExecutionRule(configOverride.executionRule, test.options?.ci?.executionRule)
+    return getStrictestExecutionRule(configOverride.executionRule, test?.options?.ci?.executionRule)
   }
 
-  return test.options?.ci?.executionRule || ExecutionRule.BLOCKING
+  return test?.options?.ci?.executionRule || ExecutionRule.BLOCKING
 }
 
 export const getStrictestExecutionRule = (configRule: ExecutionRule, testRule?: ExecutionRule): ExecutionRule => {
@@ -186,9 +188,13 @@ export const getStrictestExecutionRule = (configRule: ExecutionRule, testRule?: 
   return ExecutionRule.BLOCKING
 }
 
-export const isCriticalError = (result: Result): boolean => result.unhealthy || result.error === ERRORS.ENDPOINT
+export const isCriticalError = (result: ServerResult): boolean => result.unhealthy || result.error === ERRORS.ENDPOINT
 
-export const hasResultPassed = (result: Result, failOnCriticalErrors: boolean, failOnTimeout: boolean): boolean => {
+export const hasResultPassed = (
+  result: ServerResult,
+  failOnCriticalErrors: boolean,
+  failOnTimeout: boolean
+): boolean => {
   if (isCriticalError(result) && !failOnCriticalErrors) {
     return true
   }
@@ -215,10 +221,10 @@ export const enum ResultOutcome {
   FailedNonBlocking = 'failed-non-blocking',
 }
 
-export const getResultOutcome = (test: Test, pollResult: PollResult): ResultOutcome => {
-  const executionRule = getExecutionRule(test, pollResult.enrichment?.config_override)
+export const getResultOutcome = (result: Result): ResultOutcome => {
+  const executionRule = getExecutionRule(result.test, result.enrichment?.config_override)
 
-  if (pollResult.passed) {
+  if (result.passed) {
     if (executionRule === ExecutionRule.NON_BLOCKING) {
       return ResultOutcome.PassedNonBlocking
     }
@@ -261,6 +267,7 @@ export const waitForResults = async (
   api: APIHelper,
   triggerResponses: TriggerResponse[],
   triggerConfigs: TriggerConfig[],
+  tests: Test[],
   options: {
     defaultTimeout: number
     failOnCriticalErrors?: boolean
@@ -268,11 +275,12 @@ export const waitForResults = async (
   },
   reporter: MainReporter,
   tunnel?: Tunnel
-) => {
-  const triggerResultMap = createTriggerResultMap(triggerResponses, options.defaultTimeout, triggerConfigs)
-  const triggerResults = [...triggerResultMap.values()]
+): Promise<Result[]> => {
+  const inProgressTriggers = createInProgressTriggers(triggerResponses, options.defaultTimeout, triggerConfigs)
+  const results: Result[] = []
 
-  const maxPollingTimeout = Math.max(...triggerResults.map((tr) => tr.pollingTimeout))
+  const maxPollingTimeout = Math.max(...[...inProgressTriggers].map((tr) => tr.pollingTimeout))
+
   const pollingStartDate = new Date().getTime()
 
   let isTunnelConnected = true
@@ -283,30 +291,40 @@ export const waitForResults = async (
       .catch(() => (isTunnelConnected = false))
   }
 
-  while (triggerResults.filter((tr) => !tr.result).length) {
+  const getTest = (id: string): Test => tests.find((t) => t.public_id === id)!
+
+  while (inProgressTriggers.size) {
     const pollingDuration = new Date().getTime() - pollingStartDate
 
     // Remove test which exceeded their pollingTimeout
-    for (const triggerResult of triggerResults.filter((tr) => !tr.result)) {
+    for (const triggerResult of inProgressTriggers) {
       if (pollingDuration >= triggerResult.pollingTimeout) {
-        triggerResult.result = createFailingResult(
+        inProgressTriggers.delete(triggerResult)
+        const result = createFailingResult(
           ERRORS.TIMEOUT,
           triggerResult.result_id,
           triggerResult.device,
           triggerResult.location,
+          getTest(triggerResult.public_id),
           !!tunnel
         )
+        result.passed = hasResultPassed(result.result, options.failOnCriticalErrors!!, options.failOnTimeout!!)
+        results.push(result)
       }
     }
 
     if (tunnel && !isTunnelConnected) {
-      for (const triggerResult of triggerResults.filter((tr) => !tr.result)) {
-        triggerResult.result = createFailingResult(
-          ERRORS.TUNNEL,
-          triggerResult.result_id,
-          triggerResult.device,
-          triggerResult.location,
-          !!tunnel
+      for (const triggerResult of inProgressTriggers) {
+        inProgressTriggers.delete(triggerResult)
+        results.push(
+          createFailingResult(
+            ERRORS.TUNNEL,
+            triggerResult.result_id,
+            triggerResult.device,
+            triggerResult.location,
+            getTest(triggerResult.public_id),
+            !!tunnel
+          )
         )
       }
     }
@@ -316,20 +334,23 @@ export const waitForResults = async (
     }
 
     let polledResults: PollResult[]
-    const triggerResultsSucceed = triggerResults.filter((tr) => !tr.result)
     try {
-      polledResults = (await api.pollResults(triggerResultsSucceed.map((tr) => tr.result_id))).results
+      polledResults = (await api.pollResults([...inProgressTriggers.values()].map((tr) => tr.result_id))).results
     } catch (error) {
       if (is5xxError(error) && !options.failOnCriticalErrors) {
         polledResults = []
-        for (const triggerResult of triggerResultsSucceed) {
-          triggerResult.result = createFailingResult(
+        for (const triggerResult of inProgressTriggers) {
+          inProgressTriggers.delete(triggerResult)
+          const result = createFailingResult(
             ERRORS.ENDPOINT,
             triggerResult.result_id,
             triggerResult.device,
             triggerResult.location,
+            getTest(triggerResult.public_id),
             !!tunnel
           )
+          result.passed = hasResultPassed(result.result, options.failOnCriticalErrors!!, options.failOnTimeout!!)
+          results.push(result)
         }
       } else {
         throw error
@@ -338,59 +359,58 @@ export const waitForResults = async (
 
     for (const polledResult of polledResults) {
       if (polledResult.result.eventType === 'finished') {
-        const triggeredResult = triggerResultMap.get(polledResult.resultID)
+        const triggeredResult = [...inProgressTriggers.values()].find((r) => r.result_id === polledResult.resultID)
         if (triggeredResult) {
-          triggeredResult.result = polledResult
-        }
-        const triggerResponse = triggerResponses.find((res) => res.result_id === polledResult.resultID)
-        if (triggerResponse) {
-          reporter.testResult(triggerResponse, polledResult)
+          inProgressTriggers.delete(triggeredResult)
+          const result: Result = {
+            dcId: polledResult.dc_id,
+            enrichment: polledResult.enrichment,
+            passed: hasResultPassed(polledResult.result, options.failOnCriticalErrors!!, options.failOnTimeout!!),
+            result: polledResult.result,
+            resultId: polledResult.resultID,
+            test: deepExtend(getTest(triggeredResult.public_id), polledResult.check),
+            timestamp: polledResult.timestamp,
+          }
+          results.push(result)
+
+          const triggerResponse = triggerResponses.find((res) => res.result_id === polledResult.resultID)
+          if (triggerResponse) {
+            reporter.testResult(triggerResponse, result)
+          }
         }
       }
     }
 
-    if (!triggerResults.filter((tr) => !tr.result).length) {
+    if (!inProgressTriggers.size) {
       break
     }
 
     await wait(POLLING_INTERVAL)
   }
 
-  for (const {result} of triggerResults) {
-    if (result) {
-      result.passed = hasResultPassed(result.result, options.failOnCriticalErrors!!, options.failOnTimeout!!)
-    }
-  }
-
-  // TODO: pass a list??
-  // Bundle results by public id
-  return triggerResults.reduce((resultsByPublicId, triggerResult) => {
-    const result = triggerResult.result! // The result exists, as either polled or filled with a timeout result
-    resultsByPublicId[triggerResult.public_id] = [...(resultsByPublicId[triggerResult.public_id] || []), result]
-
-    return resultsByPublicId
-  }, {} as {[key: string]: PollResult[]})
+  return results
 }
 
-export const createTriggerResultMap = (
+const createInProgressTriggers = (
   triggerResponses: TriggerResponse[],
   defaultTimeout: number,
   triggerConfigs: TriggerConfig[]
-): Map<string, TriggerResult> => {
+): Set<TriggerResult> => {
   const timeoutByPublicId: {[key: string]: number} = {}
   for (const trigger of triggerConfigs) {
     timeoutByPublicId[trigger.id] = trigger.config.pollingTimeout ?? defaultTimeout
   }
 
-  const triggerResultMap = new Map()
+  const inProgressTriggers = new Set<TriggerResult>()
+
   for (const triggerResponse of triggerResponses) {
-    triggerResultMap.set(triggerResponse.result_id, {
+    inProgressTriggers.add({
       ...triggerResponse,
       pollingTimeout: timeoutByPublicId[triggerResponse.public_id] ?? defaultTimeout,
     })
   }
 
-  return triggerResultMap
+  return inProgressTriggers
 }
 
 const createFailingResult = (
@@ -398,9 +418,10 @@ const createFailingResult = (
   resultId: string,
   deviceId: string,
   dcId: number,
+  test: Test,
   tunnel: boolean
-): PollResult => ({
-  dc_id: dcId,
+): Result => ({
+  dcId,
   passed: false,
   result: {
     device: {height: 0, id: deviceId, width: 0},
@@ -412,7 +433,8 @@ const createFailingResult = (
     stepDetails: [],
     tunnel,
   },
-  resultID: resultId,
+  resultId,
+  test,
   timestamp: 0,
 })
 
@@ -426,7 +448,7 @@ export const createSummary = (): Summary => ({
   timedOut: 0,
 })
 
-export const getResultDuration = (result: Result): number => {
+export const getResultDuration = (result: ServerResult): number => {
   if ('duration' in result) {
     return Math.round(result.duration)
   }

--- a/src/commands/synthetics/utils.ts
+++ b/src/commands/synthetics/utils.ts
@@ -10,10 +10,9 @@ import {getCIMetadata} from '../../helpers/ci'
 import {GIT_COMMIT_MESSAGE} from '../../helpers/tags'
 import {pick} from '../../helpers/utils'
 
-import {EndpointError, formatBackendErrors, is5xxError, isNotFoundError} from './api'
+import {APIHelper, EndpointError, formatBackendErrors, is5xxError, isNotFoundError} from './api'
 import {CiError} from './errors'
 import {
-  APIHelper,
   ConfigOverride,
   ERRORS,
   ExecutionRule,


### PR DESCRIPTION
### What and why?

Preliminary PR to prepare the batch endpoint. A review commit by commit is advised.

### How?

This PR is split into 4 commits:
1. Stop typing `APIHelper` and infer from actual typings
2. Stop passing `failOnCriticalErrors` and `failOnTimeout` everywhere to get the "status" of a result. This is done by adding a property `.passed` at the root level of the result object, that takes into account those two parameters.
3. Simplify `waitForResults` output and handling of results afterwards:
    - return a flat list of results
    - clearly separate `PollResult` (what's returned by the API) from a new object `Result` which the object we built internally that contains all the fields necessary from the start. Also type `Result.result` as `ServerResult` to indicate the part of `Result` that is directly given by the server.
    - Note: the signature of `waitForResults` is  now even more complex, this could be simplified but this PR was already bigger than expected, so more cleaning will be done in another PR.
4. Fix the tests

More generally, this PR tries to introduce two principles:
- separate typings of the API which should only strictly type what's returned from the typings of our internal objects, with the format that we want
- build complete objects from the start, as much as possible, and avoids mutating objects along the way