### PR TITLE
[synthetics] Fix `--subdomain` argument

### DIFF
--- a/src/commands/synthetics/command.ts
+++ b/src/commands/synthetics/command.ts
@@ -273,7 +273,7 @@ RunTestCommand.addOption(
 )
 RunTestCommand.addOption('publicIds', Command.Array('-p,--public-id'))
 RunTestCommand.addOption('runName', Command.String('-n,--runName'))
-RunTestCommand.addOption('subdomain', Command.Boolean('--subdomain'))
+RunTestCommand.addOption('subdomain', Command.String('--subdomain'))
 RunTestCommand.addOption('testSearchQuery', Command.String('-s,--search'))
 RunTestCommand.addOption('tunnel', Command.Boolean('-t,--tunnel'))
 RunTestCommand.addOption('variableStrings', Command.Array('-v,--variable'))


### PR DESCRIPTION
### What and why?

The type of the `--subdomain` parameter was incorrect, leading to an error:

```bash
$ yarn launch synthetics run-tests --subdomain hello
Unknown Syntax Error: Extraneous positional argument ("hello").
```

### How?

Change `Boolean` to `String`.

### Review checklist

We currently have a ["all option flags are supported" test](https://github.com/DataDog/datadog-ci/blob/f3e5df8e2f455ca7194c4dbd651881c44f39aa3c/src/commands/synthetics/__tests__/cli.test.ts#L12) but it only tests that the option flag is _here_.

Testing if the type of the option flag is correct would require an e2e test, which would take a lot of time to execute.

- [ ] ~~Feature or bugfix MUST have appropriate tests (unit, integration)~~
