### PR TITLE
synthetics: simplify getTestsToTrigger

### DIFF
--- a/src/commands/synthetics/__tests__/utils.test.ts
+++ b/src/commands/synthetics/__tests__/utils.test.ts
@@ -270,10 +270,10 @@ describe('utils', () => {
     })
   })
 
-  describe('handleConfig', () => {
+  describe('getOverriddenConfig', () => {
     test('empty config returns simple payload', () => {
       const publicId = 'abc-def-ghi'
-      expect(utils.handleConfig({public_id: publicId} as Test, publicId, mockReporter)).toEqual({
+      expect(utils.getOverriddenConfig({public_id: publicId} as Test, publicId, mockReporter)).toEqual({
         executionRule: ExecutionRule.BLOCKING,
         public_id: publicId,
       })
@@ -300,10 +300,10 @@ describe('utils', () => {
 
         expect(utils.getExecutionRule(fakeTest, configOverride)).toBe(expectedExecutionRule)
 
-        const handledConfig = utils.handleConfig(fakeTest, publicId, mockReporter, configOverride)
+        const overriddenConfig = utils.getOverriddenConfig(fakeTest, publicId, mockReporter, configOverride)
 
-        expect(handledConfig.public_id).toBe(publicId)
-        expect(handledConfig.executionRule).toBe(expectedExecutionRule)
+        expect(overriddenConfig.public_id).toBe(publicId)
+        expect(overriddenConfig.executionRule).toBe(expectedExecutionRule)
       }
 
       const BLOCKING = ExecutionRule.BLOCKING
@@ -342,22 +342,22 @@ describe('utils', () => {
       }
       const expectedUrl = 'https://example.org/newPath?oldPath=/path#target'
 
-      let handledConfig = utils.handleConfig(fakeTest, publicId, mockReporter, configOverride)
-      expect(handledConfig.public_id).toBe(publicId)
-      expect(handledConfig.startUrl).toBe(expectedUrl)
+      let overriddenConfig = utils.getOverriddenConfig(fakeTest, publicId, mockReporter, configOverride)
+      expect(overriddenConfig.public_id).toBe(publicId)
+      expect(overriddenConfig.startUrl).toBe(expectedUrl)
 
       fakeTest.type = 'api'
       fakeTest.subtype = 'http'
 
-      handledConfig = utils.handleConfig(fakeTest, publicId, mockReporter, configOverride)
-      expect(handledConfig.public_id).toBe(publicId)
-      expect(handledConfig.startUrl).toBe(expectedUrl)
+      overriddenConfig = utils.getOverriddenConfig(fakeTest, publicId, mockReporter, configOverride)
+      expect(overriddenConfig.public_id).toBe(publicId)
+      expect(overriddenConfig.startUrl).toBe(expectedUrl)
 
       fakeTest.subtype = 'dns'
 
-      handledConfig = utils.handleConfig(fakeTest, publicId, mockReporter, configOverride)
-      expect(handledConfig.public_id).toBe(publicId)
-      expect(handledConfig.startUrl).toBeUndefined()
+      overriddenConfig = utils.getOverriddenConfig(fakeTest, publicId, mockReporter, configOverride)
+      expect(overriddenConfig.public_id).toBe(publicId)
+      expect(overriddenConfig.startUrl).toBeUndefined()
     })
 
     test('startUrl is not parsable', () => {
@@ -373,10 +373,10 @@ describe('utils', () => {
         startUrl: 'https://{{DOMAIN}}/newPath?oldPath={{CUSTOMVAR}}',
       }
       const expectedUrl = 'https://{{DOMAIN}}/newPath?oldPath=/newPath'
-      const handledConfig = utils.handleConfig(fakeTest, publicId, mockReporter, configOverride)
+      const overriddenConfig = utils.getOverriddenConfig(fakeTest, publicId, mockReporter, configOverride)
 
-      expect(handledConfig.public_id).toBe(publicId)
-      expect(handledConfig.startUrl).toBe(expectedUrl)
+      expect(overriddenConfig.public_id).toBe(publicId)
+      expect(overriddenConfig.startUrl).toBe(expectedUrl)
       process.env = envVars
     })
 
@@ -391,10 +391,10 @@ describe('utils', () => {
         startUrl: 'http://127.0.0.1/newPath{{PARAMS}}',
       }
       const expectedUrl = 'http://127.0.0.1/newPath'
-      const handledConfig = utils.handleConfig(fakeTest, publicId, mockReporter, configOverride)
+      const overriddenConfig = utils.getOverriddenConfig(fakeTest, publicId, mockReporter, configOverride)
 
-      expect(handledConfig.public_id).toBe(publicId)
-      expect(handledConfig.startUrl).toBe(expectedUrl)
+      expect(overriddenConfig.public_id).toBe(publicId)
+      expect(overriddenConfig.startUrl).toBe(expectedUrl)
     })
 
     test('config overrides are applied', () => {
@@ -424,7 +424,7 @@ describe('utils', () => {
         variables: {VAR_1: 'value'},
       }
 
-      expect(utils.handleConfig(fakeTest, publicId, mockReporter, configOverride)).toEqual({
+      expect(utils.getOverriddenConfig(fakeTest, publicId, mockReporter, configOverride)).toEqual({
         ...configOverride,
         public_id: publicId,
       })

--- a/src/commands/synthetics/utils.ts
+++ b/src/commands/synthetics/utils.ts
@@ -293,7 +293,7 @@ export const waitForResults = async (
     return hasTunnel ? 'Tunneled' : locationNames[dcId] || dcId
   }
 
-  const getTest = (id: string): Test => tests.find((t) => t.public_id === id)!
+  const getTestWithPublicId = (id: string): Test => tests.find((t) => t.public_id === id)!
 
   const maxPollingDate = Date.now() + options.maxPollingTimeout
   const emittedResultIndexes = new Set<number>()
@@ -345,7 +345,7 @@ export const waitForResults = async (
       pollResult.result.passed = false
     }
 
-    const test = getTest(resultInBatch.test_public_id)
+    const test = getTestWithPublicId(resultInBatch.test_public_id)
     results.push({
       executionRule: resultInBatch.execution_rule,
       location: getLocation(resultInBatch.location, test),

--- a/src/commands/synthetics/utils.ts
+++ b/src/commands/synthetics/utils.ts
@@ -455,16 +455,59 @@ export const getReporter = (reporters: Reporter[]): MainReporter => ({
   },
 })
 
+const getTest = async (api: APIHelper, {id, suite}: TriggerConfig): Promise<{test: Test} | {errorMessage: string}> => {
+  try {
+    const test = {
+      ...(await api.getTest(id)),
+      suite,
+    }
+
+    return {test}
+  } catch (error) {
+    if (isNotFoundError(error)) {
+      const errorMessage = formatBackendErrors(error)
+      return {errorMessage: `[${chalk.bold.dim(id)}] ${chalk.yellow.bold('Test not found')}: ${errorMessage}`}
+    }
+
+    throw error
+  }
+}
+
+const getTestAndOverrideConfig = async (
+  api: APIHelper,
+  {config, id, suite}: TriggerConfig,
+  reporter: MainReporter,
+  summary: Summary
+) => {
+  id = PUBLIC_ID_REGEX.test(id) ? id : id.substr(id.lastIndexOf('/') + 1)
+
+  const getTestResult = await getTest(api, {config, id, suite})
+  if ('errorMessage' in getTestResult) {
+    summary.testsNotFound.add(id)
+    return {errorMessage: getTestResult.errorMessage}
+  }
+
+  const test = getTestResult.test
+  const overriddenConfig = handleConfig(test, id, reporter, config)
+
+  reporter.testTrigger(test, id, overriddenConfig.executionRule, config)
+  if (overriddenConfig.executionRule === ExecutionRule.SKIPPED) {
+    summary.skipped++
+  } else {
+    reporter.testWait(test)
+    return {overriddenConfig, test}
+  }
+
+  return {overriddenConfig}
+}
+
 export const getTestsToTrigger = async (
   api: APIHelper,
   triggerConfigs: TriggerConfig[],
   reporter: MainReporter,
   triggerFromSearch?: boolean
 ) => {
-  const overriddenTestsToTrigger: TestPayload[] = []
   const errorMessages: string[] = []
-  const summary = createSummary()
-
   // When too many tests are triggered, if fetched from a search query: simply trim them and show a warning,
   // otherwise: retrieve them and fail later if still exceeding without skipped/missing tests.
   if (triggerConfigs.length > MAX_TESTS_TO_TRIGGER && triggerFromSearch) {
@@ -475,40 +518,26 @@ export const getTestsToTrigger = async (
     )
   }
 
-  const tests = await Promise.all(
-    triggerConfigs.map(async ({config, id, suite}) => {
-      let test: Test | undefined
-      id = PUBLIC_ID_REGEX.test(id) ? id : id.substr(id.lastIndexOf('/') + 1)
-      try {
-        test = {
-          ...(await api.getTest(id)),
-          suite,
-        }
-      } catch (error) {
-        if (isNotFoundError(error)) {
-          summary.testsNotFound.add(id)
-          const errorMessage = formatBackendErrors(error)
-          errorMessages.push(`[${chalk.bold.dim(id)}] ${chalk.yellow.bold('Test not found')}: ${errorMessage}`)
-
-          return
-        }
-
-        throw error
-      }
-
-      const overriddenConfig = handleConfig(test, id, reporter, config)
-      overriddenTestsToTrigger.push(overriddenConfig)
-
-      reporter.testTrigger(test, id, overriddenConfig.executionRule, config)
-      if (overriddenConfig.executionRule === ExecutionRule.SKIPPED) {
-        summary.skipped++
-      } else {
-        reporter.testWait(test)
-
-        return test
-      }
-    })
+  const summary = createSummary()
+  const testsAndConfigsOverride = await Promise.all(
+    triggerConfigs.map((triggerConfig) => getTestAndOverrideConfig(api, triggerConfig, reporter, summary))
   )
+
+  const overriddenTestsToTrigger: TestPayload[] = []
+  const waitedTests: Test[] = []
+  testsAndConfigsOverride.forEach(({test, errorMessage, overriddenConfig}) => {
+    if (errorMessage) {
+      errorMessages.push(errorMessage)
+    }
+
+    if (overriddenConfig) {
+      overriddenTestsToTrigger.push(overriddenConfig)
+    }
+
+    if (test) {
+      waitedTests.push(test)
+    }
+  })
 
   // Display errors at the end of all tests for better visibility.
   reporter.initErrors(errorMessages)
@@ -522,7 +551,6 @@ export const getTestsToTrigger = async (
     )
   }
 
-  const waitedTests = tests.filter(definedTypeGuard)
   if (waitedTests.length > 0) {
     reporter.testsWait(waitedTests)
   }
@@ -556,8 +584,6 @@ export const fetchTest = async (publicId: string, config: SyntheticsCIConfig): P
 
   return apiHelper.getTest(publicId)
 }
-
-const definedTypeGuard = <T>(o: T | undefined): o is T => !!o
 
 export const retry = async <T, E extends Error>(
   func: () => Promise<T>,

--- a/src/commands/synthetics/utils.ts
+++ b/src/commands/synthetics/utils.ts
@@ -48,7 +48,7 @@ const template = (st: string, context: any): string =>
 
 export let ciTriggerApp = process.env.DATADOG_SYNTHETICS_CI_TRIGGER_APP || 'npm_package'
 
-export const handleConfig = (
+export const getOverriddenConfig = (
   test: Test,
   publicId: string,
   reporter: MainReporter,
@@ -466,6 +466,7 @@ const getTest = async (api: APIHelper, {id, suite}: TriggerConfig): Promise<{tes
   } catch (error) {
     if (isNotFoundError(error)) {
       const errorMessage = formatBackendErrors(error)
+
       return {errorMessage: `[${chalk.bold.dim(id)}] ${chalk.yellow.bold('Test not found')}: ${errorMessage}`}
     }
 
@@ -484,17 +485,19 @@ const getTestAndOverrideConfig = async (
   const getTestResult = await getTest(api, {config, id, suite})
   if ('errorMessage' in getTestResult) {
     summary.testsNotFound.add(id)
+
     return {errorMessage: getTestResult.errorMessage}
   }
 
   const test = getTestResult.test
-  const overriddenConfig = handleConfig(test, id, reporter, config)
+  const overriddenConfig = getOverriddenConfig(test, id, reporter, config)
 
   reporter.testTrigger(test, id, overriddenConfig.executionRule, config)
   if (overriddenConfig.executionRule === ExecutionRule.SKIPPED) {
     summary.skipped++
   } else {
     reporter.testWait(test)
+
     return {overriddenConfig, test}
   }
 


### PR DESCRIPTION
### What and why?

- Rename `getTest` to `getTestWithPublicId`
- Extract code in `getTest` and `getAndOverrideTest` to simplify `getTestsToTrigger`
- Rename handleConfig to getOverriddenConfig
