### PR TITLE
[MAJOR][Synthetics] Remove deprecated `startUrl` native URL variables support

### DIFF
--- a/src/commands/synthetics/README.md
+++ b/src/commands/synthetics/README.md
@@ -185,7 +185,7 @@ All options under the `config` key are optional and allow overriding the configu
 - `retry`: (object) retry policy for the test.
   - `count`: (integer) number of attempts to perform in case of test failure.
   - `interval`: (integer) interval between the attempts (in milliseconds).
-- `startUrl`: (string) new start URL to provide to the test. Variables specified in brackets (`{{ EXAMPLE }}`) found in environment variables will be replaced.
+- `startUrl`: (string) new start URL to provide to the test. Variables specified in brackets (`{{ EXAMPLE }}`) found in environment variables are replaced.
 - `startUrlSubstitutionRegex`: (string) regex to modify the starting URL of the test (browser and HTTP tests only), whether it was given by the original test or by the configuration override `startUrl`. If the URL contains variables, this regex will be applied after the interpolation of the variables. The format is `s/your_regex/your_substitution/modifiers` and follow Javascript regex syntax, for instance `s/(https://www.)(.*)/$1extra-$2/` to transform `https://www.example.com` into `https://www.extra-example.com`.
 - `variables`: (object) variables to replace in the test. This object should contain as keys the name of the variable to replace and as values the new value of the variable.
 

--- a/src/commands/synthetics/README.md
+++ b/src/commands/synthetics/README.md
@@ -185,42 +185,9 @@ All options under the `config` key are optional and allow overriding the configu
 - `retry`: (object) retry policy for the test.
   - `count`: (integer) number of attempts to perform in case of test failure.
   - `interval`: (integer) interval between the attempts (in milliseconds).
-- `startUrl`: (string) new start URL to provide to the test.
+- `startUrl`: (string) new start URL to provide to the test. Variables specified in brackets (`{{ EXAMPLE }}`) found in environment variables will be replaced.
 - `startUrlSubstitutionRegex`: (string) regex to modify the starting URL of the test (browser and HTTP tests only), whether it was given by the original test or by the configuration override `startUrl`. If the URL contains variables, this regex will be applied after the interpolation of the variables. The format is `s/your_regex/your_substitution/modifiers` and follow Javascript regex syntax, for instance `s/(https://www.)(.*)/$1extra-$2/` to transform `https://www.example.com` into `https://www.extra-example.com`.
 - `variables`: (object) variables to replace in the test. This object should contain as keys the name of the variable to replace and as values the new value of the variable.
-
-<details>
-  <summary>(Deprecated) Usage of URL variables</summary>
-
-_The following has been deprecated since 0.18.1 and will be removed in a few versions. You should now use `startUrlSubstitutionRegex` or regular variable overrides._
-
-You can configure on which url your Browser or HTTP test starts by providing a `config.startUrl` to your test object and build your own starting url using any part of your test's original starting url and the following environment variables:
-
-| Environment variable | Description                  | Example                                                       |
-| -------------------- | ---------------------------- | ------------------------------------------------------------- |
-| `URL`                | Test's original starting url | `https://www.example.org:81/path/to/something?abc=123#target` |
-| `DOMAIN`             | Test's domain name           | `example.org`                                                 |
-| `HASH`               | Test's URL hash              | `#target`                                                     |
-| `HOST`               | Test's host                  | `www.example.org:81`                                          |
-| `HOSTNAME`           | Test's hostname              | `www.example.org`                                             |
-| `ORIGIN`             | Test's origin                | `https://www.example.org:81`                                  |
-| `PARAMS`             | Test's query parameters      | `?abc=123`                                                    |
-| `PATHNAME`           | Test's URl path              | `/path/to/something`                                          |
-| `PORT`               | Test's host port             | `81`                                                          |
-| `PROTOCOL`           | Test's protocol              | `https:`                                                      |
-| `SUBDOMAIN`          | Test's sub domain            | `www`                                                         |
-
-For instance, if your test's starting url is `https://www.example.org:81/path/to/something?abc=123#target`
-
-It can be written as :
-
-- `{{PROTOCOL}}//{{SUBDOMAIN}}.{{DOMAIN}}:{{PORT}}{{PATHNAME}}{{PARAMS}}{{HASH}}`
-- `{{PROTOCOL}}//{{HOST}}{{PATHNAME}}{{PARAMS}}{{HASH}}`
-- `{{URL}}`
-
-and so on...
-
-</details>
 
 ### Testing tunnel
 
@@ -260,7 +227,7 @@ Two reporters are supported out-of-the-box:
 1. `stdout`
 2. JUnit
 
