### PR TITLE
Change yarn publish into yarn npm publish.

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -19,7 +19,7 @@ jobs:
           # Publish on npm in the correct channel
           yarn
           echo "Publishing on $TAG_TO_PUBLISH channel."
-          yarn publish --tag=$TAG_TO_PUBLISH
+          yarn npm publish --tag=$TAG_TO_PUBLISH
         env:
           NPM_AUTH_TOKEN: ${{ secrets.YARN_NPM_AUTH_TOKEN }}
           TAG: ${{ github.event.release.tag_name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
         with:
           node-version: '14'
       - run: yarn
-      - run: yarn publish
+      - run: yarn npm publish
         env:
           NPM_AUTH_TOKEN: ${{ secrets.YARN_NPM_AUTH_TOKEN }}
 


### PR DESCRIPTION
### What and why?

It looks like the change to [yarn 3](https://github.com/DataDog/datadog-ci/pull/791) broke the workflows publishing to npm.
This is an attempt to fix it. Not 100% sure just replacing `yarn publish` by `yarn npm publish` is enough.

### How?

A brief description of implementation details of this PR.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
