### PR TITLE
[meta] Update codeowners from Synthetics Worker to Synthetics CT

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -22,7 +22,7 @@ src/commands/git-metadata  @DataDog/source-code-integration
 src/commands/sourcemaps    @DataDog/source-code-integration
 
 ## Synthetics
-src/commands/synthetics  @DataDog/synthetics-worker
+src/commands/synthetics  @DataDog/synthetics-ct
 
 
 # Shared utilities
@@ -31,13 +31,13 @@ src/commands/synthetics  @DataDog/synthetics-worker
 src/helpers/git  @DataDog/ci-app-libraries @DataDog/source-code-integration
 
 ## CI
-src/helpers/ci.ts                                @DataDog/ci-app-libraries @DataDog/synthetics-worker
-src/helpers/tags.ts                              @DataDog/ci-app-libraries @DataDog/synthetics-worker
-src/helpers/user-provided-git.ts                 @DataDog/ci-app-libraries @DataDog/synthetics-worker
-src/helpers/**tests**/ci-env                     @DataDog/ci-app-libraries @DataDog/synthetics-worker
-src/helpers/**tests**/ci.test.ts                 @DataDog/ci-app-libraries @DataDog/synthetics-worker
-src/helpers/**tests**/tags.test.ts               @DataDog/ci-app-libraries @DataDog/synthetics-worker
-src/helpers/**tests**/user-provided-git.test.ts  @DataDog/ci-app-libraries @DataDog/synthetics-worker
+src/helpers/ci.ts                                @DataDog/ci-app-libraries @DataDog/synthetics-ct
+src/helpers/tags.ts                              @DataDog/ci-app-libraries @DataDog/synthetics-ct
+src/helpers/user-provided-git.ts                 @DataDog/ci-app-libraries @DataDog/synthetics-ct
+src/helpers/**tests**/ci-env                     @DataDog/ci-app-libraries @DataDog/synthetics-ct
+src/helpers/**tests**/ci.test.ts                 @DataDog/ci-app-libraries @DataDog/synthetics-ct
+src/helpers/**tests**/tags.test.ts               @DataDog/ci-app-libraries @DataDog/synthetics-ct
+src/helpers/**tests**/user-provided-git.test.ts  @DataDog/ci-app-libraries @DataDog/synthetics-ct
 
 
 # Documentation


### PR DESCRIPTION
### What and why?

Changes the codeowners of the datadog-ci components that belong to Synthetics from the Synthetics Worker team to Synthetics CT.

### How?

Modifies the `.github/CODEOWNERS` file.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
