### PR TITLE
Add argument to remove sources content from react native source maps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,6 @@ dist
 
 # VSC files
 .vscode
+
+# Test generated files
+src/commands/react-native/__tests__/fixtures/with-sources-content/main.jsbundle.map.no-sources-content

--- a/src/commands/react-native/README.md
+++ b/src/commands/react-native/README.md
@@ -42,22 +42,23 @@ To upload the source maps for Android, run this command:
 datadog-ci react-native upload --platform android --service com.company.app --bundle ./index.android.bundle --sourcemap ./index.android.bundle.map --release-version 1.23.4 --build-version 1234
 ```
 
-| Parameter           | Condition | Description                                                                                                                                                                                                                                                                                                                                                                 |
-|---------------------|-----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `--platform`        | Required  | Identifies if you are uploading iOS or Android source maps.                                                                                                                                                                                                                                                                                                                 |
-| `--service`         | Required  | Set as the service name you are uploading source maps for. Datadog uses this service name to find corresponding source maps based on the `service` tag set on the RUM React Native SDK.<br>By default, the RUM React Native SDK uses your application's bundle identifier as the service.                                                                                   |
-| `--bundle`          | Required  | Should be set as the path to your generated JS bundle file, `main.jsbundle` for iOS and `index.android.bundle` for Android.                                                                                                                                                                                                                                                 |
-| `--sourcemap`       | Required  | Should be set to the path to your generated source map file, `main.jsbundle.map` for iOS and `index.android.bundle.map` for Android.                                                                                                                                                                                                                                        |
-| `--release-version` | Required  | Used to match the `version` tag set on the RUM React Native SDK. This should be the "Version" or "MARKETING_VERSION" in XCode for iOS and the "versionName" in your `android/app/build.gradle` for Android.                                                                                                                                                                 |
-| `--build-version`   | Required  | Used to avoid overwriting your source maps by accident. Only one upload is needed for a specific `build-version` and `service` combination. Subsequent uploads are ignored until the `build-version` changes. This should match the "Build" or "CURRENT_PROJECT_VERSION" in XCode for iOS and the "versionCode" in your `android/app/build.gradle` for Android.             |
+| Parameter           | Condition | Description                                                                                                                                                                                                                                                                                                                                                     |
+| ------------------- | --------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--platform`        | Required  | Identifies if you are uploading iOS or Android source maps.                                                                                                                                                                                                                                                                                                     |
+| `--service`         | Required  | Set as the service name you are uploading source maps for. Datadog uses this service name to find corresponding source maps based on the `service` tag set on the RUM React Native SDK.<br>By default, the RUM React Native SDK uses your application's bundle identifier as the service.                                                                       |
+| `--bundle`          | Required  | Should be set as the path to your generated JS bundle file, `main.jsbundle` for iOS and `index.android.bundle` for Android.                                                                                                                                                                                                                                     |
+| `--sourcemap`       | Required  | Should be set to the path to your generated source map file, `main.jsbundle.map` for iOS and `index.android.bundle.map` for Android.                                                                                                                                                                                                                            |
+| `--release-version` | Required  | Used to match the `version` tag set on the RUM React Native SDK. This should be the "Version" or "MARKETING_VERSION" in XCode for iOS and the "versionName" in your `android/app/build.gradle` for Android.                                                                                                                                                     |
+| `--build-version`   | Required  | Used to avoid overwriting your source maps by accident. Only one upload is needed for a specific `build-version` and `service` combination. Subsequent uploads are ignored until the `build-version` changes. This should match the "Build" or "CURRENT_PROJECT_VERSION" in XCode for iOS and the "versionCode" in your `android/app/build.gradle` for Android. |
 
 The following optional parameters are available:
 
-| Parameter          | Default | Description                                                                                                                                                                                                                     |
-|--------------------|---------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `--disable-git`    | False   | Prevents the command from invoking git in the current working directory and sending repository-related data to Datadog (such as the hash, remote URL, and paths within the repository of sources referenced in the source map). |
-| `--dry-run`        | False   | It runs the command without the final step of uploading. All other checks are performed.                                                                                                                                        |
-| `--repository-url` | Empty   | Overrides the remote repository with a custom URL. For example, `https://github.com/my-company/my-project`.                                                                                                                     |
+| Parameter                  | Default | Description                                                                                                                                                                                                                       |
+| -------------------------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--disable-git`            | False   | Prevents the command from invoking git in the current working directory and sending repository-related data to Datadog (such as the hash, remote URL, and paths within the repository of sources referenced in the source map).   |
+| `--dry-run`                | False   | It runs the command without the final step of uploading. All other checks are performed.                                                                                                                                          |
+| `--repository-url`         | Empty   | Overrides the remote repository with a custom URL. For example, `https://github.com/my-company/my-project`.                                                                                                                       |
+| `--remove-sources-content` | False   | Remove the `"sourcesContent"` part of the source map files. Doing so greatly reduces the size of your files while still keeping the unminification, but it also removes the code snippet next to the unminified error in Datadog. |
 
 ### Link errors with your source code
 
