### PR TITLE
[lambda] Update tests from inline snapshots to snapshots

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "prettier": "prettier \"src/**/*.{ts,js,json,yml}\" --ignore-path .gitignore",
     "test": "jest --colors",
     "test:debug": "node --inspect-brk `which jest` --runInBand",
+    "test:lambda": "jest src/commands/lambda --colors",
     "eslint": "eslint --quiet 'src/**/*.ts'",
     "typecheck": "bash bin/typecheck.sh",
     "watch": "tsc -w"

--- a/src/commands/lambda/__tests__/__snapshots__/instrument.test.ts.snap
+++ b/src/commands/lambda/__tests__/__snapshots__/instrument.test.ts.snap
@@ -43,6 +43,7 @@ TagResource -> arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world
 exports[`lambda instrument execute instrument multiple functions interactively 1`] = `
 "
 🐶 Instrumenting Lambda function
+[!] No AWS credentials found, let's set them up! Or you can re-run the command and supply the AWS credentials in the same way when you invoke the AWS CLI.
 
 [!] Configure AWS region.
 
@@ -115,6 +116,7 @@ TagResource -> arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world
 exports[`lambda instrument execute instrument multiple specified functions interactively 1`] = `
 "
 🐶 Instrumenting Lambda function
+[!] No AWS credentials found, let's set them up! Or you can re-run the command and supply the AWS credentials in the same way when you invoke the AWS CLI.
 
 [!] Configure AWS region.
 
@@ -349,6 +351,7 @@ TagResource -> arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world
 exports[`lambda instrument execute when not provided it does not set DD_ENV, DD_SERVICE, and DD_VERSION tags in interactive mode 1`] = `
 "
 🐶 Instrumenting Lambda function
+[!] No AWS credentials found, let's set them up! Or you can re-run the command and supply the AWS credentials in the same way when you invoke the AWS CLI.
 
 [!] Configure AWS region.
 
@@ -395,6 +398,7 @@ TagResource -> arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world
 exports[`lambda instrument execute when provided it sets DD_ENV, DD_SERVICE, and DD_VERSION environment variables in interactive mode 1`] = `
 "
 🐶 Instrumenting Lambda function
+[!] No AWS credentials found, let's set them up! Or you can re-run the command and supply the AWS credentials in the same way when you invoke the AWS CLI.
 
 [!] Configure AWS region.
 

--- a/src/commands/lambda/__tests__/__snapshots__/instrument.test.ts.snap
+++ b/src/commands/lambda/__tests__/__snapshots__/instrument.test.ts.snap
@@ -1,0 +1,440 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`lambda instrument execute ensure source code integration flag works from a clean repo 1`] = `
+"
+🐶 Instrumenting Lambda function
+
+[Warning] Instrument your Lambda functions in a dev or staging environment first. Should the instrumentation result be unsatisfactory, run \`uninstrument\` with the same arguments to revert the changes.
+
+[!] Functions to be updated:
+	- arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world
+
+Will apply the following updates:
+UpdateFunctionConfiguration -> arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world
+{
+  \\"FunctionName\\": \\"arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world\\",
+  \\"Handler\\": \\"/opt/nodejs/node_modules/datadog-lambda-js/handler.handler\\",
+  \\"Environment\\": {
+    \\"Variables\\": {
+      \\"DD_LAMBDA_HANDLER\\": \\"index.handler\\",
+      \\"DD_API_KEY\\": \\"1234\\",
+      \\"DD_SITE\\": \\"datadoghq.com\\",
+      \\"DD_CAPTURE_LAMBDA_PAYLOAD\\": \\"false\\",
+      \\"DD_ENV\\": \\"dummy\\",
+      \\"DD_TAGS\\": \\"git.commit.sha:1be168ff837f043bde17c0314341c84271047b31,git.repository_url:git.repository_url:github.com/datadog/test.git\\",
+      \\"DD_MERGE_XRAY_TRACES\\": \\"false\\",
+      \\"DD_SERVICE\\": \\"dummy\\",
+      \\"DD_TRACE_ENABLED\\": \\"true\\",
+      \\"DD_VERSION\\": \\"0.1\\",
+      \\"DD_FLUSH_TO_LOG\\": \\"true\\"
+    }
+  },
+  \\"Layers\\": [
+    \\"arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Node12-x:10\\"
+  ]
+}
+TagResource -> arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world
+{
+  \\"dd_sls_ci\\": \\"v2.4.0\\"
+}
+"
+`;
+
+exports[`lambda instrument execute instrument multiple functions interactively 1`] = `
+"
+🐶 Instrumenting Lambda function
+
+[!] Configure AWS region.
+
+[!] Configure Datadog settings.
+
+[Warning] The environment, service and version tags have not been configured. Learn more about Datadog unified service tagging: https://docs.datadoghq.com/getting_started/tagging/unified_service_tagging/#serverless-environment.
+
+[Warning] Instrument your Lambda functions in a dev or staging environment first. Should the instrumentation result be unsatisfactory, run \`uninstrument\` with the same arguments to revert the changes.
+
+[!] Functions to be updated:
+	- arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world
+	[Warning] At least one latest layer version is being used. Ensure to lock in versions for production applications using \`--layerVersion\` and \`--extensionVersion\`.
+	- arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world-2
+	[Warning] At least one latest layer version is being used. Ensure to lock in versions for production applications using \`--layerVersion\` and \`--extensionVersion\`.
+
+Will apply the following updates:
+UpdateFunctionConfiguration -> arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world
+{
+  \\"FunctionName\\": \\"arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world\\",
+  \\"Handler\\": \\"/opt/nodejs/node_modules/datadog-lambda-js/handler.handler\\",
+  \\"Environment\\": {
+    \\"Variables\\": {
+      \\"DD_LAMBDA_HANDLER\\": \\"index.handler\\",
+      \\"DD_API_KEY\\": \\"02aeb762fff59ac0d5ad1536cd9633bd\\",
+      \\"DD_SITE\\": \\"datadoghq.com\\",
+      \\"DD_CAPTURE_LAMBDA_PAYLOAD\\": \\"false\\",
+      \\"DD_MERGE_XRAY_TRACES\\": \\"false\\",
+      \\"DD_TRACE_ENABLED\\": \\"true\\",
+      \\"DD_FLUSH_TO_LOG\\": \\"true\\"
+    }
+  },
+  \\"Layers\\": [
+    \\"arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Extension:1\\",
+    \\"arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Node12-x:1\\"
+  ]
+}
+TagResource -> arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world
+{
+  \\"dd_sls_ci\\": \\"v2.4.0\\"
+}
+UpdateFunctionConfiguration -> arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world-2
+{
+  \\"FunctionName\\": \\"arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world-2\\",
+  \\"Handler\\": \\"/opt/nodejs/node_modules/datadog-lambda-js/handler.handler\\",
+  \\"Environment\\": {
+    \\"Variables\\": {
+      \\"DD_LAMBDA_HANDLER\\": \\"index.handler\\",
+      \\"DD_API_KEY\\": \\"02aeb762fff59ac0d5ad1536cd9633bd\\",
+      \\"DD_SITE\\": \\"datadoghq.com\\",
+      \\"DD_CAPTURE_LAMBDA_PAYLOAD\\": \\"false\\",
+      \\"DD_MERGE_XRAY_TRACES\\": \\"false\\",
+      \\"DD_TRACE_ENABLED\\": \\"true\\",
+      \\"DD_FLUSH_TO_LOG\\": \\"true\\"
+    }
+  },
+  \\"Layers\\": [
+    \\"arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Extension:1\\",
+    \\"arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Node14-x:1\\"
+  ]
+}
+TagResource -> arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world-2
+{
+  \\"dd_sls_ci\\": \\"v2.4.0\\"
+}
+[!] Confirmation needed.
+[!] Instrumenting functions.
+"
+`;
+
+exports[`lambda instrument execute instrument multiple specified functions interactively 1`] = `
+"
+🐶 Instrumenting Lambda function
+
+[!] Configure AWS region.
+
+[!] Configure Datadog settings.
+
+[Warning] The environment, service and version tags have not been configured. Learn more about Datadog unified service tagging: https://docs.datadoghq.com/getting_started/tagging/unified_service_tagging/#serverless-environment.
+
+[Warning] Instrument your Lambda functions in a dev or staging environment first. Should the instrumentation result be unsatisfactory, run \`uninstrument\` with the same arguments to revert the changes.
+
+[!] Functions to be updated:
+	- arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world
+	[Warning] At least one latest layer version is being used. Ensure to lock in versions for production applications using \`--layerVersion\` and \`--extensionVersion\`.
+	- arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world-2
+	[Warning] At least one latest layer version is being used. Ensure to lock in versions for production applications using \`--layerVersion\` and \`--extensionVersion\`.
+
+Will apply the following updates:
+UpdateFunctionConfiguration -> arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world
+{
+  \\"FunctionName\\": \\"arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world\\",
+  \\"Handler\\": \\"/opt/nodejs/node_modules/datadog-lambda-js/handler.handler\\",
+  \\"Environment\\": {
+    \\"Variables\\": {
+      \\"DD_LAMBDA_HANDLER\\": \\"index.handler\\",
+      \\"DD_API_KEY\\": \\"02aeb762fff59ac0d5ad1536cd9633bd\\",
+      \\"DD_SITE\\": \\"datadoghq.com\\",
+      \\"DD_CAPTURE_LAMBDA_PAYLOAD\\": \\"false\\",
+      \\"DD_MERGE_XRAY_TRACES\\": \\"false\\",
+      \\"DD_TRACE_ENABLED\\": \\"true\\",
+      \\"DD_FLUSH_TO_LOG\\": \\"true\\"
+    }
+  },
+  \\"Layers\\": [
+    \\"arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Extension:1\\",
+    \\"arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Node12-x:1\\"
+  ]
+}
+TagResource -> arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world
+{
+  \\"dd_sls_ci\\": \\"v2.4.0\\"
+}
+UpdateFunctionConfiguration -> arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world-2
+{
+  \\"FunctionName\\": \\"arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world-2\\",
+  \\"Handler\\": \\"/opt/nodejs/node_modules/datadog-lambda-js/handler.handler\\",
+  \\"Environment\\": {
+    \\"Variables\\": {
+      \\"DD_LAMBDA_HANDLER\\": \\"index.handler\\",
+      \\"DD_API_KEY\\": \\"02aeb762fff59ac0d5ad1536cd9633bd\\",
+      \\"DD_SITE\\": \\"datadoghq.com\\",
+      \\"DD_CAPTURE_LAMBDA_PAYLOAD\\": \\"false\\",
+      \\"DD_MERGE_XRAY_TRACES\\": \\"false\\",
+      \\"DD_TRACE_ENABLED\\": \\"true\\",
+      \\"DD_FLUSH_TO_LOG\\": \\"true\\"
+    }
+  },
+  \\"Layers\\": [
+    \\"arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Extension:1\\",
+    \\"arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Node14-x:1\\"
+  ]
+}
+TagResource -> arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world-2
+{
+  \\"dd_sls_ci\\": \\"v2.4.0\\"
+}
+[!] Confirmation needed.
+[!] Instrumenting functions.
+"
+`;
+
+exports[`lambda instrument execute prints dry run data for lambda .NET layer 1`] = `
+"
+[Dry Run] 🐶 Instrumenting Lambda function
+
+[Warning] Instrument your Lambda functions in a dev or staging environment first. Should the instrumentation result be unsatisfactory, run \`uninstrument\` with the same arguments to revert the changes.
+
+[!] Functions to be updated:
+	- arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world
+
+[Dry Run] Will apply the following updates:
+UpdateFunctionConfiguration -> arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world
+{
+  \\"FunctionName\\": \\"arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world\\",
+  \\"Environment\\": {
+    \\"Variables\\": {
+      \\"DD_API_KEY\\": \\"1234\\",
+      \\"DD_SITE\\": \\"datadoghq.com\\",
+      \\"DD_CAPTURE_LAMBDA_PAYLOAD\\": \\"false\\",
+      \\"DD_ENV\\": \\"staging\\",
+      \\"DD_TAGS\\": \\"layer:api,team:intake\\",
+      \\"DD_MERGE_XRAY_TRACES\\": \\"false\\",
+      \\"DD_SERVICE\\": \\"middletier\\",
+      \\"DD_TRACE_ENABLED\\": \\"true\\",
+      \\"DD_VERSION\\": \\"0.2\\",
+      \\"DD_FLUSH_TO_LOG\\": \\"true\\",
+      \\"CORECLR_ENABLE_PROFILING\\": \\"1\\",
+      \\"CORECLR_PROFILER\\": \\"{846F5F1C-F9AE-4B07-969E-05C26BC060D8}\\",
+      \\"CORECLR_PROFILER_PATH\\": \\"/opt/datadog/Datadog.Trace.ClrProfiler.Native.so\\",
+      \\"DD_DOTNET_TRACER_HOME\\": \\"/opt/datadog\\"
+    }
+  },
+  \\"Layers\\": [
+    \\"arn:aws:lambda:us-east-1:464622532012:layer:dd-trace-dotnet:129\\"
+  ]
+}
+TagResource -> arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world
+{
+  \\"dd_sls_ci\\": \\"v2.4.0\\"
+}
+"
+`;
+
+exports[`lambda instrument execute prints dry run data for lambda extension layer 1`] = `
+"
+[Dry Run] 🐶 Instrumenting Lambda function
+
+[Warning] Instrument your Lambda functions in a dev or staging environment first. Should the instrumentation result be unsatisfactory, run \`uninstrument\` with the same arguments to revert the changes.
+
+[!] Functions to be updated:
+	- arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world
+
+[Dry Run] Will apply the following updates:
+UpdateFunctionConfiguration -> arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world
+{
+  \\"FunctionName\\": \\"arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world\\",
+  \\"Handler\\": \\"/opt/nodejs/node_modules/datadog-lambda-js/handler.handler\\",
+  \\"Environment\\": {
+    \\"Variables\\": {
+      \\"DD_LAMBDA_HANDLER\\": \\"index.handler\\",
+      \\"DD_API_KEY\\": \\"1234\\",
+      \\"DD_SITE\\": \\"datadoghq.com\\",
+      \\"DD_CAPTURE_LAMBDA_PAYLOAD\\": \\"false\\",
+      \\"DD_ENV\\": \\"staging\\",
+      \\"DD_TAGS\\": \\"layer:api,team:intake\\",
+      \\"DD_MERGE_XRAY_TRACES\\": \\"false\\",
+      \\"DD_SERVICE\\": \\"middletier\\",
+      \\"DD_TRACE_ENABLED\\": \\"true\\",
+      \\"DD_VERSION\\": \\"0.2\\"
+    }
+  },
+  \\"Layers\\": [
+    \\"arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Extension:6\\"
+  ]
+}
+TagResource -> arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world
+{
+  \\"dd_sls_ci\\": \\"v2.4.0\\"
+}
+"
+`;
+
+exports[`lambda instrument execute prints dry run data for lambda library and extension layers using kebab case args 1`] = `
+"
+[Dry Run] 🐶 Instrumenting Lambda function
+
+[Warning] Instrument your Lambda functions in a dev or staging environment first. Should the instrumentation result be unsatisfactory, run \`uninstrument\` with the same arguments to revert the changes.
+
+[!] Functions to be updated:
+	- arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world
+
+[Dry Run] Will apply the following updates:
+UpdateFunctionConfiguration -> arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world
+{
+  \\"FunctionName\\": \\"arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world\\",
+  \\"Handler\\": \\"/opt/nodejs/node_modules/datadog-lambda-js/handler.handler\\",
+  \\"Environment\\": {
+    \\"Variables\\": {
+      \\"DD_LAMBDA_HANDLER\\": \\"index.handler\\",
+      \\"DD_API_KEY\\": \\"1234\\",
+      \\"DD_SITE\\": \\"datadoghq.com\\",
+      \\"DD_CAPTURE_LAMBDA_PAYLOAD\\": \\"false\\",
+      \\"DD_ENV\\": \\"staging\\",
+      \\"DD_TAGS\\": \\"layer:api,team:intake\\",
+      \\"DD_MERGE_XRAY_TRACES\\": \\"true\\",
+      \\"DD_SERVICE\\": \\"middletier\\",
+      \\"DD_TRACE_ENABLED\\": \\"true\\",
+      \\"DD_VERSION\\": \\"0.2\\",
+      \\"DD_LOG_LEVEL\\": \\"debug\\"
+    }
+  },
+  \\"Layers\\": [
+    \\"arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Extension:5\\",
+    \\"arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Node12-x:10\\"
+  ]
+}
+TagResource -> arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world
+{
+  \\"dd_sls_ci\\": \\"v2.4.0\\"
+}
+"
+`;
+
+exports[`lambda instrument execute prints dry run data for lambda library layer 1`] = `
+"
+[Dry Run] 🐶 Instrumenting Lambda function
+
+[Warning] Instrument your Lambda functions in a dev or staging environment first. Should the instrumentation result be unsatisfactory, run \`uninstrument\` with the same arguments to revert the changes.
+
+[!] Functions to be updated:
+	- arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world
+
+[Dry Run] Will apply the following updates:
+UpdateFunctionConfiguration -> arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world
+{
+  \\"FunctionName\\": \\"arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world\\",
+  \\"Handler\\": \\"/opt/nodejs/node_modules/datadog-lambda-js/handler.handler\\",
+  \\"Environment\\": {
+    \\"Variables\\": {
+      \\"DD_LAMBDA_HANDLER\\": \\"index.handler\\",
+      \\"DD_SITE\\": \\"datadoghq.com\\",
+      \\"DD_CAPTURE_LAMBDA_PAYLOAD\\": \\"false\\",
+      \\"DD_ENV\\": \\"staging\\",
+      \\"DD_TAGS\\": \\"layer:api,team:intake\\",
+      \\"DD_MERGE_XRAY_TRACES\\": \\"false\\",
+      \\"DD_SERVICE\\": \\"middletier\\",
+      \\"DD_TRACE_ENABLED\\": \\"true\\",
+      \\"DD_VERSION\\": \\"0.2\\",
+      \\"DD_FLUSH_TO_LOG\\": \\"true\\",
+      \\"DD_LOG_LEVEL\\": \\"debug\\"
+    }
+  },
+  \\"Layers\\": [
+    \\"arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Node12-x:10\\"
+  ]
+}
+TagResource -> arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world
+{
+  \\"dd_sls_ci\\": \\"v2.4.0\\"
+}
+"
+`;
+
+exports[`lambda instrument execute when not provided it does not set DD_ENV, DD_SERVICE, and DD_VERSION tags in interactive mode 1`] = `
+"
+🐶 Instrumenting Lambda function
+
+[!] Configure AWS region.
+
+[!] Configure Datadog settings.
+
+[Warning] The environment, service and version tags have not been configured. Learn more about Datadog unified service tagging: https://docs.datadoghq.com/getting_started/tagging/unified_service_tagging/#serverless-environment.
+
+[Warning] Instrument your Lambda functions in a dev or staging environment first. Should the instrumentation result be unsatisfactory, run \`uninstrument\` with the same arguments to revert the changes.
+
+[!] Functions to be updated:
+	- arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world
+	[Warning] At least one latest layer version is being used. Ensure to lock in versions for production applications using \`--layerVersion\` and \`--extensionVersion\`.
+
+Will apply the following updates:
+UpdateFunctionConfiguration -> arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world
+{
+  \\"FunctionName\\": \\"arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world\\",
+  \\"Handler\\": \\"/opt/nodejs/node_modules/datadog-lambda-js/handler.handler\\",
+  \\"Environment\\": {
+    \\"Variables\\": {
+      \\"DD_LAMBDA_HANDLER\\": \\"index.handler\\",
+      \\"DD_API_KEY\\": \\"02aeb762fff59ac0d5ad1536cd9633bd\\",
+      \\"DD_SITE\\": \\"datadoghq.com\\",
+      \\"DD_CAPTURE_LAMBDA_PAYLOAD\\": \\"false\\",
+      \\"DD_MERGE_XRAY_TRACES\\": \\"false\\",
+      \\"DD_TRACE_ENABLED\\": \\"true\\",
+      \\"DD_FLUSH_TO_LOG\\": \\"true\\"
+    }
+  },
+  \\"Layers\\": [
+    \\"arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Extension:1\\",
+    \\"arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Node12-x:1\\"
+  ]
+}
+TagResource -> arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world
+{
+  \\"dd_sls_ci\\": \\"v2.4.0\\"
+}
+[!] Confirmation needed.
+[!] Instrumenting functions.
+"
+`;
+
+exports[`lambda instrument execute when provided it sets DD_ENV, DD_SERVICE, and DD_VERSION environment variables in interactive mode 1`] = `
+"
+🐶 Instrumenting Lambda function
+
+[!] Configure AWS region.
+
+[!] Configure Datadog settings.
+
+[Warning] Instrument your Lambda functions in a dev or staging environment first. Should the instrumentation result be unsatisfactory, run \`uninstrument\` with the same arguments to revert the changes.
+
+[!] Functions to be updated:
+	- arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world
+	[Warning] At least one latest layer version is being used. Ensure to lock in versions for production applications using \`--layerVersion\` and \`--extensionVersion\`.
+
+Will apply the following updates:
+UpdateFunctionConfiguration -> arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world
+{
+  \\"FunctionName\\": \\"arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world\\",
+  \\"Handler\\": \\"/opt/nodejs/node_modules/datadog-lambda-js/handler.handler\\",
+  \\"Environment\\": {
+    \\"Variables\\": {
+      \\"DD_LAMBDA_HANDLER\\": \\"index.handler\\",
+      \\"DD_API_KEY\\": \\"02aeb762fff59ac0d5ad1536cd9633bd\\",
+      \\"DD_SITE\\": \\"datadoghq.com\\",
+      \\"DD_CAPTURE_LAMBDA_PAYLOAD\\": \\"false\\",
+      \\"DD_ENV\\": \\"sandbox\\",
+      \\"DD_MERGE_XRAY_TRACES\\": \\"false\\",
+      \\"DD_SERVICE\\": \\"testServiceName\\",
+      \\"DD_TRACE_ENABLED\\": \\"true\\",
+      \\"DD_VERSION\\": \\"1.0.0\\",
+      \\"DD_FLUSH_TO_LOG\\": \\"true\\"
+    }
+  },
+  \\"Layers\\": [
+    \\"arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Extension:1\\",
+    \\"arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Node12-x:1\\"
+  ]
+}
+TagResource -> arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world
+{
+  \\"dd_sls_ci\\": \\"v2.4.0\\"
+}
+[!] Confirmation needed.
+[!] Instrumenting functions.
+"
+`;

