### PR TITLE
Support gzip uploads

### DIFF
--- a/src/commands/flutter-symbols/upload.ts
+++ b/src/commands/flutter-symbols/upload.ts
@@ -312,6 +312,7 @@ export class UploadCommand extends Command {
         this.context.stdout.write(renderUpload('Android Mapping File', this.androidMappingLocation!))
       },
       retries: 5,
+      useGzip: true,
     })
     this.context.stdout.write(`Mapping upload finished: ${result}\n`)
 
@@ -372,6 +373,7 @@ export class UploadCommand extends Command {
             this.context.stdout.write(renderUpload('Flutter Symbol File', fileMetadata.filename))
           },
           retries: 5,
+          useGzip: true,
         })
       })
 

--- a/src/commands/react-native/upload.ts
+++ b/src/commands/react-native/upload.ts
@@ -319,6 +319,7 @@ export class UploadCommand extends Command {
           this.context.stdout.write(renderUpload(sourcemap))
         },
         retries: 5,
+        useGzip: true,
       })
     }
   }


### PR DESCRIPTION
### What and why?

This adds the ability to use gzip encoding when uploading. Currently this is opt in on the UploadOptions and is only used for Flutter Symbols, Android mapping files, and React Native source maps.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
