### PR TITLE
Fix Flutter Symbol Upload documentation

### DIFF
--- a/src/commands/flutter-symbols/README.md
+++ b/src/commands/flutter-symbols/README.md
@@ -45,7 +45,7 @@ datadog-ci flutter-symbols upload --dart-symbols-location ./debug-info --service
 | `--ios-dsyms-location` | Optional | Specify the location of iOS dSYM files. By default, these are located at `./build/ios/archive/Runner.xcarchive/dSYMs`. Adding this parameter automatically sets `--ios-dsyms`. |
 | `--android-mapping` | Optional | Upload Android Proguard mapping file. This is usually only necessary if you specify `--obfuscate` as a parameter to `flutter build`. |
 | `--android-mapping-location` | Optional | Specify the location of your Android Proguard mapping file. By default, this is located at `./build/app/outputs/mapping/[flavor]/mapping.txt`. Adding this parameter automatically sets `--android-mapping`. |
-| `--pubspec-location` | Optional | The location of the pubspec for this application. The pubspec is used to automatically determine the version number of the application. Defaults to the current directory. |
+| `--pubspec` | Optional | The location of the pubspec for this application. The pubspec is used to automatically determine the version number of the application. Defaults to the current directory. |
 | `--version` | Optional | The version of your application. This defaults to the version specified in your pubspec. Only one upload is needed for a specific `version`, `service`, and `flavor` combination. Subsequent uploads are ignored until one parameter changes. |
 | `--dry-run` | Optional | It runs the command without the final step of uploading. All other checks are performed. |
 | `--disable-git`    | Optional   | Prevents the command from invoking git in the current working directory and sending repository-related data to Datadog (such as the hash, remote URL, and paths within the repository of sources referenced in the source map). |


### PR DESCRIPTION
### What and why?

The documentation had `--pubspec-location` but the correct option was `pubspec`.

Fixes #844

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
