### PR TITLE
Run tests in different node versions

### DIFF
--- a/.github/workflows/ci-visibility-itr.yml
+++ b/.github/workflows/ci-visibility-itr.yml
@@ -12,9 +12,8 @@ jobs:
       fail-fast: false
       matrix:
         version: [14, 16, 18]
-        os: [ubuntu-latest, windows-latest, macos-latest]
     name: Build and test with ITR
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     env:
       DD_SERVICE: datadog-ci-tests-itr
       DD_CIVISIBILITY_AGENTLESS_ENABLED: 1

--- a/.github/workflows/ci-visibility-itr.yml
+++ b/.github/workflows/ci-visibility-itr.yml
@@ -9,6 +9,7 @@ on: push
 jobs:
   build-and-test:
     strategy:
+      fail-fast: false
       matrix:
         version: [14, 16, 18]
         os: [ubuntu-latest, windows-latest, macos-latest]

--- a/.github/workflows/ci-visibility-itr.yml
+++ b/.github/workflows/ci-visibility-itr.yml
@@ -8,8 +8,12 @@ on: push
 
 jobs:
   build-and-test:
+    strategy:
+      matrix:
+        version: [14, 16, 18]
+        os: [ubuntu-latest, windows-latest, macos-latest]
     name: Build and test with ITR
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     env:
       DD_SERVICE: datadog-ci-tests-itr
       DD_CIVISIBILITY_AGENTLESS_ENABLED: 1
@@ -26,10 +30,8 @@ jobs:
       - name: Install node
         uses: actions/setup-node@v3
         with:
-          node-version: '16'
-      - run: yarn install --ignore-engines
-        continue-on-error: true
-      - run: yarn add --dev https://github.com/DataDog/dd-trace-js/tarball/master
+          node-version: ${{ matrix.version }}
+      - run: yarn install --immutable
         continue-on-error: true
       - run: yarn test:ci-vis:itr
         continue-on-error: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,15 +6,20 @@ on: push
 
 jobs:
   build-and-test:
+    strategy:
+      matrix:
+        version: [14, 16, 18]
+        os: [ubuntu-latest, windows-latest, macos-latest]
+
     name: Build and test
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
 
     steps:
       - uses: actions/checkout@v3
       - name: Install node
         uses: actions/setup-node@v3
         with:
-          node-version: '14'
+          node-version: ${{ matrix.version }}
       - run: yarn install --immutable
       - run: yarn build
       - run: yarn lint
@@ -36,15 +41,20 @@ jobs:
           path: artifacts/
 
   e2e-test:
+    strategy:
+      matrix:
+        version: [14, 16, 18]
+        os: [ubuntu-latest, windows-latest, macos-latest]
+
     name: End-to-end test the package
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     needs: build-and-test
 
     steps:
       - name: Install node
         uses: actions/setup-node@v3
         with:
-          node-version: '14'
+          node-version: ${{ matrix.version }}
       - uses: actions/download-artifact@v1
         with:
           name: artifacts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,15 +5,14 @@ name: Continuous Integration
 on: push
 
 jobs:
-  build-and-test:
+  build-and-test-ubuntu:
     strategy:
       fail-fast: false
       matrix:
         version: [14, 16, 18]
-        os: [ubuntu-latest, windows-latest, macos-latest]
 
     name: Build and test
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v3
@@ -23,11 +22,6 @@ jobs:
           node-version: ${{ matrix.version }}
       - run: yarn install --immutable
       - run: yarn build
-        if: matrix.os != 'windows-latest'
-      - run: |
-          yarn clean:win
-          yarn build:win
-        if: matrix.os == 'windows-latest'
       - run: yarn lint
       - run: yarn no-only-in-tests
       - run: yarn test
@@ -45,6 +39,58 @@ jobs:
         with:
           name: artifacts
           path: artifacts/
