### PR TITLE
[ci-visibility] Remove sensitive data from repository url for user defined git metadata

### DIFF
--- a/src/helpers/__tests__/ci-env/azurepipelines.json
+++ b/src/helpers/__tests__/ci-env/azurepipelines.json
@@ -17,6 +17,7 @@
       "TF_BUILD": "True"
     },
     {
+      "_dd.ci.env_vars": "{\"SYSTEM_TEAMPROJECTID\":\"azure-pipelines-project-id\",\"BUILD_BUILDID\":\"azure-pipelines-build-id\",\"SYSTEM_JOBID\":\"azure-pipelines-job-id\"}",
       "ci.job.url": "azure-pipelines-server-uri/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id&view=logs&j=azure-pipelines-job-id&t=azure-pipelines-task-id",
       "ci.pipeline.id": "azure-pipelines-build-id",
       "ci.pipeline.name": "azure-pipelines-name",
@@ -51,6 +52,7 @@
       "TF_BUILD": "True"
     },
     {
+      "_dd.ci.env_vars": "{\"SYSTEM_TEAMPROJECTID\":\"azure-pipelines-project-id\",\"BUILD_BUILDID\":\"azure-pipelines-build-id\",\"SYSTEM_JOBID\":\"azure-pipelines-job-id\"}",
       "ci.job.url": "azure-pipelines-server-uri/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id&view=logs&j=azure-pipelines-job-id&t=azure-pipelines-task-id",
       "ci.pipeline.id": "azure-pipelines-build-id",
       "ci.pipeline.name": "azure-pipelines-name",
@@ -84,6 +86,7 @@
       "TF_BUILD": "True"
     },
     {
+      "_dd.ci.env_vars": "{\"SYSTEM_TEAMPROJECTID\":\"azure-pipelines-project-id\",\"BUILD_BUILDID\":\"azure-pipelines-build-id\",\"SYSTEM_JOBID\":\"azure-pipelines-job-id\"}",
       "ci.job.url": "azure-pipelines-server-uri/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id&view=logs&j=azure-pipelines-job-id&t=azure-pipelines-task-id",
       "ci.pipeline.id": "azure-pipelines-build-id",
       "ci.pipeline.name": "azure-pipelines-name",
@@ -119,6 +122,7 @@
       "USERPROFILE": "/not-my-home"
     },
     {
+      "_dd.ci.env_vars": "{\"SYSTEM_TEAMPROJECTID\":\"azure-pipelines-project-id\",\"BUILD_BUILDID\":\"azure-pipelines-build-id\",\"SYSTEM_JOBID\":\"azure-pipelines-job-id\"}",
       "ci.job.url": "azure-pipelines-server-uri/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id&view=logs&j=azure-pipelines-job-id&t=azure-pipelines-task-id",
       "ci.pipeline.id": "azure-pipelines-build-id",
       "ci.pipeline.name": "azure-pipelines-name",
@@ -154,6 +158,7 @@
       "USERPROFILE": "/not-my-home"
     },
     {
+      "_dd.ci.env_vars": "{\"SYSTEM_TEAMPROJECTID\":\"azure-pipelines-project-id\",\"BUILD_BUILDID\":\"azure-pipelines-build-id\",\"SYSTEM_JOBID\":\"azure-pipelines-job-id\"}",
       "ci.job.url": "azure-pipelines-server-uri/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id&view=logs&j=azure-pipelines-job-id&t=azure-pipelines-task-id",
       "ci.pipeline.id": "azure-pipelines-build-id",
       "ci.pipeline.name": "azure-pipelines-name",
@@ -189,6 +194,7 @@
       "USERPROFILE": "/not-my-home"
     },
     {
+      "_dd.ci.env_vars": "{\"SYSTEM_TEAMPROJECTID\":\"azure-pipelines-project-id\",\"BUILD_BUILDID\":\"azure-pipelines-build-id\",\"SYSTEM_JOBID\":\"azure-pipelines-job-id\"}",
       "ci.job.url": "azure-pipelines-server-uri/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id&view=logs&j=azure-pipelines-job-id&t=azure-pipelines-task-id",
       "ci.pipeline.id": "azure-pipelines-build-id",
       "ci.pipeline.name": "azure-pipelines-name",
@@ -224,6 +230,7 @@
       "USERPROFILE": "/not-my-home"
     },
     {
+      "_dd.ci.env_vars": "{\"SYSTEM_TEAMPROJECTID\":\"azure-pipelines-project-id\",\"BUILD_BUILDID\":\"azure-pipelines-build-id\",\"SYSTEM_JOBID\":\"azure-pipelines-job-id\"}",
       "ci.job.url": "azure-pipelines-server-uri/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id&view=logs&j=azure-pipelines-job-id&t=azure-pipelines-task-id",
       "ci.pipeline.id": "azure-pipelines-build-id",
       "ci.pipeline.name": "azure-pipelines-name",
@@ -259,6 +266,7 @@
       "USERPROFILE": "/not-my-home"
     },
     {
+      "_dd.ci.env_vars": "{\"SYSTEM_TEAMPROJECTID\":\"azure-pipelines-project-id\",\"BUILD_BUILDID\":\"azure-pipelines-build-id\",\"SYSTEM_JOBID\":\"azure-pipelines-job-id\"}",
       "ci.job.url": "azure-pipelines-server-uri/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id&view=logs&j=azure-pipelines-job-id&t=azure-pipelines-task-id",
       "ci.pipeline.id": "azure-pipelines-build-id",
       "ci.pipeline.name": "azure-pipelines-name",
@@ -292,6 +300,7 @@
       "TF_BUILD": "True"
     },
     {
+      "_dd.ci.env_vars": "{\"SYSTEM_TEAMPROJECTID\":\"azure-pipelines-project-id\",\"BUILD_BUILDID\":\"azure-pipelines-build-id\",\"SYSTEM_JOBID\":\"azure-pipelines-job-id\"}",
       "ci.job.url": "azure-pipelines-server-uri/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id&view=logs&j=azure-pipelines-job-id&t=azure-pipelines-task-id",
       "ci.pipeline.id": "azure-pipelines-build-id",
       "ci.pipeline.name": "azure-pipelines-name",
@@ -325,6 +334,7 @@
       "TF_BUILD": "True"
     },
     {
+      "_dd.ci.env_vars": "{\"SYSTEM_TEAMPROJECTID\":\"azure-pipelines-project-id\",\"BUILD_BUILDID\":\"azure-pipelines-build-id\",\"SYSTEM_JOBID\":\"azure-pipelines-job-id\"}",
       "ci.job.url": "azure-pipelines-server-uri/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id&view=logs&j=azure-pipelines-job-id&t=azure-pipelines-task-id",
       "ci.pipeline.id": "azure-pipelines-build-id",
       "ci.pipeline.name": "azure-pipelines-name",
@@ -358,6 +368,7 @@
       "TF_BUILD": "True"
     },
     {
+      "_dd.ci.env_vars": "{\"SYSTEM_TEAMPROJECTID\":\"azure-pipelines-project-id\",\"BUILD_BUILDID\":\"azure-pipelines-build-id\",\"SYSTEM_JOBID\":\"azure-pipelines-job-id\"}",
       "ci.job.url": "azure-pipelines-server-uri/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id&view=logs&j=azure-pipelines-job-id&t=azure-pipelines-task-id",
       "ci.pipeline.id": "azure-pipelines-build-id",
       "ci.pipeline.name": "azure-pipelines-name",
@@ -391,6 +402,7 @@
       "TF_BUILD": "True"
     },
     {
+      "_dd.ci.env_vars": "{\"SYSTEM_TEAMPROJECTID\":\"azure-pipelines-project-id\",\"BUILD_BUILDID\":\"azure-pipelines-build-id\",\"SYSTEM_JOBID\":\"azure-pipelines-job-id\"}",
       "ci.job.url": "azure-pipelines-server-uri/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id&view=logs&j=azure-pipelines-job-id&t=azure-pipelines-task-id",
       "ci.pipeline.id": "azure-pipelines-build-id",
       "ci.pipeline.name": "azure-pipelines-name",
@@ -424,6 +436,7 @@
       "TF_BUILD": "True"
     },
     {
+      "_dd.ci.env_vars": "{\"SYSTEM_TEAMPROJECTID\":\"azure-pipelines-project-id\",\"BUILD_BUILDID\":\"azure-pipelines-build-id\",\"SYSTEM_JOBID\":\"azure-pipelines-job-id\"}",
       "ci.job.url": "azure-pipelines-server-uri/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id&view=logs&j=azure-pipelines-job-id&t=azure-pipelines-task-id",
       "ci.pipeline.id": "azure-pipelines-build-id",
       "ci.pipeline.name": "azure-pipelines-name",
@@ -459,6 +472,7 @@
       "TF_BUILD": "True"
     },
     {
+      "_dd.ci.env_vars": "{\"SYSTEM_TEAMPROJECTID\":\"azure-pipelines-project-id\",\"BUILD_BUILDID\":\"azure-pipelines-build-id\",\"SYSTEM_JOBID\":\"azure-pipelines-job-id\"}",
       "ci.job.url": "azure-pipelines-server-uri/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id&view=logs&j=azure-pipelines-job-id&t=azure-pipelines-task-id",
       "ci.pipeline.id": "azure-pipelines-build-id",
       "ci.pipeline.name": "azure-pipelines-name",
@@ -495,6 +509,7 @@
       "TF_BUILD": "True"
     },
     {
+      "_dd.ci.env_vars": "{\"SYSTEM_TEAMPROJECTID\":\"azure-pipelines-project-id\",\"BUILD_BUILDID\":\"azure-pipelines-build-id\",\"SYSTEM_JOBID\":\"azure-pipelines-job-id\"}",
       "ci.job.url": "azure-pipelines-server-uri/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id&view=logs&j=azure-pipelines-job-id&t=azure-pipelines-task-id",
       "ci.pipeline.id": "azure-pipelines-build-id",
       "ci.pipeline.name": "azure-pipelines-name",
@@ -532,6 +547,7 @@
       "TF_BUILD": "True"
     },
     {
+      "_dd.ci.env_vars": "{\"SYSTEM_TEAMPROJECTID\":\"azure-pipelines-project-id\",\"BUILD_BUILDID\":\"azure-pipelines-build-id\",\"SYSTEM_JOBID\":\"azure-pipelines-job-id\"}",
       "ci.job.name": "azure-pipelines-job-name",
       "ci.job.url": "azure-pipelines-server-uri/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id&view=logs&j=azure-pipelines-job-id&t=azure-pipelines-task-id",
       "ci.pipeline.id": "azure-pipelines-build-id",
@@ -572,6 +588,7 @@
       "TF_BUILD": "True"
     },
     {
+      "_dd.ci.env_vars": "{\"SYSTEM_TEAMPROJECTID\":\"azure-pipelines-project-id\",\"BUILD_BUILDID\":\"azure-pipelines-build-id\",\"SYSTEM_JOBID\":\"azure-pipelines-job-id\"}",
       "ci.job.url": "azure-pipelines-server-uri/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id&view=logs&j=azure-pipelines-job-id&t=azure-pipelines-task-id",
       "ci.pipeline.id": "azure-pipelines-build-id",
       "ci.pipeline.name": "azure-pipelines-name",
@@ -614,6 +631,7 @@
       "TF_BUILD": "True"
     },
     {
+      "_dd.ci.env_vars": "{\"SYSTEM_TEAMPROJECTID\":\"azure-pipelines-project-id\",\"BUILD_BUILDID\":\"azure-pipelines-build-id\",\"SYSTEM_JOBID\":\"azure-pipelines-job-id\"}",
       "ci.job.url": "azure-pipelines-server-uri/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id&view=logs&j=azure-pipelines-job-id&t=azure-pipelines-task-id",
       "ci.pipeline.id": "azure-pipelines-build-id",
       "ci.pipeline.name": "azure-pipelines-name",
@@ -630,6 +648,34 @@
       "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
       "git.repository_url": "git@github.com:DataDog/userrepo.git",
       "git.tag": "0.0.2"
+    }
+  ],
+  [
+    {
+      "BUILD_BUILDID": "azure-pipelines-build-id",
+      "BUILD_DEFINITIONNAME": "azure-pipelines-name",
+      "BUILD_REPOSITORY_URI": "https://user:password@dev.azure.com/fabrikamfiber/",
+      "BUILD_REQUESTEDFOREMAIL": "azure-pipelines-commit-author-email@datadoghq.com",
+      "BUILD_REQUESTEDFORID": "azure-pipelines-commit-author",
+      "BUILD_SOURCEVERSIONMESSAGE": "azure-pipelines-commit-message",
+      "SYSTEM_JOBID": "azure-pipelines-job-id",
+      "SYSTEM_TASKINSTANCEID": "azure-pipelines-task-id",
+      "SYSTEM_TEAMFOUNDATIONSERVERURI": "azure-pipelines-server-uri/",
+      "SYSTEM_TEAMPROJECTID": "azure-pipelines-project-id",
+      "TF_BUILD": "True"
+    },
+    {
+      "_dd.ci.env_vars": "{\"SYSTEM_TEAMPROJECTID\":\"azure-pipelines-project-id\",\"BUILD_BUILDID\":\"azure-pipelines-build-id\",\"SYSTEM_JOBID\":\"azure-pipelines-job-id\"}",
+      "ci.job.url": "azure-pipelines-server-uri/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id&view=logs&j=azure-pipelines-job-id&t=azure-pipelines-task-id",
+      "ci.pipeline.id": "azure-pipelines-build-id",
+      "ci.pipeline.name": "azure-pipelines-name",
+      "ci.pipeline.number": "azure-pipelines-build-id",
+      "ci.pipeline.url": "azure-pipelines-server-uri/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id",
+      "ci.provider.name": "azurepipelines",
+      "git.commit.author.email": "azure-pipelines-commit-author-email@datadoghq.com",
+      "git.commit.author.name": "azure-pipelines-commit-author",
+      "git.commit.message": "azure-pipelines-commit-message",
+      "git.repository_url": "https://dev.azure.com/fabrikamfiber/"
     }
   ]
 ]

