### PR TITLE
Enable SCI by default

### DIFF
--- a/src/commands/lambda/README.md
+++ b/src/commands/lambda/README.md
@@ -98,7 +98,7 @@ You can pass the following arguments to `instrument` to specify its behavior. Th
 | `--forwarder` | | The ARN of the [datadog forwarder][10] to attach this function's LogGroup to. | |
 | `--dry` | `-d` | Preview changes running command would apply. | `false` |
 | `--log-level` | | Set to `debug` to see additional output from the Datadog Lambda Library and/or Lambda Extension for troubleshooting purposes. | |
-| `--source-code-integration` | `-s` | Whether to enable Datadog Source Code Integration. This will tag your lambda(s) with the Git metadata in the current local directory and the latest commit. **Note**: Git repository must not be ahead of remote, and must not be dirty. <br /> To disable, use `--no-source-code-integration`. | `true` |
+| `--source-code-integration` | `-s` | Whether to enable Datadog Source Code Integration. This will tag your lambda(s) with the repository url and latest commit of the current local directory. **Note**: Git repository must not be ahead of remote, and must not be dirty. <br /> To disable, use `--no-source-code-integration`. | `true` |
 
 <br />
 

--- a/src/commands/lambda/README.md
+++ b/src/commands/lambda/README.md
@@ -98,7 +98,8 @@ You can pass the following arguments to `instrument` to specify its behavior. Th
 | `--forwarder` | | The ARN of the [datadog forwarder][10] to attach this function's LogGroup to. | |
 | `--dry` | `-d` | Preview changes running command would apply. | `false` |
 | `--log-level` | | Set to `debug` to see additional output from the Datadog Lambda Library and/or Lambda Extension for troubleshooting purposes. | |
-| `--source-code-integration` | `-s` | Whether to enable Datadog Source Code Integration. This will tag your lambda(s) with the Git repository URL and the latest commit of the current local directory. **Note**: Git repository must not be ahead of remote, and must not be dirty. <br /> To disable, use `--no-source-code-integration`. | `true` |
+| `--source-code-integration` | `-s` | Whether to enable Datadog Source Code Integration. This will tag your lambda(s) with the Git repository URL and the latest commit of the current local directory. **Note**: Git repository must not be ahead of remote, and must not be dirty. | `true` |
+| `--no-source-code-integration` | | Disables Datadog Source Code Integration. | |
 
 <br />
 

--- a/src/commands/lambda/README.md
+++ b/src/commands/lambda/README.md
@@ -98,7 +98,7 @@ You can pass the following arguments to `instrument` to specify its behavior. Th
 | `--forwarder` | | The ARN of the [datadog forwarder][10] to attach this function's LogGroup to. | |
 | `--dry` | `-d` | Preview changes running command would apply. | `false` |
 | `--log-level` | | Set to `debug` to see additional output from the Datadog Lambda Library and/or Lambda Extension for troubleshooting purposes. | |
-| `--source-code-integration` | `-s` | Whether to enable Datadog Source Code Integration. This will tag your lambda(s) with the git repository url and latest commit of the current local directory. **Note**: Git repository must not be ahead of remote, and must not be dirty. <br /> To disable, use `--no-source-code-integration`. | `true` |
+| `--source-code-integration` | `-s` | Whether to enable Datadog Source Code Integration. This will tag your lambda(s) with the Git repository URL and the latest commit of the current local directory. **Note**: Git repository must not be ahead of remote, and must not be dirty. <br /> To disable, use `--no-source-code-integration`. | `true` |
 
 <br />
 

--- a/src/commands/lambda/README.md
+++ b/src/commands/lambda/README.md
@@ -98,7 +98,7 @@ You can pass the following arguments to `instrument` to specify its behavior. Th
 | `--forwarder` | | The ARN of the [datadog forwarder][10] to attach this function's LogGroup to. | |
 | `--dry` | `-d` | Preview changes running command would apply. | `false` |
 | `--log-level` | | Set to `debug` to see additional output from the Datadog Lambda Library and/or Lambda Extension for troubleshooting purposes. | |
