### PR TITLE
Use newest version of `setup-node` and `checkout` actions

### DIFF
--- a/.github/workflows/ci-visibility-itr.yml
+++ b/.github/workflows/ci-visibility-itr.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Install node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: '16'
       - run: yarn install --ignore-engines

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install node
         uses: actions/setup-node@v3
         with:
@@ -64,7 +64,7 @@ jobs:
     name: Test standalone binary in ubuntu
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install node
         uses: actions/setup-node@v3
         with:
@@ -84,7 +84,7 @@ jobs:
     name: Test standalone binary in windows
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install node
         uses: actions/setup-node@v3
         with:
@@ -104,7 +104,7 @@ jobs:
     name: Test standalone binary in macOS
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install node
         uses: actions/setup-node@v3
         with:
@@ -125,7 +125,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install node
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: '14'
       - run: yarn install --immutable
@@ -42,7 +42,7 @@ jobs:
 
     steps:
       - name: Install node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: '14'
       - uses: actions/download-artifact@v1
@@ -66,7 +66,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: '14.18.3'
       - run: yarn install --immutable
@@ -86,7 +86,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: '14.18.3'
       - run: yarn install --immutable
@@ -106,7 +106,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: '14.18.3'
       - run: yarn install --immutable
@@ -127,7 +127,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: '14'
       - run: yarn check-licenses

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v3
         with:
           node-version: '14'
       - run: |

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -6,7 +6,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
           node-version: '14'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v3
         with:
           node-version: '14'
       - run: yarn
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: '14.18.3'
       - name: Install project dependencies
@@ -46,7 +46,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: '14.18.3'
       - name: Install project dependencies
@@ -72,7 +72,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: '14.18.3'
       - name: Install project dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
           node-version: '14'
@@ -18,7 +18,7 @@ jobs:
   build-binary-ubuntu:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install node
         uses: actions/setup-node@v3
         with:
@@ -44,7 +44,7 @@ jobs:
   build-binary-windows:
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install node
         uses: actions/setup-node@v3
         with:
@@ -70,7 +70,7 @@ jobs:
   build-binary-macos:
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install node
         uses: actions/setup-node@v3
         with:


### PR DESCRIPTION
### What and why?

We're getting deprecation annotation in our github action runs: 
<img width="1581" alt="Screenshot 2022-10-21 at 13 39 06" src="https://user-images.githubusercontent.com/22798219/197188365-b78b5363-ffdb-4e22-9f41-6ef3beeedb1c.png">

As seen in https://github.com/DataDog/datadog-ci/actions/runs/3297103052

We're not using node@12 but `setup-node@v1` and `checkout@v2` are.

### How?

* Bump `setup-node` action to `v3`
* Bump `checkout` action to `v3`

With these changes we don't get warning anymore: https://github.com/DataDog/datadog-ci/actions/runs/3297156471

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