@@ -90,15 +91,14 @@ If you are not running the `react-native upload` command from your React Native 
 
 #### Supported repositories
 
-The supported repository URLs are ones whose host contains `github`, `gitlab`, or `bitbucket`. 
+The supported repository URLs are ones whose host contains `github`, `gitlab`, or `bitbucket`.
 
 This allows Datadog to create proper URLs such as:
 
-| Provider  | URL |
-| --- | --- |
-| GitHub or GitLab  | https://\<repository-url\>/blob/\<commit-hash\>/\<tracked-file-path\>#L\<line\> |
-| Bitbucket | https://\<repository-url\>/src/\<commit-hash\>/\<tracked-file-path\>#lines-\<line\>  |
-
+| Provider         | URL                                                                                 |
+| ---------------- | ----------------------------------------------------------------------------------- |
+| GitHub or GitLab | https://\<repository-url\>/blob/\<commit-hash\>/\<tracked-file-path\>#L\<line\>     |
+| Bitbucket        | https://\<repository-url\>/src/\<commit-hash\>/\<tracked-file-path\>#lines-\<line\> |
 
 ### `codepush`
 
@@ -112,24 +112,23 @@ datadog-ci react-native codepush --platform ios --service com.company.app --bund
 
 This command calls the `upload` command, setting the release version to `{releaseVersion}-codepush.{codepushLabel}`, such as `1.0.0-codepush.v4` for example.
 
-
-| Parameter           | Condition | Description                                                                                                                                                                                                                                                                                                                                                                 |
-|---------------------|-----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `--platform`        | Required  | Identifies if you are uploading iOS or Android source maps.                                                                                                                                                                                                                                                                                                                 |
-| `--service`         | Required  | Set as the service name you are uploading source maps for. Datadog uses this service name to find corresponding source maps based on the `service` tag set on the RUM React Native SDK.<br>By default, the RUM React Native SDK uses your application's bundle identifier as the service.                                                                                   |
-| `--bundle`          | Required  | Should be set as the path to your generated JS bundle file, `main.jsbundle` for iOS and `index.android.bundle` for Android.                                                                                                                                                                                                                                                 |
-| `--sourcemap`       | Required  | Should be set to the path to your generated source map file, `main.jsbundle.map` for iOS and `index.android.bundle.map` for Android.                                                                                                                                                                                                                                        |
-| `--app`             | Required  | The name of the target app in AppCenter. Must match the format OrganizationName/AppName.                                           |
-| `--deployment`      | Required  | The name of the deployment in AppCenter.             |
+| Parameter      | Condition | Description                                                                                                                                                                                                                                                                               |
+| -------------- | --------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--platform`   | Required  | Identifies if you are uploading iOS or Android source maps.                                                                                                                                                                                                                               |
+| `--service`    | Required  | Set as the service name you are uploading source maps for. Datadog uses this service name to find corresponding source maps based on the `service` tag set on the RUM React Native SDK.<br>By default, the RUM React Native SDK uses your application's bundle identifier as the service. |
+| `--bundle`     | Required  | Should be set as the path to your generated JS bundle file, `main.jsbundle` for iOS and `index.android.bundle` for Android.                                                                                                                                                               |
+| `--sourcemap`  | Required  | Should be set to the path to your generated source map file, `main.jsbundle.map` for iOS and `index.android.bundle.map` for Android.                                                                                                                                                      |
+| `--app`        | Required  | The name of the target app in AppCenter. Must match the format OrganizationName/AppName.                                                                                                                                                                                                  |
+| `--deployment` | Required  | The name of the deployment in AppCenter.                                                                                                                                                                                                                                                  |
 
 The following optional parameters are available:
 
-| Parameter          | Default | Description                                                                                                                                                                                                                     |
-|--------------------|---------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `--disable-git`    | False   | Prevents the command from invoking git in the current working directory and sending repository-related data to Datadog (such as the hash, remote URL, and paths within the repository of sources referenced in the source map). |
-| `--dry-run`        | False   | It runs the command without the final step of uploading. All other checks are performed.                                                                                                                                        |
-| `--repository-url` | Empty   | Overrides the remote repository with a custom URL. For example, `https://github.com/my-company/my-project`.                                                                                                                     |
-| `--build-version`  | 1      | Used to avoid overwriting your source maps by accident. Only one upload is needed for a specific `build-version` and `service` combination. Subsequent uploads are ignored until the `build-version` changes. This should not be necessary for CodePush unless you uploaded the wrong source maps by mistake.   | 
+| Parameter          | Default | Description                                                                                                                                                                                                                                                                                                   |
+| ------------------ | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--disable-git`    | False   | Prevents the command from invoking git in the current working directory and sending repository-related data to Datadog (such as the hash, remote URL, and paths within the repository of sources referenced in the source map).                                                                               |
+| `--dry-run`        | False   | It runs the command without the final step of uploading. All other checks are performed.                                                                                                                                                                                                                      |
+| `--repository-url` | Empty   | Overrides the remote repository with a custom URL. For example, `https://github.com/my-company/my-project`.                                                                                                                                                                                                   |
+| `--build-version`  | 1       | Used to avoid overwriting your source maps by accident. Only one upload is needed for a specific `build-version` and `service` combination. Subsequent uploads are ignored until the `build-version` changes. This should not be necessary for CodePush unless you uploaded the wrong source maps by mistake. |
 
 ### `xcode`
 
