### PR TITLE
[lint][synthetics-worker] Migrate to `eslint`

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "test": "jest --colors",
     "test:debug": "node --inspect-brk `which jest` --runInBand",
     "test:ci-vis:itr": "jest --colors --config ./jest.config-ci-vis-itr.js --passWithNoTests",
-    "eslint": "eslint 'src/**/*.ts'",
+    "eslint": "eslint $(git diff --name-only 6dba118d780aa19939edf0f52a4a48e6e5e17477..HEAD) --ignore-pattern package.json",
     "typecheck": "bash bin/typecheck.sh",
     "watch": "tsc -w"
   },

--- a/src/commands/synthetics/__tests__/cli.test.ts
+++ b/src/commands/synthetics/__tests__/cli.test.ts
@@ -1,4 +1,3 @@
-// tslint:disable: no-string-literal
 import {AxiosError, AxiosResponse} from 'axios'
 import {Cli} from 'clipanion/lib/advanced'
 import * as ciUtils from '../../../helpers/utils'

--- a/src/commands/synthetics/__tests__/fixtures.ts
+++ b/src/commands/synthetics/__tests__/fixtures.ts
@@ -356,6 +356,7 @@ export const getSyntheticsProxy = () => {
 
   const wss = new WebSocketServer({noServer: true})
 
+  // eslint-disable-next-line prefer-const
   let port: number
   const server = http.createServer({}, (request, response) => {
     const mockResponse = (call: jest.Mock, responseData: any) => {

--- a/src/commands/synthetics/__tests__/reporters/junit.test.ts
+++ b/src/commands/synthetics/__tests__/reporters/junit.test.ts
@@ -1,4 +1,3 @@
-// tslint:disable: no-string-literal
 import {promises as fs} from 'fs'
 import {Writable} from 'stream'
 

--- a/src/commands/synthetics/__tests__/run-test.test.ts
+++ b/src/commands/synthetics/__tests__/run-test.test.ts
@@ -1,7 +1,5 @@
-// tslint:disable: no-string-literal
-
-import {AxiosError, AxiosResponse} from 'axios'
 import {promises as fs} from 'fs'
+import {AxiosError, AxiosResponse} from 'axios'
 import * as ciUtils from '../../../helpers/utils'
 import * as api from '../api'
 import {MAX_TESTS_TO_TRIGGER} from '../command'

--- a/src/commands/synthetics/__tests__/tunnel.test.ts
+++ b/src/commands/synthetics/__tests__/tunnel.test.ts
@@ -1,10 +1,7 @@
-// tslint:disable: no-string-literal
-
-import {ProxyConfiguration} from '../../../../src/helpers/utils'
-
 import {PassThrough} from 'stream'
 
 import {mocked} from 'ts-jest/utils'
+import {ProxyConfiguration} from '../../../../src/helpers/utils'
 
 import {Tunnel} from '../tunnel'
 import {WebSocket} from '../websocket'

--- a/src/commands/synthetics/__tests__/utils.test.ts
+++ b/src/commands/synthetics/__tests__/utils.test.ts
@@ -38,13 +38,13 @@ jest.mock('path', () => {
   }
 })
 
-import deepExtend from 'deep-extend'
 import * as fs from 'fs'
+import child_process from 'child_process'
+import process from 'process'
+import deepExtend from 'deep-extend'
 
 import {AxiosError, default as axios} from 'axios'
-import child_process from 'child_process'
 import glob from 'glob'
-import process from 'process'
 
 process.env.DATADOG_SYNTHETICS_CI_TRIGGER_APP = 'env_default'
 

--- a/src/commands/synthetics/__tests__/websocket.test.ts
+++ b/src/commands/synthetics/__tests__/websocket.test.ts
@@ -1,5 +1,3 @@
-// tslint:disable: no-string-literal
-
 import * as ciUtils from '../../../helpers/utils'
 
 import {DEFAULT_POLLING_TIMEOUT, RunTestCommand} from '../command'

--- a/src/commands/synthetics/api.ts
+++ b/src/commands/synthetics/api.ts
@@ -249,8 +249,8 @@ export const getApiHelper = (config: SyntheticsCIConfig): APIHelper => {
   }
 
   return apiConstructor({
-    apiKey: config.apiKey!,
-    appKey: config.appKey!,
+    apiKey: config.apiKey,
+    appKey: config.appKey,
     baseIntakeUrl: getDatadogHost({useIntake: true, apiVersion: 'v1', config}),
     baseUnstableUrl: getDatadogHost({useIntake: false, apiVersion: 'unstable', config}),
     baseUrl: getDatadogHost({useIntake: false, apiVersion: 'v1', config}),

--- a/src/commands/synthetics/errors.ts
+++ b/src/commands/synthetics/errors.ts
@@ -1,4 +1,3 @@
-/* tslint:disable:max-classes-per-file */
 const nonCriticalErrorCodes = ['NO_TESTS_TO_RUN', 'MISSING_TESTS'] as const
 export type NonCriticalCiErrorCode = typeof nonCriticalErrorCodes[number]
 

--- a/src/commands/synthetics/reporters/junit.ts
+++ b/src/commands/synthetics/reporters/junit.ts
@@ -1,8 +1,8 @@
-import c from 'chalk'
-import {BaseContext} from 'clipanion'
 import {promises as fs} from 'fs'
 import path from 'path'
 import {Writable} from 'stream'
+import {BaseContext} from 'clipanion'
+import c from 'chalk'
 import {Builder} from 'xml2js'
 
 import {
@@ -105,7 +105,7 @@ export interface XMLJSON {
 }
 
 interface XMLError {
-  $: {type: string; [key: string]: string}
+  $: {[key: string]: string; type: string}
   _: string
 }
 

--- a/src/commands/synthetics/run-test.ts
+++ b/src/commands/synthetics/run-test.ts
@@ -183,7 +183,7 @@ export const getTestsList = async (
     return testsToTriggerBySearchQuery
   }
 
-  const suitesFromFiles = (await Promise.all(config.files.map((glob: string) => getSuites(glob, reporter!))))
+  const suitesFromFiles = (await Promise.all(config.files.map((glob: string) => getSuites(glob, reporter))))
     .reduce((acc, val) => acc.concat(val), [])
     .filter((suite) => !!suite.content.tests)
 

--- a/src/commands/synthetics/tunnel.ts
+++ b/src/commands/synthetics/tunnel.ts
@@ -72,8 +72,7 @@ export class Tunnel {
    * keepAlive will return a promise that tracks the state of the tunnel (and reject in case of error)
    */
   public async keepAlive() {
-    // eslint-disable-next-line @typescript-eslint/no-misused-promises
-    if (!this.ws || !this.ws.keepAlive()) {
+    if (!this.ws) {
       throw new Error('No WebSocket connection')
     }
 

--- a/src/commands/synthetics/tunnel.ts
+++ b/src/commands/synthetics/tunnel.ts
@@ -12,16 +12,17 @@ import {
 } from 'ssh2'
 import {ParsedKey} from 'ssh2-streams'
 import {Config as MultiplexerConfig, Server as Multiplexer} from 'yamux-js'
-// tslint:disable-next-line:no-var-requires - SW-1310
-const {KexInit} = require('ssh2/lib/protocol/kex')
-// tslint:disable-next-line:no-var-requires - SW-1310
-const SSH_CONSTANTS = require('ssh2/lib/protocol/constants')
 
 import {ProxyConfiguration} from '../../helpers/utils'
 
 import {generateOpenSSHKeys, parseSSHKey} from './crypto'
 import {MainReporter} from './interfaces'
 import {WebSocket} from './websocket'
+
+// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-var-requires -- SW-1310
+const SSH_CONSTANTS = require('ssh2/lib/protocol/constants')
+// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-var-requires -- SW-1310
+const {KexInit} = require('ssh2/lib/protocol/kex')
 
 export interface TunnelInfo {
   host: string
@@ -71,6 +72,7 @@ export class Tunnel {
    * keepAlive will return a promise that tracks the state of the tunnel (and reject in case of error)
    */
   public async keepAlive() {
+    // eslint-disable-next-line @typescript-eslint/no-misused-promises
     if (!this.ws || !this.ws.keepAlive()) {
       throw new Error('No WebSocket connection')
     }
@@ -258,7 +260,7 @@ export class Tunnel {
         this.logError(`Error in multiplexing: ${error}`)
       })
 
-      this.processSSHStream(stream)
+      void this.processSSHStream(stream)
     }, multiplexerConfig)
 
     // Pipe WebSocket to multiplexing

--- a/src/commands/synthetics/utils.ts
+++ b/src/commands/synthetics/utils.ts
@@ -1,13 +1,13 @@
 import {exec} from 'child_process'
-import deepExtend from 'deep-extend'
 import * as fs from 'fs'
 import * as path from 'path'
 import {URL} from 'url'
 import {promisify} from 'util'
 
+import process from 'process'
 import chalk from 'chalk'
 import glob from 'glob'
-import process from 'process'
+import deepExtend from 'deep-extend'
 
 import {getCIMetadata} from '../../helpers/ci'
 import {GIT_COMMIT_MESSAGE} from '../../helpers/tags'
@@ -438,8 +438,8 @@ export const waitForResults = async (
     getResultFromBatch(
       getLocation,
       hasExceededMaxPollingDate,
-      options.failOnCriticalErrors!!,
-      options.failOnTimeout!!,
+      options.failOnCriticalErrors ?? false,
+      options.failOnTimeout ?? false,
       pollResultMap,
       resultInBatch,
       tests


### PR DESCRIPTION
### What and why?

Related to https://github.com/DataDog/datadog-ci/pull/666.

Mostly import rearrangements, and non-null assertion operator deletions since TypeScript type inference improved over the time.

### Review checklist

You can **ignore the change in `package.json`**: it is **temporary** and here to make the CI pass on this PR. It will be removed once merged in #666.

- [ ] Ensure nothing is broken in your team scope
