### PR TITLE
[s8s] Add lib wrapper to use from outside

### DIFF
--- a/src/commands/synthetics/__tests__/run-test.test.ts
+++ b/src/commands/synthetics/__tests__/run-test.test.ts
@@ -5,16 +5,7 @@ import * as ciUtils from '../../../helpers/utils'
 import * as api from '../api'
 import {MAX_TESTS_TO_TRIGGER} from '../command'
 import {CiError, CriticalCiErrorCode, CriticalError} from '../errors'
-import {
-  CommandConfig,
-  ExecutionRule,
-  MainReporter,
-  Result,
-  Suite,
-  Summary,
-  SyntheticsCIConfig,
-  UserConfigOverride,
-} from '../interfaces'
+import {ExecutionRule, Summary, SyntheticsCIConfig, UserConfigOverride} from '../interfaces'
 import {DefaultReporter} from '../reporters/default'
 import {JUnitReporter} from '../reporters/junit'
 import * as runTests from '../run-test'

--- a/src/commands/synthetics/__tests__/run-test.test.ts
+++ b/src/commands/synthetics/__tests__/run-test.test.ts
@@ -429,11 +429,13 @@ describe('run-test', () => {
       jest.spyOn(runTests, 'executeTests').mockReturnValue(Promise.resolve({results: [], summary: {} as Summary}))
       jest.spyOn(utils, 'renderResults').mockImplementation(jest.fn())
     })
+
     test('should call executeTests and renderResults', async () => {
       await runTests.execute({}, {})
       expect(runTests.executeTests).toHaveBeenCalled()
       expect(utils.renderResults).toHaveBeenCalled()
     })
