### PR TITLE
[docs] Update main README

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,4 +9,3 @@ A brief description of implementation details of this PR.
 ### Review checklist
 
 - [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
-- [ ] \[_Synthetics_\] New releases of `datadog-ci` MUST be followed by a release of Synthetics CI integrations

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ npm install --save-dev @datadog/datadog-ci
 yarn add --dev @datadog/datadog-ci
 ```
 
-If you need `datadog-ci` as a CLI tool instead of a package, you can run it with [`npx`](https://www.npmjs.com/package/npx) or install globally:
+If you need `datadog-ci` as a CLI tool instead of a package, you can run it with [`npx`](https://www.npmjs.com/package/npx) or install it globally:
 
 ```sh
 # npx
@@ -29,64 +29,7 @@ npm install -g @datadog/datadog-ci
 yarn global add @datadog/datadog-ci
 ```
 
-### Standalone binary (**beta**)
-
-If installing nodejs in the CI is an issue, standalone binaries are provided with [releases](https://github.com/DataDog/datadog-ci/releases). Only _linux-x64_, _darwin-x64_ (macOS) and _win-x64_ (Windows) are supported at the time. **These standalone binaries are in _beta_ and their stability is not guaranteed**. To install:
-
-#### Linux
-
-```sh
-curl -L --fail "https://github.com/DataDog/datadog-ci/releases/latest/download/datadog-ci_linux-x64" --output "/usr/local/bin/datadog-ci" && chmod +x /usr/local/bin/datadog-ci
-```
-
-#### MacOS
-
-```sh
-curl -L --fail "https://github.com/DataDog/datadog-ci/releases/latest/download/datadog-ci_darwin-x64" --output "/usr/local/bin/datadog-ci" && chmod +x /usr/local/bin/datadog-ci
-```
-
-#### Windows
-
-```sh
-Invoke-WebRequest -Uri "https://github.com/DataDog/datadog-ci/releases/latest/download/datadog-ci_win-x64.exe" -OutFile "datadog-ci.exe"
-```
-
-Then you can run `datadog-ci` commands normally:
-
-```sh
-datadog-ci version
-```
-
-### Container image
-
-To run `datadog-ci` from a container, you can use the `datadog/ci` image available in Dockerhub as well as the public Amazon ECR and Google GC registries.
-
-```
-docker pull datadog/ci
-```
-
-Here's an example of how to run a command using the container and passing in the API and APP keys:
-
-```
-export DD_API_KEY=$(cat /secret/dd_api_key)
-export DD_APP_KEY=$(cat /secret/dd_app_key)
-docker run --rm -it -v $(pwd):/w -e DD_API_KEY -e DD_APP_KEY datadog/ci synthetics run-tests -p pub-lic-id1
-```
-
-#### Building your own container image
-
-You can build an image using the provided [Dockerfile](https://github.com/DataDog/datadog-ci/blob/master/container/Dockerfile):
-
-```sh
-cd container
-docker build --tag datadog-ci .
-```
-
-Optionally you can use the `VERSION` build argument to build an image for a specific version:
-
-```sh
-docker build --build-arg "VERSION=v1.14" --t datadog-ci .
-```
+For more ways to install the CLI, please refer to [this section](#more-ways-to-install-the-cli).
 
 ## Usage
 
@@ -108,7 +51,7 @@ Available commands:
 
 Each command allows interacting with a product of the Datadog platform. The commands are defined in the [src/commands](/src/commands) folder.
 
-Further documentation for each command can be found in its folder, ie:
+Further documentation for these commands can be found in their respective folders:
 
 - [Lambda](src/commands/lambda)
 - [Browser sourcemaps](src/commands/sourcemaps/)
@@ -177,7 +120,7 @@ export class HelloWorldCommand extends Command {
 module.exports = [HelloWorldCommand]
 ```
 
-Lastly, test files must be created in the `__tests__/` folder. `jest` is used to run the tests and a CI has been set using Github Actions to ensure all tests are passing when merging a Pull Request.
+Lastly, test files must be created in the `__tests__/` folder. `jest` is used to run the tests and a CI has been set using GitHub Actions to ensure all tests are passing when merging a Pull Request.
 
 The tests can then be launched through the `yarn test` command, it will find all files with a filename ending in `.test.ts` in the repo and execute them.
 
@@ -187,7 +130,7 @@ The CI performs tests to avoid regressions by building the project, running unit
 
 The end-to-end test installs the package in a new project, configures it (using files in the `.github/workflows/e2e` folder) and runs a `synthetics run-tests` command in a Datadog Org (`Synthetics E2E Testing Org`) to verify the command is able to perform a test.
 
-The synthetics tests ran are a browser test (id `neg-qw9-eut`) and an API test (id `v5u-56k-hgk`), both loading a page which outputs the headers of the request and verifying the `X-Fake-Header` header is present. This header is configured as an override in the `.github/workflows/e2e/test.synthetics.json` file. The API and Application keys used by the command are stored in Github Secrets named `datadog_api_key` and `datadog_app_key`.
+The synthetics tests ran are a browser test (id `neg-qw9-eut`) and an API test (id `v5u-56k-hgk`), both loading a page which outputs the headers of the request and verifying the `X-Fake-Header` header is present. This header is configured as an override in the `.github/workflows/e2e/test.synthetics.json` file. The API and Application keys used by the command are stored in GitHub Secrets named `datadog_api_key` and `datadog_app_key`.
 
 The goal of this test is to verify the command is able to run tests and wait for their results as expected as well as handling configuration overrides.
 
@@ -214,29 +157,94 @@ yarn prepack
 
 Releasing a new version of `datadog-ci` unfolds as follow:
 
-- create a new branch for the version upgrade
-- update the version using `yarn version [--patch|--minor|--major]` depending on the nature of the changes introduced. You may refer to [Semantic Versioning](https://semver.org/#summary) to determine which to increment.
-- push the branch along with the tag to the upstream (Github), create a Pull Request with the changes introduced detailed in the description and get at least one approval. ([sample Pull Request](https://github.com/DataDog/datadog-ci/pull/78))
-- merge the Pull Request
-- create a Github Release from the [Tags page](https://github.com/DataDog/datadog-ci/tags) with the description of changes introduced
-- Once the release has been created, a Github Action will publish the package and a Gitlab pipeline will publish the Docker image. Make sure they succeed.
+1. Create a new branch for the version upgrade.
+2. Update the version using `yarn version [--patch|--minor|--major]`, depending on the nature of the changes introduced. You may refer to [Semantic Versioning](https://semver.org/#summary) to determine which to increment.
+3. Push the branch along with the tag to the upstream (GitHub) with `git push --tags origin name-of-the-branch`, then create a Pull-Request with the changes introduced detailed in the description, and get at least one approval. ([sample Pull-Request](https://github.com/DataDog/datadog-ci/pull/78))
+4. Merge the Pull-Request.
+5. Create a GitHub Release from the [Tags page](https://github.com/DataDog/datadog-ci/tags) with the description of changes introduced.
+6. Once the release has been created, a GitHub Action will publish the package, and a Gitlab pipeline will publish the Docker image. Make sure they succeed.
+7. :warning: If the release introduced some **changes in the `synthetics` command**, you have to upgrade `datadog-ci` in the following projects:
+   * [GitHub Action](https://github.com/DataDog/synthetics-ci-github-action)
+   * [CircleCI Orb](https://github.com/DataDog/synthetics-test-automation-circleci-orb)
+   * [Azure DevOps Extension](https://github.com/DataDog/datadog-ci-azure-devops)
 
 ### Pre-Release Process
 
 If you need to create a pre-release or releasing in a different channel here's how it works:
 
-- create a new branch for the channel you want to release to (`alpha`, `beta`, ...).
-- create a PR for your feature branch with the channel branch as a base.
-- pick a version following this format `version-channel`, it can be `0.10.9-alpha` or `1-beta`...
-- update the `version` field in `package.json`
-- merge the Pull Request
-- create a [Github Release](https://github.com/DataDog/datadog-ci/releases/new?target=alpha&tag=0.10.9-alpha&prerelease=1&title=Alpha+prerelease):
-  - target the channel branch
-  - pick a tag based on your version `version-channel`
-  - check the `This is a pre-release` checkbox
-- publish the release and an action will publish it on npm
+1. Create a new branch for the channel you want to release to (`alpha`, `beta`, ...).
+2. Create a PR for your feature branch with the channel branch as a base.
+3. Pick a version following this format: `version-channel`. It can be `0.10.9-alpha`, or `1-beta`, etc.
+4. Update the `version` field in `package.json`.
+5. Merge the Pull Request.
+6. Create a [GitHub Release](https://github.com/DataDog/datadog-ci/releases/new?target=alpha&tag=0.10.9-alpha&prerelease=1&title=Alpha+prerelease):
+   1. Target the channel branch.
+   2. Pick a tag based on your version `version-channel`.
+   3. Check the `This is a pre-release` checkbox.
+7. Publish the release and an action will publish it on npm.
 
 <img src="./assets/pre-release.png" width="500"/>
+
+## More ways to install the CLI
+
+### Standalone binary (**beta**)
+
+If installing nodejs in the CI is an issue, standalone binaries are provided with [releases](https://github.com/DataDog/datadog-ci/releases). Only _linux-x64_, _darwin-x64_ (macOS) and _win-x64_ (Windows) are supported at the time. **These standalone binaries are in _beta_ and their stability is not guaranteed**. To install:
+
+#### Linux
+
+```sh
+curl -L --fail "https://github.com/DataDog/datadog-ci/releases/latest/download/datadog-ci_linux-x64" --output "/usr/local/bin/datadog-ci" && chmod +x /usr/local/bin/datadog-ci
+```
+
+#### MacOS
+
+```sh
+curl -L --fail "https://github.com/DataDog/datadog-ci/releases/latest/download/datadog-ci_darwin-x64" --output "/usr/local/bin/datadog-ci" && chmod +x /usr/local/bin/datadog-ci
+```
+
+#### Windows
+
+```sh
+Invoke-WebRequest -Uri "https://github.com/DataDog/datadog-ci/releases/latest/download/datadog-ci_win-x64.exe" -OutFile "datadog-ci.exe"
+```
+
+Then you can run `datadog-ci` commands normally:
+
+```sh
+datadog-ci version
+```
+
+### Container image
+
+To run `datadog-ci` from a container, you can use the `datadog/ci` image available in Dockerhub as well as the public Amazon ECR and Google GC registries.
+
+```
+docker pull datadog/ci
+```
+
+Here's an example of how to run a command using the container and passing in the API and APP keys:
+
+```
+export DD_API_KEY=$(cat /secret/dd_api_key)
+export DD_APP_KEY=$(cat /secret/dd_app_key)
+docker run --rm -it -v $(pwd):/w -e DD_API_KEY -e DD_APP_KEY datadog/ci synthetics run-tests -p pub-lic-id1
+```
+
+#### Building your own container image
+
+You can build an image using the provided [Dockerfile](https://github.com/DataDog/datadog-ci/blob/master/container/Dockerfile):
+
+```sh
+cd container
+docker build --tag datadog-ci .
+```
+
+Optionally you can use the `VERSION` build argument to build an image for a specific version:
+
+```sh
+docker build --build-arg "VERSION=v1.14" --t datadog-ci .
+```
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -35,35 +35,21 @@ For more ways to install the CLI, please refer to [this section](#more-ways-to-i
 
 ```bash
 Usage: datadog-ci <command> <subcommand> [options]
-
-Available commands:
-  - lambda
-  - sourcemaps
-  - synthetics
-  - dsyms
-  - git-metadata
-  - junit
-  - trace
-  - tag
-  - metric
-  - flutter-symbols
 ```
 
-Each command allows interacting with a product of the Datadog platform. The commands are defined in the [src/commands](/src/commands) folder.
+Possible values for `<command>` and their documentation:
 
-Further documentation for these commands can be found in their respective folders:
-
-- [Lambda](src/commands/lambda)
-- [Browser sourcemaps](src/commands/sourcemaps/)
-- [React Native sourcemaps](src/commands/react-native/)
-- [Synthetics CI/CD Testing](src/commands/synthetics/)
-- [iOS dSYM Files](src/commands/dsyms/)
-- [Git metadata](src/commands/git-metadata)
-- [JUnit XML](src/commands/junit)
-- [Trace](src/commands/trace)
-- [Tag](src/commands/tag)
-- [Metric](src/commands/metric)
-- [Flutter Symbols](src/commands/flutter-symbols/)
+- `dsyms`: [iOS dSYM Files](src/commands/dsyms/)
+- `flutter-symbols`: [Flutter Symbols](src/commands/flutter-symbols/)
+- `git-metadata`: [Git metadata](src/commands/git-metadata)
+- `junit`: [JUnit XML](src/commands/junit)
+- `lambda`: [Lambda](src/commands/lambda)
+- `metric`: [Metric](src/commands/metric)
+- `react-native`: [React Native sourcemaps](src/commands/react-native/)
+- `sourcemaps`: [Browser sourcemaps](src/commands/sourcemaps/)
+- `synthetics`: [Synthetics CI/CD Testing](src/commands/synthetics/)
+- `tag`: [Tag](src/commands/tag)
+- `trace`: [Trace](src/commands/trace)
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ npm install -g @datadog/datadog-ci
 yarn global add @datadog/datadog-ci
 ```
 
-For more ways to install the CLI, please refer to [this section](#more-ways-to-install-the-cli).
+For more ways to install the CLI, see [this section](#more-ways-to-install-the-cli).
 
 ## Usage
 
@@ -37,7 +37,7 @@ For more ways to install the CLI, please refer to [this section](#more-ways-to-i
 Usage: datadog-ci <command> <subcommand> [options]
 ```
 
-Possible values for `<command>` and their documentation:
+Possible values for each `<command>` and corresponding documentation include the following:
 
 - `dsyms`: [iOS dSYM Files](src/commands/dsyms/)
 - `flutter-symbols`: [Flutter Symbols](src/commands/flutter-symbols/)
@@ -114,9 +114,9 @@ The tests can then be launched through the `yarn test` command, it will find all
 
 The CI performs tests to avoid regressions by building the project, running unit tests and running one end-to-end test.
 
-The end-to-end test installs the package in a new project, configures it (using files in the `.github/workflows/e2e` folder) and runs a `synthetics run-tests` command in a Datadog Org (`Synthetics E2E Testing Org`) to verify the command is able to perform a test.
+The end-to-end test installs the package in a new project, configures it by using files in the `.github/workflows/e2e` folder, and runs a `synthetics run-tests` command in a Datadog org (such as `Synthetics E2E Testing Org`) to verify the command is able to perform a test.
 
-The synthetics tests ran are a browser test (id `neg-qw9-eut`) and an API test (id `v5u-56k-hgk`), both loading a page which outputs the headers of the request and verifying the `X-Fake-Header` header is present. This header is configured as an override in the `.github/workflows/e2e/test.synthetics.json` file. The API and Application keys used by the command are stored in GitHub Secrets named `datadog_api_key` and `datadog_app_key`.
+The Synthetic tests that are run include a browser test (with a test ID of `neg-qw9-eut`) and an API test (with a test ID of `v5u-56k-hgk`). Both tests load a page which outputs the headers of the request and verifies the `X-Fake-Header` header is present. This header is configured as an override in the `.github/workflows/e2e/test.synthetics.json` file. The API and application keys used by the command are stored in GitHub Secrets named `datadog_api_key` and `datadog_app_key`.
 
 The goal of this test is to verify the command is able to run tests and wait for their results as expected as well as handling configuration overrides.
 
@@ -141,33 +141,33 @@ yarn prepack
 
 ### Release Process
 
-Releasing a new version of `datadog-ci` unfolds as follow:
+To release a new version of `datadog-ci`:
 
 1. Create a new branch for the version upgrade.
 2. Update the version using `yarn version [--patch|--minor|--major]`, depending on the nature of the changes introduced. You may refer to [Semantic Versioning](https://semver.org/#summary) to determine which to increment.
-3. Push the branch along with the tag to the upstream (GitHub) with `git push --tags origin name-of-the-branch`, then create a Pull-Request with the changes introduced detailed in the description, and get at least one approval. ([sample Pull-Request](https://github.com/DataDog/datadog-ci/pull/78))
-4. Merge the Pull-Request.
+3. Push the branch along with the tag to the upstream (GitHub) with `git push --tags origin name-of-the-branch`, create a Pull Request with the changes introduced in the description details, and get at least one approval. For example, see this [sample pull request](https://github.com/DataDog/datadog-ci/pull/78).
+4. Merge the Pull Request.
 5. Create a GitHub Release from the [Tags page](https://github.com/DataDog/datadog-ci/tags) with the description of changes introduced.
-6. Once the release has been created, a GitHub Action will publish the package, and a Gitlab pipeline will publish the Docker image. Make sure they succeed.
-7. :warning: If the release introduced some **changes in the `synthetics` command**, you have to upgrade `datadog-ci` in the following projects:
+6. Once the release has been created, a GitHub Action publishes the package, and a Gitlab pipeline publishes the Docker image. Make sure these jobs succeed.
+7. If the release introduced some **changes in the** `synthetics` **command**, you have to upgrade `datadog-ci` in the following projects:
    * [GitHub Action](https://github.com/DataDog/synthetics-ci-github-action)
    * [CircleCI Orb](https://github.com/DataDog/synthetics-test-automation-circleci-orb)
    * [Azure DevOps Extension](https://github.com/DataDog/datadog-ci-azure-devops)
 
 ### Pre-Release Process
 
-If you need to create a pre-release or releasing in a different channel here's how it works:
+To create a pre-release or releasing in a different channel:
 
-1. Create a new branch for the channel you want to release to (`alpha`, `beta`, ...).
+1. Create a new branch for the channel you want to release to (`alpha`, `beta`, and more).
 2. Create a PR for your feature branch with the channel branch as a base.
-3. Pick a version following this format: `version-channel`. It can be `0.10.9-alpha`, or `1-beta`, etc.
+3. Pick a version following this format: `version-channel`. For example, `0.10.9-alpha`, `1-beta`, and more.
 4. Update the `version` field in `package.json`.
-5. Merge the Pull Request.
+5. Once you've received at least one approval, merge the Pull Request.
 6. Create a [GitHub Release](https://github.com/DataDog/datadog-ci/releases/new?target=alpha&tag=0.10.9-alpha&prerelease=1&title=Alpha+prerelease):
-   1. Target the channel branch.
-   2. Pick a tag based on your version `version-channel`.
-   3. Check the `This is a pre-release` checkbox.
-7. Publish the release and an action will publish it on npm.
+   - Target the channel branch.
+   - Pick a tag based on your version `version-channel`.
+   - Check the `This is a pre-release` checkbox.
+7. Publish the release and an action publishes it on npm.
 
 <img src="./assets/pre-release.png" width="500"/>
 
@@ -175,7 +175,9 @@ If you need to create a pre-release or releasing in a different channel here's h
 
 ### Standalone binary (**beta**)
 
-If installing nodejs in the CI is an issue, standalone binaries are provided with [releases](https://github.com/DataDog/datadog-ci/releases). Only _linux-x64_, _darwin-x64_ (macOS) and _win-x64_ (Windows) are supported at the time. **These standalone binaries are in _beta_ and their stability is not guaranteed**. To install:
+If installing NodeJS in the CI is an issue, standalone binaries are provided with [releases](https://github.com/DataDog/datadog-ci/releases). _linux-x64_, _darwin-x64_ (macOS), and _win-x64_ (Windows) are supported. **These standalone binaries are in beta and their stability is not guaranteed**. 
+
+To install:
 
 #### Linux
 
@@ -195,7 +197,7 @@ curl -L --fail "https://github.com/DataDog/datadog-ci/releases/latest/download/d
 Invoke-WebRequest -Uri "https://github.com/DataDog/datadog-ci/releases/latest/download/datadog-ci_win-x64.exe" -OutFile "datadog-ci.exe"
 ```
 
-Then you can run `datadog-ci` commands normally:
+Then, you can run `datadog-ci` commands normally:
 
 ```sh
 datadog-ci version
@@ -209,7 +211,7 @@ To run `datadog-ci` from a container, you can use the `datadog/ci` image availab
 docker pull datadog/ci
 ```
 
-Here's an example of how to run a command using the container and passing in the API and APP keys:
+This example demonstrates how to run a command using the container and passing in the API and APP keys:
 
 ```
 export DD_API_KEY=$(cat /secret/dd_api_key)
@@ -226,7 +228,7 @@ cd container
 docker build --tag datadog-ci .
 ```
 
-Optionally you can use the `VERSION` build argument to build an image for a specific version:
+Optionally, you can use the `VERSION` build argument to build an image for a specific version:
 
 ```sh
 docker build --build-arg "VERSION=v1.14" --t datadog-ci .


### PR DESCRIPTION
### What and why?

* Update the main README:
   * Add a step to the release process to update the CI integrations if changes to the `synthetics` command are released
   * Move the "Usage" section (with the links to other READMEs) up in the file
   * A few nits here and there
* Remove the checkbox specific to `synthetics` changes in the PR template