### PR TITLE
[github] Add workflow to auto-label issues with datadog-ci command

### DIFF
--- a/.github/advanced-issue-labeler.yml
+++ b/.github/advanced-issue-labeler.yml
@@ -1,0 +1,14 @@
+policy:
+  - section:
+      - id: [command]
+        label:
+          - name: 'ci-visibility'
+            keys: ['junit', 'metric', 'tag', 'trace']
+          - name: 'rum'
+            keys: ['dsyms', 'flutter-symbols', 'react-native']
+          - name: 'serverless'
+            keys: ['lambda']
+          - name: 'source-code-integration'
+            keys: ['git-metadata', 'sourcemaps']
+          - name: 'synthetics'
+            keys: ['synthetics']

--- a/.github/advanced-issue-labeler.yml
+++ b/.github/advanced-issue-labeler.yml
@@ -2,7 +2,7 @@ policy:
   - section:
       - id: [command]
         label:
-          - name: 'ci-visibility'
+          - name: 'ci-app'
             keys: ['junit', 'metric', 'tag', 'trace']
           - name: 'rum'
             keys: ['dsyms', 'flutter-symbols', 'react-native']

--- a/.github/workflows/issue-labeler.yml
+++ b/.github/workflows/issue-labeler.yml
@@ -1,0 +1,21 @@
+name: Issue labeler
+on:
+  issues:
+    types: [opened]
+permissions:
+  contents: read
+jobs:
+  label-component:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/checkout@v3
+      - name: Parse issue form
+        uses: stefanbuck/github-issue-parser@v3
+        id: issue-parser
+      - name: Set labels based on command
+        uses: redhat-plumbers-in-action/advanced-issue-labeler@v2
+        with:
+          issue-form: ${{ steps.issue-parser.outputs.jsonString }}
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### What and why?

Automatically label new issues with the product owning the `command` (if specified).

### How?

Use [GitHub Issue Parser](https://github.com/marketplace/actions/github-issue-parser) and [Advanced Issue Labeler](https://github.com/marketplace/actions/advanced-issue-labeler) actions.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
