### PR TITLE
[synthetics] Use locations env var for tests triggered with -p flag

### DIFF
--- a/src/commands/synthetics/run-test.ts
+++ b/src/commands/synthetics/run-test.ts
@@ -17,7 +17,13 @@ import {getSuites, getTestsToTrigger, runTests, waitForResults} from './utils'
 export const executeTests = async (reporter: MainReporter, config: CommandConfig, suites?: Suite[]) => {
   const api = getApiHelper(config)
 
-  const publicIdsFromCli = config.publicIds.map((id) => ({config: config.global, id}))
+  const publicIdsFromCli = config.publicIds.map((id) => ({
+    config: {
+      ...config.global,
+      ...(config.locations?.length ? {locations: config.locations} : {}),
+    },
+    id,
+  }))
   let testsToTrigger: TriggerConfig[]
   let tunnel: Tunnel | undefined
 


### PR DESCRIPTION
### What and why?

Currently, when a test is triggered with the `--public-id` (or `-p`) flag, only the locations set in the `global` config of the `datadog-ci.json` file are taken into account. The locations set with the env variable `DATADOG_SYNTHETICS_LOCATIONS` are ignored.

This PR fixes this issue:
* If locations are defined with the env variable, they are used.
* Otherwise, the locations from the `global` config are used.

### How?

When creating the config for tests triggered by public-id, we override the `locations` property defined in the `global` config with the `locations` from the `config`, which were retrieved from the `DATADOG_SYNTHETICS_LOCATIONS` env variable in the `command -> resolveConfig` method.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] \[_Synthetics_\] New releases of `datadog-ci` MUST be followed by a [synthetics-ci-github-action](https://github.com/DataDog/synthetics-ci-github-action) release
