### PR TITLE
Update simple-git from 3.15.0 to 3.16.0 to mitigate RCE security risk.

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "proxy-agent": "5.0.0",
     "rimraf": "^3.0.2",
     "semver": "^7.3.7",
-    "simple-git": "3.15.0",
+    "simple-git": "3.16.0",
     "ssh2": "1.9.0",
     "ssh2-streams": "0.4.10",
     "sshpk": "1.16.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5768,10 +5768,10 @@ simple-get@^3.0.3:
     once "^1.3.1"
     simple-concat "^1.0.0"
 
-simple-git@3.15.0:
-  version "3.15.0"
-  resolved "https://registry.yarnpkg.com/simple-git/-/simple-git-3.15.0.tgz#301a95a943c4f9b0a21d051eb6e6d0ffe4c9754f"
-  integrity sha512-FiWoMPlcYHQ+ApRihUsGjC/ZmIlWj62S6MBCwOunczvXcLQt+9ZdrysDrR6QVepkRQfEAaBXrN2QtJKrN6zbtg==
+simple-git@3.16.0:
+  version "3.16.0"
+  resolved "https://registry.yarnpkg.com/simple-git/-/simple-git-3.16.0.tgz#421773e24680f5716999cc4a1d60127b4b6a9dec"
+  integrity sha512-zuWYsOLEhbJRWVxpjdiXl6eyAyGo/KzVW+KFhhw9MqEEJttcq+32jTWSGyxTdf9e/YCohxRE+9xpWFj9FdiJNw==
   dependencies:
     "@kwsites/file-exists" "^1.1.1"
     "@kwsites/promise-deferred" "^1.1.1"


### PR DESCRIPTION
### What and why?

Snyk has identified that simple-git has [remote code execution](https://security.snyk.io/vuln/SNYK-JS-SIMPLEGIT-3177391) issue in versions less than 3.16.0. This repo needs simple-git updated, which this PR does.

More info here: https://security.snyk.io/package/npm/simple-git

### How?
I ran `yarn upgrade simple-git@3.16.0` to update the latest version of `simple-git`.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
