### PR TITLE
Release v1.13.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci",
-  "version": "1.12.0",
+  "version": "1.13.0",
   "description": "Run datadog actions from the CI.",
   "repository": "https://github.com/DataDog/datadog-ci",
   "license": "Apache-2.0",


### PR DESCRIPTION
### What and why?

Bumps version to 1.13.0. Changelog:

- [Synthetics] JUnit reporter: Add summary data to testsuites properties by @lefebvree https://github.com/DataDog/datadog-ci/pull/591
- [ci-visibility] Update CI env vars metadata extraction by @juan-fernandez https://github.com/DataDog/datadog-ci/pull/597
- [sourcemaps] Require minified URL to have a host, or leading slash by @rpelliard https://github.com/DataDog/datadog-ci/pull/596
- [git-metadata] Return repository remote in exported `uploadGitCommitHash` by @jybp https://github.com/DataDog/datadog-ci/pull/577