--- a/src/helpers/__tests__/ci-env/bitbucket.json
+++ b/src/helpers/__tests__/ci-env/bitbucket.json
@@ -375,5 +375,24 @@
       "git.repository_url": "git@github.com:DataDog/userrepo.git",
       "git.tag": "0.0.2"
     }
+  ],
+  [
+    {
+      "BITBUCKET_BUILD_NUMBER": "bitbucket-build-num",
+      "BITBUCKET_COMMIT": "bitbucket-commit",
+      "BITBUCKET_GIT_SSH_ORIGIN": "https://user:password@bitbucket.org/DataDog/dogweb.git",
+      "BITBUCKET_PIPELINE_UUID": "{bitbucket-uuid}",
+      "BITBUCKET_REPO_FULL_NAME": "bitbucket-repo"
+    },
+    {
+      "ci.job.url": "https://bitbucket.org/bitbucket-repo/addon/pipelines/home#!/results/bitbucket-build-num",
+      "ci.pipeline.id": "bitbucket-uuid",
+      "ci.pipeline.name": "bitbucket-repo",
+      "ci.pipeline.number": "bitbucket-build-num",
+      "ci.pipeline.url": "https://bitbucket.org/bitbucket-repo/addon/pipelines/home#!/results/bitbucket-build-num",
+      "ci.provider.name": "bitbucket",
+      "git.commit.sha": "bitbucket-commit",
+      "git.repository_url": "https://bitbucket.org/DataDog/dogweb.git"
+    }
   ]
 ]

