### PR TITLE
Support React Native 0.71

### DIFF
--- a/src/commands/react-native/utils.ts
+++ b/src/commands/react-native/utils.ts
@@ -1,0 +1,13 @@
+import {existsSync} from 'fs'
+
+export const getReactNativeVersion = (packageJsonPath: string): undefined | string => {
+  if (!existsSync(packageJsonPath)) {
+    return undefined
+  }
+
+  try {
+    return require(packageJsonPath).version as string
+  } catch (e) {
+    return undefined
+  }
+}

--- a/src/commands/react-native/xcode.ts
+++ b/src/commands/react-native/xcode.ts
@@ -8,6 +8,7 @@ import {Cli, Command} from 'clipanion'
 import {parsePlist} from '../../helpers/plist'
 
 import {UploadCommand} from './upload'
+import {getReactNativeVersion} from './utils'
 
 /**
  * Because jest cannot mock require.resolve, reactNativePath cannot
@@ -366,9 +367,22 @@ export class XCodeCommand extends Command {
   /**
    * This function reflects the logic in the react-native-xcode.sh bundle script.
    * When the composition issue is fixed in React Native, this function should
-   * return false if the React Native version is high enough.
+   * return false if the React Native version is at least 0.71 where it was fixed.
    */
   private shouldComposeHermesSourcemaps = (): boolean => {
+    /**
+     * We start by checking if the version is over 0.70, as the bug
+     * is fixed from react-native 0.71.0
+     */
+    const reactNativeVersion = getReactNativeVersion(`${reactNativePath}/package.json`)
+    if (!reactNativeVersion) {
+      return false
+    }
+    const [_, minor] = reactNativeVersion.split('.')
+    if (Number(minor) > 70) {
+      return false
+    }
+
     /**
      * This env variable is empty by default.
      * Before RN 0.70, it had to be set to `true` for Hermes to be used.


### PR DESCRIPTION
### What and why?

In React Native 0.71 we don't have to compose Hermes sourcemaps after build anymore, and we cannot as the "composable" parts are removed after the build.

### How?

Check if version of react native is over 0.70 before composing Hermes sourcemaps.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
