### PR TITLE
[sourcemaps] Log service and version when starting upload

### DIFF
--- a/src/commands/sourcemaps/__tests__/upload.test.ts
+++ b/src/commands/sourcemaps/__tests__/upload.test.ts
@@ -290,7 +290,9 @@ interface ExpectedOutput {
 
 const checkConsoleOutput = (output: string[], expected: ExpectedOutput) => {
   expect(output[0]).toContain('DRY-RUN MODE ENABLED. WILL NOT UPLOAD SOURCEMAPS')
-  expect(output[1]).toContain(`Starting upload with concurrency ${expected.concurrency}.`)
+  expect(output[1]).toContain(
+    `Starting upload for service ${expected.service}, version ${expected.version}, with concurrency ${expected.concurrency}.`
+  )
   expect(output[2]).toContain(`Will look for sourcemaps in ${expected.basePath}`)
   expect(output[3]).toContain(`Will match JS files for errors on files starting with ${expected.minifiedPathPrefix}`)
   expect(output[4]).toContain(

--- a/src/commands/sourcemaps/renderer.ts
+++ b/src/commands/sourcemaps/renderer.ts
@@ -109,7 +109,9 @@ export const renderCommandInfo = (
   if (dryRun) {
     fullStr += chalk.yellow(`${ICONS.WARNING} DRY-RUN MODE ENABLED. WILL NOT UPLOAD SOURCEMAPS\n`)
   }
-  const startStr = chalk.green(`Starting upload with concurrency ${poolLimit}. \n`)
+  const startStr = chalk.green(
+    `Starting upload for service ${service}, version ${releaseVersion}, with concurrency ${poolLimit}.\n`
+  )
   fullStr += startStr
   const basePathStr = chalk.green(`Will look for sourcemaps in ${basePath}\n`)
   fullStr += basePathStr


### PR DESCRIPTION
Logs the `--service-name` and `--release-version` parameters in the sourcemaps upload command output.

Common misuse of the CLI is to pass an incorrect service or version; since those are often passed through environment variables, the command itself or the command output don't contain these parameters, which makes it hard to debug, both for users and for us, when we only have access to the command output.