### PR TITLE
[Synthetics] Fix Browser result timeout display in timed out tests

### DIFF
--- a/src/commands/synthetics/__tests__/fixtures.ts
+++ b/src/commands/synthetics/__tests__/fixtures.ts
@@ -172,6 +172,40 @@ export const getBrowserServerResult = (opts: Partial<BrowserServerResult> = {}):
   ...opts,
 })
 
+export const getTimedOutBrowserResult = (): Result => ({
+  executionRule: ExecutionRule.BLOCKING,
+  location: 'Location name',
+  passed: false,
+  result: {
+    duration: 0,
+    failure: {code: 'TIMEOUT', message: 'Result timed out'},
+    passed: false,
+    steps: [],
+  },
+  resultId: '1',
+  test: {
+    ...getApiTest(),
+    config: {
+      assertions: [],
+      request: {
+        headers: {},
+        method: 'GET',
+        timeout: 1,
+        url: 'https://example.org/',
+      },
+      variables: [],
+    },
+    locations: [''],
+    message: 'Description.',
+    name: 'Test name',
+    options: {device_ids: ['chrome.laptop_large'], min_failure_duration: 0, min_location_failed: 1, tick_every: 300},
+    public_id: 'abc-def-hij',
+    type: 'browser',
+  },
+  timedOut: true,
+  timestamp: 1,
+})
+
 export const getFailedBrowserResult = (): Result => ({
   executionRule: ExecutionRule.BLOCKING,
   location: 'Location name',

--- a/src/commands/synthetics/__tests__/reporters/__snapshots__/default.test.ts.snap
+++ b/src/commands/synthetics/__tests__/reporters/__snapshots__/default.test.ts.snap
@@ -28,7 +28,7 @@ exports[`Default reporter resultEnd 1 API test, 1 location, 3 results: success, 
 "
 `;
 
-exports[`Default reporter resultEnd 2 Browser test: failed blocking, timed out 1`] = `
+exports[`Default reporter resultEnd 3 Browser test: failed blocking, timed out, global failure 1`] = `
 "[1m[31m✖[39m[22m [[1m[31mblocking[39m[22m] [[1m[2mabc-def-hij[22m[22m] [1mTest name[22m - [1m[31mlocation: [1mLocation name[22m[1m[39m[22m - [1m[31mdevice: [1mchrome.laptop_large[22m[1m[39m[22m
   ⎋ Total duration: 20000 ms - Result URL: [2m[36mhttps://app.datadoghq.com/synthetics/details/abc-def-hij/result/1?from_ci=true[39m[22m 
     [1m[32m✓[39m[22m | [1m1000[22mms - Navigate to start URL
@@ -44,6 +44,10 @@ exports[`Default reporter resultEnd 2 Browser test: failed blocking, timed out 1
 [1m[31m✖[39m[22m [[1m[31mblocking[39m[22m] [[1m[2mabc-def-hij[22m[22m] [1mTest name[22m - [1m[31mlocation: [1mLocation name[22m[1m[39m[22m
   ⎋ Result URL: [2m[36mhttps://app.datadoghq.com/synthetics/details/abc-def-hij/result/1?from_ci=true[39m[22m (not yet received)
 [31m    [[1mTIMEOUT[22m] - [2mResult timed out[22m[39m
+
+[1m[31m✖[39m[22m [[1m[31mblocking[39m[22m] [[1m[2mabc-def-hij[22m[22m] [1mTest name[22m - [1m[31mlocation: [1mLocation name[22m[1m[39m[22m
+  ⎋ Result URL: [2m[36mhttps://app.datadoghq.com/synthetics/details/abc-def-hij/result/1?from_ci=true[39m[22m 
+[31m    [[1mFAILURE_CODE[22m] - [2mFailure message[22m[39m
 
 "
 `;

--- a/src/commands/synthetics/__tests__/reporters/__snapshots__/default.test.ts.snap
+++ b/src/commands/synthetics/__tests__/reporters/__snapshots__/default.test.ts.snap
@@ -28,7 +28,7 @@ exports[`Default reporter resultEnd 1 API test, 1 location, 3 results: success, 
 "
 `;
 
-exports[`Default reporter resultEnd 1 Browser test: failed blocking 1`] = `
+exports[`Default reporter resultEnd 2 Browser test: failed blocking, timed out 1`] = `
 "[1m[31m✖[39m[22m [[1m[31mblocking[39m[22m] [[1m[2mabc-def-hij[22m[22m] [1mTest name[22m - [1m[31mlocation: [1mLocation name[22m[1m[39m[22m - [1m[31mdevice: [1mchrome.laptop_large[22m[1m[39m[22m
   ⎋ Total duration: 20000 ms - Result URL: [2m[36mhttps://app.datadoghq.com/synthetics/details/abc-def-hij/result/1?from_ci=true[39m[22m 
     [1m[32m✓[39m[22m | [1m1000[22mms - Navigate to start URL
@@ -40,6 +40,10 @@ exports[`Default reporter resultEnd 1 Browser test: failed blocking 1`] = `
     [2mvalue[22m
     [31m[2mStep failure[22m[39m
     [1m[33m⇢[39m[22m | 3 skipped steps
+
+[1m[31m✖[39m[22m [[1m[31mblocking[39m[22m] [[1m[2mabc-def-hij[22m[22m] [1mTest name[22m - [1m[31mlocation: [1mLocation name[22m[1m[39m[22m
+  ⎋ Result URL: [2m[36mhttps://app.datadoghq.com/synthetics/details/abc-def-hij/result/1?from_ci=true[39m[22m (not yet received)
+[31m    [[1mTIMEOUT[22m] - [2mResult timed out[22m[39m
 
 "
 `;

--- a/src/commands/synthetics/__tests__/reporters/default.test.ts
+++ b/src/commands/synthetics/__tests__/reporters/default.test.ts
@@ -3,7 +3,7 @@ import {BaseContext} from 'clipanion/lib/advanced'
 import {ConfigOverride, ExecutionRule, MainReporter, Result, Summary, Test} from '../../interfaces'
 import {DefaultReporter} from '../../reporters/default'
 import {createSummary} from '../../utils'
-import {getApiResult, getApiTest, getFailedBrowserResult} from '../fixtures'
+import {getApiResult, getApiTest, getFailedBrowserResult, getTimedOutBrowserResult} from '../fixtures'
 
 /**
  * A good amount of these tests rely on Jest snapshot assertions.
@@ -140,10 +140,10 @@ describe('Default reporter', () => {
         },
       },
       {
-        description: '1 Browser test: failed blocking',
+        description: '2 Browser test: failed blocking, timed out',
         fixtures: {
           baseUrl: baseUrlFixture,
-          results: [getFailedBrowserResult()],
+          results: [getFailedBrowserResult(), getTimedOutBrowserResult()],
         },
       },
     ]

--- a/src/commands/synthetics/__tests__/reporters/default.test.ts
+++ b/src/commands/synthetics/__tests__/reporters/default.test.ts
@@ -140,10 +140,23 @@ describe('Default reporter', () => {
         },
       },
       {
-        description: '2 Browser test: failed blocking, timed out',
+        description: '3 Browser test: failed blocking, timed out, global failure',
         fixtures: {
           baseUrl: baseUrlFixture,
-          results: [getFailedBrowserResult(), getTimedOutBrowserResult()],
+          results: [
+            getFailedBrowserResult(),
+            getTimedOutBrowserResult(),
+            {
+              ...getTimedOutBrowserResult(),
+              result: {
+                duration: 0,
+                failure: {code: 'FAILURE_CODE', message: 'Failure message'},
+                passed: false,
+                steps: [],
+              },
+              timedOut: false,
+            },
+          ],
         },
       },
     ]

--- a/src/commands/synthetics/reporters/default.ts
+++ b/src/commands/synthetics/reporters/default.ts
@@ -158,6 +158,10 @@ const renderResultOutcome = (
       return stepsDisplay.join('\n')
     }
 
+    if (result.failure) {
+      return chalk.red(`    [${chalk.bold(result.failure.code)}] - ${chalk.dim(result.failure.message)}`)
+    }
+
     return ''
   }
 }


### PR DESCRIPTION
### What and why?

Fix display of timed out results for browser tests by reporting the `failure` for results with `stepDetails`

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] \[_Synthetics_\] New releases of `datadog-ci` MUST be followed by a [synthetics-ci-github-action](https://github.com/DataDog/synthetics-ci-github-action) release
