### PR TITLE
[lint][serverless] Migrate to `eslint`

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "test": "jest --colors",
     "test:debug": "node --inspect-brk `which jest` --runInBand",
     "test:ci-vis:itr": "jest --colors --config ./jest.config-ci-vis-itr.js --passWithNoTests",
-    "eslint": "eslint 'src/**/*.ts'",
+    "eslint": "eslint $(git diff --name-only 6dba118d780aa19939edf0f52a4a48e6e5e17477..HEAD) --ignore-pattern package.json",
     "typecheck": "bash bin/typecheck.sh",
     "watch": "tsc -w"
   },

--- a/src/commands/lambda/__tests__/fixtures.ts
+++ b/src/commands/lambda/__tests__/fixtures.ts
@@ -55,7 +55,7 @@ export const makeMockLambda = (
   })),
   getLayerVersion: jest.fn().mockImplementation(({LayerName, VersionNumber}) => ({
     promise: () => {
-      const layer = LayerName + ':' + VersionNumber
+      const layer = `${LayerName}:${VersionNumber}`
 
       return layers && layers[layer] && layers[layer].Version === VersionNumber
         ? Promise.resolve(layers[layer])

--- a/src/commands/lambda/__tests__/functions/commons.test.ts
+++ b/src/commands/lambda/__tests__/functions/commons.test.ts
@@ -1,7 +1,5 @@
-/* tslint:disable:no-string-literal */
-import {config as aws_sdk_config, Credentials} from 'aws-sdk'
+import {config as aws_sdk_config, Credentials, Lambda} from 'aws-sdk'
 jest.mock('aws-sdk')
-import {Lambda} from 'aws-sdk'
 import {
   AWS_ACCESS_KEY_ID_ENV_VAR,
   AWS_SECRET_ACCESS_KEY_ENV_VAR,

--- a/src/commands/lambda/__tests__/functions/uninstrument.test.ts
+++ b/src/commands/lambda/__tests__/functions/uninstrument.test.ts
@@ -66,7 +66,7 @@ describe('uninstrument', () => {
         lambda as any,
         'arn:aws:lambda:us-east-1:000000000000:function:uninstrument'
       )
-      const updateRequest = await calculateUpdateRequest(config, config!.Runtime as any)
+      const updateRequest = calculateUpdateRequest(config, config.Runtime as any)
       expect(updateRequest).toMatchInlineSnapshot(`
         Object {
           "Environment": Object {
@@ -97,7 +97,7 @@ describe('uninstrument', () => {
         lambda as any,
         'arn:aws:lambda:us-east-1:000000000000:function:uninstrument'
       )
-      const updateRequest = await calculateUpdateRequest(config, config!.Runtime as any)
+      const updateRequest = calculateUpdateRequest(config, config.Runtime as any)
       expect(updateRequest).toMatchInlineSnapshot(`
         Object {
           "Environment": Object {
@@ -140,7 +140,7 @@ describe('uninstrument', () => {
         lambda as any,
         'arn:aws:lambda:us-east-1:000000000000:function:uninstrument'
       )
-      const updateRequest = await calculateUpdateRequest(config, config!.Runtime as any)
+      const updateRequest = calculateUpdateRequest(config, config.Runtime as any)
       expect(updateRequest).toMatchInlineSnapshot(`
         Object {
           "Environment": Object {

--- a/src/commands/lambda/__tests__/instrument.test.ts
+++ b/src/commands/lambda/__tests__/instrument.test.ts
@@ -1,11 +1,10 @@
-// tslint:disable: no-string-literal
 jest.mock('fs')
 jest.mock('aws-sdk')
 jest.mock('../prompt')
-import {Lambda} from 'aws-sdk'
-import {Cli} from 'clipanion/lib/advanced'
 import * as fs from 'fs'
 import path from 'path'
+import {Lambda} from 'aws-sdk'
+import {Cli} from 'clipanion/lib/advanced'
 import {
   AWS_ACCESS_KEY_ID_ENV_VAR,
   AWS_DEFAULT_REGION_ENV_VAR,
@@ -39,7 +38,6 @@ import {
   mockDatadogService,
   mockDatadogVersion,
 } from './fixtures'
-// tslint:disable-next-line
 const {version} = require(path.join(__dirname, '../../../../package.json'))
 describe('lambda', () => {
   describe('instrument', () => {
@@ -1713,7 +1711,7 @@ Fetching Lambda functions, this might take a while.
         let command = createCommand(InstrumentCommand)
         command['config']['region'] = 'ap-southeast-1'
         command['config']['functions'] = ['arn:aws:lambda:ap-southeast-1:123456789012:function:lambda-hello-world']
-        await command['getSettings']()
+        command['getSettings']()
         let output = command.context.stdout.toString()
         expect(output).toMatch(
           '[Warning] The environment, service and version tags have not been configured. Learn more about Datadog unified service tagging: https://docs.datadoghq.com/getting_started/tagging/unified_service_tagging/#serverless-environment.\n'
@@ -1724,7 +1722,7 @@ Fetching Lambda functions, this might take a while.
         command['config']['functions'] = ['arn:aws:lambda:ap-southeast-1:123456789012:function:lambda-hello-world']
         command['config']['environment'] = 'b'
         command['config']['service'] = 'middletier'
-        await command['getSettings']()
+        command['getSettings']()
         output = command.context.stdout.toString()
         expect(output).toMatch(
           '[Warning] The version tag has not been configured. Learn more about Datadog unified service tagging: https://docs.datadoghq.com/getting_started/tagging/unified_service_tagging/#serverless-environment.\n'
@@ -1742,7 +1740,7 @@ Fetching Lambda functions, this might take a while.
         command['config']['environment'] = 'staging'
         command['config']['version'] = '0.2'
         command['config']['extraTags'] = 'not-complying:illegal-chars-in-key,complies:valid-pair'
-        await command['getSettings']()
+        command['getSettings']()
         const output = command.context.stdout.toString()
         expect(output).toMatch('Extra tags do not comply with the <key>:<value> array.\n')
       })

--- a/src/commands/lambda/__tests__/prompt.test.ts
+++ b/src/commands/lambda/__tests__/prompt.test.ts
@@ -23,51 +23,51 @@ import {mockAwsAccessKeyId, mockAwsSecretAccessKey, mockDatadogApiKey} from './f
 
 describe('prompt', () => {
   describe('confirmationQuestion', () => {
-    test('returns question with provided message', () => {
+    test('returns question with provided message', async () => {
       const message = 'Do you want to continue?'
       const question = confirmationQuestion(message)
-      expect(question.message).toBe(message)
+      expect(await question.message).toBe(message)
     })
   })
 
   describe('datadogApiKeyTypeQuestion', () => {
-    test('returns question with message pointing to the correct given site', () => {
+    test('returns question with message pointing to the correct given site', async () => {
       const site = 'datadoghq.com'
       const question = datadogApiKeyTypeQuestion(site)
-      expect(question.message).toBe(
+      expect(await question.message).toBe(
         `Which type of Datadog API Key you want to set? \nLearn more at https://app.${site}/organization-settings/api-keys`
       )
     })
   })
 
   describe('datadogEnvVarsQuestions', () => {
-    test('returns correct message when user selects DATADOG_API_KEY', () => {
+    test('returns correct message when user selects DATADOG_API_KEY', async () => {
       const datadogApiKeyType = {
         envVar: CI_API_KEY_ENV_VAR,
         message: 'API Key:',
       }
       const question = datadogEnvVarsQuestions(datadogApiKeyType)
-      expect(question.message).toBe('API Key:')
+      expect(await question.message).toBe('API Key:')
       expect(question.name).toBe(CI_API_KEY_ENV_VAR)
     })
 
-    test('returns correct message when user selects DATADOG_KMS_API_KEY', () => {
+    test('returns correct message when user selects DATADOG_KMS_API_KEY', async () => {
       const datadogApiKeyType = {
         envVar: CI_KMS_API_KEY_ENV_VAR,
         message: 'KMS API Key:',
       }
       const question = datadogEnvVarsQuestions(datadogApiKeyType)
-      expect(question.message).toBe('KMS API Key:')
+      expect(await question.message).toBe('KMS API Key:')
       expect(question.name).toBe(CI_KMS_API_KEY_ENV_VAR)
     })
 
-    test('returns correct message when user selects DATADOG_API_KEY_SECRET_ARN', () => {
+    test('returns correct message when user selects DATADOG_API_KEY_SECRET_ARN', async () => {
       const datadogApiKeyType = {
         envVar: CI_API_KEY_SECRET_ARN_ENV_VAR,
         message: 'API Key Secret ARN:',
       }
       const question = datadogEnvVarsQuestions(datadogApiKeyType)
-      expect(question.message).toBe('API Key Secret ARN:')
+      expect(await question.message).toBe('API Key Secret ARN:')
       expect(question.name).toBe(CI_API_KEY_SECRET_ARN_ENV_VAR)
     })
   })

--- a/src/commands/lambda/__tests__/tags.test.ts
+++ b/src/commands/lambda/__tests__/tags.test.ts
@@ -4,7 +4,6 @@ import path from 'path'
 import {Lambda} from 'aws-sdk'
 import {TAG_VERSION_NAME} from '../constants'
 import {applyTagConfig, calculateTagRemoveRequest, calculateTagUpdateRequest, hasVersionTag} from '../tags'
-// tslint:disable-next-line
 const {version} = require(path.join(__dirname, '../../../../package.json'))
 
 const makeMockLambda = (

--- a/src/commands/lambda/__tests__/uninstrument.test.ts
+++ b/src/commands/lambda/__tests__/uninstrument.test.ts
@@ -1,9 +1,8 @@
-// tslint:disable: no-string-literal
 jest.mock('fs')
 jest.mock('aws-sdk')
 jest.mock('../prompt')
-import {Lambda} from 'aws-sdk'
 import * as fs from 'fs'
+import {Lambda} from 'aws-sdk'
 
 import {
   AWS_ACCESS_KEY_ID_ENV_VAR,

--- a/src/commands/lambda/constants.ts
+++ b/src/commands/lambda/constants.ts
@@ -112,8 +112,8 @@ export const MAX_LAMBDA_STATE_CHECK_ATTEMPTS = 3
 // This RegExp ensures that the --extra-tags string
 // matches a list of <key>:<value> separated by commas
 // such as: layer:api,team:intake
-export const EXTRA_TAGS_REG_EXP: RegExp = /^(([a-zA-Z]+)\w+:[\w\-/\.]+)+((\,)([a-zA-Z]+)\w+:[\w\-/\.]+)*$/g
-export const AWS_ACCESS_KEY_ID_REG_EXP: RegExp = /(?<![A-Z0-9])[A-Z0-9]{20}(?![A-Z0-9])/g
-export const AWS_SECRET_ACCESS_KEY_REG_EXP: RegExp = /(?<![A-Za-z0-9/+=])[A-Za-z0-9/+=]{40}(?![A-Za-z0-9/+=])/g
-export const DATADOG_API_KEY_REG_EXP: RegExp = /(?<![a-f0-9])[a-f0-9]{32}(?![a-f0-9])/g
-export const DATADOG_APP_KEY_REG_EXP: RegExp = /(?<![a-f0-9])[a-f0-9]{40}(?![a-f0-9])/g
+export const EXTRA_TAGS_REG_EXP = /^(([a-zA-Z]+)\w+:[\w\-/\.]+)+((\,)([a-zA-Z]+)\w+:[\w\-/\.]+)*$/g
+export const AWS_ACCESS_KEY_ID_REG_EXP = /(?<![A-Z0-9])[A-Z0-9]{20}(?![A-Z0-9])/g
+export const AWS_SECRET_ACCESS_KEY_REG_EXP = /(?<![A-Za-z0-9/+=])[A-Za-z0-9/+=]{40}(?![A-Za-z0-9/+=])/g
+export const DATADOG_API_KEY_REG_EXP = /(?<![a-f0-9])[a-f0-9]{32}(?![a-f0-9])/g
+export const DATADOG_APP_KEY_REG_EXP = /(?<![a-f0-9])[a-f0-9]{40}(?![a-f0-9])/g

--- a/src/commands/lambda/functions/commons.ts
+++ b/src/commands/lambda/functions/commons.ts
@@ -137,7 +137,7 @@ export const findLatestLayerVersion = async (layer: LayerKey, region: string) =>
       latestVersion = layerVersion
       // Increase layer version
       layerVersion += searchStep
-    } catch (e) {
+    } catch {
       // Search step is too big, reset target to previous version
       // with a smaller search step
       if (searchStep > 1) {
@@ -160,7 +160,7 @@ export const findLatestLayerVersion = async (layer: LayerKey, region: string) =>
           latestVersion = layerVersion
           // Continue the search if the next version does exist (unlikely event)
           layerVersion += searchStep
-        } catch (e) {
+        } catch {
           // The next version doesn't exist either, so the previous version is indeed the latest
           foundLatestVersion = true
         }

--- a/src/commands/lambda/functions/instrument.ts
+++ b/src/commands/lambda/functions/instrument.ts
@@ -243,7 +243,7 @@ export const calculateUpdateRequest = async (
     oldEnvVars[FLUSH_TO_LOG_ENV_VAR] !== settings.flushMetricsToLogs?.toString()
   ) {
     needsUpdate = true
-    changedEnvVars[FLUSH_TO_LOG_ENV_VAR] = settings.flushMetricsToLogs!.toString()
+    changedEnvVars[FLUSH_TO_LOG_ENV_VAR] = settings.flushMetricsToLogs.toString()
   }
 
   const newEnvVars = {...oldEnvVars, ...changedEnvVars}

--- a/src/commands/lambda/instrument.ts
+++ b/src/commands/lambda/instrument.ts
@@ -200,12 +200,12 @@ export class InstrumentCommand extends Command {
         const configs = await getInstrumentedFunctionConfigsFromRegEx(
           lambda,
           cloudWatchLogs,
-          region!,
+          region,
           this.regExPattern!,
           settings
         )
 
-        configGroups.push({configs, lambda, cloudWatchLogs, region: region!})
+        configGroups.push({configs, lambda, cloudWatchLogs, region})
       } catch (err) {
         this.context.stdout.write(`${red('[Error]')} Couldn't fetch Lambda functions. ${err}\n`)
 

--- a/src/commands/lambda/prompt.ts
+++ b/src/commands/lambda/prompt.ts
@@ -1,5 +1,6 @@
 import {blueBright, bold} from 'chalk'
 import inquirer from 'inquirer'
+import {filter} from 'fuzzy'
 import {
   AWS_ACCESS_KEY_ID_ENV_VAR,
   AWS_ACCESS_KEY_ID_REG_EXP,
@@ -18,10 +19,10 @@ import {
   VERSION_ENV_VAR,
 } from './constants'
 import {sentenceMatchesRegEx} from './functions/commons'
-/* tslint:disable-next-line */
+
 const checkboxPlusPrompt = require('inquirer-checkbox-plus-prompt')
 inquirer.registerPrompt('checkbox-plus', checkboxPlusPrompt)
-import {filter} from 'fuzzy'
+
 const awsCredentialsQuestions: inquirer.QuestionCollection = [
   {
     // AWS_ACCESS_KEY_ID question

--- a/src/commands/lambda/tags.ts
+++ b/src/commands/lambda/tags.ts
@@ -2,7 +2,6 @@ import {Lambda} from 'aws-sdk'
 import {TAG_VERSION_NAME} from './constants'
 import {TagConfiguration} from './interfaces'
 
-// tslint:disable-next-line
 const {version} = require('../../../package.json')
 
 export const applyTagConfig = async (lambda: Lambda, config: TagConfiguration) => {

--- a/src/commands/lambda/uninstrument.ts
+++ b/src/commands/lambda/uninstrument.ts
@@ -120,7 +120,7 @@ export class UninstrumentCommand extends Command {
           lambda,
           cloudWatchLogs,
           this.regExPattern!,
-          this.forwarder!
+          this.forwarder
         )
 
         configGroups.push({configs, lambda, cloudWatchLogs})
@@ -173,9 +173,9 @@ export class UninstrumentCommand extends Command {
     }
 
     // Un-instrument functions.
-    const promises = Object.values(configGroups).map((group) => {
+    const promises = Object.values(configGroups).map((group) =>
       updateLambdaFunctionConfigs(group.lambda, group.cloudWatchLogs, group.configs)
-    })
+    )
 
     try {
       await Promise.all(promises)


### PR DESCRIPTION
### What and why?

Related to https://github.com/DataDog/datadog-ci/pull/666.

Mostly import rearrangements, and non-null assertion operator deletions since TypeScript type inference improved over the time.

### Review checklist

You can **ignore the change in `package.json`**: it is **temporary** and here to make the CI pass on this PR. It will be removed once merged in #666.

- [ ] Ensure nothing is broken in your team scope
