### PR TITLE
[lint][rum-mobile] Migrate to `eslint`

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "test": "jest --colors",
     "test:debug": "node --inspect-brk `which jest` --runInBand",
     "test:ci-vis:itr": "jest --colors --config ./jest.config-ci-vis-itr.js --passWithNoTests",
-    "eslint": "eslint 'src/**/*.ts'",
+    "eslint": "eslint $(git diff --name-only 6dba118d780aa19939edf0f52a4a48e6e5e17477..HEAD) --ignore-pattern package.json",
     "typecheck": "bash bin/typecheck.sh",
     "watch": "tsc -w"
   },

--- a/src/commands/dsyms/__tests__/upload.test.ts
+++ b/src/commands/dsyms/__tests__/upload.test.ts
@@ -1,9 +1,8 @@
-// tslint:disable: no-string-literal
-import {Cli} from 'clipanion/lib/advanced'
 import {existsSync, promises} from 'fs'
-import glob from 'glob'
 import {EOL, platform} from 'os'
 import path from 'path'
+import glob from 'glob'
+import {Cli} from 'clipanion/lib/advanced'
 import {buildPath} from '../../../helpers/utils'
 import {Dsym} from '../interfaces'
 import {UploadCommand} from '../upload'

--- a/src/commands/dsyms/renderer.ts
+++ b/src/commands/dsyms/renderer.ts
@@ -1,6 +1,6 @@
+import path from 'path'
 import chalk from 'chalk'
 
-import path from 'path'
 import {ICONS} from '../../helpers/formatting'
 import {UploadStatus} from '../../helpers/upload'
 import {ArchSlice, CompressedDsym, Dsym} from './interfaces'

--- a/src/commands/dsyms/upload.ts
+++ b/src/commands/dsyms/upload.ts
@@ -1,8 +1,8 @@
+import {promises} from 'fs'
+import path from 'path'
 import chalk from 'chalk'
 import {Command} from 'clipanion'
-import {promises} from 'fs'
 import glob from 'glob'
-import path from 'path'
 import asyncPool from 'tiny-async-pool'
 
 import {ApiKeyValidator, newApiKeyValidator} from '../../helpers/apikey'
@@ -169,7 +169,7 @@ export class UploadCommand extends Command {
     }
 
     return getRequestBuilder({
-      apiKey: this.config.apiKey!,
+      apiKey: this.config.apiKey,
       baseUrl: getBaseIntakeUrl(this.config.datadogSite),
     })
   }

--- a/src/commands/dsyms/utils.ts
+++ b/src/commands/dsyms/utils.ts
@@ -2,8 +2,8 @@ import {exec} from 'child_process'
 import {promises} from 'fs'
 import {tmpdir} from 'os'
 import path from 'path'
-import rimraf from 'rimraf'
 import {promisify} from 'util'
+import rimraf from 'rimraf'
 
 import {buildPath} from '../../helpers/utils'
 

--- a/src/commands/flutter-symbols/__tests__/upload.test.ts
+++ b/src/commands/flutter-symbols/__tests__/upload.test.ts
@@ -1,10 +1,8 @@
-// tslint:disable: no-string-literal
 import {ReadStream} from 'fs'
 
 import FormData from 'form-data'
 
-import {TrackedFilesMatcher} from '../../../helpers/git/format-git-sourcemaps-data'
-import {getRepositoryData} from '../../../helpers/git/format-git-sourcemaps-data'
+import {TrackedFilesMatcher, getRepositoryData} from '../../../helpers/git/format-git-sourcemaps-data'
 import {MultipartPayload} from '../../../helpers/upload'
 import {performSubCommand} from '../../../helpers/utils'
 import * as dsyms from '../..//dsyms/upload'
@@ -35,7 +33,6 @@ jest.mock('../../../helpers/git/format-git-sourcemaps-data', () => ({
   getRepositoryData: jest.fn(),
 }))
 