@@ -146,7 +145,6 @@ $ which node #/path/to/node
 $ which yarn #/path/to/yarn
 ```
 
-
 #### For React Native >= 0.69:
 
 To ensure environment variables are well propagated in the build phase, you need to create a `custom-react-native-xcode.sh` file in your `ios` folder:
@@ -158,18 +156,18 @@ REACT_NATIVE_XCODE="node_modules/react-native/scripts/react-native-xcode.sh"
 # Replace /opt/homebrew/bin/node (resp. /opt/homebrew/bin/yarn) by the value of $(which node) (resp. $(which yarn))
 DATADOG_XCODE="/opt/homebrew/bin/node /opt/homebrew/bin/yarn datadog-ci react-native xcode"
 
-/bin/sh -c "$DATADOG_XCODE $REACT_NATIVE_XCODE" 
+/bin/sh -c "$DATADOG_XCODE $REACT_NATIVE_XCODE"
 ```
 
-This allows the file's path to be passed as one argument to the `with-environment.sh` script in the "Bundle React Native code and images" build phase: 
+This allows the file's path to be passed as one argument to the `with-environment.sh` script in the "Bundle React Native code and images" build phase:
 
 ```bash
 set -e
 export SOURCEMAP_FILE=./main.jsbundle.map
 WITH_ENVIRONMENT="../node_modules/react-native/scripts/xcode/with-environment.sh"
-REACT_NATIVE_XCODE="./custom-react-native-xcode.sh" 
+REACT_NATIVE_XCODE="./custom-react-native-xcode.sh"
 
-/bin/sh -c "$WITH_ENVIRONMENT $REACT_NATIVE_XCODE" 
+/bin/sh -c "$WITH_ENVIRONMENT $REACT_NATIVE_XCODE"
 ```
 
 #### For React Native < 0.69:
@@ -186,12 +184,12 @@ export NODE_BINARY=node
 
 #### Customize the command
 
-The first positional argument is the React Native bundle script. 
+The first positional argument is the React Native bundle script.
 
 If you use another script that requires arguments, you need to put this script in a file (such as in `scripts/bundle.sh`) and provide this file path in the `datadog-ci react-native xcode` command.
 
 | Parameter                 | Default                                                       | Description                                                                                                                                                               |
-|---------------------------|---------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ------------------------- | ------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `--service`               | Required                                                      | Set as the service name you are uploading source maps for (if it is not your bundle identifier). You can also specify a `SERVICE_NAME_IOS` environment variable.          |
 | `--force`                 | False                                                         | Force the upload of the source maps, even if the build configuration is not "Release".                                                                                    |
 | `--dry-run`               | False                                                         | Run the command without the final step of uploading. The bundle script is executed and all other checks are performed.                                                    |

--- a/src/commands/react-native/README.md
+++ b/src/commands/react-native/README.md
@@ -58,8 +58,8 @@ The following optional parameters are available:
 | `--disable-git`            | False   | Prevents the command from invoking git in the current working directory and sending repository-related data to Datadog (such as the hash, remote URL, and paths within the repository of sources referenced in the source map).   |
 | `--dry-run`                | False   | It runs the command without the final step of uploading. All other checks are performed.                                                                                                                                          |
 | `--repository-url`         | Empty   | Overrides the remote repository with a custom URL. For example, `https://github.com/my-company/my-project`.                                                                                                                       |
-| `--remove-sources-content` | False   | Remove the `"sourcesContent"` part of the source map files. Doing so greatly reduces the size of your files while still keeping the unminification, but it also removes the code snippet next to the unminified error in Datadog. |
-| `--config`                 | Empty   | Path to your `datadog-ci.json` file if not at the root of your project                                                                                                                                                            |
+| `--remove-sources-content` | False   | Removes the `"sourcesContent"` part of the source map files. This reduces the size of your files while still keeping the unminification, but it also removes the code snippet next to the unminified error in Datadog. |
+| `--config`                 | Empty   | The path to your `datadog-ci.json` file, if it is not at the root of your project.                                                                                                                                                            |
 
 ### Link errors with your source code
 
