### PR TITLE
Fix missing whitespace in `details` of some commands

### DIFF
--- a/src/commands/dsyms/upload.ts
+++ b/src/commands/dsyms/upload.ts
@@ -38,9 +38,9 @@ export class UploadCommand extends Command {
   public static usage = Command.Usage({
     description: 'Upload dSYM files to Datadog.',
     details: `
-            This command will upload all dSYM files to Datadog in order to symbolicate crash reports received by Datadog.
-            See README for details.
-        `,
+      This command will upload all dSYM files to Datadog in order to symbolicate crash reports received by Datadog.\n
+      See README for details.
+    `,
     examples: [
       ['Upload all dSYM files in Derived Data path', 'datadog-ci dsyms upload ~/Library/Developer/Xcode/DerivedData'],
       [

--- a/src/commands/git-metadata/upload.ts
+++ b/src/commands/git-metadata/upload.ts
@@ -25,9 +25,9 @@ export class UploadCommand extends Command {
   public static usage = Command.Usage({
     description: 'Report the current commit details to Datadog.',
     details: `
-            This command will upload the commit details to Datadog in order to create links to your repositories inside DataDog's UI.
-            See README for details.
-        `,
+      This command will upload the commit details to Datadog in order to create links to your repositories inside Datadog's UI.\n
+      See README for details.
+    `,
     examples: [['Upload the current commit details', 'datadog-ci report-commits upload']],
   })
 

--- a/src/commands/junit/upload.ts
+++ b/src/commands/junit/upload.ts
@@ -47,9 +47,9 @@ export class UploadJUnitXMLCommand extends Command {
   public static usage = Command.Usage({
     description: 'Upload jUnit XML test reports files to Datadog.',
     details: `
-            This command will upload to jUnit XML test reports files to Datadog.
-            See README for details.
-        `,
+      This command will upload to jUnit XML test reports files to Datadog.\n
+      See README for details.
+    `,
     examples: [
       ['Upload all jUnit XML test report files in current directory', 'datadog-ci junit upload --service my-service .'],
       [

--- a/src/commands/react-native/codepush.ts
+++ b/src/commands/react-native/codepush.ts
@@ -9,8 +9,8 @@ export class CodepushCommand extends Command {
   public static usage = Command.Usage({
     description: 'Upload your React Native Codepush bundle and sourcemaps to Datadog.',
     details: `
-    This command will upload React Native Codepush sourcemaps and their corresponding javascript bundle to Datadog in order to un-minify front-end stack traces received by Datadog.
-    See README for details.
+      This command will upload React Native Codepush sourcemaps and their corresponding javascript bundle to Datadog in order to un-minify front-end stack traces received by Datadog.\n
+      See README for details.
     `,
     examples: [
       [

--- a/src/commands/react-native/upload.ts
+++ b/src/commands/react-native/upload.ts
@@ -28,9 +28,9 @@ export class UploadCommand extends Command {
   public static usage = Command.Usage({
     description: 'Upload React Native sourcemaps to Datadog.',
     details: `
-            This command will upload React Native sourcemaps and their corresponding javascript bundle to Datadog in order to un-minify front-end stack traces received by Datadog.
-            See README for details.
-        `,
+      This command will upload React Native sourcemaps and their corresponding javascript bundle to Datadog in order to un-minify front-end stack traces received by Datadog.\n
+      See README for details.
+    `,
     examples: [
       [
         'Upload ios sourcemaps',

--- a/src/commands/react-native/xcode.ts
+++ b/src/commands/react-native/xcode.ts
@@ -25,9 +25,9 @@ export class XCodeCommand extends Command {
   public static usage = Command.Usage({
     description: 'Bundle React Native code and images in XCode and send sourcemaps to Datadog.',
     details: `
-            This command will bundle the react native code and images and then upload React Native sourcemaps and their corresponding javascript bundle to Datadog in order to un-minify front-end stack traces received by Datadog.
-            See README for details.
-        `,
+      This command will bundle the react native code and images and then upload React Native sourcemaps and their corresponding javascript bundle to Datadog in order to un-minify front-end stack traces received by Datadog.\n
+      See README for details.
+    `,
     examples: [
       [
         'Usage as XCode build phase for RN < 0.69',

--- a/src/commands/sourcemaps/upload.ts
+++ b/src/commands/sourcemaps/upload.ts
@@ -35,9 +35,9 @@ export class UploadCommand extends Command {
   public static usage = Command.Usage({
     description: 'Upload javascript sourcemaps to Datadog.',
     details: `
-            This command will upload all javascript sourcemaps and their corresponding javascript file to Datadog in order to un-minify front-end stack traces received by Datadog.
-            See README for details.
-        `,
+      This command will upload all javascript sourcemaps and their corresponding javascript file to Datadog in order to un-minify front-end stack traces received by Datadog.\n
+      See README for details.
+    `,
     examples: [
       [
         'Upload all sourcemaps in current directory',

--- a/src/commands/trace/trace.ts
+++ b/src/commands/trace/trace.ts
@@ -15,9 +15,9 @@ export class TraceCommand extends Command {
   public static usage = Command.Usage({
     description: 'Trace a command with a custom span and report it to Datadog.',
     details: `
-            This command wraps another command, which it will launch, and report a custom span to Datadog.
-            See README for details.
-        `,
+      This command wraps another command, which it will launch, and report a custom span to Datadog.\n
+      See README for details.
+    `,
     examples: [
       [
         'Trace a command with name "Say Hello" and report to Datadog',


### PR DESCRIPTION
### What and why?

For some reason, `clipanion` ignores single newlines when printing the `--help` of a command.

So what was printed for a lot of commands was something like this:

> **Details:**
> 
> This command wraps another command, which it will launch, and report a custom 
> span to Datadog.See README for details.

### How?

This PR just adds a double newline instead of a single newline. Here is the result:

> **Details:**
> 
> This command wraps another command, which it will launch, and report a custom 
> span to Datadog.
> 
> See README for details.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] \[_Synthetics_\] New releases of `datadog-ci` MUST be followed by a release of Synthetics CI integrations
