### PR TITLE
[CI Visibility] Improve handling of CI env for tag and metric cmd

### DIFF
--- a/src/commands/metric/__tests__/metric.test.ts
+++ b/src/commands/metric/__tests__/metric.test.ts
@@ -91,7 +91,13 @@ describe('execute', () => {
   })
 
   test('should fail if provider is GitHub and level is job', async () => {
-    const {context, code} = await runCLI('job', ['key:1'], {GITHUB_ACTIONS: 'true', GITHUB_RUN_ID: '40'})
+    const {context, code} = await runCLI('job', ['key:1'], {
+      GITHUB_ACTIONS: 'true',
+      GITHUB_REPOSITORY: 'example/example',
+      GITHUB_RUN_ATTEMPT: '10',
+      GITHUB_RUN_ID: '40',
+      GITHUB_SERVER_URL: 'github.com',
+    })
     expect(code).toBe(1)
     expect(context.stderr.toString()).toContain('Cannot use level "job" for GitHub Actions.')
   })

--- a/src/commands/tag/__tests__/tag.test.ts
+++ b/src/commands/tag/__tests__/tag.test.ts
@@ -70,7 +70,13 @@ describe('execute', () => {
   })
 
   test('should fail if provider is GitHub and level is job', async () => {
-    const {context, code} = await runCLI('job', ['key:value'], {GITHUB_ACTIONS: 'true', GITHUB_RUN_ID: '40'})
+    const {context, code} = await runCLI('job', ['key:value'], {
+      GITHUB_ACTIONS: 'true',
+      GITHUB_REPOSITORY: 'example/example',
+      GITHUB_RUN_ATTEMPT: '10',
+      GITHUB_RUN_ID: '40',
+      GITHUB_SERVER_URL: 'github.com',
+    })
     expect(code).toBe(1)
     expect(context.stderr.toString()).toContain('Cannot use level "job" for GitHub Actions.')
   })

--- a/src/helpers/ci.ts
+++ b/src/helpers/ci.ts
@@ -592,28 +592,28 @@ const parsePipelineNumber = (pipelineNumberStr: string | undefined): number | un
 export const getCIEnv = (): {ciEnv: Record<string, string>; provider: string} => {
   if (process.env.CIRCLECI) {
     return {
-      ciEnv: filterEnv(['CIRCLE_WORKFLOW_ID', 'CIRCLE_BUILD_NUM'], true),
+      ciEnv: filterEnv(['CIRCLE_WORKFLOW_ID', 'CIRCLE_BUILD_NUM']),
       provider: 'circleci',
     }
   }
 
   if (process.env.GITLAB_CI) {
     return {
-      ciEnv: filterEnv(['CI_PROJECT_URL', 'CI_PIPELINE_ID', 'CI_JOB_ID'], true),
+      ciEnv: filterEnv(['CI_PROJECT_URL', 'CI_PIPELINE_ID', 'CI_JOB_ID']),
       provider: 'gitlab',
     }
   }
 
   if (process.env.GITHUB_ACTIONS || process.env.GITHUB_ACTION) {
     return {
-      ciEnv: filterEnv(['GITHUB_SERVER_URL', 'GITHUB_REPOSITORY', 'GITHUB_RUN_ID', 'GITHUB_RUN_ATTEMPT'], true),
+      ciEnv: filterEnv(['GITHUB_SERVER_URL', 'GITHUB_REPOSITORY', 'GITHUB_RUN_ID', 'GITHUB_RUN_ATTEMPT']),
       provider: 'github',
     }
   }
 
   if (process.env.BUILDKITE) {
     return {
-      ciEnv: filterEnv(['BUILDKITE_BUILD_ID', 'BUILDKITE_JOB_ID'], true),
+      ciEnv: filterEnv(['BUILDKITE_BUILD_ID', 'BUILDKITE_JOB_ID']),
       provider: 'buildkite',
     }
   }
@@ -621,7 +621,7 @@ export const getCIEnv = (): {ciEnv: Record<string, string>; provider: string} =>
   throw new Error('Only providers [GitHub, GitLab, CircleCI, Buildkite] are supported')
 }
 
