### PR TITLE
v1.7.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "description": "Run datadog actions from the CI.",
   "repository": "https://github.com/DataDog/datadog-ci",
   "license": "Apache-2.0",


### PR DESCRIPTION
### What and why?

This PR releases version 1.7.2 of the package, including:

* https://github.com/DataDog/datadog-ci/pull/553
