### PR TITLE
[Synthetics] Remove support for deprecated `errorMessage`

### DIFF
--- a/src/commands/synthetics/__tests__/fixtures.ts
+++ b/src/commands/synthetics/__tests__/fixtures.ts
@@ -314,7 +314,7 @@ export const getResults = (resultsFixtures: ResultFixtures[]): Result[] => {
 
     if (timedOut) {
       result.timedOut = true
-      result.result.error = 'Timeout'
+      result.result.failure = {code: 'TIMEOUT', message: 'Result timed out'}
     }
 
     results.push(result)

--- a/src/commands/synthetics/__tests__/reporters/junit.test.ts
+++ b/src/commands/synthetics/__tests__/reporters/junit.test.ts
@@ -157,7 +157,7 @@ describe('Junit reporter', () => {
       }
       const browserResult3: Result = {
         ...globalResultMock,
-        result: {...getBrowserServerResult(), error: 'Timeout'},
+        result: {...getBrowserServerResult(), failure: {code: 'TIMEOUT', message: 'Result timed out'}},
         timedOut: true,
       }
       const apiResult: Result = {

--- a/src/commands/synthetics/__tests__/utils.test.ts
+++ b/src/commands/synthetics/__tests__/utils.test.ts
@@ -564,7 +564,7 @@ describe('utils', () => {
       ).toEqual([
         {
           ...result,
-          result: {...result.result, error: 'Timeout', passed: false},
+          result: {...result.result, failure: {code: 'TIMEOUT', message: 'Result timed out'}, passed: false},
           timedOut: true,
         },
       ])
@@ -597,7 +597,7 @@ describe('utils', () => {
       ).toStrictEqual([
         {
           ...result,
-          result: {...result.result, error: 'Timeout', passed: false},
+          result: {...result.result, failure: {code: 'TIMEOUT', message: 'Result timed out'}, passed: false},
           timedOut: true,
         },
       ])
@@ -622,7 +622,7 @@ describe('utils', () => {
       ).toEqual([
         {
           ...result,
-          result: {...result.result, error: 'Timeout', passed: false},
+          result: {...result.result, failure: {code: 'TIMEOUT', message: 'Result timed out'}, passed: false},
           timedOut: true,
         },
       ])

--- a/src/commands/synthetics/__tests__/utils.test.ts
+++ b/src/commands/synthetics/__tests__/utils.test.ts
@@ -398,7 +398,10 @@ describe('utils', () => {
       const result: ServerResult = {
         device: {height: 0, id: 'laptop_large', width: 0},
         duration: 0,
-        errorCode: 'ERRABORTED',
+        failure: {
+          code: 'ERRABORTED',
+          message: 'Connection aborted',
+        },
         passed: false,
         startUrl: '',
         stepDetails: [],
@@ -411,7 +414,10 @@ describe('utils', () => {
       const result: ServerResult = {
         device: {height: 0, id: 'laptop_large', width: 0},
         duration: 0,
-        errorCode: 'ERRABORTED',
+        failure: {
+          code: 'ERRABORTED',
+          message: 'Connection aborted',
+        },
         passed: false,
         startUrl: '',
         stepDetails: [],

--- a/src/commands/synthetics/interfaces.ts
+++ b/src/commands/synthetics/interfaces.ts
@@ -18,7 +18,6 @@ export interface MainReporter {
 export type Reporter = Partial<MainReporter>
 
 export interface BaseServerResult {
-  error?: string
   failure?: {
     code: string
     message: string
@@ -34,7 +33,6 @@ export interface BrowserServerResult extends BaseServerResult {
     width: number
   }
   duration: number
-  error?: string
   startUrl: string
   stepDetails: Step[]
 }

--- a/src/commands/synthetics/interfaces.ts
+++ b/src/commands/synthetics/interfaces.ts
@@ -19,8 +19,6 @@ export type Reporter = Partial<MainReporter>
 
 export interface BaseServerResult {
   error?: string
-  errorCode?: string
-  errorMessage?: string
   failure?: {
     code: string
     message: string

--- a/src/commands/synthetics/reporters/default.ts
+++ b/src/commands/synthetics/reporters/default.ts
@@ -111,16 +111,16 @@ const renderResultOutcome = (
   color: chalk.Chalk
 ): string | undefined => {
   // Only display critical errors if failure is not filled.
-  if (result.error && !(result.failure || result.errorMessage)) {
+  if (result.error && !result.failure) {
     return `  ${chalk.bold(`${ICONS.FAILED} | ${result.error}`)}`
   }
 
   if (result.unhealthy) {
-    const errorMessage = result.failure ? result.failure.message : result.errorMessage
-    const errorName = errorMessage && errorMessage !== 'Unknown error' ? errorMessage : 'General Error'
+    const error =
+      result.failure && result.failure.message !== 'Unknown error' ? result.failure.message : 'General Error'
 
     return [
-      `  ${chalk.yellow(`${ICONS.SKIPPED} | ${errorName}`)}`,
+      `  ${chalk.yellow(`${ICONS.SKIPPED} | ${error}`)}`,
       `  ${chalk.yellow('We had an error during the execution of this test. The result will be ignored')}`,
     ].join('\n')
   }
@@ -128,11 +128,11 @@ const renderResultOutcome = (
   if (test.type === 'api') {
     const requestDescription = renderApiRequestDescription(test.subtype, test.config)
 
-    if (result.failure || (result.errorCode && result.errorMessage)) {
-      const errorCode = result.failure ? result.failure.code : result.errorCode
-      const errorMessage = result.failure ? result.failure.message : result.errorMessage
-
-      return [`  ${icon} ${color(requestDescription)}`, renderApiError(errorCode!, errorMessage!, color)].join('\n')
+    if (result.failure) {
+      return [
+        `  ${icon} ${color(requestDescription)}`,
+        renderApiError(result.failure.code, result.failure.message, color),
+      ].join('\n')
     }
 
     return `  ${icon} ${color(requestDescription)}`

--- a/src/commands/synthetics/reporters/default.ts
+++ b/src/commands/synthetics/reporters/default.ts
@@ -110,11 +110,6 @@ const renderResultOutcome = (
   icon: string,
   color: chalk.Chalk
 ): string | undefined => {
-  // Only display critical errors if failure is not filled.
-  if (result.error && !result.failure) {
-    return `  ${chalk.bold(`${ICONS.FAILED} | ${result.error}`)}`
-  }
-
   if (result.unhealthy) {
     const error =
       result.failure && result.failure.message !== 'Unknown error' ? result.failure.message : 'General Error'

--- a/src/commands/synthetics/reporters/junit.ts
+++ b/src/commands/synthetics/reporters/junit.ts
@@ -143,7 +143,7 @@ export class JUnitReporter implements Reporter {
     if (result.timedOut) {
       testCase.error.push({
         $: {type: 'timeout'},
-        _: String(result.result.error),
+        _: String(result.result.failure?.message),
       })
     }
     if ('stepDetails' in result.result) {

--- a/src/commands/synthetics/utils.ts
+++ b/src/commands/synthetics/utils.ts
@@ -204,7 +204,7 @@ export const hasResultPassed = (
     return result.passed
   }
 
-  if (typeof result.errorCode !== 'undefined') {
+  if (typeof result.failure !== 'undefined' || typeof result.error !== 'undefined') {
     return false
   }
 

--- a/src/commands/synthetics/utils.ts
+++ b/src/commands/synthetics/utils.ts
@@ -341,6 +341,7 @@ export const waitForResults = async (
     const hasTimeout = resultInBatch.timed_out || hasExceededMaxPollingDate
     if (hasTimeout) {
       pollResult.result.error = 'Timeout'
+      delete pollResult.result.failure
       pollResult.result.passed = false
     }
 

--- a/src/commands/synthetics/utils.ts
+++ b/src/commands/synthetics/utils.ts
@@ -204,7 +204,7 @@ export const hasResultPassed = (
     return result.passed
   }
 
-  if (typeof result.failure !== 'undefined' || typeof result.error !== 'undefined') {
+  if (typeof result.failure !== 'undefined') {
     return false
   }
 
@@ -340,8 +340,7 @@ export const waitForResults = async (
     const pollResult = pollResultMap[resultInBatch.result_id]
     const hasTimeout = resultInBatch.timed_out || hasExceededMaxPollingDate
     if (hasTimeout) {
-      pollResult.result.error = 'Timeout'
-      delete pollResult.result.failure
+      pollResult.result.failure = {code: 'TIMEOUT', message: 'Result timed out'}
       pollResult.result.passed = false
     }
 


### PR DESCRIPTION
### What and why?

Stop supporting deprecated `errorMessage` & fix late result failure display.

### How?

- Stop supporting `errorCode` & `errorMessage` in favor of relying exclusively on `failure` object
- Fix failed results received after timing out still displaying their original failure, the original failure is now discarded

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] \[_Synthetics_\] New releases of `datadog-ci` MUST be followed by a [synthetics-ci-github-action](https://github.com/DataDog/synthetics-ci-github-action) release
