### PR TITLE
v2.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci",
-  "version": "2.4.1",
+  "version": "2.5.0",
   "description": "Run datadog actions from the CI.",
   "repository": "https://github.com/DataDog/datadog-ci",
   "license": "Apache-2.0",


### PR DESCRIPTION
### What and why?

This bumps the version for release 2.5.0, releasing: 

* [React Native] Add new default values for commands ran from XCode [#781](https://github.com/DataDog/datadog-ci/pull/781)
* [Flutter/dSYMs/React Native] Support Japan and US5 datacenters [#783](https://github.com/DataDog/datadog-ci/pull/783) 
* [Synthetics] Amend the synthetics-test report so it shows up the possibility to speed up tests execution through parallelisation [#784](https://github.com/DataDog/datadog-ci/pull/784) 
* Various docs changes