--- a/src/helpers/__tests__/ci-env/bitrise.json
+++ b/src/helpers/__tests__/ci-env/bitrise.json
@@ -454,5 +454,26 @@
       "git.repository_url": "git@github.com:DataDog/userrepo.git",
       "git.tag": "0.0.2"
     }
+  ],
+  [
+    {
+      "BITRISE_BUILD_NUMBER": "bitrise-pipeline-number",
+      "BITRISE_BUILD_SLUG": "bitrise-pipeline-id",
+      "BITRISE_BUILD_URL": "bitrise-build-url",
+      "BITRISE_GIT_MESSAGE": "bitrise-git-commit-message",
+      "BITRISE_TRIGGERED_WORKFLOW_ID": "bitrise-pipeline-name",
+      "GIT_CLONE_COMMIT_HASH": "bitrise-git-commit",
+      "GIT_REPOSITORY_URL": "https://user:password@github.com/DataDog/dogweb.git"
+    },
+    {
+      "ci.pipeline.id": "bitrise-pipeline-id",
+      "ci.pipeline.name": "bitrise-pipeline-name",
+      "ci.pipeline.number": "bitrise-pipeline-number",
+      "ci.pipeline.url": "bitrise-build-url",
+      "ci.provider.name": "bitrise",
+      "git.commit.message": "bitrise-git-commit-message",
+      "git.commit.sha": "bitrise-git-commit",
+      "git.repository_url": "https://github.com/DataDog/dogweb.git"
+    }
   ]
 ]

