### PR TITLE
[SC-1245] Update doc provider Azure DevOps

### DIFF
--- a/src/commands/git-metadata/README.md
+++ b/src/commands/git-metadata/README.md
@@ -36,12 +36,13 @@ datadog-ci git-metadata upload
 The repository URL is inferred from the remote named `origin` (or the first remote if none are named `origin`). The value can be overridden by using the `--repository-url` flag.
 For example: The remote `git@github.com:DataDog/example.git` will create links that point to `https://github.com/DataDog/example`.
 
-The only repository URLs supported are the ones whose host contains: `github`, `gitlab` or `bitbucket`. This allows DataDog to create proper URLs such as:
+The only repository URLs supported are the ones whose host contains: `github`, `gitlab`, `bitbucket`, or `dev.azure`. This allows DataDog to create proper URLs such as:
 
 | Provider  | URL |
 | --- | --- |
 | GitHub / GitLab  | https://\<repository-url\>/blob/\<commit-hash\>/\<tracked-file-path\>#L\<line\> |
 | Bitbucket | https://\<repository-url\>/src/\<commit-hash\>/\<tracked-file-path\>#lines-\<line\>  |
+| Azure DevOps | https://\<repository-url\>?version=GC\<commit-hash\>&path=\<tracked-file-path\>&line=\<line\>&lineEnd=\<line + 1>&lineStartColumn=1&lineEndColumn=1 |
 
 ### End-to-end testing process
 

--- a/src/commands/react-native/README.md
+++ b/src/commands/react-native/README.md
@@ -63,7 +63,7 @@ The following optional parameters are available:
 
 ### Link errors with your source code
 
-You can enrich errors in Datadog with context links to GitHub, GitLab, and Bitbucket if the following requirements are met:
+You can enrich errors in Datadog with context links to GitHub, GitLab, Bitbucket, and Azure DevOps if the following requirements are met:
 
 - You have installed the `git` executable
 - You can run `datadog-ci` in the git repository
@@ -92,7 +92,7 @@ If you are not running the `react-native upload` command from your React Native 
 
 #### Supported repositories
 
-The supported repository URLs are ones whose host contains `github`, `gitlab`, or `bitbucket`.
+The supported repository URLs are ones whose host contains `github`, `gitlab`, `bitbucket`, or `dev.azure`.
 
 This allows Datadog to create proper URLs such as:
 
@@ -100,6 +100,7 @@ This allows Datadog to create proper URLs such as:
 | ---------------- | ----------------------------------------------------------------------------------- |
 | GitHub or GitLab | https://\<repository-url\>/blob/\<commit-hash\>/\<tracked-file-path\>#L\<line\>     |
 | Bitbucket        | https://\<repository-url\>/src/\<commit-hash\>/\<tracked-file-path\>#lines-\<line\> |
+| Azure DevOps | https://\<repository-url\>?version=GC\<commit-hash\>&path=\<tracked-file-path\>&line=\<line\>&lineEnd=\<line + 1>&lineStartColumn=1&lineEndColumn=1 |
 
 ### `codepush`
 

--- a/src/commands/sourcemaps/README.md
+++ b/src/commands/sourcemaps/README.md
@@ -48,7 +48,7 @@ In addition, some optional parameters are available:
 
 ### Link errors with your source code
 
-Errors in Datadog UI can be enriched with links to GitHub/GitLab/Bitbucket if these requirements are met:
+Errors in Datadog UI can be enriched with links to GitHub/GitLab/Bitbucket/Azure DevOps if these requirements are met:
 - `git` executable is installed
 - `datadog-ci` is run within the git repository
 
@@ -79,12 +79,13 @@ For example, if your repository contains a file at `src/foo/example.js`, then:
 
 #### Supported repositories
 
-The only repository URLs supported are the ones whose host contains: `github`, `gitlab` or `bitbucket`. This allows Datadog to create proper URLs such as:
+The only repository URLs supported are the ones whose host contains: `github`, `gitlab`, `bitbucket`, or `dev.azure`. This allows Datadog to create proper URLs such as:
 
 | Provider  | URL |
 | --- | --- |
 | GitHub / GitLab  | https://\<repository-url\>/blob/\<commit-hash\>/\<tracked-file-path\>#L\<line\> |
 | Bitbucket | https://\<repository-url\>/src/\<commit-hash\>/\<tracked-file-path\>#lines-\<line\>  |
+| Azure DevOps | https://\<repository-url\>?version=GC\<commit-hash\>&path=\<tracked-file-path\>&line=\<line\>&lineEnd=\<line + 1>&lineStartColumn=1&lineEndColumn=1 |
 
 ## End-to-end testing process
 


### PR DESCRIPTION
We now support generating link for Azure DevOps repository, so updating the documentation.