### PR TITLE
[Synthetics] JUnit reporter: Add summary data to `testsuites` properties

### DIFF
--- a/src/commands/synthetics/__tests__/fixtures.ts
+++ b/src/commands/synthetics/__tests__/fixtures.ts
@@ -138,9 +138,10 @@ export const getMultiStep = (): MultiStep => ({
 
 export const getTestSuite = (): Suite => ({content: {tests: [{config: {}, id: '123-456-789'}]}, name: 'Suite 1'})
 
+export const BATCH_ID = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'
 export const getSummary = (): Summary => ({
   ...createSummary(),
-  batchId: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+  batchId: BATCH_ID,
 })
 
 const getBaseResult = (resultId: string, test: Test): Omit<Result, 'result'> => ({

--- a/src/commands/synthetics/__tests__/reporters/junit.test.ts
+++ b/src/commands/synthetics/__tests__/reporters/junit.test.ts
@@ -116,7 +116,7 @@ describe('Junit reporter', () => {
       )
       expect(reporter['json'].testsuites.$).toStrictEqual({
         batch_id: BATCH_ID,
-        batch_url: `https://app.datadoghq.com/synthetics/explorer/ci?batchResultId=${BATCH_ID}`,
+        batch_url: `${MOCK_BASE_URL}synthetics/explorer/ci?batchResultId=${BATCH_ID}`,
         name: 'Test Suite name',
         tests_critical_error: 1,
         tests_failed: 2,

--- a/src/commands/synthetics/__tests__/reporters/junit.test.ts
+++ b/src/commands/synthetics/__tests__/reporters/junit.test.ts
@@ -1,11 +1,15 @@
 // tslint:disable: no-string-literal
 import {promises as fs} from 'fs'
 import {Writable} from 'stream'
+
+import {BaseContext} from 'clipanion/lib/advanced'
+
 import {Result} from '../../interfaces'
 
 import {RunTestCommand} from '../../command'
-import {getDefaultStats, JUnitReporter, XMLTestCase} from '../../reporters/junit'
+import {Args, getDefaultStats, JUnitReporter, XMLTestCase} from '../../reporters/junit'
 import {
+  BATCH_ID,
   getApiTest,
   getBrowserResult,
   getBrowserServerResult,
@@ -23,13 +27,10 @@ const globalSummaryMock = getSummary()
 
 describe('Junit reporter', () => {
   const writeMock: Writable['write'] = jest.fn()
-  const commandMock: unknown = {
-    context: {
-      stdout: {
-        write: writeMock,
-      },
-    },
+  const commandMock: Args = {
+    context: ({stdout: {write: writeMock}} as unknown) as BaseContext,
     jUnitReport: 'junit',
+    runName: 'Test Suite name',
   }
 
   let reporter: JUnitReporter
@@ -44,7 +45,7 @@ describe('Junit reporter', () => {
     })
 
     it('should give a default run name', () => {
-      expect(reporter['json'].testsuites.$.name).toBe('Undefined run')
+      expect(new JUnitReporter({...commandMock, runName: undefined})['json'].testsuites.$.name).toBe('Undefined run')
     })
   })
 
@@ -97,11 +98,34 @@ describe('Junit reporter', () => {
       await fs.rmdir('junit')
     })
 
-    it('should add the batch_id to the report', async () => {
+    it('testsuites contains summary properties', async () => {
       jest.spyOn(fs, 'writeFile').mockResolvedValueOnce()
 
-      await reporter.runEnd(globalSummaryMock, MOCK_BASE_URL)
-      expect(reporter['json'].testsuites.$.batch_id).toBe(globalSummaryMock.batchId)
+      await reporter.runEnd(
+        {
+          ...globalSummaryMock,
+          criticalErrors: 1,
+          failed: 2,
+          failedNonBlocking: 3,
+          passed: 4,
+          skipped: 5,
+          testsNotFound: new Set(['a', 'b', 'c']),
+          timedOut: 6,
+        },
+        MOCK_BASE_URL
+      )
+      expect(reporter['json'].testsuites.$).toStrictEqual({
+        batch_id: BATCH_ID,
+        batch_url: `https://app.datadoghq.com/synthetics/explorer/ci?batchResultId=${BATCH_ID}`,
+        name: 'Test Suite name',
+        tests_critical_error: 1,
+        tests_failed: 2,
+        tests_failed_non_blocking: 3,
+        tests_not_found: 3,
+        tests_passed: 4,
+        tests_skipped: 5,
+        tests_timed_out: 6,
+      })
     })
   })
 

--- a/src/commands/synthetics/reporters/junit.ts
+++ b/src/commands/synthetics/reporters/junit.ts
@@ -8,7 +8,7 @@ import {Builder} from 'xml2js'
 import {ApiServerResult, MultiStep, Reporter, Result, Step, Summary, Vitals} from '../interfaces'
 import {getBatchUrl, getResultDuration, getResultOutcome, getResultUrl, ResultOutcome} from '../utils'
 
-interface Stats {
+interface StepStats {
   allowfailures: number
   errors: number
   failures: number
@@ -17,7 +17,7 @@ interface Stats {
   warnings: number
 }
 
-interface XMLRunProperties extends Stats {
+interface XMLRunProperties extends StepStats {
   name: string
 }
 
@@ -26,7 +26,7 @@ interface XMLRun {
   testcase: XMLTestCase[]
 }
 
-interface XMLTestCaseProperties extends Stats {
+interface XMLTestCaseProperties extends StepStats {
   name: string
   time: number | undefined
   timestamp: string
@@ -45,7 +45,7 @@ export interface XMLTestCase {
   warning: XMLError[]
 }
 
-interface XMLStepProperties extends Stats {
+interface XMLStepProperties extends StepStats {
   allow_failure: boolean
   is_skipped: boolean
   name: string
@@ -81,7 +81,7 @@ interface Args {
   runName?: string
 }
 
-export const getDefaultStats = (): Stats => ({
+export const getDefaultStats = (): StepStats => ({
   allowfailures: 0,
   errors: 0,
   failures: 0,
@@ -92,10 +92,10 @@ export const getDefaultStats = (): Stats => ({
 
 // Return the stats from a given object
 // based on getDefaultStats
-const getStats = (obj: Stats): Stats => {
+const getStats = (obj: StepStats): StepStats => {
   const baseStats = getDefaultStats()
   for (const entry of Object.entries(baseStats)) {
-    const [key, value] = entry as [keyof Stats, number]
+    const [key, value] = entry as [keyof StepStats, number]
     baseStats[key] = value || baseStats[key]
   }
 
@@ -184,7 +184,7 @@ export class JUnitReporter implements Reporter {
     }
   }
 
-  private getApiStepStats(step: MultiStep | ApiServerResult): Stats {
+  private getApiStepStats(step: MultiStep | ApiServerResult): StepStats {
     // TODO use more granular result based on step.assertionResults
     let allowfailures = 0
     let skipped = 0
@@ -227,7 +227,7 @@ export class JUnitReporter implements Reporter {
     }
   }
 
-  private getBrowserStepStats(step: Step): Stats {
+  private getBrowserStepStats(step: Step): StepStats {
     const errors = step.browserErrors ? step.browserErrors.length : 0
 
     return {
@@ -285,8 +285,8 @@ export class JUnitReporter implements Reporter {
     }
   }
 
-  private getResultStats(result: Result, stats: Stats | undefined = getDefaultStats()): Stats {
-    let stepsStats: Stats[] = []
+  private getResultStats(result: Result, stats: StepStats = getDefaultStats()): StepStats {
+    let stepsStats: StepStats[] = []
     if ('stepDetails' in result.result) {
       // It's a browser test.
       stepsStats = result.result.stepDetails

--- a/src/commands/synthetics/reporters/junit.ts
+++ b/src/commands/synthetics/reporters/junit.ts
@@ -65,7 +65,18 @@ interface XMLStep {
 
 export interface XMLJSON {
   testsuites: {
-    $: {batch_id?: string; batch_url?: string; name: string}
+    $: {
+      batch_id?: string
+      batch_url?: string
+      name: string
+      tests_critical_error: number
+      tests_failed: number
+      tests_failed_non_blocking: number
+      tests_not_found: number
+      tests_passed: number
+      tests_skipped: number
+      tests_timed_out: number
+    }
     testsuite: XMLRun[]
   }
 }
@@ -75,7 +86,7 @@ interface XMLError {
   _: string
 }
 
-interface Args {
+export interface Args {
   context: BaseContext
   jUnitReport?: string
   runName?: string
@@ -116,7 +127,19 @@ export class JUnitReporter implements Reporter {
     }
     this.builder = new Builder()
     this.json = {
-      testsuites: {$: {name: runName || 'Undefined run'}, testsuite: []},
+      testsuites: {
+        $: {
+          name: runName || 'Undefined run',
+          tests_critical_error: 0,
+          tests_failed: 0,
+          tests_failed_non_blocking: 0,
+          tests_not_found: 0,
+          tests_passed: 0,
+          tests_skipped: 0,
+          tests_timed_out: 0,
+        },
+        testsuite: [],
+      },
     }
   }
 
@@ -168,6 +191,16 @@ export class JUnitReporter implements Reporter {
   }
 
   public async runEnd(summary: Summary, baseUrl: string) {
+    Object.assign(this.json.testsuites.$, {
+      tests_critical_error: summary.criticalErrors,
+      tests_failed: summary.failed,
+      tests_failed_non_blocking: summary.failedNonBlocking,
+      tests_not_found: summary.testsNotFound.size,
+      tests_passed: summary.passed,
+      tests_skipped: summary.skipped,
+      tests_timed_out: summary.timedOut,
+    })
+
     this.json.testsuites.$.batch_id = summary.batchId
     if (summary.batchId) {
       this.json.testsuites.$.batch_url = getBatchUrl(baseUrl, summary.batchId)


### PR DESCRIPTION
### What and why?

Include all summary data in JUnit reports by adding new properties to `testsuites`.

### How?

Introduce new `testsuites` properties:
- `tests_critical_error`
- `tests_failed`
- `tests_failed_non_blocking`
- `tests_not_found`
- `tests_passed`
- `tests_skipped`
- `tests_timed_out`

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] \[_Synthetics_\] New releases of `datadog-ci` MUST be followed by a [synthetics-ci-github-action](https://github.com/DataDog/synthetics-ci-github-action) release
