### PR TITLE
[s8s] Make jUnit reporter's runEnd synchronous

### DIFF
--- a/src/commands/synthetics/__tests__/reporters/junit.test.ts
+++ b/src/commands/synthetics/__tests__/reporters/junit.test.ts
@@ -1,4 +1,5 @@
-import {promises as fs} from 'fs'
+import fs from 'fs'
+import fsp from 'fs/promises'
 import {Writable} from 'stream'
 
 import {BaseContext} from 'clipanion/lib/advanced'
@@ -56,18 +57,18 @@ describe('Junit reporter', () => {
   describe('runEnd', () => {
     beforeEach(() => {
       reporter = new JUnitReporter(commandMock as RunTestCommand)
-      jest.spyOn(fs, 'writeFile')
+      jest.spyOn(fs, 'writeFileSync')
       jest.spyOn(reporter['builder'], 'buildObject')
     })
 
     it('should build the xml', async () => {
       reporter.runEnd(globalSummaryMock, '')
       expect(reporter['builder'].buildObject).toHaveBeenCalledWith(reporter['json'])
-      expect(fs.writeFile).toHaveBeenCalledWith('junit.xml', expect.any(String), 'utf8')
+      expect(fs.writeFileSync).toHaveBeenCalledWith('junit.xml', expect.any(String), 'utf8')
       expect(writeMock).toHaveBeenCalledTimes(1)
 
       // Cleaning
-      await fs.unlink(reporter['destination'])
+      await fsp.unlink(reporter['destination'])
     })
 
     it('should gracefully fail', async () => {
@@ -77,33 +78,33 @@ describe('Junit reporter', () => {
 
       reporter.runEnd(globalSummaryMock, '')
 
-      expect(fs.writeFile).not.toHaveBeenCalled()
+      expect(fs.writeFileSync).not.toHaveBeenCalled()
       expect(writeMock).toHaveBeenCalledTimes(1)
     })
 
     it('should create the file', async () => {
       reporter['destination'] = 'junit/report.xml'
       reporter.runEnd(globalSummaryMock, '')
-      const stat = await fs.stat(reporter['destination'])
+      const stat = await fsp.stat(reporter['destination'])
       expect(stat).toBeDefined()
 
       // Cleaning
-      await fs.unlink(reporter['destination'])
-      await fs.rmdir('junit')
+      await fsp.unlink(reporter['destination'])
+      await fsp.rmdir('junit')
     })
 
     it('should not throw on existing directory', async () => {
-      await fs.mkdir('junit')
+      await fsp.mkdir('junit')
       reporter['destination'] = 'junit/report.xml'
       reporter.runEnd(globalSummaryMock, '')
 
       // Cleaning
-      await fs.unlink(reporter['destination'])
-      await fs.rmdir('junit')
+      await fsp.unlink(reporter['destination'])
+      await fsp.rmdir('junit')
     })
 
     it('testsuites contains summary properties', async () => {
-      jest.spyOn(fs, 'writeFile').mockResolvedValueOnce()
+      jest.spyOn(fs, 'writeFileSync').mockImplementation(() => {})
 
       reporter.runEnd(
         {

--- a/src/commands/synthetics/__tests__/reporters/junit.test.ts
+++ b/src/commands/synthetics/__tests__/reporters/junit.test.ts
@@ -61,7 +61,7 @@ describe('Junit reporter', () => {
     })
 
     it('should build the xml', async () => {
-      await reporter.runEnd(globalSummaryMock, '')
+      reporter.runEnd(globalSummaryMock, '')
       expect(reporter['builder'].buildObject).toHaveBeenCalledWith(reporter['json'])
       expect(fs.writeFile).toHaveBeenCalledWith('junit.xml', expect.any(String), 'utf8')
       expect(writeMock).toHaveBeenCalledTimes(1)
@@ -75,7 +75,7 @@ describe('Junit reporter', () => {
         throw new Error('Fail')
       })
 
-      await reporter.runEnd(globalSummaryMock, '')
+      reporter.runEnd(globalSummaryMock, '')
 
       expect(fs.writeFile).not.toHaveBeenCalled()
       expect(writeMock).toHaveBeenCalledTimes(1)
@@ -83,7 +83,7 @@ describe('Junit reporter', () => {
 
     it('should create the file', async () => {
       reporter['destination'] = 'junit/report.xml'
-      await reporter.runEnd(globalSummaryMock, '')
+      reporter.runEnd(globalSummaryMock, '')
       const stat = await fs.stat(reporter['destination'])
       expect(stat).toBeDefined()
 
@@ -95,7 +95,7 @@ describe('Junit reporter', () => {
     it('should not throw on existing directory', async () => {
       await fs.mkdir('junit')
       reporter['destination'] = 'junit/report.xml'
-      await reporter.runEnd(globalSummaryMock, '')
+      reporter.runEnd(globalSummaryMock, '')
 
       // Cleaning
       await fs.unlink(reporter['destination'])
@@ -105,7 +105,7 @@ describe('Junit reporter', () => {
     it('testsuites contains summary properties', async () => {
       jest.spyOn(fs, 'writeFile').mockResolvedValueOnce()
 
-      await reporter.runEnd(
+      reporter.runEnd(
         {
           ...globalSummaryMock,
           criticalErrors: 1,

--- a/src/commands/synthetics/reporters/junit.ts
+++ b/src/commands/synthetics/reporters/junit.ts
@@ -1,4 +1,4 @@
-import {promises as fs} from 'fs'
+import fs from 'fs'
 import path from 'path'
 import {Writable} from 'stream'
 
@@ -230,7 +230,7 @@ export class JUnitReporter implements Reporter {
     this.addTestCaseToSuite(suite, testCase)
   }
 
-  public async runEnd(summary: Summary, baseUrl: string) {
+  public runEnd(summary: Summary, baseUrl: string) {
     Object.assign(this.json.testsuites.$, {
       tests_critical_error: summary.criticalErrors,
       tests_failed: summary.failed,
@@ -247,8 +247,8 @@ export class JUnitReporter implements Reporter {
     // Write the file
     try {
       const xml = this.builder.buildObject(this.json)
-      await fs.mkdir(path.dirname(this.destination), {recursive: true})
-      await fs.writeFile(this.destination, xml, 'utf8')
+      fs.mkdirSync(path.dirname(this.destination), {recursive: true})
+      fs.writeFileSync(this.destination, xml, 'utf8')
       this.write(`✅ Created a jUnit report at ${c.bold.green(this.destination)}\n`)
     } catch (e) {
       this.write(`❌ Couldn't write the report to ${c.bold.green(this.destination)}:\n${e.toString()}\n`)


### PR DESCRIPTION
### What and why?

Reporters functions should not be `async`.
Or if they are, it will need a bigger fix.

### How?

jUnit reporter's `runEnd` was `async` because it was using `fs.promises` to write the files.
Instead, use `fs.mkdirSync` and `fs.writeFileSync` to keep the function synchronous.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