+
+  build-and-test-windows:
+    strategy:
+      fail-fast: false
+      matrix:
+        version: [14, 16, 18]
+
+    name: Build and test
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install node
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.version }}
+      - run: yarn install --immutable
+      - run: yarn build:win
+      - run: yarn test
+        env:
+          CI: true
+          DD_SERVICE: datadog-ci-tests
+          DD_CIVISIBILITY_AGENTLESS_ENABLED: 1
+          DD_API_KEY: ${{ secrets.DATADOG_API_KEY_MAIN_ACCOUNT }}
+          DD_ENV: ci
+          NODE_OPTIONS: -r dd-trace/ci/init
+
+  build-and-test-macos:
+    strategy:
+      fail-fast: false
+      matrix:
+        version: [14, 16, 18]
+
+    name: Build and test
+    runs-on: macos-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install node
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.version }}
+      - run: yarn install --immutable
+      - run: yarn build
+      - run: yarn test
+        env:
+          CI: true
+          DD_SERVICE: datadog-ci-tests
+          DD_CIVISIBILITY_AGENTLESS_ENABLED: 1
+          DD_API_KEY: ${{ secrets.DATADOG_API_KEY_MAIN_ACCOUNT }}
+          DD_ENV: ci
+          NODE_OPTIONS: -r dd-trace/ci/init
 
   e2e-test:
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,10 +10,9 @@ jobs:
       fail-fast: false
       matrix:
         version: [14, 16, 18]
-        os: [ubuntu-latest, macos-latest, windows-latest]
 
     name: Build and test
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v3
@@ -23,11 +22,8 @@ jobs:
           node-version: ${{ matrix.version }}
       - run: yarn install --immutable
       - run: yarn build
-      - run: |
-          yarn build
-          yarn lint
-          yarn no-only-in-tests
-        if: ${{ matrix.os == 'ubuntu-latest' }}
+      - run: yarn lint
+      - run: yarn no-only-in-tests
       - run: yarn test
         env:
           CI: true
@@ -37,7 +33,7 @@ jobs:
           DD_ENV: ci
           NODE_OPTIONS: -r dd-trace/ci/init
       - run: mkdir artifacts
-      - run: yarn pack --filename artifacts/datadog-ci-${{ matrix.os }}-${{ matrix.version }}.tgz
+      - run: yarn pack --filename artifacts/datadog-ci-${{ matrix.version }}.tgz
       - run: cp -r .github/workflows/e2e artifacts/
       - uses: actions/upload-artifact@v1
         with:
@@ -48,10 +44,9 @@ jobs:
     strategy:
       matrix:
         version: [14, 16, 18]
-        os: [ubuntu-latest, windows-latest, macos-latest]
 
     name: End-to-end test the package
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     needs: build-and-test
 
     steps:
@@ -62,7 +57,7 @@ jobs:
       - uses: actions/download-artifact@v1
         with:
           name: artifacts
-      - run: yarn add ./artifacts/datadog-ci-${{ matrix.os }}-${{ matrix.version }}.tgz
+      - run: yarn add ./artifacts/datadog-ci-${{ matrix.version }}.tgz
       - name: Run synthetics test
         run: yarn datadog-ci synthetics run-tests --config artifacts/e2e/global.config.json
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on: push
 jobs:
   build-and-test:
     strategy:
+      fail-fast: false
       matrix:
         version: [14, 16, 18]
         os: [ubuntu-latest, windows-latest, macos-latest]
@@ -22,6 +23,11 @@ jobs:
           node-version: ${{ matrix.version }}
       - run: yarn install --immutable
       - run: yarn build
+        if: matrix.os != 'windows-latest'
+      - run: |
+          yarn clean:win
+          yarn build:win
+        if: matrix.os == 'windows-latest'
       - run: yarn lint
       - run: yarn no-only-in-tests
       - run: yarn test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,14 +5,15 @@ name: Continuous Integration
 on: push
 
 jobs:
-  build-and-test-ubuntu:
+  build-and-test:
     strategy:
       fail-fast: false
       matrix:
         version: [14, 16, 18]
+        os: [ubuntu-latest, macos-latest, windows-latest]
 
     name: Build and test
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
 
     steps:
       - uses: actions/checkout@v3
