### PR TITLE
CI env vars: add support for TeamCity

### DIFF
--- a/src/commands/metric/__tests__/metric.test.ts
+++ b/src/commands/metric/__tests__/metric.test.ts
@@ -88,7 +88,7 @@ describe('execute', () => {
     const {context, code} = await runCLI('pipeline', ['key:1'], {})
     expect(code).toBe(1)
     expect(context.stderr.toString()).toContain(
-      'Only providers [GitHub, GitLab, CircleCI, Buildkite, Buddy, Jenkins] are supported'
+      'Only providers [GitHub, GitLab, CircleCI, Buildkite, Buddy, Jenkins, TeamCity] are supported'
     )
   })
 

--- a/src/commands/tag/__tests__/tag.test.ts
+++ b/src/commands/tag/__tests__/tag.test.ts
@@ -67,7 +67,7 @@ describe('execute', () => {
     const {context, code} = await runCLI('pipeline', ['key:value'], {})
     expect(code).toBe(1)
     expect(context.stderr.toString()).toContain(
-      'Only providers [GitHub, GitLab, CircleCI, Buildkite, Buddy, Jenkins] are supported'
+      'Only providers [GitHub, GitLab, CircleCI, Buildkite, Buddy, Jenkins, TeamCity] are supported'
     )
   })
 

--- a/src/helpers/__tests__/ci-env/teamcity.json
+++ b/src/helpers/__tests__/ci-env/teamcity.json
@@ -1,0 +1,78 @@
+[
+  [
+    {
+      "BUILD_URL": "the-build-url",
+      "TEAMCITY_BUILDCONF_NAME": "Test 1",
+      "TEAMCITY_VERSION": "2022.10 (build 116751)"
+    },
+    {
+      "ci.job.name": "Test 1",
+      "ci.job.url": "the-build-url",
+      "ci.provider.name": "teamcity"
+    }
+  ],
+  [
+    {
+      "BUILD_URL": "the-build-url",
+      "DD_GIT_BRANCH": "user-supplied-branch",
+      "DD_GIT_COMMIT_AUTHOR_DATE": "usersupplied-authordate",
+      "DD_GIT_COMMIT_AUTHOR_EMAIL": "usersupplied-authoremail",
+      "DD_GIT_COMMIT_AUTHOR_NAME": "usersupplied-authorname",
+      "DD_GIT_COMMIT_COMMITTER_DATE": "usersupplied-comitterdate",
+      "DD_GIT_COMMIT_COMMITTER_EMAIL": "usersupplied-comitteremail",
+      "DD_GIT_COMMIT_COMMITTER_NAME": "usersupplied-comittername",
+      "DD_GIT_COMMIT_MESSAGE": "usersupplied-message",
+      "DD_GIT_COMMIT_SHA": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "DD_GIT_REPOSITORY_URL": "git@github.com:DataDog/userrepo.git",
+      "TEAMCITY_BUILDCONF_NAME": "Test 1",
+      "TEAMCITY_VERSION": "2022.10 (build 116751)"
+    },
+    {
+      "ci.job.name": "Test 1",
+      "ci.job.url": "the-build-url",
+      "ci.provider.name": "teamcity",
+      "git.branch": "user-supplied-branch",
+      "git.commit.author.date": "usersupplied-authordate",
+      "git.commit.author.email": "usersupplied-authoremail",
+      "git.commit.author.name": "usersupplied-authorname",
+      "git.commit.committer.date": "usersupplied-comitterdate",
+      "git.commit.committer.email": "usersupplied-comitteremail",
+      "git.commit.committer.name": "usersupplied-comittername",
+      "git.commit.message": "usersupplied-message",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "git@github.com:DataDog/userrepo.git"
+    }
+  ],
+  [
+    {
+      "BUILD_URL": "the-build-url",
+      "DD_GIT_COMMIT_AUTHOR_DATE": "usersupplied-authordate",
+      "DD_GIT_COMMIT_AUTHOR_EMAIL": "usersupplied-authoremail",
+      "DD_GIT_COMMIT_AUTHOR_NAME": "usersupplied-authorname",
+      "DD_GIT_COMMIT_COMMITTER_DATE": "usersupplied-comitterdate",
+      "DD_GIT_COMMIT_COMMITTER_EMAIL": "usersupplied-comitteremail",
+      "DD_GIT_COMMIT_COMMITTER_NAME": "usersupplied-comittername",
+      "DD_GIT_COMMIT_MESSAGE": "usersupplied-message",
+      "DD_GIT_COMMIT_SHA": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "DD_GIT_REPOSITORY_URL": "git@github.com:DataDog/userrepo.git",
+      "DD_GIT_TAG": "0.0.2",
+      "TEAMCITY_BUILDCONF_NAME": "Test 1",
+      "TEAMCITY_VERSION": "2022.10 (build 116751)"
+    },
+    {
+      "ci.job.name": "Test 1",
+      "ci.job.url": "the-build-url",
+      "ci.provider.name": "teamcity",
+      "git.commit.author.date": "usersupplied-authordate",
+      "git.commit.author.email": "usersupplied-authoremail",
+      "git.commit.author.name": "usersupplied-authorname",
+      "git.commit.committer.date": "usersupplied-comitterdate",
+      "git.commit.committer.email": "usersupplied-comitteremail",
+      "git.commit.committer.name": "usersupplied-comittername",
+      "git.commit.message": "usersupplied-message",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "git@github.com:DataDog/userrepo.git",
+      "git.tag": "0.0.2"
+    }
+  ]
+]

