### PR TITLE
Release v2.5.1, Bump `fast-xml-parser`

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "clipanion": "2.2.2",
     "datadog-metrics": "0.9.3",
     "deep-extend": "0.6.0",
-    "fast-xml-parser": "4.0.11",
+    "fast-xml-parser": "^4.1.2",
     "form-data": "3.0.0",
     "fuzzy": "^0.1.3",
     "glob": "7.1.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "Run datadog actions from the CI.",
   "repository": "https://github.com/DataDog/datadog-ci",
   "license": "Apache-2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3392,10 +3392,10 @@ fast-levenshtein@^2.0.6, fast-levenshtein@~2.0.4:
   resolved "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz"
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
 
-fast-xml-parser@4.0.11:
-  version "4.0.11"
-  resolved "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-4.0.11.tgz#42332a9aca544520631c8919e6ea871c0185a985"
-  integrity sha512-4aUg3aNRR/WjQAcpceODG1C3x3lFANXRo8+1biqfieHmg9pyMt7qB4lQV/Ta6sJCTbA5vfD8fnA8S54JATiFUA==
+fast-xml-parser@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-4.1.2.tgz#5a98c18238d28a57bbdfa9fe4cda01211fff8f4a"
+  integrity sha512-CDYeykkle1LiA/uqQyNwYpFbyF6Axec6YapmpUP+/RHWIoR1zKjocdvNaTsxCxZzQ6v9MLXaSYm9Qq0thv0DHg==
   dependencies:
     strnum "^1.0.5"
 


### PR DESCRIPTION
### What and why?

- Bump `fast-xml-parser` to 4.1.2 to address Prototype Pollution [SNYK-JS-FASTXMLPARSER-3325616](https://snyk.io/vuln/SNYK-JS-FASTXMLPARSER-3325616)
- Release v2.5.1
