### PR TITLE
[lambda] Fix merge conflicts from #688

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,13 +61,13 @@ jobs:
       - name: Run synthetics test
         run: yarn datadog-ci synthetics run-tests --config artifacts/e2e/global.config.json
         env:
-          DATADOG_API_KEY: ${{ secrets.datadog_api_key }}
-          DATADOG_APP_KEY: ${{ secrets.datadog_app_key }}
+          DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY_E2E }}
+          DATADOG_APP_KEY: ${{ secrets.DATADOG_APP_KEY_E2E }}
       - name: Run sourcemaps upload test
         run: yarn datadog-ci sourcemaps upload artifacts/e2e/sourcemaps/ --release-version=e2e --service=e2e-tests --minified-path-prefix=https://e2e-tests.datadoghq.com/static/
         env:
-          DATADOG_API_KEY: ${{ secrets.datadog_api_key }}
-          DATADOG_APP_KEY: ${{ secrets.datadog_app_key }}
+          DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY_E2E }}
+          DATADOG_APP_KEY: ${{ secrets.DATADOG_APP_KEY_E2E }}
 
   standalone-binary-test-ubuntu:
     name: Test standalone binary in ubuntu

--- a/.github/workflows/e2e/global.config.json
+++ b/.github/workflows/e2e/global.config.json
@@ -1,6 +1,7 @@
 {
   "files": "{,!(node_modules)/**/}*.synthetics.json",
+  "failOnCriticalErrors": true,
+  "failOnMissingTests": true,
   "global": {},
   "timeout": 240000
 }
-

--- a/src/commands/lambda/__tests__/instrument.test.ts
+++ b/src/commands/lambda/__tests__/instrument.test.ts
@@ -1610,7 +1610,8 @@ TagResource -> arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world
         const output = context.stdout.toString()
         expect(code).toBe(1)
         expect(output).toMatchInlineSnapshot(`
-"[Error] Error: Couldn't set AWS profile credentials. Update failed!
+"\n🐶 Instrumenting Lambda function
+[Error] Error: Couldn't set AWS profile credentials. Update failed!
 "
 `)
       })

--- a/src/commands/lambda/__tests__/uninstrument.test.ts
+++ b/src/commands/lambda/__tests__/uninstrument.test.ts
@@ -610,7 +610,8 @@ UpdateFunctionConfiguration -> arn:aws:lambda:sa-east-1:123456789012:function:la
       const output = context.stdout.toString()
       expect(code).toBe(1)
       expect(output).toMatchInlineSnapshot(`
-"[Error] Error: Couldn't set AWS profile credentials. Update failed!
+"\n🐶 Uninstrumenting Lambda function
+[Error] Error: Couldn't set AWS profile credentials. Update failed!
 "
 `)
     })

--- a/src/commands/lambda/instrument.ts
+++ b/src/commands/lambda/instrument.ts
@@ -78,7 +78,7 @@ export class InstrumentCommand extends Command {
       try {
         await updateAWSProfileCredentials(profile)
       } catch (e) {
-        this.context.stdout.write(`${red('[Error]')} ${e}\n`)
+        this.context.stdout.write(renderer.renderError(e))
 
         return 1
       }

--- a/src/commands/lambda/uninstrument.ts
+++ b/src/commands/lambda/uninstrument.ts
@@ -45,7 +45,7 @@ export class UninstrumentCommand extends Command {
       try {
         await updateAWSProfileCredentials(profile)
       } catch (e) {
-        this.context.stdout.write(`${red('[Error]')} ${e}\n`)
+        this.context.stdout.write(renderer.renderError(e))
 
         return 1
       }


### PR DESCRIPTION
### What and why?

The merge of #688 didn't show a merge conflict. Making me think it would merge safely. Nonetheless, that was not the case since the `instrument.ts` and `uninstrument.ts` files got a line changed.

Also, some test snapshots were missing a line, caused by this non-showing merge conflict.

### How?

Updating the files as they should be, also its tests.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
