### PR TITLE
Fix typos in user facing files

### DIFF
--- a/src/commands/dsyms/README.md
+++ b/src/commands/dsyms/README.md
@@ -15,7 +15,7 @@ You need to have `DATADOG_API_KEY` in your environment.
 export DATADOG_API_KEY="<API KEY>"
 ```
 
-It is possible to configure the tool to use Datadog EU by defining the `DATADOG_SITE` environment variable to `datadoghq.eu`. By defaut the requests are sent to Datadog US.
+It is possible to configure the tool to use Datadog EU by defining the `DATADOG_SITE` environment variable to `datadoghq.eu`. By default the requests are sent to Datadog US.
 
 It is also possible to override the full URL for the intake endpoint by defining the `DATADOG_DSYM_INTAKE_URL` environment variable.
 

--- a/src/commands/flutter-symbols/README.md
+++ b/src/commands/flutter-symbols/README.md
@@ -33,15 +33,15 @@ This command uploads your Dart symbol files, iOS dSYMs, and Android Proguard map
 After running `flutter build --split-debug-info=./debug-info --obfuscate`, you can upload all files to Datadog by running this command: 
 
 ```bash
-datadog-ci flutter-symbols upload --dart-symbols-location ./debug-info --service-name com.companyname.application --ios-dyms --android-mapping
+datadog-ci flutter-symbols upload --dart-symbols-location ./debug-info --service-name com.companyname.application --ios-dsyms --android-mapping
 ```
 
 | Parameter | Condition | Description |
 |-----------|-----------|-------------|
 | `--service-name` | Required | Set as the service name you are uploading files for. Datadog uses this service name to find corresponding files based on the `service` options set when you configured the Datadog Flutter SDK for RUM.<br>By default, the Datadog Flutter SDK for RUM uses your application's bundle identifier as the service. |
 | `--flavor` | Optional | The build flavor that was built. Defaults to `release`. |
-| `--dart-symbols-location`  | Optional  | The locaiton of your Dart symbol files. This should be the same path specified to `--split-debug-info`. |
-| `--ios-dysms` | Optional | Upload iOS dSYM files to Datadog. |
+| `--dart-symbols-location`  | Optional  | The location of your Dart symbol files. This should be the same path specified to `--split-debug-info`. |
+| `--ios-dsyms` | Optional | Upload iOS dSYM files to Datadog. |
 | `--ios-dsyms-location` | Optional | Specify the location of iOS dSYM files. By default, these are located at `./build/ios/archive/Runner.xcarchive/dSYMs`. Adding this parameter automatically sets `--ios-dsyms`. |
 | `--android-mapping` | Optional | Upload Android Proguard mapping file. This is usually only necessary if you specify `--obfuscate` as a parameter to `flutter build`. |
 | `--android-mapping-location` | Optional | Specify the location of your Android Proguard mapping file. By default, this is located at `./build/app/outputs/mapping/[flavor]/mapping.txt`. Adding this parameter automatically sets `--android-mapping`. |

--- a/src/commands/git-metadata/README.md
+++ b/src/commands/git-metadata/README.md
@@ -13,7 +13,7 @@ You need to have `DATADOG_API_KEY` in your environment.
 export DATADOG_API_KEY="<API KEY>"
 ```
 
-It is possible to configure the tool to use Datadog EU by defining the `DATADOG_SITE` environment variable to `datadoghq.eu`. By defaut the requests are sent to Datadog US.
+It is possible to configure the tool to use Datadog EU by defining the `DATADOG_SITE` environment variable to `datadoghq.eu`. By default the requests are sent to Datadog US.
 
 It is also possible to override the full URL for the intake endpoint by defining the `DATADOG_SOURCEMAP_INTAKE_URL` environment variable.
 
@@ -33,7 +33,7 @@ datadog-ci git-metadata upload
 
 #### Limitations
 
-The repository URL is infered from the remote named `origin` (or the first remote if none are named `origin`). The value can be overriden by using the `--repository-url` flag.
+The repository URL is inferred from the remote named `origin` (or the first remote if none are named `origin`). The value can be overridden by using the `--repository-url` flag.
 For example: The remote `git@github.com:DataDog/example.git` will create links that point to `https://github.com/DataDog/example`.
 
 The only repository URLs supported are the ones whose host contains: `github`, `gitlab` or `bitbucket`. This allows DataDog to create proper URLs such as:

