### PR TITLE
Add support for buddy.works in junit upload

### DIFF
--- a/src/helpers/__tests__/ci-env/buddy.json
+++ b/src/helpers/__tests__/ci-env/buddy.json
@@ -1,0 +1,24 @@
+[
+    [
+        {
+            "BUDDY": "1",
+            "BUDDY_EXECUTION_ID": "1",
+            "BUDDY_SCM_URL": "https://github.com/datadog/datadog-ci",
+            "BUDDY_EXECUTION_BRANCH": "main",
+            "BUDDY_EXECUTION_REVISION": "e5e13f8b7f8d5c6096a0501dc09b48eef05fea96",
+            "BUDDY_EXECUTION_URL": "https://app.buddy.works/myworkspace/my-project/pipelines/pipeline/1/execution/5d9dc42c422f5a268b389d08",
+            "BUDDY_EXECUTION_REVISION_MESSAGE": "my message",
+            "BUDDY_PIPELINE_NAME": "pipeline"
+        },
+        {
+            "ci.pipeline.id": "1",
+            "ci.pipeline.name": "pipeline",
+            "ci.pipeline.url": "https://app.buddy.works/myworkspace/my-project/pipelines/pipeline/1/execution/5d9dc42c422f5a268b389d08",
+            "ci.provider.name": "buddy",
+            "git.commit.message": "my message",
+            "git.commit.sha": "e5e13f8b7f8d5c6096a0501dc09b48eef05fea96",
+            "git.repository_url": "https://github.com/datadog/datadog-ci",
+            "git.branch": "main"
+        }
+    ]
+]

--- a/src/helpers/ci.ts
+++ b/src/helpers/ci.ts
@@ -38,6 +38,7 @@ export const CI_ENGINES = {
   GITLAB: 'gitlab',
   JENKINS: 'jenkins',
   TRAVIS: 'travisci',
+  BUDDY: 'buddy',
 }
 
 // Receives a string with the form 'John Doe <john.doe@gmail.com>'
@@ -493,6 +494,29 @@ export const getCISpanTags = (): SpanTags | undefined => {
         [GIT_SHA]: APPVEYOR_REPO_COMMIT,
         [refKey]: ref,
       }
+    }
+  }
+
+  if (env.BUDDY) {
+    const {
+      BUDDY_PIPELINE_NAME,
+      BUDDY_EXECUTION_ID,
+      BUDDY_SCM_URL,
+      BUDDY_EXECUTION_BRANCH,
+      BUDDY_EXECUTION_REVISION,
+      BUDDY_EXECUTION_URL,
+      BUDDY_EXECUTION_REVISION_MESSAGE,
+    } = env
+
+    tags = {
+      [CI_PROVIDER_NAME]: CI_ENGINES.BUDDY,
+      [CI_PIPELINE_ID]: BUDDY_EXECUTION_ID,
+      [CI_PIPELINE_URL]: BUDDY_EXECUTION_URL,
+      [CI_PIPELINE_NAME]: BUDDY_PIPELINE_NAME,
+      [GIT_SHA]: BUDDY_EXECUTION_REVISION,
+      [GIT_BRANCH]: BUDDY_EXECUTION_BRANCH,
+      [GIT_REPOSITORY_URL]: BUDDY_SCM_URL,
+      [GIT_COMMIT_MESSAGE]: BUDDY_EXECUTION_REVISION_MESSAGE,
     }
   }
 


### PR DESCRIPTION
### What and why?

Change the datadog-ci so that it recognizes when it is running in [buddy.works](https://buddy.works)

### How?

Adding to the helper function the mappings for the buddy environment.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
