### PR TITLE
Release v1.12.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "description": "Run datadog actions from the CI.",
   "repository": "https://github.com/DataDog/datadog-ci",
   "license": "Apache-2.0",


### PR DESCRIPTION
### What and why?

This PR bumps version to 1.12.0, with this proposed changelog:

* Add xcode command to upload sourcemaps automatically in React Native by @louiszawadzki in https://github.com/DataDog/datadog-ci/pull/548
* Enable specifying API key and site from datadog-ci.json for dsyms command by @louiszawadzki in https://github.com/DataDog/datadog-ci/pull/580
* Universal instrumentation for Java and .NET including .NET6.0 by @nine5two7 in https://github.com/DataDog/datadog-ci/pull/556



