### PR TITLE
[Synthetics] Add tests result wait spinner to default reporter

### DIFF
--- a/src/commands/synthetics/__tests__/reporters/__snapshots__/default.test.ts.snap
+++ b/src/commands/synthetics/__tests__/reporters/__snapshots__/default.test.ts.snap
@@ -137,3 +137,9 @@ exports[`Default reporter testTrigger Skipped test, with 2 config overrides 1`] 
 "[[1m[2maaa-bbb-ccc[22m[22m] Skipped test \\"[33m[2mRequest on example.org[22m[39m\\"
 "
 `;
+
+exports[`Default reporter testsWait outputs triggered tests 1`] = `
+"- Waiting for [1m[36m11[39m[22m test results [90m(abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, …)[39m…
+
+"
+`;

--- a/src/commands/synthetics/__tests__/reporters/default.test.ts
+++ b/src/commands/synthetics/__tests__/reporters/default.test.ts
@@ -93,6 +93,12 @@ describe('Default reporter', () => {
     })
   })
 
+  test('testsWait outputs triggered tests', async () => {
+    reporter.testsWait(new Array(11).fill(getApiTest()))
+    const output = writeMock.mock.calls.map((c) => c[0]).join('\n')
+    expect(output).toMatchSnapshot()
+  })
+
   describe('resultEnd', () => {
     const createApiResult = (
       resultId: string,

--- a/src/commands/synthetics/reporters/default.ts
+++ b/src/commands/synthetics/reporters/default.ts
@@ -247,12 +247,12 @@ const getResultIconAndColor = (resultOutcome: ResultOutcome): [string, chalk.Cha
 }
 
 export class DefaultReporter implements MainReporter {
+  private context: BaseContext
   private testWaitSpinner?: ora.Ora
-  private writable: Writable
   private write: Writable['write']
 
   constructor({context}: {context: BaseContext}) {
-    this.writable = context.stdout
+    this.context = context
     this.write = context.stdout.write.bind(context.stdout)
   }
 
@@ -334,7 +334,7 @@ export class DefaultReporter implements MainReporter {
     const testsDisplay = chalk.gray(`(${testsList.join(', ')})`)
 
     this.testWaitSpinner = ora({
-      stream: this.writable,
+      stream: this.context.stdout,
       text: `Waiting for ${chalk.bold.cyan(tests.length)} test ${pluralize('result', tests.length)} ${testsDisplay}…\n`,
     }).start()
   }

--- a/src/commands/synthetics/reporters/default.ts
+++ b/src/commands/synthetics/reporters/default.ts
@@ -1,7 +1,8 @@
+import {Writable} from 'stream'
+
 import chalk from 'chalk'
 import {BaseContext} from 'clipanion'
 import ora from 'ora'
-import {Writable} from 'stream'
 
 import {
   Assertion,


### PR DESCRIPTION
### What and why?

Add a fancy spinner to the `synthetics` command when waiting for test results.

![image](https://user-images.githubusercontent.com/19409477/192010643-02d5eaf9-76e1-4d70-84fe-5ee669b1c160.png)


### How?

Use [ora](https://github.com/sindresorhus/ora) added from https://github.com/DataDog/datadog-ci/pull/638 to display `Waiting for...` text.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] \[_Synthetics_\] New releases of `datadog-ci` MUST be followed by a [synthetics-ci-github-action](https://github.com/DataDog/synthetics-ci-github-action) release
- [ ] \[_Synthetics_\] New releases of `datadog-ci` MUST be followed by a [datadog-ci-azure-devops](https://github.com/DataDog/datadog-ci-azure-devops) release
