### PR TITLE
v1.14.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci",
-  "version": "1.14.1",
+  "version": "1.14.2",
   "description": "Run datadog actions from the CI.",
   "repository": "https://github.com/DataDog/datadog-ci",
   "license": "Apache-2.0",


### PR DESCRIPTION
### What and why?

This PR bumps version to 1.14.2 to release:

- #644
- #638
- #620
- #619
- #629
- #632