### PR TITLE
Add new ap1.datadoghq.com site

### DIFF
--- a/src/commands/synthetics/__tests__/utils.test.ts
+++ b/src/commands/synthetics/__tests__/utils.test.ts
@@ -1087,11 +1087,21 @@ describe('utils', () => {
     expect(utils.getAppBaseURL({datadogSite: 'datadoghq.eu', subdomain: 'app'})).toBe('https://app.datadoghq.eu/')
     expect(utils.getAppBaseURL({datadogSite: 'datadoghq.eu', subdomain: 'myorg'})).toBe('https://myorg.datadoghq.eu/')
 
-    // US3/US5-type datadog site: the datadog site's subdomain is replaced by `subdomain` when `subdomain` is custom.
+    // AP1/US3/US5-type datadog site: the datadog site's subdomain is replaced by `subdomain` when `subdomain` is custom.
     // The correct Main DC (US3 in this case) is resolved automatically.
+    expect(utils.getAppBaseURL({datadogSite: 'ap1.datadoghq.com', subdomain: ''})).toBe('https://ap1.datadoghq.com/')
+    expect(utils.getAppBaseURL({datadogSite: 'ap1.datadoghq.com', subdomain: 'app'})).toBe('https://ap1.datadoghq.com/')
+    expect(utils.getAppBaseURL({datadogSite: 'ap1.datadoghq.com', subdomain: 'myorg'})).toBe(
+      'https://myorg.datadoghq.com/'
+    )
     expect(utils.getAppBaseURL({datadogSite: 'us3.datadoghq.com', subdomain: ''})).toBe('https://us3.datadoghq.com/')
     expect(utils.getAppBaseURL({datadogSite: 'us3.datadoghq.com', subdomain: 'app'})).toBe('https://us3.datadoghq.com/')
     expect(utils.getAppBaseURL({datadogSite: 'us3.datadoghq.com', subdomain: 'myorg'})).toBe(
+      'https://myorg.datadoghq.com/'
+    )
+    expect(utils.getAppBaseURL({datadogSite: 'us5.datadoghq.com', subdomain: ''})).toBe('https://us5.datadoghq.com/')
+    expect(utils.getAppBaseURL({datadogSite: 'us5.datadoghq.com', subdomain: 'app'})).toBe('https://us5.datadoghq.com/')
+    expect(utils.getAppBaseURL({datadogSite: 'us5.datadoghq.com', subdomain: 'myorg'})).toBe(
       'https://myorg.datadoghq.com/'
     )
   })

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -3,5 +3,6 @@ export const DATADOG_SITES: string[] = [
   'datadoghq.eu',
   'us3.datadoghq.com',
   'us5.datadoghq.com',
+  'ap1.datadoghq.com',
   'ddog-gov.com',
 ]

--- a/src/helpers/__tests__/validation.test.ts
+++ b/src/helpers/__tests__/validation.test.ts
@@ -11,10 +11,18 @@ describe('validation', () => {
     expect(isValidDatadogSite('myorg.us3.datadoghq.com')).toBe(false)
 
     expect(isValidDatadogSite('datadoghq.com')).toBe(true)
+
+    expect(isValidDatadogSite('ap1.datadoghq.com')).toBe(true)
+    expect(isValidDatadogSite('AP1.datadoghq.com')).toBe(true)
+
     expect(isValidDatadogSite('us3.datadoghq.com')).toBe(true)
     expect(isValidDatadogSite('US3.datadoghq.com')).toBe(true)
 
+    expect(isValidDatadogSite('us5.datadoghq.com')).toBe(true)
+    expect(isValidDatadogSite('US5.datadoghq.com')).toBe(true)
+
     process.env.DD_CI_BYPASS_SITE_VALIDATION = 'true'
+
     expect(isValidDatadogSite('')).toBe(true)
     expect(isValidDatadogSite('random')).toBe(true)
   })


### PR DESCRIPTION
### What and why?

Add a reference to the newly GA Datadog site: ap1.datadoghq.com.

### How?

Add an entry in the list of sites

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
