### PR TITLE
Fix typo in flutter-symbols command

### DIFF
--- a/src/commands/flutter-symbols/renderer.ts
+++ b/src/commands/flutter-symbols/renderer.ts
@@ -25,7 +25,7 @@ export const renderCommandInfo = (
 
   fullString += startStr
   uploadInfo.forEach((ui) => {
-    fullString += chalk.green(`Uploaing ${ui.platform} ${ui.fileType} at location ${ui.location}\n`)
+    fullString += chalk.green(`Uploading ${ui.platform} ${ui.fileType} at location ${ui.location}\n`)
   })
   const serviceVersionProjectPathStr = chalk.green(`  version: ${version} service: ${service} flavor: ${flavor}\n`)
   fullString += serviceVersionProjectPathStr


### PR DESCRIPTION
### What and why?

Fixed a typo in the flutter-symbols command (Uploaing -> Uploading)

### How?

I added the missing letter.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
