### PR TITLE
Update uploadGitCommitHash to return the current repo URL

### DIFF
--- a/src/commands/git-metadata/library.ts
+++ b/src/commands/git-metadata/library.ts
@@ -16,14 +16,20 @@ export const isGitRepo = async (): Promise<boolean> => {
   }
 }
 
-export const uploadGitCommitHash = async (apiKey: string, datadogSite: string): Promise<string> => {
+// UploadGitCommitHash uploads local git metadata and returns the current [repositoryURL, commitHash].
+// The current repositoryURL can be overriden by specifying the 'repositoryURL' arg.
+export const uploadGitCommitHash = async (
+  apiKey: string,
+  datadogSite: string,
+  repositoryURL?: string
+): Promise<[string, string]> => {
   const apiKeyValidator = newApiKeyValidator({
     apiKey,
     datadogSite,
   })
 
   const simpleGit = await newSimpleGit()
-  const payload = await getCommitInfo(simpleGit)
+  const payload = await getCommitInfo(simpleGit, repositoryURL)
 
   const version = require('../../../package.json').version
 
@@ -55,7 +61,7 @@ export const uploadGitCommitHash = async (apiKey: string, datadogSite: string): 
     throw new Error('Error uploading commit information.')
   }
 
-  return payload.hash
+  return [payload.remote, payload.hash]
 }
 
 export const uploadRepository = (


### PR DESCRIPTION
### What and why?

https://github.com/DataDog/serverless-plugin-datadog now has a dependency on datadog-ci for uplaoding git-metadata. The serverless plugin must know the current repository URL to be able to tag serverless functions with `git.repository_url`.

### How?

Returns the repository URL in `uploadGitCommitHash`.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] \[_Synthetics_\] New releases of `datadog-ci` MUST be followed by a [synthetics-ci-github-action](https://github.com/DataDog/synthetics-ci-github-action) release
