### PR TITLE
Bump to 2.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "description": "Run datadog actions from the CI.",
   "repository": "https://github.com/DataDog/datadog-ci",
   "license": "Apache-2.0",


### PR DESCRIPTION
### What and why?

Add a new option to datadog-ci git-metadata upload to sync the git repository. See [the PR](https://github.com/DataDog/datadog-ci/pull/790) for more detailed information.

### How?

A brief description of implementation details of this PR.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
