### PR TITLE
[SW-2292] Retry getBatch and pollResults request on HTTP 404 as well

### DIFF
--- a/src/commands/synthetics/api.ts
+++ b/src/commands/synthetics/api.ts
@@ -17,6 +17,9 @@ import {
 } from './interfaces'
 import {ciTriggerApp, retry} from './utils'
 
+const MAX_RETRIES = 3
+const DELAY_BETWEEN_RETRIES = 500 // In ms
+
 interface BackendError {
   errors: string[]
 }
@@ -139,8 +142,8 @@ const getPresignedURL = (request: (args: AxiosRequestConfig) => AxiosPromise<{ur
 type RetryPolicy = (retries: number, error: AxiosError) => number | undefined
 
 const retryOn5xxErrors: RetryPolicy = (retries, error) => {
-  if (retries < 3 && is5xxError(error)) {
-    return 500
+  if (retries < MAX_RETRIES && is5xxError(error)) {
+    return DELAY_BETWEEN_RETRIES
   }
 }
 
@@ -150,8 +153,8 @@ const retryOn5xxOr404Errors: RetryPolicy = (retries, error) => {
     return retryOn5xxDelay
   }
 
-  if (retries < 3 && isNotFoundError(error)) {
-    return 500
+  if (retries < MAX_RETRIES && isNotFoundError(error)) {
+    return DELAY_BETWEEN_RETRIES
   }
 }
 

--- a/src/commands/synthetics/api.ts
+++ b/src/commands/synthetics/api.ts
@@ -92,7 +92,7 @@ const searchTests = (request: (args: AxiosRequestConfig) => AxiosPromise<TestSea
 const getBatch = (request: (args: AxiosRequestConfig) => AxiosPromise<{data: ServerBatch}>) => async (
   batchId: string
 ): Promise<Batch> => {
-  const resp = await retryRequest({url: `/synthetics/ci/batch/${batchId}`}, request)
+  const resp = await retryRequest({url: `/synthetics/ci/batch/${batchId}`}, request, retryOn5xxOr404Errors)
 
   const serverBatch = resp.data.data
 
@@ -112,7 +112,8 @@ const pollResults = (request: (args: AxiosRequestConfig) => AxiosPromise<{result
       },
       url: '/synthetics/tests/poll_results',
     },
-    request
+    request,
+    retryOn5xxOr404Errors
   )
 
   return resp.data.results
@@ -135,8 +136,21 @@ const getPresignedURL = (request: (args: AxiosRequestConfig) => AxiosPromise<{ur
   return resp.data
 }
 
-const retryOn5xxErrors = (retries: number, error: AxiosError) => {
+type RetryPolicy = (retries: number, error: AxiosError) => number | undefined
+
+const retryOn5xxErrors: RetryPolicy = (retries, error) => {
   if (retries < 3 && is5xxError(error)) {
+    return 500
+  }
+}
+
+const retryOn5xxOr404Errors: RetryPolicy = (retries, error) => {
+  const retryOn5xxDelay = retryOn5xxErrors(retries, error)
+  if (retryOn5xxDelay) {
+    return retryOn5xxDelay
+  }
+
+  if (retries < 3 && isNotFoundError(error)) {
     return 500
   }
 }
@@ -154,8 +168,11 @@ export const is5xxError = (error: AxiosError | EndpointError) => {
   return statusCode && statusCode >= 500 && statusCode <= 599
 }
 
-const retryRequest = <T>(args: AxiosRequestConfig, request: (args: AxiosRequestConfig) => AxiosPromise<T>) =>
-  retry(() => request(args), retryOn5xxErrors)
+const retryRequest = <T>(
+  args: AxiosRequestConfig,
+  request: (args: AxiosRequestConfig) => AxiosPromise<T>,
+  retryPolicy: RetryPolicy = retryOn5xxErrors
+) => retry(() => request(args), retryPolicy)
 
 export const apiConstructor = (configuration: APIConfiguration) => {
   const {baseUrl, baseIntakeUrl, apiKey, appKey, proxyOpts} = configuration


### PR DESCRIPTION
### What and why?

This PR allows the retry mechanism to also work on HTTP 404 responses for both `getBatch` and `pollResults` API endpoints.

### How?

Make the retry policy function configurable by adding a new parameter to the `retryRequest` function: `retryPolicy`.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] \[_Synthetics_\] New releases of `datadog-ci` MUST be followed by a [synthetics-ci-github-action](https://github.com/DataDog/synthetics-ci-github-action) release
