### PR TITLE
Release docker image when a tag is pushed

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,8 +3,7 @@ stages:
   - release
 
 variables:
-  PRIVATE_IMAGE: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-ci:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}
-  PUBLIC_IMAGE: ci:v0.1
+  INTERNAL_REGISTRY: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci
 
 build-docker-image-amd64:
   stage: build
@@ -12,8 +11,8 @@ build-docker-image-amd64:
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/docker:20.10
   script:
     - cd container
-    - docker build --build-arg "VERSION=" --tag "${PRIVATE_IMAGE}-amd64" .
-    - docker push "${PRIVATE_IMAGE}-amd64"
+    - docker build --build-arg "VERSION=" --tag "${INTERNAL_REGISTRY}/datadog-ci:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-amd64" .
+    - docker push "${INTERNAL_REGISTRY}/datadog-ci:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-amd64"
 
 build-docker-image-arm64:
   stage: build
@@ -21,8 +20,8 @@ build-docker-image-arm64:
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/docker:20.10
   script:
     - cd container
-    - docker build --build-arg "VERSION=" --tag "${PRIVATE_IMAGE}-arm64" .
-    - docker push "${PRIVATE_IMAGE}-arm64"
+    - docker build --build-arg "VERSION=" --tag "${INTERNAL_REGISTRY}/datadog-ci:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-arm64" .
+    - docker push "${INTERNAL_REGISTRY}/datadog-ci:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-arm64"
 
 publish-docker-image:
   stage: release
@@ -31,6 +30,6 @@ publish-docker-image:
     branch: main
     strategy: depend
   variables:
-    IMG_SOURCES: ${PRIVATE_IMAGE}-amd64,${PRIVATE_IMAGE}-arm64
-    IMG_DESTINATIONS: ${PUBLIC_IMAGE}
+    IMG_SOURCES: ${INTERNAL_REGISTRY}/datadog-ci:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-amd64,${INTERNAL_REGISTRY}/datadog-ci:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-arm64
+    IMG_DESTINATIONS: ci:latest
     IMG_SIGNING: "false"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,31 +4,28 @@ stages:
 
 variables:
   PRIVATE_IMAGE: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-ci:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}
-  PUBLIC_IMAGE: ci:${CI_COMMIT_TAG}
+  PUBLIC_IMAGE: ci:v0.1
 
 build-docker-image-amd64:
   stage: build
-  only: [ "tags" ]
   tags: ["runner:docker"]
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/docker:20.10.3
   script:
     - cd container
-    - docker build --build-arg "VERSION=$CI_COMMIT_TAG" --tag "${PRIVATE_IMAGE}-amd64" .
+    - docker build --build-arg "VERSION=" --tag "${PRIVATE_IMAGE}-amd64" .
     - docker push "${PRIVATE_IMAGE}-amd64"
 
 build-docker-image-arm64:
   stage: build
-  only: [ "tags" ]
   tags: ["runner:docker-arm", "platform:arm64"]
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/docker:20.10.3
   script:
     - cd container
-    - docker build --build-arg "VERSION=$CI_COMMIT_TAG" --tag "${PRIVATE_IMAGE}-arm64" .
+    - docker build --build-arg "VERSION=" --tag "${PRIVATE_IMAGE}-arm64" .
     - docker push "${PRIVATE_IMAGE}-arm64"
 
 publish-docker-image:
   stage: release
-  only: [ "tags" ]
   trigger:
     project: DataDog/public-images
     branch: main

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,29 +7,32 @@ variables:
 
 build-docker-image-amd64:
   stage: build
+  only: [ "tags" ]
   tags: ["runner:docker"]
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/docker:20.10
   script:
     - cd container
-    - docker build --build-arg "VERSION=" --tag "${INTERNAL_REGISTRY}/datadog-ci:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-amd64" .
+    - docker build --build-arg "VERSION=${CI_COMMIT_TAG}" --tag "${INTERNAL_REGISTRY}/datadog-ci:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-amd64" .
     - docker push "${INTERNAL_REGISTRY}/datadog-ci:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-amd64"
 
 build-docker-image-arm64:
   stage: build
+  only: [ "tags" ]
   tags: ["runner:docker-arm", "platform:arm64"]
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/docker:20.10
   script:
     - cd container
