### PR TITLE
[synthetics] Add `--failOnMissingTests` flag

### DIFF
--- a/src/commands/synthetics/README.md
+++ b/src/commands/synthetics/README.md
@@ -47,7 +47,8 @@ The configuration file structure is the following:
   "appKey": "<DATADOG_APPLICATION_KEY>",
   "datadogSite": "datadoghq.com",
   "failOnCriticalErrors": true,
-  "failOnTimeout": "true",
+  "failOnMissingTests": true,
+  "failOnTimeout": true,
   "files": "{,!(node_modules)/**/}*.synthetics.json",
   "global": {
     "allowInsecureCertificates": true,
@@ -122,7 +123,8 @@ yarn datadog-ci synthetics run-tests -f ./component-1/**/*.synthetics.json -v PA
 #### Failure modes flags
 
 - `--failOnTimeout` (or `--no-failOnTimeout`) will make the CI fail (or pass) if one of the result exceed its test timeout.
-- `--failOnCriticalErrors` will make the command exit with an error code 1 if tests were not triggered or results could not be fetched.
+- `--failOnCriticalErrors` will make the CI fail if tests were not triggered or results could not be fetched.
+- `--failOnMissingTests` will make the CI fail if at least one test is missing.
 
 ### Test files
 

--- a/src/commands/synthetics/__tests__/config-fixtures/config-with-all-keys.json
+++ b/src/commands/synthetics/__tests__/config-fixtures/config-with-all-keys.json
@@ -4,6 +4,7 @@
   "configPath": "fake-datadog-ci.json",
   "datadogSite": "datadoghq.eu",
   "failOnCriticalErrors": true,
+  "failOnMissingTests": true,
   "failOnTimeout": false,
   "files": ["my-new-file"],
   "global": {

--- a/src/commands/synthetics/__tests__/fixtures.ts
+++ b/src/commands/synthetics/__tests__/fixtures.ts
@@ -65,6 +65,7 @@ export const ciConfig: CommandConfig = {
   configPath: 'datadog-ci.json',
   datadogSite: 'datadoghq.com',
   failOnCriticalErrors: false,
+  failOnMissingTests: false,
   failOnTimeout: true,
   files: ['{,!(node_modules)/**/}*.synthetics.json'],
   global: {},

--- a/src/commands/synthetics/__tests__/run-test.test.ts
+++ b/src/commands/synthetics/__tests__/run-test.test.ts
@@ -60,6 +60,7 @@ describe('run-test', () => {
           expect.objectContaining({id: 'public-id-2', config: userConfigOverride}),
         ]),
         expect.anything(),
+        false,
         false
       )
     })
@@ -108,6 +109,7 @@ describe('run-test', () => {
             expect.objectContaining({id: 'public-id-2', config: expectedOverriddenConfig}),
           ]),
           expect.anything(),
+          false,
           false
         )
       }
@@ -140,6 +142,7 @@ describe('run-test', () => {
           expect.objectContaining({id: 'public-id-2', config: configOverride}),
         ]),
         expect.anything(),
+        false,
         false
       )
     })
@@ -174,6 +177,7 @@ describe('run-test', () => {
           expect.objectContaining({id: 'public-id-2', config: configOverride}),
         ]),
         expect.anything(),
+        false,
         false
       )
       expect(apiHelper.getTunnelPresignedURL).not.toHaveBeenCalled()

--- a/src/commands/synthetics/errors.ts
+++ b/src/commands/synthetics/errors.ts
@@ -1,5 +1,5 @@
 /* tslint:disable:max-classes-per-file */
-const nonCriticalErrorCodes = ['NO_TESTS_TO_RUN'] as const
+const nonCriticalErrorCodes = ['NO_TESTS_TO_RUN', 'MISSING_TESTS'] as const
 export type NonCriticalCiErrorCode = typeof nonCriticalErrorCodes[number]
 
 const criticalErrorCodes = [

--- a/src/commands/synthetics/interfaces.ts
+++ b/src/commands/synthetics/interfaces.ts
@@ -376,7 +376,6 @@ export interface SyntheticsCIConfig {
   appKey: string
   configPath: string
   datadogSite: string
-  failOnCriticalErrors: boolean
   files: string[]
   global: UserConfigOverride
   locations: string[]
@@ -390,6 +389,8 @@ export interface SyntheticsCIConfig {
 }
 
 export interface CommandConfig extends SyntheticsCIConfig {
+  failOnCriticalErrors: boolean
+  failOnMissingTests: boolean
   failOnTimeout: boolean
 }
 

--- a/src/commands/synthetics/run-test.ts
+++ b/src/commands/synthetics/run-test.ts
@@ -68,7 +68,13 @@ export const executeTests = async (
 
   try {
     const triggerFromSearch = !!config.testSearchQuery
-    testsToTriggerResult = await getTestsToTrigger(api, testsToTrigger, reporter, triggerFromSearch)
+    testsToTriggerResult = await getTestsToTrigger(
+      api,
+      testsToTrigger,
+      reporter,
+      triggerFromSearch,
+      config.failOnMissingTests
+    )
   } catch (error) {
     if (error instanceof CiError) {
       throw error

--- a/src/commands/synthetics/utils.ts
+++ b/src/commands/synthetics/utils.ts
@@ -601,7 +601,8 @@ export const getTestsToTrigger = async (
   api: APIHelper,
   triggerConfigs: TriggerConfig[],
   reporter: MainReporter,
-  triggerFromSearch?: boolean
+  triggerFromSearch?: boolean,
+  failOnMissingTests?: boolean
 ) => {
   const errorMessages: string[] = []
   // When too many tests are triggered, if fetched from a search query: simply trim them and show a warning,
@@ -655,6 +656,11 @@ export const getTestsToTrigger = async (
 
   // Display errors at the end of all tests for better visibility.
   reporter.initErrors(errorMessages)
+
+  if (failOnMissingTests && initialSummary.testsNotFound.size > 0) {
+    const testsNotFoundListStr = [...initialSummary.testsNotFound].join(', ')
+    throw new CiError('MISSING_TESTS', testsNotFoundListStr)
+  }
 
   if (!overriddenTestsToTrigger.length) {
     throw new CiError('NO_TESTS_TO_RUN')


### PR DESCRIPTION
### What and why?

Currently, there is no option to make a CI fail if a given test (through `--public-id` or a config file) is missing.

### How?

We introduce a new `--failOnMissingTests` flag to support this.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] \[_Synthetics_\] New releases of `datadog-ci` MUST be followed by a release of Synthetics CI integrations
