### PR TITLE
[synthetics] Handle empty subdomain on all DCs

### DIFF
--- a/src/commands/synthetics/__tests__/utils.test.ts
+++ b/src/commands/synthetics/__tests__/utils.test.ts
@@ -1052,7 +1052,23 @@ describe('utils', () => {
   })
 
   test('getAppBaseURL', () => {
-    expect(utils.getAppBaseURL({datadogSite: 'datadoghq.eu', subdomain: 'custom'})).toBe('https://custom.datadoghq.eu/')
+    // Usual datadog site.
+    expect(utils.getAppBaseURL({datadogSite: 'datadoghq.com', subdomain: ''})).toBe('https://app.datadoghq.com/')
+    expect(utils.getAppBaseURL({datadogSite: 'datadoghq.com', subdomain: 'app'})).toBe('https://app.datadoghq.com/')
+    expect(utils.getAppBaseURL({datadogSite: 'datadoghq.com', subdomain: 'myorg'})).toBe('https://myorg.datadoghq.com/')
+
+    // Different top-level domain.
+    expect(utils.getAppBaseURL({datadogSite: 'datadoghq.eu', subdomain: ''})).toBe('https://app.datadoghq.eu/')
+    expect(utils.getAppBaseURL({datadogSite: 'datadoghq.eu', subdomain: 'app'})).toBe('https://app.datadoghq.eu/')
+    expect(utils.getAppBaseURL({datadogSite: 'datadoghq.eu', subdomain: 'myorg'})).toBe('https://myorg.datadoghq.eu/')
+
+    // US3/US5-type datadog site: the datadog site's subdomain is replaced by `subdomain` when `subdomain` is custom.
+    // The correct Main DC (US3 in this case) is resolved automatically.
+    expect(utils.getAppBaseURL({datadogSite: 'us3.datadoghq.com', subdomain: ''})).toBe('https://us3.datadoghq.com/')
+    expect(utils.getAppBaseURL({datadogSite: 'us3.datadoghq.com', subdomain: 'app'})).toBe('https://us3.datadoghq.com/')
+    expect(utils.getAppBaseURL({datadogSite: 'us3.datadoghq.com', subdomain: 'myorg'})).toBe(
+      'https://myorg.datadoghq.com/'
+    )
   })
 
   describe('sortResultsByOutcome', () => {

--- a/src/commands/synthetics/utils.ts
+++ b/src/commands/synthetics/utils.ts
@@ -749,25 +749,24 @@ export const parseVariablesFromCli = (
 }
 
 export const getAppBaseURL = ({datadogSite, subdomain}: Pick<CommandConfig, 'datadogSite' | 'subdomain'>) => {
-  // This function is exported in the API, so we must ensure
-  // the `subdomain` always defaults to `app`, even if called by an end user.
-  subdomain = subdomain || DEFAULT_COMMAND_CONFIG.subdomain
+  const validSubdomain = subdomain || DEFAULT_COMMAND_CONFIG.subdomain
+  const datadogSiteParts = datadogSite.split('.')
 
-  const datadogSiteThirdLevel = /^(us3|us5)\./
+  if (datadogSiteParts.length !== 2 && datadogSiteParts.length !== 3) {
+    throw Error(
+      'The `datadogSite` you provided is incorrect. It must look like `datadoghq.com` or `us3.datadoghq.com`.'
+    )
+  }
 
-  if (datadogSite.match(datadogSiteThirdLevel)) {
-    if (subdomain === DEFAULT_COMMAND_CONFIG.subdomain) {
-      // Ignore the `app` subdomain: use `(us3|us5).datadoghq.com` directly.
+  if (datadogSiteParts.length === 3) {
+    if (validSubdomain === DEFAULT_COMMAND_CONFIG.subdomain) {
       return `https://${datadogSite}/`
     }
 
-    // Replace `(us3|us5)` by the custom subdomain.
-    const rootDatadogSite = datadogSite.replace(datadogSiteThirdLevel, '')
-
-    return `https://${subdomain}.${rootDatadogSite}/`
+    return `https://${validSubdomain}.${datadogSiteParts[1]}.${datadogSiteParts[2]}/`
   }
 
-  return `https://${subdomain}.${datadogSite}/`
+  return `https://${validSubdomain}.${datadogSite}/`
 }
 
 export const getBatchUrl = (baseUrl: string, batchId: string) =>

--- a/src/commands/synthetics/utils.ts
+++ b/src/commands/synthetics/utils.ts
@@ -752,12 +752,6 @@ export const getAppBaseURL = ({datadogSite, subdomain}: Pick<CommandConfig, 'dat
   const validSubdomain = subdomain || DEFAULT_COMMAND_CONFIG.subdomain
   const datadogSiteParts = datadogSite.split('.')
 
-  if (datadogSiteParts.length !== 2 && datadogSiteParts.length !== 3) {
-    throw Error(
-      'The `datadogSite` you provided is incorrect. It must look like `datadoghq.com` or `us3.datadoghq.com`.'
-    )
-  }
-
   if (datadogSiteParts.length === 3) {
     if (validSubdomain === DEFAULT_COMMAND_CONFIG.subdomain) {
       return `https://${datadogSite}/`


### PR DESCRIPTION
### What and why?

For `(us3|us5).datadoghq.com` main DCs, the computed "Result URL" and "Results URL" start with `https://app.us3.datadoghq.com/`, although it should start with `https://us3.datadoghq.com/`.

### How?

Fix the logic of `getAppBaseURL()`.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] \[_Synthetics_\] New releases of `datadog-ci` MUST be followed by a release of Synthetics CI integrations
