### PR TITLE
[synthetics] `result.device` should be optional

### DIFF
--- a/src/commands/synthetics/interfaces.ts
+++ b/src/commands/synthetics/interfaces.ts
@@ -26,12 +26,14 @@ export interface BaseServerResult {
   unhealthy?: boolean
 }
 
+export interface Device {
+  height: number
+  id: string
+  width: number
+}
+
 export interface BrowserServerResult extends BaseServerResult {
-  device: {
-    height: number
-    id: string
-    width: number
-  }
+  device?: Device
   duration: number
   startUrl: string
   stepDetails: Step[]

--- a/src/commands/synthetics/reporters/default.ts
+++ b/src/commands/synthetics/reporters/default.ts
@@ -15,7 +15,7 @@ import {
   Test,
   UserConfigOverride,
 } from '../interfaces'
-import {getBatchUrl, getResultDuration, getResultOutcome, getResultUrl, ResultOutcome} from '../utils'
+import {getBatchUrl, getResultDuration, getResultOutcome, getResultUrl, isDeviceIdSet, ResultOutcome} from '../utils'
 
 // Step rendering
 
@@ -216,8 +216,7 @@ const renderExecutionResult = (test: Test, execution: Result, baseUrl: string) =
   const testLabel = `${executionRuleText}[${chalk.bold.dim(test.public_id)}] ${chalk.bold(test.name)}`
 
   const location = setColor(`location: ${chalk.bold(execution.location)}`)
-  const device =
-    test.type === 'browser' && 'device' in result ? ` - ${setColor(`device: ${chalk.bold(result.device.id)}`)}` : ''
+  const device = isDeviceIdSet(result) ? ` - ${setColor(`device: ${chalk.bold(result.device.id)}`)}` : ''
   const resultIdentification = `${icon} ${testLabel} - ${location}${device}`
 
   const outputLines = [resultIdentification]

--- a/src/commands/synthetics/reporters/junit.ts
+++ b/src/commands/synthetics/reporters/junit.ts
@@ -372,9 +372,9 @@ export class JUnitReporter implements Reporter {
           {$: {name: 'check_id', value: result.test.public_id}},
           ...(isDeviceIdSet(result.result)
             ? [
-                {$: {name: 'device', value: result.result.device?.id}},
-                {$: {name: 'width', value: result.result.device?.width}},
-                {$: {name: 'height', value: result.result.device?.height}},
+                {$: {name: 'device', value: result.result.device.id}},
+                {$: {name: 'width', value: result.result.device.width}},
+                {$: {name: 'height', value: result.result.device.height}},
               ]
             : []),
           {$: {name: 'execution_rule', value: test.options.ci?.executionRule}},

--- a/src/commands/synthetics/reporters/junit.ts
+++ b/src/commands/synthetics/reporters/junit.ts
@@ -6,7 +6,7 @@ import {Writable} from 'stream'
 import {Builder} from 'xml2js'
 
 import {ApiServerResult, MultiStep, Reporter, Result, Step, Summary, Vitals} from '../interfaces'
-import {getBatchUrl, getResultDuration, getResultOutcome, getResultUrl, ResultOutcome} from '../utils'
+import {getBatchUrl, getResultDuration, getResultOutcome, getResultUrl, isDeviceIdSet, ResultOutcome} from '../utils'
 
 interface StepStats {
   allowfailures: number
@@ -370,11 +370,11 @@ export class JUnitReporter implements Reporter {
       properties: {
         property: [
           {$: {name: 'check_id', value: result.test.public_id}},
-          ...('device' in result.result
+          ...(isDeviceIdSet(result.result)
             ? [
-                {$: {name: 'device', value: result.result.device.id}},
-                {$: {name: 'width', value: result.result.device.width}},
-                {$: {name: 'height', value: result.result.device.height}},
+                {$: {name: 'device', value: result.result.device?.id}},
+                {$: {name: 'width', value: result.result.device?.width}},
+                {$: {name: 'height', value: result.result.device?.height}},
               ]
             : []),
           {$: {name: 'execution_rule', value: test.options.ci?.executionRule}},

--- a/src/commands/synthetics/utils.ts
+++ b/src/commands/synthetics/utils.ts
@@ -16,6 +16,7 @@ import {MAX_TESTS_TO_TRIGGER} from './command'
 import {CiError, CriticalError} from './errors'
 import {
   Batch,
+  BrowserServerResult,
   CommandConfig,
   ExecutionRule,
   LocationsMapping,
@@ -550,6 +551,9 @@ const getTestAndOverrideConfig = async (
 
   return {overriddenConfig}
 }
+
+export const isDeviceIdSet = (result: ServerResult): result is Required<BrowserServerResult> =>
+  'device' in result && result.device !== undefined
 
 export const getTestsToTrigger = async (
   api: APIHelper,


### PR DESCRIPTION
### What and why?

This PR makes the `device` property optional in a browser test's `result` because it will be undefined if a test times out when waited for.

Displaying this `device` property is also refactored into a `formatDeviceId()` utility function.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] \[_Synthetics_\] New releases of `datadog-ci` MUST be followed by a [synthetics-ci-github-action](https://github.com/DataDog/synthetics-ci-github-action) release
- [ ] \[_Synthetics_\] New releases of `datadog-ci` MUST be followed by a [datadog-ci-azure-devops](https://github.com/DataDog/datadog-ci-azure-devops) release
