### PR TITLE
Use intake v2 for react-native sourcemaps uploads

### DIFF
--- a/src/commands/react-native/__tests__/interfaces.test.ts
+++ b/src/commands/react-native/__tests__/interfaces.test.ts
@@ -1,3 +1,4 @@
+import {MultipartPayload} from '../../../helpers/upload'
 import {RNSourcemap} from '../interfaces'
 
 jest.mock('fs', () => ({
@@ -9,25 +10,28 @@ describe('interfaces', () => {
     test('should return the bundle name when specified', () => {
       const sourcemap = new RNSourcemap('./custom.bundle', './custom.bundle.map', 'index.android.bundle')
       expect(
-        sourcemap.asMultipartPayload('1.0', 'com.myapp', '1.2.3', '', 'android', '102030').content.get('bundle_name')
-          ?.value
+        getMetadataFromPayload(sourcemap.asMultipartPayload('1.0', 'com.myapp', '1.2.3', '', 'android', '102030'))
+          .bundle_name
       ).toBe('index.android.bundle')
     })
 
     test('should extract the bundle name from the file when not specified', () => {
       const sourcemap = new RNSourcemap('./index.android.bundle', './index.android.bundle.map')
       expect(
-        sourcemap.asMultipartPayload('1.0', 'com.myapp', '1.2.3', '', 'android', '102030').content.get('bundle_name')
-          ?.value
+        getMetadataFromPayload(sourcemap.asMultipartPayload('1.0', 'com.myapp', '1.2.3', '', 'android', '102030'))
+          .bundle_name
       ).toBe('index.android.bundle')
     })
 
     test('should extract the bundle name from the file when not specified and no slash in path', () => {
       const sourcemap = new RNSourcemap('index.android.bundle', 'index.android.bundle.map')
       expect(
-        sourcemap.asMultipartPayload('1.0', 'com.myapp', '1.2.3', '', 'android', '102030').content.get('bundle_name')
-          ?.value
+        getMetadataFromPayload(sourcemap.asMultipartPayload('1.0', 'com.myapp', '1.2.3', '', 'android', '102030'))
+          .bundle_name
       ).toBe('index.android.bundle')
     })
   })
 })
+
+const getMetadataFromPayload = (payload: MultipartPayload): {[k: string]: any} =>
+  JSON.parse(payload.content.get('event')!.value.toString())

--- a/src/commands/react-native/interfaces.ts
+++ b/src/commands/react-native/interfaces.ts
@@ -76,8 +76,8 @@ export class RNSourcemap {
       version,
     }
     if (this.gitData !== undefined) {
-      metadata.git_repository_url = this.gitData!.gitRepositoryURL
-      metadata.git_commit_sha = this.gitData!.gitCommitSha
+      metadata.git_repository_url = this.gitData.gitRepositoryURL
+      metadata.git_commit_sha = this.gitData.gitCommitSha
     }
 
     return {


### PR DESCRIPTION
This migrates the React Native sourcemaps upload command to the v2 API endpoint. (other commands have been migrated in https://github.com/DataDog/datadog-ci/pull/560).