### PR TITLE
Remove host tag in reported metrics

### DIFF
--- a/src/helpers/metrics.ts
+++ b/src/helpers/metrics.ts
@@ -22,7 +22,6 @@ export const getMetricsLogger = (opts: MetricsLoggerOptions): MetricsLogger => {
     apiHost: apiUrl,
     defaultTags: opts.defaultTags,
     flushIntervalSeconds: 15,
-    host: 'ci',
     prefix: opts.prefix,
   }
 


### PR DESCRIPTION
The `host:ci` tag leads to a host showing up in the infrastructure list. This behaviour is not wanted, let's remove this tag which doesn't bring any information.

This will impact:
- `sourcemaps upload`
- `git-metadata upload`
- `dsyms upload`