### PR TITLE
[Synthetics] Fix duplicated output message with tunnelled runs

### DIFF
--- a/src/commands/synthetics/reporters/default.ts
+++ b/src/commands/synthetics/reporters/default.ts
@@ -259,24 +259,24 @@ export class DefaultReporter implements MainReporter {
   }
 
   public error(error: string) {
-    this.testWaitSpinner?.stopAndPersist()
+    this.stopSpinner()
     this.write(error)
   }
 
   public initErrors(errors: string[]) {
-    this.testWaitSpinner?.stopAndPersist()
+    this.stopSpinner()
     this.write(errors.join('\n') + '\n\n')
   }
 
   public log(log: string) {
-    this.testWaitSpinner?.stopAndPersist()
+    this.stopSpinner()
     this.write(log)
   }
 
   public reportStart(timings: {startTime: number}) {
     const delay = (Date.now() - timings.startTime).toString()
 
-    this.testWaitSpinner?.stopAndPersist()
+    this.stopSpinner()
     this.write(['', chalk.bold.cyan('=== REPORT ==='), `Took ${chalk.bold(delay)}ms`, '\n'].join('\n'))
   }
 
@@ -384,6 +384,11 @@ export class DefaultReporter implements MainReporter {
 
   public testWait(test: Test) {
     return
+  }
+
+  private stopSpinner() {
+    this.testWaitSpinner?.stopAndPersist()
+    delete this.testWaitSpinner
   }
 }
 


### PR DESCRIPTION
### What and why?

Fix the duplicated `Waiting for x test result` message we see with tunnelled runs.

<details><summary>Before</summary>

![image](https://user-images.githubusercontent.com/19409477/212693600-3079a13d-79b0-4f62-bb3f-9c70c060c03c.png)

</details>

<details><summary>After</summary>

![image](https://user-images.githubusercontent.com/19409477/212693718-02f76437-b5f5-4e30-aaee-57d2b5a5f8b0.png)
</details>

### How?

Destroy the spinner once stopped, every `stopAndPersist. is called it re-outputs the original message.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
