### PR TITLE
[synthetics] bump yamux-js to v0.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "tiny-async-pool": "1.2.0",
     "ws": "7.4.6",
     "xml2js": "0.4.23",
-    "yamux-js": "0.1.0"
+    "yamux-js": "0.1.1"
   },
   "devDependencies": {
     "@babel/core": "7.4.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6011,10 +6011,10 @@ yallist@^4.0.0:
   resolved "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz"
   integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
-yamux-js@0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/yamux-js/-/yamux-js-0.1.0.tgz#a0215b8cc315533f6bb3189769febe337ec7440f"
-  integrity sha512-Bg/H2ZIV/FZ2O7LZ4nNYBoE69KPljE6Vo47p5gC7flCxSQQLmbCy1EKYqvq6tLBVBb/ep+6I2niKtPuNlj6hyw==
+yamux-js@0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/yamux-js/-/yamux-js-0.1.1.tgz#69dbd63a9a3896d2417fb879ed49d14e461c1dae"
+  integrity sha512-R4cSoIIuhHTDsp0yR99nghTk8va86Z4EC2aFwemZ5QCIqfUUul9U4Fay7b6O/UnSIdiyLtqwvhwu8w50ptTpiw==
 
 yargs-parser@20.x:
   version "20.2.4"


### PR DESCRIPTION
### What and why?

This PR bumps `yamux-js` to fix an issue with the tunnel when processing big uploaded payloads.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] \[_Synthetics_\] New releases of `datadog-ci` MUST be followed by a [synthetics-ci-github-action](https://github.com/DataDog/synthetics-ci-github-action) release
- [ ] \[_Synthetics_\] New releases of `datadog-ci` MUST be followed by a [datadog-ci-azure-devops](https://github.com/DataDog/datadog-ci-azure-devops) release
