### PR TITLE
[dev] Add `DD_CI_BYPASS_SITE_VALIDATION` environment flag support

### DIFF
--- a/src/helpers/__tests__/validation.test.ts
+++ b/src/helpers/__tests__/validation.test.ts
@@ -11,5 +11,9 @@ describe('validation', () => {
     expect(isValidDatadogSite('datadoghq.com')).toBe(true)
     expect(isValidDatadogSite('us3.datadoghq.com')).toBe(true)
     expect(isValidDatadogSite('US3.datadoghq.com')).toBe(true)
+
+    process.env.DD_CI_BYPASS_SITE_VALIDATION = 'true'
+    expect(isValidDatadogSite('')).toBe(true)
+    expect(isValidDatadogSite('random')).toBe(true)
   })
 })

--- a/src/helpers/validation.ts
+++ b/src/helpers/validation.ts
@@ -19,4 +19,6 @@ export const checkFile: (path: string) => {empty: boolean; exists: boolean} = (p
   return {exists: true, empty: false}
 }
 
-export const isValidDatadogSite = (site: string) => DATADOG_SITES.includes(site.toLowerCase())
+export const isValidDatadogSite = (site: string): boolean => {
+  return !!process.env.DD_CI_BYPASS_SITE_VALIDATION || DATADOG_SITES.includes(site.toLowerCase())
+}


### PR DESCRIPTION
### What and why?

Add support for development environment variable `DD_CI_BYPASS_SITE_VALIDATION` disabling site validation.

### How?

Ignore the `datadogSite` validation when the `DD_CI_BYPASS_SITE_VALIDATION` environment var value is truthy.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
