### PR TITLE
Move datadog site validation in shared helpers

### DIFF
--- a/src/commands/lambda/constants.ts
+++ b/src/commands/lambda/constants.ts
@@ -51,14 +51,6 @@ export const ARM_LAYER_SUFFIX = '-ARM'
 export const PYTHON_HANDLER_LOCATION = 'datadog_lambda.handler.handler'
 export const NODE_HANDLER_LOCATION = '/opt/nodejs/node_modules/datadog-lambda-js/handler.handler'
 
-export const SITES: string[] = [
-  'datadoghq.com',
-  'datadoghq.eu',
-  'us3.datadoghq.com',
-  'us5.datadoghq.com',
-  'ddog-gov.com',
-]
-
 export const DEFAULT_LAYER_AWS_ACCOUNT = '464622532012'
 export const GOVCLOUD_LAYER_AWS_ACCOUNT = '002406178527'
 export const SUBSCRIPTION_FILTER_NAME = 'datadog-ci-filter'

--- a/src/commands/lambda/functions/commons.ts
+++ b/src/commands/lambda/functions/commons.ts
@@ -1,5 +1,6 @@
 import {CloudWatchLogs, config as aws_sdk_config, Lambda} from 'aws-sdk'
 import {GetFunctionRequest} from 'aws-sdk/clients/lambda'
