### PR TITLE
[synthetics] Make jUnit reports compatible with GitLab

### DIFF
--- a/src/commands/synthetics/__tests__/fixtures.ts
+++ b/src/commands/synthetics/__tests__/fixtures.ts
@@ -286,6 +286,40 @@ export const getMultiStepsServerResult = (): MultiStepsServerResult => ({
   steps: [],
 })
 
+export const getFailedMultiStepsServerResult = (): MultiStepsServerResult => ({
+  duration: 123,
+  failure: {code: 'INCORRECT_ASSERTION', message: 'incorrect assertion'},
+  passed: false,
+  steps: [
+    {
+      ...getMultiStep(),
+      passed: true,
+    },
+    {
+      ...getMultiStep(),
+      skipped: true,
+    },
+    {
+      ...getMultiStep(),
+      allowFailure: true,
+      failure: {
+        code: 'INCORRECT_ASSERTION',
+        message: 'incorrect assertion',
+      },
+      passed: false,
+    },
+    {
+      ...getMultiStep(),
+      allowFailure: false,
+      failure: {
+        code: 'INCORRECT_ASSERTION',
+        message: 'incorrect assertion',
+      },
+      passed: false,
+    },
+  ],
+})
+
 export const mockLocation: Location = {
   display_name: 'Frankfurt (AWS)',
   id: 1,

--- a/src/commands/synthetics/__tests__/reporters/__snapshots__/default.test.ts.snap
+++ b/src/commands/synthetics/__tests__/reporters/__snapshots__/default.test.ts.snap
@@ -16,13 +16,13 @@ exports[`Default reporter resultEnd 1 API test, 1 location, 3 results: success, 
 [1m[33m✖[39m[22m [[1m[33mnon-blocking[39m[22m] [[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m - [1m[33mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m
   ⎋ Total duration: 123 ms - Result URL: [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=2&from_ci=true[39m[22m 
   [1m[33m✖[39m[22m [1m[33m[1mGET[22m[1m - http://fake.url[39m[22m
-[1m[33m  - Assertion(s) failed:[39m[22m
+[1m[33m  - Assertion failed:[39m[22m
 [1m[33m    ▶ responseTime should be less than [4m1000[24m. Actual: [4m1234[24m[39m[22m
 
 [1m[31m✖[39m[22m [[1m[31mblocking[39m[22m] [[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m - [1m[31mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m
   ⎋ Total duration: 123 ms - Result URL: [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=3&from_ci=true[39m[22m 
   [1m[31m✖[39m[22m [1m[31m[1mGET[22m[1m - http://fake.url[39m[22m
-[1m[31m  - Assertion(s) failed:[39m[22m
+[1m[31m  - Assertion failed:[39m[22m
 [1m[31m    ▶ responseTime should be less than [4m1000[24m. Actual: [4m1234[24m[39m[22m
 
 "

--- a/src/commands/synthetics/__tests__/reporters/junit.test.ts
+++ b/src/commands/synthetics/__tests__/reporters/junit.test.ts
@@ -146,11 +146,17 @@ describe('Junit reporter', () => {
     })
 
     it('should use the same report for tests from same suite', () => {
-      const result = {...globalResultMock, test: {...globalTestMock, suite: 'same suite'}}
-      reporter.resultEnd(result, '')
-      reporter.resultEnd(result, '')
+      const results = [
+        {...globalResultMock, test: {...globalTestMock, suite: 'same suite'}},
+        {...globalResultMock, test: {...globalTestMock, suite: 'same suite'}},
+      ]
 
-      expect(reporter['json'].testsuites.testsuite.length).not.toBe(2)
+      results.forEach((result) => reporter.resultEnd(result, ''))
+
+      // We should have 1 unique report. Not 2 different ones.
+      expect(reporter['json'].testsuites.testsuite.length).toBe(1)
+
+      // And this unique report should include the 2 tests.
       expect(reporter['json'].testsuites.testsuite[0].$).toMatchObject({
         ...getDefaultSuiteStats(),
         tests: 2,
@@ -516,7 +522,7 @@ describe('GitLab test report compatibility', () => {
     expect(testCase.failure).toStrictEqual([
       {
         $: {step: 'Test name', type: 'INCORRECT_ASSERTION'},
-        _: '- Assertion(s) failed:\n    ▶ responseTime should be less than 1000. Actual: 1234',
+        _: '- Assertion failed:\n    ▶ responseTime should be less than 1000. Actual: 1234',
       },
     ])
   })

--- a/src/commands/synthetics/__tests__/reporters/junit.test.ts
+++ b/src/commands/synthetics/__tests__/reporters/junit.test.ts
@@ -4,15 +4,20 @@ import {Writable} from 'stream'
 
 import {BaseContext} from 'clipanion/lib/advanced'
 
-import {Result} from '../../interfaces'
+import {Device, ExecutionRule, Result, Test} from '../../interfaces'
 
 import {RunTestCommand} from '../../command'
-import {Args, getDefaultStats, JUnitReporter, XMLTestCase} from '../../reporters/junit'
+import {Args, getDefaultSuiteStats, getDefaultTestCaseStats, JUnitReporter, XMLTestCase} from '../../reporters/junit'
 import {
   BATCH_ID,
+  getApiResult,
+  getApiServerResult,
   getApiTest,
   getBrowserResult,
   getBrowserServerResult,
+  getBrowserTest,
+  getFailedBrowserResult,
+  getFailedMultiStepsServerResult,
   getMultiStep,
   getMultiStepsServerResult,
   getStep,
@@ -141,15 +146,45 @@ describe('Junit reporter', () => {
     })
 
     it('should use the same report for tests from same suite', () => {
-      const result = {...globalResultMock, test: {suite: 'Suite 1', ...globalTestMock}}
+      const result = {...globalResultMock, test: {...globalTestMock, suite: 'same suite'}}
       reporter.resultEnd(result, '')
-      expect(reporter['json'].testsuites.testsuite.length).toBe(1)
+      reporter.resultEnd(result, '')
+
+      expect(reporter['json'].testsuites.testsuite.length).not.toBe(2)
+      expect(reporter['json'].testsuites.testsuite[0].$).toMatchObject({
+        ...getDefaultSuiteStats(),
+        tests: 2,
+      })
     })
 
     it('should add stats to the run', () => {
-      reporter.resultEnd(globalResultMock, '')
-      const testsuite = reporter['json'].testsuites.testsuite[0]
-      expect(testsuite.$).toMatchObject(getDefaultStats())
+      reporter.resultEnd({...globalResultMock, test: {...globalTestMock, suite: 'suite 1'}}, '')
+      reporter.resultEnd(
+        {
+          ...globalResultMock,
+          passed: false,
+          result: getFailedMultiStepsServerResult(),
+          test: {
+            ...globalTestMock,
+            suite: 'suite 2',
+          },
+        },
+        ''
+      )
+
+      const [suitePassed, suiteFailed] = reporter['json'].testsuites.testsuite
+
+      expect(suitePassed.$).toMatchObject({
+        ...getDefaultSuiteStats(),
+        tests: 1,
+      })
+      expect(suiteFailed.$).toMatchObject({
+        ...getDefaultSuiteStats(),
+        errors: 0,
+        failures: 1,
+        skipped: 0,
+        tests: 1,
+      })
     })
 
     it('should report errors', () => {
@@ -225,14 +260,48 @@ describe('Junit reporter', () => {
         const result = results[i]
         expect(testcase.allowed_error.length).toBe(result[0])
         expect(testcase.browser_error.length).toBe(result[1])
-        expect(testcase.error.length).toBe(result[2])
+        expect(testcase.failure.length).toBe(result[2])
         expect(testcase.warning.length).toBe(result[3])
       }
     })
   })
 
   describe('getTestCase', () => {
-    it('should add stats to the suite', () => {
+    beforeEach(() => {
+      reporter = new JUnitReporter(commandMock as RunTestCommand)
+    })
+
+    it('should add stats to the test case - api test', () => {
+      const resultMock = {
+        ...globalResultMock,
+        result: getApiServerResult({passed: false}),
+      }
+      const testCase = reporter['getTestCase'](resultMock, '')
+      expect(testCase.$).toMatchObject({
+        ...getDefaultTestCaseStats(),
+        steps_count: 1,
+        steps_errors: 1,
+        steps_failures: 1,
+      })
+    })
+
+    it('should add stats to the test case - multistep test', () => {
+      const resultMock = {
+        ...globalResultMock,
+        result: getFailedMultiStepsServerResult(),
+      }
+      const testCase = reporter['getTestCase'](resultMock, '')
+      expect(testCase.$).toMatchObject({
+        ...getDefaultTestCaseStats(),
+        steps_allowfailures: 1,
+        steps_count: 4,
+        steps_errors: 2,
+        steps_failures: 2,
+        steps_skipped: 1,
+      })
+    })
+
+    it('should add stats to the test case - browser test', () => {
       const resultMock = {
         ...globalResultMock,
         ...{
@@ -253,14 +322,202 @@ describe('Junit reporter', () => {
           },
         },
       }
-      const suite = reporter['getTestCase'](resultMock, MOCK_BASE_URL)
-      expect(suite.$).toMatchObject({
-        ...getDefaultStats(),
-        errors: 2,
-        failures: 1,
-        tests: 3,
-        warnings: 1,
+      const testCase = reporter['getTestCase'](resultMock, '')
+      expect(testCase.$).toMatchObject({
+        ...getDefaultTestCaseStats(),
+        steps_count: 3,
+        steps_errors: 2,
+        steps_failures: 1,
+        steps_warnings: 1,
       })
     })
+  })
+})
+
+describe('GitLab test report compatibility', () => {
+  const writeMock: Writable['write'] = jest.fn()
+  const commandMock: Args = {
+    context: ({stdout: {write: writeMock}} as unknown) as BaseContext,
+    jUnitReport: 'junit',
+    runName: 'Test Suite name',
+  }
+
+  let reporter: JUnitReporter
+
+  beforeEach(() => {
+    reporter = new JUnitReporter(commandMock as RunTestCommand)
+  })
+
+  it('all test case names are unique', () => {
+    const locations = ['aws:eu-central-1', 'aws:eu-central-2']
+    const devices = {
+      chrome: {height: 1100, id: 'chrome.laptop_large', width: 1440},
+      firefox: {height: 1100, id: 'firefox.laptop_large', width: 1440},
+    }
+
+    const apiTest = getApiTest('aaa-aaa-aaa', {locations})
+    const browserTest = getBrowserTest('bbb-bbb-bbb', [devices.chrome.id, devices.firefox.id], {locations})
+
+    const getTestCase = (
+      test: Test,
+      resultId: string,
+      {
+        location,
+        device,
+        timedOut,
+      }: {
+        device?: Device
+        location?: string
+        timedOut?: boolean
+      }
+    ): XMLTestCase =>
+      reporter['getTestCase'](
+        {
+          ...(test.type === 'browser' ? getBrowserResult(resultId, test, {device}) : getApiResult(resultId, test)),
+          ...(location && {location}),
+          ...(timedOut && {timedOut}),
+        },
+        ''
+      )
+
+    const testCases = [
+      // API test, location 1
+      getTestCase(apiTest, '1', {location: locations[0]}),
+      // API test, location 2
+      getTestCase(apiTest, '2', {location: locations[1]}),
+      // API test, location 1 (timed out)
+      getTestCase(apiTest, '3', {location: locations[0], timedOut: true}),
+      // API test, location 2 (timed out)
+      getTestCase(apiTest, '4', {location: locations[1], timedOut: true}),
+
+      // Browser test, location 1, device 1
+      getTestCase(browserTest, '5', {location: locations[0], device: devices.chrome}),
+      // Browser test, location 1, device 2
+      getTestCase(browserTest, '6', {location: locations[0], device: devices.firefox}),
+      // Browser test, location 2, device 1
+      getTestCase(browserTest, '7', {location: locations[1], device: devices.chrome}),
+      // Browser test, location 2, device 2
+      getTestCase(browserTest, '8', {location: locations[1], device: devices.firefox}),
+      // Browser test, location 1, (timed out)
+      getTestCase(browserTest, '9', {location: locations[0], timedOut: true}),
+      // Browser test, location 1, (timed out)
+      getTestCase(browserTest, '10', {location: locations[0], timedOut: true}),
+      // Browser test, location 2, (timed out)
+      getTestCase(browserTest, '11', {location: locations[1], timedOut: true}),
+      // Browser test, location 2, (timed out)
+      getTestCase(browserTest, '12', {location: locations[1], timedOut: true}),
+    ]
+
+    const caseNames = testCases.map((testCase) => testCase.$.name)
+
+    const uniqueCaseNames = [...new Set(caseNames)]
+    expect(uniqueCaseNames.length).toEqual(caseNames.length)
+
+    expect(caseNames).toStrictEqual([
+      // API tests.
+      'Test name - id: aaa-aaa-aaa - location: aws:eu-central-1',
+      'Test name - id: aaa-aaa-aaa - location: aws:eu-central-2',
+      'Test name - id: aaa-aaa-aaa - location: aws:eu-central-1 - result id: 3 (not yet received)',
+      'Test name - id: aaa-aaa-aaa - location: aws:eu-central-2 - result id: 4 (not yet received)',
+
+      // Browser tests.
+      'Test name - id: bbb-bbb-bbb - location: aws:eu-central-1 - device: chrome.laptop_large',
+      'Test name - id: bbb-bbb-bbb - location: aws:eu-central-1 - device: firefox.laptop_large',
+      'Test name - id: bbb-bbb-bbb - location: aws:eu-central-2 - device: chrome.laptop_large',
+      'Test name - id: bbb-bbb-bbb - location: aws:eu-central-2 - device: firefox.laptop_large',
+      'Test name - id: bbb-bbb-bbb - location: aws:eu-central-1 - result id: 9 (not yet received)',
+      'Test name - id: bbb-bbb-bbb - location: aws:eu-central-1 - result id: 10 (not yet received)',
+      'Test name - id: bbb-bbb-bbb - location: aws:eu-central-2 - result id: 11 (not yet received)',
+      'Test name - id: bbb-bbb-bbb - location: aws:eu-central-2 - result id: 12 (not yet received)',
+    ])
+  })
+
+  it('all columns are filled in the test report table', () => {
+    const baseResult = getFailedBrowserResult()
+    const result: Result = {
+      ...baseResult,
+      test: {...baseResult.test, suite: 'tests.json'},
+    }
+
+    reporter['resultEnd'](result, '')
+
+    const testCase = reporter['json'].testsuites.testsuite[0].testcase[0]
+
+    const name = 'Test name - id: abc-def-ghi - location: Location name - device: chrome.laptop_large'
+    const failure = {
+      $: {
+        allowFailure: 'false',
+        step: 'Assert',
+        type: 'assertion',
+      },
+      _: 'Step failure',
+    }
+
+    expect(testCase.$).toHaveProperty('classname', 'tests.json') // Suite
+    expect(testCase.$).toHaveProperty('name', name) // Name
+    expect(testCase.$).toHaveProperty('file', 'tests.json') // Filename
+    expect(testCase.failure).toStrictEqual([failure]) // Status
+    expect(testCase.$).toHaveProperty('time', 20) // Duration
+  })
+
+  it('the icon in the Status column is correct (blocking vs. non-blocking)', () => {
+    // Mimics how GitLab chooses the Status icon.
+    const getStatusIcon = (testCase: XMLTestCase) => {
+      if (testCase.failure.length > 0) {
+        return '❌'
+      }
+      if (testCase.error.length > 0) {
+        return '❗️'
+      }
+      if (testCase.skipped.length > 0) {
+        return '⏩'
+      }
+
+      return '✅'
+    }
+
+    reporter['testTrigger'](globalTestMock, '', ExecutionRule.SKIPPED, {})
+
+    reporter['resultEnd']({...getFailedBrowserResult(), executionRule: ExecutionRule.BLOCKING}, '')
+    reporter['resultEnd']({...getFailedBrowserResult(), executionRule: ExecutionRule.NON_BLOCKING}, '')
+    reporter['resultEnd']({...getBrowserResult('', globalTestMock), executionRule: ExecutionRule.BLOCKING}, '')
+
+    const [testCaseSkipped, testCaseBlocking, testCaseNonBlocking, testCasePassed] = reporter[
+      'json'
+    ].testsuites.testsuite[0].testcase
+
+    expect(getStatusIcon(testCaseSkipped)).toBe('⏩')
+    expect(getStatusIcon(testCaseBlocking)).toBe('❌')
+    expect(getStatusIcon(testCaseNonBlocking)).toBe('❗️')
+    expect(getStatusIcon(testCasePassed)).toBe('✅')
+  })
+
+  it('api errors are nicely rendered', () => {
+    const errorMessage = JSON.stringify([
+      {
+        actual: 1234,
+        operator: 'lessThan',
+        target: 1000,
+        type: 'responseTime',
+      },
+    ])
+    const failure = {code: 'INCORRECT_ASSERTION', message: errorMessage}
+
+    const baseResult = getApiResult('1', globalTestMock)
+    const result: Result = {
+      ...baseResult,
+      passed: false,
+      result: {...baseResult.result, failure},
+    }
+
+    reporter['resultEnd'](result, '')
+
+    const testCase = reporter['json'].testsuites.testsuite[0].testcase[0]
+    expect(testCase.failure).toStrictEqual([
+      {
+        $: {step: 'Test name', type: 'INCORRECT_ASSERTION'},
+        _: '- Assertion(s) failed:\n    ▶ responseTime should be less than 1000. Actual: 1234',
+      },
+    ])
   })
 })

--- a/src/commands/synthetics/__tests__/reporters/junit.test.ts
+++ b/src/commands/synthetics/__tests__/reporters/junit.test.ts
@@ -354,7 +354,7 @@ describe('GitLab test report compatibility', () => {
     reporter = new JUnitReporter(commandMock as RunTestCommand)
   })
 
-  it('all test case names are unique', () => {
+  test('all test case names are unique', () => {
     const locations = ['aws:eu-central-1', 'aws:eu-central-2']
     const devices = {
       chrome: {height: 1100, id: 'chrome.laptop_large', width: 1440},
@@ -438,7 +438,7 @@ describe('GitLab test report compatibility', () => {
     ])
   })
 
-  it('all columns are filled in the test report table', () => {
+  test('all columns are filled in the test report table', () => {
     const baseResult = getFailedBrowserResult()
     const result: Result = {
       ...baseResult,
@@ -466,7 +466,7 @@ describe('GitLab test report compatibility', () => {
     expect(testCase.$).toHaveProperty('time', 20) // Duration
   })
 
-  it('the icon in the Status column is correct (blocking vs. non-blocking)', () => {
+  test('the icon in the Status column is correct (blocking vs. non-blocking)', () => {
     // Mimics how GitLab chooses the Status icon.
     const getStatusIcon = (testCase: XMLTestCase) => {
       if (testCase.failure.length > 0) {
@@ -498,7 +498,7 @@ describe('GitLab test report compatibility', () => {
     expect(getStatusIcon(testCasePassed)).toBe('✅')
   })
 
-  it('api errors are nicely rendered', () => {
+  test('api errors are nicely rendered', () => {
     const errorMessage = JSON.stringify([
       {
         actual: 1234,

--- a/src/commands/synthetics/reporters/default.ts
+++ b/src/commands/synthetics/reporters/default.ts
@@ -7,7 +7,6 @@ import {
   Batch,
   ExecutionRule,
   MainReporter,
-  Operator,
   Result,
   ServerResult,
   Step,
@@ -15,7 +14,15 @@ import {
   Test,
   UserConfigOverride,
 } from '../interfaces'
-import {getBatchUrl, getResultDuration, getResultOutcome, getResultUrl, isDeviceIdSet, ResultOutcome} from '../utils'
+import {
+  getBatchUrl,
+  getResultDuration,
+  getResultOutcome,
+  getResultUrl,
+  isDeviceIdSet,
+  readableOperation,
+  ResultOutcome,
+} from '../utils'
 
 // Step rendering
 
@@ -72,23 +79,6 @@ const renderSkippedSteps = (steps: Step[]): string | undefined => {
   }
 
   return `    ${ICONS.SKIPPED} | ${steps.length} skipped steps`
-}
-
-const readableOperation: {[key in Operator]: string} = {
-  [Operator.contains]: 'should contain',
-  [Operator.doesNotContain]: 'should not contain',
-  [Operator.is]: 'should be',
-  [Operator.isNot]: 'should not be',
-  [Operator.lessThan]: 'should be less than',
-  [Operator.matches]: 'should match',
-  [Operator.doesNotMatch]: 'should not match',
-  [Operator.isInLessThan]: 'will expire in less than',
-  [Operator.isInMoreThan]: 'will expire in more than',
-  [Operator.lessThanOrEqual]: 'should be less than or equal to',
-  [Operator.moreThan]: 'should be more than',
-  [Operator.moreThanOrEqual]: 'should be less than or equal to',
-  [Operator.validatesJSONPath]: 'assert on JSONPath extracted value',
-  [Operator.validatesXPath]: 'assert on XPath extracted value',
 }
 
 const renderApiError = (errorCode: string, errorMessage: string, color: chalk.Chalk) => {

--- a/src/commands/synthetics/reporters/default.ts
+++ b/src/commands/synthetics/reporters/default.ts
@@ -20,6 +20,7 @@ import {
   getResultOutcome,
   getResultUrl,
   isDeviceIdSet,
+  pluralize,
   readableOperation,
   ResultOutcome,
 } from '../utils'
@@ -85,7 +86,7 @@ const renderApiError = (errorCode: string, errorMessage: string, color: chalk.Ch
   if (errorCode === 'INCORRECT_ASSERTION') {
     try {
       const assertionsErrors: Assertion[] = JSON.parse(errorMessage)
-      const output = ['  - Assertion(s) failed:']
+      const output = [`  - ${pluralize('Assertion', assertionsErrors.length)} failed:`]
       output.push(
         ...assertionsErrors.map((error) => {
           const expected = chalk.underline(`${error.target}`)
@@ -373,5 +374,3 @@ export class DefaultReporter implements MainReporter {
     return
   }
 }
-
-const pluralize = (word: string, count: number): string => (count === 1 ? word : `${word}s`)

--- a/src/commands/synthetics/reporters/junit.ts
+++ b/src/commands/synthetics/reporters/junit.ts
@@ -23,6 +23,7 @@ import {
   getResultOutcome,
   getResultUrl,
   isDeviceIdSet,
+  pluralize,
   readableOperation,
   ResultOutcome,
 } from '../utils'
@@ -118,7 +119,7 @@ const renderApiError = (errorCode: string, errorMessage: string) => {
   if (errorCode === 'INCORRECT_ASSERTION') {
     try {
       const assertionsErrors: Assertion[] = JSON.parse(errorMessage)
-      const output = ['- Assertion(s) failed:']
+      const output = [`- ${pluralize('Assertion', assertionsErrors.length)} failed:`]
       output.push(
         ...assertionsErrors.map((error) => {
           const expected = error.target

--- a/src/commands/synthetics/reporters/junit.ts
+++ b/src/commands/synthetics/reporters/junit.ts
@@ -5,28 +5,59 @@ import path from 'path'
 import {Writable} from 'stream'
 import {Builder} from 'xml2js'
 
-import {ApiServerResult, MultiStep, Reporter, Result, Step, Summary, Vitals} from '../interfaces'
-import {getBatchUrl, getResultDuration, getResultOutcome, getResultUrl, isDeviceIdSet, ResultOutcome} from '../utils'
+import {
+  ApiServerResult,
+  Assertion,
+  ExecutionRule,
+  MultiStep,
+  Reporter,
+  Result,
+  Step,
+  Summary,
+  Test,
+  UserConfigOverride,
+} from '../interfaces'
+import {
+  getBatchUrl,
+  getResultDuration,
+  getResultOutcome,
+  getResultUrl,
+  isDeviceIdSet,
+  readableOperation,
+  ResultOutcome,
+} from '../utils'
 
-interface StepStats {
-  allowfailures: number
+interface SuiteStats {
   errors: number
   failures: number
   skipped: number
   tests: number
-  warnings: number
 }
 
-interface XMLRunProperties extends StepStats {
+interface TestCaseStats {
+  steps_allowfailures: number
+  steps_count: number
+  steps_errors: number
+  steps_failures: number
+  steps_skipped: number
+  steps_warnings: number
+}
+
+interface XMLSuiteProperties extends SuiteStats {
   name: string
 }
 
-interface XMLRun {
-  $: XMLRunProperties
+interface XMLSuite {
+  $: XMLSuiteProperties
   testcase: XMLTestCase[]
 }
 
-interface XMLTestCaseProperties extends StepStats {
+interface XMLTestCaseProperties extends TestCaseStats {
+  // Those properties are shown in the GitLab Pipeline's test report tab.
+  // https://gitlab.com/gitlab-org/gitlab/-/blob/1847b49a8ab5205f756611ec3dfc98f405b662ac/lib/gitlab/ci/parsers/test/junit.rb#L66-94
+  classname: string | undefined // Shown in the Suite column.
+  file: string | undefined // Shown as a hyperlink to the test config file: must be a file path.
+
   name: string
   time: number | undefined
   timestamp: string
@@ -37,35 +68,26 @@ export interface XMLTestCase {
   // These are singular for a better display in the XML format of the report.
   allowed_error: XMLError[]
   browser_error: XMLError[]
+  // Displays ❗️ in the Status column of the GitLab Pipeline's test report tab.
+  // This is used when a test fails but is non-blocking i.e. does not block the CI/CD pipeline.
   error: XMLError[]
+  // Displays ❌ in the Status column of the GitLab Pipeline's test report tab.
+  // This is used when a test fails and is blocking.
+  failure: XMLError[]
   properties: {
     property: {$: {name: string; value: any}}[]
   }
-  testcase: XMLStep[]
+  // Displays ⏩ in the Status column of the GitLab Pipeline's test report tab.
+  // This is used when a test is skipped.
+  skipped: string[]
   warning: XMLError[]
-}
-
-interface XMLStepProperties extends StepStats {
-  allow_failure: boolean
-  is_skipped: boolean
-  name: string
-  substep_public_id?: string
-  time: number
-  type: string
-  url?: string
-}
-
-interface XMLStep {
-  $: XMLStepProperties
-  browser_error?: {$: {name: string; type: string}; _: string}[]
-  error: {$: {type: 'assertion'}; _: string}[]
-  vitals?: {$: Vitals}[]
-  warning?: {$: {type: string}; _: string}[]
 }
 
 export interface XMLJSON {
   testsuites: {
     $: {
+      // All these attributes are non-standard to a jUnit report.
+      // https://github.com/windyroad/JUnit-Schema/blob/master/JUnit.xsd
       batch_id: string
       batch_url: string
       name: string
@@ -77,7 +99,7 @@ export interface XMLJSON {
       tests_skipped: number
       tests_timed_out: number
     }
-    testsuite: XMLRun[]
+    testsuite: XMLSuite[]
   }
 }
 
@@ -92,21 +114,51 @@ export interface Args {
   runName?: string
 }
 
-export const getDefaultStats = (): StepStats => ({
-  allowfailures: 0,
+const renderApiError = (errorCode: string, errorMessage: string) => {
+  if (errorCode === 'INCORRECT_ASSERTION') {
+    try {
+      const assertionsErrors: Assertion[] = JSON.parse(errorMessage)
+      const output = ['- Assertion(s) failed:']
+      output.push(
+        ...assertionsErrors.map((error) => {
+          const expected = error.target
+          const actual = error.actual
+
+          return `▶ ${error.type} ${readableOperation[error.operator]} ${expected}. Actual: ${actual}`
+        })
+      )
+
+      return output.join('\n    ')
+    } catch (e) {
+      // JSON parsing failed, do nothing to return the raw error
+    }
+  }
+
+  return `  [${errorCode}] - ${errorMessage}`
+}
+
+export const getDefaultTestCaseStats = (): TestCaseStats => ({
+  steps_allowfailures: 0,
+  steps_count: 0,
+  steps_errors: 0,
+  steps_failures: 0,
+  steps_skipped: 0,
+  steps_warnings: 0,
+})
+
+export const getDefaultSuiteStats = (): SuiteStats => ({
   errors: 0,
   failures: 0,
   skipped: 0,
   tests: 0,
-  warnings: 0,
 })
 
 // Return the stats from a given object
-// based on getDefaultStats
-const getStats = (obj: StepStats): StepStats => {
-  const baseStats = getDefaultStats()
-  for (const entry of Object.entries(baseStats)) {
-    const [key, value] = entry as [keyof StepStats, number]
+// based on getDefaultSuiteStats
+const getStats = (obj: XMLSuiteProperties): SuiteStats => {
+  const baseStats = getDefaultSuiteStats()
+  for (const entry of Object.entries(obj)) {
+    const [key, value] = entry as [keyof SuiteStats, number]
     baseStats[key] = value || baseStats[key]
   }
 
@@ -146,27 +198,29 @@ export class JUnitReporter implements Reporter {
   }
 
   public resultEnd(result: Result, baseUrl: string) {
-    const suiteRunName = result.test.suite || 'Undefined suite'
-    let suiteRun = this.json.testsuites.testsuite.find((suite: XMLRun) => suite.$.name === suiteRunName)
+    const suiteName = result.test.suite || 'Undefined suite'
+    let suite = this.json.testsuites.testsuite.find((element: XMLSuite) => element.$.name === suiteName)
 
-    if (!suiteRun) {
-      suiteRun = {
-        $: {name: suiteRunName, ...getDefaultStats()},
+    if (!suite) {
+      suite = {
+        $: {name: suiteName, ...getDefaultSuiteStats()},
         testcase: [],
       }
-      this.json.testsuites.testsuite.push(suiteRun as XMLRun)
+      this.json.testsuites.testsuite.push(suite as XMLSuite)
     }
 
-    // Update stats for the suite.
-    suiteRun.$ = {
-      ...suiteRun.$,
-      ...this.getResultStats(result, getStats(suiteRun.$)),
-    }
+    const testCase = this.getTestCase(result, baseUrl)
 
-    const testCase: XMLTestCase = this.getTestCase(result, baseUrl)
+    // Errors and failures cannot co-exist: GitLab will always choose failures over errors.
+    // The icon in the Status column will depend on this choice, and only the list of what is chosen will be displayed in the "System output".
+    const errorsOrFailures =
+      result.executionRule === ExecutionRule.NON_BLOCKING
+        ? testCase.error // ❗️
+        : testCase.failure // ❌
+
     // Timeout errors are only reported at the top level.
     if (result.timedOut) {
-      testCase.error.push({
+      errorsOrFailures.push({
         $: {type: 'timeout'},
         _: String(result.result.failure?.message),
       })
@@ -174,22 +228,32 @@ export class JUnitReporter implements Reporter {
     if ('stepDetails' in result.result) {
       // It's a browser test.
       for (const stepDetail of result.result.stepDetails) {
-        const {allowed_error, browser_error, error, warning} = this.getBrowserTestStep(stepDetail)
+        const {allowed_error, browser_error, error, warning} = this.getBrowserTestErrors(stepDetail)
         testCase.allowed_error.push(...allowed_error)
         testCase.browser_error.push(...browser_error)
-        testCase.error.push(...error)
+        errorsOrFailures.push(...error)
         testCase.warning.push(...warning)
       }
     } else if ('steps' in result.result) {
       // It's a multistep test.
       for (const step of result.result.steps) {
-        const {allowed_error, error} = this.getApiTestStep(step)
+        const {allowed_error, error} = this.getMultiStepTestErrors(step)
         testCase.allowed_error.push(...allowed_error)
-        testCase.error.push(...error)
+        errorsOrFailures.push(...error)
       }
+    } else {
+      // It's an api test.
+      const {error} = this.getApiTestErrors(result)
+      errorsOrFailures.push(...error)
     }
 
-    suiteRun.testcase.push(testCase)
+    // Update stats for the suite.
+    suite.$ = {
+      ...suite.$,
+      ...this.getSuiteStats(testCase, getStats(suite.$)),
+    }
+
+    suite.testcase.push(testCase)
   }
 
   public async runEnd(summary: Summary, baseUrl: string) {
@@ -217,7 +281,36 @@ export class JUnitReporter implements Reporter {
     }
   }
 
-  private getApiStepStats(step: MultiStep | ApiServerResult): StepStats {
+  // Handle skipped tests (`resultEnd()` is not called for them since they don't have a result).
+  public testTrigger(test: Test, testId: string, executionRule: ExecutionRule, config: UserConfigOverride): void {
+    if (executionRule !== ExecutionRule.SKIPPED) {
+      return
+    }
+
+    const suiteName = test.suite || 'Undefined suite'
+    let suite = this.json.testsuites.testsuite.find((element: XMLSuite) => element.$.name === suiteName)
+
+    if (!suite) {
+      suite = {
+        $: {name: suiteName, ...getDefaultSuiteStats()},
+        testcase: [],
+      }
+      this.json.testsuites.testsuite.push(suite as XMLSuite)
+    }
+
+    const testCase = this.getSkippedTestCase(test)
+    testCase.skipped.push('This test was skipped because of its execution rule configuration in Datadog')
+
+    // Update stats for the suite.
+    suite.$ = {
+      ...suite.$,
+      ...this.getSuiteStats(testCase, getStats(suite.$)),
+    }
+
+    suite.testcase.push(testCase)
+  }
+
+  private getApiStepStats(step: MultiStep | ApiServerResult): TestCaseStats {
     // TODO use more granular result based on step.assertionResults
     let allowfailures = 0
     let skipped = 0
@@ -229,51 +322,45 @@ export class JUnitReporter implements Reporter {
     }
 
     return {
-      allowfailures,
-      errors: step.passed ? 1 : 0,
-      failures: step.passed ? 1 : 0,
-      skipped,
-      tests: 1,
-      warnings: 0,
+      steps_allowfailures: allowfailures,
+      steps_count: 1,
+      steps_errors: step.passed ? 0 : 1,
+      steps_failures: step.passed ? 0 : 1,
+      steps_skipped: skipped,
+      steps_warnings: 0,
     }
   }
 
-  private getApiTestStep(step: MultiStep): {allowed_error: XMLError[]; error: XMLError[]} {
-    const allowedError = []
+  private getApiTestErrors(result: Result): {error: XMLError[]} {
     const error = []
 
-    if (step.failure) {
+    if (result.result.failure) {
       const xmlError = {
-        $: {type: step.failure.code, step: step.name, allowFailure: `${step.allowFailure}`},
-        _: step.failure.message,
+        $: {type: result.result.failure.code, step: result.test.name},
+        _: renderApiError(result.result.failure.code, result.result.failure.message),
       }
-      if (step.allowFailure) {
-        allowedError.push(xmlError)
-      } else {
-        error.push(xmlError)
-      }
+      error.push(xmlError)
     }
 
     return {
-      allowed_error: allowedError,
       error,
     }
   }
 
-  private getBrowserStepStats(step: Step): StepStats {
+  private getBrowserStepStats(step: Step): TestCaseStats {
     const errors = step.browserErrors ? step.browserErrors.length : 0
 
     return {
-      allowfailures: step.allowFailure ? 1 : 0,
-      errors: errors + (step.error ? 1 : 0),
-      failures: step.error ? 1 : 0,
-      skipped: step.skipped ? 1 : 0,
-      tests: step.subTestStepDetails ? step.subTestStepDetails.length : 1,
-      warnings: step.warnings ? step.warnings.length : 0,
+      steps_allowfailures: step.allowFailure ? 1 : 0,
+      steps_count: step.subTestStepDetails ? step.subTestStepDetails.length : 1,
+      steps_errors: errors + (step.error ? 1 : 0),
+      steps_failures: step.error ? 1 : 0,
+      steps_skipped: step.skipped ? 1 : 0,
+      steps_warnings: step.warnings ? step.warnings.length : 0,
     }
   }
 
-  private getBrowserTestStep(
+  private getBrowserTestErrors(
     stepDetail: Step
   ): {allowed_error: XMLError[]; browser_error: XMLError[]; error: XMLError[]; warning: XMLError[]} {
     const allowedError = []
@@ -318,37 +405,70 @@ export class JUnitReporter implements Reporter {
     }
   }
 
-  private getResultStats(result: Result, stats: StepStats = getDefaultStats()): StepStats {
-    let stepsStats: StepStats[] = []
-    if ('stepDetails' in result.result) {
-      // It's a browser test.
-      stepsStats = result.result.stepDetails
-        .map((step) => {
-          if (!step.subTestStepDetails) {
-            return [step]
-          }
+  private getMultiStepTestErrors(step: MultiStep): {allowed_error: XMLError[]; error: XMLError[]} {
+    const allowedError = []
+    const error = []
 
-          return [step, ...step.subTestStepDetails]
-        })
-        .reduce((acc, val) => acc.concat(val), [])
-        .map(this.getBrowserStepStats)
-    } else if ('steps' in result.result) {
-      // It's an multistep API test
-      stepsStats = result.result.steps.map(this.getApiStepStats)
-    } else {
-      stepsStats = [this.getApiStepStats(result.result)]
+    if (step.failure) {
+      const xmlError = {
+        $: {type: step.failure.code, step: step.name, allowFailure: `${step.allowFailure}`},
+        _: renderApiError(step.failure.code, step.failure.message),
+      }
+      if (step.allowFailure) {
+        allowedError.push(xmlError)
+      } else {
+        error.push(xmlError)
+      }
     }
 
-    for (const stepStats of stepsStats) {
-      stats.tests += stepStats.tests
-      stats.errors += stepStats.errors
-      stats.failures += stepStats.failures
-      stats.skipped += stepStats.skipped
-      stats.allowfailures += stepStats.allowfailures
-      stats.warnings += stepStats.warnings
+    return {
+      allowed_error: allowedError,
+      error,
     }
+  }
 
-    return stats
+  private getSkippedTestCase(test: Test): XMLTestCase {
+    const id = `id: ${test.public_id}`
+    const resultIdentification = `${test.name} - ${id} (skipped)`
+
+    return {
+      $: {
+        classname: test.suite,
+        file: test.suite,
+        name: resultIdentification,
+        time: 0,
+        timestamp: new Date().toISOString(),
+        ...getDefaultTestCaseStats(),
+      },
+      allowed_error: [],
+      browser_error: [],
+      error: [],
+      failure: [],
+      properties: {
+        property: [
+          {$: {name: 'check_id', value: test.public_id}},
+          {$: {name: 'execution_rule', value: test.options.ci?.executionRule}},
+          {$: {name: 'message', value: test.message}},
+          {$: {name: 'monitor_id', value: test.monitor_id}},
+          {$: {name: 'public_id', value: test.public_id}},
+          {$: {name: 'status', value: test.status}},
+          {$: {name: 'tags', value: test.tags.join(',')}},
+          {$: {name: 'type', value: test.type}},
+        ].filter((prop) => prop.$.value),
+      },
+      skipped: [],
+      warning: [],
+    }
+  }
+
+  // Update the current stats of a suite based on the processed test case.
+  private getSuiteStats(testCase: XMLTestCase, current: SuiteStats = getDefaultSuiteStats()): SuiteStats {
+    current.tests += 1
+    current.errors += testCase.error.length
+    current.failures += testCase.failure.length
+    current.skipped += testCase.skipped.length
+
+    return current
   }
 
   private getTestCase(result: Result, baseUrl: string): XMLTestCase {
@@ -357,19 +477,30 @@ export class JUnitReporter implements Reporter {
     const resultUrl = getResultUrl(baseUrl, test, result.resultId)
     const passed = [ResultOutcome.Passed, ResultOutcome.PassedNonBlocking].includes(resultOutcome)
 
+    const id = `id: ${test.public_id}`
+    const location = `location: ${result.location}`
+    const device = isDeviceIdSet(result.result) ? ` - device: ${result.result.device.id}` : ''
+    const resultTimedOut = result.timedOut ? ` - result id: ${result.resultId} (not yet received)` : ''
+
+    // This has to identify results, otherwise GitLab will only show the last result with the same name.
+    const resultIdentification = `${test.name} - ${id} - ${location}${device}${resultTimedOut}`
+
     return {
       $: {
-        name: test.name,
+        classname: test.suite,
+        file: test.suite,
+        name: resultIdentification,
         time: getResultDuration(result.result) / 1000,
         timestamp: new Date(result.timestamp).toISOString(),
-        ...this.getResultStats(result),
+        ...this.getTestCaseStats(result),
       },
       allowed_error: [],
       browser_error: [],
       error: [],
+      failure: [],
       properties: {
         property: [
-          {$: {name: 'check_id', value: result.test.public_id}},
+          {$: {name: 'check_id', value: test.public_id}},
           ...(isDeviceIdSet(result.result)
             ? [
                 {$: {name: 'device', value: result.result.device.id}},
@@ -392,8 +523,42 @@ export class JUnitReporter implements Reporter {
           {$: {name: 'type', value: test.type}},
         ].filter((prop) => prop.$.value),
       },
-      testcase: [],
+      skipped: [],
       warning: [],
     }
+  }
+
+  // Update the current stats of a test case based on the processed result.
+  private getTestCaseStats(result: Result, current: TestCaseStats = getDefaultTestCaseStats()): TestCaseStats {
+    let stepsStats: TestCaseStats[] = []
+    if ('stepDetails' in result.result) {
+      // It's a browser test.
+      stepsStats = result.result.stepDetails
+        .map((step) => {
+          if (!step.subTestStepDetails) {
+            return [step]
+          }
+
+          return [step, ...step.subTestStepDetails]
+        })
+        .reduce((acc, val) => acc.concat(val), [])
+        .map(this.getBrowserStepStats)
+    } else if ('steps' in result.result) {
+      // It's an multistep API test
+      stepsStats = result.result.steps.map(this.getApiStepStats)
+    } else {
+      stepsStats = [this.getApiStepStats(result.result)]
+    }
+
+    for (const stepStats of stepsStats) {
+      current.steps_count += stepStats.steps_count
+      current.steps_errors += stepStats.steps_errors
+      current.steps_failures += stepStats.steps_failures
+      current.steps_skipped = current.steps_skipped + stepStats.steps_skipped
+      current.steps_allowfailures += stepStats.steps_allowfailures
+      current.steps_warnings += stepStats.steps_warnings
+    }
+
+    return current
   }
 }

--- a/src/commands/synthetics/utils.ts
+++ b/src/commands/synthetics/utils.ts
@@ -813,3 +813,5 @@ export const getDatadogHost = (useIntake = false, config: SyntheticsCIConfig) =>
 
   return `${host}/${apiPath}`
 }
+
+export const pluralize = (word: string, count: number): string => (count === 1 ? word : `${word}s`)

--- a/src/commands/synthetics/utils.ts
+++ b/src/commands/synthetics/utils.ts
@@ -21,6 +21,7 @@ import {
   ExecutionRule,
   LocationsMapping,
   MainReporter,
+  Operator,
   Payload,
   PollResult,
   Reporter,
@@ -44,6 +45,23 @@ const POLLING_INTERVAL = 5000 // In ms
 const PUBLIC_ID_REGEX = /^[\d\w]{3}-[\d\w]{3}-[\d\w]{3}$/
 const SUBDOMAIN_REGEX = /(.*?)\.(?=[^\/]*\..{2,5})/
 const TEMPLATE_REGEX = /{{\s*([^{}]*?)\s*}}/g
+
+export const readableOperation: {[key in Operator]: string} = {
+  [Operator.contains]: 'should contain',
+  [Operator.doesNotContain]: 'should not contain',
+  [Operator.is]: 'should be',
+  [Operator.isNot]: 'should not be',
+  [Operator.lessThan]: 'should be less than',
+  [Operator.matches]: 'should match',
+  [Operator.doesNotMatch]: 'should not match',
+  [Operator.isInLessThan]: 'will expire in less than',
+  [Operator.isInMoreThan]: 'will expire in more than',
+  [Operator.lessThanOrEqual]: 'should be less than or equal to',
+  [Operator.moreThan]: 'should be more than',
+  [Operator.moreThanOrEqual]: 'should be less than or equal to',
+  [Operator.validatesJSONPath]: 'assert on JSONPath extracted value',
+  [Operator.validatesXPath]: 'assert on XPath extracted value',
+}
 
 const template = (st: string, context: any): string =>
   st.replace(TEMPLATE_REGEX, (match: string, p1: string) => (p1 in context ? context[p1] : match))


### PR DESCRIPTION
### What and why?

This PR makes the jUnit reports generated for Synthetic tests compatible with the test report tab in the results of a GitLab pipeline.

<img width="1186" alt="image" src="https://user-images.githubusercontent.com/9317502/191971335-fe579423-d64a-4da3-965a-e78d6e812a0d.png">

### How?

- Use the 3 possible status icons:
  - ⏩ for skipped tests
  - ❗️for failed non-blocking tests
  - ❌ for failed blocking tests

- Decouple test suites' stats and test cases' step stats:
  - Test suites' stats now **only include**: `errors`, `failures`, `skipped` and `tests`. The `allowfailures` and `warnings` stats were removed because they were too specific to the steps inside of a test case.
  - Test cases' stats are now **all prefixed with `steps_`: `steps_allowfailures`, `steps_count`, `steps_errors`, `steps_failures`, `steps_skipped`, `steps_warnings`. It's clearer what those stats are about **and** `skipped` was conflicting with the `<skipped>reason</skipped>` of a skipped test.

### Useful links

- Official XML schema: https://github.com/windyroad/JUnit-Schema/blob/master/JUnit.xsd
- Simplified XML schema: https://github.com/behave/behave/blob/main/etc/junit.xml/junit-4.xsd
- GitLab's JUnit report parser: https://gitlab.com/gitlab-org/gitlab/-/blob/master/lib/gitlab/ci/parsers/test/junit.rb

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] \[_Synthetics_\] New releases of `datadog-ci` MUST be followed by a [synthetics-ci-github-action](https://github.com/DataDog/synthetics-ci-github-action) release
- [ ] \[_Synthetics_\] New releases of `datadog-ci` MUST be followed by a [datadog-ci-azure-devops](https://github.com/DataDog/datadog-ci-azure-devops) release
