### PR TITLE
Minor documentation change

### DIFF
--- a/src/commands/flutter-symbols/README.md
+++ b/src/commands/flutter-symbols/README.md
@@ -39,14 +39,14 @@ datadog-ci flutter-symbols upload --dart-symbols-location ./debug-info --service
 | Parameter | Condition | Description |
 |-----------|-----------|-------------|
 | `--service-name` | Required | Set as the service name you are uploading files for. Datadog uses this service name to find corresponding files based on the `service` options set when you configured the Datadog Flutter SDK for RUM.<br>By default, the Datadog Flutter SDK for RUM uses your application's bundle identifier as the service. |
-| `--flavor` | Optional | The build flavor that was built. Defaults to `release`. |
+| `--flavor` | Optional | The build flavor that was built. Only one upload is needed for a specific `version`, `service`, and `flavor` combination. Subsequent uploads are ignored until one parameter changes. Defaults to `release`. |
 | `--dart-symbols-location`  | Optional  | The location of your Dart symbol files. This should be the same path specified to `--split-debug-info`. |
 | `--ios-dsyms` | Optional | Upload iOS dSYM files to Datadog. |
 | `--ios-dsyms-location` | Optional | Specify the location of iOS dSYM files. By default, these are located at `./build/ios/archive/Runner.xcarchive/dSYMs`. Adding this parameter automatically sets `--ios-dsyms`. |
 | `--android-mapping` | Optional | Upload Android Proguard mapping file. This is usually only necessary if you specify `--obfuscate` as a parameter to `flutter build`. |
 | `--android-mapping-location` | Optional | Specify the location of your Android Proguard mapping file. By default, this is located at `./build/app/outputs/mapping/[flavor]/mapping.txt`. Adding this parameter automatically sets `--android-mapping`. |
 | `--pubspec-location` | Optional | The location of the pubspec for this application. The pubspec is used to automatically determine the version number of the application. Defaults to the current directory. |
-| `--version` | Optional | The version of your application. This defaults to the version specified in your pubspec. Only one upload is needed for a specific `version` and `service` combination. Subsequent uploads are ignored until the `version` changes. |
+| `--version` | Optional | The version of your application. This defaults to the version specified in your pubspec. Only one upload is needed for a specific `version`, `service`, and `flavor` combination. Subsequent uploads are ignored until one parameter changes. |
 | `--dry-run` | Optional | It runs the command without the final step of uploading. All other checks are performed. |
 | `--disable-git`    | Optional   | Prevents the command from invoking git in the current working directory and sending repository-related data to Datadog (such as the hash, remote URL, and paths within the repository of sources referenced in the source map). |
 | `--repository-url` | Optional | Overrides the remote repository with a custom URL. For example, `https://github.com/my-company/my-project`. |


### PR DESCRIPTION
### What and why?

Add some phrasing to the documentation to make it clear that Flutter symbol uploads are keyed off of `flavor` on top of `service` and `version`. Current phrasing makes it sound like only version and service are considered.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
