### PR TITLE
[Synthetics] Update command output: Add batch URL, ignore skipped step

### DIFF
--- a/src/commands/synthetics/README.md
+++ b/src/commands/synthetics/README.md
@@ -266,4 +266,4 @@ Reporters can hook themselves into the `MainReporter` of the command.
 | `testTrigger`    | `(test: Test, testId: string, executionRule: ExecutionRule, config: ConfigOverride)` | called when a test is triggered.                                |
 | `testWait`       | `(test: Test)`                                                                       | called when a test is waiting to receive its results.           |
 | `testsWait`      | `(tests: Test[])`                                                                    | called when all tests are waiting to receive their results.     |
-| `runEnd`         | `(summary: Summary)`                                                                 | called at the end of the run.                                   |
+| `runEnd`         | `(summary: Summary, baseUrl: string)`                                                | called at the end of the run.                                   |

--- a/src/commands/synthetics/__tests__/cli.test.ts
+++ b/src/commands/synthetics/__tests__/cli.test.ts
@@ -551,15 +551,13 @@ describe('run-test', () => {
 
       expect((mockReporter as MockedReporter).resultEnd).toHaveBeenCalledTimes(testCase.results.length)
 
+      const baseUrl = `https://${DEFAULT_COMMAND_CONFIG.subdomain}.${DEFAULT_COMMAND_CONFIG.datadogSite}/`
       for (const result of testCase.results) {
-        expect((mockReporter as MockedReporter).resultEnd).toHaveBeenCalledWith(
-          result,
-          `https://${DEFAULT_COMMAND_CONFIG.subdomain}.${DEFAULT_COMMAND_CONFIG.datadogSite}/`
-        )
+        expect((mockReporter as MockedReporter).resultEnd).toHaveBeenCalledWith(result, baseUrl)
       }
 
       expect(testCase.summary).toEqual(testCase.expected.summary)
-      expect((mockReporter as MockedReporter).runEnd).toHaveBeenCalledWith(testCase.expected.summary)
+      expect((mockReporter as MockedReporter).runEnd).toHaveBeenCalledWith(testCase.expected.summary, baseUrl)
 
       expect(exitCode).toBe(testCase.expected.exitCode)
     })

--- a/src/commands/synthetics/__tests__/fixtures.ts
+++ b/src/commands/synthetics/__tests__/fixtures.ts
@@ -172,6 +172,84 @@ export const getBrowserServerResult = (opts: Partial<BrowserServerResult> = {}):
   ...opts,
 })
 