-    - docker build --build-arg "VERSION=" --tag "${INTERNAL_REGISTRY}/datadog-ci:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-arm64" .
+    - docker build --build-arg "VERSION=${CI_COMMIT_TAG}" --tag "${INTERNAL_REGISTRY}/datadog-ci:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-arm64" .
     - docker push "${INTERNAL_REGISTRY}/datadog-ci:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-arm64"
 
 publish-docker-image:
   stage: release
+  only: [ "tags" ]
   trigger:
     project: DataDog/public-images
     branch: main
     strategy: depend
   variables:
     IMG_SOURCES: ${INTERNAL_REGISTRY}/datadog-ci:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-amd64,${INTERNAL_REGISTRY}/datadog-ci:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-arm64
-    IMG_DESTINATIONS: ci:latest
+    IMG_DESTINATIONS: ci:${CI_COMMIT_TAG},ci:latest
     IMG_SIGNING: "false"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,7 +9,7 @@ variables:
 build-docker-image-amd64:
   stage: build
   tags: ["runner:docker"]
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/docker:20.10.3
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/docker:20.10
   script:
     - cd container
     - docker build --build-arg "VERSION=" --tag "${PRIVATE_IMAGE}-amd64" .
@@ -18,7 +18,7 @@ build-docker-image-amd64:
 build-docker-image-arm64:
   stage: build
   tags: ["runner:docker-arm", "platform:arm64"]
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/docker:20.10.3
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/docker:20.10
   script:
     - cd container
     - docker build --build-arg "VERSION=" --tag "${PRIVATE_IMAGE}-arm64" .

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,39 @@
+stages:
+  - build
+  - release
+
+variables:
+  PRIVATE_IMAGE: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-ci:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}
+  PUBLIC_IMAGE: ci:${CI_COMMIT_TAG}
+
+build-docker-image-amd64:
+  stage: build
+  only: [ "tags" ]
+  tags: ["runner:docker"]
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/docker:20.10.3
+  script:
+    - cd container
+    - docker build --build-arg "VERSION=$CI_COMMIT_TAG" --tag "${PRIVATE_IMAGE}-amd64" .
+    - docker push "${PRIVATE_IMAGE}-amd64"
+
+build-docker-image-arm64:
+  stage: build
+  only: [ "tags" ]
+  tags: ["runner:docker-arm", "platform:arm64"]
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/docker:20.10.3
+  script:
+    - cd container
+    - docker build --build-arg "VERSION=$CI_COMMIT_TAG" --tag "${PRIVATE_IMAGE}-arm64" .
+    - docker push "${PRIVATE_IMAGE}-arm64"
+
+publish-docker-image:
+  stage: release
+  only: [ "tags" ]
+  trigger:
+    project: DataDog/public-images
+    branch: main
+    strategy: depend
+  variables:
+    IMG_SOURCES: ${PRIVATE_IMAGE}-amd64,${PRIVATE_IMAGE}-arm64
+    IMG_DESTINATIONS: ${PUBLIC_IMAGE}
+    IMG_SIGNING: "false"

--- a/README.md
+++ b/README.md
@@ -65,9 +65,17 @@ To run `datadog-ci` from a container, you can use the `datadog/ci` image availab
 docker pull datadog/ci
 ```
 
-## Building your own container image
+Here's an example of how to run a command using the container and passing in the API and APP keys:
 
-You can build an image using the provided Dockerfile:
+```
+export DD_API_KEY=$(cat /secret/dd_api_key)
+export DD_APP_KEY=$(cat /secret/dd_app_key)
+docker run --rm -it -v $(pwd):/w -e DD_API_KEY -e DD_APP_KEY datadog/ci synthetics run-tests -p pub-lic-id1
+```
+
+#### Building your own container image
+
+You can build an image using the provided [Dockerfile](https://github.com/DataDog/datadog-ci/blob/master/container/Dockerfile):
 
 ```sh
 cd container
@@ -77,7 +85,6 @@ docker build --tag datadog-ci .
 Optionally you can use the `VERSION` build argument to build an image for a specific version:
 
 ```sh
-cd container
 docker build --build-arg "VERSION=v1.14" --t datadog-ci .
 ```
 
