### PR TITLE
v1.13.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci",
-  "version": "1.13.0",
+  "version": "1.13.1",
   "description": "Run datadog actions from the CI.",
   "repository": "https://github.com/DataDog/datadog-ci",
   "license": "Apache-2.0",


### PR DESCRIPTION
Bump version to `v1.13.1`:
* https://github.com/DataDog/datadog-ci/pull/601
