### PR TITLE
Add `--mobileApplicationVersionFilePath` option

### DIFF
--- a/src/commands/synthetics/__tests__/cli.test.ts
+++ b/src/commands/synthetics/__tests__/cli.test.ts
@@ -12,17 +12,20 @@ test('all option flags are supported', async () => {
   const options = [
     'apiKey',
     'appKey',
-    'failOnCriticalErrors',
     'config',
     'datadogSite',
-    'files',
+    'failOnCriticalErrors',
+    'failOnMissingTests',
     'failOnTimeout',
+    'files',
+    'jUnitReport',
+    'mobileApplicationVersionFilePath',
     'public-id',
+    'runName',
     'search',
     'subdomain',
     'tunnel',
-    'jUnitReport',
-    'runName',
+    'variable',
   ]
 
   const cli = new Cli()

--- a/src/commands/synthetics/__tests__/cli.test.ts
+++ b/src/commands/synthetics/__tests__/cli.test.ts
@@ -78,7 +78,11 @@ describe('run-test', () => {
         failOnMissingTests: true,
         failOnTimeout: false,
         files: ['my-new-file'],
-        global: {locations: [], pollingTimeout: 2},
+        global: {
+          locations: [],
+          pollingTimeout: 2,
+          mobileApplicationVersionFilePath: './path/to/application.apk',
+        },
         locations: [],
         pollingTimeout: 1,
         proxy: {protocol: 'https'},
@@ -102,8 +106,10 @@ describe('run-test', () => {
         configPath: 'src/commands/synthetics/__tests__/config-fixtures/empty-config-file.json',
         datadogSite: 'datadoghq.eu',
         failOnCriticalErrors: true,
+        failOnMissingTests: true,
         failOnTimeout: false,
         files: ['new-file'],
+        mobileApplicationVersionFilePath: './path/to/application.apk',
         publicIds: ['ran-dom-id'],
         subdomain: 'new-sub-domain',
         testSearchQuery: 'a-search-query',
@@ -116,8 +122,10 @@ describe('run-test', () => {
       command['configPath'] = overrideCLI.configPath
       command['datadogSite'] = overrideCLI.datadogSite
       command['failOnCriticalErrors'] = overrideCLI.failOnCriticalErrors
+      command['failOnMissingTests'] = overrideCLI.failOnMissingTests
       command['failOnTimeout'] = overrideCLI.failOnTimeout
       command['files'] = overrideCLI.files
+      command['mobileApplicationVersionFilePath'] = overrideCLI.mobileApplicationVersionFilePath
       command['publicIds'] = overrideCLI.publicIds
       command['subdomain'] = overrideCLI.subdomain
       command['tunnel'] = overrideCLI.tunnel
@@ -131,9 +139,13 @@ describe('run-test', () => {
         configPath: 'src/commands/synthetics/__tests__/config-fixtures/empty-config-file.json',
         datadogSite: 'datadoghq.eu',
         failOnCriticalErrors: true,
+        failOnMissingTests: true,
         failOnTimeout: false,
         files: ['new-file'],
-        global: {pollingTimeout: DEFAULT_POLLING_TIMEOUT},
+        global: {
+          pollingTimeout: DEFAULT_POLLING_TIMEOUT,
+          mobileApplicationVersionFilePath: './path/to/application.apk',
+        },
         publicIds: ['ran-dom-id'],
         subdomain: 'new-sub-domain',
         testSearchQuery: 'a-search-query',

--- a/src/commands/synthetics/__tests__/config-fixtures/config-with-all-keys.json
+++ b/src/commands/synthetics/__tests__/config-fixtures/config-with-all-keys.json
@@ -9,7 +9,8 @@
   "files": ["my-new-file"],
   "global": {
     "locations": [],
-    "pollingTimeout": 2
+    "pollingTimeout": 2,
+    "mobileApplicationVersionFilePath": "./path/to/application.apk"
   },
   "locations": [],
   "pollingTimeout": 1,

--- a/src/commands/synthetics/command.ts
+++ b/src/commands/synthetics/command.ts
@@ -54,6 +54,7 @@ export class RunTestCommand extends Command {
   private testSearchQuery?: string
   private tunnel?: boolean
   private variableStrings?: string[]
+  private mobileApplicationVersionFilePath?: string
 
   public async execute() {
     const reporters: Reporter[] = [new DefaultReporter(this)]
@@ -235,6 +236,7 @@ export class RunTestCommand extends Command {
     this.config.global = deepExtend(
       this.config.global,
       removeUndefinedValues({
+        mobileApplicationVersionFilePath: this.mobileApplicationVersionFilePath,
         variables: parseVariablesFromCli(this.variableStrings, (log) => this.reporter?.log(log)),
       })
     )
@@ -265,6 +267,7 @@ RunTestCommand.addOption('failOnMissingTests', Command.Boolean('--failOnMissingT
 RunTestCommand.addOption('failOnTimeout', Command.Boolean('--failOnTimeout'))
 RunTestCommand.addOption('files', Command.Array('-f,--files'))
 RunTestCommand.addOption('jUnitReport', Command.String('-j,--jUnitReport'))
+RunTestCommand.addOption('mobileApplicationVersionFilePath', Command.String('--mobileApplicationVersionFilePath'))
 RunTestCommand.addOption('publicIds', Command.Array('-p,--public-id'))
 RunTestCommand.addOption('runName', Command.String('-n,--runName'))
 RunTestCommand.addOption('subdomain', Command.Boolean('--subdomain'))

--- a/src/commands/synthetics/command.ts
+++ b/src/commands/synthetics/command.ts
@@ -184,9 +184,9 @@ export class RunTestCommand extends Command {
   }
 
   private async resolveConfig() {
-    // Default < file < ENV < CLI
+    // Defaults < file < ENV < CLI
 
-    // Override with file config variables
+    // Override with config file variables (e.g. datadog-ci.json)
     try {
       this.config = await resolveConfigFromFile(this.config, {
         configPath: this.configPath,

--- a/src/commands/synthetics/mobile.ts
+++ b/src/commands/synthetics/mobile.ts
@@ -60,9 +60,7 @@ export const overrideMobileConfig = (
       referenceId: localApplicationOverride.fileName,
       referenceType: 'temporary',
     }
-  }
-
-  if (!localApplicationOverride && userConfigOverride.mobileApplicationVersion) {
+  } else if (userConfigOverride.mobileApplicationVersion) {
     overriddenTest.mobileApplication = {
       applicationId: test.options.mobileApplication!.applicationId,
       referenceId: userConfigOverride.mobileApplicationVersion,

--- a/src/commands/synthetics/run-test.ts
+++ b/src/commands/synthetics/run-test.ts
@@ -212,7 +212,7 @@ export const getTestsList = async (
   const configFromEnvironment = config.locations?.length ? {locations: config.locations} : {}
 
   const overrideTestConfig = (test: TriggerConfig): UserConfigOverride =>
-    // Global < env < test config
+    // {} < global < ENV < test file
     ({
       ...config.global,
       ...configFromEnvironment,

--- a/src/commands/synthetics/utils.ts
+++ b/src/commands/synthetics/utils.ts
@@ -505,13 +505,17 @@ const getTest = async (api: APIHelper, {id, suite}: TriggerConfig): Promise<{tes
   }
 }
 
+type NotFound = {errorMessage: string}
+type Skipped = {overriddenConfig: TestPayload}
+type TestWithOverride = {test: Test; overriddenConfig: TestPayload}
+
 export const getTestAndOverrideConfig = async (
   api: APIHelper,
   {config, id, suite}: TriggerConfig,
   reporter: MainReporter,
   summary: InitialSummary,
   isTunnelEnabled?: boolean
-) => {
+): Promise<NotFound | Skipped | TestWithOverride> => {
   const normalizedId = PUBLIC_ID_REGEX.test(id) ? id : id.substr(id.lastIndexOf('/') + 1)
 
   const testResult = await getTest(api, {config, id: normalizedId, suite})
@@ -573,9 +577,18 @@ export const getTestsToTrigger = async (
     )
   )
 
+  // Keep track of uploaded applications to avoid uploading them twice.
   const uploadedApplicationByPath: {[applicationFilePath: string]: {applicationId: string; fileName: string}[]} = {}
-  for (const {test, overriddenConfig} of testsAndConfigsOverride) {
-    if (test && test.type === 'mobile' && overriddenConfig) {
+
+  for (const item of testsAndConfigsOverride) {
+    // Ignore not found and skipped tests.
+    if ('errorMessage' in item || !('test' in item)) {
+      continue
+    }
+
+    const {test, overriddenConfig} = item
+
+    if (test.type === 'mobile') {
       const {config: userConfigOverride} = triggerConfigs.find(({id}) => id === test.public_id)!
       try {
         await uploadApplicationAndOverrideConfig(
@@ -593,17 +606,17 @@ export const getTestsToTrigger = async (
 
   const overriddenTestsToTrigger: TestPayload[] = []
   const waitedTests: Test[] = []
-  testsAndConfigsOverride.forEach(({test, errorMessage, overriddenConfig}) => {
-    if (errorMessage) {
-      errorMessages.push(errorMessage)
+  testsAndConfigsOverride.forEach((item) => {
+    if ('errorMessage' in item) {
+      errorMessages.push(item.errorMessage)
     }
 
-    if (overriddenConfig) {
-      overriddenTestsToTrigger.push(overriddenConfig)
+    if ('overriddenConfig' in item) {
+      overriddenTestsToTrigger.push(item.overriddenConfig)
     }
 
-    if (test) {
-      waitedTests.push(test)
+    if ('test' in item) {
+      waitedTests.push(item.test)
     }
   })
 

--- a/src/commands/synthetics/utils.ts
+++ b/src/commands/synthetics/utils.ts
@@ -516,7 +516,7 @@ export const getTestAndOverrideConfig = async (
   summary: InitialSummary,
   isTunnelEnabled?: boolean
 ): Promise<NotFound | Skipped | TestWithOverride> => {
-  const normalizedId = PUBLIC_ID_REGEX.test(id) ? id : id.substr(id.lastIndexOf('/') + 1)
+  const normalizedId = PUBLIC_ID_REGEX.test(id) ? id : id.substring(id.lastIndexOf('/') + 1)
 
   const testResult = await getTest(api, {config, id: normalizedId, suite})
   if ('errorMessage' in testResult) {


### PR DESCRIPTION
💡This PR can be reviewed commit by commit

---

### What and why?

Currently, we need to use a test file to configure this option:
```json
// myTest.synthetics.json
{
  "tests": [
    {
      "id": "aaa-aaa-aaa",
      "config": {
        "mobileApplicationVersionFilePath": "path/to/application.apk"
      }
    }
  ]
}
```

To ease this, this PR adds a `--mobileApplicationVersionFilePath` option which will be a global override. This can still be overridden for specific tests thanks to a test file.

### How?

Because this argument is passed as a CLI option, it should affect all tests (unless there is a more precise override for specific tests).

So the option is added in `config.global` (which is a `UserConfigOverride`), and applied to all tests by:

https://github.com/DataDog/datadog-ci/blob/ed341f6b18b872f1d45d8a597e9bff708b824e2e/src/commands/synthetics/run-test.ts#L214-L220

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
