### PR TITLE
Sdeprez/add batch endpoint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
       - run: yarn install --immutable
       - run: yarn build
       - run: yarn lint
+      - run: yarn no-only-in-tests
       - run: yarn test
         env:
           CI: true

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "launch": "ts-node --transpile-only src/cli.ts",
     "launch:debug": "node -r ts-node/register/transpile-only --inspect-brk src/cli.ts",
     "lint": "(yarn tslint && yarn prettier --check) || (echo \"\nYou can fix this by running ==> yarn format <==\n\" && false)",
+    "no-only-in-tests": "grep -R \"\\.only[(\\.]\" $(find src -name '*.ts' | grep '__tests__'); test $? -eq 1 || (echo '.only was found in the tests, please remove it.' && false)",
     "prepack": "yarn build && node ./bin/make-it-executable.js",
     "prettier": "prettier \"src/**/*.{ts,js,json,yml}\" --ignore-path .gitignore",
     "test": "jest --colors",

--- a/src/commands/synthetics/__tests__/api.test.ts
+++ b/src/commands/synthetics/__tests__/api.test.ts
@@ -23,6 +23,7 @@ describe('dd-api', () => {
     region: 'fake-region',
   }
   const RESULT_ID = '123'
+  const BATCH_ID = 'bid'
   const POLL_RESULTS: {results: PollResult[]} = {
     results: [
       {
@@ -35,15 +36,8 @@ describe('dd-api', () => {
   }
   const TRIGGERED_TEST_ID = 'fakeId'
   const TRIGGER_RESULTS: Trigger = {
+    batch_id: BATCH_ID,
     locations: [LOCATION],
-    results: [
-      {
-        device: 'laptop_large',
-        location: 42,
-        public_id: TRIGGERED_TEST_ID,
-        result_id: RESULT_ID,
-      },
-    ],
   }
   const PRESIGNED_URL_PAYLOAD = {
     url: 'wss://presigned.url',
@@ -52,8 +46,7 @@ describe('dd-api', () => {
   test('should get results from api', async () => {
     jest.spyOn(axios, 'create').mockImplementation((() => () => ({data: POLL_RESULTS})) as any)
     const api = apiConstructor(apiConfiguration)
-    const {pollResults} = api
-    const {results} = await pollResults([RESULT_ID])
+    const results = await api.pollResults([RESULT_ID])
     expect(results[0].resultID).toBe(RESULT_ID)
   })
 
@@ -62,9 +55,8 @@ describe('dd-api', () => {
     const api = apiConstructor(apiConfiguration)
     const {triggerTests} = api
     const tests: TestPayload[] = [{public_id: TRIGGERED_TEST_ID, executionRule: ExecutionRule.BLOCKING}]
-    const {results} = await triggerTests({tests})
-    expect(results[0].public_id).toBe(TRIGGERED_TEST_ID)
-    expect(results[0].result_id).toBe(RESULT_ID)
+    const {batch_id: batchId} = await triggerTests({tests})
+    expect(batchId).toBe(BATCH_ID)
   })
 
   test('should retry request that failed with code 5xx', async () => {

--- a/src/commands/synthetics/__tests__/reporters/__snapshots__/default.test.ts.snap
+++ b/src/commands/synthetics/__tests__/reporters/__snapshots__/default.test.ts.snap
@@ -1,6 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Default reporter resultEnd 1 API test (blocking), 1 location, 3 results: success, failed non-blocking, failed 1`] = `
+exports[`Default reporter resultEnd 1 API test, 1 location, 1 result: success 1`] = `
+"[1m[32m✓[39m[22m [[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m - [1m[32mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m
+  ⎋ Total duration: 123 ms - Result URL: [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=1&from_ci=true[39m[22m 
+  [1m[32m✓[39m[22m [1m[32m[1mGET[22m[1m - http://fake.url[39m[22m
+
+"
+`;
+
+exports[`Default reporter resultEnd 1 API test, 1 location, 3 results: success, failed non-blocking, failed blocking 1`] = `
 "[1m[32m✓[39m[22m [[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m - [1m[32mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m
   ⎋ Total duration: 123 ms - Result URL: [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=1&from_ci=true[39m[22m 
   [1m[32m✓[39m[22m [1m[32m[1mGET[22m[1m - http://fake.url[39m[22m
@@ -16,34 +24,6 @@ exports[`Default reporter resultEnd 1 API test (blocking), 1 location, 3 results
   [1m[31m✖[39m[22m [1m[31m[1mGET[22m[1m - http://fake.url[39m[22m
 [1m[31m  - Assertion(s) failed:[39m[22m
 [1m[31m    ▶ responseTime should be less than [4m1000[24m. Actual: [4m1234[24m[39m[22m
-
-"
-`;
-
-exports[`Default reporter resultEnd 1 API test (non-blocking), 1 location, 3 results: success, failed non-blocking, failed 1`] = `
-"[1m[32m✓[39m[22m [[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m - [1m[32mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m
-  ⎋ Total duration: 123 ms - Result URL: [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=1&from_ci=true[39m[22m 
-  [1m[32m✓[39m[22m [1m[32m[1mGET[22m[1m - http://fake.url[39m[22m
-
-[1m[33m✖[39m[22m [[1m[33mnon-blocking[39m[22m] [[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m - [1m[33mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m
-  ⎋ Total duration: 123 ms - Result URL: [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=2&from_ci=true[39m[22m 
-  [1m[33m✖[39m[22m [1m[33m[1mGET[22m[1m - http://fake.url[39m[22m
-[1m[33m  - Assertion(s) failed:[39m[22m
-[1m[33m    ▶ responseTime should be less than [4m1000[24m. Actual: [4m1234[24m[39m[22m
-
-[1m[33m✖[39m[22m [[1m[33mnon-blocking[39m[22m] [[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m - [1m[33mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m
-  ⎋ Total duration: 123 ms - Result URL: [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=3&from_ci=true[39m[22m 
-  [1m[33m✖[39m[22m [1m[33m[1mGET[22m[1m - http://fake.url[39m[22m
-[1m[33m  - Assertion(s) failed:[39m[22m
-[1m[33m    ▶ responseTime should be less than [4m1000[24m. Actual: [4m1234[24m[39m[22m
-
-"
-`;
-
-exports[`Default reporter resultEnd 1 API test, 1 location, 1 result: success 1`] = `
-"[1m[32m✓[39m[22m [[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m - [1m[32mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m
-  ⎋ Total duration: 123 ms - Result URL: [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=1&from_ci=true[39m[22m 
-  [1m[32m✓[39m[22m [1m[32m[1mGET[22m[1m - http://fake.url[39m[22m
 
 "
 `;

--- a/src/commands/synthetics/__tests__/reporters/default.test.ts
+++ b/src/commands/synthetics/__tests__/reporters/default.test.ts
@@ -92,7 +92,7 @@ describe('Default reporter', () => {
     })
   })
 
-  describe.only('resultEnd', () => {
+  describe('resultEnd', () => {
     const createApiResult = (
       resultId: string,
       passed: boolean,

--- a/src/commands/synthetics/__tests__/reporters/junit.test.ts
+++ b/src/commands/synthetics/__tests__/reporters/junit.test.ts
@@ -1,7 +1,7 @@
 // tslint:disable: no-string-literal
 import {promises as fs} from 'fs'
 import {Writable} from 'stream'
-import {ERRORS, Result} from '../../interfaces'
+import {Result} from '../../interfaces'
 
 import {RunTestCommand} from '../../command'
 import {getDefaultStats, JUnitReporter, XMLTestCase} from '../../reporters/junit'
@@ -119,7 +119,7 @@ describe('Junit reporter', () => {
     })
 
     it('should report errors', () => {
-      const browserResult1 = {
+      const browserResult1: Result = {
         ...globalResultMock,
         result: {
           ...getBrowserServerResult(),
@@ -151,15 +151,16 @@ describe('Junit reporter', () => {
           ],
         },
       }
-      const browserResult2 = {
+      const browserResult2: Result = {
         ...globalResultMock,
         result: getBrowserServerResult(),
       }
-      const browserResult3 = {
+      const browserResult3: Result = {
         ...globalResultMock,
-        result: {...getBrowserServerResult(), error: ERRORS.TIMEOUT},
+        result: {...getBrowserServerResult(), error: 'Timeout'},
+        timedOut: true,
       }
-      const apiResult = {
+      const apiResult: Result = {
         ...globalResultMock,
         result: {
           ...getMultiStepsServerResult(),

--- a/src/commands/synthetics/__tests__/run-test.test.ts
+++ b/src/commands/synthetics/__tests__/run-test.test.ts
@@ -181,8 +181,9 @@ describe('run-test', () => {
       jest.spyOn(utils, 'runTests').mockResolvedValue(mockTestTriggerResponse)
 
       const apiHelper = {
+        getBatch: () => ({results: []}),
         getPresignedURL: () => ({url: 'url'}),
-        pollResults: () => ({results: [getApiResult('1', getApiTest())]}),
+        pollResults: () => [getApiResult('1', getApiTest())],
         triggerTests: () => mockTestTriggerResponse,
       }
 
@@ -316,8 +317,8 @@ describe('run-test', () => {
 
       jest.spyOn(utils, 'runTests').mockReturnValue(
         Promise.resolve({
+          batch_id: 'bid',
           locations: [location],
-          results: [{device: 'chrome_laptop.large', location: 1, public_id: 'publicId', result_id: '1111'}],
         })
       )
 
@@ -326,6 +327,7 @@ describe('run-test', () => {
       serverError.config = {baseURL: 'baseURL', url: 'url'}
 
       const apiHelper = {
+        getBatch: () => ({results: []}),
         getPresignedURL: () => ({url: 'url'}),
         pollResults: jest.fn(() => {
           throw serverError
@@ -340,7 +342,12 @@ describe('run-test', () => {
           publicIds: ['public-id-1', 'public-id-2'],
           tunnel: true,
         })
-      ).rejects.toMatchError(new CriticalError('POLL_RESULTS_FAILED', 'Server Error'))
+      ).rejects.toMatchError(
+        new CriticalError(
+          'POLL_RESULTS_FAILED',
+          'Failed to poll results: query on baseURLurl returned: "Bad Gateway"\n'
+        )
+      )
       expect(stopTunnelSpy).toHaveBeenCalledTimes(1)
     })
   })
@@ -394,6 +401,7 @@ describe('run-test', () => {
       )
     })
   })
+
   describe('getTestsList', () => {
     beforeEach(() => {
       jest.restoreAllMocks()

--- a/src/commands/synthetics/errors.ts
+++ b/src/commands/synthetics/errors.ts
@@ -1,5 +1,5 @@
 /* tslint:disable:max-classes-per-file */
-const nonCriticalErrorCodes = ['NO_TESTS_TO_RUN', 'NO_RESULTS_TO_POLL'] as const
+const nonCriticalErrorCodes = ['NO_TESTS_TO_RUN'] as const
 export type NonCriticalCiErrorCode = typeof nonCriticalErrorCodes[number]
 
 const criticalErrorCodes = [

--- a/src/commands/synthetics/interfaces.ts
+++ b/src/commands/synthetics/interfaces.ts
@@ -99,24 +99,29 @@ export interface Result {
 
 type Status = 'passed' | 'failed' | 'in_progress'
 
-export interface ServerResultInBatch {
+export interface ResultInBatch {
   execution_rule: ExecutionRule
   location: string
-  // Skipped results do not have a result id.
-  result_id?: string
-  status: Status | 'skipped'
+  result_id: string
+  status: Status
   test_public_id: string
   timed_out: boolean
 }
 
-export interface ServerBatch {
-  results: ServerResultInBatch[]
+export interface Batch {
+  results: ResultInBatch[]
   status: Status
 }
 
-export interface Batch {
-  // We don't care about skipped results internally.
-  results: (ServerResultInBatch & {result_id: string; status: Status})[]
+interface SkippedResultInBatch extends Omit<ResultInBatch, 'result_id' | 'status'> {
+  status: 'skipped'
+}
+type ServerResultInBatch = SkippedResultInBatch | ResultInBatch
+
+export interface ServerBatch {
+  // The batch from the server contains skipped results, which we're going to remove since we don't
+  // care about skipped results internally.
+  results: ServerResultInBatch[]
   status: Status
 }
 

--- a/src/commands/synthetics/reporters/junit.ts
+++ b/src/commands/synthetics/reporters/junit.ts
@@ -5,7 +5,7 @@ import path from 'path'
 import {Writable} from 'stream'
 import {Builder} from 'xml2js'
 
-import {ApiServerResult, ERRORS, MultiStep, Reporter, Result, Step, Vitals} from '../interfaces'
+import {ApiServerResult, MultiStep, Reporter, Result, Step, Vitals} from '../interfaces'
 import {getResultDuration, getResultOutcome, ResultOutcome} from '../utils'
 
 interface Stats {
@@ -140,10 +140,10 @@ export class JUnitReporter implements Reporter {
 
     const testCase: XMLTestCase = this.getTestCase(result)
     // Timeout errors are only reported at the top level.
-    if (result.result.error === ERRORS.TIMEOUT) {
+    if (result.timedOut) {
       testCase.error.push({
         $: {type: 'timeout'},
-        _: result.result.error,
+        _: String(result.result.error),
       })
     }
     if ('stepDetails' in result.result) {
@@ -315,7 +315,6 @@ export class JUnitReporter implements Reporter {
 
   private getTestCase(result: Result): XMLTestCase {
     const test = result.test
-    const timeout = result.result.error === ERRORS.TIMEOUT
     const resultOutcome = getResultOutcome(result)
     const passed = [ResultOutcome.Passed, ResultOutcome.PassedNonBlocking].includes(resultOutcome)
 
@@ -349,7 +348,7 @@ export class JUnitReporter implements Reporter {
           ...('startUrl' in result.result ? [{$: {name: 'start_url', value: result.result.startUrl}}] : []),
           {$: {name: 'status', value: test.status}},
           {$: {name: 'tags', value: test.tags.join(',')}},
-          {$: {name: 'timeout', value: `${timeout}`}},
+          {$: {name: 'timeout', value: `${result.timedOut}`}},
           {$: {name: 'type', value: test.type}},
         ].filter((prop) => prop.$.value),
       },

--- a/src/commands/synthetics/run-test.ts
+++ b/src/commands/synthetics/run-test.ts
@@ -104,21 +104,16 @@ export const executeTests = async (reporter: MainReporter, config: CommandConfig
     throw new CriticalError('TRIGGER_TESTS_FAILED', error.message)
   }
 
-  if (!triggers.results) {
-    await stopTunnel()
-    throw new CiError('NO_RESULTS_TO_POLL')
-  }
-
   try {
+    const maxPollingTimeout = Math.max(...testsToTrigger.map((t) => t.config.pollingTimeout || config.pollingTimeout))
     const results = await waitForResults(
       api,
       triggers,
-      testsToTrigger,
       tests,
       {
-        defaultTimeout: config.pollingTimeout,
         failOnCriticalErrors: config.failOnCriticalErrors,
         failOnTimeout: config.failOnTimeout,
+        maxPollingTimeout,
       },
       reporter,
       tunnel


### PR DESCRIPTION
### What and why?

Add the [get batch endpoint](https://docs.datadoghq.com/api/latest/synthetics/#get-details-of-batch).

### How?

The main change is in the `waitForResults` function where:
- before: continuously poll the results until they are all finished, computed timeouts on `datadog-ci` side
- after: continuously poll the batch until it's over, then at the end poll the results once to get full data. Also use the timeout from the batch data, which is the source of truth

I've made some changes around the handling of critical errors on tunnel and endpoints to simplify:
- for errors on endpoint calls: before we were keeping the results already finished and marking the other ones with an `ERROR.ENDPOINT`. I simplified that to have those errors critical and stopping everything, without preserving any results and with a simplified output. `failOncriticalErrors` is still respected though. 
- for errors on tunnel: before we applied a similar logic than for endpoints errors, now we only emit [an error](https://github.com/DataDog/datadog-ci/pull/551/files#diff-741a985551714cec0c6f7a6423d704525619e8f57db6c4f7c685d95d88a8d0cfR326)  
