### PR TITLE
To support Java and .NET including 6.0 universal instrumentation

### DIFF
--- a/src/commands/lambda/__tests__/functions/versionChecker.test.ts
+++ b/src/commands/lambda/__tests__/functions/versionChecker.test.ts
@@ -1,0 +1,41 @@
+import {RuntimeType} from '../../constants'
+import {
+  isExtensionCompatibleWithTrace,
+  isExtensionSupportUniversalInstrumentation,
+} from '../../functions/versionChecker'
+
+describe(`Test extension and trace version checker`, () => {
+  test.each`
+    runtimeType           | extensionVersion | result
+    ${RuntimeType.JAVA}   | ${27}            | ${true}
+    ${RuntimeType.JAVA}   | ${23}            | ${false}
+    ${RuntimeType.JAVA}   | ${undefined}     | ${false}
+    ${RuntimeType.DOTNET} | ${27}            | ${true}
+    ${RuntimeType.DOTNET} | ${23}            | ${false}
+    ${RuntimeType.DOTNET} | ${undefined}     | ${false}
+    ${RuntimeType.NODE}   | ${27}            | ${true}
+    ${RuntimeType.PYTHON} | ${23}            | ${true}
+  `(
+    `should function isExtensionSupportUniversalInstrumentation() return $result if runtimeType=$runtimeType and extensionVersion=$extensionVersion`,
+    ({runtimeType, extensionVersion, result}) => {
+      expect(isExtensionSupportUniversalInstrumentation(runtimeType, extensionVersion)).toEqual(result)
+    }
+  )
+
+  test.each`
+    runtimeType           | traceVersion | result
+    ${RuntimeType.JAVA}   | ${5}         | ${true}
+    ${RuntimeType.JAVA}   | ${4}         | ${false}
+    ${RuntimeType.JAVA}   | ${undefined} | ${true}
+    ${RuntimeType.DOTNET} | ${3}         | ${false}
+    ${RuntimeType.DOTNET} | ${4}         | ${true}
+    ${RuntimeType.DOTNET} | ${undefined} | ${true}
+    ${RuntimeType.NODE}   | ${8}         | ${true}
+    ${RuntimeType.PYTHON} | ${2}         | ${true}
+  `(
+    `should function isExtensionCompatibleWithTrace() return $result if runtimeType=$runtimeType and traceVersion=$traceVersion`,
+    ({runtimeType, traceVersion, result}) => {
+      expect(isExtensionCompatibleWithTrace(runtimeType, traceVersion)).toEqual(result)
+    }
+  )
+})

