### PR TITLE
Update container image instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,28 +59,26 @@ datadog-ci version
 
 ### Container image (**experimental**)
 
-In order to run `datadog-ci` from a container, you can use the following `Dockerfile:
+In order to run `datadog-ci` from a container, you can use the following `Dockerfile`:
 
 ```dockerfile
-ARG VERSION
-FROM ubuntu:20.04
-
-ADD https://github.com/DataDog/datadog-ci/releases/download/$VERSION/datadog-ci_linux-x64 /usr/local/bin/datadog-ci
-RUN chmod +x /usr/local/bin/datadog-ci
-
-ENTRYPOINT ["/usr/local/bin/datadog-ci"]
+FROM alpine
+WORKDIR /w
+RUN apk add --update npm git
+RUN npm install -g @datadog/datadog-ci
+ENTRYPOINT ["datadog-ci"]
 ```
 
 To build and run it, the following commands can be used:
 
 ```sh
 # Build the container
-docker build -t datadog-ci:dev --build-arg VERSION=v1.7.2 .
+docker build -t datadog-ci .
 
 # Run a command using the container
 export DD_API_KEY=$(cat /secret/dd_api_key)
 export DD_APP_KEY=$(cat /secret/dd_app_key)
-docker run --rm -it --name datadog-ci -e DD_API_KEY -e DD_APP_KEY datadog-ci:dev synthetics run-tests -p pub-lic-id1
+docker run --rm -it -v $(pwd):/w -e DD_API_KEY -e DD_APP_KEY datadog-ci synthetics run-tests -p pub-lic-id1
 ```
 
 ## Usage


### PR DESCRIPTION
### What and why?

Changes the instructions on how to build a run the CLI using a container. The current instructions do not take into account the fact that the CLI needs `git` for some commands and access to the local filesystem.

### How?

- New `Dockerfile` that is `alpine` based (to reduce size) and that installs `git` (required by several commands) and the CLI using `npm` (as the static binary is still experimental). It also installs the latest version of the CLI.
- Adds mounting the current directory into the container to have access to git metadata (required by several commands).


### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] \[_Synthetics_\] New releases of `datadog-ci` MUST be followed by a [synthetics-ci-github-action](https://github.com/DataDog/synthetics-ci-github-action) release