@@ -22,8 +23,11 @@ jobs:
           node-version: ${{ matrix.version }}
       - run: yarn install --immutable
       - run: yarn build
-      - run: yarn lint
-      - run: yarn no-only-in-tests
+      - run: |
+          yarn build
+          yarn lint
+          yarn no-only-in-tests
+        if: ${{ matrix.os == 'ubuntu-latest' }}
       - run: yarn test
         env:
           CI: true
@@ -33,64 +37,12 @@ jobs:
           DD_ENV: ci
           NODE_OPTIONS: -r dd-trace/ci/init
       - run: mkdir artifacts
-      - run: yarn pack --filename artifacts/datadog-ci.tgz
+      - run: yarn pack --filename artifacts/datadog-ci-${{ matrix.os }}-${{ matrix.version }}.tgz
       - run: cp -r .github/workflows/e2e artifacts/
       - uses: actions/upload-artifact@v1
         with:
           name: artifacts
           path: artifacts/
-
-  build-and-test-windows:
-    strategy:
-      fail-fast: false
-      matrix:
-        version: [14, 16, 18]
-
-    name: Build and test
-    runs-on: windows-latest
-
-    steps:
-      - uses: actions/checkout@v3
-      - name: Install node
-        uses: actions/setup-node@v3
-        with:
-          node-version: ${{ matrix.version }}
-      - run: yarn install --immutable
-      - run: yarn build:win
-      - run: yarn test
-        env:
-          CI: true
-          DD_SERVICE: datadog-ci-tests
-          DD_CIVISIBILITY_AGENTLESS_ENABLED: 1
-          DD_API_KEY: ${{ secrets.DATADOG_API_KEY_MAIN_ACCOUNT }}
-          DD_ENV: ci
-          NODE_OPTIONS: -r dd-trace/ci/init
-
-  build-and-test-macos:
-    strategy:
-      fail-fast: false
-      matrix:
-        version: [14, 16, 18]
-
-    name: Build and test
-    runs-on: macos-latest
-
-    steps:
-      - uses: actions/checkout@v3
-      - name: Install node
-        uses: actions/setup-node@v3
-        with:
-          node-version: ${{ matrix.version }}
-      - run: yarn install --immutable
-      - run: yarn build
-      - run: yarn test
-        env:
-          CI: true
-          DD_SERVICE: datadog-ci-tests
-          DD_CIVISIBILITY_AGENTLESS_ENABLED: 1
-          DD_API_KEY: ${{ secrets.DATADOG_API_KEY_MAIN_ACCOUNT }}
-          DD_ENV: ci
-          NODE_OPTIONS: -r dd-trace/ci/init
 
   e2e-test:
     strategy:
@@ -100,7 +52,7 @@ jobs:
 
     name: End-to-end test the package
     runs-on: ${{ matrix.os }}
-    needs: [build-and-test-ubuntu, build-and-test-windows, build-and-test-macos]
+    needs: build-and-test
 
     steps:
       - name: Install node
@@ -110,7 +62,7 @@ jobs:
       - uses: actions/download-artifact@v1
         with:
           name: artifacts
-      - run: yarn add ./artifacts/datadog-ci.tgz
+      - run: yarn add ./artifacts/datadog-ci-${{ matrix.os }}-${{ matrix.version }}.tgz
       - name: Run synthetics test
         run: yarn datadog-ci synthetics run-tests --config artifacts/e2e/global.config.json
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,7 +100,7 @@ jobs:
 
     name: End-to-end test the package
     runs-on: ${{ matrix.os }}
-    needs: build-and-test
+    needs: [build-and-test-ubuntu, build-and-test-windows, build-and-test-macos]
 
     steps:
       - name: Install node


### PR DESCRIPTION
### What and why?

Run tests in different node versions to improve reliability.

At some point we'd want to test different operating systems, but windows tests are broken right now, so that will require a different PR.

### How?

* Run unit tests in node@14, node@16 and node@18.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
