### PR TITLE
[sourcemaps] Require minified URL to have a host, or leading slash

### DIFF
--- a/src/commands/sourcemaps/__tests__/upload.test.ts
+++ b/src/commands/sourcemaps/__tests__/upload.test.ts
@@ -37,7 +37,7 @@ describe('upload', () => {
   })
 
   describe('isMinifiedPathPrefixValid: full URL', () => {
-    test('should return false', () => {
+    test('should return true', () => {
       const command = new UploadCommand()
       command['minifiedPathPrefix'] = 'http://datadog.com/js'
 
@@ -46,7 +46,7 @@ describe('upload', () => {
   })
 
   describe('isMinifiedPathPrefixValid: URL without protocol', () => {
-    test('should return false', () => {
+    test('should return true', () => {
       const command = new UploadCommand()
       command['minifiedPathPrefix'] = '//datadog.com/js'
 
@@ -55,7 +55,7 @@ describe('upload', () => {
   })
 
   describe('isMinifiedPathPrefixValid: leading slash', () => {
-    test('should return false', () => {
+    test('should return true', () => {
       const command = new UploadCommand()
       command['minifiedPathPrefix'] = '/js'
 
@@ -67,6 +67,15 @@ describe('upload', () => {
     test('should return false', () => {
       const command = new UploadCommand()
       command['minifiedPathPrefix'] = 'js'
+
+      expect(command['isMinifiedPathPrefixValid']()).toBe(false)
+    })
+  })
+
+  describe('isMinifiedPathPrefixValid: invalid URL without host', () => {
+    test('should return false', () => {
+      const command = new UploadCommand()
+      command['minifiedPathPrefix'] = 'info: undesired log line\nhttps://example.com/static/js/'
 
       expect(command['isMinifiedPathPrefixValid']()).toBe(false)
     })

--- a/src/commands/sourcemaps/upload.ts
+++ b/src/commands/sourcemaps/upload.ts
@@ -248,15 +248,15 @@ export class UploadCommand extends Command {
   }
 
   private isMinifiedPathPrefixValid(): boolean {
-    let protocol
+    let host
     try {
       const objUrl = new URL(this.minifiedPathPrefix!)
-      protocol = objUrl.protocol
+      host = objUrl.host
     } catch {
       // Do nothing.
     }
 
-    if (!protocol && !this.minifiedPathPrefix!.startsWith('/')) {
+    if (!host && !this.minifiedPathPrefix!.startsWith('/')) {
       return false
     }
 


### PR DESCRIPTION
### What and why?

This improves the validation of the `--minified-path-prefix` parameter.
Today, passing something like `warn: unrelated log line\nhttps://example.com/statix/js` passes the validation, while it shouldn't.
This can be an issue if the output of a command (with unexpected logs in stdout) is passed to this parameter.

### How?

Instead of requiring the parsed URL to have a `protocol` (we have a test weirdly testing the opposite, which I suspect is accidentally passing because of the leading slash), require it to have a host.

`warn: unrelated log line\nhttps://example.com/statix/js` is being parsed without error by [`new URL`](https://nodejs.org/api/url.html#new-urlinput-base), but gives an almost empty URL with only a protocol.
Checking that the `host` is present should filter out this case, and should still validate correctly the two options we want to offer to the user, i.e. either:
- Pass a full URL with a host (and optional URL path) (and optional URL schema, which is ignored for unminification)
- Pass a path only (starting with a leading `/`)

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] \[_Synthetics_\] New releases of `datadog-ci` MUST be followed by a [synthetics-ci-github-action](https://github.com/DataDog/synthetics-ci-github-action) release
