### PR TITLE
[synthetics] Export new utils for error handling

### DIFF
--- a/src/commands/synthetics/__tests__/utils.test.ts
+++ b/src/commands/synthetics/__tests__/utils.test.ts
@@ -1289,7 +1289,7 @@ describe('utils', () => {
         summary: testCase.summary,
       })
 
-      const exitCode = utils.handleExit(mockReporter, config, testCase.results)
+      const exitCode = utils.toExitCode(utils.getExitReason(config, {results: testCase.results}))
 
       expect((mockReporter as MockedReporter).reportStart).toHaveBeenCalledWith({startTime})
       expect((mockReporter as MockedReporter).resultEnd).toHaveBeenCalledTimes(testCase.results.length)

--- a/src/commands/synthetics/__tests__/utils.test.ts
+++ b/src/commands/synthetics/__tests__/utils.test.ts
@@ -55,7 +55,17 @@ import * as ciUtils from '../../../helpers/utils'
 import {apiConstructor, APIHelper} from '../api'
 import {DEFAULT_COMMAND_CONFIG, MAX_TESTS_TO_TRIGGER} from '../command'
 import {CiError} from '../errors'
-import {Batch, ExecutionRule, PollResult, Result, ServerResult, Test, Trigger, UserConfigOverride} from '../interfaces'
+import {
+  Batch,
+  ExecutionRule,
+  PollResult,
+  Result,
+  ServerResult,
+  SyntheticsCIConfig,
+  Test,
+  Trigger,
+  UserConfigOverride,
+} from '../interfaces'
 import * as mobile from '../mobile'
 import * as utils from '../utils'
 
@@ -1344,10 +1354,12 @@ describe('utils', () => {
     })
   })
 
-  test('getOrgSettings is not that important to throw', async () => {
+  test('getOrgSettings is not important enough to throw', async () => {
     jest.spyOn(api, 'getSyntheticsOrgSettings').mockImplementation(() => {
       throw getAxiosHttpError(502, {message: 'Server Error'})
     })
-    expect(await utils.getOrgSettings(api, mockReporter)).toBeUndefined()
+
+    const config = (apiConfiguration as unknown) as SyntheticsCIConfig
+    expect(await utils.getOrgSettings(mockReporter, config)).toBeUndefined()
   })
 })

