### PR TITLE
[lambda] Add ora dependency

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -36,6 +36,7 @@ jest,dev,MIT,Copyright (c) Facebook, Inc. and its affiliates.
 jest-environment-node,dev,MIT,Copyright (c) Facebook, Inc. and its affiliates.
 jest-matcher-specific-error,dev,MIT,Copyright (c) 2020 Daniel Hreben
 js-yaml,import,MIT,Copyright (C) 2011-2015 by Vitaly Puzrin
+ora,import,MIT,Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (https://sindresorhus.com)
 pkg,dev,MIT,Copyright (c) 2021 Vercel, Inc.
 prettier,dev,MIT,Copyright © James Long and contributors
 proxy,dev,MIT,Copyright (c) 2013 Nathan Rajlich <nathan@tootallnate.net>

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "inquirer": "8.2.0",
     "inquirer-checkbox-plus-prompt": "^1.0.1",
     "js-yaml": "3.13.1",
+    "ora": "5.4.1",
     "proxy-agent": "5.0.0",
     "rimraf": "^3.0.2",
     "semver": "^7.3.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4501,7 +4501,7 @@ optionator@^0.8.1:
     type-check "~0.3.2"
     wordwrap "~1.0.0"
 
-ora@^5.4.1:
+ora@5.4.1, ora@^5.4.1:
   version "5.4.1"
   resolved "https://registry.yarnpkg.com/ora/-/ora-5.4.1.tgz#1b2678426af4ac4a509008e5e4ac9e9959db9e18"
   integrity sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==


### PR DESCRIPTION
### What and why?

Add `ora` package for `'elegant' terminal spinners`.

We want to improve user experience for our interactive modes in the Lambda command. Some of our workflows require the user to wait until we load a large amount of data. Adding indications, like a spinner, will provide them with certainty that the terminal is not frozen.

![Loading example](https://raw.githubusercontent.com/sindresorhus/ora/main/screenshot-2.gif
)
Image used from the `ora` package.

### How?

Installing the dependency.
```sh
yarn add ora@5.4.1
```

Installing `5.4.1` since newer versions require a bumped version of Typescript which we currently do not support.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] \[_Synthetics_\] New releases of `datadog-ci` MUST be followed by a [synthetics-ci-github-action](https://github.com/DataDog/synthetics-ci-github-action) release
- [ ] \[_Synthetics_\] New releases of `datadog-ci` MUST be followed by a [datadog-ci-azure-devops](https://github.com/DataDog/datadog-ci-azure-devops) release
