### PR TITLE
v1.16.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "description": "Run datadog actions from the CI.",
   "repository": "https://github.com/DataDog/datadog-ci",
   "license": "Apache-2.0",


### PR DESCRIPTION
### What and why?

This PR releases version 1.16.0 of datadog-ci.

### Changes

* https://github.com/DataDog/datadog-ci/pull/657
* https://github.com/DataDog/datadog-ci/pull/656
* https://github.com/DataDog/datadog-ci/pull/652
* https://github.com/DataDog/datadog-ci/pull/655
* https://github.com/DataDog/datadog-ci/pull/659
* https://github.com/DataDog/datadog-ci/pull/640
* https://github.com/DataDog/datadog-ci/pull/649
* https://github.com/DataDog/datadog-ci/pull/654