### PR TITLE
Fix a copypasta typo

### DIFF
--- a/src/commands/lambda/README.md
+++ b/src/commands/lambda/README.md
@@ -44,7 +44,7 @@ datadog-ci lambda uninstrument -f <function-name> -f <another-function-name> -r 
 # Uninstrument function(s) in interactive mode
 datadog-ci lambda uninstrument -i
 
-# Instrument multiple functions that match a regex pattern
+# Uninstrument multiple functions that match a regex pattern
 datadog-ci lambda uninstrument --functions-regex <valid-regex-pattern> -r us-east-1
 
 # Dry run of all updates


### PR DESCRIPTION
### What and why?

Fix a typo. Comment is inconsistent with the command. Noticed by a translator on the public docs site.

### How?

Change "Instrument" to "Uninstrument"

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] \[_Synthetics_\] New releases of `datadog-ci` MUST be followed by a [synthetics-ci-github-action](https://github.com/DataDog/synthetics-ci-github-action) release
