### PR TITLE
[ci-visibility] Create new workflow for ITR

### DIFF
--- a/.github/workflows/ci-visibility-itr.yml
+++ b/.github/workflows/ci-visibility-itr.yml
@@ -32,6 +32,7 @@ jobs:
           node-version: '16'
       - run: yarn install --ignore-engines
       - run: yarn add --dev https://github.com/DataDog/dd-trace-js/tarball/master
+      - run: yarn build
       - run: yarn test:ci-vis:itr
         continue-on-error: true
         env:

--- a/.github/workflows/ci-visibility-itr.yml
+++ b/.github/workflows/ci-visibility-itr.yml
@@ -4,11 +4,7 @@
 
 name: CI Visibility ITR
 
-# TO BE MODIFIED TO "ON PUSH"
-on:
-  push:
-    branches:
-      - juan-fernandez/create-itr-workflow
+on: push
 
 jobs:
   build-and-test:

--- a/.github/workflows/ci-visibility-itr.yml
+++ b/.github/workflows/ci-visibility-itr.yml
@@ -1,5 +1,6 @@
 # This workflow is used to dogfood CI Visibility's Intelligent Test Runner
-# It is *not* intended to block merges or releases.
+# It is *not* intended to block merges or releases, so steps are marked
+# to continue-on-error
 
 name: CI Visibility ITR
 
@@ -31,8 +32,9 @@ jobs:
         with:
           node-version: '16'
       - run: yarn install --ignore-engines
+        continue-on-error: true
       - run: yarn add --dev https://github.com/DataDog/dd-trace-js/tarball/master
-      - run: yarn build
+        continue-on-error: true
       - run: yarn test:ci-vis:itr
         continue-on-error: true
         env:

--- a/.github/workflows/ci-visibility-itr.yml
+++ b/.github/workflows/ci-visibility-itr.yml
@@ -1,0 +1,41 @@
+# This workflow is used to dogfood CI Visibility's Intelligent Test Runner
+# It is *not* intended to block merges or releases.
+
+name: CI Visibility ITR
+
+# TO BE MODIFIED TO "ON PUSH"
+on:
+  push:
+    branches:
+      - juan-fernandez/create-itr-workflow
+
+jobs:
+  build-and-test:
+    name: Build and test with ITR
+    runs-on: ubuntu-latest
+    env:
+      DD_SERVICE: datadog-ci-tests-itr
+      DD_CIVISIBILITY_AGENTLESS_ENABLED: 1
+      DD_API_KEY: ${{ secrets.DATADOG_API_KEY_MAIN_ACCOUNT }}
+      DD_APP_KEY: ${{ secrets.DATADOG_APP_KEY_MAIN_ACCOUNT }}
+      DD_CIVISIBILITY_GIT_UPLOAD_ENABLED: 1
+      DD_CIVISIBILITY_ITR_ENABLED: 1
+      DD_ENV: ci
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Install node
+        uses: actions/setup-node@v1
+        with:
+          node-version: '16'
+      - run: yarn install --ignore-engines
+      - run: yarn add --dev https://github.com/DataDog/dd-trace-js/tarball/master
+      - run: yarn test:ci-vis:itr
+        continue-on-error: true
+        env:
+          CI: true
+          NODE_OPTIONS: -r dd-trace/ci/init
+          DD_TRACE_DEBUG: 1
+          DD_TRACE_LOG_LEVEL: error

--- a/jest.config-ci-vis-itr.js
+++ b/jest.config-ci-vis-itr.js
@@ -8,5 +8,6 @@ module.exports = {
     },
   },
   roots: ['src'],
-  setupFilesAfterEnv: ['jest-matcher-specific-error']
+  setupFilesAfterEnv: ['jest-matcher-specific-error'],
+  collectCoverage: true
 }

--- a/jest.config-ci-vis-itr.js
+++ b/jest.config-ci-vis-itr.js
@@ -1,0 +1,12 @@
+module.exports = {
+  clearMocks: true,
+  testMatch: ['**/__tests__/**/*.test.ts'],
+  preset: 'ts-jest',
+  globals: {
+    'ts-jest': {
+      tsconfig: 'tsconfig.json',
+    },
+  },
+  roots: ['src'],
+  setupFilesAfterEnv: ['jest-matcher-specific-error']
+}

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "prettier": "prettier \"src/**/*.{ts,js,json,yml}\" --ignore-path .gitignore",
     "test": "jest --colors",
     "test:debug": "node --inspect-brk `which jest` --runInBand",
-    "test:ci-vis:itr": "jest --config ./jest.config-ci-vis-itr.js",
+    "test:ci-vis:itr": "jest --colors --config ./jest.config-ci-vis-itr.js",
     "tslint": "tslint -p tsconfig.json -c tslint.json",
     "typecheck": "bash bin/typecheck.sh",
     "watch": "tsc -w"

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "prettier": "prettier \"src/**/*.{ts,js,json,yml}\" --ignore-path .gitignore",
     "test": "jest --colors",
     "test:debug": "node --inspect-brk `which jest` --runInBand",
-    "test:ci-vis:itr": "jest --colors --config ./jest.config-ci-vis-itr.js",
+    "test:ci-vis:itr": "jest --colors --config ./jest.config-ci-vis-itr.js --passWithNoTests",
     "tslint": "tslint -p tsconfig.json -c tslint.json",
     "typecheck": "bash bin/typecheck.sh",
     "watch": "tsc -w"

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "prettier": "prettier \"src/**/*.{ts,js,json,yml}\" --ignore-path .gitignore",
     "test": "jest --colors",
     "test:debug": "node --inspect-brk `which jest` --runInBand",
+    "test:ci-vis:itr": "jest --config ./jest.config-ci-vis-itr.js",
     "tslint": "tslint -p tsconfig.json -c tslint.json",
     "typecheck": "bash bin/typecheck.sh",
     "watch": "tsc -w"


### PR DESCRIPTION
### What and why?

CI Visibility's Intelligent test runner is able to skip tests based on code coverage and git diff metadata. This workflow enables ITR when running unit tests, but in a different, non blocking workflow, so we can battle test it before moving it to the current workflow. 

### How?

Add a new workflow for running unit tests using ITR. 


