### PR TITLE
Manual Docker image release

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -8,6 +8,8 @@ variables:
 build-docker-image-amd64:
   stage: build
   only: [ "tags" ]
+  when: manual
+  allow_failure: false
   tags: ["runner:docker"]
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/docker:20.10
   script:
@@ -18,6 +20,8 @@ build-docker-image-amd64:
 build-docker-image-arm64:
   stage: build
   only: [ "tags" ]
+  when: manual
+  allow_failure: false
   tags: ["runner:docker-arm", "platform:arm64"]
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/docker:20.10
   script:
@@ -28,6 +32,7 @@ build-docker-image-arm64:
 publish-docker-image:
   stage: release
   only: [ "tags" ]
+  needs: [ "build-docker-image-amd64", "build-docker-image-arm64" ]
   trigger:
     project: DataDog/public-images
     branch: main

--- a/README.md
+++ b/README.md
@@ -149,8 +149,8 @@ To release a new version of `datadog-ci`:
 4. Merge the Pull Request.
 5. Create a GitHub Release from the [Tags page](https://github.com/DataDog/datadog-ci/tags) with the description of changes introduced.
 6. Once the release has been created, a GitHub Action publishes the package. Make sure the job succeeds.
-7. Once the package has been published, [go to Gitlab](https://gitlab.ddbuild.io/DataDog/datadog-ci/-/pipelines), find the pipeline for your tag and run the Docker image build jobs by pressing the "play" button on the `build` stage. Once the jobs pass, the `release` stage will automatically trigger. Make sure all the jobs succeed.
-8. If the release introduced some **changes in the** `synthetics` **command**, you have to upgrade `datadog-ci` in the following projects:
+7. Once the package has been published, [go to GitLab](https://gitlab.ddbuild.io/DataDog/datadog-ci/-/pipelines), find the pipeline for your tag, and press the **play** button on the `build` stage to run the Docker image build jobs. Once the jobs pass, the `release` stage automatically triggers. Make sure all the jobs succeed.
+8. If the release introduced any **changes in the** `synthetics` **command**, you have to upgrade `datadog-ci` in the following projects:
    * [GitHub Action](https://github.com/DataDog/synthetics-ci-github-action)
    * [CircleCI Orb](https://github.com/DataDog/synthetics-test-automation-circleci-orb)
    * [Azure DevOps Extension](https://github.com/DataDog/datadog-ci-azure-devops)

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ To release a new version of `datadog-ci`:
 4. Merge the Pull Request.
 5. Create a GitHub Release from the [Tags page](https://github.com/DataDog/datadog-ci/tags) with the description of changes introduced.
 6. Once the release has been created, a GitHub Action publishes the package. Make sure the job succeeds.
-7. Once the package has been published, [go to GitLab](https://gitlab.ddbuild.io/DataDog/datadog-ci/-/pipelines), find the pipeline for your tag, and press the **play** button on the `build` stage to run the Docker image build jobs. Once the jobs pass, the `release` stage automatically triggers. Make sure all the jobs succeed.
+7. When the package has been published, go to the [Datadog GitLab pipelines](https://gitlab.ddbuild.io/DataDog/datadog-ci/-/pipelines), find the pipeline for your tag, and start the `build` stage to run the Docker image build jobs. Once the jobs pass, the `release` stage automatically triggers. Make sure all the jobs succeed.
 8. If the release introduced any **changes in the** `synthetics` **command**, you have to upgrade `datadog-ci` in the following projects:
    * [GitHub Action](https://github.com/DataDog/synthetics-ci-github-action)
    * [CircleCI Orb](https://github.com/DataDog/synthetics-test-automation-circleci-orb)

--- a/README.md
+++ b/README.md
@@ -148,8 +148,9 @@ To release a new version of `datadog-ci`:
 3. Push the branch along with the tag to the upstream (GitHub) with `git push --tags origin name-of-the-branch`, create a Pull Request with the changes introduced in the description details, and get at least one approval. For example, see this [sample pull request](https://github.com/DataDog/datadog-ci/pull/78).
 4. Merge the Pull Request.
 5. Create a GitHub Release from the [Tags page](https://github.com/DataDog/datadog-ci/tags) with the description of changes introduced.
-6. Once the release has been created, a GitHub Action publishes the package, and a Gitlab pipeline publishes the Docker image. Make sure these jobs succeed.
-7. If the release introduced some **changes in the** `synthetics` **command**, you have to upgrade `datadog-ci` in the following projects:
+6. Once the release has been created, a GitHub Action publishes the package. Make sure the job succeeds.
+7. Once the package has been published, [go to Gitlab](https://gitlab.ddbuild.io/DataDog/datadog-ci/-/pipelines), find the pipeline for your tag and run the Docker image build jobs by pressing the "play" button on the `build` stage. Once the jobs pass, the `release` stage will automatically trigger. Make sure all the jobs succeed.
+8. If the release introduced some **changes in the** `synthetics` **command**, you have to upgrade `datadog-ci` in the following projects:
    * [GitHub Action](https://github.com/DataDog/synthetics-ci-github-action)
    * [CircleCI Orb](https://github.com/DataDog/synthetics-test-automation-circleci-orb)
    * [Azure DevOps Extension](https://github.com/DataDog/datadog-ci-azure-devops)


### PR DESCRIPTION
### What?

Makes building the Docker image a manual step that needs to be triggered by hand during the release process.

### Why?

During releases, there was a race condition between publishing the package and trying to build the Docker image. 

This was because the Gitlab pipeline that builds the Docker image ran automatically once a tag was pushed, but the package might not yet be available at that point.