+export const getFailedBrowserResult = (): Result => ({
+  executionRule: ExecutionRule.BLOCKING,
+  location: 'Location name',
+  passed: false,
+  result: {
+    device: {height: 1100, id: 'chrome.laptop_large', width: 1440},
+    duration: 20000,
+    error: 'Step failed because it took more than 20 seconds.',
+    failure: {code: 'STEP_TIMEOUT', message: 'Step failed because it took more than 20 seconds.'},
+    passed: false,
+    startUrl: 'https://example.org/',
+    stepDetails: [
+      {
+        ...getStep(),
+        browserErrors: [{description: 'Error', name: 'Console error', type: 'js'}],
+        description: 'Navigate to start URL',
+        duration: 1000,
+        skipped: false,
+        stepId: -1,
+        type: 'goToUrlAndMeasureTti',
+        url: 'https://example.org/',
+        value: 'https://example.org/',
+        vitalsMetrics: [{url: 'https://example.com', lcp: 100, cls: 0}],
+      },
+      {
+        ...getStep(),
+        allowFailure: true,
+        description: 'Navigate',
+        duration: 1000,
+        error: 'Navigation failure',
+        skipped: true,
+        stepId: 2,
+        type: 'goToUrl',
+        url: 'https://example.org/',
+        value: 'https://example.org/',
+        vitalsMetrics: [],
+      },
+      {
+        ...getStep(),
+        description: 'Assert',
+        duration: 1000,
+        error: 'Step failure',
+        publicId: 'abc-def-hij',
+        skipped: true,
+        stepId: 3,
+        type: 'assertElementContent',
+        url: 'https://example.org/',
+        vitalsMetrics: [],
+      },
+      {...getStep(), skipped: true},
+      {...getStep(), skipped: true},
+      {...getStep(), skipped: true},
+    ],
+  },
+  resultId: '1',
+  test: {
+    ...getApiTest(),
+    config: {
+      assertions: [],
+      request: {
+        headers: {},
+        method: 'GET',
+        timeout: 1,
+        url: 'https://example.org/',
+      },
+      variables: [],
+    },
+    locations: [''],
+    message: 'Description.',
+    name: 'Test name',
+    options: {device_ids: ['chrome.laptop_large'], min_failure_duration: 0, min_location_failed: 1, tick_every: 300},
+    public_id: 'abc-def-hij',
+    type: 'browser',
+  },
+  timedOut: false,
+  timestamp: 1,
+})
+
 export const getApiServerResult = (opts: Partial<ApiServerResult> = {}): ApiServerResult => ({
   assertionResults: [
     {

--- a/src/commands/synthetics/__tests__/reporters/__snapshots__/default.test.ts.snap
+++ b/src/commands/synthetics/__tests__/reporters/__snapshots__/default.test.ts.snap
@@ -28,6 +28,22 @@ exports[`Default reporter resultEnd 1 API test, 1 location, 3 results: success, 
 "
 `;
 
+exports[`Default reporter resultEnd 1 Browser test: failed blocking 1`] = `
+"[1m[31m✖[39m[22m [[1m[31mblocking[39m[22m] [[1m[2mabc-def-hij[22m[22m] [1mTest name[22m - [1m[31mlocation: [1mLocation name[22m[1m[39m[22m - [1m[31mdevice: [1mchrome.laptop_large[22m[1m[39m[22m
+  ⎋ Total duration: 20000 ms - Result URL: [2m[36mhttps://app.datadoghq.com/synthetics/details/abc-def-hij/result/1?from_ci=true[39m[22m 
+    [1m[32m✓[39m[22m | [1m1000[22mms - Navigate to start URL
+    [2mhttps://example.org/[22m
+    [1m[31m✖[39m[22m | [1m1000[22mms - Navigate
+    [2mhttps://example.org/[22m
+    [31m[2mNavigation failure[22m[39m
+    [1m[31m✖[39m[22m | [1m1000[22mms - Assert
+    [2mvalue[22m
+    [31m[2mStep failure[22m[39m
+    [1m[33m⇢[39m[22m | 3 skipped steps
+
+"
+`;
+
 exports[`Default reporter runEnd Case where some outcomes are empty or missing 1`] = `
 "[33m[1m1[22m test not found[39m [90m(bbb-bbb-bbb)[39m
 [1mRun summary:[22m [32m[1m3[22m passed[39m, [31m[1m0[22m failed[39m, [33m[1m1[22m failed (non-blocking)[39m ([31m[1m1[22m critical errors[39m)
@@ -37,6 +53,7 @@ exports[`Default reporter runEnd Case where some outcomes are empty or missing 1
 
 exports[`Default reporter runEnd Complex case with all the tests and results outcomes possible 1`] = `
 "[33m[1m2[22m tests not found[39m [90m(ccc-ccc-ccc, ddd-ddd-ddd)[39m
+Results URL: [2m[36mhttps://app.datadoghq.com/synthetics/explorer/ci?batchResultId=batch-id[39m[22m
 [1mRun summary:[22m [32m[1m2[22m passed[39m, [31m[1m1[22m failed[39m, [33m[1m3[22m failed (non-blocking)[39m, [1m1[22m skipped ([33m[1m1[22m timed out[39m, [31m[1m2[22m critical errors[39m)
 
 "
@@ -89,12 +106,12 @@ exports[`Default reporter testTrigger Non-blocking test, with 2 config overrides
 `;
 
 exports[`Default reporter testTrigger Skipped test from Datadog, with 1 config override 1`] = `
-"[[1m[2maaa-bbb-ccc[22m[22m] Skipped test \\"[33m[2mRequest on example.org[22m[39m\\" because of execution rule configuration in Datadog [90m(1 config override)[39m
+"[[1m[2maaa-bbb-ccc[22m[22m] Skipped test \\"[33m[2mRequest on example.org[22m[39m\\" because of execution rule configuration in Datadog
 "
 `;
 
 exports[`Default reporter testTrigger Skipped test from Datadog, with 2 config overrides 1`] = `
-"[[1m[2maaa-bbb-ccc[22m[22m] Skipped test \\"[33m[2mRequest on example.org[22m[39m\\" because of execution rule configuration in Datadog [90m(2 config overrides)[39m
+"[[1m[2maaa-bbb-ccc[22m[22m] Skipped test \\"[33m[2mRequest on example.org[22m[39m\\" because of execution rule configuration in Datadog
 "
 `;
 
@@ -104,11 +121,11 @@ exports[`Default reporter testTrigger Skipped test from Datadog, without config 
 `;
 
 exports[`Default reporter testTrigger Skipped test, with 1 config override 1`] = `
-"[[1m[2maaa-bbb-ccc[22m[22m] Skipped test \\"[33m[2mRequest on example.org[22m[39m\\" [90m(1 config override)[39m
+"[[1m[2maaa-bbb-ccc[22m[22m] Skipped test \\"[33m[2mRequest on example.org[22m[39m\\"
 "
 `;
 
 exports[`Default reporter testTrigger Skipped test, with 2 config overrides 1`] = `
-"[[1m[2maaa-bbb-ccc[22m[22m] Skipped test \\"[33m[2mRequest on example.org[22m[39m\\" [90m(2 config overrides)[39m
+"[[1m[2maaa-bbb-ccc[22m[22m] Skipped test \\"[33m[2mRequest on example.org[22m[39m\\"
 "
 `;

--- a/src/commands/synthetics/command.ts
+++ b/src/commands/synthetics/command.ts
@@ -137,7 +137,7 @@ export class RunTestCommand extends Command {
       this.reporter?.resultEnd(result, this.getAppBaseURL())
     }
 
-    this.reporter?.runEnd(summary)
+    this.reporter?.runEnd(summary, this.getAppBaseURL())
 
     return hasSucceeded ? 0 : 1
   }

--- a/src/commands/synthetics/interfaces.ts
+++ b/src/commands/synthetics/interfaces.ts
@@ -9,7 +9,7 @@ export interface MainReporter {
   reportStart(timings: {startTime: number}): void
   resultEnd(result: Result, baseUrl: string): void
   resultReceived(result: Batch['results'][0]): void
-  runEnd(summary: Summary): void
+  runEnd(summary: Summary, baseUrl: string): void
   testsWait(tests: Test[]): void
   testTrigger(test: Test, testId: string, executionRule: ExecutionRule, config: ConfigOverride): void
   testWait(test: Test): void
@@ -331,6 +331,7 @@ export interface Suite {
 }
 
 export interface Summary {
+  batchId?: string
   criticalErrors: number
   failed: number
   failedNonBlocking: number

--- a/src/commands/synthetics/reporters/default.ts
+++ b/src/commands/synthetics/reporters/default.ts
@@ -153,11 +153,14 @@ const renderResultOutcome = (
     // We render the step only if the test hasn't passed to avoid cluttering the output.
     if (!result.passed && 'stepDetails' in result) {
       const criticalFailedStepIndex = result.stepDetails.findIndex((s) => s.error && !s.allowFailure) + 1
+      const stepsDisplay = result.stepDetails.slice(0, criticalFailedStepIndex).map(renderStep)
 
-      return [
-        ...result.stepDetails.slice(0, criticalFailedStepIndex).map(renderStep),
-        renderSkippedSteps(result.stepDetails.slice(criticalFailedStepIndex)),
-      ].join('\n')
+      const skippedStepDisplay = renderSkippedSteps(result.stepDetails.slice(criticalFailedStepIndex))
+      if (skippedStepDisplay) {
+        stepsDisplay.push(skippedStepDisplay)
+      }
+
+      return stepsDisplay.join('\n')
     }
 
     return ''

--- a/src/commands/synthetics/reporters/default.ts
+++ b/src/commands/synthetics/reporters/default.ts
@@ -212,6 +212,8 @@ const getResultUrl = (baseUrl: string, test: Test, resultId: string) => {
   return `${testDetailUrl}?resultId=${resultId}&${ciQueryParam}`
 }
 
+const getBatchUrl = (baseUrl: string, batchId: string) => `${baseUrl}synthetics/explorer/ci?batchResultId=${batchId}`
+
 const renderExecutionResult = (test: Test, execution: Result, baseUrl: string) => {
   const {executionRule, test: overriddenTest, resultId, result, timedOut} = execution
   const resultOutcome = getResultOutcome(execution)
@@ -295,7 +297,7 @@ export class DefaultReporter implements MainReporter {
     return
   }
 
-  public runEnd(summary: Summary) {
+  public runEnd(summary: Summary, baseUrl: string) {
     const {bold: b, gray, green, red, yellow} = chalk
 
     const lines: string[] = []
@@ -328,6 +330,9 @@ export class DefaultReporter implements MainReporter {
     }
     const extraInfoStr = extraInfo.length ? ' (' + extraInfo.join(', ') + ')' : ''
 
+    if (summary.batchId) {
+      lines.push('Results URL: ' + chalk.dim.cyan(getBatchUrl(baseUrl, summary.batchId)))
+    }
     lines.push(`${b('Run summary:')} ${runSummary.join(', ')}${extraInfoStr}\n\n`)
 
     this.write(lines.join('\n'))

--- a/src/commands/synthetics/run-test.ts
+++ b/src/commands/synthetics/run-test.ts
@@ -96,9 +96,10 @@ export const executeTests = async (reporter: MainReporter, config: CommandConfig
     }
   }
 
-  let triggers: Trigger
+  let trigger: Trigger
   try {
-    triggers = await runTests(api, overriddenTestsToTrigger)
+    trigger = await runTests(api, overriddenTestsToTrigger)
+    summary.batchId = trigger.batch_id
   } catch (error) {
     await stopTunnel()
     throw new CriticalError('TRIGGER_TESTS_FAILED', error.message)
@@ -108,7 +109,7 @@ export const executeTests = async (reporter: MainReporter, config: CommandConfig
     const maxPollingTimeout = Math.max(...testsToTrigger.map((t) => t.config.pollingTimeout || config.pollingTimeout))
     const results = await waitForResults(
       api,
-      triggers,
+      trigger,
       tests,
       {
         failOnCriticalErrors: config.failOnCriticalErrors,

--- a/src/commands/synthetics/utils.ts
+++ b/src/commands/synthetics/utils.ts
@@ -424,10 +424,10 @@ export const getReporter = (reporters: Reporter[]): MainReporter => ({
       }
     }
   },
-  runEnd: (summary) => {
+  runEnd: (summary, baseUrl) => {
     for (const reporter of reporters) {
       if (typeof reporter.runEnd === 'function') {
-        reporter.runEnd(summary)
+        reporter.runEnd(summary, baseUrl)
       }
     }
   },


### PR DESCRIPTION
### What and why?

Improve datadog-ci Synthetics command output.

### How?

- Don't display skipped steps following critical failed step in Browser test results (replace with `⇢ | X skipped steps`)
- Display batch URL above summary
- Stop displaying override count on skipped tests

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] \[_Synthetics_\] New releases of `datadog-ci` MUST be followed by a [synthetics-ci-github-action](https://github.com/DataDog/synthetics-ci-github-action) release
