### PR TITLE
Remove beta warning of metric command

### DIFF
--- a/src/commands/metric/README.md
+++ b/src/commands/metric/README.md
@@ -1,7 +1,5 @@
 # metric command
 
-:warning: This command is in beta stage.
-
 Add numeric tags to CI Visibility pipeline and job spans.
 
 ## Usage


### PR DESCRIPTION
### What and why?

Remove old beta warning

### How?

A brief description of implementation details of this PR.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] \[_Synthetics_\] New releases of `datadog-ci` MUST be followed by a [synthetics-ci-github-action](https://github.com/DataDog/synthetics-ci-github-action) release