--- a/src/commands/lambda/__tests__/__snapshots__/instrument.test.ts.snap
+++ b/src/commands/lambda/__tests__/__snapshots__/instrument.test.ts.snap
@@ -35,7 +35,7 @@ UpdateFunctionConfiguration -> arn:aws:lambda:us-east-1:123456789012:function:la
 }
 TagResource -> arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world
 {
-  \\"dd_sls_ci\\": \\"v2.4.0\\"
+  \\"dd_sls_ci\\": \\"vXXXX\\"
 }
 "
 `;
@@ -82,7 +82,7 @@ UpdateFunctionConfiguration -> arn:aws:lambda:sa-east-1:123456789012:function:la
 }
 TagResource -> arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world
 {
-  \\"dd_sls_ci\\": \\"v2.4.0\\"
+  \\"dd_sls_ci\\": \\"vXXXX\\"
 }
 UpdateFunctionConfiguration -> arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world-2
 {
@@ -106,7 +106,7 @@ UpdateFunctionConfiguration -> arn:aws:lambda:sa-east-1:123456789012:function:la
 }
 TagResource -> arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world-2
 {
-  \\"dd_sls_ci\\": \\"v2.4.0\\"
+  \\"dd_sls_ci\\": \\"vXXXX\\"
 }
 [!] Confirmation needed.
 [!] Instrumenting functions.
@@ -155,7 +155,7 @@ UpdateFunctionConfiguration -> arn:aws:lambda:sa-east-1:123456789012:function:la
 }
 TagResource -> arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world
 {
-  \\"dd_sls_ci\\": \\"v2.4.0\\"
+  \\"dd_sls_ci\\": \\"vXXXX\\"
 }
 UpdateFunctionConfiguration -> arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world-2
 {
@@ -179,7 +179,7 @@ UpdateFunctionConfiguration -> arn:aws:lambda:sa-east-1:123456789012:function:la
 }
 TagResource -> arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world-2
 {
-  \\"dd_sls_ci\\": \\"v2.4.0\\"
+  \\"dd_sls_ci\\": \\"vXXXX\\"
 }
 [!] Confirmation needed.
 [!] Instrumenting functions.
@@ -223,7 +223,7 @@ UpdateFunctionConfiguration -> arn:aws:lambda:us-east-1:123456789012:function:la
 }
 TagResource -> arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world
 {
-  \\"dd_sls_ci\\": \\"v2.4.0\\"
+  \\"dd_sls_ci\\": \\"vXXXX\\"
 }
 "
 `;
@@ -262,7 +262,7 @@ UpdateFunctionConfiguration -> arn:aws:lambda:us-east-1:123456789012:function:la
 }
 TagResource -> arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world
 {
-  \\"dd_sls_ci\\": \\"v2.4.0\\"
+  \\"dd_sls_ci\\": \\"vXXXX\\"
 }
 "
 `;
@@ -303,7 +303,7 @@ UpdateFunctionConfiguration -> arn:aws:lambda:us-east-1:123456789012:function:la
 }
 TagResource -> arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world
 {
-  \\"dd_sls_ci\\": \\"v2.4.0\\"
+  \\"dd_sls_ci\\": \\"vXXXX\\"
 }
 "
 `;
@@ -343,7 +343,7 @@ UpdateFunctionConfiguration -> arn:aws:lambda:us-east-1:123456789012:function:la
 }
 TagResource -> arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world
 {
-  \\"dd_sls_ci\\": \\"v2.4.0\\"
+  \\"dd_sls_ci\\": \\"vXXXX\\"
 }
 "
 `;
@@ -388,7 +388,7 @@ UpdateFunctionConfiguration -> arn:aws:lambda:sa-east-1:123456789012:function:la
 }
 TagResource -> arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world
 {
-  \\"dd_sls_ci\\": \\"v2.4.0\\"
+  \\"dd_sls_ci\\": \\"vXXXX\\"
 }
 [!] Confirmation needed.
 [!] Instrumenting functions.
@@ -436,7 +436,7 @@ UpdateFunctionConfiguration -> arn:aws:lambda:sa-east-1:123456789012:function:la
 }
 TagResource -> arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world
 {
-  \\"dd_sls_ci\\": \\"v2.4.0\\"
+  \\"dd_sls_ci\\": \\"vXXXX\\"
 }
 [!] Confirmation needed.
 [!] Instrumenting functions.

--- a/src/commands/lambda/__tests__/__snapshots__/uninstrument.test.ts.snap
+++ b/src/commands/lambda/__tests__/__snapshots__/uninstrument.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`uninstrument execute uninstrument multiple functions interactively 1`] = `
+exports[`lambda uninstrument execute uninstrument multiple functions interactively 1`] = `
 "
 🐶 Uninstrumenting Lambda function
 
@@ -34,7 +34,7 @@ UpdateFunctionConfiguration -> arn:aws:lambda:sa-east-1:123456789012:function:la
 "
 `;
 