-| `--source-code-integration` | `-s` | Whether to enable Datadog Source Code Integration. This will tag your lambda(s) with the repository url and latest commit of the current local directory. **Note**: Git repository must not be ahead of remote, and must not be dirty. <br /> To disable, use `--no-source-code-integration`. | `true` |
+| `--source-code-integration` | `-s` | Whether to enable Datadog Source Code Integration. This will tag your lambda(s) with the git repository url and latest commit of the current local directory. **Note**: Git repository must not be ahead of remote, and must not be dirty. <br /> To disable, use `--no-source-code-integration`. | `true` |
 
 <br />
 

--- a/src/commands/lambda/README.md
+++ b/src/commands/lambda/README.md
@@ -98,7 +98,7 @@ You can pass the following arguments to `instrument` to specify its behavior. Th
 | `--forwarder` | | The ARN of the [datadog forwarder][10] to attach this function's LogGroup to. | |
 | `--dry` | `-d` | Preview changes running command would apply. | `false` |
 | `--log-level` | | Set to `debug` to see additional output from the Datadog Lambda Library and/or Lambda Extension for troubleshooting purposes. | |
-| `--source-code-integration` | `-s` | Whether to enable Datadog Source Code Integration. This will send Datadog the Git metadata in the current local directory and tag your lambda(s) with the latest commit. Provide `DATADOG_API_KEY` if using this feature. **Note**: Git repository must not be ahead of remote, and must not be dirty. | `false` |
+| `--source-code-integration` | `-s` | Whether to enable Datadog Source Code Integration. This will tag your lambda(s) with the Git metadata in the current local directory and the latest commit. **Note**: Git repository must not be ahead of remote, and must not be dirty. <br /> To disable, use `--no-source-code-integration`. | `true` |
 
 <br />
 

--- a/src/commands/lambda/__tests__/instrument.test.ts
+++ b/src/commands/lambda/__tests__/instrument.test.ts
@@ -90,6 +90,7 @@ describe('lambda', () => {
             '0.2',
             '--extra-tags',
             'layer:api,team:intake',
+            '--no-source-code-integration',
           ],
           context
         )
@@ -172,6 +173,7 @@ TagResource -> arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world
             'false',
             '--log-level',
             'debug',
+            '--no-source-code-integration',
           ],
           context
         )
@@ -247,6 +249,7 @@ TagResource -> arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world
             '0.2',
             '--extra-tags',
             'layer:api,team:intake',
+            '--no-source-code-integration',
           ],
           context
         )
@@ -319,6 +322,7 @@ TagResource -> arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world
             'staging',
             '--version',
             '0.2',
+            '--no-source-code-integration',
           ],
           context
         )
@@ -655,6 +659,7 @@ TagResource -> arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world
             'arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world',
             '--layerVersion',
             '10',
+            '--no-source-code-integration',
           ],
           context
         )
@@ -682,6 +687,7 @@ TagResource -> arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world
             'arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world',
             '--extensionVersion',
             '6',
+            '--no-source-code-integration',
           ],
           context
         )
@@ -758,6 +764,7 @@ TagResource -> arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world
             'staging',
             '--version',
             '0.2',
+            '--no-source-code-integration',
           ],
           context
         )
@@ -799,6 +806,7 @@ TagResource -> arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world
             'staging',
             '--version',
             '0.2',
+            '--no-source-code-integration',
           ],
           context
         )
@@ -870,6 +878,7 @@ TagResource -> arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world
         command['config']['region'] = 'ap-southeast-1'
         command['config']['functions'] = ['arn:aws:lambda:ap-southeast-1:123456789012:function:lambda-hello-world']
         command['regExPattern'] = 'valid-pattern'