--- a/src/helpers/__tests__/ci.test.ts
+++ b/src/helpers/__tests__/ci.test.ts
@@ -182,7 +182,7 @@ describe('getCIEnv', () => {
     process.env = {APPVEYOR: 'true'}
     expect(() => {
       getCIEnv()
-    }).toThrow('Only providers [GitHub, GitLab, CircleCI, Buildkite, Buddy, Jenkins] are supported')
+    }).toThrow('Only providers [GitHub, GitLab, CircleCI, Buildkite, Buddy, Jenkins, TeamCity] are supported')
   })
 
   test('buildkite', () => {
@@ -234,6 +234,19 @@ describe('getCIEnv', () => {
     expect(getCIEnv()).toEqual({
       ciEnv: {DD_CUSTOM_PARENT_ID: 'span-id', DD_CUSTOM_TRACE_ID: 'trace-id'},
       provider: 'jenkins',
+    })
+  })
+
+  test('teamcity', () => {
+    process.env = {TEAMCITY_VERSION: 'something'}
+    expect(() => {
+      getCIEnv()
+    }).toThrow()
+
+    process.env = {TEAMCITY_VERSION: 'something', DATADOG_BUILD_ID: 'build-id'}
+    expect(getCIEnv()).toEqual({
+      ciEnv: {DATADOG_BUILD_ID: 'build-id'},
+      provider: 'teamcity',
     })
   })
 })

--- a/src/helpers/ci.ts
+++ b/src/helpers/ci.ts
@@ -36,6 +36,7 @@ export const CI_ENGINES = {
   GITLAB: 'gitlab',
   JENKINS: 'jenkins',
   TRAVIS: 'travisci',
+  TEAMCITY: 'teamcity',
   BUDDY: 'buddy',
 }
 
@@ -376,6 +377,16 @@ export const getCISpanTags = (): SpanTags | undefined => {
     }
   }
 
+  if (env.TEAMCITY_VERSION) {
+    const {BUILD_URL, TEAMCITY_BUILDCONF_NAME} = env
+
+    tags = {
+      [CI_PROVIDER_NAME]: CI_ENGINES.TEAMCITY,
+      [CI_JOB_URL]: BUILD_URL,
+      [CI_JOB_NAME]: TEAMCITY_BUILDCONF_NAME,
+    }
+  }
+
   if (env.TF_BUILD) {
     const {
       BUILD_SOURCESDIRECTORY,
@@ -644,6 +655,13 @@ export const getCIEnv = (): {ciEnv: Record<string, string>; provider: string} =>
     }
   }
 
+  if (process.env.TEAMCITY_VERSION) {
+    return {
+      ciEnv: filterEnv(['DATADOG_BUILD_ID']),
+      provider: 'teamcity',
+    }
+  }
+
   if (process.env.JENKINS_URL) {
     return {
       ciEnv: filterEnv(['DD_CUSTOM_PARENT_ID', 'DD_CUSTOM_TRACE_ID']),
@@ -651,7 +669,7 @@ export const getCIEnv = (): {ciEnv: Record<string, string>; provider: string} =>
     }
   }
 
-  throw new Error('Only providers [GitHub, GitLab, CircleCI, Buildkite, Buddy, Jenkins] are supported')
+  throw new Error('Only providers [GitHub, GitLab, CircleCI, Buildkite, Buddy, Jenkins, TeamCity] are supported')
 }
 
 const filterEnv = (values: string[]): Record<string, string> => {


### PR DESCRIPTION
### What and why?

When running in TeamCity CI, read the job info from the env vars.


### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
