### PR TITLE
v1.14.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci",
-  "version": "1.14.0",
+  "version": "1.14.1",
   "description": "Run datadog actions from the CI.",
   "repository": "https://github.com/DataDog/datadog-ci",
   "license": "Apache-2.0",


### PR DESCRIPTION
### What and why?

Bump version for v1.14.1
* Fixes semver not listed as a direct dependency