--- a/src/helpers/__tests__/ci-env/buildkite.json
+++ b/src/helpers/__tests__/ci-env/buildkite.json
@@ -672,5 +672,36 @@
       "git.repository_url": "git@github.com:DataDog/userrepo.git",
       "git.tag": "0.0.2"
     }
+  ],
+  [
+    {
+      "BUILDKITE": "true",
+      "BUILDKITE_BRANCH": "",
+      "BUILDKITE_BUILD_AUTHOR": "buildkite-git-commit-author-name",
+      "BUILDKITE_BUILD_AUTHOR_EMAIL": "buildkite-git-commit-author-email@datadoghq.com",
+      "BUILDKITE_BUILD_ID": "buildkite-pipeline-id",
+      "BUILDKITE_BUILD_NUMBER": "buildkite-pipeline-number",
+      "BUILDKITE_BUILD_URL": "buildkite-build-url",
+      "BUILDKITE_COMMIT": "buildkite-git-commit",
+      "BUILDKITE_JOB_ID": "buildkite-job-id",
+      "BUILDKITE_MESSAGE": "buildkite-git-commit-message",
+      "BUILDKITE_PIPELINE_SLUG": "buildkite-pipeline-name",
+      "BUILDKITE_REPO": "https://user:password@github.com/DataDog/dogweb.git",
+      "BUILDKITE_TAG": ""
+    },
+    {
+      "_dd.ci.env_vars": "{\"BUILDKITE_BUILD_ID\":\"buildkite-pipeline-id\",\"BUILDKITE_JOB_ID\":\"buildkite-job-id\"}",
+      "ci.job.url": "buildkite-build-url#buildkite-job-id",
+      "ci.pipeline.id": "buildkite-pipeline-id",
+      "ci.pipeline.name": "buildkite-pipeline-name",
+      "ci.pipeline.number": "buildkite-pipeline-number",
+      "ci.pipeline.url": "buildkite-build-url",
+      "ci.provider.name": "buildkite",
+      "git.commit.author.email": "buildkite-git-commit-author-email@datadoghq.com",
+      "git.commit.author.name": "buildkite-git-commit-author-name",
+      "git.commit.message": "buildkite-git-commit-message",
+      "git.commit.sha": "buildkite-git-commit",
+      "git.repository_url": "https://github.com/DataDog/dogweb.git"
+    }
   ]
 ]

