### PR TITLE
[synthetics] Validate `datadogSite` on config resolved

### DIFF
--- a/src/commands/synthetics/__tests__/utils.test.ts
+++ b/src/commands/synthetics/__tests__/utils.test.ts
@@ -1077,6 +1077,16 @@ describe('utils', () => {
     expect(utils.parseVariablesFromCli(undefined, mockLogFunction)).toBeUndefined()
   })
 
+  test('validateDatadogSite', () => {
+    expect(() => utils.validateDatadogSite('')).toThrow()
+    expect(() => utils.validateDatadogSite('random')).toThrow()
+    expect(() => utils.validateDatadogSite('myorg.app.datadoghq.com')).toThrow()
+    expect(() => utils.validateDatadogSite('myorg.us3.datadoghq.com')).toThrow()
+
+    expect(() => utils.validateDatadogSite('datadoghq.com')).not.toThrow()
+    expect(() => utils.validateDatadogSite('us3.datadoghq.com')).not.toThrow()
+  })
+
   test('getAppBaseURL', () => {
     // Usual datadog site.
     expect(utils.getAppBaseURL({datadogSite: 'datadoghq.com', subdomain: ''})).toBe('https://app.datadoghq.com/')

--- a/src/commands/synthetics/errors.ts
+++ b/src/commands/synthetics/errors.ts
@@ -4,6 +4,7 @@ export type NonCriticalCiErrorCode = typeof nonCriticalErrorCodes[number]
 
 const criticalErrorCodes = [
   'AUTHORIZATION_ERROR',
+  'INVALID_CONFIG',
   'MISSING_API_KEY',
   'MISSING_APP_KEY',
   'POLL_RESULTS_FAILED',

--- a/src/commands/synthetics/utils.ts
+++ b/src/commands/synthetics/utils.ts
@@ -754,6 +754,18 @@ export const parseVariablesFromCli = (
   return Object.keys(variables).length > 0 ? variables : undefined
 }
 
+export const validateDatadogSite = (datadogSite: string) => {
+  const datadogSiteParts = datadogSite.split('.')
+
+  if (datadogSiteParts.length !== 2 && datadogSiteParts.length !== 3) {
+    throw new CriticalError(
+      'INVALID_CONFIG',
+      'The `datadogSite` config property must match one of the sites supported by Datadog.\n' +
+        'For more information, see "Site parameter" in our documentation: https://docs.datadoghq.com/getting_started/site/#access-the-datadog-site'
+    )
+  }
+}
+
 export const getAppBaseURL = ({datadogSite, subdomain}: Pick<CommandConfig, 'datadogSite' | 'subdomain'>) =>
   `https://${subdomain}.${datadogSite}/`
 


### PR DESCRIPTION
### What and why?

This PR introduces a new `INVALID_CONFIG` critical error. For now, it's only used if the `datadogSite` is invalid to show a nice error message. It could later be used to do additional validation on the config.

This doesn't change the behavior in case of an invalid `datadogSite` since the command would have failed when querying the test configs anyway.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] \[_Synthetics_\] New releases of `datadog-ci` MUST be followed by a release of Synthetics CI integrations
