### PR TITLE
[lambda] Add ARM layer support for `dotnet6` runtime

### DIFF
--- a/src/commands/lambda/__tests__/functions/commons.test.ts
+++ b/src/commands/lambda/__tests__/functions/commons.test.ts
@@ -477,7 +477,7 @@ describe('commons', () => {
       expect(layerArn).toEqual(`arn:aws:lambda:${region}:${mockAwsAccount}:layer:Datadog-Node12-x`)
     })
 
-    test('gets sa-east-1 Python3.9 arm64 Lambda Library layer ARN', async () => {
+    test('gets sa-east-1 Python39 arm64 Lambda Library layer ARN', async () => {
       const runtime = 'python3.9'
       const config = {
         Architectures: ['arm64'],
@@ -525,6 +525,22 @@ describe('commons', () => {
       expect(layerArn).toEqual(
         `arn:aws-us-gov:lambda:${region}:${GOVCLOUD_LAYER_AWS_ACCOUNT}:layer:Datadog-Python39-ARM`
       )
+    })
+    test('gets dotnet6 arm64 Lambda Library layer ARN', async () => {
+      const runtime = 'dotnet6'
+      const config = {
+        Runtime: runtime,
+        Architectures: ['arm64'],
+      }
+      const settings = {
+        flushMetricsToLogs: false,
+        layerAWSAccount: mockAwsAccount,
+        mergeXrayTraces: false,
+        tracingEnabled: false,
+      }
+      const region = 'us-east-1'
+      const layerArn = getLayerArn(config, config.Runtime as LayerKey, region, settings)
+      expect(layerArn).toEqual(`arn:aws:lambda:${region}:${mockAwsAccount}:layer:dd-trace-dotnet-ARM`)
     })
   })
 

--- a/src/commands/lambda/constants.ts
+++ b/src/commands/lambda/constants.ts
@@ -1,6 +1,5 @@
 export const DD_LAMBDA_EXTENSION_LAYER_NAME = 'Datadog-Extension'
 export const EXTENSION_LAYER_KEY = 'extension'
-export const DOTNET_RUNTIME = 'dotnetcore3.1'
 export const LAYER_LOOKUP = {
   [EXTENSION_LAYER_KEY]: DD_LAMBDA_EXTENSION_LAYER_NAME,
   dotnet6: 'dd-trace-dotnet',
@@ -46,7 +45,7 @@ export const RUNTIME_LOOKUP = {
 
 export type Runtime = keyof typeof RUNTIME_LOOKUP
 export type LayerKey = keyof typeof LAYER_LOOKUP
-export const ARM_LAYERS = [EXTENSION_LAYER_KEY, 'python3.8', 'python3.9']
+export const ARM_LAYERS = [EXTENSION_LAYER_KEY, 'dotnet6', 'python3.8', 'python3.9']
 export const ARM64_ARCHITECTURE = 'arm64'
 export const ARM_LAYER_SUFFIX = '-ARM'
 


### PR DESCRIPTION
### What and why?
The current supported ARM instrumentations don't include the runtime `dotnet6`, which has been available since the version 4 of the tracer layer, we are currently at the 7th.

Didn't add runtime `dotnetcore3.1` because automatic instrumentation for ARM architectures is only supported starting `dotnet5`. See more about this [here](https://docs.datadoghq.com/tracing/trace_collection/compatibility/dotnet-core/#supported-processor-architectures).

### How?

Adding the runtime `dotnet6` to the ARM layer array.

Tested adding a unit test to make sure the correct layer is given. Also tested manually.
<img width="597" alt="Screenshot 2023-02-28 at 9 03 32 PM" src="https://user-images.githubusercontent.com/30836115/222026038-94bcaf44-361b-4f19-a183-0acba0233c3e.png">


### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