--- a/src/helpers/__tests__/ci-env/circleci.json
+++ b/src/helpers/__tests__/ci-env/circleci.json
@@ -518,5 +518,28 @@
       "git.repository_url": "git@github.com:DataDog/userrepo.git",
       "git.tag": "0.0.2"
     }
+  ],
+  [
+    {
+      "CIRCLECI": "circleCI",
+      "CIRCLE_BUILD_NUM": "circleci-pipeline-number",
+      "CIRCLE_BUILD_URL": "circleci-build-url",
+      "CIRCLE_JOB": "circleci-job-name",
+      "CIRCLE_PROJECT_REPONAME": "circleci-pipeline-name",
+      "CIRCLE_REPOSITORY_URL": "https://user:password@github.com/DataDog/dogweb.git",
+      "CIRCLE_SHA1": "circleci-git-commit",
+      "CIRCLE_WORKFLOW_ID": "circleci-pipeline-id"
+    },
+    {
+      "_dd.ci.env_vars": "{\"CIRCLE_WORKFLOW_ID\":\"circleci-pipeline-id\",\"CIRCLE_BUILD_NUM\":\"circleci-pipeline-number\"}",
+      "ci.job.name": "circleci-job-name",
+      "ci.job.url": "circleci-build-url",
+      "ci.pipeline.id": "circleci-pipeline-id",
+      "ci.pipeline.name": "circleci-pipeline-name",
+      "ci.pipeline.url": "https://app.circleci.com/pipelines/workflows/circleci-pipeline-id",
+      "ci.provider.name": "circleci",
+      "git.commit.sha": "circleci-git-commit",
+      "git.repository_url": "https://github.com/DataDog/dogweb.git"
+    }
   ]
 ]