-exports[`uninstrument execute uninstrument multiple specified functions interactively 1`] = `
+exports[`lambda uninstrument execute uninstrument multiple specified functions interactively 1`] = `
 "
 🐶 Uninstrumenting Lambda function
 

--- a/src/commands/lambda/__tests__/__snapshots__/uninstrument.test.ts.snap
+++ b/src/commands/lambda/__tests__/__snapshots__/uninstrument.test.ts.snap
@@ -1,0 +1,69 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`uninstrument execute uninstrument multiple functions interactively 1`] = `
+"
+🐶 Uninstrumenting Lambda function
+
+[!] Functions to be updated:
+	- arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world
+	- arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world-2
+
+Will apply the following updates:
+UpdateFunctionConfiguration -> arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world
+{
+  \\"FunctionName\\": \\"arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world\\",
+  \\"Handler\\": \\"lambda_function.lambda_handler\\",
+  \\"Environment\\": {
+    \\"Variables\\": {
+      \\"USER_VARIABLE\\": \\"shouldnt be deleted by uninstrumentation\\"
+    }
+  },
+  \\"Layers\\": []
+}
+UpdateFunctionConfiguration -> arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world-2
+{
+  \\"FunctionName\\": \\"arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world-2\\",
+  \\"Handler\\": \\"lambda_function.lambda_handler\\",
+  \\"Environment\\": {
+    \\"Variables\\": {}
+  },
+  \\"Layers\\": []
+}
+[!] Confirmation needed.
+[!] Uninstrumenting functions.
+"
+`;
+
+exports[`uninstrument execute uninstrument multiple specified functions interactively 1`] = `
+"
+🐶 Uninstrumenting Lambda function
+
+[!] Functions to be updated:
+	- arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world
+	- arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world-2
+
+Will apply the following updates:
+UpdateFunctionConfiguration -> arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world
+{
+  \\"FunctionName\\": \\"arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world\\",
+  \\"Handler\\": \\"lambda_function.lambda_handler\\",
+  \\"Environment\\": {
+    \\"Variables\\": {
+      \\"USER_VARIABLE\\": \\"shouldnt be deleted by uninstrumentation\\"
+    }
+  },
+  \\"Layers\\": []
+}
+UpdateFunctionConfiguration -> arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world-2
+{
+  \\"FunctionName\\": \\"arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world-2\\",
+  \\"Handler\\": \\"lambda_function.lambda_handler\\",
+  \\"Environment\\": {
+    \\"Variables\\": {}
+  },
+  \\"Layers\\": []
+}
+[!] Confirmation needed.
+[!] Uninstrumenting functions.
+"
+`;

--- a/src/commands/lambda/__tests__/__snapshots__/uninstrument.test.ts.snap
+++ b/src/commands/lambda/__tests__/__snapshots__/uninstrument.test.ts.snap
@@ -3,6 +3,7 @@
 exports[`lambda uninstrument execute uninstrument multiple functions interactively 1`] = `
 "
 🐶 Uninstrumenting Lambda function
+[!] No AWS credentials found, let's set them up! Or you can re-run the command and supply the AWS credentials in the same way when you invoke the AWS CLI.
 
 [!] Functions to be updated:
 	- arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world
@@ -37,6 +38,7 @@ UpdateFunctionConfiguration -> arn:aws:lambda:sa-east-1:123456789012:function:la
 exports[`lambda uninstrument execute uninstrument multiple specified functions interactively 1`] = `
 "
 🐶 Uninstrumenting Lambda function
+[!] No AWS credentials found, let's set them up! Or you can re-run the command and supply the AWS credentials in the same way when you invoke the AWS CLI.
 
 [!] Functions to be updated:
 	- arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world

--- a/src/commands/lambda/__tests__/instrument.test.ts
+++ b/src/commands/lambda/__tests__/instrument.test.ts
@@ -2,6 +2,7 @@ jest.mock('fs')
 jest.mock('aws-sdk')
 jest.mock('../prompt')
 jest.mock('../renderer', () => require('../__mocks__/renderer'))
+jest.mock('../../../../package.json', () => ({ version: 'XXXX'}))
 
 import * as fs from 'fs'
 