@@ -130,8 +130,8 @@ The following optional parameters are available:
 | `--dry-run`                | False   | It runs the command without the final step of uploading. All other checks are performed.                                                                                                                                                                                                                      |
 | `--repository-url`         | Empty   | Overrides the remote repository with a custom URL. For example, `https://github.com/my-company/my-project`.                                                                                                                                                                                                   |
 | `--build-version`          | 1       | Used to avoid overwriting your source maps by accident. Only one upload is needed for a specific `build-version` and `service` combination. Subsequent uploads are ignored until the `build-version` changes. This should not be necessary for CodePush unless you uploaded the wrong source maps by mistake. |
-| `--remove-sources-content` | False   | Remove the `"sourcesContent"` part of the source map files. Doing so greatly reduces the size of your files while still keeping the unminification, but it also removes the code snippet next to the unminified error in Datadog.                                                                             |
-| `--config`                 | Empty   | Path to your `datadog-ci.json` file if not at the root of your project                                                                                                                                                                                                                                        |
+| `--remove-sources-content` | False   | Removes the `"sourcesContent"` part of the source map files. This reduces the size of your files while still keeping the unminification, but it also removes the code snippet next to the unminified error in Datadog.                                                                             |
+| `--config`                 | Empty   | The path to your `datadog-ci.json` file, if it is not at the root of your project.                                                                                                                                                                                                                                        |
 
 ### `xcode`
 
@@ -202,10 +202,10 @@ The following optional parameters are available:
 
 | Parameter                  | Default | Description                                                                                                                                                                                                                       |
 | -------------------------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `--disable-git`            | False   | Prevents the command from invoking git in the current working directory and sending repository-related data to Datadog (such as the hash, remote URL, and paths within the repository of sources referenced in the source map).   |
+| `--disable-git`            | False   | Prevents the command from invoking git in the current working directory and from sending repository-related data to Datadog (such as the hash, remote URL, and paths within the repository of sources referenced in the source map).   |
 | `--repository-url`         | Empty   | Overrides the remote repository with a custom URL. For example, `https://github.com/my-company/my-project`.                                                                                                                       |
-| `--remove-sources-content` | False   | Remove the `"sourcesContent"` part of the source map files. Doing so greatly reduces the size of your files while still keeping the unminification, but it also removes the code snippet next to the unminified error in Datadog. |
-| `--config`                 | Empty   | Path to your `datadog-ci.json` file if not at the root of your project                                                                                                                                                            |
+| `--remove-sources-content` | False   | Removes the `"sourcesContent"` part of the source map files. This reduces the size of your files while still keeping the unminification, but it also removes the code snippet next to the unminified error in Datadog. |
+| `--config`                 | Empty   | The path to your `datadog-ci.json` file, if it is not at the root of your project.                                                                                                                                                            |
 
 ## End-to-end testing process
 

--- a/src/commands/react-native/README.md
+++ b/src/commands/react-native/README.md
@@ -59,6 +59,7 @@ The following optional parameters are available:
 | `--dry-run`                | False   | It runs the command without the final step of uploading. All other checks are performed.                                                                                                                                          |
 | `--repository-url`         | Empty   | Overrides the remote repository with a custom URL. For example, `https://github.com/my-company/my-project`.                                                                                                                       |
 | `--remove-sources-content` | False   | Remove the `"sourcesContent"` part of the source map files. Doing so greatly reduces the size of your files while still keeping the unminification, but it also removes the code snippet next to the unminified error in Datadog. |
+| `--config`                 | Empty   | Path to your `datadog-ci.json` file if not at the root of your project                                                                                                                                                            |
 
 ### Link errors with your source code
 