--- a/src/commands/synthetics/__tests__/utils.test.ts
+++ b/src/commands/synthetics/__tests__/utils.test.ts
@@ -1270,7 +1270,7 @@ describe('utils', () => {
 
       const startTime = Date.now()
 
-      const exitCode = utils.renderResults({
+      utils.renderResults({
         config,
         orgSettings: {orgMaxConcurrencyCap: 1},
         reporter: mockReporter,
@@ -1279,8 +1279,9 @@ describe('utils', () => {
         summary: testCase.summary,
       })
 
-      expect((mockReporter as MockedReporter).reportStart).toHaveBeenCalledWith({startTime})
+      const exitCode = utils.handleExit(mockReporter, config, testCase.results)
 
+      expect((mockReporter as MockedReporter).reportStart).toHaveBeenCalledWith({startTime})
       expect((mockReporter as MockedReporter).resultEnd).toHaveBeenCalledTimes(testCase.results.length)
 
       const baseUrl = `https://${DEFAULT_COMMAND_CONFIG.subdomain}.${DEFAULT_COMMAND_CONFIG.datadogSite}/`

--- a/src/commands/synthetics/command.ts
+++ b/src/commands/synthetics/command.ts
@@ -10,13 +10,14 @@ import {DefaultReporter} from './reporters/default'
 import {JUnitReporter} from './reporters/junit'
 import {executeTests} from './run-test'
 import {
-  handleExit,
-  handleExitOnError,
+  getExitReason,
   getOrgSettings,
   getReporter,
   parseVariablesFromCli,
   renderResults,
   reportCiError,
+  toExitCode,
+  reportExitLogs,
 } from './utils'
 
 export const MAX_TESTS_TO_TRIGGER = 100
@@ -93,7 +94,9 @@ export class RunTestCommand extends Command {
     try {
       ;({results, summary} = await executeTests(this.reporter, this.config))
     } catch (error) {
-      return handleExitOnError(this.reporter, this.config, error)
+      reportExitLogs(this.reporter, this.config, {error})
+
+      return toExitCode(getExitReason(this.config, {error}))
     }
 
     const orgSettings = await getOrgSettings(this.reporter, this.config)
@@ -107,7 +110,9 @@ export class RunTestCommand extends Command {
       summary,
     })
 
-    return handleExit(this.reporter, this.config, results)
+    reportExitLogs(this.reporter, this.config, {results})
+
+    return toExitCode(getExitReason(this.config, {results}))
   }
 
   private async resolveConfig() {

--- a/src/commands/synthetics/command.ts
+++ b/src/commands/synthetics/command.ts
@@ -11,7 +11,7 @@ import {CommandConfig, MainReporter, Reporter, Result, Summary} from './interfac
 import {DefaultReporter} from './reporters/default'
 import {JUnitReporter} from './reporters/junit'
 import {executeTests} from './run-test'
-import {getOrgSettings, getReporter, parseVariablesFromCli, renderResults} from './utils'
+import {getOrgSettings, getReporter, parseVariablesFromCli, renderResults, reportCiError} from './utils'
 
 export const MAX_TESTS_TO_TRIGGER = 100
 
@@ -68,7 +68,7 @@ export class RunTestCommand extends Command {
       await this.resolveConfig()
     } catch (error) {
       if (error instanceof CiError) {
-        this.reportCiError(error, this.reporter)
+        reportCiError(error, this.reporter)
       }
 
       return 1
@@ -88,7 +88,7 @@ export class RunTestCommand extends Command {
       ;({results, summary} = await executeTests(this.reporter, this.config))
     } catch (error) {
       if (error instanceof CiError) {
-        this.reportCiError(error, this.reporter)
+        reportCiError(error, this.reporter)
 
         if (this.config.failOnMissingTests && error.code === 'MISSING_TESTS') {
           return 1
@@ -130,57 +130,6 @@ export class RunTestCommand extends Command {
       startTime,
       summary,
     })
-  }
-
-  private reportCiError(error: CiError, reporter: MainReporter) {
-    switch (error.code) {
-      case 'NO_TESTS_TO_RUN':
-        reporter.log('No test to run.\n')
-        break
-      case 'MISSING_TESTS':
-        reporter.error(`\n${chalk.bgRed.bold(' ERROR: some tests are missing ')}\n${error.message}\n\n`)
-        break
-
-      // Critical command errors
-      case 'AUTHORIZATION_ERROR':
-        reporter.error(`\n${chalk.bgRed.bold(' ERROR: authorization error ')}\n${error.message}\n\n`)
-        reporter.log('Credentials refused, make sure `apiKey`, `appKey` and `datadogSite` are correct.\n')
-        break
-      case 'INVALID_CONFIG':
-        reporter.error(`\n${chalk.bgRed.bold(' ERROR: invalid config ')}\n${error.message}\n\n`)
-        break
-      case 'MISSING_APP_KEY':
-        reporter.error(`Missing ${chalk.red.bold('DATADOG_APP_KEY')} in your environment.\n`)
-        break
-      case 'MISSING_API_KEY':
-        reporter.error(`Missing ${chalk.red.bold('DATADOG_API_KEY')} in your environment.\n`)
-        break
-      case 'POLL_RESULTS_FAILED':
-        reporter.error(`\n${chalk.bgRed.bold(' ERROR: unable to poll test results ')}\n${error.message}\n\n`)
-        break
-      case 'TUNNEL_START_FAILED':
-        reporter.error(`\n${chalk.bgRed.bold(' ERROR: unable to start tunnel ')}\n${error.message}\n\n`)
-        break
-      case 'TOO_MANY_TESTS_TO_TRIGGER':
-        reporter.error(`\n${chalk.bgRed.bold(' ERROR: too many tests to trigger ')}\n${error.message}\n\n`)
-        break
-      case 'TRIGGER_TESTS_FAILED':
-        reporter.error(`\n${chalk.bgRed.bold(' ERROR: unable to trigger tests ')}\n${error.message}\n\n`)
-        break
-      case 'UNAVAILABLE_TEST_CONFIG':
-        reporter.error(
-          `\n${chalk.bgRed.bold(' ERROR: unable to obtain test configurations with search query ')}\n${
-            error.message
-          }\n\n`
-        )
-        break
-      case 'UNAVAILABLE_TUNNEL_CONFIG':
-        reporter.error(`\n${chalk.bgRed.bold(' ERROR: unable to get tunnel configuration ')}\n${error.message}\n\n`)
-        break
-
-      default:
-        reporter.error(`\n${chalk.bgRed.bold(' ERROR ')}\n${error.message}\n\n`)
-    }
   }
 
   private async resolveConfig() {

--- a/src/commands/synthetics/command.ts
+++ b/src/commands/synthetics/command.ts
@@ -4,7 +4,6 @@ import deepExtend from 'deep-extend'
 import {removeUndefinedValues, resolveConfigFromFile} from '../../helpers/utils'
 import {isValidDatadogSite} from '../../helpers/validation'
 
-import {getApiHelper} from './api'
 import {CiError} from './errors'
 import {CommandConfig, MainReporter, Reporter, Result, Summary} from './interfaces'
 import {DefaultReporter} from './reporters/default'
@@ -97,7 +96,7 @@ export class RunTestCommand extends Command {
       return handleExitOnError(this.reporter, this.config, error)
     }
 
-    const orgSettings = await getOrgSettings(getApiHelper(this.config), this.reporter)
+    const orgSettings = await getOrgSettings(this.reporter, this.config)
 
     renderResults({
       config: this.config,

--- a/src/commands/synthetics/run-test.ts
+++ b/src/commands/synthetics/run-test.ts
@@ -31,6 +31,7 @@ import {
   renderResults,
   runTests,
   waitForResults,
+  handleExit,
 } from './utils'
 
 export const executeTests = async (
@@ -289,7 +290,7 @@ export const execute = async (
 
   const orgSettings = await getOrgSettings(getApiHelper(localConfig), mainReporter)
 
-  return renderResults({
+  renderResults({
     config: localConfig,
     reporter: mainReporter,
     results,
@@ -297,4 +298,6 @@ export const execute = async (
     startTime,
     summary,
   })
+
+  return handleExit(mainReporter, localConfig, results)
 }

--- a/src/commands/synthetics/run-test.ts
+++ b/src/commands/synthetics/run-test.ts
@@ -288,7 +288,7 @@ export const execute = async (
   const mainReporter = getReporter(localReporters)
   const {results, summary} = await executeTests(mainReporter, localConfig, suites)
 
-  const orgSettings = await getOrgSettings(getApiHelper(localConfig), mainReporter)
+  const orgSettings = await getOrgSettings(mainReporter, localConfig)
 
   renderResults({
     config: localConfig,

--- a/src/commands/synthetics/run-test.ts
+++ b/src/commands/synthetics/run-test.ts
@@ -31,7 +31,9 @@ import {
   renderResults,
   runTests,
   waitForResults,
-  handleExit,
+  getExitReason,
+  toExitCode,
+  reportExitLogs,
 } from './utils'
 
 export const executeTests = async (
@@ -299,5 +301,7 @@ export const execute = async (
     summary,
   })
 
-  return handleExit(mainReporter, localConfig, results)
+  reportExitLogs(mainReporter, localConfig, {results})
+
+  return toExitCode(getExitReason(localConfig, {results}))
 }

--- a/src/commands/synthetics/utils.ts
+++ b/src/commands/synthetics/utils.ts
@@ -829,55 +829,61 @@ export const renderResults = ({
   reporter.runEnd(summary, getAppBaseURL(config), orgSettings)
 }
 
-export const handleExit = (
+export const reportExitLogs = (
   reporter: MainReporter,
-  config: Pick<CommandConfig, 'failOnTimeout'>,
-  results: Result[]
-): 0 | 1 => {
-  if (!config.failOnTimeout && results.some((result) => result.timedOut)) {
+  config: Pick<CommandConfig, 'failOnTimeout' | 'failOnCriticalErrors'>,
+  {results, error}: {results?: Result[]; error?: unknown}
+) => {
+  if (!config.failOnTimeout && results?.some((result) => result.timedOut)) {
     reporter.error(
       chalk.yellow(
-        'Because `failOnTimeout` is disabled, the command will exit with an error code 0. ' +
-          'Use `failOnTimeout: true` to exit with an error code 1.\n'
+        'Because `failOnTimeout` is disabled, the command will succeed. ' +
+          'Use `failOnTimeout: true` to make it fail instead.\n'
       )
     )
   }
 
-  const hasFailedTests = results.some((result) => getResultOutcome(result) === ResultOutcome.Failed)
-  if (hasFailedTests) {
-    return 1
+  if (!config.failOnCriticalErrors && error instanceof CriticalError) {
+    reporter.error(
+      chalk.yellow(
+        'Because `failOnCriticalErrors` is not set or disabled, the command will succeed. ' +
+          'Use `failOnCriticalErrors: true` to make it fail instead.\n'
+      )
+    )
   }
 
-  return 0
-}
-
-export const handleExitOnError = (
-  reporter: MainReporter,
-  config: Pick<CommandConfig, 'failOnCriticalErrors' | 'failOnMissingTests'>,
-  error: unknown
-): 0 | 1 => {
   if (error instanceof CiError) {
     reportCiError(error, reporter)
+  }
+}
 
+export const getExitReason = (
+  config: Pick<CommandConfig, 'failOnCriticalErrors' | 'failOnMissingTests'>,
+  {results, error}: {results?: Result[]; error?: unknown}
+) => {
+  if (results?.some((result) => getResultOutcome(result) === ResultOutcome.Failed)) {
+    return 'failing-tests'
+  }
+
+  if (error instanceof CiError) {
     if (config.failOnMissingTests && error.code === 'MISSING_TESTS') {
-      return 1
+      return 'missing-tests'
     }
 
     if (error instanceof CriticalError) {
       if (config.failOnCriticalErrors) {
-        return 1
+        return 'critical-error'
       }
-
-      reporter.error(
-        chalk.yellow(
-          'Because `failOnCriticalErrors` is not set or disabled, the command will exit with an error code 0. ' +
-            'Use `failOnCriticalErrors: true` to exit with an error code 1.\n'
-        )
-      )
     }
   }
 
-  return 0
+  return 'passed'
+}
+
+export type ExitReason = ReturnType<typeof getExitReason>
+
+export const toExitCode = (reason: ExitReason) => {
+  return reason === 'passed' ? 0 : 1
 }
 
 export const getDatadogHost = (hostConfig: {

--- a/src/commands/synthetics/utils.ts
+++ b/src/commands/synthetics/utils.ts
@@ -846,3 +846,52 @@ export const getDatadogHost = (hostConfig: {
 }
 
 export const pluralize = (word: string, count: number): string => (count === 1 ? word : `${word}s`)
+
+export const reportCiError = (error: CiError, reporter: MainReporter) => {
+  switch (error.code) {
+    case 'NO_TESTS_TO_RUN':
+      reporter.log('No test to run.\n')
+      break
+    case 'MISSING_TESTS':
+      reporter.error(`\n${chalk.bgRed.bold(' ERROR: some tests are missing ')}\n${error.message}\n\n`)
+      break
+
+    // Critical command errors
+    case 'AUTHORIZATION_ERROR':
+      reporter.error(`\n${chalk.bgRed.bold(' ERROR: authorization error ')}\n${error.message}\n\n`)
+      reporter.log('Credentials refused, make sure `apiKey`, `appKey` and `datadogSite` are correct.\n')
+      break
+    case 'INVALID_CONFIG':
+      reporter.error(`\n${chalk.bgRed.bold(' ERROR: invalid config ')}\n${error.message}\n\n`)
+      break
+    case 'MISSING_APP_KEY':
+      reporter.error(`Missing ${chalk.red.bold('DATADOG_APP_KEY')} in your environment.\n`)
+      break
+    case 'MISSING_API_KEY':
+      reporter.error(`Missing ${chalk.red.bold('DATADOG_API_KEY')} in your environment.\n`)
+      break
+    case 'POLL_RESULTS_FAILED':
+      reporter.error(`\n${chalk.bgRed.bold(' ERROR: unable to poll test results ')}\n${error.message}\n\n`)
+      break
+    case 'TUNNEL_START_FAILED':
+      reporter.error(`\n${chalk.bgRed.bold(' ERROR: unable to start tunnel ')}\n${error.message}\n\n`)
+      break
+    case 'TOO_MANY_TESTS_TO_TRIGGER':
+      reporter.error(`\n${chalk.bgRed.bold(' ERROR: too many tests to trigger ')}\n${error.message}\n\n`)
+      break
+    case 'TRIGGER_TESTS_FAILED':
+      reporter.error(`\n${chalk.bgRed.bold(' ERROR: unable to trigger tests ')}\n${error.message}\n\n`)
+      break
+    case 'UNAVAILABLE_TEST_CONFIG':
+      reporter.error(
+        `\n${chalk.bgRed.bold(' ERROR: unable to obtain test configurations with search query ')}\n${error.message}\n\n`
+      )
+      break
+    case 'UNAVAILABLE_TUNNEL_CONFIG':
+      reporter.error(`\n${chalk.bgRed.bold(' ERROR: unable to get tunnel configuration ')}\n${error.message}\n\n`)
+      break
+
+    default:
+      reporter.error(`\n${chalk.bgRed.bold(' ERROR ')}\n${error.message}\n\n`)
+  }
+}

--- a/src/commands/synthetics/utils.ts
+++ b/src/commands/synthetics/utils.ts
@@ -269,11 +269,13 @@ const getPollResultMap = async (api: APIHelper, batch: Batch) => {
 }
 
 export const getOrgSettings = async (
-  api: APIHelper,
-  reporter: MainReporter
+  reporter: MainReporter,
+  config: SyntheticsCIConfig
 ): Promise<SyntheticsOrgSettings | undefined> => {
+  const apiHelper = getApiHelper(config)
+
   try {
-    return await api.getSyntheticsOrgSettings()
+    return await apiHelper.getSyntheticsOrgSettings()
   } catch (e) {
     reporter.error(`Failed to get settings: ${formatBackendErrors(e)}`)
   }
@@ -331,6 +333,7 @@ const getResultFromBatch = (
   }
 }
 
+// XXX: We shouldn't export functions that take an `APIHelper` because the `utils` module is exported while `api` is not.
 export const waitForResults = async (
   api: APIHelper,
   trigger: Trigger,
@@ -509,6 +512,7 @@ type NotFound = {errorMessage: string}
 type Skipped = {overriddenConfig: TestPayload}
 type TestWithOverride = {test: Test; overriddenConfig: TestPayload}
 
+// XXX: We shouldn't export functions that take an `APIHelper` because the `utils` module is exported while `api` is not.
 export const getTestAndOverrideConfig = async (
   api: APIHelper,
   {config, id, suite}: TriggerConfig,
@@ -551,6 +555,7 @@ export const getTestAndOverrideConfig = async (
 export const isDeviceIdSet = (result: ServerResult): result is Required<BrowserServerResult> =>
   'device' in result && result.device !== undefined
 
+// XXX: We shouldn't export functions that take an `APIHelper` because the `utils` module is exported while `api` is not.
 export const getTestsToTrigger = async (
   api: APIHelper,
   triggerConfigs: TriggerConfig[],
@@ -644,6 +649,7 @@ export const getTestsToTrigger = async (
   return {tests: waitedTests, overriddenTestsToTrigger, initialSummary}
 }
 
+// XXX: We shouldn't export functions that take an `APIHelper` because the `utils` module is exported while `api` is not.
 export const runTests = async (api: APIHelper, testsToTrigger: TestPayload[]): Promise<Trigger> => {
   const payload: Payload = {tests: testsToTrigger}
   const tagsToLimit = {
@@ -720,6 +726,8 @@ export const parseVariablesFromCli = (
   return Object.keys(variables).length > 0 ? variables : undefined
 }
 
+// XXX: `CommandConfig` should be replaced by `SyntheticsCIConfig` here because it's the smallest
+//      interface that we need, and it's better semantically.
 export const getAppBaseURL = ({datadogSite, subdomain}: Pick<CommandConfig, 'datadogSite' | 'subdomain'>) => {
   const validSubdomain = subdomain || DEFAULT_COMMAND_CONFIG.subdomain
   const datadogSiteParts = datadogSite.split('.')


### PR DESCRIPTION
### What and why?

Currently, the error handling in our CI integrations isn't aligned with what datadog-ci does (#663).

This PR refactors datadog-ci to extract and export new utils that will be used in our CI integrations.

Draft PRs on the CI integrations to use this new API:
- https://github.com/DataDog/synthetics-ci-github-action/pull/122
- https://github.com/DataDog/datadog-ci-azure-devops/pull/46

### How?

This PR creates 4 new utils:
- `reportCiError()` will allow us to remove files like [src/report-ci-error.ts (github action)](https://github.com/DataDog/synthetics-ci-github-action/blob/main/src/report-ci-error.ts).
- `reportExitLogs()` reports all logs that are common between failed and successful runs.
- `getExitReason()` replaces code that does manual error handling, like in [here](https://github.com/DataDog/synthetics-ci-github-action/blob/345aa9092cc2b009d51650d6b6ea59b0ed30c76c/src/main.ts#L28-L33) or [here](https://github.com/DataDog/synthetics-ci-github-action/blob/345aa9092cc2b009d51650d6b6ea59b0ed30c76c/src/main.ts#L16-L26).
- `toExitCode()` is a helper that is used for CLI usages only.

In the CI integrations, we had code like:

```ts
if (
  resultSummary.criticalErrors > 0 ||
  resultSummary.failed > 0 ||                                  
  (resultSummary.timedOut > 0 && config.failOnTimeout) ||      
  resultSummary.testsNotFound.size > 0                         
) {
  core.setFailed(`Datadog Synthetics tests failed: ${printSummary(resultSummary, config)}`)
}
```

But `getExitReason()` [uses `getResultOutcome()`](https://github.com/DataDog/datadog-ci/blob/b8116d049ffe4a2d1c1025eec7911c13b9d2283b/src/commands/synthetics/utils.ts#L813), which uses `result.passed`:

https://github.com/DataDog/datadog-ci/blob/b8116d049ffe4a2d1c1025eec7911c13b9d2283b/src/commands/synthetics/interfaces.ts#L91-L92

So, the following conditions will be checked implicitly by `getExitReason()`:
- `resultSummary.criticalErrors > 0` (which **wasn't aligned** with `datadog-ci` because it was ignoring `failOnCriticalErrors`)
- `resultSummary.timedOut > 0 && config.failOnTimeout`
- `resultSummary.failed > 0`

And `getExitReason()` can replace `resultSummary.testsNotFound.size > 0` because `executeTests()` will throw `MISSING_TESTS` if `failOnMissingTests` is enabled.

With this PR, the **non critical error** `NO_TESTS_TO_RUN` will never make the CI fail. There is **no configuration option** that changes this behavior and that's expected (we have a [unit test for that](https://github.com/DataDog/datadog-ci/blob/b8116d049ffe4a2d1c1025eec7911c13b9d2283b/src/commands/synthetics/__tests__/cli.test.ts#L280-L296)). This will solve #663.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
