### PR TITLE
[Synthetics] Fix reported test URL when using config overrides

### DIFF
--- a/src/commands/synthetics/utils.ts
+++ b/src/commands/synthetics/utils.ts
@@ -384,7 +384,7 @@ const getResultFromBatch = (
     passed: hasResultPassed(pollResult.result, hasTimeout, failOnCriticalErrors, failOnTimeout),
     result: pollResult.result,
     resultId: resultInBatch.result_id,
-    test: deepExtend(test, pollResult.check),
+    test: deepExtend({}, test, pollResult.check),
     timedOut: hasTimeout,
     timestamp: pollResult.timestamp,
   }


### PR DESCRIPTION
### What and why?

Using config overrides with different start URLs for the same test, we noticed that the URL reported in the results in the output was displaying the same URL for all the results. It should actually show a different URL as we overrode it for each test, in the config overrides.

### How?

The `test` retrieved with `getTestByPublicId` is a shared instance for all the results because the public ID is the same. Therefore, doing `deepExtend(test, pollResult.check)` a few lines below was actually overriding the same `test` object for all the results. Thus, all the results ended up with the test overrides of the last iteration.

https://github.com/DataDog/datadog-ci/blob/4965ff27a6b1642bd3dc11d012376f4e38dff37f/src/commands/synthetics/utils.ts#L379-L391

The solution was to clone the whole `test` object for each result, then apply the overrides, using `deepExtend({}, test, pollResult.check)`.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] \[_Synthetics_\] New releases of `datadog-ci` MUST be followed by a release of Synthetics CI integrations