+import {isValidDatadogSite} from '../../../helpers/validation'
 import {
   ARM64_ARCHITECTURE,
   ARM_LAYERS,
@@ -18,7 +19,6 @@ import {
   MAX_LAMBDA_STATE_CHECK_ATTEMPTS,
   Runtime,
   RUNTIME_LOOKUP,
-  SITES,
 } from '../constants'
 import {FunctionConfiguration, InstrumentationSettings} from '../interfaces'
 import {applyLogGroupConfig} from '../loggroup'
@@ -175,10 +175,11 @@ export const isMissingAWSCredentials = () =>
   // If env vars and aws_sdk_config.credentials are not set return true otherwise return false
   (process.env[AWS_ACCESS_KEY_ID_ENV_VAR] === undefined || process.env[AWS_SECRET_ACCESS_KEY_ENV_VAR] === undefined) &&
   !aws_sdk_config.credentials
+
 export const isMissingDatadogSiteEnvVar = () => {
   const site = process.env[CI_SITE_ENV_VAR]
   if (site !== undefined) {
-    return !SITES.includes(site)
+    return !isValidDatadogSite(site)
   }
 
   return true

--- a/src/commands/lambda/functions/instrument.ts
+++ b/src/commands/lambda/functions/instrument.ts
@@ -1,4 +1,5 @@
 import {CloudWatchLogs, Lambda} from 'aws-sdk'
+import {isValidDatadogSite} from '../../../helpers/validation'
 import {
   API_KEY_ENV_VAR,
   API_KEY_SECRET_ARN_ENV_VAR,
@@ -35,7 +36,6 @@ import {
   RuntimeType,
   RUNTIME_LOOKUP,
   SERVICE_ENV_VAR,
-  SITES,
   SITE_ENV_VAR,
   TRACE_ENABLED_ENV_VAR,
   VERSION_ENV_VAR,
@@ -204,7 +204,7 @@ export const calculateUpdateRequest = async (
   }
 
   if (site !== undefined && oldEnvVars[SITE_ENV_VAR] !== site) {
-    if (SITES.includes(site.toLowerCase())) {
+    if (isValidDatadogSite(site)) {
       needsUpdate = true
       changedEnvVars[SITE_ENV_VAR] = site
     } else {

--- a/src/commands/lambda/prompt.ts
+++ b/src/commands/lambda/prompt.ts
@@ -1,5 +1,6 @@
 import {blueBright, bold} from 'chalk'
 import inquirer from 'inquirer'
+import {DATADOG_SITES} from '../../constants'
 import {
   AWS_ACCESS_KEY_ID_ENV_VAR,
   AWS_ACCESS_KEY_ID_REG_EXP,
@@ -14,7 +15,6 @@ import {
   DATADOG_API_KEY_REG_EXP,
   ENVIRONMENT_ENV_VAR,
   SERVICE_ENV_VAR,
-  SITES,
   VERSION_ENV_VAR,
 } from './constants'
 import {sentenceMatchesRegEx} from './functions/commons'
@@ -100,7 +100,7 @@ export const datadogApiKeyTypeQuestion = (datadogSite: string): inquirer.ListQue
 
 const datadogSiteQuestion: inquirer.ListQuestion = {
   // DATADOG SITE
-  choices: SITES,
+  choices: DATADOG_SITES,
   message: `Select the Datadog site to send data. \nLearn more at ${blueBright(
     'https://docs.datadoghq.com/getting_started/site/'
   )}`,

--- a/src/commands/synthetics/__tests__/cli.test.ts
+++ b/src/commands/synthetics/__tests__/cli.test.ts
@@ -150,7 +150,7 @@ describe('run-test', () => {
         ...(config as Record<string, unknown>),
         apiKey: 'api_key_config_file',
         appKey: 'app_key_config_file',
-        datadogSite: 'datadog.config.file',
+        datadogSite: 'us5.datadoghq.com',
       }))
 
       process.env = {
@@ -166,7 +166,7 @@ describe('run-test', () => {
         ...DEFAULT_COMMAND_CONFIG,
         apiKey: 'api_key_cli',
         appKey: 'app_key_env',
-        datadogSite: 'datadog.config.file',
+        datadogSite: 'us5.datadoghq.com',
         global: {pollingTimeout: DEFAULT_POLLING_TIMEOUT},
       })
     })

--- a/src/commands/synthetics/__tests__/config-fixtures/config-with-global-keys.json
+++ b/src/commands/synthetics/__tests__/config-fixtures/config-with-global-keys.json
@@ -1,5 +1,5 @@
 {
   "apiKey": "api_key_config_file",
   "appKey": "app_key_config_file",
-  "datadogSite": "datadog.config.file"
+  "datadogSite": "us5.datadoghq.com"
 }

--- a/src/commands/synthetics/__tests__/utils.test.ts
+++ b/src/commands/synthetics/__tests__/utils.test.ts
@@ -1077,16 +1077,6 @@ describe('utils', () => {
     expect(utils.parseVariablesFromCli(undefined, mockLogFunction)).toBeUndefined()
   })
 
-  test('validateDatadogSite', () => {
-    expect(() => utils.validateDatadogSite('')).toThrow()
-    expect(() => utils.validateDatadogSite('random')).toThrow()
-    expect(() => utils.validateDatadogSite('myorg.app.datadoghq.com')).toThrow()
-    expect(() => utils.validateDatadogSite('myorg.us3.datadoghq.com')).toThrow()
-
-    expect(() => utils.validateDatadogSite('datadoghq.com')).not.toThrow()
-    expect(() => utils.validateDatadogSite('us3.datadoghq.com')).not.toThrow()
-  })
-
   test('getAppBaseURL', () => {
     // Usual datadog site.
     expect(utils.getAppBaseURL({datadogSite: 'datadoghq.com', subdomain: ''})).toBe('https://app.datadoghq.com/')

--- a/src/commands/synthetics/command.ts
+++ b/src/commands/synthetics/command.ts
@@ -1,9 +1,9 @@
 import chalk from 'chalk'
 import {Command} from 'clipanion'
 import deepExtend from 'deep-extend'
-import {isValidDatadogSite} from '../../helpers/validation'
 
 import {removeUndefinedValues, resolveConfigFromFile} from '../../helpers/utils'
+import {isValidDatadogSite} from '../../helpers/validation'
 import {CiError, CriticalError} from './errors'
 import {CommandConfig, MainReporter, Reporter, Result, Summary} from './interfaces'
 import {DefaultReporter} from './reporters/default'

--- a/src/commands/synthetics/command.ts
+++ b/src/commands/synthetics/command.ts
@@ -1,6 +1,7 @@
 import chalk from 'chalk'
 import {Command} from 'clipanion'
 import deepExtend from 'deep-extend'
+import {isValidDatadogSite} from '../../helpers/validation'
 
 import {removeUndefinedValues, resolveConfigFromFile} from '../../helpers/utils'
 import {CiError, CriticalError} from './errors'
@@ -8,7 +9,7 @@ import {CommandConfig, MainReporter, Reporter, Result, Summary} from './interfac
 import {DefaultReporter} from './reporters/default'
 import {JUnitReporter} from './reporters/junit'
 import {executeTests} from './run-test'
-import {getReporter, parseVariablesFromCli, renderResults, validateDatadogSite} from './utils'
+import {getReporter, parseVariablesFromCli, renderResults} from './utils'
 
 export const MAX_TESTS_TO_TRIGGER = 100
 
@@ -223,7 +224,14 @@ export class RunTestCommand extends Command {
       this.config.files = [this.config.files]
     }
 
-    validateDatadogSite(this.config.datadogSite)
+    if (!isValidDatadogSite(this.config.datadogSite)) {
+      throw new CiError(
+        'INVALID_CONFIG',
+        `The \`datadogSite\` config property (${JSON.stringify(
+          this.config.datadogSite
+        )}) must match one of the sites supported by Datadog.\nFor more information, see "Site parameter" in our documentation: https://docs.datadoghq.com/getting_started/site/#access-the-datadog-site`
+      )
+    }
   }
 }
 

--- a/src/commands/synthetics/utils.ts
+++ b/src/commands/synthetics/utils.ts
@@ -754,18 +754,6 @@ export const parseVariablesFromCli = (
   return Object.keys(variables).length > 0 ? variables : undefined
 }
 
-export const validateDatadogSite = (datadogSite: string) => {
-  const datadogSiteParts = datadogSite.split('.')
-
-  if (datadogSiteParts.length !== 2 && datadogSiteParts.length !== 3) {
-    throw new CriticalError(
-      'INVALID_CONFIG',
-      'The `datadogSite` config property must match one of the sites supported by Datadog.\n' +
-        'For more information, see "Site parameter" in our documentation: https://docs.datadoghq.com/getting_started/site/#access-the-datadog-site'
-    )
-  }
-}
-
 export const getAppBaseURL = ({datadogSite, subdomain}: Pick<CommandConfig, 'datadogSite' | 'subdomain'>) => {
   const validSubdomain = subdomain || DEFAULT_COMMAND_CONFIG.subdomain
   const datadogSiteParts = datadogSite.split('.')

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,7 @@
+export const DATADOG_SITES: string[] = [
+  'datadoghq.com',
+  'datadoghq.eu',
+  'us3.datadoghq.com',
+  'us5.datadoghq.com',
+  'ddog-gov.com',
+]

--- a/src/helpers/__tests__/validation.test.ts
+++ b/src/helpers/__tests__/validation.test.ts
@@ -1,0 +1,14 @@
+import {isValidDatadogSite} from '../validation'
+
+describe('validation', () => {
+  test('isValidDatadogSite', () => {
+    expect(isValidDatadogSite('')).toBe(false)
+    expect(isValidDatadogSite('random')).toBe(false)
+    expect(isValidDatadogSite('myorg.app.datadoghq.com')).toBe(false)
+    expect(isValidDatadogSite('myorg.us3.datadoghq.com')).toBe(false)
+
+    expect(isValidDatadogSite('datadoghq.com')).toBe(true)
+    expect(isValidDatadogSite('us3.datadoghq.com')).toBe(true)
+    expect(isValidDatadogSite('US3.datadoghq.com')).toBe(true)
+  })
+})

--- a/src/helpers/__tests__/validation.test.ts
+++ b/src/helpers/__tests__/validation.test.ts
@@ -4,6 +4,7 @@ describe('validation', () => {
   test('isValidDatadogSite', () => {
     expect(isValidDatadogSite('')).toBe(false)
     expect(isValidDatadogSite('random')).toBe(false)
+    expect(isValidDatadogSite('myorg.datadoghq.com')).toBe(false)
     expect(isValidDatadogSite('myorg.app.datadoghq.com')).toBe(false)
     expect(isValidDatadogSite('myorg.us3.datadoghq.com')).toBe(false)
 

--- a/src/helpers/validation.ts
+++ b/src/helpers/validation.ts
@@ -1,4 +1,5 @@
 import fs from 'fs'
+import {DATADOG_SITES} from '../constants'
 
 export const checkFile: (path: string) => {empty: boolean; exists: boolean} = (path: string) => {
   try {
@@ -16,3 +17,5 @@ export const checkFile: (path: string) => {empty: boolean; exists: boolean} = (p
 
   return {exists: true, empty: false}
 }
+
+export const isValidDatadogSite = (site: string) => DATADOG_SITES.includes(site.toLowerCase())


### PR DESCRIPTION
### What and why?

We didn't want to maintain a list of datadog sites in #660, but the `lambda` command already does it. So, let's move this in the shared helpers so that all commands can use it.

### How?

Move `SITES` in a new `src/constants.ts` file and create a new `isValidDatadogSite()` validation helper.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] \[_Synthetics_\] New releases of `datadog-ci` MUST be followed by a release of Synthetics CI integrations
