### PR TITLE
Display warning message when SCI fails, rather than exiting.

### DIFF
--- a/src/commands/lambda/instrument.ts
+++ b/src/commands/lambda/instrument.ts
@@ -177,9 +177,7 @@ export class InstrumentCommand extends Command {
           settings.extraTags = `git.commit.sha:${gitData.commitSha},git.repository_url:${gitData.gitRemote}`
         }
       } catch (err) {
-        this.context.stdout.write(renderer.renderError(err))
-
-        return 1
+        this.context.stdout.write(renderer.renderSourceCodeIntegrationWarning(err))
       }
     }
 

--- a/src/commands/lambda/renderer.ts
+++ b/src/commands/lambda/renderer.ts
@@ -159,7 +159,7 @@ export const renderSoftWarning = (warning: string) => `${warningExclamationSignT
  * @returns a warning message, with the source code integration error attached.
  *
  * ```txt
- * [Warning] Couldn't add source code integration. Error: Couldn't get local git status.
+ * [Warning] Couldn't add source code integration. The provided error goes here!
  * ```
  */
 export const renderSourceCodeIntegrationWarning = (sourceCodeIntegrationError: unknown) =>

--- a/src/commands/lambda/renderer.ts
+++ b/src/commands/lambda/renderer.ts
@@ -155,6 +155,17 @@ export const renderWarning = (warning: string) => `${warningTag} ${warning}\n`
 export const renderSoftWarning = (warning: string) => `${warningExclamationSignTag} ${warning}\n`
 
 /**
+ * @param sourceCodeIntegrationError the error encountered when trying to enable source code integration.
+ * @returns a warning message, with the source code integration error attached.
+ *
+ * ```txt
+ * [Warning] Couldn't add source code integration. Error: Couldn't get local git status.
+ * ```
+ */
+export const renderSourceCodeIntegrationWarning = (sourceCodeIntegrationError: unknown) =>
+  `\n${renderWarning(`Couldn't add source code integration. ${sourceCodeIntegrationError}.`)}`
+
+/**
  * @returns a message suggesting to instrument in dev or staging environment first.
  *
  * ```txt

--- a/src/commands/lambda/renderer.ts
+++ b/src/commands/lambda/renderer.ts
@@ -163,7 +163,7 @@ export const renderSoftWarning = (warning: string) => `${warningExclamationSignT
  * ```
  */
 export const renderSourceCodeIntegrationWarning = (sourceCodeIntegrationError: unknown) =>
-  `\n${renderWarning(`Couldn't add source code integration. ${sourceCodeIntegrationError}.`)}`
+  `\n${renderWarning(`Couldn't add source code integration, continuing without it. ${sourceCodeIntegrationError}.`)}`
 
 /**
  * @returns a message suggesting to instrument in dev or staging environment first.


### PR DESCRIPTION
### What and why?

Adds a warning if source code integration fails when instrumenting lambda functions. 

Previously, the CI would exit completely if SCI fails.

Example warning printed:
![image](https://user-images.githubusercontent.com/51187184/214100128-87bfe729-8dd1-4035-8de9-c6ae49faff29.png)


### How?

Rather than returning, prints "[Warning] Couldn't add source code integration. Error: {SCI error encountered}"

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
