### PR TITLE
Use intake v2 format for sourcemap, git-metadata and dsym uploads

### DIFF
--- a/src/commands/git-metadata/interfaces.ts
+++ b/src/commands/git-metadata/interfaces.ts
@@ -1,4 +1,4 @@
-import {MultipartPayload} from '../../helpers/upload'
+import {MultipartPayload, MultipartValue} from '../../helpers/upload'
 
 export class CommitInfo {
   public hash: string
@@ -14,8 +14,7 @@ export class CommitInfo {
   public asMultipartPayload(cliVersion: string): MultipartPayload {
     return {
       content: new Map([
-        ['cli_version', {value: cliVersion}],
-        ['type', {value: 'repository'}],
+        ['event', this.getMetadataPayload(cliVersion)],
         [
           'repository',
           {
@@ -26,9 +25,22 @@ export class CommitInfo {
             value: this.repositoryPayload(),
           },
         ],
-        ['git_repository_url', {value: this.remote}],
-        ['git_commit_sha', {value: this.hash}],
       ]),
+    }
+  }
+
+  private getMetadataPayload(cliVersion: string): MultipartValue {
+    return {
+      options: {
+        contentType: 'application/json',
+        filename: 'event',
+      },
+      value: JSON.stringify({
+        cli_version: cliVersion,
+        git_commit_sha: this.hash,
+        git_repository_url: this.remote,
+        type: 'repository',
+      }),
     }
   }
 

--- a/src/commands/sourcemaps/interfaces.ts
+++ b/src/commands/sourcemaps/interfaces.ts
@@ -60,7 +60,7 @@ export class Sourcemap {
     }
     if (this.gitData !== undefined) {
       metadata.git_repository_url = this.gitData!.gitRepositoryURL
-      metadata.git_commit_sha = this.gitData!.gitRepositoryURL
+      metadata.git_commit_sha = this.gitData!.gitCommitSha
     }
 
     return {


### PR DESCRIPTION
This migrates the `sourcemaps`, `dsyms` and `git-metadata` commands to the new format of the API endpoint used to upload files.

The new format must contain all JSON-encoded metadata as a single part of the request named `event`, and each attachment in a separate part, with an appropriate `filename`.