-To enable the JUnit report, pass the `--jUnitReport` (`-j` shorthand) in your command, specifying a filename for your JUnit XML report. 
+To enable the JUnit report, pass the `--jUnitReport` (`-j` shorthand) in your command, specifying a filename for your JUnit XML report.
 
 ```bash
 yarn datadog-ci synthetics run-tests -s 'tag:e2e-tests' --config global.config.json --jUnitReport e2e-test-junit

--- a/src/commands/synthetics/__tests__/utils.test.ts
+++ b/src/commands/synthetics/__tests__/utils.test.ts
@@ -473,36 +473,6 @@ describe('utils', () => {
       expectHandledConfigToBe(SKIPPED, SKIPPED, NON_BLOCKING)
     })
 
-    test('startUrl template is rendered if correct test type or subtype', () => {
-      const publicId = 'abc-def-ghi'
-      const fakeTest = {
-        config: {request: {url: 'http://example.org/path#target'}},
-        public_id: publicId,
-        type: 'browser',
-      } as Test
-      const configOverride = {
-        startUrl: 'https://{{DOMAIN}}/newPath?oldPath={{ PATHNAME   }}{{HASH}}',
-      }
-      const expectedUrl = 'https://example.org/newPath?oldPath=/path#target'
-
-      let overriddenConfig = utils.getOverriddenConfig(fakeTest, publicId, mockReporter, configOverride)
-      expect(overriddenConfig.public_id).toBe(publicId)
-      expect(overriddenConfig.startUrl).toBe(expectedUrl)
-
-      fakeTest.type = 'api'
-      fakeTest.subtype = 'http'
-
-      overriddenConfig = utils.getOverriddenConfig(fakeTest, publicId, mockReporter, configOverride)
-      expect(overriddenConfig.public_id).toBe(publicId)
-      expect(overriddenConfig.startUrl).toBe(expectedUrl)
-
-      fakeTest.subtype = 'dns'
-
-      overriddenConfig = utils.getOverriddenConfig(fakeTest, publicId, mockReporter, configOverride)
-      expect(overriddenConfig.public_id).toBe(publicId)
-      expect(overriddenConfig.startUrl).toBeUndefined()
-    })
-
     test('startUrl is not parsable', () => {
       const envVars = {...process.env}
       process.env = {CUSTOMVAR: '/newPath'}
@@ -513,31 +483,14 @@ describe('utils', () => {
         type: 'browser',
       } as Test
       const configOverride = {
-        startUrl: 'https://{{DOMAIN}}/newPath?oldPath={{CUSTOMVAR}}',
+        startUrl: 'https://{{FAKE_VAR}}/newPath?oldPath={{CUSTOMVAR}}',
       }
-      const expectedUrl = 'https://{{DOMAIN}}/newPath?oldPath=/newPath'
+      const expectedUrl = 'https://{{FAKE_VAR}}/newPath?oldPath=/newPath'
       const overriddenConfig = utils.getOverriddenConfig(fakeTest, publicId, mockReporter, configOverride)
 
       expect(overriddenConfig.public_id).toBe(publicId)
       expect(overriddenConfig.startUrl).toBe(expectedUrl)
       process.env = envVars
-    })
-
-    test('startUrl with empty variable is replaced', () => {
-      const publicId = 'abc-def-ghi'
-      const fakeTest = {
-        config: {request: {url: 'http://exmaple.org/path'}},
-        public_id: publicId,
-        type: 'browser',
-      } as Test
-      const configOverride = {
-        startUrl: 'http://127.0.0.1/newPath{{PARAMS}}',
-      }
-      const expectedUrl = 'http://127.0.0.1/newPath'
-      const overriddenConfig = utils.getOverriddenConfig(fakeTest, publicId, mockReporter, configOverride)
-
-      expect(overriddenConfig.public_id).toBe(publicId)
-      expect(overriddenConfig.startUrl).toBe(expectedUrl)
     })
 
     test('config overrides are applied', () => {

--- a/src/commands/synthetics/interfaces.ts
+++ b/src/commands/synthetics/interfaces.ts
@@ -309,23 +309,6 @@ export interface BasicAuthCredentials {
   password: string
   username: string
 }
-
-export interface TemplateVariables {
-  DOMAIN?: string
-  HASH?: string
-  HOST?: string
-  HOSTNAME?: string
-  ORIGIN?: string
-  PARAMS?: string
-  PATHNAME?: string
-  PORT?: string
-  PROTOCOL?: string
-  SUBDOMAIN?: string
-  URL: string
-}
-
-export interface TemplateContext extends TemplateVariables, NodeJS.ProcessEnv {}
-
 export interface TriggerConfig {
   config: UserConfigOverride
   id: string


### PR DESCRIPTION
### What and why?

Remove `startUrl` native URL variables support (usage of `HOSTNAME`, `SUBDOMAIN`...) which has been deprecated [since `0.18.0`](https://github.com/DataDog/datadog-ci/pull/484):
- https://github.com/DataDog/datadog-ci/pull/483

This feature has been replaced with the more powerful and less confusing `startUrlSubstitutionRegex` and support for Synthetic variables and environment variables overrides. Synthetics runners now perform the URL computation based on variable overrides and substitution on test reception.

### How?

Remove code related to native URL variables.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
