### PR TITLE
[CI App] Add support for custom tags & metrics in Jenkins

### DIFF
--- a/src/commands/metric/__tests__/metric.test.ts
+++ b/src/commands/metric/__tests__/metric.test.ts
@@ -87,7 +87,9 @@ describe('execute', () => {
   test('should fail if not running in a supported provider', async () => {
     const {context, code} = await runCLI('pipeline', ['key:1'], {})
     expect(code).toBe(1)
-    expect(context.stderr.toString()).toContain('Only providers [GitHub, GitLab, CircleCI, Buildkite, Buddy, Jenkins] are supported')
+    expect(context.stderr.toString()).toContain(
+      'Only providers [GitHub, GitLab, CircleCI, Buildkite, Buddy, Jenkins] are supported'
+    )
   })
 
   test('should fail if provider is GitHub and level is job', async () => {

--- a/src/commands/metric/__tests__/metric.test.ts
+++ b/src/commands/metric/__tests__/metric.test.ts
@@ -87,7 +87,7 @@ describe('execute', () => {
   test('should fail if not running in a supported provider', async () => {
     const {context, code} = await runCLI('pipeline', ['key:1'], {})
     expect(code).toBe(1)
-    expect(context.stderr.toString()).toContain('Only providers [GitHub, GitLab, CircleCI, Buildkite] are supported')
+    expect(context.stderr.toString()).toContain('Only providers [GitHub, GitLab, CircleCI, Buildkite, Buddy, Jenkins] are supported')
   })
 
   test('should fail if provider is GitHub and level is job', async () => {

--- a/src/commands/tag/__tests__/tag.test.ts
+++ b/src/commands/tag/__tests__/tag.test.ts
@@ -66,7 +66,9 @@ describe('execute', () => {
   test('should fail if not running in a supported provider', async () => {
     const {context, code} = await runCLI('pipeline', ['key:value'], {})
     expect(code).toBe(1)
-    expect(context.stderr.toString()).toContain('Only providers [GitHub, GitLab, CircleCI, Buildkite, Buddy, Jenkins] are supported')
+    expect(context.stderr.toString()).toContain(
+      'Only providers [GitHub, GitLab, CircleCI, Buildkite, Buddy, Jenkins] are supported'
+    )
   })
 
   test('should fail if provider is GitHub and level is job', async () => {

--- a/src/commands/tag/__tests__/tag.test.ts
+++ b/src/commands/tag/__tests__/tag.test.ts
@@ -66,7 +66,7 @@ describe('execute', () => {
   test('should fail if not running in a supported provider', async () => {
     const {context, code} = await runCLI('pipeline', ['key:value'], {})
     expect(code).toBe(1)
-    expect(context.stderr.toString()).toContain('Only providers [GitHub, GitLab, CircleCI, Buildkite] are supported')
+    expect(context.stderr.toString()).toContain('Only providers [GitHub, GitLab, CircleCI, Buildkite, Buddy, Jenkins] are supported')
   })
 
   test('should fail if provider is GitHub and level is job', async () => {

--- a/src/helpers/__tests__/ci.test.ts
+++ b/src/helpers/__tests__/ci.test.ts
@@ -224,7 +224,7 @@ describe('getCIEnv', () => {
     })
   })
 
-  test('gitlab', () => {
+  test('jenkins', () => {
     process.env = {JENKINS_URL: 'something'}
     expect(() => {
       getCIEnv()

--- a/src/helpers/__tests__/ci.test.ts
+++ b/src/helpers/__tests__/ci.test.ts
@@ -182,7 +182,7 @@ describe('getCIEnv', () => {
     process.env = {APPVEYOR: 'true'}
     expect(() => {
       getCIEnv()
-    }).toThrow('Only providers [GitHub, GitLab, CircleCI, Buildkite] are supported')
+    }).toThrow('Only providers [GitHub, GitLab, CircleCI, Buildkite, Buddy, Jenkins] are supported')
   })
 
   test('buildkite', () => {
@@ -221,6 +221,19 @@ describe('getCIEnv', () => {
     expect(getCIEnv()).toEqual({
       ciEnv: {CI_PIPELINE_ID: 'build-id', CI_JOB_ID: '10', CI_PROJECT_URL: 'url'},
       provider: 'gitlab',
+    })
+  })
+
+  test('gitlab', () => {
+    process.env = {JENKINS_URL: 'something'}
+    expect(() => {
+      getCIEnv()
+    }).toThrow()
+
+    process.env = {JENKINS_URL: 'something', DD_CUSTOM_PARENT_ID: 'span-id', DD_CUSTOM_TRACE_ID: 'trace-id'}
+    expect(getCIEnv()).toEqual({
+      ciEnv: {DD_CUSTOM_PARENT_ID: 'span-id', DD_CUSTOM_TRACE_ID: 'trace-id'},
+      provider: 'jenkins',
     })
   })
 })

--- a/src/helpers/ci.ts
+++ b/src/helpers/ci.ts
@@ -659,7 +659,14 @@ export const getCIEnv = (): {ciEnv: Record<string, string>; provider: string} =>
     }
   }
 
-  throw new Error('Only providers [GitHub, GitLab, CircleCI, Buildkite] are supported')
+  if (process.env.JENKINS_URL) {
+    return {
+      ciEnv: filterEnv(['DD_CUSTOM_PARENT_ID', 'DD_CUSTOM_TRACE_ID']),
+      provider: 'jenkins',
+    }
+  }
+
+  throw new Error('Only providers [GitHub, GitLab, CircleCI, Buildkite, Buddy, Jenkins] are supported')
 }
 
 const filterEnv = (values: string[]): Record<string, string> => {


### PR DESCRIPTION
### What and why?

Detect when running on Jenkins and forward the right env vars so we can add custom tags and metrics to Jenkins pipelines.

Also updates the error message to say that Jenkins and Buddy are supported (buddy was added recently but the message not updated).

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