-const filterEnv = (values: string[], allValues: boolean): Record<string, string> => {
+const filterEnv = (values: string[]): Record<string, string> => {
   const ciEnvs: Record<string, string> = {}
   const missing: string[] = []
 
@@ -634,7 +634,7 @@ const filterEnv = (values: string[], allValues: boolean): Record<string, string>
     }
   })
 
-  if (allValues && missing.length > 0) {
+  if (missing.length > 0) {
     // Get the missing values for better error
     throw new Error(`Missing environment variables [${missing.toString()}]`)
   }

--- a/src/helpers/ci.ts
+++ b/src/helpers/ci.ts
@@ -592,28 +592,28 @@ const parsePipelineNumber = (pipelineNumberStr: string | undefined): number | un
 export const getCIEnv = (): {ciEnv: Record<string, string>; provider: string} => {
   if (process.env.CIRCLECI) {
     return {
-      ciEnv: getEnvVars('CIRCLE_'),
+      ciEnv: filterEnv(['CIRCLE_WORKFLOW_ID', 'CIRCLE_BUILD_NUM'], true),
       provider: 'circleci',
     }
   }
 
   if (process.env.GITLAB_CI) {
     return {
-      ciEnv: getEnvVars('CI_'),
+      ciEnv: filterEnv(['CI_PROJECT_URL', 'CI_PIPELINE_ID', 'CI_JOB_ID'], true),
       provider: 'gitlab',
     }
   }
 
   if (process.env.GITHUB_ACTIONS || process.env.GITHUB_ACTION) {
     return {
-      ciEnv: getEnvVars('GITHUB_'),
+      ciEnv: filterEnv(['GITHUB_SERVER_URL', 'GITHUB_REPOSITORY', 'GITHUB_RUN_ID', 'GITHUB_RUN_ATTEMPT'], true),
       provider: 'github',
     }
   }
 
   if (process.env.BUILDKITE) {
     return {
-      ciEnv: getEnvVars('BUILDKITE_'),
+      ciEnv: filterEnv(['BUILDKITE_BUILD_ID', 'BUILDKITE_JOB_ID'], true),
       provider: 'buildkite',
     }
   }
@@ -621,7 +621,23 @@ export const getCIEnv = (): {ciEnv: Record<string, string>; provider: string} =>
   throw new Error('Only providers [GitHub, GitLab, CircleCI, Buildkite] are supported')
 }
 
-const getEnvVars = (prefix: string): Record<string, string> =>
-  Object.entries(process.env)
-    .filter(([key, value]) => key.startsWith(prefix) && !/(PASS)|(TOKEN)|(SECRET)|(KEY)/i.test(key))
-    .reduce((accum, [key, value]) => ({...accum, [key]: value}), {})
+const filterEnv = (values: string[], allValues: boolean): Record<string, string> => {
+  const ciEnvs: Record<string, string> = {}
+  const missing: string[] = []
+
+  values.forEach((envKey) => {
+    const envValue = process.env[envKey]
+    if (envValue) {
+      ciEnvs[envKey] = envValue
+    } else {
+      missing.push(envKey)
+    }
+  })
+
+  if (allValues && missing.length > 0) {
+    // Get the missing values for better error
+    throw new Error(`Missing environment variables [${missing.toString()}]`)
+  }
+
+  return ciEnvs
+}


### PR DESCRIPTION
### What and why?
This PR changes how we get the CI env for the tag and metrics command so that we only retrieve what is strictly needed as well as return an error if some of the env needed is missing.

### How?

Hardcode the required env

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] \[_Synthetics_\] New releases of `datadog-ci` MUST be followed by a release of Synthetics CI integrations
