### PR TITLE
Better back of for tags rate limit

### DIFF
--- a/src/commands/tag/tag.ts
+++ b/src/commands/tag/tag.ts
@@ -116,6 +116,8 @@ export class TagCommand extends Command {
           )
         },
         retries: 5,
+        minTimeout: 5000,
+        maxTimeout: 30000,
       })
     } catch (error) {
       this.context.stderr.write(`${chalk.red.bold('[ERROR]')} Could not send tags: ${error.message}\n`)

--- a/src/commands/tag/tag.ts
+++ b/src/commands/tag/tag.ts
@@ -110,14 +110,14 @@ export class TagCommand extends Command {
 
     try {
       await retryRequest(doRequest, {
+        maxTimeout: 30000,
+        minTimeout: 5000,
         onRetry: (e, attempt) => {
           this.context.stderr.write(
             chalk.yellow(`[attempt ${attempt}] Could not send tags. Retrying...: ${e.message}\n`)
           )
         },
         retries: 5,
-        minTimeout: 5000,
-        maxTimeout: 30000,
       })
     } catch (error) {
       this.context.stderr.write(`${chalk.red.bold('[ERROR]')} Could not send tags: ${error.message}\n`)


### PR DESCRIPTION
### What and why?

Increase the backoff when we do retries to the custom tags endpoint as some customers that send a lot of them may be hitting the rate limit and the to fast retries is making it worse as it not gives enough time for the rate limit threshold to refresh.

### How?

Increasing the initial backoff time

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] \[_Synthetics_\] New releases of `datadog-ci` MUST be followed by a [synthetics-ci-github-action](https://github.com/DataDog/synthetics-ci-github-action) release