@@ -49,6 +50,7 @@ describe('lambda', () => {
       beforeEach(() => {
         jest.resetModules()
         process.env = {}
+        
       })
       afterAll(() => {
         process.env = OLD_ENV

--- a/src/commands/lambda/__tests__/instrument.test.ts
+++ b/src/commands/lambda/__tests__/instrument.test.ts
@@ -4,7 +4,6 @@ jest.mock('../prompt')
 jest.mock('../renderer', () => require('../__mocks__/renderer'))
 
 import * as fs from 'fs'
-import path from 'path'
 
 import {config as aws_sdk_config, Lambda, SharedIniFileCredentials} from 'aws-sdk'
 import {Cli} from 'clipanion/lib/advanced'
@@ -43,7 +42,6 @@ import {
   mockDatadogService,
   mockDatadogVersion,
 } from './fixtures'
-const {version} = require(path.join(__dirname, '../../../../package.json'))
 describe('lambda', () => {
   describe('instrument', () => {
     describe('execute', () => {

--- a/src/commands/lambda/__tests__/instrument.test.ts
+++ b/src/commands/lambda/__tests__/instrument.test.ts
@@ -96,41 +96,7 @@ describe('lambda', () => {
         )
         const output = context.stdout.toString()
         expect(code).toBe(0)
-        expect(output).toMatchInlineSnapshot(`
-"\n[Dry Run] 🐶 Instrumenting Lambda function
-\n[Warning] Instrument your Lambda functions in a dev or staging environment first. Should the instrumentation result be unsatisfactory, run \`uninstrument\` with the same arguments to revert the changes.
-\n[!] Functions to be updated:
-\t- arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world\n
-[Dry Run] Will apply the following updates:
-UpdateFunctionConfiguration -> arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world
-{
-  \\"FunctionName\\": \\"arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world\\",
-  \\"Handler\\": \\"/opt/nodejs/node_modules/datadog-lambda-js/handler.handler\\",
-  \\"Environment\\": {
-    \\"Variables\\": {
-      \\"DD_LAMBDA_HANDLER\\": \\"index.handler\\",
-      \\"DD_SITE\\": \\"datadoghq.com\\",
-      \\"DD_CAPTURE_LAMBDA_PAYLOAD\\": \\"false\\",
-      \\"DD_ENV\\": \\"staging\\",
-      \\"DD_TAGS\\": \\"layer:api,team:intake\\",
-      \\"DD_MERGE_XRAY_TRACES\\": \\"false\\",
-      \\"DD_SERVICE\\": \\"middletier\\",
-      \\"DD_TRACE_ENABLED\\": \\"true\\",
-      \\"DD_VERSION\\": \\"0.2\\",
-      \\"DD_FLUSH_TO_LOG\\": \\"true\\",
-      \\"DD_LOG_LEVEL\\": \\"debug\\"
-    }
-  },
-  \\"Layers\\": [
-    \\"arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Node12-x:10\\"
-  ]
-}
-TagResource -> arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world
-{
-  \\"dd_sls_ci\\": \\"v${version}\\"
-}
-"
-`)
+        expect(output).toMatchSnapshot()
       })
 
       test('prints dry run data for lambda library and extension layers using kebab case args', async () => {
@@ -179,42 +145,7 @@ TagResource -> arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world
         )
         const output = context.stdout.toString()
         expect(code).toBe(0)
-        expect(output).toMatchInlineSnapshot(`
-"\n[Dry Run] 🐶 Instrumenting Lambda function
-\n[Warning] Instrument your Lambda functions in a dev or staging environment first. Should the instrumentation result be unsatisfactory, run \`uninstrument\` with the same arguments to revert the changes.
-\n[!] Functions to be updated:
-\t- arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world\n
-[Dry Run] Will apply the following updates:
-UpdateFunctionConfiguration -> arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world
-{
-  \\"FunctionName\\": \\"arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world\\",
-  \\"Handler\\": \\"/opt/nodejs/node_modules/datadog-lambda-js/handler.handler\\",
-  \\"Environment\\": {
-    \\"Variables\\": {
-      \\"DD_LAMBDA_HANDLER\\": \\"index.handler\\",
-      \\"DD_API_KEY\\": \\"1234\\",
-      \\"DD_SITE\\": \\"datadoghq.com\\",
-      \\"DD_CAPTURE_LAMBDA_PAYLOAD\\": \\"false\\",
-      \\"DD_ENV\\": \\"staging\\",
-      \\"DD_TAGS\\": \\"layer:api,team:intake\\",
-      \\"DD_MERGE_XRAY_TRACES\\": \\"true\\",
-      \\"DD_SERVICE\\": \\"middletier\\",
-      \\"DD_TRACE_ENABLED\\": \\"true\\",
-      \\"DD_VERSION\\": \\"0.2\\",
-      \\"DD_LOG_LEVEL\\": \\"debug\\"
-    }
-  },
-  \\"Layers\\": [
-    \\"arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Extension:5\\",
-    \\"arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Node12-x:10\\"
-  ]
-}
-TagResource -> arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world
-{
-  \\"dd_sls_ci\\": \\"v${version}\\"
-}
-"
-`)
+        expect(output).toMatchSnapshot()
       })
 
       test('prints dry run data for lambda extension layer', async () => {
@@ -255,40 +186,7 @@ TagResource -> arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world
         )
         const output = context.stdout.toString()
         expect(code).toBe(0)
-        expect(output).toMatchInlineSnapshot(`
-"\n[Dry Run] 🐶 Instrumenting Lambda function
-\n[Warning] Instrument your Lambda functions in a dev or staging environment first. Should the instrumentation result be unsatisfactory, run \`uninstrument\` with the same arguments to revert the changes.
-\n[!] Functions to be updated:
-\t- arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world\n
-[Dry Run] Will apply the following updates:
-UpdateFunctionConfiguration -> arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world
-{
-  \\"FunctionName\\": \\"arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world\\",
-  \\"Handler\\": \\"/opt/nodejs/node_modules/datadog-lambda-js/handler.handler\\",
-  \\"Environment\\": {
-    \\"Variables\\": {
-      \\"DD_LAMBDA_HANDLER\\": \\"index.handler\\",
-      \\"DD_API_KEY\\": \\"1234\\",
-      \\"DD_SITE\\": \\"datadoghq.com\\",
-      \\"DD_CAPTURE_LAMBDA_PAYLOAD\\": \\"false\\",
-      \\"DD_ENV\\": \\"staging\\",
-      \\"DD_TAGS\\": \\"layer:api,team:intake\\",
-      \\"DD_MERGE_XRAY_TRACES\\": \\"false\\",
-      \\"DD_SERVICE\\": \\"middletier\\",
-      \\"DD_TRACE_ENABLED\\": \\"true\\",
-      \\"DD_VERSION\\": \\"0.2\\"
-    }
-  },
-  \\"Layers\\": [
-    \\"arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Extension:6\\"
-  ]
-}
-TagResource -> arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world
-{
-  \\"dd_sls_ci\\": \\"v${version}\\"
-}
-"
-`)
+        expect(output).toMatchSnapshot()
       })
 
       test('prints dry run data for lambda .NET layer', async () => {
@@ -328,43 +226,7 @@ TagResource -> arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world
         )
         const output = context.stdout.toString()
         expect(code).toBe(0)
-        expect(output).toMatchInlineSnapshot(`
-"\n[Dry Run] 🐶 Instrumenting Lambda function
-\n[Warning] Instrument your Lambda functions in a dev or staging environment first. Should the instrumentation result be unsatisfactory, run \`uninstrument\` with the same arguments to revert the changes.
-\n[!] Functions to be updated:
-\t- arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world\n
-[Dry Run] Will apply the following updates:
-UpdateFunctionConfiguration -> arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world
-{
-  \\"FunctionName\\": \\"arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world\\",
-  \\"Environment\\": {
-    \\"Variables\\": {
-      \\"DD_API_KEY\\": \\"1234\\",
-      \\"DD_SITE\\": \\"datadoghq.com\\",
-      \\"DD_CAPTURE_LAMBDA_PAYLOAD\\": \\"false\\",
-      \\"DD_ENV\\": \\"staging\\",
-      \\"DD_TAGS\\": \\"layer:api,team:intake\\",
-      \\"DD_MERGE_XRAY_TRACES\\": \\"false\\",
-      \\"DD_SERVICE\\": \\"middletier\\",
-      \\"DD_TRACE_ENABLED\\": \\"true\\",
-      \\"DD_VERSION\\": \\"0.2\\",
-      \\"DD_FLUSH_TO_LOG\\": \\"true\\",
-      \\"CORECLR_ENABLE_PROFILING\\": \\"1\\",
-      \\"CORECLR_PROFILER\\": \\"{846F5F1C-F9AE-4B07-969E-05C26BC060D8}\\",
-      \\"CORECLR_PROFILER_PATH\\": \\"/opt/datadog/Datadog.Trace.ClrProfiler.Native.so\\",
-      \\"DD_DOTNET_TRACER_HOME\\": \\"/opt/datadog\\"
-    }
-  },
-  \\"Layers\\": [
-    \\"arn:aws:lambda:us-east-1:464622532012:layer:dd-trace-dotnet:129\\"
-  ]
-}
-TagResource -> arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world
-{
-  \\"dd_sls_ci\\": \\"v${version}\\"
-}
-"
-`)
+        expect(output).toMatchSnapshot()
       })
 
       test('instrumenting with source code integrations fails if not run within a git repo', async () => {
@@ -489,41 +351,7 @@ TagResource -> arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world
           context
         )
         const output = context.stdout.toString()
-        expect(output).toMatchInlineSnapshot(`
-"\n🐶 Instrumenting Lambda function\n
-[Warning] Instrument your Lambda functions in a dev or staging environment first. Should the instrumentation result be unsatisfactory, run \`uninstrument\` with the same arguments to revert the changes.
-\n[!] Functions to be updated:
-\t- arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world\n
-Will apply the following updates:
-UpdateFunctionConfiguration -> arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world
-{
-  \\"FunctionName\\": \\"arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world\\",
-  \\"Handler\\": \\"/opt/nodejs/node_modules/datadog-lambda-js/handler.handler\\",
-  \\"Environment\\": {
-    \\"Variables\\": {
-      \\"DD_LAMBDA_HANDLER\\": \\"index.handler\\",
-      \\"DD_API_KEY\\": \\"1234\\",
-      \\"DD_SITE\\": \\"datadoghq.com\\",
-      \\"DD_CAPTURE_LAMBDA_PAYLOAD\\": \\"false\\",
-      \\"DD_ENV\\": \\"dummy\\",
-      \\"DD_TAGS\\": \\"git.commit.sha:1be168ff837f043bde17c0314341c84271047b31,git.repository_url:git.repository_url:github.com/datadog/test.git\\",
-      \\"DD_MERGE_XRAY_TRACES\\": \\"false\\",
-      \\"DD_SERVICE\\": \\"dummy\\",
-      \\"DD_TRACE_ENABLED\\": \\"true\\",
-      \\"DD_VERSION\\": \\"0.1\\",
-      \\"DD_FLUSH_TO_LOG\\": \\"true\\"
-    }
-  },
-  \\"Layers\\": [
-    \\"arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Node12-x:10\\"
-  ]
-}
-TagResource -> arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world
-{
-  \\"dd_sls_ci\\": \\"v${version}\\"
-}
-"
-`)
+        expect(output).toMatchSnapshot()
       })
 
       test('ensure the instrument command ran from a local git repo ahead of the origin fails', async () => {
@@ -938,71 +766,7 @@ TagResource -> arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world
         const code = await cli.run(['lambda', 'instrument', '-i', '--no-source-code-integration'], context)
         const output = context.stdout.toString()
         expect(code).toBe(0)
-        expect(output).toMatchInlineSnapshot(`
-"\n🐶 Instrumenting Lambda function
-[!] No AWS credentials found, let's set them up! Or you can re-run the command and supply the AWS credentials in the same way when you invoke the AWS CLI.
-\n[!] Configure AWS region.
-\n[!] Configure Datadog settings.
-\n[Warning] The environment, service and version tags have not been configured. Learn more about Datadog unified service tagging: https://docs.datadoghq.com/getting_started/tagging/unified_service_tagging/#serverless-environment.
-\n[Warning] Instrument your Lambda functions in a dev or staging environment first. Should the instrumentation result be unsatisfactory, run \`uninstrument\` with the same arguments to revert the changes.
-\n[!] Functions to be updated:
-\t- arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world
-\t[Warning] At least one latest layer version is being used. Ensure to lock in versions for production applications using \`--layerVersion\` and \`--extensionVersion\`.
-\t- arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world-2
-\t[Warning] At least one latest layer version is being used. Ensure to lock in versions for production applications using \`--layerVersion\` and \`--extensionVersion\`.\n
-Will apply the following updates:
-UpdateFunctionConfiguration -> arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world
-{
-  \\"FunctionName\\": \\"arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world\\",
-  \\"Handler\\": \\"/opt/nodejs/node_modules/datadog-lambda-js/handler.handler\\",
-  \\"Environment\\": {
-    \\"Variables\\": {
-      \\"DD_LAMBDA_HANDLER\\": \\"index.handler\\",
-      \\"DD_API_KEY\\": \\"02aeb762fff59ac0d5ad1536cd9633bd\\",
-      \\"DD_SITE\\": \\"datadoghq.com\\",
-      \\"DD_CAPTURE_LAMBDA_PAYLOAD\\": \\"false\\",
-      \\"DD_MERGE_XRAY_TRACES\\": \\"false\\",
-      \\"DD_TRACE_ENABLED\\": \\"true\\",
-      \\"DD_FLUSH_TO_LOG\\": \\"true\\"
-    }
-  },
-  \\"Layers\\": [
-    \\"arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Extension:1\\",
-    \\"arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Node12-x:1\\"
-  ]
-}
-TagResource -> arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world
-{
-  \\"dd_sls_ci\\": \\"v${version}\\"
-}
-UpdateFunctionConfiguration -> arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world-2
-{
-  \\"FunctionName\\": \\"arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world-2\\",
-  \\"Handler\\": \\"/opt/nodejs/node_modules/datadog-lambda-js/handler.handler\\",
-  \\"Environment\\": {
-    \\"Variables\\": {
-      \\"DD_LAMBDA_HANDLER\\": \\"index.handler\\",
-      \\"DD_API_KEY\\": \\"02aeb762fff59ac0d5ad1536cd9633bd\\",
-      \\"DD_SITE\\": \\"datadoghq.com\\",
-      \\"DD_CAPTURE_LAMBDA_PAYLOAD\\": \\"false\\",
-      \\"DD_MERGE_XRAY_TRACES\\": \\"false\\",
-      \\"DD_TRACE_ENABLED\\": \\"true\\",
-      \\"DD_FLUSH_TO_LOG\\": \\"true\\"
-    }
-  },
-  \\"Layers\\": [
-    \\"arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Extension:1\\",
-    \\"arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Node14-x:1\\"
-  ]
-}
-TagResource -> arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world-2
-{
-  \\"dd_sls_ci\\": \\"v${version}\\"
-}
-[!] Confirmation needed.
-[!] Instrumenting functions.
-"
-`)
+        expect(output).toMatchSnapshot()
       })
 
       test('instrument multiple specified functions interactively', async () => {
@@ -1082,71 +846,7 @@ TagResource -> arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world
         )
         const output = context.stdout.toString()
         expect(code).toBe(0)
-        expect(output).toMatchInlineSnapshot(`
-"\n🐶 Instrumenting Lambda function
-[!] No AWS credentials found, let's set them up! Or you can re-run the command and supply the AWS credentials in the same way when you invoke the AWS CLI.
-\n[!] Configure AWS region.
-\n[!] Configure Datadog settings.
-\n[Warning] The environment, service and version tags have not been configured. Learn more about Datadog unified service tagging: https://docs.datadoghq.com/getting_started/tagging/unified_service_tagging/#serverless-environment.
-\n[Warning] Instrument your Lambda functions in a dev or staging environment first. Should the instrumentation result be unsatisfactory, run \`uninstrument\` with the same arguments to revert the changes.
-\n[!] Functions to be updated:
-\t- arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world
-\t[Warning] At least one latest layer version is being used. Ensure to lock in versions for production applications using \`--layerVersion\` and \`--extensionVersion\`.
-\t- arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world-2
-\t[Warning] At least one latest layer version is being used. Ensure to lock in versions for production applications using \`--layerVersion\` and \`--extensionVersion\`.\n
-Will apply the following updates:
-UpdateFunctionConfiguration -> arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world
-{
-  \\"FunctionName\\": \\"arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world\\",
-  \\"Handler\\": \\"/opt/nodejs/node_modules/datadog-lambda-js/handler.handler\\",
-  \\"Environment\\": {
-    \\"Variables\\": {
-      \\"DD_LAMBDA_HANDLER\\": \\"index.handler\\",
-      \\"DD_API_KEY\\": \\"02aeb762fff59ac0d5ad1536cd9633bd\\",
-      \\"DD_SITE\\": \\"datadoghq.com\\",
-      \\"DD_CAPTURE_LAMBDA_PAYLOAD\\": \\"false\\",
-      \\"DD_MERGE_XRAY_TRACES\\": \\"false\\",
-      \\"DD_TRACE_ENABLED\\": \\"true\\",
-      \\"DD_FLUSH_TO_LOG\\": \\"true\\"
-    }
-  },
-  \\"Layers\\": [
-    \\"arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Extension:1\\",
-    \\"arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Node12-x:1\\"
-  ]
-}
-TagResource -> arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world
-{
-  \\"dd_sls_ci\\": \\"v${version}\\"
-}
-UpdateFunctionConfiguration -> arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world-2
-{
-  \\"FunctionName\\": \\"arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world-2\\",
-  \\"Handler\\": \\"/opt/nodejs/node_modules/datadog-lambda-js/handler.handler\\",
-  \\"Environment\\": {
-    \\"Variables\\": {
-      \\"DD_LAMBDA_HANDLER\\": \\"index.handler\\",
-      \\"DD_API_KEY\\": \\"02aeb762fff59ac0d5ad1536cd9633bd\\",
-      \\"DD_SITE\\": \\"datadoghq.com\\",
-      \\"DD_CAPTURE_LAMBDA_PAYLOAD\\": \\"false\\",
-      \\"DD_MERGE_XRAY_TRACES\\": \\"false\\",
-      \\"DD_TRACE_ENABLED\\": \\"true\\",
-      \\"DD_FLUSH_TO_LOG\\": \\"true\\"
-    }
-  },
-  \\"Layers\\": [
-    \\"arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Extension:1\\",
-    \\"arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Node14-x:1\\"
-  ]
-}
-TagResource -> arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world-2
-{
-  \\"dd_sls_ci\\": \\"v${version}\\"
-}
-[!] Confirmation needed.
-[!] Instrumenting functions.
-"
-`)
+        expect(output).toMatchSnapshot()
       })
 
       test('aborts if a problem occurs while setting the AWS credentials interactively', async () => {
@@ -1237,48 +937,7 @@ TagResource -> arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world
         const code = await cli.run(['lambda', 'instrument', '-i', '--no-source-code-integration'], context)
         const output = context.stdout.toString()
         expect(code).toBe(0)
-        expect(output).toMatchInlineSnapshot(`
-"\n🐶 Instrumenting Lambda function
-[!] No AWS credentials found, let's set them up! Or you can re-run the command and supply the AWS credentials in the same way when you invoke the AWS CLI.
-\n[!] Configure AWS region.
-\n[!] Configure Datadog settings.
-\n[Warning] Instrument your Lambda functions in a dev or staging environment first. Should the instrumentation result be unsatisfactory, run \`uninstrument\` with the same arguments to revert the changes.
-\n[!] Functions to be updated:
-\t- arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world
-\t[Warning] At least one latest layer version is being used. Ensure to lock in versions for production applications using \`--layerVersion\` and \`--extensionVersion\`.
-
-Will apply the following updates:
-UpdateFunctionConfiguration -> arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world
-{
-  \\"FunctionName\\": \\"arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world\\",
-  \\"Handler\\": \\"/opt/nodejs/node_modules/datadog-lambda-js/handler.handler\\",
-  \\"Environment\\": {
-    \\"Variables\\": {
-      \\"DD_LAMBDA_HANDLER\\": \\"index.handler\\",
-      \\"DD_API_KEY\\": \\"02aeb762fff59ac0d5ad1536cd9633bd\\",
-      \\"DD_SITE\\": \\"datadoghq.com\\",
-      \\"DD_CAPTURE_LAMBDA_PAYLOAD\\": \\"false\\",
-      \\"DD_ENV\\": \\"sandbox\\",
-      \\"DD_MERGE_XRAY_TRACES\\": \\"false\\",
-      \\"DD_SERVICE\\": \\"testServiceName\\",
-      \\"DD_TRACE_ENABLED\\": \\"true\\",
-      \\"DD_VERSION\\": \\"1.0.0\\",
-      \\"DD_FLUSH_TO_LOG\\": \\"true\\"
-    }
-  },
-  \\"Layers\\": [
-    \\"arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Extension:1\\",
-    \\"arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Node12-x:1\\"
-  ]
-}
-TagResource -> arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world
-{
-  \\"dd_sls_ci\\": \\"v${version}\\"
-}
-[!] Confirmation needed.
-[!] Instrumenting functions.
-"
-`)
+        expect(output).toMatchSnapshot()
       })
 
       test('when not provided it does not set DD_ENV, DD_SERVICE, and DD_VERSION tags in interactive mode', async () => {
@@ -1331,46 +990,7 @@ TagResource -> arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world
         const code = await cli.run(['lambda', 'instrument', '-i', '--no-source-code-integration'], context)
         const output = context.stdout.toString()
         expect(code).toBe(0)
-        expect(output).toMatchInlineSnapshot(`
-"\n🐶 Instrumenting Lambda function
-[!] No AWS credentials found, let's set them up! Or you can re-run the command and supply the AWS credentials in the same way when you invoke the AWS CLI.
-\n[!] Configure AWS region.
-\n[!] Configure Datadog settings.
-\n[Warning] The environment, service and version tags have not been configured. Learn more about Datadog unified service tagging: https://docs.datadoghq.com/getting_started/tagging/unified_service_tagging/#serverless-environment.
-\n[Warning] Instrument your Lambda functions in a dev or staging environment first. Should the instrumentation result be unsatisfactory, run \`uninstrument\` with the same arguments to revert the changes.
-\n[!] Functions to be updated:
-\t- arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world
-\t[Warning] At least one latest layer version is being used. Ensure to lock in versions for production applications using \`--layerVersion\` and \`--extensionVersion\`.
-
-Will apply the following updates:
-UpdateFunctionConfiguration -> arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world
-{
-  \\"FunctionName\\": \\"arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world\\",
-  \\"Handler\\": \\"/opt/nodejs/node_modules/datadog-lambda-js/handler.handler\\",
-  \\"Environment\\": {
-    \\"Variables\\": {
-      \\"DD_LAMBDA_HANDLER\\": \\"index.handler\\",
-      \\"DD_API_KEY\\": \\"02aeb762fff59ac0d5ad1536cd9633bd\\",
-      \\"DD_SITE\\": \\"datadoghq.com\\",
-      \\"DD_CAPTURE_LAMBDA_PAYLOAD\\": \\"false\\",
-      \\"DD_MERGE_XRAY_TRACES\\": \\"false\\",
-      \\"DD_TRACE_ENABLED\\": \\"true\\",
-      \\"DD_FLUSH_TO_LOG\\": \\"true\\"
-    }
-  },
-  \\"Layers\\": [
-    \\"arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Extension:1\\",
-    \\"arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Node12-x:1\\"
-  ]
-}
-TagResource -> arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world
-{
-  \\"dd_sls_ci\\": \\"v${version}\\"
-}
-[!] Confirmation needed.
-[!] Instrumenting functions.
-"
-`)
+        expect(output).toMatchSnapshot()
       })
 
       test('aborts if there are no functions to instrument in the user AWS account', async () => {

--- a/src/commands/lambda/__tests__/instrument.test.ts
+++ b/src/commands/lambda/__tests__/instrument.test.ts
@@ -2,7 +2,7 @@ jest.mock('fs')
 jest.mock('aws-sdk')
 jest.mock('../prompt')
 jest.mock('../renderer', () => require('../__mocks__/renderer'))
-jest.mock('../../../../package.json', () => ({ version: 'XXXX'}))
+jest.mock('../../../../package.json', () => ({version: 'XXXX'}))
 
 import * as fs from 'fs'
 
@@ -50,7 +50,6 @@ describe('lambda', () => {
       beforeEach(() => {
         jest.resetModules()
         process.env = {}
-        
       })
       afterAll(() => {
         process.env = OLD_ENV

--- a/src/commands/lambda/__tests__/uninstrument.test.ts
+++ b/src/commands/lambda/__tests__/uninstrument.test.ts
@@ -495,11 +495,12 @@ describe('lambda', () => {
         const output = context.stdout.toString()
         expect(code).toBe(1)
         expect(output).toMatchInlineSnapshot(`
-            "\n🐶 Uninstrumenting Lambda function
-            [!] No AWS credentials found, let's set them up! Or you can re-run the command and supply the AWS credentials in the same way when you invoke the AWS CLI.
-            [Error] Unexpected error
-            "
-          `)
+          "
+          🐶 Uninstrumenting Lambda function
+          [!] No AWS credentials found, let's set them up! Or you can re-run the command and supply the AWS credentials in the same way when you invoke the AWS CLI.
+          [Error] Unexpected error
+          "
+        `)
       })
 
       test('aborts if there are no functions to uninstrument in the user AWS account', async () => {

--- a/src/commands/lambda/__tests__/uninstrument.test.ts
+++ b/src/commands/lambda/__tests__/uninstrument.test.ts
@@ -33,23 +33,91 @@ import {
   mockAwsSecretAccessKey,
 } from './fixtures'
 
-describe('uninstrument', () => {
-  describe('execute', () => {
-    const OLD_ENV = process.env
-    beforeEach(() => {
-      jest.resetModules()
-      process.env = {}
-    })
-    afterAll(() => {
-      process.env = OLD_ENV
-    })
+describe('lambda', () => {
+  describe('uninstrument', () => {
+    describe('execute', () => {
+      const OLD_ENV = process.env
+      beforeEach(() => {
+        jest.resetModules()
+        process.env = {}
+      })
+      afterAll(() => {
+        process.env = OLD_ENV
+      })
 
-    test('prints dry run data for a valid uninstrumentation', async () => {
-      ;(fs.readFile as any).mockImplementation((a: any, b: any, callback: any) => callback({code: 'ENOENT'}))
-      ;(Lambda as any).mockImplementation(() =>
-        makeMockLambda({
+      test('prints dry run data for a valid uninstrumentation', async () => {
+        ;(fs.readFile as any).mockImplementation((a: any, b: any, callback: any) => callback({code: 'ENOENT'}))
+        ;(Lambda as any).mockImplementation(() =>
+          makeMockLambda({
+            'arn:aws:lambda:us-east-1:000000000000:function:uninstrument': {
+              Architectures: ['x86_64'],
+              Environment: {
+                Variables: {
+                  [ENVIRONMENT_ENV_VAR]: 'staging',
+                  [FLUSH_TO_LOG_ENV_VAR]: 'true',
+                  [LAMBDA_HANDLER_ENV_VAR]: 'lambda_function.lambda_handler',
+                  [LOG_LEVEL_ENV_VAR]: 'debug',
+                  [MERGE_XRAY_TRACES_ENV_VAR]: 'false',
+                  [SERVICE_ENV_VAR]: 'middletier',
+                  [SITE_ENV_VAR]: 'datadoghq.com',
+                  [TRACE_ENABLED_ENV_VAR]: 'true',
+                  [VERSION_ENV_VAR]: '0.2',
+                  USER_VARIABLE: 'shouldnt be deleted by uninstrumentation',
+                },
+              },
+              FunctionArn: 'arn:aws:lambda:us-east-1:000000000000:function:uninstrument',
+              Handler: 'datadog_lambda.handler.handler',
+              Layers: [
+                {
+                  Arn: 'arn:aws:lambda:sa-east-1:000000000000:layer:Datadog-Extension:11',
+                  CodeSize: 0,
+                  SigningJobArn: 'some-signing-job-arn',
+                  SigningProfileVersionArn: 'some-signing-profile',
+                },
+                {
+                  Arn: 'arn:aws:lambda:sa-east-1:000000000000:layer:Datadog-Python38:49',
+                  CodeSize: 0,
+                  SigningJobArn: 'some-signing-job-arn',
+                  SigningProfileVersionArn: 'some-signing-profile',
+                },
+              ],
+              Runtime: 'python3.8',
+            },
+          })
+        )
+        const cli = makeCli()
+        const context = createMockContext() as any
+        const functionARN = 'arn:aws:lambda:us-east-1:000000000000:function:uninstrument'
+        process.env.DATADOG_API_KEY = '1234'
+        const code = await cli.run(['lambda', 'uninstrument', '-f', functionARN, '-r', 'us-east-1', '-d'], context)
+        const output = context.stdout.toString()
+        expect(code).toBe(0)
+        expect(output).toMatchInlineSnapshot(`
+          "
+          [Dry Run] 🐶 Uninstrumenting Lambda function
+
+          [!] Functions to be updated:
+          	- arn:aws:lambda:us-east-1:000000000000:function:uninstrument
+
+          [Dry Run] Will apply the following updates:
+          UpdateFunctionConfiguration -> arn:aws:lambda:us-east-1:000000000000:function:uninstrument
+          {
+            \\"FunctionName\\": \\"arn:aws:lambda:us-east-1:000000000000:function:uninstrument\\",
+            \\"Handler\\": \\"lambda_function.lambda_handler\\",
+            \\"Environment\\": {
+              \\"Variables\\": {
+                \\"USER_VARIABLE\\": \\"shouldnt be deleted by uninstrumentation\\"
+              }
+            },
+            \\"Layers\\": []
+          }
+          "
+        `)
+      })
+      test('runs function update command for valid uninstrumentation', async () => {
+        ;(fs.readFile as any).mockImplementation((a: any, b: any, callback: any) => callback({code: 'ENOENT'}))
+        const lambda = makeMockLambda({
           'arn:aws:lambda:us-east-1:000000000000:function:uninstrument': {
-            Architectures: ['x86_64'],
             Environment: {
               Variables: {
                 [ENVIRONMENT_ENV_VAR]: 'staging',
@@ -83,492 +151,438 @@ describe('uninstrument', () => {
             Runtime: 'python3.8',
           },
         })
-      )
-      const cli = makeCli()
-      const context = createMockContext() as any
-      const functionARN = 'arn:aws:lambda:us-east-1:000000000000:function:uninstrument'
-      process.env.DATADOG_API_KEY = '1234'
-      const code = await cli.run(['lambda', 'uninstrument', '-f', functionARN, '-r', 'us-east-1', '-d'], context)
-      const output = context.stdout.toString()
-      expect(code).toBe(0)
-      expect(output).toMatchInlineSnapshot(`
-"\n[Dry Run] 🐶 Uninstrumenting Lambda function
-\n[!] Functions to be updated:
-\t- arn:aws:lambda:us-east-1:000000000000:function:uninstrument\n
-[Dry Run] Will apply the following updates:
-UpdateFunctionConfiguration -> arn:aws:lambda:us-east-1:000000000000:function:uninstrument
-{
-  \\"FunctionName\\": \\"arn:aws:lambda:us-east-1:000000000000:function:uninstrument\\",
-  \\"Handler\\": \\"lambda_function.lambda_handler\\",
-  \\"Environment\\": {
-    \\"Variables\\": {
-      \\"USER_VARIABLE\\": \\"shouldnt be deleted by uninstrumentation\\"
-    }
-  },
-  \\"Layers\\": []
-}
-"
-`)
-    })
-    test('runs function update command for valid uninstrumentation', async () => {
-      ;(fs.readFile as any).mockImplementation((a: any, b: any, callback: any) => callback({code: 'ENOENT'}))
-      const lambda = makeMockLambda({
-        'arn:aws:lambda:us-east-1:000000000000:function:uninstrument': {
-          Environment: {
-            Variables: {
-              [ENVIRONMENT_ENV_VAR]: 'staging',
-              [FLUSH_TO_LOG_ENV_VAR]: 'true',
-              [LAMBDA_HANDLER_ENV_VAR]: 'lambda_function.lambda_handler',
-              [LOG_LEVEL_ENV_VAR]: 'debug',
-              [MERGE_XRAY_TRACES_ENV_VAR]: 'false',
-              [SERVICE_ENV_VAR]: 'middletier',
-              [SITE_ENV_VAR]: 'datadoghq.com',
-              [TRACE_ENABLED_ENV_VAR]: 'true',
-              [VERSION_ENV_VAR]: '0.2',
-              USER_VARIABLE: 'shouldnt be deleted by uninstrumentation',
-            },
-          },
-          FunctionArn: 'arn:aws:lambda:us-east-1:000000000000:function:uninstrument',
-          Handler: 'datadog_lambda.handler.handler',
-          Layers: [
-            {
-              Arn: 'arn:aws:lambda:sa-east-1:000000000000:layer:Datadog-Extension:11',
-              CodeSize: 0,
-              SigningJobArn: 'some-signing-job-arn',
-              SigningProfileVersionArn: 'some-signing-profile',
-            },
-            {
-              Arn: 'arn:aws:lambda:sa-east-1:000000000000:layer:Datadog-Python38:49',
-              CodeSize: 0,
-              SigningJobArn: 'some-signing-job-arn',
-              SigningProfileVersionArn: 'some-signing-profile',
-            },
-          ],
-          Runtime: 'python3.8',
-        },
+        ;(Lambda as any).mockImplementation(() => lambda)
+
+        const cli = makeCli()
+        const context = createMockContext() as any
+        const functionARN = 'arn:aws:lambda:us-east-1:000000000000:function:uninstrument'
+        process.env.DATADOG_API_KEY = '1234'
+        await cli.run(['lambda', 'uninstrument', '-f', functionARN, '-r', 'us-east-1'], context)
+        expect(lambda.updateFunctionConfiguration).toHaveBeenCalled()
       })
-      ;(Lambda as any).mockImplementation(() => lambda)
+      test('aborts early when the aws-sdk throws an error', async () => {
+        ;(fs.readFile as any).mockImplementation((a: any, b: any, callback: any) => callback({code: 'ENOENT'}))
+        ;(Lambda as any).mockImplementation(() => ({
+          getFunction: jest.fn().mockImplementation(() => ({promise: () => Promise.reject('Lambda failed')})),
+        }))
 
-      const cli = makeCli()
-      const context = createMockContext() as any
-      const functionARN = 'arn:aws:lambda:us-east-1:000000000000:function:uninstrument'
-      process.env.DATADOG_API_KEY = '1234'
-      await cli.run(['lambda', 'uninstrument', '-f', functionARN, '-r', 'us-east-1'], context)
-      expect(lambda.updateFunctionConfiguration).toHaveBeenCalled()
-    })
-    test('aborts early when the aws-sdk throws an error', async () => {
-      ;(fs.readFile as any).mockImplementation((a: any, b: any, callback: any) => callback({code: 'ENOENT'}))
-      ;(Lambda as any).mockImplementation(() => ({
-        getFunction: jest.fn().mockImplementation(() => ({promise: () => Promise.reject('Lambda failed')})),
-      }))
+        process.env = {}
+        const command = createCommand(UninstrumentCommand)
+        command['functions'] = ['my-func']
+        command['region'] = 'us-east-1'
 
-      process.env = {}
-      const command = createCommand(UninstrumentCommand)
-      command['functions'] = ['my-func']
-      command['region'] = 'us-east-1'
+        const code = await command['execute']()
+        const output = command.context.stdout.toString()
+        expect(code).toBe(1)
+        expect(output).toMatch("[Error] Couldn't fetch Lambda functions. Lambda failed\n")
+      })
+      test("aborts early when function regions can't be found", async () => {
+        ;(fs.readFile as any).mockImplementation((a: any, b: any, callback: any) => callback({code: 'ENOENT'}))
+        ;(Lambda as any).mockImplementation(() => makeMockLambda({}))
 
-      const code = await command['execute']()
-      const output = command.context.stdout.toString()
-      expect(code).toBe(1)
-      expect(output).toMatch("[Error] Couldn't fetch Lambda functions. Lambda failed\n")
-    })
-    test("aborts early when function regions can't be found", async () => {
-      ;(fs.readFile as any).mockImplementation((a: any, b: any, callback: any) => callback({code: 'ENOENT'}))
-      ;(Lambda as any).mockImplementation(() => makeMockLambda({}))
+        const cli = makeCli()
+        const context = createMockContext() as any
+        const code = await cli.run(['lambda', 'uninstrument', '--function', 'my-func'], context)
 
-      const cli = makeCli()
-      const context = createMockContext() as any
-      const code = await cli.run(['lambda', 'uninstrument', '--function', 'my-func'], context)
+        const output = context.stdout.toString()
+        expect(code).toBe(1)
+        expect(output).toMatch(
+          'No default region specified for ["my-func"]. Use -r, --region, or use a full functionARN'
+        )
+      })
+      test('aborts early when no functions are specified', async () => {
+        ;(fs.readFile as any).mockImplementation((a: any, b: any, callback: any) => callback({code: 'ENOENT'}))
+        ;(Lambda as any).mockImplementation(() => makeMockLambda({}))
+        const cli = makeCli()
+        const context = createMockContext() as any
+        const code = await cli.run(['lambda', 'uninstrument'], context)
+        const output = context.stdout.toString()
+        expect(code).toBe(1)
+        expect(output).toMatchInlineSnapshot(`
+          "
+          🐶 Uninstrumenting Lambda function
+          [Error] No functions specified to remove instrumentation.
+          "
+        `)
+      })
+      test('aborts early when no functions are specified while using config file', async () => {
+        ;(fs.readFile as any).mockImplementation((a: any, b: any, callback: any) => callback({}))
 
-      const output = context.stdout.toString()
-      expect(code).toBe(1)
-      expect(output).toMatch('No default region specified for ["my-func"]. Use -r, --region, or use a full functionARN')
-    })
-    test('aborts early when no functions are specified', async () => {
-      ;(fs.readFile as any).mockImplementation((a: any, b: any, callback: any) => callback({code: 'ENOENT'}))
-      ;(Lambda as any).mockImplementation(() => makeMockLambda({}))
-      const cli = makeCli()
-      const context = createMockContext() as any
-      const code = await cli.run(['lambda', 'uninstrument'], context)
-      const output = context.stdout.toString()
-      expect(code).toBe(1)
-      expect(output).toMatchInlineSnapshot(`
-"\n🐶 Uninstrumenting Lambda function
-[Error] No functions specified to remove instrumentation.
-"
-`)
-    })
-    test('aborts early when no functions are specified while using config file', async () => {
-      ;(fs.readFile as any).mockImplementation((a: any, b: any, callback: any) => callback({}))
+        process.env = {}
+        const command = createCommand(UninstrumentCommand)
+        command['config']['region'] = 'ap-southeast-1'
+        await command['execute']()
+        const output = command.context.stdout.toString()
+        expect(output).toMatchInlineSnapshot(`
+          "
+          🐶 Uninstrumenting Lambda function
+          [Error] No functions specified to remove instrumentation.
+          "
+        `)
+      })
+      test('aborts if functions and a pattern are set at the same time', async () => {
+        ;(fs.readFile as any).mockImplementation((a: any, b: any, callback: any) => callback({}))
 
-      process.env = {}
-      const command = createCommand(UninstrumentCommand)
-      command['config']['region'] = 'ap-southeast-1'
-      await command['execute']()
-      const output = command.context.stdout.toString()
-      expect(output).toMatchInlineSnapshot(`
-"\n🐶 Uninstrumenting Lambda function
-[Error] No functions specified to remove instrumentation.
-"
-`)
-    })
-    test('aborts if functions and a pattern are set at the same time', async () => {
-      ;(fs.readFile as any).mockImplementation((a: any, b: any, callback: any) => callback({}))
+        process.env = {}
+        let command = createCommand(UninstrumentCommand)
+        command['config']['region'] = 'ap-southeast-1'
+        command['config']['functions'] = ['arn:aws:lambda:ap-southeast-1:123456789012:function:lambda-hello-world']
+        command['regExPattern'] = 'valid-pattern'
+        await command['execute']()
+        let output = command.context.stdout.toString()
+        expect(output).toMatch(
+          'Functions in config file and "--functions-regex" should not be used at the same time.\n'
+        )
 
-      process.env = {}
-      let command = createCommand(UninstrumentCommand)
-      command['config']['region'] = 'ap-southeast-1'
-      command['config']['functions'] = ['arn:aws:lambda:ap-southeast-1:123456789012:function:lambda-hello-world']
-      command['regExPattern'] = 'valid-pattern'
-      await command['execute']()
-      let output = command.context.stdout.toString()
-      expect(output).toMatch('Functions in config file and "--functions-regex" should not be used at the same time.\n')
+        command = createCommand(UninstrumentCommand)
+        command['region'] = 'ap-southeast-1'
+        command['functions'] = ['arn:aws:lambda:ap-southeast-1:123456789012:function:lambda-hello-world']
+        command['regExPattern'] = 'valid-pattern'
+        await command['execute']()
+        output = command.context.stdout.toString()
+        expect(output).toMatch('"--functions" and "--functions-regex" should not be used at the same time.\n')
+      })
+      test('aborts if the regEx pattern is an ARN', async () => {
+        ;(fs.readFile as any).mockImplementation((a: any, b: any, callback: any) => callback({}))
 
-      command = createCommand(UninstrumentCommand)
-      command['region'] = 'ap-southeast-1'
-      command['functions'] = ['arn:aws:lambda:ap-southeast-1:123456789012:function:lambda-hello-world']
-      command['regExPattern'] = 'valid-pattern'
-      await command['execute']()
-      output = command.context.stdout.toString()
-      expect(output).toMatch('"--functions" and "--functions-regex" should not be used at the same time.\n')
-    })
-    test('aborts if the regEx pattern is an ARN', async () => {
-      ;(fs.readFile as any).mockImplementation((a: any, b: any, callback: any) => callback({}))
+        process.env = {}
+        const command = createCommand(UninstrumentCommand)
+        command['region'] = 'ap-southeast-1'
+        command['regExPattern'] = 'arn:aws:lambda:ap-southeast-1:123456789012:function:*'
+        const code = await command['execute']()
+        const output = command.context.stdout.toString()
+        expect(code).toBe(1)
+        expect(output).toMatch(`"--functions-regex" isn't meant to be used with ARNs.\n`)
+      })
 
-      process.env = {}
-      const command = createCommand(UninstrumentCommand)
-      command['region'] = 'ap-southeast-1'
-      command['regExPattern'] = 'arn:aws:lambda:ap-southeast-1:123456789012:function:*'
-      const code = await command['execute']()
-      const output = command.context.stdout.toString()
-      expect(code).toBe(1)
-      expect(output).toMatch(`"--functions-regex" isn't meant to be used with ARNs.\n`)
-    })
+      test('aborts if the regEx pattern is set but no region is specified', async () => {
+        ;(fs.readFile as any).mockImplementation((a: any, b: any, callback: any) => callback({}))
 
-    test('aborts if the regEx pattern is set but no region is specified', async () => {
-      ;(fs.readFile as any).mockImplementation((a: any, b: any, callback: any) => callback({}))
+        process.env = {}
+        const command = createCommand(UninstrumentCommand)
+        command['regExPattern'] = 'my-function'
+        const code = await command['execute']()
+        const output = command.context.stdout.toString()
+        expect(code).toBe(1)
+        expect(output).toMatch('No default region specified. Use `-r`, `--region`.')
+      })
 
-      process.env = {}
-      const command = createCommand(UninstrumentCommand)
-      command['regExPattern'] = 'my-function'
-      const code = await command['execute']()
-      const output = command.context.stdout.toString()
-      expect(code).toBe(1)
-      expect(output).toMatch('No default region specified. Use `-r`, `--region`.')
-    })
+      test('aborts if the the aws-sdk fails', async () => {
+        ;(fs.readFile as any).mockImplementation((a: any, b: any, callback: any) => callback({}))
+        ;(Lambda as any).mockImplementation(() => ({
+          listFunctions: jest.fn().mockImplementation(() => ({promise: () => Promise.reject('ListFunctionsError')})),
+        }))
+        process.env = {}
+        ;(Lambda as any).mockImplementation(() => ({
+          listFunctions: jest.fn().mockImplementation(() => ({promise: () => Promise.reject('ListFunctionsError')})),
+        }))
+        const command = createCommand(UninstrumentCommand)
+        command['region'] = 'ap-southeast-1'
+        command['regExPattern'] = 'my-function'
+        const code = await command['execute']()
+        const output = command.context.stdout.toString()
+        expect(code).toBe(1)
+        expect(output).toMatch(
+          "\n[Error] Couldn't fetch Lambda functions. Error: Max retry count exceeded. ListFunctionsError\n"
+        )
+      })
 
-    test('aborts if the the aws-sdk fails', async () => {
-      ;(fs.readFile as any).mockImplementation((a: any, b: any, callback: any) => callback({}))
-      ;(Lambda as any).mockImplementation(() => ({
-        listFunctions: jest.fn().mockImplementation(() => ({promise: () => Promise.reject('ListFunctionsError')})),
-      }))
-      process.env = {}
-      ;(Lambda as any).mockImplementation(() => ({
-        listFunctions: jest.fn().mockImplementation(() => ({promise: () => Promise.reject('ListFunctionsError')})),
-      }))
-      const command = createCommand(UninstrumentCommand)
-      command['region'] = 'ap-southeast-1'
-      command['regExPattern'] = 'my-function'
-      const code = await command['execute']()
-      const output = command.context.stdout.toString()
-      expect(code).toBe(1)
-      expect(output).toMatch(
-        "\n[Error] Couldn't fetch Lambda functions. Error: Max retry count exceeded. ListFunctionsError\n"
-      )
-    })
-
-    test('uninstrument multiple functions interactively', async () => {
-      ;(fs.readFile as any).mockImplementation((a: any, b: any, callback: any) => callback({code: 'ENOENT'}))
-      ;(Lambda as any).mockImplementation(() =>
-        makeMockLambda({
-          'arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world': {
-            Architectures: ['x86_64'],
-            Environment: {
-              Variables: {
-                [ENVIRONMENT_ENV_VAR]: 'staging',
-                [FLUSH_TO_LOG_ENV_VAR]: 'true',
-                [LAMBDA_HANDLER_ENV_VAR]: 'lambda_function.lambda_handler',
-                [LOG_LEVEL_ENV_VAR]: 'debug',
-                [MERGE_XRAY_TRACES_ENV_VAR]: 'false',
-                [SERVICE_ENV_VAR]: 'middletier',
-                [SITE_ENV_VAR]: 'datadoghq.com',
-                [TRACE_ENABLED_ENV_VAR]: 'true',
-                [VERSION_ENV_VAR]: '0.2',
-                USER_VARIABLE: 'shouldnt be deleted by uninstrumentation',
+      test('uninstrument multiple functions interactively', async () => {
+        ;(fs.readFile as any).mockImplementation((a: any, b: any, callback: any) => callback({code: 'ENOENT'}))
+        ;(Lambda as any).mockImplementation(() =>
+          makeMockLambda({
+            'arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world': {
+              Architectures: ['x86_64'],
+              Environment: {
+                Variables: {
+                  [ENVIRONMENT_ENV_VAR]: 'staging',
+                  [FLUSH_TO_LOG_ENV_VAR]: 'true',
+                  [LAMBDA_HANDLER_ENV_VAR]: 'lambda_function.lambda_handler',
+                  [LOG_LEVEL_ENV_VAR]: 'debug',
+                  [MERGE_XRAY_TRACES_ENV_VAR]: 'false',
+                  [SERVICE_ENV_VAR]: 'middletier',
+                  [SITE_ENV_VAR]: 'datadoghq.com',
+                  [TRACE_ENABLED_ENV_VAR]: 'true',
+                  [VERSION_ENV_VAR]: '0.2',
+                  USER_VARIABLE: 'shouldnt be deleted by uninstrumentation',
+                },
               },
+              FunctionArn: 'arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world',
+              FunctionName: 'lambda-hello-world',
+              Handler: 'datadog_lambda.handler.handler',
+              Layers: [
+                {
+                  Arn: 'arn:aws:lambda:sa-east-1:000000000000:layer:Datadog-Extension:11',
+                  CodeSize: 0,
+                  SigningJobArn: 'some-signing-job-arn',
+                  SigningProfileVersionArn: 'some-signing-profile',
+                },
+                {
+                  Arn: 'arn:aws:lambda:sa-east-1:000000000000:layer:Datadog-Python38:49',
+                  CodeSize: 0,
+                  SigningJobArn: 'some-signing-job-arn',
+                  SigningProfileVersionArn: 'some-signing-profile',
+                },
+              ],
+              Runtime: 'python3.8',
             },
-            FunctionArn: 'arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world',
-            FunctionName: 'lambda-hello-world',
-            Handler: 'datadog_lambda.handler.handler',
-            Layers: [
-              {
-                Arn: 'arn:aws:lambda:sa-east-1:000000000000:layer:Datadog-Extension:11',
-                CodeSize: 0,
-                SigningJobArn: 'some-signing-job-arn',
-                SigningProfileVersionArn: 'some-signing-profile',
+            'arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world-2': {
+              Architectures: ['x86_64'],
+              Environment: {
+                Variables: {
+                  [ENVIRONMENT_ENV_VAR]: 'staging',
+                  [FLUSH_TO_LOG_ENV_VAR]: 'true',
+                  [LAMBDA_HANDLER_ENV_VAR]: 'lambda_function.lambda_handler',
+                  [LOG_LEVEL_ENV_VAR]: 'debug',
+                  [MERGE_XRAY_TRACES_ENV_VAR]: 'false',
+                  [SERVICE_ENV_VAR]: 'middletier',
+                  [SITE_ENV_VAR]: 'datadoghq.com',
+                  [TRACE_ENABLED_ENV_VAR]: 'true',
+                  [VERSION_ENV_VAR]: '0.2',
+                },
               },
-              {
-                Arn: 'arn:aws:lambda:sa-east-1:000000000000:layer:Datadog-Python38:49',
-                CodeSize: 0,
-                SigningJobArn: 'some-signing-job-arn',
-                SigningProfileVersionArn: 'some-signing-profile',
-              },
-            ],
-            Runtime: 'python3.8',
-          },
-          'arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world-2': {
-            Architectures: ['x86_64'],
-            Environment: {
-              Variables: {
-                [ENVIRONMENT_ENV_VAR]: 'staging',
-                [FLUSH_TO_LOG_ENV_VAR]: 'true',
-                [LAMBDA_HANDLER_ENV_VAR]: 'lambda_function.lambda_handler',
-                [LOG_LEVEL_ENV_VAR]: 'debug',
-                [MERGE_XRAY_TRACES_ENV_VAR]: 'false',
-                [SERVICE_ENV_VAR]: 'middletier',
-                [SITE_ENV_VAR]: 'datadoghq.com',
-                [TRACE_ENABLED_ENV_VAR]: 'true',
-                [VERSION_ENV_VAR]: '0.2',
-              },
+              FunctionArn: 'arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world-2',
+              FunctionName: 'lambda-hello-world-2',
+              Handler: 'datadog_lambda.handler.handler',
+              Layers: [
+                {
+                  Arn: 'arn:aws:lambda:sa-east-1:000000000000:layer:Datadog-Extension:11',
+                  CodeSize: 0,
+                  SigningJobArn: 'some-signing-job-arn',
+                  SigningProfileVersionArn: 'some-signing-profile',
+                },
+                {
+                  Arn: 'arn:aws:lambda:sa-east-1:000000000000:layer:Datadog-Python39:49',
+                  CodeSize: 0,
+                  SigningJobArn: 'some-signing-job-arn',
+                  SigningProfileVersionArn: 'some-signing-profile',
+                },
+              ],
+              Runtime: 'python3.9',
             },
-            FunctionArn: 'arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world-2',
-            FunctionName: 'lambda-hello-world-2',
-            Handler: 'datadog_lambda.handler.handler',
-            Layers: [
-              {
-                Arn: 'arn:aws:lambda:sa-east-1:000000000000:layer:Datadog-Extension:11',
-                CodeSize: 0,
-                SigningJobArn: 'some-signing-job-arn',
-                SigningProfileVersionArn: 'some-signing-profile',
-              },
-              {
-                Arn: 'arn:aws:lambda:sa-east-1:000000000000:layer:Datadog-Python39:49',
-                CodeSize: 0,
-                SigningJobArn: 'some-signing-job-arn',
-                SigningProfileVersionArn: 'some-signing-profile',
-              },
-            ],
-            Runtime: 'python3.9',
-          },
+          })
+        )
+        ;(requestAWSCredentials as any).mockImplementation(() => {
+          process.env[AWS_ACCESS_KEY_ID_ENV_VAR] = mockAwsAccessKeyId
+          process.env[AWS_SECRET_ACCESS_KEY_ENV_VAR] = mockAwsSecretAccessKey
+          process.env[AWS_DEFAULT_REGION_ENV_VAR] = 'sa-east-1'
         })
-      )
-      ;(requestAWSCredentials as any).mockImplementation(() => {
-        process.env[AWS_ACCESS_KEY_ID_ENV_VAR] = mockAwsAccessKeyId
-        process.env[AWS_SECRET_ACCESS_KEY_ENV_VAR] = mockAwsSecretAccessKey
-        process.env[AWS_DEFAULT_REGION_ENV_VAR] = 'sa-east-1'
-      })
-      ;(requestFunctionSelection as any).mockImplementation(() => [
-        'arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world',
-        'arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world-2',
-      ])
-      ;(requestChangesConfirmation as any).mockImplementation(() => true)
-
-      const cli = makeCli()
-      const context = createMockContext() as any
-      const code = await cli.run(['lambda', 'uninstrument', '-i'], context)
-      const output = context.stdout.toString()
-      expect(code).toBe(0)
-      expect(output).toMatchSnapshot()
-    })
-
-    test('uninstrument multiple specified functions interactively', async () => {
-      ;(fs.readFile as any).mockImplementation((a: any, b: any, callback: any) => callback({code: 'ENOENT'}))
-      ;(Lambda as any).mockImplementation(() =>
-        makeMockLambda({
-          'arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world': {
-            Architectures: ['x86_64'],
-            Environment: {
-              Variables: {
-                [ENVIRONMENT_ENV_VAR]: 'staging',
-                [FLUSH_TO_LOG_ENV_VAR]: 'true',
-                [LAMBDA_HANDLER_ENV_VAR]: 'lambda_function.lambda_handler',
-                [LOG_LEVEL_ENV_VAR]: 'debug',
-                [MERGE_XRAY_TRACES_ENV_VAR]: 'false',
-                [SERVICE_ENV_VAR]: 'middletier',
-                [SITE_ENV_VAR]: 'datadoghq.com',
-                [TRACE_ENABLED_ENV_VAR]: 'true',
-                [VERSION_ENV_VAR]: '0.2',
-                USER_VARIABLE: 'shouldnt be deleted by uninstrumentation',
-              },
-            },
-            FunctionArn: 'arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world',
-            FunctionName: 'lambda-hello-world',
-            Handler: 'datadog_lambda.handler.handler',
-            Layers: [
-              {
-                Arn: 'arn:aws:lambda:sa-east-1:000000000000:layer:Datadog-Extension:11',
-                CodeSize: 0,
-                SigningJobArn: 'some-signing-job-arn',
-                SigningProfileVersionArn: 'some-signing-profile',
-              },
-              {
-                Arn: 'arn:aws:lambda:sa-east-1:000000000000:layer:Datadog-Python38:49',
-                CodeSize: 0,
-                SigningJobArn: 'some-signing-job-arn',
-                SigningProfileVersionArn: 'some-signing-profile',
-              },
-            ],
-            Runtime: 'python3.8',
-          },
-          'arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world-2': {
-            Architectures: ['x86_64'],
-            Environment: {
-              Variables: {
-                [ENVIRONMENT_ENV_VAR]: 'staging',
-                [FLUSH_TO_LOG_ENV_VAR]: 'true',
-                [LAMBDA_HANDLER_ENV_VAR]: 'lambda_function.lambda_handler',
-                [LOG_LEVEL_ENV_VAR]: 'debug',
-                [MERGE_XRAY_TRACES_ENV_VAR]: 'false',
-                [SERVICE_ENV_VAR]: 'middletier',
-                [SITE_ENV_VAR]: 'datadoghq.com',
-                [TRACE_ENABLED_ENV_VAR]: 'true',
-                [VERSION_ENV_VAR]: '0.2',
-              },
-            },
-            FunctionArn: 'arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world-2',
-            FunctionName: 'lambda-hello-world-2',
-            Handler: 'datadog_lambda.handler.handler',
-            Layers: [
-              {
-                Arn: 'arn:aws:lambda:sa-east-1:000000000000:layer:Datadog-Extension:11',
-                CodeSize: 0,
-                SigningJobArn: 'some-signing-job-arn',
-                SigningProfileVersionArn: 'some-signing-profile',
-              },
-              {
-                Arn: 'arn:aws:lambda:sa-east-1:000000000000:layer:Datadog-Python39:49',
-                CodeSize: 0,
-                SigningJobArn: 'some-signing-job-arn',
-                SigningProfileVersionArn: 'some-signing-profile',
-              },
-            ],
-            Runtime: 'python3.9',
-          },
-        })
-      )
-      ;(requestAWSCredentials as any).mockImplementation(() => {
-        process.env[AWS_ACCESS_KEY_ID_ENV_VAR] = mockAwsAccessKeyId
-        process.env[AWS_SECRET_ACCESS_KEY_ENV_VAR] = mockAwsSecretAccessKey
-        process.env[AWS_DEFAULT_REGION_ENV_VAR] = 'sa-east-1'
-      })
-      ;(requestFunctionSelection as any).mockImplementation(() => [
-        'arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world',
-        'arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world-2',
-      ])
-      ;(requestChangesConfirmation as any).mockImplementation(() => true)
-
-      const cli = makeCli()
-      const context = createMockContext() as any
-      const code = await cli.run(
-        [
-          'lambda',
-          'uninstrument',
-          '-i',
-          '-f',
+        ;(requestFunctionSelection as any).mockImplementation(() => [
           'arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world',
-          '-f',
           'arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world-2',
-        ],
-        context
-      )
-      const output = context.stdout.toString()
-      expect(code).toBe(0)
-      expect(output).toMatchSnapshot()
-    })
+        ])
+        ;(requestChangesConfirmation as any).mockImplementation(() => true)
 
-    test('aborts if a problem occurs while setting the AWS credentials interactively', async () => {
-      ;(fs.readFile as any).mockImplementation((a: any, b: any, callback: any) => callback({code: 'ENOENT'}))
-      ;(requestAWSCredentials as any).mockImplementation(() => Promise.reject('Unexpected error'))
-      const cli = makeCli()
-      const context = createMockContext() as any
-      const code = await cli.run(['lambda', 'uninstrument', '-i'], context)
-      const output = context.stdout.toString()
-      expect(code).toBe(1)
-      expect(output).toMatchInlineSnapshot(`
-"\n🐶 Uninstrumenting Lambda function
-[!] No AWS credentials found, let's set them up! Or you can re-run the command and supply the AWS credentials in the same way when you invoke the AWS CLI.
-[Error] Unexpected error
-"
-`)
-    })
-
-    test('aborts if there are no functions to uninstrument in the user AWS account', async () => {
-      process.env = {
-        [AWS_ACCESS_KEY_ID_ENV_VAR]: mockAwsAccessKeyId,
-        [AWS_SECRET_ACCESS_KEY_ENV_VAR]: mockAwsSecretAccessKey,
-        [AWS_DEFAULT_REGION_ENV_VAR]: 'sa-east-1',
-      }
-      ;(fs.readFile as any).mockImplementation((a: any, b: any, callback: any) => callback({code: 'ENOENT'}))
-      ;(Lambda as any).mockImplementation(() => makeMockLambda({}))
-      const cli = makeCli()
-      const context = createMockContext() as any
-      const code = await cli.run(['lambda', 'uninstrument', '-i'], context)
-      const output = context.stdout.toString()
-      expect(code).toBe(1)
-      expect(output).toMatchInlineSnapshot(`
-"\n🐶 Uninstrumenting Lambda function
-[Error] Couldn't find any Lambda functions in the specified region.
-"
-`)
-    })
-
-    test('aborts early when the aws-sdk throws an error while uninstrumenting interactively', async () => {
-      process.env = {
-        [AWS_ACCESS_KEY_ID_ENV_VAR]: mockAwsAccessKeyId,
-        [AWS_SECRET_ACCESS_KEY_ENV_VAR]: mockAwsSecretAccessKey,
-        [AWS_DEFAULT_REGION_ENV_VAR]: 'sa-east-1',
-      }
-      ;(fs.readFile as any).mockImplementation((a: any, b: any, callback: any) => callback({code: 'ENOENT'}))
-      ;(Lambda as any).mockImplementation(() => ({
-        listFunctions: jest.fn().mockImplementation(() => ({promise: () => Promise.reject('ListFunctionsError')})),
-      }))
-
-      const cli = makeCli()
-      const context = createMockContext() as any
-      const code = await cli.run(['lambda', 'uninstrument', '-i'], context)
-      const output = context.stdout.toString()
-      expect(code).toBe(1)
-      expect(output).toMatchInlineSnapshot(`
-"\n🐶 Uninstrumenting Lambda function
-[Error] Couldn't fetch Lambda functions. Error: Max retry count exceeded. ListFunctionsError
-"
-`)
-    })
-
-    test('prints error when updating aws profile credentials fails', async () => {
-      ;(SharedIniFileCredentials as any).mockImplementation(() => {
-        throw Error('Update failed!')
+        const cli = makeCli()
+        const context = createMockContext() as any
+        const code = await cli.run(['lambda', 'uninstrument', '-i'], context)
+        const output = context.stdout.toString()
+        expect(code).toBe(0)
+        expect(output).toMatchSnapshot()
       })
 
-      const cli = makeCli()
-      const context = createMockContext() as any
-      const functionARN = 'arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world'
-      const code = await cli.run(
-        ['lambda', 'uninstrument', '-f', functionARN, '--profile', 'SOME-AWS-PROFILE'],
-        context
-      )
-      const output = context.stdout.toString()
-      expect(code).toBe(1)
-      expect(output).toMatchInlineSnapshot(`
-"\n🐶 Uninstrumenting Lambda function
-[Error] Error: Couldn't set AWS profile credentials. Update failed!
-"
-`)
+      test('uninstrument multiple specified functions interactively', async () => {
+        ;(fs.readFile as any).mockImplementation((a: any, b: any, callback: any) => callback({code: 'ENOENT'}))
+        ;(Lambda as any).mockImplementation(() =>
+          makeMockLambda({
+            'arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world': {
+              Architectures: ['x86_64'],
+              Environment: {
+                Variables: {
+                  [ENVIRONMENT_ENV_VAR]: 'staging',
+                  [FLUSH_TO_LOG_ENV_VAR]: 'true',
+                  [LAMBDA_HANDLER_ENV_VAR]: 'lambda_function.lambda_handler',
+                  [LOG_LEVEL_ENV_VAR]: 'debug',
+                  [MERGE_XRAY_TRACES_ENV_VAR]: 'false',
+                  [SERVICE_ENV_VAR]: 'middletier',
+                  [SITE_ENV_VAR]: 'datadoghq.com',
+                  [TRACE_ENABLED_ENV_VAR]: 'true',
+                  [VERSION_ENV_VAR]: '0.2',
+                  USER_VARIABLE: 'shouldnt be deleted by uninstrumentation',
+                },
+              },
+              FunctionArn: 'arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world',
+              FunctionName: 'lambda-hello-world',
+              Handler: 'datadog_lambda.handler.handler',
+              Layers: [
+                {
+                  Arn: 'arn:aws:lambda:sa-east-1:000000000000:layer:Datadog-Extension:11',
+                  CodeSize: 0,
+                  SigningJobArn: 'some-signing-job-arn',
+                  SigningProfileVersionArn: 'some-signing-profile',
+                },
+                {
+                  Arn: 'arn:aws:lambda:sa-east-1:000000000000:layer:Datadog-Python38:49',
+                  CodeSize: 0,
+                  SigningJobArn: 'some-signing-job-arn',
+                  SigningProfileVersionArn: 'some-signing-profile',
+                },
+              ],
+              Runtime: 'python3.8',
+            },
+            'arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world-2': {
+              Architectures: ['x86_64'],
+              Environment: {
+                Variables: {
+                  [ENVIRONMENT_ENV_VAR]: 'staging',
+                  [FLUSH_TO_LOG_ENV_VAR]: 'true',
+                  [LAMBDA_HANDLER_ENV_VAR]: 'lambda_function.lambda_handler',
+                  [LOG_LEVEL_ENV_VAR]: 'debug',
+                  [MERGE_XRAY_TRACES_ENV_VAR]: 'false',
+                  [SERVICE_ENV_VAR]: 'middletier',
+                  [SITE_ENV_VAR]: 'datadoghq.com',
+                  [TRACE_ENABLED_ENV_VAR]: 'true',
+                  [VERSION_ENV_VAR]: '0.2',
+                },
+              },
+              FunctionArn: 'arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world-2',
+              FunctionName: 'lambda-hello-world-2',
+              Handler: 'datadog_lambda.handler.handler',
+              Layers: [
+                {
+                  Arn: 'arn:aws:lambda:sa-east-1:000000000000:layer:Datadog-Extension:11',
+                  CodeSize: 0,
+                  SigningJobArn: 'some-signing-job-arn',
+                  SigningProfileVersionArn: 'some-signing-profile',
+                },
+                {
+                  Arn: 'arn:aws:lambda:sa-east-1:000000000000:layer:Datadog-Python39:49',
+                  CodeSize: 0,
+                  SigningJobArn: 'some-signing-job-arn',
+                  SigningProfileVersionArn: 'some-signing-profile',
+                },
+              ],
+              Runtime: 'python3.9',
+            },
+          })
+        )
+        ;(requestAWSCredentials as any).mockImplementation(() => {
+          process.env[AWS_ACCESS_KEY_ID_ENV_VAR] = mockAwsAccessKeyId
+          process.env[AWS_SECRET_ACCESS_KEY_ENV_VAR] = mockAwsSecretAccessKey
+          process.env[AWS_DEFAULT_REGION_ENV_VAR] = 'sa-east-1'
+        })
+        ;(requestFunctionSelection as any).mockImplementation(() => [
+          'arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world',
+          'arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world-2',
+        ])
+        ;(requestChangesConfirmation as any).mockImplementation(() => true)
+
+        const cli = makeCli()
+        const context = createMockContext() as any
+        const code = await cli.run(
+          [
+            'lambda',
+            'uninstrument',
+            '-i',
+            '-f',
+            'arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world',
+            '-f',
+            'arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world-2',
+          ],
+          context
+        )
+        const output = context.stdout.toString()
+        expect(code).toBe(0)
+        expect(output).toMatchSnapshot()
+      })
+
+      test('aborts if a problem occurs while setting the AWS credentials interactively', async () => {
+        ;(fs.readFile as any).mockImplementation((a: any, b: any, callback: any) => callback({code: 'ENOENT'}))
+        ;(requestAWSCredentials as any).mockImplementation(() => Promise.reject('Unexpected error'))
+        const cli = makeCli()
+        const context = createMockContext() as any
+        const code = await cli.run(['lambda', 'uninstrument', '-i'], context)
+        const output = context.stdout.toString()
+        expect(code).toBe(1)
+        expect(output).toMatchInlineSnapshot(`
+            "\n🐶 Uninstrumenting Lambda function
+            [!] No AWS credentials found, let's set them up! Or you can re-run the command and supply the AWS credentials in the same way when you invoke the AWS CLI.
+            [Error] Unexpected error
+            "
+          `)
+      })
+
+      test('aborts if there are no functions to uninstrument in the user AWS account', async () => {
+        process.env = {
+          [AWS_ACCESS_KEY_ID_ENV_VAR]: mockAwsAccessKeyId,
+          [AWS_SECRET_ACCESS_KEY_ENV_VAR]: mockAwsSecretAccessKey,
+          [AWS_DEFAULT_REGION_ENV_VAR]: 'sa-east-1',
+        }
+        ;(fs.readFile as any).mockImplementation((a: any, b: any, callback: any) => callback({code: 'ENOENT'}))
+        ;(Lambda as any).mockImplementation(() => makeMockLambda({}))
+        const cli = makeCli()
+        const context = createMockContext() as any
+        const code = await cli.run(['lambda', 'uninstrument', '-i'], context)
+        const output = context.stdout.toString()
+        expect(code).toBe(1)
+        expect(output).toMatchInlineSnapshot(`
+          "
+          🐶 Uninstrumenting Lambda function
+          [Error] Couldn't find any Lambda functions in the specified region.
+          "
+        `)
+      })
+
+      test('aborts early when the aws-sdk throws an error while uninstrumenting interactively', async () => {
+        process.env = {
+          [AWS_ACCESS_KEY_ID_ENV_VAR]: mockAwsAccessKeyId,
+          [AWS_SECRET_ACCESS_KEY_ENV_VAR]: mockAwsSecretAccessKey,
+          [AWS_DEFAULT_REGION_ENV_VAR]: 'sa-east-1',
+        }
+        ;(fs.readFile as any).mockImplementation((a: any, b: any, callback: any) => callback({code: 'ENOENT'}))
+        ;(Lambda as any).mockImplementation(() => ({
+          listFunctions: jest.fn().mockImplementation(() => ({promise: () => Promise.reject('ListFunctionsError')})),
+        }))
+
+        const cli = makeCli()
+        const context = createMockContext() as any
+        const code = await cli.run(['lambda', 'uninstrument', '-i'], context)
+        const output = context.stdout.toString()
+        expect(code).toBe(1)
+        expect(output).toMatchInlineSnapshot(`
+          "
+          🐶 Uninstrumenting Lambda function
+          [Error] Couldn't fetch Lambda functions. Error: Max retry count exceeded. ListFunctionsError
+          "
+        `)
+      })
+
+      test('prints error when updating aws profile credentials fails', async () => {
+        ;(SharedIniFileCredentials as any).mockImplementation(() => {
+          throw Error('Update failed!')
+        })
+
+        const cli = makeCli()
+        const context = createMockContext() as any
+        const functionARN = 'arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world'
+        const code = await cli.run(
+          ['lambda', 'uninstrument', '-f', functionARN, '--profile', 'SOME-AWS-PROFILE'],
+          context
+        )
+        const output = context.stdout.toString()
+        expect(code).toBe(1)
+        expect(output).toMatchInlineSnapshot(`
+          "
+          🐶 Uninstrumenting Lambda function
+          [Error] Error: Couldn't set AWS profile credentials. Update failed!
+          "
+        `)
+      })
     })
-  })
 
-  describe('printPlannedActions', () => {
-    test('prints no output when list is empty', () => {
-      process.env = {}
-      const command = createCommand(UninstrumentCommand)
+    describe('printPlannedActions', () => {
+      test('prints no output when list is empty', () => {
+        process.env = {}
+        const command = createCommand(UninstrumentCommand)
 
-      command['printPlannedActions']([])
-      const output = command.context.stdout.toString()
-      expect(output).toMatchInlineSnapshot(`
-       "
-       No updates will be applied.
-       "
-      `)
+        command['printPlannedActions']([])
+        const output = command.context.stdout.toString()
+        expect(output).toMatchInlineSnapshot(`
+                   "
+                   No updates will be applied.
+                   "
+                `)
+      })
     })
   })
 })

--- a/src/commands/lambda/__tests__/uninstrument.test.ts
+++ b/src/commands/lambda/__tests__/uninstrument.test.ts
@@ -368,37 +368,7 @@ UpdateFunctionConfiguration -> arn:aws:lambda:us-east-1:000000000000:function:un
       const code = await cli.run(['lambda', 'uninstrument', '-i'], context)
       const output = context.stdout.toString()
       expect(code).toBe(0)
-      expect(output).toMatchInlineSnapshot(`
-"\n🐶 Uninstrumenting Lambda function
-[!] No AWS credentials found, let's set them up! Or you can re-run the command and supply the AWS credentials in the same way when you invoke the AWS CLI.
-\n[!] Functions to be updated:
-\t- arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world
-\t- arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world-2\n
-Will apply the following updates:
-UpdateFunctionConfiguration -> arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world
-{
-  \\"FunctionName\\": \\"arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world\\",
-  \\"Handler\\": \\"lambda_function.lambda_handler\\",
-  \\"Environment\\": {
-    \\"Variables\\": {
-      \\"USER_VARIABLE\\": \\"shouldnt be deleted by uninstrumentation\\"
-    }
-  },
-  \\"Layers\\": []
-}
-UpdateFunctionConfiguration -> arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world-2
-{
-  \\"FunctionName\\": \\"arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world-2\\",
-  \\"Handler\\": \\"lambda_function.lambda_handler\\",
-  \\"Environment\\": {
-    \\"Variables\\": {}
-  },
-  \\"Layers\\": []
-}
-[!] Confirmation needed.
-[!] Uninstrumenting functions.
-"
-`)
+      expect(output).toMatchSnapshot()
     })
 
     test('uninstrument multiple specified functions interactively', async () => {
@@ -503,37 +473,7 @@ UpdateFunctionConfiguration -> arn:aws:lambda:sa-east-1:123456789012:function:la
       )
       const output = context.stdout.toString()
       expect(code).toBe(0)
-      expect(output).toMatchInlineSnapshot(`
-"\n🐶 Uninstrumenting Lambda function
-[!] No AWS credentials found, let's set them up! Or you can re-run the command and supply the AWS credentials in the same way when you invoke the AWS CLI.\n
-[!] Functions to be updated:
-\t- arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world
-\t- arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world-2\n
-Will apply the following updates:
-UpdateFunctionConfiguration -> arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world
-{
-  \\"FunctionName\\": \\"arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world\\",
-  \\"Handler\\": \\"lambda_function.lambda_handler\\",
-  \\"Environment\\": {
-    \\"Variables\\": {
-      \\"USER_VARIABLE\\": \\"shouldnt be deleted by uninstrumentation\\"
-    }
-  },
-  \\"Layers\\": []
-}
-UpdateFunctionConfiguration -> arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world-2
-{
-  \\"FunctionName\\": \\"arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world-2\\",
-  \\"Handler\\": \\"lambda_function.lambda_handler\\",
-  \\"Environment\\": {
-    \\"Variables\\": {}
-  },
-  \\"Layers\\": []
-}
-[!] Confirmation needed.
-[!] Uninstrumenting functions.
-"
-`)
+      expect(output).toMatchSnapshot()
     })
 
     test('aborts if a problem occurs while setting the AWS credentials interactively', async () => {


### PR DESCRIPTION
### What and why?

Updates long inline snapshots to snapshot files.
Added the command `test:lambda` easy access to `jest src/commands/lambda --colors`

It's worth noting that only really large pieces of inline snapshots are being moved to snapshots. This so our test files are smaller and those snapshots are generated by running a command.


### How?

Replacing `.toMatchInlineSnapshot(...)` to `toMatchSnapshot()`.
Then run `--updateSnapshot`

### Review checklist

- [x] Ensured generated tests were the same as the previous ones.