@@ -123,12 +124,14 @@ This command calls the `upload` command, setting the release version to `{releas
 
 The following optional parameters are available:
 
-| Parameter          | Default | Description                                                                                                                                                                                                                                                                                                   |
-| ------------------ | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `--disable-git`    | False   | Prevents the command from invoking git in the current working directory and sending repository-related data to Datadog (such as the hash, remote URL, and paths within the repository of sources referenced in the source map).                                                                               |
-| `--dry-run`        | False   | It runs the command without the final step of uploading. All other checks are performed.                                                                                                                                                                                                                      |
-| `--repository-url` | Empty   | Overrides the remote repository with a custom URL. For example, `https://github.com/my-company/my-project`.                                                                                                                                                                                                   |
-| `--build-version`  | 1       | Used to avoid overwriting your source maps by accident. Only one upload is needed for a specific `build-version` and `service` combination. Subsequent uploads are ignored until the `build-version` changes. This should not be necessary for CodePush unless you uploaded the wrong source maps by mistake. |
+| Parameter                  | Default | Description                                                                                                                                                                                                                                                                                                   |
+| -------------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--disable-git`            | False   | Prevents the command from invoking git in the current working directory and sending repository-related data to Datadog (such as the hash, remote URL, and paths within the repository of sources referenced in the source map).                                                                               |
+| `--dry-run`                | False   | It runs the command without the final step of uploading. All other checks are performed.                                                                                                                                                                                                                      |
+| `--repository-url`         | Empty   | Overrides the remote repository with a custom URL. For example, `https://github.com/my-company/my-project`.                                                                                                                                                                                                   |
+| `--build-version`          | 1       | Used to avoid overwriting your source maps by accident. Only one upload is needed for a specific `build-version` and `service` combination. Subsequent uploads are ignored until the `build-version` changes. This should not be necessary for CodePush unless you uploaded the wrong source maps by mistake. |
+| `--remove-sources-content` | False   | Remove the `"sourcesContent"` part of the source map files. Doing so greatly reduces the size of your files while still keeping the unminification, but it also removes the code snippet next to the unminified error in Datadog.                                                                             |
+| `--config`                 | Empty   | Path to your `datadog-ci.json` file if not at the root of your project                                                                                                                                                                                                                                        |
 
 ### `xcode`
 
@@ -194,6 +197,15 @@ If you use another script that requires arguments, you need to put this script i
 | `--force`                 | False                                                         | Force the upload of the source maps, even if the build configuration is not "Release".                                                                                    |
 | `--dry-run`               | False                                                         | Run the command without the final step of uploading. The bundle script is executed and all other checks are performed.                                                    |
 | `--composeSourcemapsPath` | `../node_modules/react-native/scripts/compose-source-maps.js` | If you use Hermes, you need to compose the source maps after the bundle phase. Only use this argument if your node modules are not on the same level as the `ios` folder. |
+
+The following optional parameters are available:
+
+| Parameter                  | Default | Description                                                                                                                                                                                                                       |
+| -------------------------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--disable-git`            | False   | Prevents the command from invoking git in the current working directory and sending repository-related data to Datadog (such as the hash, remote URL, and paths within the repository of sources referenced in the source map).   |
+| `--repository-url`         | Empty   | Overrides the remote repository with a custom URL. For example, `https://github.com/my-company/my-project`.                                                                                                                       |
+| `--remove-sources-content` | False   | Remove the `"sourcesContent"` part of the source map files. Doing so greatly reduces the size of your files while still keeping the unminification, but it also removes the code snippet next to the unminified error in Datadog. |
+| `--config`                 | Empty   | Path to your `datadog-ci.json` file if not at the root of your project                                                                                                                                                            |
 
 ## End-to-end testing process
 

--- a/src/commands/react-native/__tests__/fixtures/with-sources-content/main.jsbundle.map
+++ b/src/commands/react-native/__tests__/fixtures/with-sources-content/main.jsbundle.map
@@ -1,0 +1,4 @@
+{
+    "sources": ["Users/me/datadog-ci/src/commands/sourcemaps/__tests__/git.test.ts"],
+    "sourcesContent": ["/* here is some code that includes closing characters ]}\""]
+}

--- a/src/commands/react-native/__tests__/interfaces.test.ts
+++ b/src/commands/react-native/__tests__/interfaces.test.ts
@@ -1,12 +1,15 @@
+import fs from 'fs'
 import {MultipartPayload} from '../../../helpers/upload'
 import {RNSourcemap} from '../interfaces'
 