--- a/src/helpers/__tests__/ci-env/gitlab.json
+++ b/src/helpers/__tests__/ci-env/gitlab.json
@@ -854,5 +854,39 @@
       "git.repository_url": "git@github.com:DataDog/userrepo.git",
       "git.tag": "0.0.2"
     }
+  ],
+  [
+    {
+      "CI_COMMIT_AUTHOR": "John Doe <john@doe.com>",
+      "CI_COMMIT_MESSAGE": "gitlab-git-commit-message",
+      "CI_COMMIT_SHA": "gitlab-git-commit",
+      "CI_COMMIT_TIMESTAMP": "2021-07-21T11:43:07-04:00",
+      "CI_JOB_ID": "gitlab-job-id",
+      "CI_JOB_NAME": "gitlab-job-name",
+      "CI_JOB_STAGE": "gitlab-stage-name",
+      "CI_JOB_URL": "gitlab-job-url",
+      "CI_PIPELINE_ID": "gitlab-pipeline-id",
+      "CI_PIPELINE_IID": "gitlab-pipeline-number",
+      "CI_PROJECT_PATH": "gitlab-pipeline-name",
+      "CI_PROJECT_URL": "gitlab-project-url",
+      "CI_REPOSITORY_URL": "https://user:password@gitlab.com/DataDog/dogweb.git",
+      "GITLAB_CI": "gitlab"
+    },
+    {
+      "_dd.ci.env_vars": "{\"CI_PROJECT_URL\":\"gitlab-project-url\",\"CI_PIPELINE_ID\":\"gitlab-pipeline-id\",\"CI_JOB_ID\":\"gitlab-job-id\"}",
+      "ci.job.name": "gitlab-job-name",
+      "ci.job.url": "gitlab-job-url",
+      "ci.pipeline.id": "gitlab-pipeline-id",
+      "ci.pipeline.name": "gitlab-pipeline-name",
+      "ci.pipeline.number": "gitlab-pipeline-number",
+      "ci.provider.name": "gitlab",
+      "ci.stage.name": "gitlab-stage-name",
+      "git.commit.author.date": "2021-07-21T11:43:07-04:00",
+      "git.commit.author.email": "john@doe.com",
+      "git.commit.author.name": "John Doe",
+      "git.commit.message": "gitlab-git-commit-message",
+      "git.commit.sha": "gitlab-git-commit",
+      "git.repository_url": "https://gitlab.com/DataDog/dogweb.git"
+    }
   ]
 ]

--- a/src/helpers/__tests__/ci-env/jenkins.json
+++ b/src/helpers/__tests__/ci-env/jenkins.json
@@ -665,5 +665,26 @@
       "git.repository_url": "git@github.com:DataDog/userrepo.git",
       "git.tag": "0.0.2"
     }
