### PR TITLE
Add semver as a direct dependency

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -41,6 +41,7 @@ prettier,dev,MIT,Copyright © James Long and contributors
 proxy,dev,MIT,Copyright (c) 2013 Nathan Rajlich <nathan@tootallnate.net>
 proxy-agent,import,MIT,Copyright (c) 2013 Nathan Rajlich <nathan@tootallnate.net>
 rimraf,import,ISC,Copyright (c) 2011-2022 Isaac Z. Schlueter and Contributors
+semver,import,ISC,Copyright (c) Isaac Z. Schlueter and Contributors
 simple-git,import,MIT,Copyright (c) 2015 Steve King
 ssh2,import,MIT,Copyright (c) Brian White
 ssh2-streams,import,MIT,Copyright (c) 2014 Brian White

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "js-yaml": "3.13.1",
     "proxy-agent": "5.0.0",
     "rimraf": "^3.0.2",
+    "semver": "^7.3.7",
     "simple-git": "3.5.0",
     "ssh2": "1.9.0",
     "ssh2-streams": "0.4.10",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5081,6 +5081,13 @@ semver@^7.3.5:
   dependencies:
     lru-cache "^6.0.0"
 
+semver@^7.3.7:
+  version "7.3.7"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.7.tgz#12c5b649afdbf9049707796e22a4028814ce523f"
+  integrity sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==
+  dependencies:
+    lru-cache "^6.0.0"
+
 set-blocking@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"


### PR DESCRIPTION
### What and why?

Add semver as a direct dependency to fix #634 

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] \[_Synthetics_\] New releases of `datadog-ci` MUST be followed by a [synthetics-ci-github-action](https://github.com/DataDog/synthetics-ci-github-action) release
