### PR TITLE
Do not hardcode version in snapshots

### DIFF
--- a/src/commands/lambda/__tests__/__snapshots__/uninstrument.test.ts.snap
+++ b/src/commands/lambda/__tests__/__snapshots__/uninstrument.test.ts.snap
@@ -32,7 +32,7 @@ UpdateFunctionConfiguration -> arn:aws:lambda:us-east-1:123456789012:function:la
 }
 TagResource -> arn:aws:lambda:us-east-1:123456789012:function:lambda-1-us-east-1
 {
-  \\"dd_sls_ci\\": \\"v2.4.0\\"
+  \\"dd_sls_ci\\": \\"vXXXX\\"
 }
 UpdateFunctionConfiguration -> arn:aws:lambda:us-east-2:123456789012:function:lambda-1-us-east-2
 {
@@ -51,7 +51,7 @@ UpdateFunctionConfiguration -> arn:aws:lambda:us-east-2:123456789012:function:la
 }
 TagResource -> arn:aws:lambda:us-east-2:123456789012:function:lambda-1-us-east-2
 {
-  \\"dd_sls_ci\\": \\"v2.4.0\\"
+  \\"dd_sls_ci\\": \\"vXXXX\\"
 }
 [Error] Failed updating arn:aws:lambda:us-east-1:123456789012:function:lambda-1-us-east-1 Error: Unexpected error updating request
 [Error] Failed updating arn:aws:lambda:us-east-2:123456789012:function:lambda-1-us-east-2 Error: Unexpected error updating request
@@ -96,7 +96,7 @@ UpdateFunctionConfiguration -> arn:aws:lambda:us-east-1:123456789012:function:la
 }
 TagResource -> arn:aws:lambda:us-east-1:123456789012:function:lambda-1-us-east-1
 {
-  \\"dd_sls_ci\\": \\"v2.4.0\\"
+  \\"dd_sls_ci\\": \\"vXXXX\\"
 }
 UpdateFunctionConfiguration -> arn:aws:lambda:us-east-1:123456789012:function:lambda-2-us-east-1
 {
@@ -115,7 +115,7 @@ UpdateFunctionConfiguration -> arn:aws:lambda:us-east-1:123456789012:function:la
 }
 TagResource -> arn:aws:lambda:us-east-1:123456789012:function:lambda-2-us-east-1
 {
-  \\"dd_sls_ci\\": \\"v2.4.0\\"
+  \\"dd_sls_ci\\": \\"vXXXX\\"
 }
 UpdateFunctionConfiguration -> arn:aws:lambda:us-east-1:123456789012:function:lambda-3-us-east-1
 {
@@ -134,7 +134,7 @@ UpdateFunctionConfiguration -> arn:aws:lambda:us-east-1:123456789012:function:la
 }
 TagResource -> arn:aws:lambda:us-east-1:123456789012:function:lambda-3-us-east-1
 {
-  \\"dd_sls_ci\\": \\"v2.4.0\\"
+  \\"dd_sls_ci\\": \\"vXXXX\\"
 }
 UpdateFunctionConfiguration -> arn:aws:lambda:us-east-2:123456789012:function:lambda-1-us-east-2
 {
@@ -153,7 +153,7 @@ UpdateFunctionConfiguration -> arn:aws:lambda:us-east-2:123456789012:function:la
 }
 TagResource -> arn:aws:lambda:us-east-2:123456789012:function:lambda-1-us-east-2
 {
-  \\"dd_sls_ci\\": \\"v2.4.0\\"
+  \\"dd_sls_ci\\": \\"vXXXX\\"
 }
 UpdateFunctionConfiguration -> arn:aws:lambda:us-east-2:123456789012:function:lambda-2-us-east-2
 {
@@ -172,7 +172,7 @@ UpdateFunctionConfiguration -> arn:aws:lambda:us-east-2:123456789012:function:la
 }
 TagResource -> arn:aws:lambda:us-east-2:123456789012:function:lambda-2-us-east-2
 {
-  \\"dd_sls_ci\\": \\"v2.4.0\\"
+  \\"dd_sls_ci\\": \\"vXXXX\\"
 }
 UpdateFunctionConfiguration -> arn:aws:lambda:us-east-2:123456789012:function:lambda-3-us-east-2
 {
@@ -191,7 +191,7 @@ UpdateFunctionConfiguration -> arn:aws:lambda:us-east-2:123456789012:function:la
 }
 TagResource -> arn:aws:lambda:us-east-2:123456789012:function:lambda-3-us-east-2
 {
-  \\"dd_sls_ci\\": \\"v2.4.0\\"
+  \\"dd_sls_ci\\": \\"vXXXX\\"
 }
 [Error] Failed updating arn:aws:lambda:us-east-1:123456789012:function:lambda-1-us-east-1 Error: Unexpected error updating request
 [Error] Failed updating arn:aws:lambda:us-east-1:123456789012:function:lambda-2-us-east-1 Error: Unexpected error updating request

--- a/src/commands/lambda/__tests__/uninstrument.test.ts
+++ b/src/commands/lambda/__tests__/uninstrument.test.ts
@@ -2,6 +2,7 @@ jest.mock('fs')
 jest.mock('aws-sdk')
 jest.mock('../prompt')
 jest.mock('../renderer', () => require('../__mocks__/renderer'))
+jest.mock('../../../../package.json', () => ({version: 'XXXX'}))
 
 import * as fs from 'fs'
 


### PR DESCRIPTION
### What and why?

The last version v2.4.0 was hardcoded in a test's snapshots, so it started to fail with the latest release. 

### How?

Mock `package.json`, the same way as already done in `instrument.test.ts`.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
