### PR TITLE
[sourcemaps] Detect --minified-path-prefix misusage

### DIFF
--- a/src/commands/sourcemaps/__tests__/upload.test.ts
+++ b/src/commands/sourcemaps/__tests__/upload.test.ts
@@ -101,7 +101,8 @@ describe('upload', () => {
         new Sourcemap(
           'src/commands/sourcemaps/__tests__/fixtures/sourcemap-with-no-files/empty.min.js',
           'http://example/empty.min.js',
-          'src/commands/sourcemaps/__tests__/fixtures/sourcemap-with-no-files/empty.min.js.map'
+          'src/commands/sourcemaps/__tests__/fixtures/sourcemap-with-no-files/empty.min.js.map',
+          ''
         )
       )
       // The command will fetch git metadatas for the current datadog-ci repository.
@@ -121,7 +122,8 @@ describe('upload', () => {
         new Sourcemap(
           'src/commands/sourcemaps/__tests__/fixtures/basic/common.min.js',
           'http://example/common.min.js',
-          'src/commands/sourcemaps/__tests__/fixtures/basic/common.min.js.map'
+          'src/commands/sourcemaps/__tests__/fixtures/basic/common.min.js.map',
+          ''
         )
       )
       // The command will fetch git metadatas for the current datadog-ci repository.

--- a/src/commands/sourcemaps/__tests__/upload.test.ts
+++ b/src/commands/sourcemaps/__tests__/upload.test.ts
@@ -12,9 +12,10 @@ describe('upload', () => {
       const command = new UploadCommand()
       command['basePath'] = '/js/sourcemaps'
       command['minifiedPathPrefix'] = 'http://datadog.com/js'
-      expect(command['getMinifiedURL']('/js/sourcemaps/common.min.js.map')).toBe(
-        'http://datadog.com/js/common.min.js.map'
-      )
+      expect(command['getMinifiedURLAndRelativePath']('/js/sourcemaps/common.min.js.map')).toStrictEqual([
+        'http://datadog.com/js/common.min.js.map',
+        '/common.min.js.map',
+      ])
     })
   })
 
@@ -23,7 +24,10 @@ describe('upload', () => {
       const command = new UploadCommand()
       command['basePath'] = '/js/sourcemaps'
       command['minifiedPathPrefix'] = '//datadog.com/js'
-      expect(command['getMinifiedURL']('/js/sourcemaps/common.min.js.map')).toBe('//datadog.com/js/common.min.js.map')
+      expect(command['getMinifiedURLAndRelativePath']('/js/sourcemaps/common.min.js.map')).toStrictEqual([
+        '//datadog.com/js/common.min.js.map',
+        '/common.min.js.map',
+      ])
     })
   })
 
@@ -32,7 +36,10 @@ describe('upload', () => {
       const command = new UploadCommand()
       command['basePath'] = '/js/sourcemaps'
       command['minifiedPathPrefix'] = '/js'
-      expect(command['getMinifiedURL']('/js/sourcemaps/common.min.js.map')).toBe('/js/common.min.js.map')
+      expect(command['getMinifiedURLAndRelativePath']('/js/sourcemaps/common.min.js.map')).toStrictEqual([
+        '/js/common.min.js.map',
+        '/common.min.js.map',
+      ])
     })
   })
 
@@ -102,6 +109,7 @@ describe('upload', () => {
           'src/commands/sourcemaps/__tests__/fixtures/sourcemap-with-no-files/empty.min.js',
           'http://example/empty.min.js',
           'src/commands/sourcemaps/__tests__/fixtures/sourcemap-with-no-files/empty.min.js.map',
+          '',
           ''
         )
       )
@@ -123,6 +131,7 @@ describe('upload', () => {
           'src/commands/sourcemaps/__tests__/fixtures/basic/common.min.js',
           'http://example/common.min.js',
           'src/commands/sourcemaps/__tests__/fixtures/basic/common.min.js.map',
+          '',
           ''
         )
       )

