### PR TITLE
[Synthetics] Fix wrongfully timed out results

### DIFF
--- a/src/commands/synthetics/__tests__/utils.test.ts
+++ b/src/commands/synthetics/__tests__/utils.test.ts
@@ -562,7 +562,12 @@ describe('utils', () => {
     })
 
     test('results should be timed out if global pollingTimeout is exceeded', async () => {
-      mockApi({getBatchImplementation: async () => ({...batch, status: 'in_progress'})})
+      mockApi({
+        getBatchImplementation: async () => ({
+          results: [{...batch.results[0], timed_out: undefined}],
+          status: 'in_progress',
+        }),
+      })
 
       expect(
         await utils.waitForResults(
@@ -585,9 +590,14 @@ describe('utils', () => {
       // The original failure of a result received between timing-out in batch poll
       // and retrieving it should be ignored in favor of timeout.
       mockApi({
+        getBatchImplementation: async () => ({
+          results: [{...batch.results[0], timed_out: undefined}],
+          status: 'in_progress',
+        }),
         pollResultsImplementation: async () => [
           {
             ...pollResult,
+            passed: false,
             result: {
               ...pollResult.result,
               failure: {code: 'FAILURE', message: 'Original failure, should be ignored'},

--- a/src/commands/synthetics/__tests__/utils.test.ts
+++ b/src/commands/synthetics/__tests__/utils.test.ts
@@ -564,23 +564,33 @@ describe('utils', () => {
     test('results should be timed out if global pollingTimeout is exceeded', async () => {
       mockApi({
         getBatchImplementation: async () => ({
-          results: [{...batch.results[0], timed_out: undefined}],
+          results: [batch.results[0], {...batch.results[0], result_id: '3', timed_out: undefined}],
           status: 'in_progress',
         }),
+        pollResultsImplementation: async () => [
+          {...pollResult, result: {...pollResult.result}},
+          {...pollResult, result: {...pollResult.result}, resultID: '3'},
+        ],
       })
 
       expect(
         await utils.waitForResults(
           api,
           trigger,
-          [result.test],
+          [result.test, result.test],
           {maxPollingTimeout: 0, failOnCriticalErrors: false},
           mockReporter
         )
       ).toEqual([
+        result,
         {
           ...result,
-          result: {...result.result, failure: {code: 'TIMEOUT', message: 'Result timed out'}, passed: false},
+          result: {
+            ...result.result,
+            failure: {code: 'TIMEOUT', message: 'Result timed out'},
+            passed: false,
+          },
+          resultId: '3',
           timedOut: true,
         },
       ])

--- a/src/commands/synthetics/interfaces.ts
+++ b/src/commands/synthetics/interfaces.ts
@@ -101,7 +101,7 @@ export interface ResultInBatch {
   result_id: string
   status: Status
   test_public_id: string
-  timed_out: boolean
+  timed_out?: boolean
 }
 
 export interface Batch {

--- a/src/commands/synthetics/utils.ts
+++ b/src/commands/synthetics/utils.ts
@@ -318,8 +318,8 @@ export const waitForResults = async (
   // let's add a check to ensure it eventually times out.
   let hasExceededMaxPollingDate = Date.now() >= maxPollingDate
   while (batch.status === 'in_progress' && !hasExceededMaxPollingDate) {
-    batch = await processBatch()
     await wait(POLLING_INTERVAL)
+    batch = await processBatch()
     hasExceededMaxPollingDate = Date.now() >= maxPollingDate
   }
 
@@ -339,7 +339,7 @@ export const waitForResults = async (
 
   for (const resultInBatch of batch.results) {
     const pollResult = pollResultMap[resultInBatch.result_id]
-    const hasTimeout = resultInBatch.timed_out || hasExceededMaxPollingDate
+    const hasTimeout = resultInBatch.timed_out || (hasExceededMaxPollingDate && resultInBatch.timed_out !== false)
     if (hasTimeout) {
       pollResult.result.failure = {code: 'TIMEOUT', message: 'Result timed out'}
       pollResult.result.passed = false


### PR DESCRIPTION
### What and why?

If the command reaches `pollingTimeout` (`hasExceededMaxPollingDate = true`), all result are currently force-failed and marked as timed out due to this condition:
https://github.com/DataDog/datadog-ci/blob/2097278e942f571d8ae8f79635b7f5f795283b88/src/commands/synthetics/utils.ts#L342

This PR adds a check on `resultInBatch.timed_out !== false` to ensure results marked as timed out were not received when the batch was last polled. Tests needed to be updated to not set `timed_out: false`.

Also removes the extra 5s wait on last poll in `waitForResults()` by switching `wait` and `processBatch` so that polling does:
```
processBatch()
wait()
processBatch()
wait()
processBatch()
```

instead of:
```
processBatch()
processBatch()
wait()
processBatch()
wait()
```

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] \[_Synthetics_\] New releases of `datadog-ci` MUST be followed by a [synthetics-ci-github-action](https://github.com/DataDog/synthetics-ci-github-action) release