--- a/src/commands/lambda/__tests__/instrument.test.ts
+++ b/src/commands/lambda/__tests__/instrument.test.ts
@@ -1504,50 +1504,6 @@ ${red('[Error]')} Couldn't fetch Lambda functions. Error: Max retry count exceed
 `)
       })
 
-      test('aborts early when a layer version is set for Java', async () => {
-        ;(fs.readFile as any).mockImplementation((a: any, b: any, callback: any) => callback({code: 'ENOENT'}))
-        ;(Lambda as any).mockImplementation(() =>
-          makeMockLambda({
-            'arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world': {
-              FunctionArn: 'arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world',
-              Runtime: 'java8.al2',
-            },
-          })
-        )
-        const cli = makeCli()
-        const context = createMockContext() as any
-        const functionARN = 'arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world'
-        process.env.DATADOG_API_KEY = '1234'
-        const code = await cli.run(
-          [
-            'lambda',
-            'instrument',
-            '-f',
-            functionARN,
-            '--dry',
-            '-v',
-            '6',
-            '--extra-tags',
-            'layer:api,team:intake',
-            '--service',
-            'middletier',
-            '--env',
-            'staging',
-            '--version',
-            '0.2',
-          ],
-          context
-        )
-        const output = context.stdout.toString()
-        expect(code).toBe(1)
-        expect(output).toMatchInlineSnapshot(`
-"${red(
-          '[Error]'
-        )} Couldn't fetch Lambda functions. Error: Only the --extension-version argument should be set for the java8.al2 runtime. Please remove the --layer-version argument from the instrument command.
-"
-`)
-      })
-
       test('aborts early when a layer version is set for Ruby', async () => {
         ;(fs.readFile as any).mockImplementation((a: any, b: any, callback: any) => callback({code: 'ENOENT'}))
         ;(Lambda as any).mockImplementation(() =>

--- a/src/commands/lambda/constants.ts
+++ b/src/commands/lambda/constants.ts
@@ -4,6 +4,9 @@ export const DOTNET_RUNTIME = 'dotnetcore3.1'
 export const LAYER_LOOKUP = {
   [EXTENSION_LAYER_KEY]: DD_LAMBDA_EXTENSION_LAYER_NAME,
   'dotnetcore3.1': 'dd-trace-dotnet',
+  dotnet6: 'dd-trace-dotnet',
+  java11: 'dd-trace-java',
+  'java8.al2': 'dd-trace-java',
   'nodejs12.x': 'Datadog-Node12-x',
   'nodejs14.x': 'Datadog-Node14-x',
   'nodejs16.x': 'Datadog-Node16-x',
@@ -24,6 +27,7 @@ export enum RuntimeType {
 
 export const RUNTIME_LOOKUP = {
   'dotnetcore3.1': RuntimeType.DOTNET,
+  dotnet6: RuntimeType.DOTNET,
   java11: RuntimeType.JAVA,
   'java8.al2': RuntimeType.JAVA,
   'nodejs12.x': RuntimeType.NODE,
@@ -59,6 +63,10 @@ export const DEFAULT_LAYER_AWS_ACCOUNT = '464622532012'
 export const GOVCLOUD_LAYER_AWS_ACCOUNT = '002406178527'
 export const SUBSCRIPTION_FILTER_NAME = 'datadog-ci-filter'
 export const TAG_VERSION_NAME = 'dd_sls_ci'
+
+// Env variables for Univeral instrument lambda exec wrapper
+export const AWS_LAMBDA_EXEC_WRAPPER_VAR = 'AWS_LAMBDA_EXEC_WRAPPER'
+export const AWS_LAMBDA_EXEC_WRAPPER = '/opt/datadog_wrapper'
 
 // Export const values for .NET tracer
 export const CORECLR_ENABLE_PROFILING = '1'

--- a/src/commands/lambda/functions/instrument.ts
+++ b/src/commands/lambda/functions/instrument.ts
@@ -38,6 +38,8 @@ import {
   SITES,
   TRACE_ENABLED_ENV_VAR,
   VERSION_ENV_VAR,
+  AWS_LAMBDA_EXEC_WRAPPER_VAR,
+  AWS_LAMBDA_EXEC_WRAPPER,
 } from '../constants'
 import {FunctionConfiguration, InstrumentationSettings, LogGroupConfiguration, TagConfiguration} from '../interfaces'
 import {calculateLogGroupUpdateRequest} from '../loggroup'
@@ -53,6 +55,7 @@ import {
   isLayerRuntime,
   isSupportedRuntime,
 } from './commons'
+import {isExtensionCompatibleWithTrace, isExtensionSupportUniversalInstrumentation} from './versionChecker'
 
 export const getInstrumentedFunctionConfigs = async (
   lambda: Lambda,
@@ -146,12 +149,9 @@ export const calculateUpdateRequest = async (
     FunctionName: functionARN,
   }
   let needsUpdate = false
+  let runtimeType = RUNTIME_LOOKUP[runtime]
 
-  if (
-    RUNTIME_LOOKUP[runtime] === RuntimeType.JAVA ||
-    RUNTIME_LOOKUP[runtime] === RuntimeType.CUSTOM ||
-    RUNTIME_LOOKUP[runtime] === RuntimeType.RUBY
-  ) {
+  if (runtimeType === RuntimeType.CUSTOM || runtimeType === RuntimeType.RUBY) {
     if (settings.layerVersion !== undefined) {
       throw new Error(
         `Only the --extension-version argument should be set for the ${runtime} runtime. Please remove the --layer-version argument from the instrument command.`
@@ -160,7 +160,7 @@ export const calculateUpdateRequest = async (
   }
 
   // We don't support ARM Architecture for .NET at this time. Abort instrumentation if the combination is detected.
-  if (RUNTIME_LOOKUP[runtime] === RuntimeType.DOTNET) {
+  if (runtimeType === RuntimeType.DOTNET) {
     if (config.Architectures?.includes(ARM64_ARCHITECTURE)) {
       throw new Error(
         'Instrumenting arm64 architecture is not currently supported for .NET. Please only instrument .NET functions using x86_64 architecture.'
@@ -169,7 +169,7 @@ export const calculateUpdateRequest = async (
   }
 
   // Update Python Handler
-  if (RUNTIME_LOOKUP[runtime] === RuntimeType.PYTHON) {
+  if (runtimeType === RuntimeType.PYTHON) {
     const expectedHandler = PYTHON_HANDLER_LOCATION
     if (config.Handler !== expectedHandler) {
       needsUpdate = true
@@ -178,7 +178,7 @@ export const calculateUpdateRequest = async (
   }
 
   // Update Node Handler
-  if (RUNTIME_LOOKUP[runtime] === RuntimeType.NODE) {
+  if (runtimeType === RuntimeType.NODE) {
     const expectedHandler = NODE_HANDLER_LOCATION
     if (config.Handler !== expectedHandler) {
       needsUpdate = true
@@ -187,7 +187,7 @@ export const calculateUpdateRequest = async (
   }
 
   // Update Env Vars
-  if (RUNTIME_LOOKUP[runtime] === RuntimeType.PYTHON || RUNTIME_LOOKUP[runtime] === RuntimeType.NODE) {
+  if (runtimeType === RuntimeType.PYTHON || runtimeType === RuntimeType.NODE) {
     if (oldEnvVars[LAMBDA_HANDLER_ENV_VAR] === undefined) {
       needsUpdate = true
       changedEnvVars[LAMBDA_HANDLER_ENV_VAR] = config.Handler ?? ''
@@ -199,7 +199,7 @@ export const calculateUpdateRequest = async (
     needsUpdate = true
     changedEnvVars[KMS_API_KEY_ENV_VAR] = apiKmsKey
   } else if (apiKeySecretArn !== undefined && oldEnvVars[API_KEY_SECRET_ARN_ENV_VAR] !== apiKeySecretArn) {
-    const isNode = RUNTIME_LOOKUP[runtime] === RuntimeType.NODE
+    const isNode = runtimeType === RuntimeType.NODE
     const isSendingSynchronousMetrics = settings.extensionVersion === undefined && !settings.flushMetricsToLogs
     if (isSendingSynchronousMetrics && isNode) {
       throw new Error(
@@ -267,46 +267,64 @@ export const calculateUpdateRequest = async (
     }
   }
 
-  if (runtime === DOTNET_RUNTIME) {
-    needsUpdate = true
-    newEnvVars[ENABLE_PROFILING_ENV_VAR] = CORECLR_ENABLE_PROFILING
-    newEnvVars[PROFILER_ENV_VAR] = CORECLR_PROFILER
-    newEnvVars[PROFILER_PATH_ENV_VAR] = CORECLR_PROFILER_PATH
-    newEnvVars[DOTNET_TRACER_HOME_ENV_VAR] = DD_DOTNET_TRACER_HOME
-  }
-
-  updateRequest.Environment = {
-    Variables: newEnvVars,
-  }
-
   let layerARNs = getLayers(config)
   const originalLayerARNs = layerARNs
   let needsLayerUpdate = false
+  let layerOrTraceVersion: number | undefined
   if (isLayerRuntime(runtime)) {
     const lambdaLibraryLayerArn = getLayerArn(config, config.Runtime as LayerKey, region, settings)
     const lambdaLibraryLayerName = LAYER_LOOKUP[runtime as LayerKey]
     let fullLambdaLibraryLayerARN: string | undefined
     if (settings.layerVersion !== undefined || settings.interactive) {
-      let layerVersion = settings.layerVersion
+      layerOrTraceVersion = settings.layerVersion
       if (settings.interactive && !settings.layerVersion) {
-        layerVersion = await findLatestLayerVersion(config.Runtime as LayerKey, region)
+        layerOrTraceVersion = await findLatestLayerVersion(config.Runtime as LayerKey, region)
       }
-      fullLambdaLibraryLayerARN = `${lambdaLibraryLayerArn}:${layerVersion}`
+      fullLambdaLibraryLayerARN = `${lambdaLibraryLayerArn}:${layerOrTraceVersion}`
     }
     layerARNs = addLayerArn(fullLambdaLibraryLayerARN, lambdaLibraryLayerName, layerARNs)
   }
 
   const lambdaExtensionLayerArn = getLayerArn(config, EXTENSION_LAYER_KEY as LayerKey, region, settings)
   let fullExtensionLayerARN: string | undefined
+  let extensionVersion: number | undefined
   if (settings.extensionVersion !== undefined || settings.interactive) {
-    let extensionVersion = settings.extensionVersion
+    extensionVersion = settings.extensionVersion
     if (settings.interactive && !settings.extensionVersion) {
       extensionVersion = await findLatestLayerVersion(EXTENSION_LAYER_KEY as LayerKey, region)
     }
     fullExtensionLayerARN = `${lambdaExtensionLayerArn}:${extensionVersion}`
   }
-
   layerARNs = addLayerArn(fullExtensionLayerARN, DD_LAMBDA_EXTENSION_LAYER_NAME, layerARNs)
+
+  // Special handling for .NET and Java to support universal instrumentation
+  if (runtimeType === RuntimeType.DOTNET || runtimeType === RuntimeType.JAVA) {
+    if (layerOrTraceVersion && isExtensionSupportUniversalInstrumentation(runtimeType, extensionVersion)) {
+      // if the user configures the trace version and the extension support univeral instrumenation
+      // Then check whether the trace and extension are compatible with each other
+      if (isExtensionCompatibleWithTrace(runtimeType, layerOrTraceVersion)) {
+        needsUpdate = true
+        newEnvVars[AWS_LAMBDA_EXEC_WRAPPER_VAR] = AWS_LAMBDA_EXEC_WRAPPER
+      } else {
+        throw new Error(
+          `For the ${runtime} runtime, the dd-trace version ${layerOrTraceVersion} is not compatible with the dd-extension version ${extensionVersion}`
+        )
+      }
+    } else {
+      // if it is an old extension version or the trace version is null, leave it is as the old workflow
+      if (runtimeType === RuntimeType.DOTNET) {
+        needsUpdate = true
+        newEnvVars[ENABLE_PROFILING_ENV_VAR] = CORECLR_ENABLE_PROFILING
+        newEnvVars[PROFILER_ENV_VAR] = CORECLR_PROFILER
+        newEnvVars[PROFILER_PATH_ENV_VAR] = CORECLR_PROFILER_PATH
+        newEnvVars[DOTNET_TRACER_HOME_ENV_VAR] = DD_DOTNET_TRACER_HOME
+      }
+    }
+  }
+
+  updateRequest.Environment = {
+    Variables: newEnvVars,
+  }
 
   if (originalLayerARNs.sort().join(',') !== layerARNs.sort().join(',')) {
     needsLayerUpdate = true

--- a/src/commands/lambda/functions/versionChecker.ts
+++ b/src/commands/lambda/functions/versionChecker.ts
@@ -1,0 +1,38 @@
+import {RuntimeType} from '../constants'
+
+const UNIVERSAL_INSTRUMENT_JAVA_EXTENSION_VERSION = 24
+const UNIVERSAL_INSTRUMENT_JAVA_TRACE_VERSION = 5
+const UNIVERSAL_INSTRUMENT_DOTNET_EXTENSION_VERSION = 24
+const UNIVERSAL_INSTRUMENT_DOTNET_TRACE_VERSION = 4
+
+export const isExtensionSupportUniversalInstrumentation = (
+  runtimeType: RuntimeType,
+  extensionVersion?: number
+): boolean => {
+  if (extensionVersion === undefined) {
+    return false
+  }
+  switch (runtimeType) {
+    case RuntimeType.JAVA:
+      return extensionVersion >= UNIVERSAL_INSTRUMENT_JAVA_EXTENSION_VERSION
+    case RuntimeType.DOTNET:
+      return extensionVersion >= UNIVERSAL_INSTRUMENT_DOTNET_EXTENSION_VERSION
+    default:
+      return true
+  }
+}
+
+export const isExtensionCompatibleWithTrace = (runtimeType: RuntimeType, traceVersion?: number): boolean => {
+  // more complex compatbility rules can be configured for each extension version if necessary
+  if (traceVersion === undefined) {
+    return true
+  }
+  switch (runtimeType) {
+    case RuntimeType.JAVA:
+      return traceVersion >= UNIVERSAL_INSTRUMENT_JAVA_TRACE_VERSION
+    case RuntimeType.DOTNET:
+      return traceVersion >= UNIVERSAL_INSTRUMENT_DOTNET_TRACE_VERSION
+    default:
+      return true
+  }
+}


### PR DESCRIPTION
### What and why?

This PR is to support Java and .NET universal instrumentation . In addition, it also tries to support dotnet6.
For new extensions (>= version 24), cases handled include: 1) New trace version, 2) Old trace version, and 3) Undefined trace version
For old extension versions, the previous workflows are still used.

### How?
1) Check the extension version and trace version for Java and .NET runtime
2) Create a separate versionChecker to verify whether an extension version supports universal instrument, and a trace version is compatible with a given extension version

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] \[_Synthetics_\] New releases of `datadog-ci` MUST be followed by a [synthetics-ci-github-action](https://github.com/DataDog/synthetics-ci-github-action) release
