### PR TITLE
[React Native] Support environment variables in Info.plist for react-native xcode

### DIFF
--- a/src/helpers/__tests__/plist.test.ts
+++ b/src/helpers/__tests__/plist.test.ts
@@ -25,7 +25,7 @@ describe('plist util', () => {
     it('returns an empty string for an env variable that is not declared', () => {
       const plist = parsePlist('src/helpers/__tests__/plist-fixtures/Info.plist')
       expect(() => plist.getPropertyValue('CFBundleExecutable')).toThrowError(
-        "Environment variable EXECUTABLE_NAME for property value $(EXECUTABLE_NAME) wasn't found."
+        "Environment variable $(EXECUTABLE_NAME) for key CFBundleExecutable wasn't found."
       )
     })
 

--- a/src/helpers/__tests__/plist.test.ts
+++ b/src/helpers/__tests__/plist.test.ts
@@ -2,6 +2,9 @@ import {parsePlist} from '../plist'
 
 describe('plist util', () => {
   describe('parsePlist', () => {
+    afterEach(() => {
+      delete process.env.EXECUTABLE_NAME
+    })
     it('parses the content of the info plist file', () => {
       const plist = parsePlist('src/helpers/__tests__/plist-fixtures/Info.plist')
       expect(plist.getContent()).toMatchSnapshot()
@@ -11,6 +14,17 @@ describe('plist util', () => {
       const plist = parsePlist('src/helpers/__tests__/plist-fixtures/Info.plist')
       expect(plist.getPropertyValue('CFBundleShortVersionString')).toBe('1.0.4')
       expect(plist.getPropertyValue('CFBundleVersion')).toBe(12)
+    })
+
+    it('returns the value for an env variable', () => {
+      process.env.EXECUTABLE_NAME = 'executable name'
+      const plist = parsePlist('src/helpers/__tests__/plist-fixtures/Info.plist')
+      expect(plist.getPropertyValue('CFBundleExecutable')).toBe('executable name')
+    })
+
+    it('returns an empty string for an env variable that is not declared', () => {
+      const plist = parsePlist('src/helpers/__tests__/plist-fixtures/Info.plist')
+      expect(plist.getPropertyValue('CFBundleExecutable')).toBe('')
     })
 
     it('throws an error if a property does not exist', () => {

--- a/src/helpers/__tests__/plist.test.ts
+++ b/src/helpers/__tests__/plist.test.ts
@@ -24,7 +24,9 @@ describe('plist util', () => {
 
     it('returns an empty string for an env variable that is not declared', () => {
       const plist = parsePlist('src/helpers/__tests__/plist-fixtures/Info.plist')
-      expect(plist.getPropertyValue('CFBundleExecutable')).toBe('')
+      expect(() => plist.getPropertyValue('CFBundleExecutable')).toThrowError(
+        "Environment variable EXECUTABLE_NAME for property value $(EXECUTABLE_NAME) wasn't found."
+      )
     })
 
     it('throws an error if a property does not exist', () => {

--- a/src/helpers/plist.ts
+++ b/src/helpers/plist.ts
@@ -17,7 +17,14 @@ const parseIfEnvVariable = (propertyValue: string | number): string | number => 
 
   // matchedEnvVariable[0] is the matched string, i.e. "$(VARIABLE_NAME)"
   // matchedEnvVariable[1] is the captured group, i.e. "VARIABLE_NAME"
-  return process.env[matchedEnvVariable[1]] || ''
+  const value = process.env[matchedEnvVariable[1]]
+  if (value !== undefined) {
+    return value
+  }
+
+  throw new Error(
+    `Environment variable ${matchedEnvVariable[1]} for property value ${matchedEnvVariable[0]} wasn't found.`
+  )
 }
 
 class PlistContent {


### PR DESCRIPTION
### What and why?

On the default template for React Native, the Info.plist file uses environment variables for the version and build number.


### How?

We look if the value in the Info.plist is an env variable. 
If that's the case, we look for the environment variable or use the default values.

Screenshot of a working example:
![image](https://user-images.githubusercontent.com/8973379/233410536-37eef0a1-3c25-48f5-9768-1ada9a604c74.png)

![image](https://user-images.githubusercontent.com/8973379/233410424-420b198d-e344-428e-b5b3-c7d74ede5418.png)

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