--- a/src/commands/sourcemaps/__tests__/utils.test.ts
+++ b/src/commands/sourcemaps/__tests__/utils.test.ts
@@ -1,4 +1,4 @@
-import {getMinifiedFilePath, islastFolderRepeated, arelastFoldersRepeated} from '../utils'
+import {getMinifiedFilePath, extractRepeatedPath} from '../utils'
 
 describe('utils', () => {
   describe('getMinifiedFilePath', () => {
@@ -18,16 +18,21 @@ describe('utils', () => {
       const minifiedPathPrefix = 'https://subdomain.domain.dev/static/js'
       const relativePath = '/static/js/1.23.chunk.js'
 
-      expect(arelastFoldersRepeated(minifiedPathPrefix, relativePath)).toBe(true)
-      expect(islastFolderRepeated(minifiedPathPrefix, relativePath)).toBe(true)
+      expect(extractRepeatedPath(minifiedPathPrefix, relativePath)).toBe('static/js')
+    })
+
+    test('should return true 2', () => {
+      const minifiedPathPrefix = 'https://subdomain.domain.dev/static/js/'
+      const relativePath = '/static/js/1.23.chunk.js'
+
+      expect(extractRepeatedPath(minifiedPathPrefix, relativePath)).toBe('static/js')
     })
 
     test('should return false', () => {
       const minifiedPathPrefix = 'https://subdomain.domain.dev/static/js'
       const relativePath = '/1.23.chunk.js'
 
-      expect(arelastFoldersRepeated(minifiedPathPrefix, relativePath)).toBe(false)
-      expect(islastFolderRepeated(minifiedPathPrefix, relativePath)).toBe(false)
+      expect(extractRepeatedPath(minifiedPathPrefix, relativePath)).toBe(undefined)
     })
   })
   

--- a/src/commands/sourcemaps/__tests__/utils.test.ts
+++ b/src/commands/sourcemaps/__tests__/utils.test.ts
@@ -1,4 +1,4 @@
-import {getMinifiedFilePath, extractRepeatedPath} from '../utils'
+import {extractRepeatedPath, getMinifiedFilePath} from '../utils'
 
 describe('utils', () => {
   describe('getMinifiedFilePath', () => {
@@ -35,5 +35,4 @@ describe('utils', () => {
       expect(extractRepeatedPath(minifiedPathPrefix, relativePath)).toBe(undefined)
     })
   })
-  
 })

--- a/src/commands/sourcemaps/__tests__/utils.test.ts
+++ b/src/commands/sourcemaps/__tests__/utils.test.ts
@@ -1,4 +1,4 @@
-import {getMinifiedFilePath} from '../utils'
+import {getMinifiedFilePath, islastFolderRepeated, arelastFoldersRepeated} from '../utils'
 
 describe('utils', () => {
   describe('getMinifiedFilePath', () => {
@@ -12,4 +12,23 @@ describe('utils', () => {
       )
     })
   })
+
+  describe('arelastFoldersRepeated', () => {
+    test('should return true', () => {
+      const minifiedPathPrefix = 'https://subdomain.domain.dev/static/js'
+      const relativePath = '/static/js/1.23.chunk.js'
+
+      expect(arelastFoldersRepeated(minifiedPathPrefix, relativePath)).toBe(true)
+      expect(islastFolderRepeated(minifiedPathPrefix, relativePath)).toBe(true)
+    })
+
+    test('should return false', () => {
+      const minifiedPathPrefix = 'https://subdomain.domain.dev/static/js'
+      const relativePath = '/1.23.chunk.js'
+
+      expect(arelastFoldersRepeated(minifiedPathPrefix, relativePath)).toBe(false)
+      expect(islastFolderRepeated(minifiedPathPrefix, relativePath)).toBe(false)
+    })
+  })
+  
 })

--- a/src/commands/sourcemaps/interfaces.ts
+++ b/src/commands/sourcemaps/interfaces.ts
@@ -7,13 +7,21 @@ export class Sourcemap {
   public minifiedFilePath: string
   public minifiedPathPrefix?: string
   public minifiedUrl: string
+  public relativePath: string
   public sourcemapPath: string
 
-  constructor(minifiedFilePath: string, minifiedUrl: string, sourcemapPath: string, minifiedPathPrefix?: string) {
+  constructor(
+    minifiedFilePath: string,
+    minifiedUrl: string,
+    sourcemapPath: string,
+    relativePath: string,
+    minifiedPathPrefix?: string
+  ) {
     this.minifiedFilePath = minifiedFilePath
-    this.minifiedUrl = minifiedUrl
-    this.sourcemapPath = sourcemapPath
     this.minifiedPathPrefix = minifiedPathPrefix
+    this.minifiedUrl = minifiedUrl
+    this.relativePath = relativePath
+    this.sourcemapPath = sourcemapPath
   }
 
   public addRepositoryData(gitData: GitData) {

--- a/src/commands/sourcemaps/interfaces.ts
+++ b/src/commands/sourcemaps/interfaces.ts
@@ -7,11 +7,13 @@ export class Sourcemap {
   public minifiedFilePath: string
   public minifiedUrl: string
   public sourcemapPath: string
+  public minifiedPathPrefix?: string
 
-  constructor(minifiedFilePath: string, minifiedUrl: string, sourcemapPath: string) {
+  constructor(minifiedFilePath: string, minifiedUrl: string, sourcemapPath: string, minifiedPathPrefix?: string) {
     this.minifiedFilePath = minifiedFilePath
     this.minifiedUrl = minifiedUrl
     this.sourcemapPath = sourcemapPath
+    this.minifiedPathPrefix = minifiedPathPrefix
   }
 
   public addRepositoryData(gitData: GitData) {

--- a/src/commands/sourcemaps/interfaces.ts
+++ b/src/commands/sourcemaps/interfaces.ts
@@ -5,9 +5,9 @@ import {MultipartPayload, MultipartValue} from '../../helpers/upload'
 export class Sourcemap {
   public gitData?: GitData
   public minifiedFilePath: string
+  public minifiedPathPrefix?: string
   public minifiedUrl: string
   public sourcemapPath: string
-  public minifiedPathPrefix?: string
 
   constructor(minifiedFilePath: string, minifiedUrl: string, sourcemapPath: string, minifiedPathPrefix?: string) {
     this.minifiedFilePath = minifiedFilePath

--- a/src/commands/sourcemaps/renderer.ts
+++ b/src/commands/sourcemaps/renderer.ts
@@ -24,7 +24,7 @@ export const renderInvalidPrefix = chalk.red(
 
 export const renderMinifiedPathPrefixMisusage = (sourcemap: Sourcemap, repeated: string) =>
   chalk.yellow(
-    `${ICONS.WARNING} The --minified-path-prefix flag value (${sourcemap.minifiedPathPrefix}) seems to repeat "${repeated}" which is alredy present in the minified filepath ${sourcemap.minifiedFilePath}\n`
+    `${ICONS.WARNING} The --minified-path-prefix flag value "${sourcemap.minifiedPathPrefix}" seems to repeat "${repeated}" which is already present in the path "${sourcemap.relativePath}"\n`
   )
 
 export const renderFailedUpload = (sourcemap: Sourcemap, errorMessage: string) => {

--- a/src/commands/sourcemaps/renderer.ts
+++ b/src/commands/sourcemaps/renderer.ts
@@ -22,6 +22,9 @@ export const renderInvalidPrefix = chalk.red(
   `${ICONS.FAILED} --minified-path-prefix should either be an URL (such as "http://example.com/static") or an absolute path starting with a / such as "/static"\n`
 )
 
+export const renderMinifiedPathPrefixMisusage = (sourcemap: Sourcemap, repeated: string) =>
+  chalk.yellow(`${ICONS.WARNING} The --minified-path-prefix flag value (${sourcemap.minifiedPathPrefix}) seems to repeat "${repeated}" which is alredy present in the minified filepath ${sourcemap.minifiedFilePath}\n`)
+
 export const renderFailedUpload = (sourcemap: Sourcemap, errorMessage: string) => {
   const sourcemapPathBold = `[${chalk.bold.dim(sourcemap.sourcemapPath)}]`
 

--- a/src/commands/sourcemaps/renderer.ts
+++ b/src/commands/sourcemaps/renderer.ts
@@ -23,7 +23,9 @@ export const renderInvalidPrefix = chalk.red(
 )
 
 export const renderMinifiedPathPrefixMisusage = (sourcemap: Sourcemap, repeated: string) =>
-  chalk.yellow(`${ICONS.WARNING} The --minified-path-prefix flag value (${sourcemap.minifiedPathPrefix}) seems to repeat "${repeated}" which is alredy present in the minified filepath ${sourcemap.minifiedFilePath}\n`)
+  chalk.yellow(
+    `${ICONS.WARNING} The --minified-path-prefix flag value (${sourcemap.minifiedPathPrefix}) seems to repeat "${repeated}" which is alredy present in the minified filepath ${sourcemap.minifiedFilePath}\n`
+  )
 
 export const renderFailedUpload = (sourcemap: Sourcemap, errorMessage: string) => {
   const sourcemapPathBold = `[${chalk.bold.dim(sourcemap.sourcemapPath)}]`

--- a/src/commands/sourcemaps/upload.ts
+++ b/src/commands/sourcemaps/upload.ts
@@ -176,6 +176,7 @@ export class UploadCommand extends Command {
       sourcemapFiles.map(async (sourcemapPath) => {
         const minifiedFilePath = getMinifiedFilePath(sourcemapPath)
         const minifiedURL = this.getMinifiedURL(minifiedFilePath)
+
         return new Sourcemap(minifiedFilePath, minifiedURL, sourcemapPath, this.minifiedPathPrefix)
       })
     )

--- a/src/commands/sourcemaps/upload.ts
+++ b/src/commands/sourcemaps/upload.ts
@@ -175,17 +175,17 @@ export class UploadCommand extends Command {
     return Promise.all(
       sourcemapFiles.map(async (sourcemapPath) => {
         const minifiedFilePath = getMinifiedFilePath(sourcemapPath)
-        const minifiedURL = this.getMinifiedURL(minifiedFilePath)
+        const [minifiedURL, relativePath] = this.getMinifiedURLAndRelativePath(minifiedFilePath)
 
-        return new Sourcemap(minifiedFilePath, minifiedURL, sourcemapPath, this.minifiedPathPrefix)
+        return new Sourcemap(minifiedFilePath, minifiedURL, sourcemapPath, relativePath, this.minifiedPathPrefix)
       })
     )
   }
 
-  private getMinifiedURL(minifiedFilePath: string): string {
+  private getMinifiedURLAndRelativePath(minifiedFilePath: string): [string, string] {
     const relativePath = minifiedFilePath.replace(this.basePath!, '')
 
-    return buildPath(this.minifiedPathPrefix!, relativePath)
+    return [buildPath(this.minifiedPathPrefix!, relativePath), relativePath]
   }
 
   private getPayloadsToUpload = async (useGit: boolean): Promise<Sourcemap[]> => {

--- a/src/commands/sourcemaps/upload.ts
+++ b/src/commands/sourcemaps/upload.ts
@@ -176,8 +176,7 @@ export class UploadCommand extends Command {
       sourcemapFiles.map(async (sourcemapPath) => {
         const minifiedFilePath = getMinifiedFilePath(sourcemapPath)
         const minifiedURL = this.getMinifiedURL(minifiedFilePath)
-
-        return new Sourcemap(minifiedFilePath, minifiedURL, sourcemapPath)
+        return new Sourcemap(minifiedFilePath, minifiedURL, sourcemapPath, this.minifiedPathPrefix)
       })
     )
   }
@@ -270,7 +269,7 @@ export class UploadCommand extends Command {
   ): (sourcemap: Sourcemap) => Promise<UploadStatus> {
     return async (sourcemap: Sourcemap) => {
       try {
-        validatePayload(sourcemap)
+        validatePayload(sourcemap, this.context.stdout)
       } catch (error) {
         if (error instanceof InvalidPayload) {
           this.context.stdout.write(renderFailedUpload(sourcemap, error.message))

--- a/src/commands/sourcemaps/utils.ts
+++ b/src/commands/sourcemaps/utils.ts
@@ -8,7 +8,7 @@ export const getMinifiedFilePath = (sourcemapPath: string) => {
   return sourcemapPath.replace(new RegExp('\\.map$'), '')
 }
 
-// ExtractRepeatedPath checks if the last part of paths of the first arg are found at the start of the second arg.
+// ExtractRepeatedPath checks if the last part of paths of the first arg are repeated at the start of the second arg.
 export const extractRepeatedPath = (path1: string, path2: string): string | undefined => {
   const splitOnSlashes = new RegExp(/[\/]+|[\\]+/)
   const trimSlashes = new RegExp(/^[\/]+|^[\\]+|[\/]+$|[\\]+$/)

--- a/src/commands/sourcemaps/utils.ts
+++ b/src/commands/sourcemaps/utils.ts
@@ -8,18 +8,19 @@ export const getMinifiedFilePath = (sourcemapPath: string) => {
   return sourcemapPath.replace(new RegExp('\\.map$'), '')
 }
 
-// extractRepeatedPath checks if the last part of paths of the first arg are found at the start of the second arg. 
+// ExtractRepeatedPath checks if the last part of paths of the first arg are found at the start of the second arg.
 export const extractRepeatedPath = (path1: string, path2: string): string | undefined => {
-  let splitOnSlashes = new RegExp(/[\/]+|[\\]+/)
-  let trimSlashes = new RegExp(/^[\/]+|^[\\]+|[\/]+$|[\\]+$/)
-  let path1split = path1.trim().replace(trimSlashes, '').split(splitOnSlashes)
-  let path2split = path2.trim().replace(trimSlashes, '').split(splitOnSlashes)
-  let normalizedpath2 = path2split.join('/')
-  for (var i = path1split.length; i > 0; i--) {
-    var path1subset = path1split.slice(-i).join('/')
-    if(normalizedpath2.startsWith(path1subset)) {
-      return path1subset;
+  const splitOnSlashes = new RegExp(/[\/]+|[\\]+/)
+  const trimSlashes = new RegExp(/^[\/]+|^[\\]+|[\/]+$|[\\]+$/)
+  const path1split = path1.trim().replace(trimSlashes, '').split(splitOnSlashes)
+  const path2split = path2.trim().replace(trimSlashes, '').split(splitOnSlashes)
+  const normalizedpath2 = path2split.join('/')
+  for (let i = path1split.length; i > 0; i--) {
+    const path1subset = path1split.slice(-i).join('/')
+    if (normalizedpath2.startsWith(path1subset)) {
+      return path1subset
     }
   }
-  return undefined;
+
+  return undefined
 }

--- a/src/commands/sourcemaps/utils.ts
+++ b/src/commands/sourcemaps/utils.ts
@@ -7,3 +7,30 @@ export const getMinifiedFilePath = (sourcemapPath: string) => {
 
   return sourcemapPath.replace(new RegExp('\\.map$'), '')
 }
+
+// arelastFoldersRepeated checks if the last folders of the first arg are found within the second. 
+export const arelastFoldersRepeated = (path1: string, path2: string): boolean => {
+  let splitOnSlashes = new RegExp(/[\/]+|[\\]+/)
+  let trimSlashes = new RegExp(/^[\/]+|^[\\]+|[\/]+$|[\\]+$/)
+  let path1split = path1.trim().replace(trimSlashes, '').split(splitOnSlashes)
+  let path2split = path2.trim().replace(trimSlashes, '').split(splitOnSlashes)
+  let normalizedpath2 = path2split.join('/')
+  for (var i = path1split.length; i > 0; i--) {
+    var path1subset = path1split.slice(-i).join('/')
+    console.log(path1subset+' => '+normalizedpath2+'\n')
+    if(normalizedpath2.startsWith(path1subset)) {
+      return true;
+    }
+  }
+  return false
+}
+
+// islastFolderRepeated checks if the last folder of the first arg is found within the second. 
+export const islastFolderRepeated = (path1: string, path2: string): boolean => {
+  let splitOnSlashes = new RegExp(/[\/]+|[\\]+/)
+  let trimSlashes = new RegExp(/^[\/]+|^[\\]+|[\/]+$|[\\]+$/)
+  let path1split = path1.trim().replace(trimSlashes, '').split(splitOnSlashes)
+  let path2split = path2.trim().replace(trimSlashes, '').split(splitOnSlashes)
+  let lastFolder = path1split[path1split.length-1]
+  return path2split.includes(lastFolder)
+}

--- a/src/commands/sourcemaps/utils.ts
+++ b/src/commands/sourcemaps/utils.ts
@@ -8,8 +8,8 @@ export const getMinifiedFilePath = (sourcemapPath: string) => {
   return sourcemapPath.replace(new RegExp('\\.map$'), '')
 }
 
-// arelastFoldersRepeated checks if the last folders of the first arg are found within the second. 
-export const arelastFoldersRepeated = (path1: string, path2: string): boolean => {
+// extractRepeatedPath checks if the last part of paths of the first arg are found at the start of the second arg. 
+export const extractRepeatedPath = (path1: string, path2: string): string | undefined => {
   let splitOnSlashes = new RegExp(/[\/]+|[\\]+/)
   let trimSlashes = new RegExp(/^[\/]+|^[\\]+|[\/]+$|[\\]+$/)
   let path1split = path1.trim().replace(trimSlashes, '').split(splitOnSlashes)
@@ -17,20 +17,9 @@ export const arelastFoldersRepeated = (path1: string, path2: string): boolean =>
   let normalizedpath2 = path2split.join('/')
   for (var i = path1split.length; i > 0; i--) {
     var path1subset = path1split.slice(-i).join('/')
-    console.log(path1subset+' => '+normalizedpath2+'\n')
     if(normalizedpath2.startsWith(path1subset)) {
-      return true;
+      return path1subset;
     }
   }
-  return false
-}
-
-// islastFolderRepeated checks if the last folder of the first arg is found within the second. 
-export const islastFolderRepeated = (path1: string, path2: string): boolean => {
-  let splitOnSlashes = new RegExp(/[\/]+|[\\]+/)
-  let trimSlashes = new RegExp(/^[\/]+|^[\\]+|[\/]+$|[\\]+$/)
-  let path1split = path1.trim().replace(trimSlashes, '').split(splitOnSlashes)
-  let path2split = path2.trim().replace(trimSlashes, '').split(splitOnSlashes)
-  let lastFolder = path1split[path1split.length-1]
-  return path2split.includes(lastFolder)
+  return undefined;
 }

--- a/src/commands/sourcemaps/validation.ts
+++ b/src/commands/sourcemaps/validation.ts
@@ -1,8 +1,8 @@
+import {Writable} from 'stream'
 import {checkFile} from '../../helpers/validation'
 import {Sourcemap} from './interfaces'
+import {renderMinifiedPathPrefixMisusage} from './renderer'
 import {extractRepeatedPath} from './utils'
-import { Writable } from 'stream';
-import { renderMinifiedPathPrefixMisusage  } from './renderer'
 
 export class InvalidPayload extends Error {
   public reason: string
@@ -40,12 +40,9 @@ export const validatePayload = (sourcemap: Sourcemap, stdout: Writable) => {
 
   // Check that the folders part of the --minified-path-prefix flag are not present within the minifiedFilePath.
   if (sourcemap.minifiedPathPrefix) {
-    let repeated = extractRepeatedPath(sourcemap.minifiedPathPrefix!, sourcemap.minifiedFilePath)
+    const repeated = extractRepeatedPath(sourcemap.minifiedPathPrefix!, sourcemap.minifiedFilePath)
     if (repeated) {
-      stdout.write(
-        renderMinifiedPathPrefixMisusage(sourcemap, repeated)
-      )
+      stdout.write(renderMinifiedPathPrefixMisusage(sourcemap, repeated))
     }
   }
-
 }

--- a/src/commands/sourcemaps/validation.ts
+++ b/src/commands/sourcemaps/validation.ts
@@ -38,9 +38,9 @@ export const validatePayload = (sourcemap: Sourcemap, stdout: Writable) => {
     )
   }
 
-  // Check that the folders part of the --minified-path-prefix flag are not present within the minifiedFilePath.
+  // Check for --minified-path-prefix flag misuages.
   if (sourcemap.minifiedPathPrefix) {
-    const repeated = extractRepeatedPath(sourcemap.minifiedPathPrefix!, sourcemap.minifiedFilePath)
+    const repeated = extractRepeatedPath(sourcemap.minifiedPathPrefix!, sourcemap.relativePath)
     if (repeated) {
       stdout.write(renderMinifiedPathPrefixMisusage(sourcemap, repeated))
     }


### PR DESCRIPTION
### What and why?

The PR adds a warning in the output when the `--minified-path-prefix` flag may have been misused.
We've had several tickets already where unminification wasn't working because customers uploaded sourcemaps with the wrong flag value which might not be easy to spot at first glance. The outputs were as such:

```
Uploading sourcemap build/static/js/abc.chunk.js.map for JS file available at https://my-website.com/static/js/static/js/abc.chunk.js
``` 

After this PR, launching the following command:
```
$ yarn launch sourcemaps upload ./src/commands/sourcemaps/__tests__ --service my-service --minified-path-prefix https://static.datadog.com/fixtures/basic --release-version 1.2
```

will now output the following warning:

```
⚠️ The --minified-path-prefix flag value "https://static.datadog.com/fixtures/basic" seems to repeat "fixtures/basic" which is already present in the path "/fixtures/basic/common.min.js"
```

### How?

We try to detect if the suffix of `--minified-path-prefix` is already present as a prefix in the path inferred from the first positional argument (directory in which sourcemaps are located).

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] \[_Synthetics_\] New releases of `datadog-ci` MUST be followed by a [synthetics-ci-github-action](https://github.com/DataDog/synthetics-ci-github-action) release
