### PR TITLE
[lambda] update how AWS credentials are handled

### DIFF
--- a/src/commands/lambda/__tests__/instrument.test.ts
+++ b/src/commands/lambda/__tests__/instrument.test.ts
@@ -1,5 +1,8 @@
 jest.mock('fs')
-jest.mock('@aws-sdk/credential-providers')
+jest.mock('@aws-sdk/credential-providers', () => ({
+  ...jest.requireActual('@aws-sdk/credential-providers'),
+  fromIni: jest.fn(),
+}))
 jest.mock('../prompt')
 jest.mock('../renderer', () => require('../__mocks__/renderer'))
 jest.mock('../../../../package.json', () => ({version: 'XXXX'}))

--- a/src/commands/lambda/__tests__/uninstrument.test.ts
+++ b/src/commands/lambda/__tests__/uninstrument.test.ts
@@ -1,5 +1,8 @@
 jest.mock('fs')
-jest.mock('@aws-sdk/credential-providers')
+jest.mock('@aws-sdk/credential-providers', () => ({
+  ...jest.requireActual('@aws-sdk/credential-providers'),
+  fromIni: jest.fn(),
+}))
 jest.mock('../prompt')
 jest.mock('../renderer', () => require('../__mocks__/renderer'))
 jest.mock('../../../../package.json', () => ({version: 'XXXX'}))

--- a/src/commands/lambda/instrument.ts
+++ b/src/commands/lambda/instrument.ts
@@ -23,7 +23,7 @@ import {
   getAWSProfileCredentials,
   getAllLambdaFunctionConfigs,
   handleLambdaFunctionUpdates,
-  isMissingAWSCredentials,
+  getAWSCredentials,
   isMissingDatadogEnvVars,
   sentenceMatchesRegEx,
   willUpdateFunctionConfigs,
@@ -98,9 +98,12 @@ export class InstrumentCommand extends Command {
     let hasSpecifiedFunctions = this.functions.length !== 0 || this.config.functions.length !== 0
     if (this.interactive) {
       try {
-        if (isMissingAWSCredentials()) {
+        const credentials = await getAWSCredentials()
+        if (credentials === undefined) {
           this.context.stdout.write(renderer.renderNoAWSCredentialsFound())
           await requestAWSCredentials()
+        } else {
+          this.credentials = credentials
         }
 
         // Always ask for region since the user may

--- a/src/commands/lambda/uninstrument.ts
+++ b/src/commands/lambda/uninstrument.ts
@@ -12,7 +12,7 @@ import {
   getAllLambdaFunctionConfigs,
   getAWSProfileCredentials,
   handleLambdaFunctionUpdates,
-  isMissingAWSCredentials,
+  getAWSCredentials,
   willUpdateFunctionConfigs,
 } from './functions/commons'
 import {getUninstrumentedFunctionConfigs, getUninstrumentedFunctionConfigsFromRegEx} from './functions/uninstrument'
@@ -58,9 +58,12 @@ export class UninstrumentCommand extends Command {
     let hasSpecifiedFunctions = this.functions.length !== 0 || this.config.functions.length !== 0
     if (this.interactive) {
       try {
-        if (isMissingAWSCredentials()) {
+        const credentials = await getAWSCredentials()
+        if (credentials === undefined) {
           this.context.stdout.write(renderer.renderNoAWSCredentialsFound())
           await requestAWSCredentials()
+        } else {
+          this.credentials = credentials
         }
       } catch (err) {
         this.context.stdout.write(renderer.renderError(err))


### PR DESCRIPTION
### What and why?

AWS CloudShell already provides credentials. These are not being used by `datadog-ci` since we only check for environment variables. Therefore, an update of how we get AWS credentials from environment is required.

### How?

Instead of checking just for credentials in environment variables, we are using the function `fromNodeProviderChain` from `@aws-sdk/credential-provider` which is a chain that checks in multiple places for AWS credentials.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
