### PR TITLE
[lint][source-code-integration] Migrate to `eslint`

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "test": "jest --colors",
     "test:debug": "node --inspect-brk `which jest` --runInBand",
     "test:ci-vis:itr": "jest --colors --config ./jest.config-ci-vis-itr.js --passWithNoTests",
-    "eslint": "eslint 'src/**/*.ts'",
+    "eslint": "eslint $(git diff --name-only 6dba118d780aa19939edf0f52a4a48e6e5e17477..HEAD) --ignore-pattern package.json",
     "typecheck": "bash bin/typecheck.sh",
     "watch": "tsc -w"
   },

--- a/src/commands/git-metadata/__tests__/git.test.ts
+++ b/src/commands/git-metadata/__tests__/git.test.ts
@@ -14,7 +14,7 @@ const createMockSimpleGit = (conf: MockConfig) => ({
       throw Error('Unexpected call to getRemotes')
     }
 
-    return conf.remotes!
+    return conf.remotes
   },
   raw: async (command: string) => {
     if (command === 'ls-files' && conf.trackedFiles !== undefined) {
@@ -27,7 +27,7 @@ const createMockSimpleGit = (conf: MockConfig) => ({
       throw Error('Unexpected call to revparse')
     }
 
-    return conf.hash!
+    return conf.hash
   },
 })
 