@@ -100,14 +107,6 @@ Available commands:
 ```
 
 Each command allows interacting with a product of the Datadog platform. The commands are defined in the [src/commands](/src/commands) folder.
-
-Some commands need a Datadog API and/or APP key. Here's an example of how to pass them to the container:
-
-```
-export DD_API_KEY=$(cat /secret/dd_api_key)
-export DD_APP_KEY=$(cat /secret/dd_app_key)
-docker run --rm -it -v $(pwd):/w -e DD_API_KEY -e DD_APP_KEY datadog/ci synthetics run-tests -p pub-lic-id1
-```
 
 Further documentation for each command can be found in its folder, ie:
 
@@ -219,7 +218,7 @@ Releasing a new version of `datadog-ci` unfolds as follow:
 - push the branch along with the tag to the upstream (Github), create a Pull Request with the changes introduced detailed in the description and get at least one approval. ([sample Pull Request](https://github.com/DataDog/datadog-ci/pull/78))
 - merge the Pull Request
 - create a Github Release from the [Tags page](https://github.com/DataDog/datadog-ci/tags) with the description of changes introduced
-- Once the release has been created, a Github Action will publish the package
+- Once the release has been created, a Github Action will publish the package and a Gitlab pipeline will publish the Docker image. Make sure they succeed.
 
 ### Pre-Release Process
 

--- a/README.md
+++ b/README.md
@@ -57,28 +57,28 @@ Then you can run `datadog-ci` commands normally:
 datadog-ci version
 ```
 
-### Container image (**experimental**)
+### Container image
 
-In order to run `datadog-ci` from a container, you can use the following `Dockerfile`:
+To run `datadog-ci` from a container, you can use the `datadog/ci` image available in Dockerhub as well as the public Amazon ECR and Google GC registries.
 
-```dockerfile
-FROM alpine
-WORKDIR /w
-RUN apk add --update npm git
-RUN npm install -g @datadog/datadog-ci
-ENTRYPOINT ["datadog-ci"]
+```
+docker pull datadog/ci
 ```
 
-To build and run it, the following commands can be used:
+## Building your own container image
+
+You can build an image using the provided Dockerfile:
 
 ```sh
-# Build the container
-docker build -t datadog-ci .
+cd container
+docker build --tag datadog-ci .
+```
 
-# Run a command using the container
-export DD_API_KEY=$(cat /secret/dd_api_key)
-export DD_APP_KEY=$(cat /secret/dd_app_key)
-docker run --rm -it -v $(pwd):/w -e DD_API_KEY -e DD_APP_KEY datadog-ci synthetics run-tests -p pub-lic-id1
+Optionally you can use the `VERSION` build argument to build an image for a specific version:
+
+```sh
+cd container
+docker build --build-arg "VERSION=v1.14" --t datadog-ci .
 ```
 
 ## Usage
@@ -100,6 +100,14 @@ Available commands:
 ```
 
 Each command allows interacting with a product of the Datadog platform. The commands are defined in the [src/commands](/src/commands) folder.
+
+Some commands need a Datadog API and/or APP key. Here's an example of how to pass them to the container:
+
+```
+export DD_API_KEY=$(cat /secret/dd_api_key)
+export DD_APP_KEY=$(cat /secret/dd_app_key)
+docker run --rm -it -v $(pwd):/w -e DD_API_KEY -e DD_APP_KEY datadog/ci synthetics run-tests -p pub-lic-id1
+```
 
 Further documentation for each command can be found in its folder, ie:
 

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -1,0 +1,10 @@
+FROM alpine
+
+WORKDIR /w
+RUN apk add --update npm git
+
+ARG VERSION
+RUN npm install -g "@datadog/datadog-ci@${VERSION}" \
+    && echo "Installed datadog-ci version: $(npm list -g | grep datadog-ci | grep -o '[^@]*$')"
+
+ENTRYPOINT ["datadog-ci"]


### PR DESCRIPTION
### What and why?

Add a CI job that will build and publish a docker image when we push a new tag.

### How?

This is done in Gitlab CI so we can reuse the logic to push to all registries (Dockerhub, Amazon ECR and Google GCR) used for other Datadog images like the Agent image or the Watermark Pod Autoscaler image.
