### PR TITLE
[deps] Upgrade yamux-js to 0.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "tiny-async-pool": "1.2.0",
     "ws": "7.4.6",
     "xml2js": "0.4.23",
-    "yamux-js": "0.1.1"
+    "yamux-js": "0.1.2"
   },
   "devDependencies": {
     "@babel/core": "7.8.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6472,10 +6472,10 @@ yallist@^4.0.0:
   resolved "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz"
   integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
-yamux-js@0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/yamux-js/-/yamux-js-0.1.1.tgz#69dbd63a9a3896d2417fb879ed49d14e461c1dae"
-  integrity sha512-R4cSoIIuhHTDsp0yR99nghTk8va86Z4EC2aFwemZ5QCIqfUUul9U4Fay7b6O/UnSIdiyLtqwvhwu8w50ptTpiw==
+yamux-js@0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/yamux-js/-/yamux-js-0.1.2.tgz#a157e4922f8f0393725955c352b418f16259fd48"
+  integrity sha512-bhsPlPZ9xB4Dawyf6nkS58u4F3IvGCaybkEKGnneUeepcI7MPoG3Tt6SaKCU5x/kP2/2w20Qm/GqbpwAM16vYw==
 
 yargs-parser@^20.2.2:
   version "20.2.9"


### PR DESCRIPTION
### What and why?

Upgrade yamux-js to 0.1.2:
- https://github.com/th-ch/yamux-js/pull/14