### PR TITLE
v2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci",
-  "version": "1.17.0",
+  "version": "2.0.0",
   "description": "Run datadog actions from the CI.",
   "repository": "https://github.com/DataDog/datadog-ci",
   "license": "Apache-2.0",


### PR DESCRIPTION
### What and why?

This PR bumps to version 2.0.0, releasing:

* Add custom tags and metrics support for Buddy by @cg14823 in https://github.com/DataDog/datadog-ci/pull/677
* Bump minimum supported node version to node 14 and bump other dependencies by @juan-fernandez in https://github.com/DataDog/datadog-ci/pull/682
* [CI Visibility] unitxml custom tags with xpath by @AdrianLC in https://github.com/DataDog/datadog-ci/pull/683
* [Synthetics] Remove deprecated `startUrl` native URL variables support by @lefebvree in https://github.com/DataDog/datadog-ci/pull/687
* [React Native] Support Expo managed application without expo dev client by @louiszawadzki in https://github.com/DataDog/datadog-ci/pull/686
* [React Native] Set USE_HERMES env variable for RN 0.70 by @louiszawadzki in https://github.com/DataDog/datadog-ci/pull/693
* [lambda] Fix interactive API key validation by @sfirrin in https://github.com/DataDog/datadog-ci/pull/639
* Update target lib from `es2019` to `es2020` by @duncanista in https://github.com/DataDog/datadog-ci/pull/695
