### PR TITLE
Add commit-hash option in `sourcemaps upload` command

### DIFF
--- a/src/commands/flutter-symbols/upload.ts
+++ b/src/commands/flutter-symbols/upload.ts
@@ -194,7 +194,7 @@ export class UploadCommand extends Command {
 
   private async getGitMetadata(): Promise<RepositoryData | undefined> {
     try {
-      return await getRepositoryData(await newSimpleGit(), this.repositoryUrl)
+      return await getRepositoryData(await newSimpleGit(), this.repositoryUrl, undefined)
     } catch (e) {
       this.context.stdout.write(renderGitWarning(e))
     }

--- a/src/commands/react-native/__tests__/xcode.test.ts
+++ b/src/commands/react-native/__tests__/xcode.test.ts
@@ -608,7 +608,7 @@ describe('xcode', () => {
         'Upload of ./src/commands/react-native/__tests__/fixtures/basic-ios/main.jsbundle.map for bundle ./src/commands/react-native/__tests__/fixtures/basic-ios/main.jsbundle on platform ios'
       )
       expect(output).toContain('version: 0.0.2 build: 000020 service: com.myapp.test')
-      expect(getRepositoryDataSpy).toHaveBeenCalledWith(expect.anything(), 'https://example.com')
+      expect(getRepositoryDataSpy).toHaveBeenCalledWith(expect.anything(), 'https://example.com', undefined)
     })
 
     test('should disable git in upload command', async () => {

--- a/src/commands/react-native/upload.ts
+++ b/src/commands/react-native/upload.ts
@@ -185,7 +185,7 @@ export class UploadCommand extends Command {
   // Fills the 'repository' field of each payload with data gathered using git.
   private addRepositoryDataToPayloads = async (payloads: RNSourcemap[]) => {
     try {
-      const repositoryData = await getRepositoryData(await newSimpleGit(), this.repositoryURL)
+      const repositoryData = await getRepositoryData(await newSimpleGit(), this.repositoryURL, undefined)
       payloads.forEach((payload) => {
         const repositoryPayload = this.getRepositoryPayload(repositoryData, payload.sourcemapPath)
         payload.addRepositoryData({

--- a/src/commands/sourcemaps/README.md
+++ b/src/commands/sourcemaps/README.md
@@ -73,7 +73,7 @@ This behavior can be overridden with links to `https://gitlab.com/Datadog/exampl
 
 The value can be overridden with `--commit-hash`.
 
-Example: Pass commit hash when there is no `.git/` directory, such as build in Docker.
+Example: Pass commit hash when there is no `.git/` directory, such as a build in Docker.
 
 This behavior can be overridden with links to `36485fb1c5cba61e95bbbf7b30c673f2b96e415d` with the flag `--commit-hash=36485fb1c5cba61e95bbbf7b30c673f2b96e415d`.
 

--- a/src/commands/sourcemaps/README.md
+++ b/src/commands/sourcemaps/README.md
@@ -69,6 +69,14 @@ The value can be overridden with `--repository-url`.
 Example: With a remote `git@github.com:Datadog/example.git`, links pointing to `https://github.com/Datadog/example` are generated.
 This behavior can be overridden with links to `https://gitlab.com/Datadog/example` with the flag `--repository-url=https://gitlab.com/Datadog/example`.
 
+#### Override commit hash
+
+The value can be overridden with `--commit-hash`.
+
+Example: Pass commit hash when there is no `.git/` directory, such as build in Docker.
+
+This behavior can be overridden with links to `36485fb1c5cba61e95bbbf7b30c673f2b96e415d` with the flag `--commit-hash=36485fb1c5cba61e95bbbf7b30c673f2b96e415d`.
+
 #### Setting the project path
 
 If the file paths referenced by your sourcemaps have a prefix before the part relative to the repository root, you need to specify the `--project-path` argument.

--- a/src/commands/sourcemaps/upload.ts
+++ b/src/commands/sourcemaps/upload.ts
@@ -151,7 +151,7 @@ export class UploadCommand extends Command {
   // Fills the 'repository' field of each payload with data gathered using git.
   private addRepositoryDataToPayloads = async (payloads: Sourcemap[]) => {
     try {
-      const repositoryData = await getRepositoryData(await newSimpleGit(), this.repositoryURL)
+      const repositoryData = await getRepositoryData(await newSimpleGit(), this.repositoryURL, undefined)
       await Promise.all(
         payloads.map(async (payload) => {
           const repositoryPayload = this.getRepositoryPayload(repositoryData, payload.sourcemapPath)

--- a/src/commands/sourcemaps/upload.ts
+++ b/src/commands/sourcemaps/upload.ts
@@ -63,6 +63,7 @@ export class UploadCommand extends Command {
   private projectPath = ''
   private releaseVersion?: string
   private repositoryURL?: string
+  private commitHash?: string
   private service?: string
 
   constructor() {
@@ -151,7 +152,7 @@ export class UploadCommand extends Command {
   // Fills the 'repository' field of each payload with data gathered using git.
   private addRepositoryDataToPayloads = async (payloads: Sourcemap[]) => {
     try {
-      const repositoryData = await getRepositoryData(await newSimpleGit(), this.repositoryURL, undefined)
+      const repositoryData = await getRepositoryData(await newSimpleGit(), this.repositoryURL, this.commitHash)
       await Promise.all(
         payloads.map(async (payload) => {
           const repositoryPayload = this.getRepositoryPayload(repositoryData, payload.sourcemapPath)
@@ -328,4 +329,5 @@ UploadCommand.addOption('projectPath', Command.String('--project-path'))
 UploadCommand.addOption('maxConcurrency', Command.String('--max-concurrency'))
 UploadCommand.addOption('dryRun', Command.Boolean('--dry-run'))
 UploadCommand.addOption('repositoryURL', Command.String('--repository-url'))
+UploadCommand.addOption('commitHash', Command.String('--commit-hash'))
 UploadCommand.addOption('disableGit', Command.Boolean('--disable-git'))

--- a/src/helpers/git/__tests__/format-git-sourcemaps-data.test.ts
+++ b/src/helpers/git/__tests__/format-git-sourcemaps-data.test.ts
@@ -74,7 +74,7 @@ describe('git', () => {
     })
 
     test('integration', async () => {
-      const data = await getRepositoryData(createMockSimpleGit() as any, '')
+      const data = await getRepositoryData(createMockSimpleGit() as any, '', '')
       if (!data) {
         fail('data should not be undefined')
       }
@@ -89,7 +89,7 @@ describe('git', () => {
     })
 
     test('integration: remote override', async () => {
-      const data = await getRepositoryData(createMockSimpleGit() as any, 'git@github.com:user/other.git')
+      const data = await getRepositoryData(createMockSimpleGit() as any, 'git@github.com:user/other.git', '')
       if (!data) {
         fail('data should not be undefined')
       }

--- a/src/helpers/git/format-git-sourcemaps-data.ts
+++ b/src/helpers/git/format-git-sourcemaps-data.ts
@@ -36,7 +36,8 @@ export interface RepositoryData {
 // To obtain the list of tracked files paths tied to a specific sourcemap, invoke the 'matchSourcemap' method.
 export const getRepositoryData = async (
   git: simpleGit.SimpleGit,
-  repositoryURL: string | undefined
+  repositoryURL: string | undefined,
+  commitHash: string | undefined
 ): Promise<RepositoryData> => {
   // Invoke git commands to retrieve the remote, hash and tracked files.
   // We're using Promise.all instead of Promise.allSettled since we want to fail early if
@@ -45,12 +46,11 @@ export const getRepositoryData = async (
   let hash: string
   let trackedFiles: string[]
   try {
-    if (repositoryURL) {
-      ;[hash, trackedFiles] = await Promise.all([gitHash(git), gitTrackedFiles(git)])
-      remote = repositoryURL
-    } else {
-      ;[remote, hash, trackedFiles] = await Promise.all([gitRemote(git), gitHash(git), gitTrackedFiles(git)])
-    }
+    ;[remote, hash, trackedFiles] = await Promise.all([
+      repositoryURL ? Promise.resolve(repositoryURL) : gitRemote(git),
+      commitHash ? Promise.resolve(commitHash) : gitHash(git),
+      gitTrackedFiles(git)
+    ])
   } catch (e) {
     throw e
   }


### PR DESCRIPTION
### What and why?

https://github.com/DataDog/datadog-ci/issues/753 override commit hash when `sourcemaps upload`.

### How?

add `--commit-hash` option in `sourcemaps upload` command.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
