### PR TITLE
Synthetics: Extract code to simplify waitForResults

### DIFF
--- a/src/commands/synthetics/utils.ts
+++ b/src/commands/synthetics/utils.ts
@@ -337,6 +337,7 @@ const getResultFromBatch = (
   }
 
   const test = getTestByPublicId(resultInBatch.test_public_id, tests)
+
   return {
     executionRule: resultInBatch.execution_rule,
     location: getLocation(resultInBatch.location, test),

--- a/src/commands/synthetics/utils.ts
+++ b/src/commands/synthetics/utils.ts
@@ -262,12 +262,12 @@ export const getSuites = async (GLOB: string, reporter: MainReporter): Promise<S
 
 export const wait = async (duration: number) => new Promise((resolve) => setTimeout(resolve, duration))
 
-const processBatch = async (
+const getBatch = async (
   api: APIHelper,
   emittedResultIndexes: Set<number>,
   trigger: Trigger,
   reporter: MainReporter
-) => {
+): Promise<Batch> => {
   try {
     const currentBatch = await api.getBatch(trigger.batch_id)
     for (const [index, result] of currentBatch.results.entries()) {
@@ -332,13 +332,13 @@ export const waitForResults = async (
   const maxPollingDate = Date.now() + options.maxPollingTimeout
   const emittedResultIndexes = new Set<number>()
 
-  let batch = await processBatch(api, emittedResultIndexes, trigger, reporter)
+  let batch = await getBatch(api, emittedResultIndexes, trigger, reporter)
   // In theory polling the batch is enough, but in case something goes wrong backend-side
   // let's add a check to ensure it eventually times out.
   let hasExceededMaxPollingDate = Date.now() >= maxPollingDate
   while (batch.status === 'in_progress' && !hasExceededMaxPollingDate) {
     await wait(POLLING_INTERVAL)
-    batch = await processBatch(api, emittedResultIndexes, trigger, reporter)
+    batch = await getBatch(api, emittedResultIndexes, trigger, reporter)
     hasExceededMaxPollingDate = Date.now() >= maxPollingDate
   }
 

--- a/src/commands/synthetics/utils.ts
+++ b/src/commands/synthetics/utils.ts
@@ -394,20 +394,17 @@ export const waitForResults = async (
   }
 
   const pollResultMap = await getPollResultMap(api, batch)
-  const results: Result[] = []
-  for (const resultInBatch of batch.results) {
-    results.push(
-      getResultFromBatch(
-        getLocation,
-        hasExceededMaxPollingDate,
-        options.failOnCriticalErrors!!,
-        options.failOnTimeout!!,
-        pollResultMap,
-        resultInBatch,
-        tests
-      )
+  const results = batch.results.map((resultInBatch) =>
+    getResultFromBatch(
+      getLocation,
+      hasExceededMaxPollingDate,
+      options.failOnCriticalErrors!!,
+      options.failOnTimeout!!,
+      pollResultMap,
+      resultInBatch,
+      tests
     )
-  }
+  )
 
   return results
 }

--- a/src/commands/synthetics/utils.ts
+++ b/src/commands/synthetics/utils.ts
@@ -362,10 +362,6 @@ export const waitForResults = async (
     return hasTunnel ? 'Tunneled' : locationNames[dcId] || dcId
   }
 
-  if (tunnel && !isTunnelConnected) {
-    reporter.error('The tunnel has stopped working, this may have affected the results.')
-  }
-
   const pollResultMap = await getPollResultMap(api, batch)
   const results: Result[] = []
   for (const resultInBatch of batch.results) {


### PR DESCRIPTION
### What and why?
Why: readability.

- Extract code in `getBatch`, `getTestByPublicId` , `getPollResultMap` and `waitForBatchToFinish`