### PR TITLE
[deps] bump axios to 0.21.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@types/datadog-metrics": "0.6.1",
     "async-retry": "1.3.1",
     "aws-sdk": "2.1012.0",
-    "axios": "0.21.2",
+    "axios": "0.21.4",
     "chalk": "3.0.0",
     "clipanion": "2.2.2",
     "datadog-metrics": "0.9.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1915,10 +1915,10 @@ aws-sdk@2.1012.0:
     uuid "3.3.2"
     xml2js "0.4.19"
 
-axios@0.21.2:
-  version "0.21.2"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.2.tgz#21297d5084b2aeeb422f5d38e7be4fbb82239017"
-  integrity sha512-87otirqUw3e8CzHTMO+/9kh/FSgXt/eVDvipijwDtEuwbkySWZ9SBm6VEubmJ/kLKEoLQV/POhxXFb66bfekfg==
+axios@0.21.4:
+  version "0.21.4"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.4.tgz#c67b90dc0568e5c1cf2b0b858c43ba28e2eda575"
+  integrity sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==
   dependencies:
     follow-redirects "^1.14.0"
 


### PR DESCRIPTION
### What and why?

This PR bumps axios to version 0.21.4 to fix https://github.com/DataDog/datadog-ci/issues/549
