### PR TITLE
[synthetics] Improve context on API errors

### DIFF
--- a/src/commands/synthetics/__tests__/api.test.ts
+++ b/src/commands/synthetics/__tests__/api.test.ts
@@ -10,6 +10,7 @@ import {APIConfiguration, ExecutionRule, PollResult, ServerResult, TestPayload, 
 import {
   ciConfig,
   getApiTest,
+  getAxiosHttpError,
   getSyntheticsProxy,
   MOBILE_PRESIGNED_URL_PAYLOAD,
   mockSearchResponse,
@@ -301,39 +302,26 @@ describe('getApiHelper', () => {
 
 describe('formatBackendErrors', () => {
   test('backend error - no error', () => {
-    const backendError = {
-      config: {baseURL: 'baseURL', url: 'url'},
-      response: {data: {errors: []}},
-    } as AxiosError
-
-    expect(formatBackendErrors(backendError)).toBe('error querying baseURLurl')
+    const backendError = getAxiosHttpError(500, {errors: []})
+    expect(formatBackendErrors(backendError)).toBe('error querying https://app.datadoghq.com/example')
   })
 
   test('backend error - single error', () => {
-    const backendError = {
-      config: {baseURL: 'baseURL', url: 'url'},
-      response: {data: {errors: ['single error']}},
-    } as AxiosError
-
-    expect(formatBackendErrors(backendError)).toBe('query on baseURLurl returned: "single error"')
+    const backendError = getAxiosHttpError(500, {errors: ['single error']})
+    expect(formatBackendErrors(backendError)).toBe(
+      'query on https://app.datadoghq.com/example returned: "single error"'
+    )
   })
 
   test('backend error - multiple errors', () => {
-    const backendError = {
-      config: {baseURL: 'baseURL', url: 'url'},
-      response: {data: {errors: ['error 1', 'error 2']}},
-    } as AxiosError
-
-    expect(formatBackendErrors(backendError)).toBe('query on baseURLurl returned:\n  - error 1\n  - error 2')
+    const backendError = getAxiosHttpError(500, {errors: ['error 1', 'error 2']})
+    expect(formatBackendErrors(backendError)).toBe(
+      'query on https://app.datadoghq.com/example returned:\n  - error 1\n  - error 2'
+    )
   })
 
   test('not a backend error', () => {
-    const requestError = {
-      config: {baseURL: 'baseURL', url: 'url'},
-      message: 'Forbidden',
-      response: {status: 403},
-    } as AxiosError
-
-    expect(formatBackendErrors(requestError)).toBe('could not query baseURLurl\nForbidden')
+    const requestError = getAxiosHttpError(403, {message: 'Forbidden'})
+    expect(formatBackendErrors(requestError)).toBe('could not query https://app.datadoghq.com/example\nForbidden')
   })
 })

--- a/src/commands/synthetics/__tests__/cli.test.ts
+++ b/src/commands/synthetics/__tests__/cli.test.ts
@@ -1,11 +1,10 @@
 // tslint:disable: no-string-literal
-import {AxiosError, AxiosResponse} from 'axios'
 import {Cli} from 'clipanion/lib/advanced'
 import * as ciUtils from '../../../helpers/utils'
 import * as api from '../api'
 import {DEFAULT_COMMAND_CONFIG, DEFAULT_POLLING_TIMEOUT, RunTestCommand} from '../command'
 import * as utils from '../utils'
-import {getApiTest, getTestSuite, mockTestTriggerResponse} from './fixtures'
+import {getApiTest, getAxiosHttpError, getTestSuite, mockTestTriggerResponse} from './fixtures'
 
 test('all option flags are supported', async () => {
   const options = [
@@ -30,14 +29,6 @@ test('all option flags are supported', async () => {
 
   options.forEach((option) => expect(usage).toContain(`--${option}`))
 })
-
-const getAxiosHttpError = (status: number, error: string) => {
-  const serverError = new Error(error) as AxiosError
-  serverError.response = {data: {errors: [error]}, status} as AxiosResponse
-  serverError.config = {baseURL: 'baseURL', url: 'url'}
-
-  return serverError
-}
 
 describe('run-test', () => {
   beforeEach(() => {
@@ -194,7 +185,7 @@ describe('run-test', () => {
 
       // Throw to stop the test
       const triggerTests = jest.fn(() => {
-        throw getAxiosHttpError(502, 'Bad Gateway')
+        throw getAxiosHttpError(502, {message: 'Bad Gateway'})
       })
 
       const apiHelper = {
@@ -291,7 +282,7 @@ describe('run-test', () => {
 
       const apiHelper = {
         getTest: jest.fn(() => {
-          throw getAxiosHttpError(404, 'Test not found')
+          throw getAxiosHttpError(404, {errors: ['Test not found']})
         }),
       }
       jest.spyOn(api, 'getApiHelper').mockImplementation(() => apiHelper as any)
@@ -315,7 +306,7 @@ describe('run-test', () => {
 
           const apiHelper = {
             searchTests: jest.fn(() => {
-              throw errorCode ? getAxiosHttpError(errorCode, 'Error') : new Error('Unknown error')
+              throw errorCode ? getAxiosHttpError(errorCode, {message: 'Error'}) : new Error('Unknown error')
             }),
           }
           jest.spyOn(api, 'getApiHelper').mockImplementation(() => apiHelper as any)
@@ -332,7 +323,7 @@ describe('run-test', () => {
 
           const apiHelper = {
             getTest: jest.fn(() => {
-              throw errorCode ? getAxiosHttpError(errorCode, 'Error') : new Error('Unknown error')
+              throw errorCode ? getAxiosHttpError(errorCode, {message: 'Error'}) : new Error('Unknown error')
             }),
           }
           jest.spyOn(api, 'getApiHelper').mockImplementation(() => apiHelper as any)
@@ -351,7 +342,7 @@ describe('run-test', () => {
           const apiHelper = {
             getTest: () => getApiTest('123-456-789'),
             triggerTests: jest.fn(() => {
-              throw errorCode ? getAxiosHttpError(errorCode, 'Error') : new Error('Unknown error')
+              throw errorCode ? getAxiosHttpError(errorCode, {message: 'Error'}) : new Error('Unknown error')
             }),
           }
           jest.spyOn(api, 'getApiHelper').mockImplementation(() => apiHelper as any)
@@ -371,7 +362,7 @@ describe('run-test', () => {
             getBatch: () => ({results: [], status: 'success'}),
             getTest: () => getApiTest('123-456-789'),
             pollResults: jest.fn(() => {
-              throw errorCode ? getAxiosHttpError(errorCode, 'Error') : new Error('Unknown error')
+              throw errorCode ? getAxiosHttpError(errorCode, {message: 'Error'}) : new Error('Unknown error')
             }),
             triggerTests: () => mockTestTriggerResponse,
           }
@@ -404,7 +395,7 @@ describe('run-test', () => {
         const apiHelper = {
           getTest: jest.fn((testId: string) => {
             if (testId === 'mis-sin-ggg') {
-              throw getAxiosHttpError(404, 'Test not found')
+              throw getAxiosHttpError(404, {errors: ['Test not found']})
             }
 
             return {}
@@ -438,8 +429,7 @@ describe('run-test', () => {
       const apiHelper = {
         getTest: jest.fn((testId: string) => {
           if (testId === 'for-bid-den') {
-            const serverError = getAxiosHttpError(403, 'Forbidden')
-            serverError.config.baseURL = 'https://api.example.org/'
+            const serverError = getAxiosHttpError(403, {errors: ['Forbidden']})
             serverError.config.url = 'tests/for-bid-den'
             throw serverError
           }
@@ -469,7 +459,7 @@ describe('run-test', () => {
       expect(writeMock).toHaveBeenCalledWith('[aaa-aaa-aaa] Found test "aaa-aaa-aaa" (1 config override)\n')
       expect(writeMock).toHaveBeenCalledWith('[bbb-bbb-bbb] Found test "bbb-bbb-bbb" (1 config override)\n')
       expect(writeMock).toHaveBeenCalledWith(
-        '\n ERROR: authorization error \nFailed to get test: query on https://api.example.org/tests/for-bid-den returned: "Forbidden"\n\n\n'
+        '\n ERROR: authorization error \nFailed to get test: query on https://app.datadoghq.com/tests/for-bid-den returned: "Forbidden"\n\n\n'
       )
       expect(writeMock).toHaveBeenCalledWith(
         'Credentials refused, make sure `apiKey`, `appKey` and `datadogSite` are correct.\n'

--- a/src/commands/synthetics/__tests__/fixtures.ts
+++ b/src/commands/synthetics/__tests__/fixtures.ts
@@ -1,3 +1,4 @@
+import {AxiosError, AxiosResponse} from 'axios'
 import * as http from 'http'
 import {URL} from 'url'
 
@@ -76,6 +77,13 @@ export const ciConfig: CommandConfig = {
   subdomain: 'app',
   tunnel: false,
   variableStrings: [],
+}
+
+export const getAxiosHttpError = (status: number, {errors, message}: {errors?: string[]; message?: string}) => {
+  const serverError = new Error(message) as AxiosError
+  serverError.config = {baseURL: MOCK_BASE_URL, url: 'example'}
+  serverError.response = {data: {errors}, status} as AxiosResponse
+  return serverError
 }
 
 export const getApiTest = (publicId = 'abc-def-ghi', opts: Partial<Test> = {}): Test => ({

--- a/src/commands/synthetics/__tests__/fixtures.ts
+++ b/src/commands/synthetics/__tests__/fixtures.ts
@@ -83,6 +83,7 @@ export const getAxiosHttpError = (status: number, {errors, message}: {errors?: s
   const serverError = new Error(message) as AxiosError
   serverError.config = {baseURL: MOCK_BASE_URL, url: 'example'}
   serverError.response = {data: {errors}, status} as AxiosResponse
+
   return serverError
 }
 

--- a/src/commands/synthetics/__tests__/run-test.test.ts
+++ b/src/commands/synthetics/__tests__/run-test.test.ts
@@ -1,6 +1,5 @@
 // tslint:disable: no-string-literal
 
-import {AxiosError, AxiosResponse} from 'axios'
 import {promises as fs} from 'fs'
 import * as ciUtils from '../../../helpers/utils'
 import * as api from '../api'

--- a/src/commands/synthetics/__tests__/run-test.test.ts
+++ b/src/commands/synthetics/__tests__/run-test.test.ts
@@ -251,7 +251,9 @@ describe('run-test', () => {
         jest.spyOn(api, 'getApiHelper').mockImplementation(() => apiHelper as any)
         await expect(
           runTests.executeTests(mockReporter, {...ciConfig, publicIds: ['public-id-1'], tunnel: true})
-        ).rejects.toMatchError(new CriticalError(error, 'Server Error'))
+        ).rejects.toMatchError(
+          new CriticalError(error, 'Failed to get test: query on baseURLurl returned: "Bad Gateway"\n')
+        )
       })
     })
 

--- a/src/commands/synthetics/__tests__/run-test.test.ts
+++ b/src/commands/synthetics/__tests__/run-test.test.ts
@@ -14,6 +14,7 @@ import {
   ciConfig,
   getApiResult,
   getApiTest,
+  getAxiosHttpError,
   getMobileTest,
   MOBILE_PRESIGNED_URL_PAYLOAD,
   mockReporter,
@@ -225,12 +226,9 @@ describe('run-test', () => {
     ]
     describe.each(cases)('%s triggers %s', (status, error) => {
       test(`getTestsList throws - ${status}`, async () => {
-        const serverError = new Error('Server Error') as AxiosError
-        serverError.response = {data: {errors: ['Error']}, status} as AxiosResponse
-        serverError.config = {baseURL: 'baseURL', url: 'url'}
         const apiHelper = {
           searchTests: jest.fn(() => {
-            throw serverError
+            throw getAxiosHttpError(status, {message: 'Server Error'})
           }),
         }
         jest.spyOn(api, 'getApiHelper').mockImplementation(() => apiHelper as any)
@@ -240,19 +238,19 @@ describe('run-test', () => {
       })
 
       test(`getTestsToTrigger throws - ${status}`, async () => {
-        const serverError = new Error('Server Error') as AxiosError
-        serverError.response = {data: {errors: ['Bad Gateway']}, status} as AxiosResponse
-        serverError.config = {baseURL: 'baseURL', url: 'url'}
         const apiHelper = {
           getTest: jest.fn(() => {
-            throw serverError
+            throw getAxiosHttpError(status, {errors: ['Bad Gateway']})
           }),
         }
         jest.spyOn(api, 'getApiHelper').mockImplementation(() => apiHelper as any)
         await expect(
           runTests.executeTests(mockReporter, {...ciConfig, publicIds: ['public-id-1'], tunnel: true})
         ).rejects.toMatchError(
-          new CriticalError(error, 'Failed to get test: query on baseURLurl returned: "Bad Gateway"\n')
+          new CriticalError(
+            error,
+            'Failed to get test: query on https://app.datadoghq.com/example returned: "Bad Gateway"\n'
+          )
         )
       })
     })
@@ -266,12 +264,9 @@ describe('run-test', () => {
         })
       )
 
-      const serverError = new Error('Server Error') as AxiosError
-      serverError.response = {data: {errors: ['Bad Gateway']}, status: 502} as AxiosResponse
-      serverError.config = {baseURL: 'baseURL', url: 'url'}
       const apiHelper = {
         getTunnelPresignedURL: jest.fn(() => {
-          throw serverError
+          throw getAxiosHttpError(502, {message: 'Server Error'})
         }),
       }
 
@@ -292,12 +287,9 @@ describe('run-test', () => {
 
       jest.spyOn(fs, 'readFile').mockImplementation(async () => Buffer.from('aa'))
 
-      const serverError = new Error('Server Error') as AxiosError
-      serverError.response = {data: {errors: ['Bad Gateway']}, status: 502} as AxiosResponse
-      serverError.config = {baseURL: 'baseURL', url: 'url'}
       const apiHelper = {
         getMobileApplicationPresignedURL: jest.fn(() => {
-          throw serverError
+          throw getAxiosHttpError(502, {message: 'Server Error'})
         }),
       }
 
@@ -322,13 +314,10 @@ describe('run-test', () => {
 
       jest.spyOn(fs, 'readFile').mockImplementation(async () => Buffer.from('aa'))
 
-      const serverError = new Error('Server Error') as AxiosError
-      serverError.response = {data: {errors: ['Bad Gateway']}, status: 502} as AxiosResponse
-      serverError.config = {baseURL: 'baseURL', url: 'url'}
       const apiHelper = {
         getMobileApplicationPresignedURL: jest.fn(() => MOBILE_PRESIGNED_URL_PAYLOAD),
         uploadMobileApplication: jest.fn(() => {
-          throw serverError
+          throw getAxiosHttpError(502, {message: 'Server Error'})
         }),
       }
 
@@ -356,13 +345,10 @@ describe('run-test', () => {
         })
       )
 
-      const serverError = new Error('Server Error') as AxiosError
-      serverError.response = {data: {errors: ['Bad Gateway']}, status: 502} as AxiosResponse
-      serverError.config = {baseURL: 'baseURL', url: 'url'}
       const apiHelper = {
         getTunnelPresignedURL: () => ({url: 'url'}),
         triggerTests: jest.fn(() => {
-          throw serverError
+          throw getAxiosHttpError(502, {errors: ['Bad Gateway']})
         }),
       }
 
@@ -372,7 +358,7 @@ describe('run-test', () => {
       ).rejects.toMatchError(
         new CriticalError(
           'TRIGGER_TESTS_FAILED',
-          '[] Failed to trigger tests: query on baseURLurl returned: "Bad Gateway"\n'
+          '[] Failed to trigger tests: query on https://app.datadoghq.com/example returned: "Bad Gateway"\n'
         )
       )
       expect(stopTunnelSpy).toHaveBeenCalledTimes(1)
@@ -405,15 +391,11 @@ describe('run-test', () => {
         })
       )
 
-      const serverError = new Error('Server Error') as AxiosError
-      serverError.response = {data: {errors: ['Bad Gateway']}, status: 502} as AxiosResponse
-      serverError.config = {baseURL: 'baseURL', url: 'url'}
-
       const apiHelper = {
         getBatch: () => ({results: []}),
         getTunnelPresignedURL: () => ({url: 'url'}),
         pollResults: jest.fn(() => {
-          throw serverError
+          throw getAxiosHttpError(502, {errors: ['Bad Gateway']})
         }),
       }
 
@@ -428,7 +410,7 @@ describe('run-test', () => {
       ).rejects.toMatchError(
         new CriticalError(
           'POLL_RESULTS_FAILED',
-          'Failed to poll results: query on baseURLurl returned: "Bad Gateway"\n'
+          'Failed to poll results: query on https://app.datadoghq.com/example returned: "Bad Gateway"\n'
         )
       )
       expect(stopTunnelSpy).toHaveBeenCalledTimes(1)

--- a/src/commands/synthetics/__tests__/utils.test.ts
+++ b/src/commands/synthetics/__tests__/utils.test.ts
@@ -41,7 +41,7 @@ jest.mock('path', () => {
 import deepExtend from 'deep-extend'
 import * as fs from 'fs'
 
-import {AxiosError, AxiosResponse, default as axios} from 'axios'
+import {default as axios} from 'axios'
 import child_process from 'child_process'
 import glob from 'glob'
 import process from 'process'

--- a/src/commands/synthetics/api.ts
+++ b/src/commands/synthetics/api.ts
@@ -46,11 +46,11 @@ export const formatBackendErrors = (requestError: AxiosError<BackendError>) => {
     } else if (errors.length) {
       return `${serverHead} "${errors[0]}"`
     } else {
-      return `error querying ${requestError.config.baseURL} ${requestError.config.url}`
+      return `error querying ${requestError.config.baseURL}${requestError.config.url}`
     }
   }
 
-  return requestError.message
+  return `could not query ${requestError.config.baseURL}${requestError.config.url}\n${requestError.message}`
 }
 
 const triggerTests = (request: (args: AxiosRequestConfig) => AxiosPromise<Trigger>) => async (data: Payload) => {

--- a/src/commands/synthetics/utils.ts
+++ b/src/commands/synthetics/utils.ts
@@ -560,7 +560,7 @@ const getTest = async (api: APIHelper, {id, suite}: TriggerConfig): Promise<{tes
       return {errorMessage: `[${chalk.bold.dim(id)}] ${chalk.yellow.bold('Test not found')}: ${errorMessage}`}
     }
 
-    throw error
+    throw new EndpointError(`Failed to get test: ${formatBackendErrors(error)}\n`, error.response?.status)
   }
 }
 


### PR DESCRIPTION
### What and why?

This PR adds more context in API errors, specifically the URL which was used.
Thanks to this, there should be enough context to know what test failed with a 403 when getting all the test configs.

### How?

1. The `getTest()` method now throws a `EndpointError` in case of an error different than 404 not found.
2. The `formatBackendErrors()` now always logs the URL that was used for the query.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] \[_Synthetics_\] New releases of `datadog-ci` MUST be followed by a release of Synthetics CI integrations
