### PR TITLE
Do not bundle and compose react native sourcemaps if no upload

### DIFF
--- a/src/commands/react-native/__tests__/xcode.test.ts
+++ b/src/commands/react-native/__tests__/xcode.test.ts
@@ -194,7 +194,33 @@ describe('xcode', () => {
       expect(output).toContain('version: 0.0.2 build: 000020 service: com.myapp.test')
     })
 
-    test('should not upload sourcemaps when the build configuration is Debug', async () => {
+    test('should not compose sourcemaps when using hermes and source maps are not uploaded', async () => {
+      process.env = {
+        ...process.env,
+        ...basicEnvironment,
+        CONFIGURATION_BUILD_DIR: './src/commands/react-native/__tests__/fixtures/compose-sourcemaps',
+        UNLOCALIZED_RESOURCES_FOLDER_PATH: 'MyApp.app',
+        USE_HERMES: 'true',
+        CONFIGURATION: 'Debug',
+      }
+      const {context, code} = await runCLI(
+        './src/commands/react-native/__tests__/fixtures/bundle-script/successful_script.sh',
+        {
+          composeSourcemapsPath:
+            './src/commands/react-native/__tests__/fixtures/compose-sourcemaps/compose-sourcemaps.js',
+        }
+      )
+      // Uncomment these lines for debugging failing script
+      // console.log(context.stdout.toString())
+      // console.log(context.stderr.toString())
+
+      expect(code).toBe(0)
+      const output = context.stdout.toString()
+      expect(output).toContain('Build configuration Debug is not Release, skipping sourcemaps upload')
+      expect(output).not.toContain('Hermes detected, composing sourcemaps')
+    })
+
+    test('should not bundle nor upload sourcemaps when the build configuration is Debug', async () => {
       process.env = {
         ...process.env,
         ...basicEnvironment,
@@ -210,6 +236,7 @@ describe('xcode', () => {
       expect(code).toBe(0)
       const output = context.stdout.toString()
       expect(output).toContain('Build configuration Debug is not Release, skipping sourcemaps upload')
+      expect(output).not.toContain('Starting successful script')
     })
 
     test('should run the provided script and upload sourcemaps when the build configuration is Debug with force option', async () => {

--- a/src/commands/react-native/xcode.ts
+++ b/src/commands/react-native/xcode.ts
@@ -115,6 +115,14 @@ export class XCodeCommand extends Command {
       return 1
     }
 
+    if (!this.shouldUploadSourcemaps()) {
+      this.context.stdout.write(
+        `Build configuration ${process.env.CONFIGURATION} is not Release, skipping sourcemaps upload`
+      )
+
+      return 0
+    }
+
     // Run bundle script
     try {
       await this.bundleReactNativeCodeAndImages()
@@ -134,15 +142,8 @@ export class XCodeCommand extends Command {
       return 1
     }
 
-    if (!this.shouldUploadSourcemaps()) {
-      this.context.stdout.write(
-        `Build configuration ${process.env.CONFIGURATION} is not Release, skipping sourcemaps upload`
-      )
-
-      return 0
-    }
     if (this.force) {
-      this.context.stdout.write(`Force upload for configuration Debug ${process.env.CONFIGURATION}`)
+      this.context.stdout.write(`Force upload for configuration ${process.env.CONFIGURATION}`)
     }
 
     // Run upload script in the background


### PR DESCRIPTION
### What and why?

Prevents bundling (and composing if hermes is enabled) react native sourcemaps when no upload is planned in `react-native xcode` command.
This makes iOS debug builds faster, and avoids propagating errors to debug builds if some configuration is missing. 

### How?

Exit before bundling if source maps are not supposed to be uploaded.
The `react-native-xcode.sh` script also exits early if configuration is "Debug".

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