-jest.mock('fs', () => ({
-  createReadStream: jest.fn(),
-}))
-
 describe('interfaces', () => {
+  beforeEach(() => {
+    jest.restoreAllMocks()
+  })
   describe('getBundleName', () => {
+    beforeEach(() => {
+      jest.spyOn(fs, 'createReadStream').mockImplementation(() => undefined as any)
+    })
     test('should return the bundle name when specified', () => {
       const sourcemap = new RNSourcemap('./custom.bundle', './custom.bundle.map', 'index.android.bundle')
       expect(
@@ -29,6 +32,28 @@ describe('interfaces', () => {
         getMetadataFromPayload(sourcemap.asMultipartPayload('1.0', 'com.myapp', '1.2.3', '', 'android', '102030'))
           .bundle_name
       ).toBe('index.android.bundle')
+    })
+  })
+
+  describe('removeSourcesContentFromSourceMap', () => {
+    test('should remove the sources content part of sourcemaps', (done) => {
+      const sourcemap = new RNSourcemap(
+        './src/commands/react-native/__tests__/fixtures/basic-ios/main.jsbundle',
+        './src/commands/react-native/__tests__/fixtures/with-sources-content/main.jsbundle.map'
+      )
+      sourcemap.removeSourcesContentFromSourceMap()
+      const payload = sourcemap.asMultipartPayload('1.0', 'com.myapp', '1.2.3', '', 'android', '102030')
+
+      const sourcemapFileHandle = payload.content.get('source_map')?.value as fs.ReadStream
+      let fileContent = ''
+      sourcemapFileHandle.on('close', () => {
+        expect(fileContent).toContain('"sources":["Users/me/datadog-ci/src/commands/sourcemaps/__tests__/git.test.ts"]')
+        expect(fileContent).not.toContain('"sourcesContent"')
+        done()
+      })
+      sourcemapFileHandle.on('data', (chunk) => {
+        fileContent = `${fileContent}${chunk.toString()}`
+      })
     })
   })
 })

--- a/src/commands/react-native/codepush.ts
+++ b/src/commands/react-native/codepush.ts
@@ -39,6 +39,7 @@ export class CodepushCommand extends Command {
   private platform?: RNPlatform
   private projectPath?: string
   private releaseVersion?: string
+  private removeSourcesContent?: boolean
   private repositoryURL?: string
   private service?: string
   private sourcemap?: string
@@ -132,6 +133,9 @@ export class CodepushCommand extends Command {
     if (this.disableGit) {
       uploadCommand.push('--disable-git')
     }
+    if (this.removeSourcesContent) {
+      uploadCommand.push('--remove-sources-content')
+    }
     if (this.dryRun) {
       uploadCommand.push('--dry-run')
     }
@@ -182,3 +186,4 @@ CodepushCommand.addOption('projectPath', Command.String('--project-path'))
 CodepushCommand.addOption('configPath', Command.String('--config'))
 CodepushCommand.addOption('appCenterAppName', Command.String('--app'))
 CodepushCommand.addOption('appCenterDeployment', Command.String('--deployment'))
+CodepushCommand.addOption('removeSourcesContent', Command.Boolean('--remove-sources-content'))

--- a/src/commands/react-native/interfaces.ts
+++ b/src/commands/react-native/interfaces.ts
@@ -46,6 +46,16 @@ export class RNSourcemap {
     }
   }
 
+  public removeSourcesContentFromSourceMap = () => {
+    const newSourcemapFilePath = `${this.sourcemapPath}.no-sources-content`
+    const data = fs.readFileSync(this.sourcemapPath, 'utf8')
+    const sourcemap = JSON.parse(data)
+    delete sourcemap.sourcesContent
+
+    fs.writeFileSync(newSourcemapFilePath, JSON.stringify(sourcemap), 'utf8')
+    this.sourcemapPath = newSourcemapFilePath
+  }
+
   private getBundleName(bundlePath: string, bundleName?: string): string {
     if (bundleName) {
       return bundleName

--- a/src/commands/react-native/renderer.ts
+++ b/src/commands/react-native/renderer.ts
@@ -22,10 +22,10 @@ export const renderFailedUpload = (sourcemap: RNSourcemap, errorMessage: string)
   const sourcemapPathBold = `[${chalk.bold.dim(sourcemap.sourcemapPath)}]`
   let message = chalk.red(`${ICONS.FAILED} Failed upload sourcemap for ${sourcemapPathBold}: ${errorMessage}\n`)
   if (errorMessage.includes('413 (Request Entity Too Large)')) {
-    message = `${message}\n It looks like your sourcemap is too large. To make it lighter you can:\n
-    - Pass an empty file as --bundle argument to the upload command (no impact on the error explorer as of now)\n
-    - Pass the --remove-sources-content argument to the upload command (you will lose the code snippet next to the unminified error)\n
-    - Try to split your bundle, by using a tool such as repack (https://github.com/callstack/repack)`
+    message = `${message}\n It looks like your sourcemap is too large. To make it lighter you can:
+    - Pass an empty file as --bundle argument to the upload command (no impact on the error explorer as of now)
+    - Pass the --remove-sources-content argument to the upload command (you will lose the code snippet next to the unminified error)
+    - Try to split your bundle, by using a tool such as repack (https://github.com/callstack/repack)\n`
   }
 
   return message
@@ -37,8 +37,10 @@ export const renderRetriedUpload = (payload: RNSourcemap, errorMessage: string, 
   return chalk.yellow(`[attempt ${attempt}] Retrying sourcemap upload ${sourcemapPathBold}: ${errorMessage}\n`)
 }
 
-export const renderRemoveSourcesContentWarning = () => `Removing the "sourcesContent" part of the sourcemap file.
-  ${chalk.red('Use the --remove-sources-content only if your sourcemap file is too heavy to upload to Datadog.')}`
+export const renderRemoveSourcesContentWarning = () =>
+  `Removing the "sourcesContent" part of the sourcemap file. ${chalk.yellow(
+    'Use the --remove-sources-content only if your sourcemap file is too heavy to upload to Datadog.\n'
+  )}`
 
 export const renderFailedSourcesContentRemovalError = (payload: RNSourcemap, errorMessage: string) => `${chalk.red(
   `An error occured while removing the "sourcesContent" part of the sourcemap file ${payload.sourcemapPath}": ${errorMessage}`

--- a/src/commands/react-native/renderer.ts
+++ b/src/commands/react-native/renderer.ts
@@ -20,8 +20,15 @@ export const renderConfigurationError = (error: Error) => chalk.red(`${ICONS.FAI
 
 export const renderFailedUpload = (sourcemap: RNSourcemap, errorMessage: string) => {
   const sourcemapPathBold = `[${chalk.bold.dim(sourcemap.sourcemapPath)}]`
+  let message = chalk.red(`${ICONS.FAILED} Failed upload sourcemap for ${sourcemapPathBold}: ${errorMessage}\n`)
+  if (errorMessage.includes('413 (Request Entity Too Large)')) {
+    message = `${message}\n It looks like your sourcemap is too large. To make it lighter you can:\n
+    - Pass an empty file as --bundle argument to the upload command (no impact on the error explorer as of now)\n
+    - Pass the --remove-sources-content argument to the upload command (you will lose the code snippet next to the unminified error)\n
+    - Try to split your bundle, by using a tool such as repack (https://github.com/callstack/repack)`
+  }
 
-  return chalk.red(`${ICONS.FAILED} Failed upload sourcemap for ${sourcemapPathBold}: ${errorMessage}\n`)
+  return message
 }
 
 export const renderRetriedUpload = (payload: RNSourcemap, errorMessage: string, attempt: number) => {

--- a/src/commands/react-native/renderer.ts
+++ b/src/commands/react-native/renderer.ts
@@ -30,6 +30,14 @@ export const renderRetriedUpload = (payload: RNSourcemap, errorMessage: string, 
   return chalk.yellow(`[attempt ${attempt}] Retrying sourcemap upload ${sourcemapPathBold}: ${errorMessage}\n`)
 }
 
+export const renderRemoveSourcesContentWarning = () => `Removing the "sourcesContent" part of the sourcemap file.
+  ${chalk.red('Use the --remove-sources-content only if your sourcemap file is too heavy to upload to Datadog.')}`
+
+export const renderFailedSourcesContentRemovalError = (payload: RNSourcemap, errorMessage: string) => `${chalk.red(
+  `An error occured while removing the "sourcesContent" part of the sourcemap file ${payload.sourcemapPath}": ${errorMessage}`
+)}.
+  Trying to upload the full sourcemap with the "sourcesContent".`
+
 /**
  * As of now, this command takes an array of one signe UploadStatus element since we only support upload
  * of a single sourcemap.

--- a/src/commands/react-native/upload.ts
+++ b/src/commands/react-native/upload.ts
@@ -14,9 +14,11 @@ import {RNPlatform, RNSourcemap, RN_SUPPORTED_PLATFORMS} from './interfaces'
 import {
   renderCommandInfo,
   renderConfigurationError,
+  renderFailedSourcesContentRemovalError,
   renderFailedUpload,
   renderGitDataNotAttachedWarning,
   renderGitWarning,
+  renderRemoveSourcesContentWarning,
   renderRetriedUpload,
   renderSourcesNotFoundWarning,
   renderSuccessfulCommand,
@@ -57,6 +59,7 @@ export class UploadCommand extends Command {
   private platform?: RNPlatform
   private projectPath: string = process.cwd() || ''
   private releaseVersion?: string
+  private removeSourcesContent = false
   private repositoryURL?: string
   private service?: string
   private sourcemap?: string
@@ -283,6 +286,15 @@ export class UploadCommand extends Command {
         return UploadStatus.Skipped
       }
 
+      if (this.removeSourcesContent) {
+        try {
+          this.context.stdout.write(renderRemoveSourcesContentWarning())
+          sourcemap.removeSourcesContentFromSourceMap()
+        } catch (error) {
+          this.context.stdout.write(renderFailedSourcesContentRemovalError(sourcemap, error.message))
+        }
+      }
+
       const payload = sourcemap.asMultipartPayload(
         this.cliVersion,
         this.service!,
@@ -329,3 +341,4 @@ UploadCommand.addOption('disableGit', Command.Boolean('--disable-git'))
 UploadCommand.addOption('maxConcurrency', Command.String('--max-concurrency'))
 UploadCommand.addOption('projectPath', Command.String('--project-path'))
 UploadCommand.addOption('configPath', Command.String('--config'))
+UploadCommand.addOption('removeSourcesContent', Command.Boolean('--remove-sources-content'))

--- a/src/commands/react-native/xcode.ts
+++ b/src/commands/react-native/xcode.ts
@@ -45,6 +45,7 @@ export class XCodeCommand extends Command {
   private disableGit?: boolean
   private dryRun = false
   private force = false
+  private removeSourcesContent?: boolean
   private repositoryURL?: string
   private scriptPath = `${reactNativePath}/scripts/react-native-xcode.sh`
   private service?: string = process.env.PRODUCT_BUNDLE_IDENTIFIER
@@ -183,6 +184,9 @@ export class XCodeCommand extends Command {
     if (this.repositoryURL) {
       uploadCommand.push('--repository-url', this.repositoryURL)
     }
+    if (this.removeSourcesContent) {
+      uploadCommand.push('--remove-sources-content')
+    }
     if (this.dryRun) {
       uploadCommand.push('--dry-run')
     }
@@ -320,3 +324,4 @@ XCodeCommand.addOption('composeSourcemapsPath', Command.String('--compose-source
 XCodeCommand.addOption('repositoryURL', Command.String('--repository-url'))
 XCodeCommand.addOption('disableGit', Command.Boolean('--disable-git'))
 XCodeCommand.addOption('configPath', Command.String('--config'))
+XCodeCommand.addOption('removeSourcesContent', Command.Boolean('--remove-sources-content'))

--- a/src/commands/react-native/xcode.ts
+++ b/src/commands/react-native/xcode.ts
@@ -190,7 +190,7 @@ export class XCodeCommand extends Command {
       this.context.stderr.write(`[bundle script]: ${data}`)
     })
 
-    const [status, signal] = await new Promise((resolve, reject) => {
+    const [status, signal] = await new Promise<[number, string]>((resolve, reject) => {
       bundleJSChildProcess.on('error', (error: Error) => {
         reject(error)
       })
@@ -239,7 +239,7 @@ export class XCodeCommand extends Command {
       this.context.stderr.write(`[compose sourcemaps script]: ${data}`)
     })
 
-    const [status, signal] = await new Promise((resolve, reject) => {
+    const [status, signal] = await new Promise<[number, string]>((resolve, reject) => {
       composeHermesSourcemapsChildProcess.on('error', (error: Error) => {
         reject(error)
       })

--- a/src/commands/react-native/xcode.ts
+++ b/src/commands/react-native/xcode.ts
@@ -41,8 +41,11 @@ export class XCodeCommand extends Command {
   })
 
   private composeSourcemapsPath = `${reactNativePath}/scripts/compose-source-maps.js`
+  private configPath?: string
+  private disableGit?: boolean
   private dryRun = false
   private force = false
+  private repositoryURL?: string
   private scriptPath = `${reactNativePath}/scripts/react-native-xcode.sh`
   private service?: string = process.env.PRODUCT_BUNDLE_IDENTIFIER
 
@@ -171,6 +174,15 @@ export class XCodeCommand extends Command {
       '--sourcemap',
       sourcemapsLocation,
     ]
+    if (this.configPath) {
+      uploadCommand.push('--config', this.configPath)
+    }
+    if (this.disableGit) {
+      uploadCommand.push('--disable-git')
+    }
+    if (this.repositoryURL) {
+      uploadCommand.push('--repository-url', this.repositoryURL)
+    }
     if (this.dryRun) {
       uploadCommand.push('--dry-run')
     }
@@ -305,3 +317,6 @@ XCodeCommand.addOption('service', Command.String('--service'))
 XCodeCommand.addOption('dryRun', Command.Boolean('--dry-run'))
 XCodeCommand.addOption('force', Command.Boolean('--force'))
 XCodeCommand.addOption('composeSourcemapsPath', Command.String('--compose-sourcemaps-path'))
+XCodeCommand.addOption('repositoryURL', Command.String('--repository-url'))
+XCodeCommand.addOption('disableGit', Command.Boolean('--disable-git'))
+XCodeCommand.addOption('configPath', Command.String('--config'))


### PR DESCRIPTION
### What and why?

Enable removal of sources content from react native source maps.
This can reduce the size of the sourcemap by 60%.
However doing so will result in not having the code snippet next to the unminified error, but that is considered nice to have for now.

Solves https://github.com/DataDog/dd-sdk-reactnative/issues/302

### How?

Also added some optional arguments to the xcode command.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] \[_Synthetics_\] New releases of `datadog-ci` MUST be followed by a release of Synthetics CI integrations
