### PR TITLE
[test] Fix flaky standalone-binary e2e test

### DIFF
--- a/standalone-e2e/standalone-binary.test.ts
+++ b/standalone-e2e/standalone-binary.test.ts
@@ -16,6 +16,20 @@ const STANDALONE_BINARY_PATH = `${isWin ? '.\\' : './'}${STANDALONE_BINARY}${isW
 const sanitizeOutput = (output: string) => output.replace(/(\r\n|\n|\r)/gm, '')
 
 describe('standalone binary', () => {
+  beforeAll(
+    async () => {
+      await expect(execPromise(`${STANDALONE_BINARY_PATH}`, {})).rejects.toThrow(
+        expect.objectContaining({
+          code: 1,
+          stdout: expect.stringContaining('Unknown Syntax Error'),
+        })
+      )
+    },
+    // The cold start of the binary sometimes takes >5s on macOS, resulting in a flaky CI for this OS.
+    // This `beforeAll` is here to warm up the binary.
+    6 * 1000
+  )
+
   describe('version', () => {
     it('can be called', async () => {
       const {stdout} = await execPromise(`${STANDALONE_BINARY_PATH} version`)


### PR DESCRIPTION
### What and why?

The cold start of the binary sometimes takes >5s on macOS, resulting in a flaky CI for this OS.

Example of flaky job: https://github.com/DataDog/datadog-ci/actions/runs/4677729427/jobs/8285575146

I think it may be caused by some security checks done by macOS, or some cache that is reused in subsequent runs.

This is not related to the package compression (we use `pkg --compress GZip`): there is the same "cold start" effect with compression disabled.


<details>
  <summary>It's reproducible on M1 laptops (expand to see steps)</summary>

```bash
yarn && yarn build

# Build the binary
yarn dist-standalone -t node14-macos-x64 -o datadog-ci_darwin-x64
```

When running `yarn dist-standalone:test` the first time, we'll see the 1st test taking longer:

![image](https://user-images.githubusercontent.com/9317502/231772580-d62f7133-707d-49a0-836e-5c97dfa48189.png)

Then, running it a second time (without rebuilding the package) won't show any cold start:

![image](https://user-images.githubusercontent.com/9317502/231774259-bf3d643a-25ee-4f59-977a-09bd6d22b1fd.png)

Finally, rebuilding the package brings back the cold start:

![image](https://user-images.githubusercontent.com/9317502/231774868-3f79b5cd-45ae-4398-a76a-4d578561adcf.png)

</details>

### How?

Warm up the binary in a `beforeAll` Jest hook.

### Review checklist

- [ ] ~~Feature or bugfix MUST have appropriate tests (unit, integration)~~
