### PR TITLE
command-synthetics: Use header-4 instead of tabs

### DIFF
--- a/src/commands/synthetics/README.md
+++ b/src/commands/synthetics/README.md
@@ -10,8 +10,7 @@ To configure which URL your test starts on, provide a `startUrl` to your test ob
 
 ### Install the package
 
-{{< tabs >}}
-{{% tab "NPM" %}}
+#### NPM
 
 Install the package through NPM:
 
@@ -19,17 +18,13 @@ Install the package through NPM:
 npm install --save-dev @datadog/datadog-ci
 ```
 
-{{% /tab %}}
-{{% tab "Yarn" %}}
+#### Yarn
 
 Install the package through Yarn:
 
 ```bash
 yarn add --dev @datadog/datadog-ci
 ```
-
-{{% /tab %}}
-{{< /tabs >}}
 
 ### Setup the client
 


### PR DESCRIPTION
### What and why?

- Use header4 instead of tabs because tabs don't work as expected.

### Diff:

<img width="1254" alt="image" src="https://user-images.githubusercontent.com/19287532/210258313-dc14c271-3fbc-4013-b38f-69243e27bfee.png">

### Open question:

Should we remove the phrases "Install the package through XXX"?

