### PR TITLE
Add new default values for commands ran from XCode

### DIFF
--- a/src/commands/dsyms/upload.ts
+++ b/src/commands/dsyms/upload.ts
@@ -11,7 +11,7 @@ import {InvalidConfigurationError} from '../../helpers/errors'
 import {RequestBuilder} from '../../helpers/interfaces'
 import {getMetricsLogger, MetricsLogger} from '../../helpers/metrics'
 import {upload, UploadStatus} from '../../helpers/upload'
-import {buildPath, DEFAULT_CONFIG_PATH, getRequestBuilder, resolveConfigFromFile} from '../../helpers/utils'
+import {buildPath, getRequestBuilder, resolveConfigFromFile} from '../../helpers/utils'
 
 import {ArchSlice, CompressedDsym, Dsym} from './interfaces'
 import {
@@ -74,7 +74,7 @@ export class UploadCommand extends Command {
 
     this.config = await resolveConfigFromFile(this.config, {
       configPath: this.configPath,
-      defaultConfigPath: DEFAULT_CONFIG_PATH,
+      defaultConfigPaths: ['datadog-ci.json', '../datadog-ci.json'],
     })
 
     const metricsLogger = getMetricsLogger({

--- a/src/commands/flutter-symbols/upload.ts
+++ b/src/commands/flutter-symbols/upload.ts
@@ -10,7 +10,7 @@ import {newApiKeyValidator} from '../../helpers/apikey'
 import {getRepositoryData, RepositoryData} from '../../helpers/git/format-git-sourcemaps-data'
 import {getMetricsLogger, MetricsLogger} from '../../helpers/metrics'
 import {MultipartValue, UploadStatus} from '../../helpers/upload'
-import {buildPath, DEFAULT_CONFIG_PATH, performSubCommand, resolveConfigFromFile} from '../../helpers/utils'
+import {buildPath, DEFAULT_CONFIG_PATHS, performSubCommand, resolveConfigFromFile} from '../../helpers/utils'
 
 import * as dsyms from '../dsyms/upload'
 import {newSimpleGit} from '../git-metadata/git'
@@ -119,7 +119,7 @@ export class UploadCommand extends Command {
 
     this.config = await resolveConfigFromFile(this.config, {
       configPath: this.configPath,
-      defaultConfigPath: DEFAULT_CONFIG_PATH,
+      defaultConfigPaths: DEFAULT_CONFIG_PATHS,
     })
 
     if (!this.disableGit) {

--- a/src/commands/lambda/instrument.ts
+++ b/src/commands/lambda/instrument.ts
@@ -2,7 +2,7 @@ import {CloudWatchLogs, Lambda} from 'aws-sdk'
 import {bold} from 'chalk'
 import {Cli, Command} from 'clipanion'
 
-import {resolveConfigFromFile, filterAndFormatGithubRemote} from '../../helpers/utils'
+import {resolveConfigFromFile, filterAndFormatGithubRemote, DEFAULT_CONFIG_PATHS} from '../../helpers/utils'
 
 import {getCommitInfo, newSimpleGit} from '../git-metadata/git'
 import {UploadCommand} from '../git-metadata/upload'
@@ -76,7 +76,7 @@ export class InstrumentCommand extends Command {
 
     const lambdaConfig = {lambda: this.config}
     this.config = (
-      await resolveConfigFromFile(lambdaConfig, {configPath: this.configPath, defaultConfigPath: 'datadog-ci.json'})
+      await resolveConfigFromFile(lambdaConfig, {configPath: this.configPath, defaultConfigPaths: DEFAULT_CONFIG_PATHS})
     ).lambda
 
     const profile = this.profile ?? this.config.profile

--- a/src/commands/lambda/uninstrument.ts
+++ b/src/commands/lambda/uninstrument.ts
@@ -2,7 +2,7 @@ import {CloudWatchLogs, Lambda} from 'aws-sdk'
 import {bold} from 'chalk'
 import {Command} from 'clipanion'
 
-import {resolveConfigFromFile} from '../../helpers/utils'
+import {DEFAULT_CONFIG_PATHS, resolveConfigFromFile} from '../../helpers/utils'
 
 import {AWS_DEFAULT_REGION_ENV_VAR} from './constants'
 import {
@@ -37,7 +37,7 @@ export class UninstrumentCommand extends Command {
 
     const lambdaConfig = {lambda: this.config}
     this.config = (
-      await resolveConfigFromFile(lambdaConfig, {configPath: this.configPath, defaultConfigPath: 'datadog-ci.json'})
+      await resolveConfigFromFile(lambdaConfig, {configPath: this.configPath, defaultConfigPaths: DEFAULT_CONFIG_PATHS})
     ).lambda
 
     const profile = this.profile ?? this.config.profile

--- a/src/commands/react-native/README.md
+++ b/src/commands/react-native/README.md
@@ -141,23 +141,14 @@ The upload only happens when your target has a "Release" build configuration; th
 
 You can use the same environment variables as the `upload` command: `DATADOG_API_KEY` (required), `DATADOG_SITE`, and `DATADOG_SOURCEMAP_INTAKE_URL`.
 
-To get the location to your `node` and `yarn` binaries, run the following in a terminal:
-
-```bash
-$ which node #/path/to/node
-$ which yarn #/path/to/yarn
-```
-
 #### For React Native >= 0.69:
 
 To ensure environment variables are well propagated in the build phase, you need to create a `custom-react-native-xcode.sh` file in your `ios` folder:
 
 ```bash
 #!/bin/sh
-
-REACT_NATIVE_XCODE="node_modules/react-native/scripts/react-native-xcode.sh"
-# Replace /opt/homebrew/bin/node (resp. /opt/homebrew/bin/yarn) by the value of $(which node) (resp. $(which yarn))
-DATADOG_XCODE="/opt/homebrew/bin/node /opt/homebrew/bin/yarn datadog-ci react-native xcode"
+REACT_NATIVE_XCODE="../node_modules/react-native/scripts/react-native-xcode.sh"
+DATADOG_XCODE="../node_modules/.bin/datadog-ci react-native xcode"
 
 /bin/sh -c "$DATADOG_XCODE $REACT_NATIVE_XCODE"
 ```
@@ -166,7 +157,7 @@ This allows the file's path to be passed as one argument to the `with-environmen
 
 ```bash
 set -e
-export SOURCEMAP_FILE=./main.jsbundle.map
+export SOURCEMAP_FILE=$DERIVED_FILE_DIR/main.jsbundle.map
 WITH_ENVIRONMENT="../node_modules/react-native/scripts/xcode/with-environment.sh"
 REACT_NATIVE_XCODE="./custom-react-native-xcode.sh"
 
@@ -179,10 +170,7 @@ Change the "Bundle React Native code and images" build phase:
 
 ```bash
 set -e
-export SOURCEMAP_FILE=./build/main.jsbundle.map
-export NODE_BINARY=node
-# Change /opt/homebrew/bin/node (resp. /opt/homebrew/bin/yarn) by the value of $(which node) (resp. $(which yarn))
-/opt/homebrew/bin/node /opt/homebrew/bin/yarn datadog-ci react-native xcode node_modules/react-native/scripts/react-native-xcode.sh
+../node_modules/.bin/datadog-ci react-native xcode ../node_modules/react-native/scripts/react-native-xcode.sh
 ```
 
 #### Customize the command

--- a/src/commands/react-native/upload.ts
+++ b/src/commands/react-native/upload.ts
@@ -9,7 +9,7 @@ import {getRepositoryData, newSimpleGit, RepositoryData} from '../../helpers/git
 import {RequestBuilder} from '../../helpers/interfaces'
 import {getMetricsLogger, MetricsLogger} from '../../helpers/metrics'
 import {upload, UploadStatus} from '../../helpers/upload'
-import {DEFAULT_CONFIG_PATH, getRequestBuilder, resolveConfigFromFile} from '../../helpers/utils'
+import {getRequestBuilder, resolveConfigFromFile} from '../../helpers/utils'
 
 import {RNPlatform, RNSourcemap, RN_SUPPORTED_PLATFORMS} from './interfaces'
 import {
@@ -131,7 +131,7 @@ export class UploadCommand extends Command {
 
     this.config = await resolveConfigFromFile(this.config, {
       configPath: this.configPath,
-      defaultConfigPath: DEFAULT_CONFIG_PATH,
+      defaultConfigPaths: ['datadog-ci.json', '../datadog-ci.json'],
     })
 
     const metricsLogger = getMetricsLogger({

--- a/src/commands/react-native/xcode.ts
+++ b/src/commands/react-native/xcode.ts
@@ -22,6 +22,12 @@ const reactNativePath = (() => {
     // We need to remove the trailing "/index.js" at the end of the path
     return reactNativeIndexFile.split(sep).slice(0, -1).join(sep)
   } catch (error) {
+    // When the command is ran from XCode with `../node_modules/.bin/datadog-ci react-native xcode`
+    if (existsSync('../node_modules/react-native/package.json')) {
+      return '../node_modules/react-native'
+    }
+
+    // When the command is ran from XCode with yarn react-native xcode` (legacy)
     return 'node_modules/react-native'
   }
 })()

--- a/src/commands/synthetics/command.ts
+++ b/src/commands/synthetics/command.ts
@@ -179,7 +179,7 @@ export class RunTestCommand extends Command {
     try {
       this.config = await resolveConfigFromFile(this.config, {
         configPath: this.configPath,
-        defaultConfigPath: this.config.configPath,
+        defaultConfigPaths: [this.config.configPath],
       })
     } catch (error) {
       if (this.configPath) {

--- a/src/helpers/__tests__/utils.test.ts
+++ b/src/helpers/__tests__/utils.test.ts
@@ -41,7 +41,7 @@ describe('utils', () => {
     test('should have no effect if no config path is provided and default file is absent', async () => {
       const originalConfig = {}
       const config = await ciUtils.resolveConfigFromFile(originalConfig, {
-        defaultConfigPath: '/veryuniqueandabsentfile',
+        defaultConfigPaths: ['/veryuniqueandabsentfile'],
       })
 
       expect(config).toEqual(originalConfig)

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -8,7 +8,7 @@ import {BaseContext, CommandClass, Cli} from 'clipanion'
 import deepExtend from 'deep-extend'
 import ProxyAgent from 'proxy-agent'
 
-export const DEFAULT_CONFIG_PATH = 'datadog-ci.json'
+export const DEFAULT_CONFIG_PATHS = ['datadog-ci.json']
 
 export const pick = <T extends Record<any, any>, K extends keyof T>(base: T, keys: K[]) => {
   const definedKeys = keys.filter((key) => !!base[key])
@@ -35,10 +35,10 @@ export const getConfig = async (configPath: string) => {
 
 const resolveConfigPath = ({
   configPath,
-  defaultConfigPath,
+  defaultConfigPaths,
 }: {
   configPath?: string
-  defaultConfigPath?: string
+  defaultConfigPaths?: string[]
 }): string | undefined => {
   if (configPath) {
     if (existsSync(configPath)) {
@@ -47,8 +47,12 @@ const resolveConfigPath = ({
     throw new Error('Config file not found')
   }
 
-  if (defaultConfigPath && existsSync(defaultConfigPath)) {
-    return defaultConfigPath
+  if (defaultConfigPaths) {
+    for (const path of defaultConfigPaths) {
+      if (existsSync(path)) {
+        return path
+      }
+    }
   }
 
   return undefined
@@ -56,7 +60,7 @@ const resolveConfigPath = ({
 
 export const resolveConfigFromFile = async <T>(
   baseConfig: T,
-  params: {configPath?: string; defaultConfigPath?: string}
+  params: {configPath?: string; defaultConfigPaths?: string[]}
 ): Promise<T> => {
   const resolvedConfigPath = resolveConfigPath(params)
   if (!resolvedConfigPath) {


### PR DESCRIPTION
### What and why?

We can now run the `xcode` command with `../node_modules/.bin/datadog-ci react-native xcode`, instead of `yarn datadog-ci react-native xcode`.
This changes the current working directory to be the `ios/` folder of the RN app instead of the root of the RN app.
We have a similar change for the dsyms command.

The default value for the `react-native` path should be in this case `../node_modules/react-native` instead of `node_modules/react-native`.
Similarly, the default path for the `datadog-ci.json` file should be `../datadog-ci.json` instead of `./datadog-ci.json`.

### How?

I've left the legacy values to be picked up first to avoid regressions.
I've only changed the default path for `datadog-ci.json` for the react native and dsyms upload commands.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