+  ],
+  [
+    {
+      "BUILD_NUMBER": "jenkins-pipeline-number",
+      "BUILD_TAG": "jenkins-pipeline-id",
+      "BUILD_URL": "jenkins-pipeline-url",
+      "DD_CUSTOM_TRACE_ID": "jenkins-custom-trace-id",
+      "GIT_COMMIT": "jenkins-git-commit",
+      "GIT_URL_1": "https://user:password@github.com/DataDog/dogweb.git",
+      "JENKINS_URL": "jenkins",
+      "JOB_URL": "jenkins-job-url"
+    },
+    {
+      "_dd.ci.env_vars": "{\"DD_CUSTOM_TRACE_ID\":\"jenkins-custom-trace-id\"}",
+      "ci.pipeline.id": "jenkins-pipeline-id",
+      "ci.pipeline.number": "jenkins-pipeline-number",
+      "ci.pipeline.url": "jenkins-pipeline-url",
+      "ci.provider.name": "jenkins",
+      "git.commit.sha": "jenkins-git-commit",
+      "git.repository_url": "https://github.com/DataDog/dogweb.git"
+    }
   ]
 ]

--- a/src/helpers/__tests__/ci-env/travisci.json
+++ b/src/helpers/__tests__/ci-env/travisci.json
@@ -493,5 +493,33 @@
       "git.repository_url": "git@github.com:DataDog/userrepo.git",
       "git.tag": "0.0.2"
     }
+  ],
+  [
+    {
+      "TRAVIS": "travisCI",
+      "TRAVIS_BRANCH": "origin/tags/0.1.0",
+      "TRAVIS_BUILD_DIR": "/foo/bar",
+      "TRAVIS_BUILD_ID": "travis-pipeline-id",
+      "TRAVIS_BUILD_NUMBER": "travis-pipeline-number",
+      "TRAVIS_BUILD_WEB_URL": "travis-pipeline-url",
+      "TRAVIS_COMMIT": "travis-git-commit",
+      "TRAVIS_COMMIT_MESSAGE": "travis-commit-message",
+      "TRAVIS_JOB_WEB_URL": "travis-job-url",
+      "TRAVIS_REPO_SLUG": "user/repo",
+      "TRAVIS_TAG": "origin/tags/0.1.0"
+    },
+    {
+      "ci.job.url": "travis-job-url",
+      "ci.pipeline.id": "travis-pipeline-id",
+      "ci.pipeline.name": "user/repo",
+      "ci.pipeline.number": "travis-pipeline-number",
+      "ci.pipeline.url": "travis-pipeline-url",
+      "ci.provider.name": "travisci",
+      "ci.workspace_path": "/foo/bar",
+      "git.commit.message": "travis-commit-message",
+      "git.commit.sha": "travis-git-commit",
+      "git.repository_url": "https://github.com/user/repo.git",
+      "git.tag": "0.1.0"
+    }
   ]
 ]

--- a/src/helpers/__tests__/ci-env/usersupplied.json
+++ b/src/helpers/__tests__/ci-env/usersupplied.json
@@ -154,5 +154,29 @@
       "git.repository_url": "git@github.com:DataDog/userrepo.git",
       "git.tag": "0.0.2"
     }
+  ],
+  [
+    {
+      "DD_GIT_COMMIT_AUTHOR_DATE": "usersupplied-authordate",
+      "DD_GIT_COMMIT_AUTHOR_EMAIL": "usersupplied-authoremail",
+      "DD_GIT_COMMIT_AUTHOR_NAME": "usersupplied-authorname",
+      "DD_GIT_COMMIT_COMMITTER_DATE": "usersupplied-comitterdate",
+      "DD_GIT_COMMIT_COMMITTER_EMAIL": "usersupplied-comitteremail",
+      "DD_GIT_COMMIT_COMMITTER_NAME": "usersupplied-comittername",
+      "DD_GIT_COMMIT_MESSAGE": "usersupplied-message",
+      "DD_GIT_COMMIT_SHA": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "DD_GIT_REPOSITORY_URL": "https://user:password@github.com/DataDog/dogweb.git"
+    },
+    {
+      "git.commit.author.date": "usersupplied-authordate",
+      "git.commit.author.email": "usersupplied-authoremail",
+      "git.commit.author.name": "usersupplied-authorname",
+      "git.commit.committer.date": "usersupplied-comitterdate",
+      "git.commit.committer.email": "usersupplied-comitteremail",
+      "git.commit.committer.name": "usersupplied-comittername",
+      "git.commit.message": "usersupplied-message",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "https://github.com/DataDog/dogweb.git"
+    }
   ]
 ]

