### PR TITLE
Publish v1.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "description": "Run datadog actions from the CI.",
   "repository": "https://github.com/DataDog/datadog-ci",
   "license": "Apache-2.0",


### PR DESCRIPTION
### What and why?

This PR releases version 1.9.0, containing:

- `react-native upload` command for react native sourcemaps
- use intake v2 for dsyms, sourcemaps and git-metadata
- remove `host:ci` from metrics for dsyms, sourcemaps and git-metadata
- support for Azure DevOps extensions