@@ -95,9 +95,9 @@ describe('git', () => {
       const commitInfo = await getCommitInfo(mock)
 
       expect(commitInfo).toBeDefined()
-      expect(commitInfo!.hash).toBe('abcd')
-      expect(commitInfo!.trackedFiles).toStrictEqual(['myfile.js'])
-      expect(commitInfo!.remote).toBe('https://git-repo/')
+      expect(commitInfo.hash).toBe('abcd')
+      expect(commitInfo.trackedFiles).toStrictEqual(['myfile.js'])
+      expect(commitInfo.remote).toBe('https://git-repo/')
     })
     test('should return commit info with overridden repo name', async () => {
       const mock = createMockSimpleGit({
@@ -107,9 +107,9 @@ describe('git', () => {
       const commitInfo = await getCommitInfo(mock, 'https://overridden')
 
       expect(commitInfo).toBeDefined()
-      expect(commitInfo!.hash).toBe('abcd')
-      expect(commitInfo!.trackedFiles).toStrictEqual(['myfile.js'])
-      expect(commitInfo!.remote).toBe('https://overridden')
+      expect(commitInfo.hash).toBe('abcd')
+      expect(commitInfo.trackedFiles).toStrictEqual(['myfile.js'])
+      expect(commitInfo.remote).toBe('https://overridden')
     })
   })
 

--- a/src/commands/git-metadata/__tests__/upload.test.ts
+++ b/src/commands/git-metadata/__tests__/upload.test.ts
@@ -1,4 +1,3 @@
-// tslint:disable: no-string-literal
 import os from 'os'
 
 import chalk from 'chalk'

--- a/src/commands/git-metadata/git.ts
+++ b/src/commands/git-metadata/git.ts
@@ -1,5 +1,5 @@
-import * as simpleGit from 'simple-git'
 import {URL} from 'url'
+import * as simpleGit from 'simple-git'
 
 import {CommitInfo} from './interfaces'
 

--- a/src/commands/git-metadata/upload.ts
+++ b/src/commands/git-metadata/upload.ts
@@ -131,7 +131,7 @@ export class UploadCommand extends Command {
     }
 
     return getRequestBuilder({
-      apiKey: this.config.apiKey!,
+      apiKey: this.config.apiKey,
       baseUrl: getBaseIntakeUrl(),
       headers: new Map([
         ['DD-EVP-ORIGIN', 'datadog-ci git-metadata'],

--- a/src/commands/sourcemaps/__tests__/upload.test.ts
+++ b/src/commands/sourcemaps/__tests__/upload.test.ts
@@ -1,4 +1,3 @@
-// tslint:disable: no-string-literal
 import os from 'os'
 
 import chalk from 'chalk'

--- a/src/commands/sourcemaps/interfaces.ts
+++ b/src/commands/sourcemaps/interfaces.ts
@@ -39,13 +39,13 @@ export class Sourcemap {
       ['source_map', {value: fs.createReadStream(this.sourcemapPath), options: {filename: 'source_map'}}],
       ['minified_file', {value: fs.createReadStream(this.minifiedFilePath), options: {filename: 'minified_file'}}],
     ])
-    if (this.gitData !== undefined && this.gitData!.gitRepositoryPayload !== undefined) {
+    if (this.gitData !== undefined && this.gitData.gitRepositoryPayload !== undefined) {
       content.set('repository', {
         options: {
           contentType: 'application/json',
           filename: 'repository',
         },
-        value: this.gitData!.gitRepositoryPayload,
+        value: this.gitData.gitRepositoryPayload,
       })
     }
 
@@ -69,8 +69,8 @@ export class Sourcemap {
       version,
     }
     if (this.gitData !== undefined) {
-      metadata.git_repository_url = this.gitData!.gitRepositoryURL
-      metadata.git_commit_sha = this.gitData!.gitCommitSha
+      metadata.git_repository_url = this.gitData.gitRepositoryURL
+      metadata.git_commit_sha = this.gitData.gitCommitSha
     }
 
     return {

--- a/src/commands/sourcemaps/upload.ts
+++ b/src/commands/sourcemaps/upload.ts
@@ -1,9 +1,9 @@
+import path from 'path'
+import {URL} from 'url'
 import chalk from 'chalk'
 import {Command} from 'clipanion'
 import glob from 'glob'
-import path from 'path'
 import asyncPool from 'tiny-async-pool'
-import {URL} from 'url'
 
 import {ApiKeyValidator, newApiKeyValidator} from '../../helpers/apikey'
 import {getBaseSourcemapIntakeUrl} from '../../helpers/base-intake-url'
@@ -12,7 +12,7 @@ import {getRepositoryData, newSimpleGit, RepositoryData} from '../../helpers/git
 import {RequestBuilder} from '../../helpers/interfaces'
 import {getMetricsLogger, MetricsLogger} from '../../helpers/metrics'
 import {upload, UploadStatus} from '../../helpers/upload'
-import {getRequestBuilder} from '../../helpers/utils'
+import {getRequestBuilder, buildPath} from '../../helpers/utils'
 import {Sourcemap} from './interfaces'
 import {
   renderCommandInfo,
@@ -28,8 +28,6 @@ import {
 } from './renderer'
 import {getMinifiedFilePath} from './utils'
 import {InvalidPayload, validatePayload} from './validation'
-
-import {buildPath} from '../../helpers/utils'
 
 export class UploadCommand extends Command {
   public static usage = Command.Usage({
@@ -100,7 +98,7 @@ export class UploadCommand extends Command {
     this.basePath = path.posix.normalize(this.basePath!)
     this.context.stdout.write(
       renderCommandInfo(
-        this.basePath!,
+        this.basePath,
         this.minifiedPathPrefix,
         this.projectPath,
         this.releaseVersion,
@@ -154,7 +152,7 @@ export class UploadCommand extends Command {
       const repositoryData = await getRepositoryData(await newSimpleGit(), this.repositoryURL)
       await Promise.all(
         payloads.map(async (payload) => {
-          const repositoryPayload = this.getRepositoryPayload(repositoryData!, payload.sourcemapPath)
+          const repositoryPayload = this.getRepositoryPayload(repositoryData, payload.sourcemapPath)
           payload.addRepositoryData({
             gitCommitSha: repositoryData.hash,
             gitRepositoryPayload: repositoryPayload,
@@ -237,7 +235,7 @@ export class UploadCommand extends Command {
     }
 
     return getRequestBuilder({
-      apiKey: this.config.apiKey!,
+      apiKey: this.config.apiKey,
       baseUrl: getBaseSourcemapIntakeUrl(this.config.datadogSite),
       headers: new Map([
         ['DD-EVP-ORIGIN', 'datadog-ci sourcemaps'],

--- a/src/commands/sourcemaps/validation.ts
+++ b/src/commands/sourcemaps/validation.ts
@@ -40,7 +40,7 @@ export const validatePayload = (sourcemap: Sourcemap, stdout: Writable) => {
 
   // Check for --minified-path-prefix flag misuages.
   if (sourcemap.minifiedPathPrefix) {
-    const repeated = extractRepeatedPath(sourcemap.minifiedPathPrefix!, sourcemap.relativePath)
+    const repeated = extractRepeatedPath(sourcemap.minifiedPathPrefix, sourcemap.relativePath)
     if (repeated) {
       stdout.write(renderMinifiedPathPrefixMisusage(sourcemap, repeated))
     }


### PR DESCRIPTION
### What and why?

Related to https://github.com/DataDog/datadog-ci/pull/666.

Mostly import rearrangements, and non-null assertion operator deletions since TypeScript type inference improved over the time.

### Review checklist

You can **ignore the change in `package.json`**: it is **temporary** and here to make the CI pass on this PR. It will be removed once merged in #666.

- [ ] Ensure nothing is broken in your team scope
