### PR TITLE
[ci] Detect wrong license csv format

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -19,25 +19,25 @@ Component,Origin,Licence,Copyright
 @types/xml2js,dev,MIT,Copyright Microsoft Corporation
 @types/ws,dev,MIT,Copyright Microsoft Corporation
 aws-sdk,import,Apache-2.0,Copyright Amazon Web Services
-async-retry,import,MIT,Copyright (c) 2017 ZEIT, Inc.
+async-retry,import,MIT,"Copyright (c) 2017 ZEIT, Inc."
 axios,import,MIT,Copyright (c) 2014-present Matt Zabriskie
 chalk,import,MIT,Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
 clipanion,import,MIT,Copyright (c) 2019 Mael Nison
 datadog-metrics,import,MIT,Copyright (c) 2014 Daniel Bader
 dd-trace,import,Apache-2.0,Copyright 2016-Present Datadog Inc.
-deep-extend,import,MIT,Copyright (c) 2013-2018, Viacheslav Lotsmanov
+deep-extend,import,MIT,"Copyright (c) 2013-2018, Viacheslav Lotsmanov"
 fast-xml-parser,import,MIT,Copyright (c) 2017 Amit Kumar Gupta
 form-data,import,MIT,Copyright (c) 2012 Felix Geisendörfer (felix@debuggable.com) and contributors
 fuzzy,import,MIT,Copyright (c) 2012 Matt York
 glob,import,ISC,Copyright (c) Isaac Z. Schlueter and Contributors
 inquirer,import,MIT,Copyright (c) 2012 Simon Boudrias
 inquirer-checkbox-plus-prompt,import,MIT,Copyright (c) 2018 Mohammad Anas Fares
-jest,dev,MIT,Copyright (c) Facebook, Inc. and its affiliates.
-jest-environment-node,dev,MIT,Copyright (c) Facebook, Inc. and its affiliates.
+jest,dev,MIT,"Copyright (c) Facebook, Inc. and its affiliates."
+jest-environment-node,dev,MIT,"Copyright (c) Facebook, Inc. and its affiliates."
 jest-matcher-specific-error,dev,MIT,Copyright (c) 2020 Daniel Hreben
 js-yaml,import,MIT,Copyright (C) 2011-2015 by Vitaly Puzrin
 ora,import,MIT,Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (https://sindresorhus.com)
-pkg,dev,MIT,Copyright (c) 2021 Vercel, Inc.
+pkg,dev,MIT,"Copyright (c) 2021 Vercel, Inc."
 prettier,dev,MIT,Copyright © James Long and contributors
 proxy,dev,MIT,Copyright (c) 2013 Nathan Rajlich <nathan@tootallnate.net>
 proxy-agent,import,MIT,Copyright (c) 2013 Nathan Rajlich <nathan@tootallnate.net>
@@ -46,11 +46,11 @@ semver,import,ISC,Copyright (c) Isaac Z. Schlueter and Contributors
 simple-git,import,MIT,Copyright (c) 2015 Steve King
 ssh2,import,MIT,Copyright (c) Brian White
 ssh2-streams,import,MIT,Copyright (c) 2014 Brian White
-sshpk,import,MIT,Copyright (c) Joyent, Inc.
+sshpk,import,MIT,"Copyright (c) Joyent, Inc."
 tiny-async-pool,import,MIT,Copyright (c) 2017 Rafael Xavier de Souza http://rafael.xavier.blog.br
 ts-jest,dev,MIT,Copyright (c) 2016-2018
 ts-node,import,MIT,Copyright (c) 2014 Blake Embrey (hello@blakeembrey.com)
-tslint,dev,Apache-2.0,Copyright 2013-2019 Palantir Technologies, Inc.
+tslint,dev,Apache-2.0,"Copyright 2013-2019 Palantir Technologies, Inc."
 tslint-config-prettier,dev,MIT,Copyright 2017 Alex Jover Morales <alexjovermorales@gmail.com>
 tslint-lines-between-class-members,dev,ISC,Copytight (c) Heather Roberts
 typescript,dev,Apache-2.0,Copyright (c) Microsoft Corporation.


### PR DESCRIPTION
### What and why?

Tools that analyze license listing files can break because of a wrong CSV format.

It's the case for GitHub for instance:
![image](https://user-images.githubusercontent.com/9317502/195869147-3e9cdd10-97a0-4986-8216-4860c1b0f5a2.png)

### How?

Check for a wrong format in the `check-licenses.js` script.

A failing pipeline would look like this:

```
Look for dependencies in:
 [ './package.json' ] 

LICENSE-3rdparty.csv: Line 22 has 5 columns, but header has 4.
LICENSE-3rdparty.csv: Line 28 has 5 columns, but header has 4.
LICENSE-3rdparty.csv: Line 35 has 5 columns, but header has 4.
LICENSE-3rdparty.csv: Line 36 has 5 columns, but header has 4.
LICENSE-3rdparty.csv: Line 40 has 5 columns, but header has 4.
LICENSE-3rdparty.csv: Line 49 has 5 columns, but header has 4.
LICENSE-3rdparty.csv: Line 53 has 5 columns, but header has 4.

✅ All dependencies listed in LICENSE-3rdparty.csv

Stacktrace:
 Error: The CSV format is incorrect. You may have an extra comma in a copyright.
    at main (/Users/corentin.girard/repos/datadog-ci/bin/check-licenses.js:40:11)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
```

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] \[_Synthetics_\] New releases of `datadog-ci` MUST be followed by a release of Synthetics CI integrations