-// tslint:disable-next-line:no-var-requires
 const cliVersion = require('../../../../package.json').version
 const fixtureDir = './src/commands/flutter-symbols/__tests__/fixtures'
 
@@ -78,7 +75,6 @@ describe('flutter-symbol upload', () => {
 
   describe('parameter validation', () => {
     test('fails if no service name given', async () => {
-      // tslint:disable-next-line:no-empty
       const {exitCode, context} = await runCommand((_) => {})
       const errorOutput = context.stderr.toString()
 

--- a/src/commands/flutter-symbols/upload.ts
+++ b/src/commands/flutter-symbols/upload.ts
@@ -6,7 +6,7 @@ import yaml from 'js-yaml'
 import semver from 'semver'
 import asyncPool from 'tiny-async-pool'
 
-import {ApiKeyValidator, newApiKeyValidator} from '../../helpers/apikey'
+import {newApiKeyValidator} from '../../helpers/apikey'
 import {getRepositoryData, RepositoryData} from '../../helpers/git/format-git-sourcemaps-data'
 import {getMetricsLogger, MetricsLogger} from '../../helpers/metrics'
 import {MultipartValue, UploadStatus} from '../../helpers/upload'
@@ -94,21 +94,21 @@ export class UploadCommand extends Command {
     if (this.iosDsymsLocation) {
       uploadInfo.push({
         fileType: 'dSYMs',
-        location: this.iosDsymsLocation!,
+        location: this.iosDsymsLocation,
         platform: 'ios',
       })
     }
     if (this.androidMappingLocation) {
       uploadInfo.push({
         fileType: 'Proguard Mapping File',
-        location: this.androidMappingLocation!,
+        location: this.androidMappingLocation,
         platform: 'Android',
       })
     }
     if (this.dartSymbolsLocation) {
       uploadInfo.push({
         fileType: 'Dart Symbol Files',
-        location: this.dartSymbolsLocation!,
+        location: this.dartSymbolsLocation,
         platform: 'Flutter',
       })
     }
@@ -337,7 +337,7 @@ export class UploadCommand extends Command {
         }
 
         if (this.dryRun) {
-          this.context.stdout.write(`[DRYRUN] ${renderUpload('Dart Symbol File', fileMetadata.filename!)}`)
+          this.context.stdout.write(`[DRYRUN] ${renderUpload('Dart Symbol File', fileMetadata.filename)}`)
 
           return UploadStatus.Success
         }
@@ -359,7 +359,7 @@ export class UploadCommand extends Command {
         return uploadMultipartHelper(requestBuilder, payload, {
           apiKeyValidator,
           onError: (e) => {
-            this.context.stdout.write(renderFailedUpload(fileMetadata.filename!, e.message))
+            this.context.stdout.write(renderFailedUpload(fileMetadata.filename, e.message))
             metricsLogger.logger.increment('failed', 1)
           },
           onRetry: (e, attempts) => {

--- a/src/commands/react-native/__tests__/codepush.test.ts
+++ b/src/commands/react-native/__tests__/codepush.test.ts
@@ -1,6 +1,5 @@
-// tslint:disable: no-string-literal
-import {Cli} from 'clipanion/lib/advanced'
 import {readFileSync} from 'fs'
+import {Cli} from 'clipanion/lib/advanced'
 import {CodepushCommand} from '../codepush'
 
 jest.mock('child_process', () => ({

--- a/src/commands/react-native/__tests__/upload.test.ts
+++ b/src/commands/react-native/__tests__/upload.test.ts
@@ -1,4 +1,3 @@
-// tslint:disable: no-string-literal
 import os from 'os'
 
 import chalk from 'chalk'

--- a/src/commands/react-native/__tests__/xcode.test.ts
+++ b/src/commands/react-native/__tests__/xcode.test.ts
@@ -1,4 +1,3 @@
-// tslint:disable: no-string-literal
 import {Cli} from 'clipanion/lib/advanced'
 import {XCodeCommand} from '../xcode'
 

--- a/src/commands/react-native/errors.ts
+++ b/src/commands/react-native/errors.ts
@@ -1,4 +1,3 @@
-/* tslint:disable:max-classes-per-file */
 export class NoCodepushReleaseError extends Error {
   constructor(appCenterAppName: string, appCenterDeployment: string) {
     super(`No codepush release has been created yet for ${appCenterAppName} ${appCenterDeployment}`)
@@ -13,19 +12,21 @@ export class CodepushHistoryParseError extends Error {
 
 export class CodepushHistoryCommandError extends Error {
   constructor(message: string, command: string) {
+    let errorMessage: string
     try {
-      const commandMessage: string = JSON.parse(message).errorMessage
+      errorMessage = JSON.parse(message).errorMessage
       // Error returned when there is no network
-      if (commandMessage.match('Cannot read properties of undefined')) {
+      if (errorMessage.match('Cannot read properties of undefined')) {
         super(
           `You need to have network access to be able to get the latest codepush label.\nCheck that ${command} returns a correct value.\nAlternatively, you can directly use the "datadog-ci react-native upload" command to upload your sourcemaps with the correct release version.`
         )
 
         return
       }
-      super(commandMessage)
     } catch (e) {
-      super(message)
+      errorMessage = message
     }
+
+    super(errorMessage)
   }
 }

--- a/src/commands/react-native/interfaces.ts
+++ b/src/commands/react-native/interfaces.ts
@@ -31,13 +31,13 @@ export class RNSourcemap {
       ['source_map', {value: fs.createReadStream(this.sourcemapPath), options: {filename: 'source_map'}}],
       ['minified_file', {value: fs.createReadStream(this.bundlePath), options: {filename: 'minified_file'}}],
     ])
-    if (this.gitData !== undefined && this.gitData!.gitRepositoryPayload !== undefined) {
+    if (this.gitData !== undefined && this.gitData.gitRepositoryPayload !== undefined) {
       content.set('repository', {
         options: {
           contentType: 'application/json',
           filename: 'repository',
         },
-        value: this.gitData!.gitRepositoryPayload,
+        value: this.gitData.gitRepositoryPayload,
       })
     }
 

--- a/src/commands/react-native/upload.ts
+++ b/src/commands/react-native/upload.ts
@@ -183,7 +183,7 @@ export class UploadCommand extends Command {
     try {
       const repositoryData = await getRepositoryData(await newSimpleGit(), this.repositoryURL)
       payloads.forEach((payload) => {
-        const repositoryPayload = this.getRepositoryPayload(repositoryData!, payload.sourcemapPath)
+        const repositoryPayload = this.getRepositoryPayload(repositoryData, payload.sourcemapPath)
         payload.addRepositoryData({
           gitCommitSha: repositoryData.hash,
           gitRepositoryPayload: repositoryPayload,
@@ -248,7 +248,7 @@ export class UploadCommand extends Command {
     }
 
     return getRequestBuilder({
-      apiKey: this.config.apiKey!,
+      apiKey: this.config.apiKey,
       baseUrl: getBaseSourcemapIntakeUrl(this.config.datadogSite),
       headers: new Map([
         ['DD-EVP-ORIGIN', 'datadog-ci react-native'],

--- a/src/commands/react-native/xcode.ts
+++ b/src/commands/react-native/xcode.ts
@@ -1,8 +1,7 @@
-// tslint:disable: no-null-keyword
 import {spawn} from 'child_process'
-import {Cli, Command} from 'clipanion'
 import {existsSync} from 'fs'
 import {sep} from 'path'
+import {Cli, Command} from 'clipanion'
 import {UploadCommand} from './upload'
 
 /**


### PR DESCRIPTION
### What and why?

Related to https://github.com/DataDog/datadog-ci/pull/666.

Mostly import rearrangements, and non-null assertion operator deletions since TypeScript type inference improved over the time.

### Review checklist

You can **ignore the change in `package.json`**: it is **temporary** and here to make the CI pass on this PR. It will be removed once merged in #666.

- [ ] Ensure nothing is broken in your team scope