+
     test('should extend config', async () => {
       const runConfig = {apiKey: 'apiKey', appKey: 'appKey'}
       await runTests.execute(runConfig, {})
@@ -443,6 +445,7 @@ describe('run-test', () => {
         undefined
       )
     })
+
     test('should bypass files if suite is passed', async () => {
       const suites = [{content: {tests: []}}]
       await runTests.execute({}, {suites})
@@ -452,14 +455,17 @@ describe('run-test', () => {
         suites
       )
     })
+
     describe('reporters', () => {
       beforeEach(() => {
         jest.spyOn(utils, 'getReporter').mockImplementation(jest.fn())
       })
+
       test('should use default reporter whith empty config', async () => {
         await runTests.execute({}, {})
         expect(utils.getReporter).toHaveBeenCalledWith(expect.arrayContaining([expect.any(DefaultReporter)]))
       })
+
       test('should use custom reporters', async () => {
         const CustomReporter = {}
         await runTests.execute({}, {reporters: ['junit', CustomReporter]})

--- a/src/commands/synthetics/index.ts
+++ b/src/commands/synthetics/index.ts
@@ -1,5 +1,5 @@
 export {CiError, CriticalError} from './errors'
 export * from './interfaces'
 export {DefaultReporter} from './reporters/default'
-export {executeTests} from './run-test'
+export {executeTests, execute} from './run-test'
 export * as utils from './utils'

--- a/src/commands/synthetics/interfaces.ts
+++ b/src/commands/synthetics/interfaces.ts
@@ -3,6 +3,8 @@ import {ProxyConfiguration} from '../../helpers/utils'
 
 import {TunnelInfo} from './tunnel'
 
+export type SupportedReporter = 'junit' | 'default'
+
 export interface MainReporter {
   error(error: string): void
   initErrors(errors: string[]): void
@@ -377,6 +379,8 @@ export interface CommandConfig extends SyntheticsCIConfig {
   failOnMissingTests: boolean
   failOnTimeout: boolean
 }
+
+export type WrapperConfig = Partial<CommandConfig>
 
 export interface PresignedUrlResponse {
   file_name: string

--- a/src/commands/synthetics/run-test.ts
+++ b/src/commands/synthetics/run-test.ts
@@ -244,7 +244,7 @@ export const execute = async (
     runId?: string
     suites?: Suite[]
   }
-) => {
+): Promise<0 | 1> => {
   const startTime = Date.now()
   const localConfig = {
     ...DEFAULT_COMMAND_CONFIG,
@@ -283,8 +283,8 @@ export const execute = async (
     localReporters.push(new DefaultReporter({context: process}))
   }
 
-  const localReporter = getReporter(localReporters)
-  const {results, summary} = await executeTests(localReporter, localConfig, suites)
+  const mainReporter = getReporter(localReporters)
+  const {results, summary} = await executeTests(mainReporter, localConfig, suites)
 
-  return renderResults({config: localConfig, reporter: localReporter, results, startTime, summary})
+  return renderResults({config: localConfig, reporter: mainReporter, results, startTime, summary})
 }

--- a/src/commands/synthetics/run-test.ts
+++ b/src/commands/synthetics/run-test.ts
@@ -1,24 +1,36 @@
 import {getProxyAgent} from '../../helpers/utils'
 
 import {APIHelper, getApiHelper, isForbiddenError} from './api'
-import {MAX_TESTS_TO_TRIGGER} from './command'
+import {DEFAULT_COMMAND_CONFIG, MAX_TESTS_TO_TRIGGER} from './command'
 import {CiError, CriticalError} from './errors'
 import {
   CommandConfig,
   MainReporter,
+  Reporter,
   Result,
   Suite,
   Summary,
+  SupportedReporter,
   SyntheticsCIConfig,
   Test,
   TestPayload,
   Trigger,
   TriggerConfig,
   UserConfigOverride,
+  WrapperConfig,
 } from './interfaces'
-import {getTunnelReporter} from './reporters/default'
+import {DefaultReporter, getTunnelReporter} from './reporters/default'
+import {JUnitReporter} from './reporters/junit'
 import {Tunnel} from './tunnel'
-import {getSuites, getTestsToTrigger, InitialSummary, runTests, waitForResults} from './utils'
+import {
+  getReporter,
+  getSuites,
+  getTestsToTrigger,
+  InitialSummary,
+  renderResults,
+  runTests,
+  waitForResults,
+} from './utils'
 
 export const executeTests = async (
   reporter: MainReporter,
@@ -217,4 +229,62 @@ export const getTestsList = async (
     .reduce((acc, suiteTests) => acc.concat(suiteTests), [])
 
   return testsToTrigger
+}
+
+export const execute = async (
+  runConfig: WrapperConfig,
+  {
+    jUnitReport,
+    reporters,
+    runId,
+    suites,
+  }: {
+    jUnitReport?: string
+    reporters?: (SupportedReporter | Reporter)[]
+    runId?: string
+    suites?: Suite[]
+  }
+) => {
+  const startTime = Date.now()
+  const localConfig = {
+    ...DEFAULT_COMMAND_CONFIG,
+    ...runConfig,
+  }
+
+  // We don't want to have default globs in case suites are given.
+  if (!runConfig.files && suites?.length) {
+    localConfig.files = []
+  }
+
+  // Handle reporters for the run.
+  const localReporters: Reporter[] = []
+  // If the config asks for specific reporters.
+  if (reporters) {
+    for (const reporter of reporters) {
+      // Add our own reporters if required.
+      if (reporter === 'junit') {
+        localReporters.push(
+          new JUnitReporter({
+            context: process,
+            jUnitReport: jUnitReport || './junit.xml',
+            runName: `Run ${runId || 'undefined'}`,
+          })
+        )
+      }
+      if (reporter === 'default') {
+        localReporters.push(new DefaultReporter({context: process}))
+      }
+      // This is a custom reporter, so simply add it.
+      if (typeof reporter !== 'string') {
+        localReporters.push(reporter)
+      }
+    }
+  } else {
+    localReporters.push(new DefaultReporter({context: process}))
+  }
+
+  const localReporter = getReporter(localReporters)
+  const {results, summary} = await executeTests(localReporter, localConfig, suites)
+
+  return renderResults({config: localConfig, reporter: localReporter, results, startTime, summary})
 }


### PR DESCRIPTION
### What and why?

Using `executeTests` from outside is quite complex and requires a somewhat big bootstrap we should not have to worry about when using this as a library.

### How?

Create a wrapper around `executeTests` called `execute` (open on the naming).
This wrapper will handle the reporters and configuration defaults.

Also tested locally with 
- https://github.com/DataDog/web-ui/pull/77588

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
