### PR TITLE
Remove git metadata uploading + add git repo url tag for SCI

### DIFF
--- a/src/commands/lambda/__tests__/instrument.test.ts
+++ b/src/commands/lambda/__tests__/instrument.test.ts
@@ -476,6 +476,75 @@ TagResource -> arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world
         expect(output).toMatch('Error: Local git repository is dirty')
       })
 
+      test ('ensure source code integration git remotes get formatted correctly', async () => {
+        ;(fs.readFile as any).mockImplementation((a: any, b: any, callback: any) => callback({code: 'ENOENT'}))
+        const lambda = makeMockLambda({
+          'arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world': {
+            FunctionArn: 'arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world',
+            Handler: 'index.handler',
+            Runtime: 'nodejs12.x',
+          },
+        })
+        ;(Lambda as any).mockImplementation(() => lambda)
+        process.env.DATADOG_API_KEY = '1234'
+
+        const context = createMockContext() as any
+        const instrumentCommand = InstrumentCommand
+        const instrumentCommandSpy = jest.spyOn(instrumentCommand.prototype as any, 'filterAndFormatGitRemote')
+
+        const mockGitStatus = jest.spyOn(instrumentCommand.prototype as any, 'getCurrentGitStatus')
+        mockGitStatus.mockImplementation(() => ({
+          ahead: 0,
+          hash: '1be168ff837f043bde17c0314341c84271047b31',
+          remote: 'https://github.com/datadog/test.git',
+          isClean: true,
+        }))
+
+        const cli = new Cli()
+        cli.register(instrumentCommand)
+
+        const cliInput = [
+          'lambda',
+          'instrument',
+          '--function',
+          'arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world',
+          '--layerVersion',
+          '10',
+          '-s',
+          '--service',
+          'dummy',
+          '--env',
+          'dummy',
+          '--version',
+          '0.1',
+        ]
+
+        await cli.run(cliInput, context)
+
+        mockGitStatus.mockImplementation(() => ({
+          ahead: 0,
+          hash: '1be168ff837f043bde17c0314341c84271047b31',
+          remote: 'git@github.com:datadog/test.git',
+          isClean: true,
+        }))
+
+        await cli.run(cliInput, context)
+
+        mockGitStatus.mockImplementation(() => ({
+          ahead: 0,
+          hash: '1be168ff837f043bde17c0314341c84271047b31',
+          remote: 'github.com/datadog/test.git',
+          isClean: true,
+        }))
+
+        await cli.run(cliInput, context)
+
+        expect(instrumentCommandSpy).toHaveBeenCalledTimes(3);
+        expect(instrumentCommandSpy).toHaveNthReturnedWith(1, 'github.com/datadog/test.git')
+        expect(instrumentCommandSpy).toHaveNthReturnedWith(2, 'github.com/datadog/test.git')
+        expect(instrumentCommandSpy).toHaveNthReturnedWith(3, 'github.com/datadog/test.git')
+      })
+
       test('ensure source code integration flag works from a clean repo', async () => {
         ;(fs.readFile as any).mockImplementation((a: any, b: any, callback: any) => callback({code: 'ENOENT'}))
         const lambda = makeMockLambda({
@@ -536,7 +605,7 @@ UpdateFunctionConfiguration -> arn:aws:lambda:us-east-1:123456789012:function:la
       \\"DD_SITE\\": \\"datadoghq.com\\",
       \\"DD_CAPTURE_LAMBDA_PAYLOAD\\": \\"false\\",
       \\"DD_ENV\\": \\"dummy\\",
-      \\"DD_TAGS\\": \\"git.commit.sha:1be168ff837f043bde17c0314341c84271047b31,git.repository_url:git.repository_url:git@github.com:datadog/test.git\\",
+      \\"DD_TAGS\\": \\"git.commit.sha:1be168ff837f043bde17c0314341c84271047b31,git.repository_url:git.repository_url:github.com/datadog/test.git\\",
       \\"DD_MERGE_XRAY_TRACES\\": \\"false\\",
       \\"DD_SERVICE\\": \\"dummy\\",
       \\"DD_TRACE_ENABLED\\": \\"true\\",

--- a/src/commands/lambda/__tests__/instrument.test.ts
+++ b/src/commands/lambda/__tests__/instrument.test.ts
@@ -476,7 +476,7 @@ TagResource -> arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world
         expect(output).toMatch('Error: Local git repository is dirty')
       })
 
-      test ('ensure source code integration git remotes get formatted correctly', async () => {
+      test('ensure source code integration git remotes get formatted correctly', async () => {
         ;(fs.readFile as any).mockImplementation((a: any, b: any, callback: any) => callback({code: 'ENOENT'}))
         const lambda = makeMockLambda({
           'arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world': {
@@ -539,7 +539,7 @@ TagResource -> arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world
 
         await cli.run(cliInput, context)
 
-        expect(instrumentCommandSpy).toHaveBeenCalledTimes(3);
+        expect(instrumentCommandSpy).toHaveBeenCalledTimes(3)
         expect(instrumentCommandSpy).toHaveNthReturnedWith(1, 'github.com/datadog/test.git')
         expect(instrumentCommandSpy).toHaveNthReturnedWith(2, 'github.com/datadog/test.git')
         expect(instrumentCommandSpy).toHaveNthReturnedWith(3, 'github.com/datadog/test.git')

--- a/src/commands/lambda/__tests__/instrument.test.ts
+++ b/src/commands/lambda/__tests__/instrument.test.ts
@@ -496,10 +496,6 @@ TagResource -> arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world
           remote: 'git.repository_url:git@github.com:datadog/test.git',
           isClean: true,
         }))
-        const mockUploadFunction = jest.spyOn(instrumentCommand.prototype as any, 'uploadGitData')
-        mockUploadFunction.mockImplementation(() => {
-          return
-        })
 
         const cli = new Cli()
         cli.register(instrumentCommand)
@@ -601,7 +597,7 @@ TagResource -> arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world
           context
         )
         const output = context.stdout.toString()
-        expect(output).toMatch('Error: Local changes have not been pushed remotely. Aborting git upload.')
+        expect(output).toMatch('Error: Local changes have not been pushed remotely. Aborting git data tagging.')
       })
 
       test('runs function update command for lambda library layer', async () => {

--- a/src/commands/lambda/__tests__/instrument.test.ts
+++ b/src/commands/lambda/__tests__/instrument.test.ts
@@ -398,40 +398,6 @@ TagResource -> arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world
         expect(output.replace('\n', '')).toMatch(/.*Error: Couldn't get local git status.*/)
       })
 
-      test('instrumenting with source code integrations fails if DATADOG_API_KEY is not provided', async () => {
-        ;(fs.readFile as any).mockImplementation((a: any, b: any, callback: any) => callback({code: 'ENOENT'}))
-        const lambda = makeMockLambda({
-          'arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world': {
-            FunctionArn: 'arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world',
-            Handler: 'index.handler',
-            Runtime: 'nodejs12.x',
-          },
-        })
-        ;(Lambda as any).mockImplementation(() => lambda)
-        const cli = makeCli()
-        const context = createMockContext() as any
-        await cli.run(
-          [
-            'lambda',
-            'instrument',
-            '--function',
-            'arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world',
-            '--layerVersion',
-            '10',
-            '-s',
-            '--service',
-            'dummy',
-            '--env',
-            'dummy',
-            '--version',
-            '0.1',
-          ],
-          context
-        )
-        const output = context.stdout.toString()
-        expect(output).toMatch(/.*Missing DATADOG_API_KEY in your environment.*/i)
-      })
-
       test('ensure the instrument command ran from a dirty git repo fails', async () => {
         ;(fs.readFile as any).mockImplementation((a: any, b: any, callback: any) => callback({code: 'ENOENT'}))
         const lambda = makeMockLambda({

--- a/src/commands/lambda/__tests__/instrument.test.ts
+++ b/src/commands/lambda/__tests__/instrument.test.ts
@@ -493,6 +493,7 @@ TagResource -> arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world
         mockGitStatus.mockImplementation(() => ({
           ahead: 0,
           hash: '1be168ff837f043bde17c0314341c84271047b31',
+          remote: 'git.repository_url:git@github.com:datadog/test.git',
           isClean: true,
         }))
         const mockUploadFunction = jest.spyOn(instrumentCommand.prototype as any, 'uploadGitData')
@@ -539,7 +540,7 @@ UpdateFunctionConfiguration -> arn:aws:lambda:us-east-1:123456789012:function:la
       \\"DD_SITE\\": \\"datadoghq.com\\",
       \\"DD_CAPTURE_LAMBDA_PAYLOAD\\": \\"false\\",
       \\"DD_ENV\\": \\"dummy\\",
-      \\"DD_TAGS\\": \\"git.commit.sha:1be168ff837f043bde17c0314341c84271047b31\\",
+      \\"DD_TAGS\\": \\"git.commit.sha:1be168ff837f043bde17c0314341c84271047b31,git.repository_url:git.repository_url:git@github.com:datadog/test.git\\",
       \\"DD_MERGE_XRAY_TRACES\\": \\"false\\",
       \\"DD_SERVICE\\": \\"dummy\\",
       \\"DD_TRACE_ENABLED\\": \\"true\\",

--- a/src/commands/lambda/instrument.ts
+++ b/src/commands/lambda/instrument.ts
@@ -329,7 +329,7 @@ export class InstrumentCommand extends Command {
     if (!rawRemote) {
       return rawRemote
     }
-    rawRemote = rawRemote.replace(/git@github.com:|https:\/\/github.com\//, 'github.com/')
+    rawRemote = rawRemote.replace(/git@github\.com:|https:\/\/github\.com\//, 'github.com/')
 
     return rawRemote
   }

--- a/src/commands/lambda/instrument.ts
+++ b/src/commands/lambda/instrument.ts
@@ -329,8 +329,7 @@ export class InstrumentCommand extends Command {
     if (!rawRemote) {
       return rawRemote
     }
-    rawRemote = rawRemote.replace('git@github.com:', 'github.com/')
-    rawRemote = rawRemote.replace('https://github.com', 'github.com')
+    rawRemote = rawRemote.replace(/git@github.com:|https:\/\/github.com\//, 'github.com/')
 
     return rawRemote
   }

--- a/src/commands/lambda/instrument.ts
+++ b/src/commands/lambda/instrument.ts
@@ -169,11 +169,6 @@ export class InstrumentCommand extends Command {
     }
 
     if (this.sourceCodeIntegration) {
-      if (!process.env.DATADOG_API_KEY) {
-        this.context.stdout.write(renderer.renderMissingDatadogApiKeyError())
-
-        return 1
-      }
       try {
         const gitData = await this.getGitData()
         if (settings.extraTags) {

--- a/src/commands/lambda/instrument.ts
+++ b/src/commands/lambda/instrument.ts
@@ -5,7 +5,6 @@ import {Cli, Command} from 'clipanion'
 import {resolveConfigFromFile, filterSensitiveInfoFromRepository} from '../../helpers/utils'
 
 import {getCommitInfo, newSimpleGit} from '../git-metadata/git'
-import {UploadCommand} from '../git-metadata/upload'
 
 import {
   AWS_DEFAULT_REGION_ENV_VAR,
@@ -338,7 +337,7 @@ export class InstrumentCommand extends Command {
     }
 
     if (currentStatus.ahead > 0) {
-      throw Error('Local changes have not been pushed remotely. Aborting git upload.')
+      throw Error('Local changes have not been pushed remotely. Aborting git data tagging.')
     }
 
     return {commitSha: currentStatus.hash, gitRemote: filterSensitiveInfoFromRepository(currentStatus.remote)}
@@ -513,16 +512,6 @@ export class InstrumentCommand extends Command {
     this.environment = process.env[ENVIRONMENT_ENV_VAR] || undefined
     this.service = process.env[SERVICE_ENV_VAR] || undefined
     this.version = process.env[VERSION_ENV_VAR] || undefined
-  }
-
-  private async uploadGitData() {
-    const cli = new Cli()
-    cli.register(UploadCommand)
-    if ((await cli.run(['git-metadata', 'upload'], this.context)) !== 0) {
-      throw Error("Couldn't upload git metadata")
-    }
-
-    return
   }
 }
 

--- a/src/commands/lambda/instrument.ts
+++ b/src/commands/lambda/instrument.ts
@@ -329,6 +329,16 @@ export class InstrumentCommand extends Command {
     }
   }
 
+  private filterAndFormatGitRemote(rawRemote: string | undefined): string | undefined {
+    rawRemote = filterSensitiveInfoFromRepository(rawRemote)
+    if (!rawRemote) {
+      return rawRemote
+    }
+    rawRemote = rawRemote.replace("git@github.com:", "github.com/")
+    rawRemote = rawRemote.replace("https://github.com", "github.com")
+    return rawRemote
+  }
+
   private async getGitData() {
     let currentStatus
 
@@ -346,7 +356,9 @@ export class InstrumentCommand extends Command {
       throw Error('Local changes have not been pushed remotely. Aborting git data tagging.')
     }
 
-    return {commitSha: currentStatus.hash, gitRemote: filterSensitiveInfoFromRepository(currentStatus.remote)}
+    const gitRemote = this.filterAndFormatGitRemote(currentStatus.remote)
+
+    return {commitSha: currentStatus.hash, gitRemote: gitRemote}
   }
 
   private getSettings(): InstrumentationSettings | undefined {

--- a/src/commands/lambda/instrument.ts
+++ b/src/commands/lambda/instrument.ts
@@ -334,8 +334,9 @@ export class InstrumentCommand extends Command {
     if (!rawRemote) {
       return rawRemote
     }
-    rawRemote = rawRemote.replace("git@github.com:", "github.com/")
-    rawRemote = rawRemote.replace("https://github.com", "github.com")
+    rawRemote = rawRemote.replace('git@github.com:', 'github.com/')
+    rawRemote = rawRemote.replace('https://github.com', 'github.com')
+
     return rawRemote
   }
 
@@ -358,7 +359,7 @@ export class InstrumentCommand extends Command {
 
     const gitRemote = this.filterAndFormatGitRemote(currentStatus.remote)
 
-    return {commitSha: currentStatus.hash, gitRemote: gitRemote}
+    return {commitSha: currentStatus.hash, gitRemote}
   }
 
   private getSettings(): InstrumentationSettings | undefined {

--- a/src/commands/lambda/instrument.ts
+++ b/src/commands/lambda/instrument.ts
@@ -2,7 +2,7 @@ import {CloudWatchLogs, Lambda} from 'aws-sdk'
 import {bold} from 'chalk'
 import {Cli, Command} from 'clipanion'
 
-import {resolveConfigFromFile} from '../../helpers/utils'
+import {resolveConfigFromFile, filterSensitiveInfoFromRepository} from '../../helpers/utils'
 
 import {getCommitInfo, newSimpleGit} from '../git-metadata/git'
 import {UploadCommand} from '../git-metadata/upload'
@@ -341,7 +341,7 @@ export class InstrumentCommand extends Command {
       throw Error('Local changes have not been pushed remotely. Aborting git upload.')
     }
 
-    return {commitSha: currentStatus.hash, gitRemote: currentStatus.remote}
+    return {commitSha: currentStatus.hash, gitRemote: filterSensitiveInfoFromRepository(currentStatus.remote)}
   } 
 
   private getSettings(): InstrumentationSettings | undefined {

--- a/src/commands/lambda/instrument.ts
+++ b/src/commands/lambda/instrument.ts
@@ -1,6 +1,6 @@
 import {CloudWatchLogs, Lambda} from 'aws-sdk'
 import {bold} from 'chalk'
-import {Cli, Command} from 'clipanion'
+import {Command} from 'clipanion'
 
 import {resolveConfigFromFile, filterSensitiveInfoFromRepository} from '../../helpers/utils'
 
@@ -320,7 +320,13 @@ export class InstrumentCommand extends Command {
     }
     const status = await simpleGit.status()
 
-    return {isClean: status.isClean(), ahead: status.ahead, files: status.files, hash: gitCommitInfo?.hash, remote: gitCommitInfo?.remote}
+    return {
+      isClean: status.isClean(),
+      ahead: status.ahead,
+      files: status.files,
+      hash: gitCommitInfo?.hash,
+      remote: gitCommitInfo?.remote,
+    }
   }
 
   private async getGitData() {
@@ -341,7 +347,7 @@ export class InstrumentCommand extends Command {
     }
 
     return {commitSha: currentStatus.hash, gitRemote: filterSensitiveInfoFromRepository(currentStatus.remote)}
-  } 
+  }
 
   private getSettings(): InstrumentationSettings | undefined {
     const layerVersionStr = this.layerVersion ?? this.config.layerVersion


### PR DESCRIPTION
### What and why?

Remove git metadata uploading when running the `lambda instrument` command with flag `-s` (`--source-code-integration`). Instead, add the repo url as a tag (alongside the commit sha that's already added) to the `DD_TAGS` env var. Fix tests.

This PR does not touch the datadog-ci `git-metadata` (`git-metadata upload`) command

### How?

A brief description of implementation details of this PR.

Remove unneeded git upload function, get repo url from the git commit info (same place we get the commit hash).

These tags are added to `DD_TAGS` separated by commas, no spaces. The repo url is formatted in the following way:
`git.repository_url:github.com/thedavl/python_cdk_app.git`

- In order to not break backwards compatibility with tracer versions that don't support colons in tags, logic has been added to format git remotes turning `git@github.com:datadog/test.git` and `https://github.com/datadog/test.git` into `github.com/datadog/test.git`

- Previously, we would give an error if source code integration was enabled and the ddog api key wasn't provided. Removed this check (and an associated unit test), as this is no longer needed. The api key was previously used to upload the git metadata to datadog.

### Testing

Manually tested, by creating a new personal git repo with a sample app (which includes a forced exception in the lambda code), instrumenting it using my local modified `datadog-ci` with the `-s` flag, and checking for SCI functionality.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
