### PR TITLE
Remove api endpoint override for flutter-symbols command.

### DIFF
--- a/src/commands/dsyms/upload.ts
+++ b/src/commands/dsyms/upload.ts
@@ -173,6 +173,7 @@ export class UploadCommand extends Command {
     return getRequestBuilder({
       apiKey: this.config.apiKey,
       baseUrl: getBaseIntakeUrl(this.config.datadogSite),
+      overrideUrl: 'api/v2/srcmap',
     })
   }
 

--- a/src/commands/flutter-symbols/helpers.ts
+++ b/src/commands/flutter-symbols/helpers.ts
@@ -13,6 +13,7 @@ export const getFlutterRequestBuilder = (apiKey: string, cliVersion: string, sit
       ['DD-EVP-ORIGIN', 'datadog-ci flutter-symbols'],
       ['DD-EVP-ORIGIN-VERSION', cliVersion],
     ]),
+    overrideUrl: 'api/v2/srcmap',
   })
 
 // This function exists partially just to make mocking networkc calls easier.

--- a/src/commands/flutter-symbols/helpers.ts
+++ b/src/commands/flutter-symbols/helpers.ts
@@ -13,7 +13,6 @@ export const getFlutterRequestBuilder = (apiKey: string, cliVersion: string, sit
       ['DD-EVP-ORIGIN', 'datadog-ci flutter-symbols'],
       ['DD-EVP-ORIGIN-VERSION', cliVersion],
     ]),
-    overrideUrl: `v1/input/${apiKey}`,
   })
 
 // This function exists partially just to make mocking networkc calls easier.

--- a/src/commands/react-native/upload.ts
+++ b/src/commands/react-native/upload.ts
@@ -258,7 +258,7 @@ export class UploadCommand extends Command {
         ['DD-EVP-ORIGIN', 'datadog-ci react-native'],
         ['DD-EVP-ORIGIN-VERSION', this.cliVersion],
       ]),
-      overrideUrl: `v1/input/${this.config.apiKey}`,
+      overrideUrl: 'api/v2/srcmap',
     })
   }
 


### PR DESCRIPTION
### What and why?

The `flutter-symbols upload` command was overriding the API endpoint to the old v1 api. It does not appear that this is necessary anymore and prevents symbols from being uploaded to certain data centers, so I removed it.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
