### PR TITLE
[package] Remove test files when published

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "launch:debug": "node -r ts-node/register/transpile-only --inspect-brk src/cli.ts",
     "lint": "yarn eslint || (echo \"\nYou can fix this by running ==> yarn format <==\n\" && false)",
     "no-only-in-tests": "grep -R \"\\.only[(\\.]\" $(find src -name '*.ts' | grep '__tests__'); test $? -eq 1 || (echo '.only was found in the tests, please remove it.' && false)",
-    "prepack": "yarn build && node ./bin/make-it-executable.js",
+    "prepack": "yarn build && node ./bin/make-it-executable.js && rimraf 'dist/**/__tests__'",
     "prettier": "prettier \"src/**/*.{ts,js,json,yml}\" --ignore-path .gitignore",
     "test": "jest --colors",
     "test:debug": "node --inspect-brk `which jest` --runInBand",


### PR DESCRIPTION
### What and why?

I noticed we were not excluding the test files when creating the `.tgz` file to publish on NPM. So they end up in the `node_modules` when datadog-ci is installed somewhere.

You can explore the files [here](https://www.npmjs.com/package/@datadog/datadog-ci/v/2.4.1?activeTab=explore).

### How?

Sadly, Yarn 1 (that we're using in this project) [doesn't fully support](https://github.com/yarnpkg/yarn/issues/685#issuecomment-484304385) `.npmignore` or blocklist rules in the `files` property of `package.json`.

So I had to use `rimraf` in the `prepack` script.

- Before:
  -  `yarn prepack && du -sh dist`: **3.2 MB**
- After:
  -  `yarn prepack && du -sh dist`: **1.8 MB**

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
