### PR TITLE
DOCS-5226 CI/CD Integrations Configuration Edits

### DIFF
--- a/src/commands/synthetics/README.md
+++ b/src/commands/synthetics/README.md
@@ -96,7 +96,7 @@ The duration (in milliseconds) after which `datadog-ci` stops polling for test r
 : The name of the custom subdomain set to access your Datadog application. If the URL used to access Datadog is `myorg.datadoghq.com`, the `subdomain` value needs to be set to `myorg`.
 
 `tunnel`
-: Use the [testing tunnel][3] to execute your test batch.
+: Use the [Continuous Testing Tunnel](#use-the-testing-tunnel) to execute your test batch.
 
 `testSearchQuery`
 : Pass a query to select which Synthetic tests to run. If you are running tests in the CLI, use the `-s` flag.
@@ -115,7 +115,7 @@ For example:
 {
     "apiKey": "<DATADOG_API_KEY>",
     "appKey": "<DATADOG_APPLICATION_KEY>",
-    "datadogSite": "datadoghq.com", // You can use another Datadog site. By default, requests are sent to Datadog US1. 
+    "datadogSite": "{{< region-param key="dd_site" code="true" >}}", // You can use another Datadog site. By default, requests are sent to Datadog US1. 
     "files": "{,!(node_modules)/**/}*.synthetics.json",
     "failOnCriticalErrors": false,
     "failOnMissingTests": false,
@@ -177,7 +177,7 @@ For example:
 {
   "apiKey": "<DATADOG_API_KEY>",
   "appKey": "<DATADOG_APPLICATION_KEY>",
-  "datadogSite": "datadoghq.com",
+  "datadogSite": "{{< region-param key="dd_site" code="true" >}}",
   "failOnCriticalErrors": true,
   "failOnMissingTests": true,
   "failOnTimeout": true,

--- a/src/commands/synthetics/README.md
+++ b/src/commands/synthetics/README.md
@@ -115,7 +115,7 @@ For example:
 {
     "apiKey": "<DATADOG_API_KEY>",
     "appKey": "<DATADOG_APPLICATION_KEY>",
-    "datadogSite": "{{< region-param key="dd_site" code="true" >}}", // You can use another Datadog site. By default, requests are sent to Datadog US1. 
+    "datadogSite": "datadoghq.com", // You can use another Datadog site in https://docs.datadoghq.com/getting_started/site/. By default, requests are sent to Datadog US1. 
     "files": "{,!(node_modules)/**/}*.synthetics.json",
     "failOnCriticalErrors": false,
     "failOnMissingTests": false,
@@ -177,7 +177,7 @@ For example:
 {
   "apiKey": "<DATADOG_API_KEY>",
   "appKey": "<DATADOG_APPLICATION_KEY>",
-  "datadogSite": "{{< region-param key="dd_site" code="true" >}}",
+  "datadogSite": "datadoghq.com", // You can use another Datadog site in https://docs.datadoghq.com/getting_started/site/. By default, requests are sent to Datadog US1. 
   "failOnCriticalErrors": true,
   "failOnMissingTests": true,
   "failOnTimeout": true,


### PR DESCRIPTION
### What and why?

Adds a site address shortcode in the Configuration doc page.

### How?

DOCS-5226

## Preview

https://docs-staging.datadoghq.com/alai97/continuous-testing-cicd-integrations-site-region-update/continuous_testing/cicd_integrations/configuration

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
