### PR TITLE
[junit] Send the hostname

### DIFF
--- a/src/commands/junit/__tests__/upload.test.ts
+++ b/src/commands/junit/__tests__/upload.test.ts
@@ -160,6 +160,19 @@ describe('upload', () => {
         key2: 'value2',
       })
     })
+    test('should set hostname', async () => {
+      const context = createMockContext()
+      const command = new UploadJUnitXMLCommand()
+      const [firstFile, secondFile] = await command['getMatchingJUnitXMLFiles'].call({
+        basePaths: ['./src/commands/junit/__tests__/fixtures'],
+        config: {},
+        context,
+        service: 'service',
+      })
+
+      expect(firstFile.hostname).toEqual(os.hostname())
+      expect(secondFile.hostname).toEqual(os.hostname())
+    })
     test('should parse tags argument', async () => {
       const context = createMockContext()
       const command = new UploadJUnitXMLCommand()

--- a/src/commands/junit/api.ts
+++ b/src/commands/junit/api.ts
@@ -37,7 +37,8 @@ export const uploadJUnitXML = (request: (args: AxiosRequestConfig) => AxiosPromi
   const spanTags: Record<string, string | undefined> = {
     service: jUnitXML.service,
     ...jUnitXML.spanTags,
-    '_dd.cireport_version': '2',
+    '_dd.cireport_version': '3',
+    '_dd.hostname': jUnitXML.hostname,
   }
 
   if (jUnitXML.logsEnabled) {

--- a/src/commands/junit/interfaces.ts
+++ b/src/commands/junit/interfaces.ts
@@ -4,6 +4,7 @@ import {Writable} from 'stream'
 import {SpanTags} from '../../helpers/interfaces'
 
 export interface Payload {
+  hostname: string
   logsEnabled: boolean
   service: string
   spanTags: SpanTags

--- a/src/commands/junit/upload.ts
+++ b/src/commands/junit/upload.ts
@@ -3,6 +3,7 @@ import {Command} from 'clipanion'
 import xmlParser from 'fast-xml-parser'
 import fs from 'fs'
 import glob from 'glob'
+import os from 'os'
 import path from 'path'
 import asyncPool from 'tiny-async-pool'
 
@@ -176,6 +177,7 @@ export class UploadJUnitXMLCommand extends Command {
     })
 
     return validUniqueFiles.map((jUnitXMLFilePath) => ({
+      hostname: os.hostname(),
       logsEnabled: this.logs,
       service: this.service!,
       spanTags,


### PR DESCRIPTION

### What and why?

Adds a new tag with the hostname that uploads the xml. This will be used if the XML itself doesn't contain an hostname field and the user doesn't override it manually by setting a `hostname` tag.

Also bumps `cireport_version`.

### How?

Reads `os.hostname()` in `upload.ts` and passes it in the payload that is sent in `api.ts`.

An alternative would be to call `os.hostname()` directly from `api.ts`, but I find it cleaner this way (happy to discuss though).

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] \[_Synthetics_\] New releases of `datadog-ci` MUST be followed by a [synthetics-ci-github-action](https://github.com/DataDog/synthetics-ci-github-action) release