+        command['sourceCodeIntegration'] = false
         await command['execute']()
         let output = command.context.stdout.toString()
         expect(output).toMatch(
@@ -883,6 +892,7 @@ TagResource -> arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world
         command['region'] = 'ap-southeast-1'
         command['functions'] = ['arn:aws:lambda:ap-southeast-1:123456789012:function:lambda-hello-world']
         command['regExPattern'] = 'valid-pattern'
+        command['sourceCodeIntegration'] = false
         await command['execute']()
         output = command.context.stdout.toString()
         expect(output).toMatch('"--functions" and "--functions-regex" should not be used at the same time.\n')
@@ -897,6 +907,7 @@ TagResource -> arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world
         command['service'] = 'middletier'
         command['version'] = '2'
         command['regExPattern'] = 'valid-pattern'
+        command['sourceCodeIntegration'] = false
         await command['execute']()
         const output = command.context.stdout.toString()
         expect(output).toMatch('[Error] No default region specified. Use `-r`, `--region`.\n')
@@ -911,6 +922,7 @@ TagResource -> arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world
         command['version'] = '2'
         command['region'] = 'ap-southeast-1'
         command['regExPattern'] = 'arn:aws:lambda:ap-southeast-1:123456789012:function:*'
+        command['sourceCodeIntegration'] = false
         await command['execute']()
         const output = command.context.stdout.toString()
         expect(output).toMatch(`"--functions-regex" isn't meant to be used with ARNs.\n`)
@@ -992,7 +1004,7 @@ TagResource -> arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world
 
         const cli = makeCli()
         const context = createMockContext() as any
-        const code = await cli.run(['lambda', 'instrument', '-i'], context)
+        const code = await cli.run(['lambda', 'instrument', '-i', '--no-source-code-integration'], context)
         const output = context.stdout.toString()
         expect(code).toBe(0)
         expect(output).toMatchInlineSnapshot(`
@@ -1133,6 +1145,7 @@ TagResource -> arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world
             'arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world',
             '-f',
             'arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world-2',
+            '--no-source-code-integration',
           ],
           context
         )
@@ -1290,7 +1303,7 @@ TagResource -> arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world
 
         const cli = makeCli()
         const context = createMockContext() as any
-        const code = await cli.run(['lambda', 'instrument', '-i'], context)
+        const code = await cli.run(['lambda', 'instrument', '-i', '--no-source-code-integration'], context)
         const output = context.stdout.toString()
         expect(code).toBe(0)
         expect(output).toMatchInlineSnapshot(`
@@ -1384,7 +1397,7 @@ TagResource -> arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world
 
         const cli = makeCli()
         const context = createMockContext() as any
-        const code = await cli.run(['lambda', 'instrument', '-i'], context)
+        const code = await cli.run(['lambda', 'instrument', '-i', '--no-source-code-integration'], context)
         const output = context.stdout.toString()
         expect(code).toBe(0)
         expect(output).toMatchInlineSnapshot(`
@@ -1509,6 +1522,7 @@ TagResource -> arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world
             'staging',
             '--version',
             '0.2',
+            '--no-source-code-integration',
           ],
           context
         )
@@ -1552,6 +1566,7 @@ TagResource -> arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world
             'staging',
             '--version',
             '0.2',
+            '--no-source-code-integration',
           ],
           context
         )
@@ -1596,6 +1611,7 @@ TagResource -> arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world
             'staging',
             '--version',
             '0.2',
+            '--no-source-code-integration',
           ],
           context
         )
@@ -1631,7 +1647,7 @@ TagResource -> arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world
         const context = createMockContext() as any
         const functionARN = 'arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world'
         const code = await cli.run(
-          ['lambda', 'instrument', '-f', functionARN, '--profile', 'SOME-AWS-PROFILE'],
+          ['lambda', 'instrument', '-f', functionARN, '--profile', 'SOME-AWS-PROFILE', '--no-source-code-integration'],
           context
         )
         expect(code).toBe(0)

--- a/src/commands/lambda/instrument.ts
+++ b/src/commands/lambda/instrument.ts
@@ -60,7 +60,7 @@ export class InstrumentCommand extends Command {
   private regExPattern?: string
   private region?: string
   private service?: string
-  private sourceCodeIntegration = false
+  private sourceCodeIntegration = true
   private tracing?: string
   private version?: string
 


### PR DESCRIPTION
### What and why?

Enable the source code integration feature by default (tagging lambdas with the user's current git repo url + commit hash)

To disable, the flag `--no-source-code-integration` should be appended to the `instrument` command.

### How?

`private sourceCodeIntegration = true`

document it in the README

update unit tests

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
