### PR TITLE
Fix React Native path in xcode command

### DIFF
--- a/src/commands/react-native/xcode.ts
+++ b/src/commands/react-native/xcode.ts
@@ -2,13 +2,20 @@
 import {spawn} from 'child_process'
 import {Cli, Command} from 'clipanion'
 import {existsSync} from 'fs'
+import {sep} from 'path'
 import {UploadCommand} from './upload'
 
+/**
+ * Because jest cannot mock require.resolve, reactNativePath cannot
+ * be unit tested. If you make any change to it, make sure to test
+ * it with a real project.
+ */
 const reactNativePath = (() => {
   try {
     const reactNativeIndexFile = require.resolve('react-native')
 
-    return `${reactNativeIndexFile}/..`
+    // We need to remove the trailing "/index.js" at the end of the path
+    return reactNativeIndexFile.split(sep).slice(0, -1).join(sep)
   } catch (error) {
     return 'node_modules/react-native'
   }


### PR DESCRIPTION
### What and why?

Using `${indexFilePath}/..` would return ENOTDIR when trying to spawn the bundle script, so I removed last part of the path instead.
I could have also used `.replace('/index.js', '')` but I think this solution is more robust if the name of the "main" file changes.

### How?

Require.resolve cannot be mocked by jest, and I don't think it is worth adding `react-native` as a dependency to this project.
I could not find a way to unit testing this in a way that prevents potential bugs, so I added a comment instead.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] \[_Synthetics_\] New releases of `datadog-ci` MUST be followed by a [synthetics-ci-github-action](https://github.com/DataDog/synthetics-ci-github-action) release
