### PR TITLE
[datadog-ci] update target lib from `es2019` to `es2020`

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,7 @@
     },
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
-    "lib": ["es2019"],
+    "lib": ["es2020"],
     "resolveJsonModule": true
   },
   "include": ["src/**/*"]


### PR DESCRIPTION
### What and why?

Just updating the target lib from `es2019` to `es2020` in order to use `Promise.allSettled` API.

### How?

Updating `tsconfig.json`:`lib` target to `es2020`, previously, the array contained only `es2019`.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
