### PR TITLE
[ci-visibility] Add `--metrics` and `DD_METRICS` options

### DIFF
--- a/src/commands/junit/README.md
+++ b/src/commands/junit/README.md
@@ -24,6 +24,8 @@ datadog-ci junit upload --service my-service --tags key1:value1 --tags key2:valu
 - `--service` (default: `DD_SERVICE` env var) should be set as the name of the service you're uploading jUnit XML reports for.
 - `--tags` is a array of key value pairs of the shape `key:value`. This will set global tags applied to all spans.
   - The resulting dictionary will be merged with whatever is in the `DD_TAGS` environment variable. If a `key` appears both in `--tags` and `DD_TAGS`, whatever value is in `DD_TAGS` will take precedence.
+- `--metrics` is a array of key numerical value pairs of the shape `key:123`. This will set global metrics applied to all spans.
+  - The resulting dictionary will be merged with whatever is in the `DD_METRICS` environment variable. If a `key` appears both in `--metrics` and `DD_METRICS`, whatever value is in `DD_METRICS` will take precedence.
 - `--env` (default: `DD_ENV` env var) is a string that represents the environment where you want your tests to appear in.
 - `--max-concurrency` (default: `20`): number of concurrent uploads to the API.
 - `--dry-run` (default: `false`): it will run the command without the final upload step. All other checks are performed.
@@ -38,6 +40,8 @@ Additionally you might configure the `junit` command with environment variables:
 - `DD_SERVICE`: if you haven't specified a service through `--service` you might do it with this env var.
 - `DD_TAGS`: set global tags applied to all spans. The format must be `key1:value1,key2:value2`.
   - The resulting dictionary will be merged with whatever is in the `--tags` parameter. If a `key` appears both in `--tags` and `DD_TAGS`, whatever value is in `DD_TAGS` will take precedence.
+- `DD_METRICS`: set global numerical tags applied to all spans. The format must be `key1:123,key2:321`.
+  - The resulting dictionary will be merged with whatever is in the `--metrics` parameter. If a `key` appears both in `--metrics` and `DD_METRICS`, whatever value is in `DD_METRICS` will take precedence.
 - `DATADOG_SITE`: choose your Datadog site, e.g. datadoghq.com or datadoghq.eu.
 - `DD_CIVISIBILITY_LOGS_ENABLED`: it will enable collecting logs from the content in the XML reports.
 

--- a/src/commands/junit/README.md
+++ b/src/commands/junit/README.md
@@ -24,7 +24,7 @@ datadog-ci junit upload --service my-service --tags key1:value1 --tags key2:valu
 - `--service` (default: `DD_SERVICE` env var) should be set as the name of the service you're uploading jUnit XML reports for.
 - `--tags` is a array of key value pairs of the shape `key:value`. This will set global tags applied to all spans.
   - The resulting dictionary will be merged with whatever is in the `DD_TAGS` environment variable. If a `key` appears both in `--tags` and `DD_TAGS`, whatever value is in `DD_TAGS` will take precedence.
-- `--metrics` is a array of key numerical value pairs of the shape `key:123`. This will set global metrics applied to all spans.
+- `--metrics` is an array of key numerical value pairs of the shape `key:123`. This will set global metrics applied to all spans.
   - The resulting dictionary will be merged with whatever is in the `DD_METRICS` environment variable. If a `key` appears both in `--metrics` and `DD_METRICS`, whatever value is in `DD_METRICS` will take precedence.
 - `--env` (default: `DD_ENV` env var) is a string that represents the environment where you want your tests to appear in.
 - `--max-concurrency` (default: `20`): number of concurrent uploads to the API.

