### PR TITLE
[synthetics] Do incremental MD5 calculation in `uploadMobileApplications`

### DIFF
--- a/src/commands/synthetics/__tests__/mobile.test.ts
+++ b/src/commands/synthetics/__tests__/mobile.test.ts
@@ -1,10 +1,23 @@
+import fs from 'fs'
+import path from 'path'
+
 import * as mobile from '../mobile'
 
 import {getApiHelper, getMobileTest, getTestPayload} from './fixtures'
 
 describe('getMD5HashFromFileBuffer', () => {
   test('correctly compute md5 of a file', async () => {
-    expect(await mobile.getMD5HashFromFileBuffer(Buffer.from('Compute md5'))).toBe('odk1EOlpz16oPIgnco2nfg==')
+    const tmpdir = fs.mkdtempSync('getMD5HashFromFileBuffer')
+    try {
+      // write test content to a file in the temporary directory
+      const filename = path.join(tmpdir, 'compute_md5_test')
+      fs.writeFileSync(filename, 'Compute md5')
+
+      expect(await mobile.getMD5HashFromFile(filename)).toBe('odk1EOlpz16oPIgnco2nfg==')
+    } finally {
+      // always clean up created tmpdir
+      fs.rmSync(tmpdir, {recursive: true, force: true})
+    }
   })
 })
 

--- a/src/commands/synthetics/__tests__/run-test.test.ts
+++ b/src/commands/synthetics/__tests__/run-test.test.ts
@@ -1,4 +1,5 @@
-import {promises as fs} from 'fs'
+import fs from 'fs'
+import {Readable} from 'stream'
 
 import * as ciUtils from '../../../helpers/utils'
 
@@ -291,7 +292,9 @@ describe('run-test', () => {
         })
       )
 
-      jest.spyOn(fs, 'readFile').mockImplementation(async () => Buffer.from('aa'))
+      // use /dev/null to create a valid empty fs.ReadStream
+      const testStream = fs.createReadStream('/dev/null')
+      jest.spyOn(fs, 'createReadStream').mockReturnValue(testStream)
 
       const apiHelper = {
         getMobileApplicationPresignedURL: jest.fn(() => {
@@ -318,7 +321,11 @@ describe('run-test', () => {
         })
       )
 
-      jest.spyOn(fs, 'readFile').mockImplementation(async () => Buffer.from('aa'))
+      // use /dev/null to create a valid empty fs.ReadStream
+      const testStream = fs.createReadStream('/dev/null')
+      jest.spyOn(fs, 'createReadStream').mockReturnValue(testStream)
+
+      jest.spyOn(fs.promises, 'readFile').mockImplementation(async () => Buffer.from('aa'))
 
       const apiHelper = {
         getMobileApplicationPresignedURL: jest.fn(() => MOBILE_PRESIGNED_URL_PAYLOAD),

--- a/src/commands/synthetics/__tests__/run-test.test.ts
+++ b/src/commands/synthetics/__tests__/run-test.test.ts
@@ -1,5 +1,4 @@
 import fs from 'fs'
-import {Readable} from 'stream'
 
 import * as ciUtils from '../../../helpers/utils'
 

--- a/src/commands/synthetics/mobile.ts
+++ b/src/commands/synthetics/mobile.ts
@@ -4,13 +4,6 @@ import fs from 'fs'
 import {APIHelper} from './api'
 import {Test, TestPayload, UserConfigOverride} from './interfaces'
 
-/**
- * Create an md5 hash of a file at a given path. This is done incrementally so
- * entire file does not need to fit in memory.
-
- * @param file path to the file that will be hashed
- * @returns md5 hash of file as string
- */
 export const getMD5HashFromFile = async (file: string): Promise<string> => {
   const hash = crypto.createHash('md5')
   const input = fs.createReadStream(file)

--- a/src/commands/synthetics/mobile.ts
+++ b/src/commands/synthetics/mobile.ts
@@ -1,13 +1,24 @@
 import * as crypto from 'crypto'
-import {promises as fs} from 'fs'
+import fs from 'fs'
 
 import {APIHelper} from './api'
 import {Test, TestPayload, UserConfigOverride} from './interfaces'
 
-export const getMD5HashFromFileBuffer = async (fileBuffer: Buffer): Promise<string> => {
-  const hash = crypto.createHash('md5').update(fileBuffer).digest('base64')
+/**
+ * Create an md5 hash of a file at a given path. This is done incrementally so
+ * entire file does not need to fit in memory.
 
-  return hash
+ * @param file path to the file that will be hashed
+ * @returns md5 hash of file as string
+ */
+export const getMD5HashFromFile = async (file: string): Promise<string> => {
+  const hash = crypto.createHash('md5')
+  const input = fs.createReadStream(file)
+  for await (const chunk of input) {
+    hash.update(chunk)
+  }
+
+  return hash.digest('base64')
 }
 
 export const uploadMobileApplications = async (
@@ -15,13 +26,13 @@ export const uploadMobileApplications = async (
   applicationPathToUpload: string,
   mobileApplicationId: string
 ): Promise<string> => {
-  const fileBuffer = await fs.readFile(applicationPathToUpload)
-  const md5 = await getMD5HashFromFileBuffer(fileBuffer)
+  const md5 = await getMD5HashFromFile(applicationPathToUpload)
   const {presigned_url_params: presignedUrl, file_name: fileName} = await api.getMobileApplicationPresignedURL(
     mobileApplicationId,
     md5
   )
 
+  const fileBuffer = await fs.promises.readFile(applicationPathToUpload)
   await api.uploadMobileApplication(fileBuffer, presignedUrl)
 
   return fileName


### PR DESCRIPTION
### What and why?

Avoid calculating MD5 hash on entire file at once as this caused issues with large files in similar front-end code.


### How?
Use `fs.ReadStream` to incrementally calculate MD5 and avoid doing it on the entire file at once.

However, the upload itself *still* reads the entire file into memory using `fs.readFile` in order to set `Content-Length` header in the upload request. This will need to be revisited to handle uploads larger than 2GB which are disallowed by
the `fs.readFile` API. One solution may be to use multi-part upload in combination with `fs.ReadStream` when doing
the upload.

### Review checklist

- [ X] Feature or bugfix MUST have appropriate tests (unit, integration)
  - Associated unit test modified and passing
  - Also manually tested with sample mini app upload