--- a/src/helpers/ci.ts
+++ b/src/helpers/ci.ts
@@ -25,7 +25,7 @@ import {
   GIT_TAG,
 } from './tags'
 import {getUserCISpanTags, getUserGitSpanTags} from './user-provided-git'
-import {normalizeRef, removeEmptyValues, removeUndefinedValues} from './utils'
+import {normalizeRef, removeEmptyValues, removeUndefinedValues, filterSensitiveInfoFromRepository} from './utils'
 
 export const CI_ENGINES = {
   APPVEYOR: 'appveyor',
@@ -73,22 +73,6 @@ const resolveTilde = (filePath: string | undefined) => {
   }
 
   return filePath
-}
-
-const filterSensitiveInfoFromRepository = (repositoryUrl: string) => {
-  if (repositoryUrl.startsWith('git@')) {
-    return repositoryUrl
-  }
-  try {
-    const {protocol, hostname, pathname} = new URL(repositoryUrl)
-    if (!protocol || !hostname) {
-      return repositoryUrl
-    }
-
-    return `${protocol}//${hostname}${pathname}`
-  } catch (e) {
-    return repositoryUrl
-  }
 }
 
 export const getCISpanTags = (): SpanTags | undefined => {
@@ -446,6 +430,11 @@ export const getCISpanTags = (): SpanTags | undefined => {
       [GIT_COMMIT_MESSAGE]: BUILD_SOURCEVERSIONMESSAGE,
       [CI_STAGE_NAME]: SYSTEM_STAGEDISPLAYNAME,
       [CI_JOB_NAME]: SYSTEM_JOBDISPLAYNAME,
+      [CI_ENV_VARS]: JSON.stringify({
+        SYSTEM_TEAMPROJECTID,
+        BUILD_BUILDID,
+        SYSTEM_JOBID,
+      }),
     }
 
     if (SYSTEM_TEAMFOUNDATIONSERVERURI && SYSTEM_TEAMPROJECTID && BUILD_BUILDID) {

--- a/src/helpers/user-provided-git.ts
+++ b/src/helpers/user-provided-git.ts
@@ -20,7 +20,7 @@ import {
   GIT_SHA,
   GIT_TAG,
 } from './tags'
-import {normalizeRef, removeEmptyValues} from './utils'
+import {normalizeRef, removeEmptyValues, filterSensitiveInfoFromRepository} from './utils'
 
 export const getUserGitSpanTags = () => {
   const {
@@ -50,7 +50,7 @@ export const getUserGitSpanTags = () => {
   }
 
   return removeEmptyValues({
-    [GIT_REPOSITORY_URL]: DD_GIT_REPOSITORY_URL,
+    [GIT_REPOSITORY_URL]: filterSensitiveInfoFromRepository(DD_GIT_REPOSITORY_URL),
     [GIT_BRANCH]: branch,
     [GIT_SHA]: DD_GIT_COMMIT_SHA,
     [GIT_TAG]: tag,

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -259,3 +259,22 @@ export const performSubCommand = (command: CommandClass<BaseContext>, commandArg
 
   return cli.run(commandArgs, context)
 }
+
+export const filterSensitiveInfoFromRepository = (repositoryUrl: string | undefined) => {
+  try {
+    if (!repositoryUrl) {
+      return repositoryUrl
+    }
+    if (repositoryUrl.startsWith('git@')) {
+      return repositoryUrl
+    }
+    const {protocol, hostname, pathname} = new URL(repositoryUrl)
+    if (!protocol || !hostname) {
+      return repositoryUrl
+    }
+
+    return `${protocol}//${hostname}${pathname}`
+  } catch (e) {
+    return repositoryUrl
+  }
+}


### PR DESCRIPTION
### What and why?

* Remove sensitive data from repository url when the user provides `DD_GIT_REPOSITORY_URL`. This was done for CI providers metadata but not for the user defined one.

Additionally, we add `_dd.ci.env_vars` to azure pipelines (unrelated to the above).

### How?

* Apply `filterSensitiveInfoFromRepository` to user defined git metadata too.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
