### PR TITLE
Add upload git metadata parameter to lambda instrument README.md

### DIFF
--- a/src/commands/lambda/README.md
+++ b/src/commands/lambda/README.md
@@ -98,10 +98,10 @@ You can pass the following arguments to `instrument` to specify its behavior. Th
 | `--forwarder` | | The ARN of the [datadog forwarder][10] to attach this function's LogGroup to. | |
 | `--dry` | `-d` | Preview changes running command would apply. | `false` |
 | `--log-level` | | Set to `debug` to see additional output from the Datadog Lambda Library and/or Lambda Extension for troubleshooting purposes. | |
-| `--source-code-integration` | `-s` | Whether to enable Datadog Source Code Integration. This will tag your lambda(s) with the Git repository URL and the latest commit of the current local directory. **Note**: Git repository must not be ahead of remote, and must not be dirty. | `true` |
+| `--source-code-integration` | `-s` | Whether to enable [Datadog Source Code Integration][13]. This will tag your lambda(s) with the Git repository URL and the latest commit hash of the current local directory. **Note**: Git repository must not be ahead of remote, and must not be dirty. | `true` |
 | `--no-source-code-integration` | | Disables Datadog Source Code Integration. | |
-| `--upload-git-metadata` | `-u` | Whether to enable git metadata uploading, as a part of source code integration. Used to enable Datadog Source Code Integration, if the Datadog Github Integration is not installed. | `true` | 
-| `--no-upload-git-metadata` | | Disables git metadata uploading, as a part of source code integration. Use this parameter if you have the Datadog Github Integration installed. ||
+| `--upload-git-metadata` | `-u` | Whether to enable Git metadata uploading, as a part of source code integration. Git metadata uploading is only required if you don't have the Datadog Github Integration installed. | `true` | 
+| `--no-upload-git-metadata` | | Disables Git metadata uploading, as a part of source code integration. Use this flag if you have the Datadog Github Integration installed, as this renders Git metadata uploading unnecessary. ||
 <br />
 
 #### `uninstrument`
@@ -160,3 +160,4 @@ For product feedback and questions, join the `#serverless` channel in the [Datad
 [10]: https://docs.datadoghq.com/serverless/forwarder/
 [11]: https://docs.datadoghq.com/serverless/custom_metrics?tab=python#enabling-asynchronous-custom-metrics
 [12]: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html#using-profiles
+[13]: https://docs.datadoghq.com/integrations/guide/source-code-integration

--- a/src/commands/lambda/README.md
+++ b/src/commands/lambda/README.md
@@ -101,7 +101,7 @@ You can pass the following arguments to `instrument` to specify its behavior. Th
 | `--source-code-integration` | `-s` | Whether to enable [Datadog Source Code Integration][13]. This will tag your lambda(s) with the Git repository URL and the latest commit hash of the current local directory. **Note**: Git repository must not be ahead of remote, and must not be dirty. | `true` |
 | `--no-source-code-integration` | | Disables Datadog Source Code Integration. | |
 | `--upload-git-metadata` | `-u` | Whether to enable Git metadata uploading, as a part of source code integration. Git metadata uploading is only required if you don't have the Datadog Github Integration installed. | `true` | 
-| `--no-upload-git-metadata` | | Disables Git metadata uploading, as a part of source code integration. Use this flag if you have the Datadog Github Integration installed, as this renders Git metadata uploading unnecessary. ||
+| `--no-upload-git-metadata` | | Disables Git metadata uploading, as a part of source code integration. Use this flag if you have the Datadog Github Integration installed, as it renders Git metadata uploading unnecessary. ||
 <br />
 
 #### `uninstrument`

--- a/src/commands/lambda/README.md
+++ b/src/commands/lambda/README.md
@@ -100,7 +100,8 @@ You can pass the following arguments to `instrument` to specify its behavior. Th
 | `--log-level` | | Set to `debug` to see additional output from the Datadog Lambda Library and/or Lambda Extension for troubleshooting purposes. | |
 | `--source-code-integration` | `-s` | Whether to enable Datadog Source Code Integration. This will tag your lambda(s) with the Git repository URL and the latest commit of the current local directory. **Note**: Git repository must not be ahead of remote, and must not be dirty. | `true` |
 | `--no-source-code-integration` | | Disables Datadog Source Code Integration. | |
-
+| `--upload-git-metadata` | `-u` | Whether to enable git metadata uploading, as a part of source code integration. Used to enable Datadog Source Code Integration, if the Datadog Github Integration is not installed. | `true` | 
+| `--no-upload-git-metadata` | | Disables git metadata uploading, as a part of source code integration. Use this parameter if you have the Datadog Github Integration installed. ||
 <br />
 
 #### `uninstrument`


### PR DESCRIPTION
### What and why?

Document the option for users to disable git metadata uploading (which was turned on by default in [this PR](https://github.com/DataDog/datadog-ci/pull/772)). Git metadata uploading should be turned off if users have the Datadog Github Integration installed, as source code integration will work without it.

### How?

Documents the `--upload-git-metadata` flag in the lambda instrument command, which defaults to true. When users pass `--no-upload-git-metadata`, the CI will refrain from uploading git metadata to Datadog.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
