### PR TITLE
[git-metadata|lambda] Normalize repository URL

### DIFF
--- a/src/commands/git-metadata/__tests__/git.test.ts
+++ b/src/commands/git-metadata/__tests__/git.test.ts
@@ -1,6 +1,6 @@
 import * as simpleGit from 'simple-git'
 
-import {getCommitInfo, gitRemote, newSimpleGit, stripCredentials} from '../git'
+import {getCommitInfo, gitRemote, newSimpleGit, normalizeRemote, stripCredentials} from '../git'
 
 interface MockConfig {
   hash?: string
@@ -57,39 +57,111 @@ describe('git', () => {
     })
   })
 
-  describe('stripCredentials: git protocol', () => {
-    test('should return the same value', () => {
+  describe('stripCredentials', () => {
+    test('git protocol', () => {
       const input = 'git@github.com:user/project.git'
 
       expect(stripCredentials(input)).toBe(input)
     })
-  })
-  describe('stripCredentials: nothing to remove', () => {
-    test('should return the same value', () => {
+
+    test('nothing to remove', () => {
       const input = 'https://gitlab.com/user/project.git'
 
       expect(stripCredentials(input)).toBe(input)
     })
-  })
-  describe('stripCredentials: user:pwd', () => {
-    test('should return without credentials', () => {
+
+    test('user:pwd', () => {
       const input = 'https://token:[MASKED]@gitlab.com/user/project.git'
 
       expect(stripCredentials(input)).toBe('https://gitlab.com/user/project.git')
     })
-  })
-  describe('stripCredentials: token', () => {
-    test('should return without credentials', () => {
+
+    test('token', () => {
       const input = 'https://token@gitlab.com/user/project.git'
 
       expect(stripCredentials(input)).toBe('https://gitlab.com/user/project.git')
     })
   })
+
+  describe('normalizeRemote', () => {
+    test('ssh://alex@host.xz:1234/path/to/repo.git', () => {
+      const input = 'ssh://alex@host.xz:1234/path/to/repo.git'
+      expect(normalizeRemote(input)).toBe('host.xz/path/to/repo')
+    })
+    test('git://host.xz:1234/path/to/repo.git', () => {
+      const input = 'git://host.xz:1234/path/to/repo.git'
+      expect(normalizeRemote(input)).toBe('host.xz/path/to/repo')
+    })
+    test('https://host.xz:1234/path/to/repo.git', () => {
+      const input = 'https://host.xz:1234/path/to/repo.git'
+      expect(normalizeRemote(input)).toBe('host.xz/path/to/repo')
+    })
+    test('ftp://host.xz:1234/path/to/repo.git', () => {
+      const input = 'ftp://host.xz:1234/path/to/repo.git'
+      expect(normalizeRemote(input)).toBe('host.xz/path/to/repo')
+    })
+    test('alex@host.xz:path/to/repo.git', () => {
+      const input = 'alex@host.xz:path/to/repo.git'
+      expect(normalizeRemote(input)).toBe('host.xz/path/to/repo')
+    })
+    test('ssh://alex@host.xz:1234/~alex/path/to/repo.git', () => {
+      const input = 'ssh://alex@host.xz:1234/~alex/path/to/repo.git'
+      expect(normalizeRemote(input)).toBe('host.xz/~alex/path/to/repo')
+    })
+    test('git://host.xz:1234/~alex/path/to/repo.git', () => {
+      const input = 'git://host.xz:1234/~alex/path/to/repo.git'
+      expect(normalizeRemote(input)).toBe('host.xz/~alex/path/to/repo')
+    })
+    test('https://gitlab.awspro.pason.com/pasonsystems/repos/puppet/puppet-r10k.git', () => {
+      const input = 'https://gitlab.awspro.pason.com/pasonsystems/repos/puppet/puppet-r10k.git'
+      expect(normalizeRemote(input)).toBe('gitlab.awspro.pason.com/pasonsystems/repos/puppet/puppet-r10k')
+    })
+    test('git@github.com:DataDog/datadog-junit4-tests.git', () => {
+      const input = 'git@github.com:DataDog/datadog-junit4-tests.git'
+      expect(normalizeRemote(input)).toBe('github.com/DataDog/datadog-junit4-tests')
+    })
+    test('https://github-ci-token:MYTOKEN@github.com/DataDog/datadog-junit4-tests.git', () => {
+      const input = 'https://github-ci-token:MYTOKEN@github.com/DataDog/datadog-junit4-tests.git'
+      expect(normalizeRemote(input)).toBe('github.com/DataDog/datadog-junit4-tests')
+    })
+    test('ssh://stash.cvent.net:7999/incb/sre-observ-test.git', () => {
+      const input = 'ssh://stash.cvent.net:7999/incb/sre-observ-test.git'
+      expect(normalizeRemote(input)).toBe('stash.cvent.net/incb/sre-observ-test')
+    })
+    test('git://host.xz:1234/~alex/path/to/repo.git', () => {
+      const input = 'git://host.xz:1234/~alex/path/to/repo.git'
+      expect(normalizeRemote(input)).toBe('host.xz/~alex/path/to/repo')
+    })
+    test('https://git.mcmakler.com/md.aftab/mcm-deploy.git', () => {
+      const input = 'https://git.mcmakler.com/md.aftab/mcm-deploy.git'
+      expect(normalizeRemote(input)).toBe('git.mcmakler.com/md.aftab/mcm-deploy')
+    })
+    test('org-49461806@github.com:squareup/riker.git', () => {
+      const input = 'org-49461806@github.com:squareup/riker.git'
+      expect(normalizeRemote(input)).toBe('github.com/squareup/riker')
+    })
+    test('org_49461806@github.com:squareup/hw-spe_automation.git', () => {
+      const input = 'org_49461806@github.com:squareup/hw-spe_automation.git'
+      expect(normalizeRemote(input)).toBe('github.com/squareup/hw-spe_automation')
+    })
+    test('bitbucket.org:harver/saas-talentpitch.git', () => {
+      const input = 'bitbucket.org:harver/saas-talentpitch.git'
+      expect(normalizeRemote(input)).toBe('bitbucket.org/harver/saas-talentpitch')
+    })
+    test('ssh.dev.azure.com:v3/bushelpowered/bushel-integrations-translator-mono/bushel-integrations-translator-mono', () => {
+      const input =
+        'ssh.dev.azure.com:v3/bushelpowered/bushel-integrations-translator-mono/bushel-integrations-translator-mono'
+      expect(normalizeRemote(input)).toBe(
+        'ssh.dev.azure.com/v3/bushelpowered/bushel-integrations-translator-mono/bushel-integrations-translator-mono'
+      )
+    })
+  })
+
   describe('getCommitInfo', () => {
     test('should return commit info from simple git', async () => {
       const mock = createMockSimpleGit({
         hash: 'abcd',
-        remotes: [{name: 'first', refs: {push: 'https://git-repo'}}],
+        remotes: [{name: 'first', refs: {push: 'https://git-host/repo'}}],
         trackedFiles: ['myfile.js'],
       }) as any
       const commitInfo = await getCommitInfo(mock)
@@ -97,19 +169,19 @@ describe('git', () => {
       expect(commitInfo).toBeDefined()
       expect(commitInfo!.hash).toBe('abcd')
       expect(commitInfo!.trackedFiles).toStrictEqual(['myfile.js'])
-      expect(commitInfo!.remote).toBe('https://git-repo/')
+      expect(commitInfo!.remote).toBe('https://git-host/repo')
     })
     test('should return commit info with overridden repo name', async () => {
       const mock = createMockSimpleGit({
         hash: 'abcd',
         trackedFiles: ['myfile.js'],
       }) as any
-      const commitInfo = await getCommitInfo(mock, 'https://overridden')
+      const commitInfo = await getCommitInfo(mock, 'https://overridden/repo')
 
       expect(commitInfo).toBeDefined()
       expect(commitInfo!.hash).toBe('abcd')
       expect(commitInfo!.trackedFiles).toStrictEqual(['myfile.js'])
-      expect(commitInfo!.remote).toBe('https://overridden')
+      expect(commitInfo!.remote).toBe('https://overridden/repo')
     })
   })
 

--- a/src/commands/git-metadata/library.ts
+++ b/src/commands/git-metadata/library.ts
@@ -2,7 +2,7 @@ import {newApiKeyValidator} from '../../helpers/apikey'
 import {RequestBuilder} from '../../helpers/interfaces'
 import {upload, UploadOptions, UploadStatus} from '../../helpers/upload'
 import {getRequestBuilder} from '../../helpers/utils'
-import {getCommitInfo, newSimpleGit} from './git'
+import {getCommitInfo, newSimpleGit, normalizeRemote} from './git'
 import {CommitInfo} from './interfaces'
 
 export const isGitRepo = async (): Promise<boolean> => {
@@ -61,7 +61,7 @@ export const uploadGitCommitHash = async (
     throw new Error('Error uploading commit information.')
   }
 
-  return [payload.remote, payload.hash]
+  return [normalizeRemote(payload.remote), payload.hash]
 }
 
 export const uploadRepository = (

--- a/src/commands/lambda/__tests__/instrument.test.ts
+++ b/src/commands/lambda/__tests__/instrument.test.ts
@@ -503,6 +503,7 @@ TagResource -> arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world
           ahead: 0,
           hash: '1be168ff837f043bde17c0314341c84271047b31',
           isClean: true,
+          remote: 'github.com/DataDog/datadog-ci',
         }))
         const mockUploadFunction = jest.spyOn(instrumentCommand.prototype as any, 'uploadGitData')
         mockUploadFunction.mockImplementation(() => {
@@ -551,7 +552,7 @@ UpdateFunctionConfiguration -> arn:aws:lambda:us-east-1:123456789012:function:la
       \\"DD_SITE\\": \\"datadoghq.com\\",
       \\"DD_CAPTURE_LAMBDA_PAYLOAD\\": \\"false\\",
       \\"DD_ENV\\": \\"dummy\\",
-      \\"DD_TAGS\\": \\"git.commit.sha:1be168ff837f043bde17c0314341c84271047b31\\",
+      \\"DD_TAGS\\": \\"git.commit.sha:1be168ff837f043bde17c0314341c84271047b31,git.repository_url:github.com/DataDog/datadog-ci\\",
       \\"DD_MERGE_XRAY_TRACES\\": \\"false\\",
       \\"DD_SERVICE\\": \\"dummy\\",
       \\"DD_TRACE_ENABLED\\": \\"true\\",


### PR DESCRIPTION
Add a new `normalizeRemote` function to prevent colons from ending up in `git.repository_url` tags and being improperly parsed by tracers. 

-----

`normalizeRemote` is added to:
-  the `lambda` command before tagging
- the exported `uploadGitCommitHash` in library.ts used by `serverless-plugin-datadog`
