### PR TITLE
[SW-2256] Add batch_id to the junit report

### DIFF
--- a/src/commands/synthetics/__tests__/fixtures.ts
+++ b/src/commands/synthetics/__tests__/fixtures.ts
@@ -23,6 +23,7 @@ import {
   Trigger,
   User,
 } from '../interfaces'
+import {createSummary} from '../utils'
 
 const mockUser: User = {
   email: '',
@@ -134,6 +135,11 @@ export const getMultiStep = (): MultiStep => ({
 })
 
 export const getTestSuite = (): Suite => ({content: {tests: [{config: {}, id: '123-456-789'}]}, name: 'Suite 1'})
+
+export const getSummary = (): Summary => ({
+  ...createSummary(),
+  batchId: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+})
 
 const getBaseResult = (resultId: string, test: Test): Omit<Result, 'result'> => ({
   executionRule: ExecutionRule.BLOCKING,

--- a/src/commands/synthetics/interfaces.ts
+++ b/src/commands/synthetics/interfaces.ts
@@ -327,6 +327,8 @@ export interface Suite {
 }
 
 export interface Summary {
+  // The batchId is set later in the process, so it first needs to be undefined ; it will always be defined eventually.
+  // Multiple suites will have the same batchId.
   batchId?: string
   criticalErrors: number
   failed: number

--- a/src/commands/synthetics/reporters/junit.ts
+++ b/src/commands/synthetics/reporters/junit.ts
@@ -5,7 +5,7 @@ import path from 'path'
 import {Writable} from 'stream'
 import {Builder} from 'xml2js'
 
-import {ApiServerResult, MultiStep, Reporter, Result, Step, Vitals} from '../interfaces'
+import {ApiServerResult, MultiStep, Reporter, Result, Step, Summary, Vitals} from '../interfaces'
 import {getResultDuration, getResultOutcome, ResultOutcome} from '../utils'
 
 interface Stats {
@@ -65,7 +65,7 @@ interface XMLStep {
 
 export interface XMLJSON {
   testsuites: {
-    $: {name: string}
+    $: {batch_id?: string; name: string}
     testsuite: XMLRun[]
   }
 }
@@ -167,7 +167,9 @@ export class JUnitReporter implements Reporter {
     suiteRun.testcase.push(testCase)
   }
 
-  public async runEnd() {
+  public async runEnd(summary: Summary) {
+    this.json.testsuites.$.batch_id = summary.batchId
+
     // Write the file
     try {
       const xml = this.builder.buildObject(this.json)


### PR DESCRIPTION
### What and why?

This PR adds a `batch_id` property to the `testsuites` element's attributes of a JUnit report.

### How?

The `batch_id` property needs to be an attribute, part of the `testsuites` element (and not `testsuite` or `testcase`) because if multiple suites are run (e.g. multiple test config files are loaded), the suites' tests will be flattened and all run in the same batch.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] \[_Synthetics_\] New releases of `datadog-ci` MUST be followed by a [synthetics-ci-github-action](https://github.com/DataDog/synthetics-ci-github-action) release
