### PR TITLE
Update env var for publishing to NPM.

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -21,5 +21,5 @@ jobs:
           echo "Publishing on $TAG_TO_PUBLISH channel."
           yarn npm publish --tag=$TAG_TO_PUBLISH
         env:
-          NPM_AUTH_TOKEN: ${{ secrets.YARN_NPM_AUTH_TOKEN }}
+          YARN_NPM_AUTH_TOKEN: ${{ secrets.YARN_NPM_AUTH_TOKEN }}
           TAG: ${{ github.event.release.tag_name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
       - run: yarn
       - run: yarn npm publish
         env:
-          NPM_AUTH_TOKEN: ${{ secrets.YARN_NPM_AUTH_TOKEN }}
+          YARN_NPM_AUTH_TOKEN: ${{ secrets.YARN_NPM_AUTH_TOKEN }}
 
   build-binary-ubuntu:
     runs-on: ubuntu-latest


### PR DESCRIPTION
yarn 2+ documentation mentions the setting `npmAuthToken` and says it can be defined as an env var; in which case the syntax is YARN_<setting>.
This seems to confirm it:
https://github.com/yarnpkg/berry/blob/15d31310cc6a5164df9ba4e7a99289657ec58be6/packages/acceptance-tests/pkg-tests-specs/sources/commands/publish.test.ts#L40
