### PR TITLE
Add custom tags and metrics support for Buddy

### DIFF
--- a/src/commands/metric/metric.ts
+++ b/src/commands/metric/metric.ts
@@ -59,9 +59,9 @@ export class MetricCommand extends Command {
     try {
       const metrics = parseMetrics(this.metrics)
       const {provider, ciEnv} = getCIEnv()
-      // For GitHub only the pipeline level is supported as there is no way to identify the job from the runner.
-      if (provider === 'github' && this.level === 'job') {
-        this.context.stderr.write(`${chalk.red.bold('[ERROR]')} Cannot use level "job" for GitHub Actions.`)
+      // For GitHub and Buddy only the pipeline level is supported as there is no way to identify the job from the runner.
+      if ((provider === 'github' || provider === 'buddy') && this.level === 'job') {
+        this.context.stderr.write(`${chalk.red.bold('[ERROR]')} Cannot use level "job" for CI provider ${provider}.`)
 
         return 1
       }

--- a/src/commands/metric/metric.ts
+++ b/src/commands/metric/metric.ts
@@ -1,7 +1,7 @@
 import chalk from 'chalk'
 import {Command} from 'clipanion'
 
-import {getCIEnv} from '../../helpers/ci'
+import {getCIEnv, PROVIDER_TO_DISPLAY_NAME} from '../../helpers/ci'
 import {retryRequest} from '../../helpers/retry'
 import {getApiHostForSite, getRequestBuilder} from '../../helpers/utils'
 
@@ -61,7 +61,9 @@ export class MetricCommand extends Command {
       const {provider, ciEnv} = getCIEnv()
       // For GitHub and Buddy only the pipeline level is supported as there is no way to identify the job from the runner.
       if ((provider === 'github' || provider === 'buddy') && this.level === 'job') {
-        this.context.stderr.write(`${chalk.red.bold('[ERROR]')} Cannot use level "job" for CI provider ${provider}.`)
+        this.context.stderr.write(
+          `${chalk.red.bold('[ERROR]')} Cannot use level "job" for ${PROVIDER_TO_DISPLAY_NAME[provider]}.`
+        )
 
         return 1
       }

--- a/src/commands/tag/tag.ts
+++ b/src/commands/tag/tag.ts
@@ -1,7 +1,7 @@
 import chalk from 'chalk'
 import {Command} from 'clipanion'
 
-import {getCIEnv} from '../../helpers/ci'
+import {getCIEnv, PROVIDER_TO_DISPLAY_NAME} from '../../helpers/ci'
 import {retryRequest} from '../../helpers/retry'
 import {parseTags} from '../../helpers/tags'
 import {getApiHostForSite, getRequestBuilder} from '../../helpers/utils'
@@ -51,7 +51,9 @@ export class TagCommand extends Command {
       const {provider, ciEnv} = getCIEnv()
       // For GitHub and Buddy only the pipeline level is supported as there is no way to identify the job from the runner.
       if ((provider === 'github' || provider === 'buddy') && this.level === 'job') {
-        this.context.stderr.write(`${chalk.red.bold('[ERROR]')} Cannot use level "job" for CI provider ${provider}.`)
+        this.context.stderr.write(
+          `${chalk.red.bold('[ERROR]')} Cannot use level "job" for ${PROVIDER_TO_DISPLAY_NAME[provider]}.`
+        )
 
         return 1
       }

--- a/src/commands/tag/tag.ts
+++ b/src/commands/tag/tag.ts
@@ -49,9 +49,9 @@ export class TagCommand extends Command {
 
     try {
       const {provider, ciEnv} = getCIEnv()
-      // For GitHub only the pipeline level is supported as there is no way to identify the job from the runner.
-      if (provider === 'github' && this.level === 'job') {
-        this.context.stderr.write(`${chalk.red.bold('[ERROR]')} Cannot use level "job" for GitHub Actions.`)
+      // For GitHub and Buddy only the pipeline level is supported as there is no way to identify the job from the runner.
+      if ((provider === 'github' || provider === 'buddy') && this.level === 'job') {
+        this.context.stderr.write(`${chalk.red.bold('[ERROR]')} Cannot use level "job" for CI provider ${provider}.`)
 
         return 1
       }

--- a/src/helpers/ci.ts
+++ b/src/helpers/ci.ts
@@ -639,6 +639,13 @@ export const getCIEnv = (): {ciEnv: Record<string, string>; provider: string} =>
     }
   }
 
+  if (process.env.BUDDY) {
+    return {
+      ciEnv: filterEnv(['BUDDY_PIPELINE_ID', 'BUDDY_EXECUTION_ID', 'BUDDY_EXECUTION_START_DATE']),
+      provider: 'buddy',
+    }
+  }
+
   throw new Error('Only providers [GitHub, GitLab, CircleCI, Buildkite] are supported')
 }
 

--- a/src/helpers/ci.ts
+++ b/src/helpers/ci.ts
@@ -41,6 +41,11 @@ export const CI_ENGINES = {
   BUDDY: 'buddy',
 }
 
+export const PROVIDER_TO_DISPLAY_NAME = {
+  github: 'GitHub Actions',
+  buddy: 'Buddy',
+}
+
 // Receives a string with the form 'John Doe <john.doe@gmail.com>'
 // and returns { name: 'John Doe', email: 'john.doe@gmail.com' }
 const parseEmailAndName = (emailAndName: string | undefined) => {


### PR DESCRIPTION
### What and why?
Adds support for creating custom tags and metrics for Buddy. Note that only pipeline level is supported as we do not have enough information to identify a job.

⚠️  Do not merge until the backend is deployed

### How?

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
