### PR TITLE
[ci] Update e2e keys, fail on synthetics test errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,13 +61,13 @@ jobs:
       - name: Run synthetics test
         run: yarn datadog-ci synthetics run-tests --config artifacts/e2e/global.config.json
         env:
-          DATADOG_API_KEY: ${{ secrets.datadog_api_key }}
-          DATADOG_APP_KEY: ${{ secrets.datadog_app_key }}
+          DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY_E2E }}
+          DATADOG_APP_KEY: ${{ secrets.DATADOG_APP_KEY_E2E }}
       - name: Run sourcemaps upload test
         run: yarn datadog-ci sourcemaps upload artifacts/e2e/sourcemaps/ --release-version=e2e --service=e2e-tests --minified-path-prefix=https://e2e-tests.datadoghq.com/static/
         env:
-          DATADOG_API_KEY: ${{ secrets.datadog_api_key }}
-          DATADOG_APP_KEY: ${{ secrets.datadog_app_key }}
+          DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY_E2E }}
+          DATADOG_APP_KEY: ${{ secrets.DATADOG_APP_KEY_E2E }}
 
   standalone-binary-test-ubuntu:
     name: Test standalone binary in ubuntu

--- a/.github/workflows/e2e/global.config.json
+++ b/.github/workflows/e2e/global.config.json
@@ -1,6 +1,7 @@
 {
   "files": "{,!(node_modules)/**/}*.synthetics.json",
+  "failOnCriticalErrors": true,
+  "failOnMissingTests": true,
   "global": {},
   "timeout": 240000
 }
-


### PR DESCRIPTION
### What and why?

- Update the API and App key name to reflect the associated account
- Set the Synthetics E2E tests config to fail on critical errors and missing tests