--- a/src/commands/junit/__tests__/upload.test.ts
+++ b/src/commands/junit/__tests__/upload.test.ts
@@ -214,7 +214,7 @@ describe('upload', () => {
       })
     })
     test('should parse DD_METRICS environment variable', async () => {
-      process.env.DD_METRICS = 'key1:321,key2:123'
+      process.env.DD_METRICS = 'key1:321,key2:123,key3:321.1,key4:abc,key5:-12.1'
       const context = createMockContext()
       const command = new UploadJUnitXMLCommand()
       const spanTags: SpanTags = await command['getSpanTags'].call({
@@ -226,6 +226,8 @@ describe('upload', () => {
       expect(spanTags).toMatchObject({
         key1: 321,
         key2: 123,
+        key3: 321.1,
+        key5: -12.1,
       })
     })
     test('should parse tags argument', async () => {

--- a/src/commands/junit/__tests__/upload.test.ts
+++ b/src/commands/junit/__tests__/upload.test.ts
@@ -213,6 +213,21 @@ describe('upload', () => {
         key2: 'value2',
       })
     })
+    test('should parse DD_METRICS environment variable', async () => {
+      process.env.DD_METRICS = 'key1:321,key2:123'
+      const context = createMockContext()
+      const command = new UploadJUnitXMLCommand()
+      const spanTags: SpanTags = await command['getSpanTags'].call({
+        config: {
+          envVarMetrics: process.env.DD_METRICS,
+        },
+        context,
+      })
+      expect(spanTags).toMatchObject({
+        key1: 321,
+        key2: 123,
+      })
+    })
     test('should parse tags argument', async () => {
       const context = createMockContext()
       const command = new UploadJUnitXMLCommand()

--- a/src/helpers/__tests__/tags.test.ts
+++ b/src/helpers/__tests__/tags.test.ts
@@ -1,4 +1,4 @@
-import {parseTags} from '../tags'
+import {parseTags, parseMetrics} from '../tags'
 
 describe('parseTags', () => {
   test('falls back to empty object if invalid format', () => {
@@ -11,5 +11,19 @@ describe('parseTags', () => {
   })
   test('should not include invalid key:value pairs', () => {
     expect(parseTags(['key1:value1', 'key2:value2', 'invalidkeyvalue'])).toEqual({key1: 'value1', key2: 'value2'})
+  })
+})
+
+describe('parseMetrics', () => {
+  test('falls back to empty object if invalid format', () => {
+    expect(parseMetrics([''])).toEqual({})
+    expect(parseMetrics(['not.correct.format'])).toEqual({})
+    expect(parseMetrics(['not.correct.format,either'])).toEqual({})
+  })
+  test('returns an object with the tags with well formatted numbers', () => {
+    expect(parseMetrics(['key1:123', 'key2:321'])).toEqual({key1: 123, key2: 321})
+  })
+  test('should not include invalid key:value pairs', () => {
+    expect(parseMetrics(['key1:123', 'key2:321', 'invalidkeyvalue', 'key3:a'])).toEqual({key1: 123, key2: 321})
   })
 })

--- a/src/helpers/__tests__/tags.test.ts
+++ b/src/helpers/__tests__/tags.test.ts
@@ -21,7 +21,7 @@ describe('parseMetrics', () => {
     expect(parseMetrics(['not.correct.format,either'])).toEqual({})
   })
   test('returns an object with the tags with well formatted numbers', () => {
-    expect(parseMetrics(['key1:123', 'key2:321'])).toEqual({key1: 123, key2: 321})
+    expect(parseMetrics(['key1:123', 'key2:321', 'key3:321.1', 'key4:-123.1'])).toEqual({key1: 123, key2: 321, key3: 321.1, key4: -123.1})
   })
   test('should not include invalid key:value pairs', () => {
     expect(parseMetrics(['key1:123', 'key2:321', 'invalidkeyvalue', 'key3:a'])).toEqual({key1: 123, key2: 321})

--- a/src/helpers/__tests__/tags.test.ts
+++ b/src/helpers/__tests__/tags.test.ts
@@ -21,7 +21,9 @@ describe('parseMetrics', () => {
     expect(parseMetrics(['not.correct.format,either'])).toEqual({})
   })
   test('returns an object with the tags with well formatted numbers', () => {
-    expect(parseMetrics(['key1:123', 'key2:321', 'key3:321.1', 'key4:-123.1'])).toEqual({key1: 123, key2: 321, key3: 321.1, key4: -123.1})
+    expect(parseMetrics(['key1:123', 'key2:321', 'key3:321.1', 'key4:-123.1'])).toEqual({
+      key1: 123, key2: 321, key3: 321.1, key4: -123.1,
+    })
   })
   test('should not include invalid key:value pairs', () => {
     expect(parseMetrics(['key1:123', 'key2:321', 'invalidkeyvalue', 'key3:a'])).toEqual({key1: 123, key2: 321})

--- a/src/helpers/__tests__/tags.test.ts
+++ b/src/helpers/__tests__/tags.test.ts
@@ -22,7 +22,10 @@ describe('parseMetrics', () => {
   })
   test('returns an object with the tags with well formatted numbers', () => {
     expect(parseMetrics(['key1:123', 'key2:321', 'key3:321.1', 'key4:-123.1'])).toEqual({
-      key1: 123, key2: 321, key3: 321.1, key4: -123.1,
+      key1: 123,
+      key2: 321,
+      key3: 321.1,
+      key4: -123.1,
     })
   })
   test('should not include invalid key:value pairs', () => {

--- a/src/helpers/tags.ts
+++ b/src/helpers/tags.ts
@@ -29,6 +29,14 @@ export const GIT_TAG = 'git.tag'
 // General
 export const SPAN_TYPE = 'span.type'
 
+const parseNumericTag = (numericTag: string | undefined): number | undefined => {
+  if (numericTag) {
+    const number = parseInt(numericTag, 10)
+
+    return isFinite(number) ? number : undefined
+  }
+}
+
 /**
  * Receives an array of the form ['key:value', 'key2:value2']
  * and returns an object of the form {key: 'value', key2: 'value2'}
@@ -48,6 +56,38 @@ export const parseTags = (tags: string[]) => {
         ...acc,
         [key]: value,
       }
+    }, {})
+  } catch (e) {
+    return {}
+  }
+}
+
+/**
+ * Similar to `parseTags` but it's assumed that numbers are received
+ * Receives an array of the form ['key:123', 'key2:321']
+ * and returns an object of the form {key: 123, key2: 321}
+ */
+export const parseMetrics = (tags: string[]) => {
+  try {
+    return tags.reduce((acc, keyValuePair) => {
+      if (!keyValuePair.includes(':')) {
+        return acc
+      }
+      const firstColon = keyValuePair.indexOf(':')
+
+      const key = keyValuePair.substring(0, firstColon)
+      const value = keyValuePair.substring(firstColon + 1)
+
+      const number = parseNumericTag(value)
+
+      if (number !== undefined) {
+        return {
+          ...acc,
+          [key]: number,
+        }
+      }
+
+      return acc
     }, {})
   } catch (e) {
     return {}

--- a/src/helpers/tags.ts
+++ b/src/helpers/tags.ts
@@ -31,7 +31,7 @@ export const SPAN_TYPE = 'span.type'
 
 const parseNumericTag = (numericTag: string | undefined): number | undefined => {
   if (numericTag) {
-    const number = parseInt(numericTag, 10)
+    const number = parseFloat(numericTag)
 
     return isFinite(number) ? number : undefined
   }


### PR DESCRIPTION
### What and why?

Some customers want to add numerical tags (metrics) to their JUnit uploads. They can't do so through `DD_TAGS` because every tag is assumed a string. 

By adding `--metrics` and `DD_METRICS`, customers are able to pass numerical tags to their tests. 

### How?

* Add `--metrics` option to `junit upload` command. 
* Add `DD_METRICS` env var.


### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
