### PR TITLE
[synthetics] `Summary.batchId` should be required

### DIFF
--- a/src/commands/synthetics/__tests__/fixtures.ts
+++ b/src/commands/synthetics/__tests__/fixtures.ts
@@ -25,7 +25,7 @@ import {
   Trigger,
   User,
 } from '../interfaces'
-import {createSummary} from '../utils'
+import {createInitialSummary} from '../utils'
 
 const mockUser: User = {
   email: '',
@@ -154,7 +154,7 @@ export const getTestSuite = (): Suite => ({content: {tests: [{config: {}, id: '1
 
 export const BATCH_ID = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'
 export const getSummary = (): Summary => ({
-  ...createSummary(),
+  ...createInitialSummary(),
   batchId: BATCH_ID,
 })
 

--- a/src/commands/synthetics/__tests__/reporters/__snapshots__/default.test.ts.snap
+++ b/src/commands/synthetics/__tests__/reporters/__snapshots__/default.test.ts.snap
@@ -54,6 +54,7 @@ exports[`Default reporter resultEnd 3 Browser test: failed blocking, timed out, 
 
 exports[`Default reporter runEnd Case where some outcomes are empty or missing 1`] = `
 "[33m[1m1[22m test not found[39m [90m(bbb-bbb-bbb)[39m
+Results URL: [2m[36mhttps://app.datadoghq.com/synthetics/explorer/ci?batchResultId=aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa[39m[22m
 [1mRun summary:[22m [32m[1m3[22m passed[39m, [31m[1m0[22m failed[39m, [33m[1m1[22m failed (non-blocking)[39m ([31m[1m1[22m critical errors[39m)
 
 "
@@ -68,7 +69,8 @@ Results URL: [2m[36mhttps://app.datadoghq.com/synthetics/explorer/ci?batchResu
 `;
 
 exports[`Default reporter runEnd Simple case with 1 test with 1 result (passed) 1`] = `
-"[1mRun summary:[22m [32m[1m1[22m passed[39m, [31m[1m0[22m failed[39m
+"Results URL: [2m[36mhttps://app.datadoghq.com/synthetics/explorer/ci?batchResultId=aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa[39m[22m
+[1mRun summary:[22m [32m[1m1[22m passed[39m, [31m[1m0[22m failed[39m
 
 "
 `;

--- a/src/commands/synthetics/__tests__/reporters/default.test.ts
+++ b/src/commands/synthetics/__tests__/reporters/default.test.ts
@@ -2,8 +2,14 @@ import {BaseContext} from 'clipanion/lib/advanced'
 
 import {ExecutionRule, MainReporter, Result, Summary, Test, UserConfigOverride} from '../../interfaces'
 import {DefaultReporter} from '../../reporters/default'
-import {createSummary} from '../../utils'
-import {getApiResult, getApiTest, getFailedBrowserResult, getTimedOutBrowserResult, MOCK_BASE_URL} from '../fixtures'
+import {
+  getApiResult,
+  getApiTest,
+  getFailedBrowserResult,
+  getSummary,
+  getTimedOutBrowserResult,
+  MOCK_BASE_URL,
+} from '../fixtures'
 
 /**
  * A good amount of these tests rely on Jest snapshot assertions.
@@ -26,16 +32,18 @@ describe('Default reporter', () => {
   const reporter = new DefaultReporter(mockContext as {context: BaseContext})
 
   it('should log for each hook', () => {
+    type ReporterCall = {[Fn in keyof MainReporter]: [Fn, Parameters<MainReporter[Fn]>]}[keyof MainReporter]
+
     // `testWait`/`resultReceived` is skipped as nothing is logged for the default reporter.
-    const calls: [keyof MainReporter, any[]][] = [
+    const calls: ReporterCall[] = [
       ['error', ['error']],
       ['initErrors', [['error']]],
       ['log', ['log']],
       ['reportStart', [{startTime: 0}]],
       ['resultEnd', [getApiResult('1', getApiTest()), '']],
-      ['runEnd', [createSummary(), '']],
-      ['testTrigger', [{}, '', '', {}]],
-      ['testsWait', [[{}]]],
+      ['runEnd', [getSummary(), '']],
+      ['testTrigger', [getApiTest(), '', ExecutionRule.BLOCKING, {}]],
+      ['testsWait', [[getApiTest()]]],
     ]
     for (const [fnName, args] of calls) {
       ;(reporter[fnName] as any)(...args)
@@ -176,7 +184,7 @@ describe('Default reporter', () => {
       writeMock.mockClear()
     })
 
-    const baseSummary: Summary = createSummary()
+    const baseSummary: Summary = getSummary()
 
     const complexSummary: Summary = {
       batchId: 'batch-id',

--- a/src/commands/synthetics/__tests__/run-test.test.ts
+++ b/src/commands/synthetics/__tests__/run-test.test.ts
@@ -21,8 +21,8 @@ describe('run-test', () => {
     test('should apply config override for tests triggered by public id', async () => {
       const getTestsToTriggersMock = jest.spyOn(utils, 'getTestsToTrigger').mockReturnValue(
         Promise.resolve({
+          initialSummary: utils.createInitialSummary(),
           overriddenTestsToTrigger: [],
-          summary: utils.createSummary(),
           tests: [],
         })
       )
@@ -75,8 +75,8 @@ describe('run-test', () => {
       async (text, partialCIConfig, expectedOverriddenConfig) => {
         const getTestsToTriggersMock = jest.spyOn(utils, 'getTestsToTrigger').mockReturnValue(
           Promise.resolve({
+            initialSummary: utils.createInitialSummary(),
             overriddenTestsToTrigger: [],
-            summary: utils.createSummary(),
             tests: [],
           })
         )
@@ -106,8 +106,8 @@ describe('run-test', () => {
     test('should not wait for `skipped` only tests batch results', async () => {
       const getTestsToTriggersMock = jest.spyOn(utils, 'getTestsToTrigger').mockReturnValue(
         Promise.resolve({
+          initialSummary: utils.createInitialSummary(),
           overriddenTestsToTrigger: [],
-          summary: utils.createSummary(),
           tests: [],
         })
       )
@@ -137,8 +137,8 @@ describe('run-test', () => {
     test('should not open tunnel if no test to run', async () => {
       const getTestsToTriggersMock = jest.spyOn(utils, 'getTestsToTrigger').mockReturnValue(
         Promise.resolve({
+          initialSummary: utils.createInitialSummary(),
           overriddenTestsToTrigger: [],
-          summary: utils.createSummary(),
           tests: [],
         })
       )
@@ -178,8 +178,8 @@ describe('run-test', () => {
 
       jest.spyOn(utils, 'getTestsToTrigger').mockReturnValue(
         Promise.resolve({
+          initialSummary: utils.createInitialSummary(),
           overriddenTestsToTrigger: [],
-          summary: utils.createSummary(),
           tests: [{options: {ci: {executionRule: ExecutionRule.BLOCKING}}, public_id: '123-456-789'} as any],
         })
       )
@@ -244,8 +244,8 @@ describe('run-test', () => {
     test('getTunnelPresignedURL throws', async () => {
       jest.spyOn(utils, 'getTestsToTrigger').mockReturnValue(
         Promise.resolve({
+          initialSummary: utils.createInitialSummary(),
           overriddenTestsToTrigger: [],
-          summary: utils.createSummary(),
           tests: [{options: {ci: {executionRule: ExecutionRule.BLOCKING}}, public_id: 'publicId'} as any],
         })
       )
@@ -273,8 +273,8 @@ describe('run-test', () => {
 
       jest.spyOn(utils, 'getTestsToTrigger').mockReturnValue(
         Promise.resolve({
+          initialSummary: utils.createInitialSummary(),
           overriddenTestsToTrigger: [],
-          summary: utils.createSummary(),
           tests: [{options: {ci: {executionRule: ExecutionRule.BLOCKING}}, public_id: 'publicId'} as any],
         })
       )
@@ -315,8 +315,8 @@ describe('run-test', () => {
       const stopTunnelSpy = jest.spyOn(Tunnel.prototype, 'stop')
       jest.spyOn(utils, 'getTestsToTrigger').mockReturnValue(
         Promise.resolve({
+          initialSummary: utils.createInitialSummary(),
           overriddenTestsToTrigger: [],
-          summary: utils.createSummary(),
           tests: [{options: {ci: {executionRule: ExecutionRule.BLOCKING}}, public_id: 'publicId'} as any],
         })
       )

--- a/src/commands/synthetics/__tests__/utils.test.ts
+++ b/src/commands/synthetics/__tests__/utils.test.ts
@@ -35,6 +35,7 @@ import {
   getBatch,
   getBrowserServerResult,
   getResults,
+  getSummary,
   MockedReporter,
   mockLocation,
   mockReporter,
@@ -200,7 +201,7 @@ describe('utils', () => {
         {suite: 'Suite 2', config: {}, id: '987-654-321'},
         {suite: 'Suite 3', config: {}, id: 'ski-ppe-d01'},
       ]
-      const {tests, overriddenTestsToTrigger, summary} = await utils.getTestsToTrigger(
+      const {tests, overriddenTestsToTrigger, initialSummary} = await utils.getTestsToTrigger(
         api,
         triggerConfigs,
         mockReporter
@@ -212,7 +213,7 @@ describe('utils', () => {
         {executionRule: ExecutionRule.SKIPPED, public_id: 'ski-ppe-d01'},
       ])
 
-      const expectedSummary: Summary = {
+      const expectedSummary: utils.InitialSummary = {
         criticalErrors: 0,
         failed: 0,
         failedNonBlocking: 0,
@@ -221,7 +222,7 @@ describe('utils', () => {
         testsNotFound: new Set(['987-654-321']),
         timedOut: 0,
       }
-      expect(summary).toEqual(expectedSummary)
+      expect(initialSummary).toEqual(expectedSummary)
     })
 
     test('no tests triggered throws an error', async () => {
@@ -937,7 +938,7 @@ describe('utils', () => {
   })
 
   describe('Render results', () => {
-    const emptySummary = utils.createSummary()
+    const emptySummary = getSummary()
 
     const cases: RenderResultsTestCase[] = [
       {

--- a/src/commands/synthetics/interfaces.ts
+++ b/src/commands/synthetics/interfaces.ts
@@ -345,9 +345,8 @@ export interface Suite {
 }
 
 export interface Summary {
-  // The batchId is set later in the process, so it first needs to be undefined ; it will always be defined eventually.
-  // Multiple suites will have the same batchId.
-  batchId?: string
+  // The batchId is associated to a full run of datadog-ci: multiple suites will be in the same batch.
+  batchId: string
   criticalErrors: number
   failed: number
   failedNonBlocking: number

--- a/src/commands/synthetics/reporters/junit.ts
+++ b/src/commands/synthetics/reporters/junit.ts
@@ -66,8 +66,8 @@ interface XMLStep {
 export interface XMLJSON {
   testsuites: {
     $: {
-      batch_id?: string
-      batch_url?: string
+      batch_id: string
+      batch_url: string
       name: string
       tests_critical_error: number
       tests_failed: number
@@ -129,6 +129,8 @@ export class JUnitReporter implements Reporter {
     this.json = {
       testsuites: {
         $: {
+          batch_id: '',
+          batch_url: '',
           name: runName || 'Undefined run',
           tests_critical_error: 0,
           tests_failed: 0,
@@ -202,9 +204,7 @@ export class JUnitReporter implements Reporter {
     })
 
     this.json.testsuites.$.batch_id = summary.batchId
-    if (summary.batchId) {
-      this.json.testsuites.$.batch_url = getBatchUrl(baseUrl, summary.batchId)
-    }
+    this.json.testsuites.$.batch_url = getBatchUrl(baseUrl, summary.batchId)
 
     // Write the file
     try {

--- a/src/commands/synthetics/run-test.ts
+++ b/src/commands/synthetics/run-test.ts
@@ -4,6 +4,7 @@ import {CiError, CriticalError} from './errors'
 import {
   CommandConfig,
   MainReporter,
+  Result,
   Suite,
   Summary,
   SyntheticsCIConfig,
@@ -14,9 +15,16 @@ import {
   UserConfigOverride,
 } from './interfaces'
 import {Tunnel} from './tunnel'
-import {getSuites, getTestsToTrigger, runTests, waitForResults} from './utils'
+import {getSuites, getTestsToTrigger, InitialSummary, runTests, waitForResults} from './utils'
 
-export const executeTests = async (reporter: MainReporter, config: CommandConfig, suites?: Suite[]) => {
+export const executeTests = async (
+  reporter: MainReporter,
+  config: CommandConfig,
+  suites?: Suite[]
+): Promise<{
+  results: Result[]
+  summary: Summary
+}> => {
   const api = getApiHelper(config)
 
   const publicIdsFromCli = config.publicIds.map((id) => ({
@@ -53,8 +61,8 @@ export const executeTests = async (reporter: MainReporter, config: CommandConfig
   }
 
   let testsToTriggerResult: {
+    initialSummary: InitialSummary
     overriddenTestsToTrigger: TestPayload[]
-    summary: Summary
     tests: Test[]
   }
 
@@ -69,7 +77,7 @@ export const executeTests = async (reporter: MainReporter, config: CommandConfig
     throw new CriticalError(isForbiddenError(error) ? 'AUTHORIZATION_ERROR' : 'UNAVAILABLE_TEST_CONFIG', error.message)
   }
 
-  const {tests, overriddenTestsToTrigger, summary} = testsToTriggerResult
+  const {tests, overriddenTestsToTrigger, initialSummary} = testsToTriggerResult
 
   // All tests have been skipped or are missing.
   if (!tests.length) {
@@ -102,8 +110,6 @@ export const executeTests = async (reporter: MainReporter, config: CommandConfig
   let trigger: Trigger
   try {
     trigger = await runTests(api, overriddenTestsToTrigger)
-
-    summary.batchId = trigger.batch_id
   } catch (error) {
     await stopTunnel()
     throw new CriticalError('TRIGGER_TESTS_FAILED', error.message)
@@ -124,7 +130,13 @@ export const executeTests = async (reporter: MainReporter, config: CommandConfig
       tunnel
     )
 
-    return {results, summary}
+    return {
+      results,
+      summary: {
+        ...initialSummary,
+        batchId: trigger.batch_id,
+      },
+    }
   } catch (error) {
     throw new CriticalError('POLL_RESULTS_FAILED', error.message)
   } finally {

--- a/src/commands/synthetics/utils.ts
+++ b/src/commands/synthetics/utils.ts
@@ -409,7 +409,9 @@ export const waitForResults = async (
   return results
 }
 
-export const createSummary = (): Summary => ({
+export type InitialSummary = Omit<Summary, 'batchId'>
+
+export const createInitialSummary = (): InitialSummary => ({
   criticalErrors: 0,
   failed: 0,
   failedNonBlocking: 0,
@@ -526,7 +528,7 @@ const getTestAndOverrideConfig = async (
   api: APIHelper,
   {config, id, suite}: TriggerConfig,
   reporter: MainReporter,
-  summary: Summary
+  summary: InitialSummary
 ) => {
   const normalizedId = PUBLIC_ID_REGEX.test(id) ? id : id.substr(id.lastIndexOf('/') + 1)
 
@@ -572,9 +574,9 @@ export const getTestsToTrigger = async (
     )
   }
 
-  const summary = createSummary()
+  const initialSummary = createInitialSummary()
   const testsAndConfigsOverride = await Promise.all(
-    triggerConfigs.map((triggerConfig) => getTestAndOverrideConfig(api, triggerConfig, reporter, summary))
+    triggerConfigs.map((triggerConfig) => getTestAndOverrideConfig(api, triggerConfig, reporter, initialSummary))
   )
 
   const overriddenTestsToTrigger: TestPayload[] = []
@@ -609,7 +611,7 @@ export const getTestsToTrigger = async (
     reporter.testsWait(waitedTests)
   }
 
-  return {tests: waitedTests, overriddenTestsToTrigger, summary}
+  return {tests: waitedTests, overriddenTestsToTrigger, initialSummary}
 }
 
 export const runTests = async (api: APIHelper, testsToTrigger: TestPayload[]): Promise<Trigger> => {


### PR DESCRIPTION
### What and why?

In our interface, the `batchId` property of a run summary was optional because it's not initially set.
But seen from the outside, the `batchId` will always be defined.

### How?

Internally we use an `InitialSummary` but we expose a `Summary`.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] \[_Synthetics_\] New releases of `datadog-ci` MUST be followed by a [synthetics-ci-github-action](https://github.com/DataDog/synthetics-ci-github-action) release
- [ ] \[_Synthetics_\] New releases of `datadog-ci` MUST be followed by a [datadog-ci-azure-devops](https://github.com/DataDog/datadog-ci-azure-devops) release