--- a/src/commands/lambda/README.md
+++ b/src/commands/lambda/README.md
@@ -93,7 +93,7 @@ You can pass the following arguments to `instrument` to specify its behavior. Th
 | `--tracing` |  | Whether to enable dd-trace tracing on your Lambda. | `true` |
 | `--merge-xray-traces` | | Whether to join dd-trace traces to AWS X-Ray traces. Useful for tracing API Gateway spans. | `false` |
 | `--flush-metrics-to-logs` | | Whether to send metrics via the Datadog Forwarder [asynchronously][11]. If you disable this parameter, it's required to export `DATADOG_API_KEY` (or if encrypted, `DATADOG_KMS_API_KEY` or `DATADOG_API_KEY_SECRET_ARN`). | `true` |
-| `--capture-lambda-payload` | | Whether to capture and store the payload and reponse of a lambda invocation. | `false` |
+| `--capture-lambda-payload` | | Whether to capture and store the payload and response of a lambda invocation. | `false` |
 | `--forwarder` | | The ARN of the [datadog forwarder][10] to attach this function's LogGroup to. | |
 | `--dry` | `-d` | Preview changes running command would apply. | `false` |
 | `--log-level` | | Set to `debug` to see additional output from the Datadog Lambda Library and/or Lambda Extension for troubleshooting purposes. | |

--- a/src/commands/react-native/README.md
+++ b/src/commands/react-native/README.md
@@ -76,7 +76,7 @@ For example, for a sourcemap referencing `["/Users/myname/path/to/ReactNativeApp
 
 #### Override repository URL
 
-The repository URL is inferred from the remote named `origin` (if present). Otherwise, it is inferred from the first remote. The value can be overriden with `--repository-url`.
+The repository URL is inferred from the remote named `origin` (if present). Otherwise, it is inferred from the first remote. The value can be overridden with `--repository-url`.
 
 For example, with a remote like `git@github.com:Datadog/example.git`, links pointing to `https://github.com/Datadog/example` are generated.
 

--- a/src/commands/sourcemaps/README.md
+++ b/src/commands/sourcemaps/README.md
@@ -11,7 +11,7 @@ You need to have `DATADOG_API_KEY` in your environment.
 export DATADOG_API_KEY="<API KEY>"
 ```
 
-It is possible to configure the tool to use Datadog EU by defining the `DATADOG_SITE` environment variable to `datadoghq.eu`. By defaut the requests are sent to Datadog US.
+It is possible to configure the tool to use Datadog EU by defining the `DATADOG_SITE` environment variable to `datadoghq.eu`. By default the requests are sent to Datadog US.
 
 It is also possible to override the full URL for the intake endpoint by defining the `DATADOG_SOURCEMAP_INTAKE_URL` environment variable.
 
@@ -64,10 +64,10 @@ The repository URL is inferred
 - from the remote named `origin` if present
 - from the first remote otherwise
 
-The value can be overriden with `--repository-url`.
+The value can be overridden with `--repository-url`.
 
 Example: With a remote `git@github.com:Datadog/example.git`, links pointing to `https://github.com/Datadog/example` are generated.
-This behavior can be overriden with links to `https://gitlab.com/Datadog/example` with the flag `--repository-url=https://gitlab.com/Datadog/example`.
+This behavior can be overridden with links to `https://gitlab.com/Datadog/example` with the flag `--repository-url=https://gitlab.com/Datadog/example`.
 
 #### Setting the project path
 

--- a/src/commands/sourcemaps/upload.ts
+++ b/src/commands/sourcemaps/upload.ts
@@ -45,7 +45,7 @@ export class UploadCommand extends Command {
       ],
       [
         'Upload all sourcemaps in /home/users/ci with 50 concurrent uploads',
-        'datadog-ci sourcemaps upload /home/users/ci --service my-service --minified-path-prefix https://static.datadog.com --release-version 1.234 --concurency 50',
+        'datadog-ci sourcemaps upload /home/users/ci --service my-service --minified-path-prefix https://static.datadog.com --release-version 1.234 --max-concurrency 50',
       ],
     ],
   })


### PR DESCRIPTION
### What and why?

I noticed some typos in READMEs and in one example for `datadog-ci sourcemaps upload`.