### PR TITLE
v2.9.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ yarn prepack
 To release a new version of `datadog-ci`:
 
 1. Create a new branch for the version upgrade.
-2. Update the `package.json` version, commit the change `vX.X.X` and tag it with `git tag vX.X.X`. Depending on the nature of the changes introduced. You may refer to [Semantic Versioning](https://semver.org/#summary) to determine what level to increment.
+2. Update the `package.json` version, commit the change `vX.X.X` and tag it with `git tag vX.X.X`, based on the version you are upgrading to. You may refer to [Semantic Versioning](https://semver.org/#summary) to determine what level to increment.
 3. Push the branch along with the tag to the upstream (GitHub) with `git push --tags origin name-of-the-branch`, create a Pull Request with the changes introduced in the description details, and get at least one approval. For example, see this [sample pull request](https://github.com/DataDog/datadog-ci/pull/78).
 4. Merge the Pull Request.
 5. Create a GitHub Release from the [Tags page](https://github.com/DataDog/datadog-ci/tags) with the description of changes introduced.

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ yarn prepack
 To release a new version of `datadog-ci`:
 
 1. Create a new branch for the version upgrade.
-2. Update the version using `yarn version [--patch|--minor|--major]`, depending on the nature of the changes introduced. You may refer to [Semantic Versioning](https://semver.org/#summary) to determine which to increment.
+2. Update the `package.json` version, commit the change `vX.X.X` and tag it with `git tag vX.X.X`. Depending on the nature of the changes introduced. You may refer to [Semantic Versioning](https://semver.org/#summary) to determine what level to increment.
 3. Push the branch along with the tag to the upstream (GitHub) with `git push --tags origin name-of-the-branch`, create a Pull Request with the changes introduced in the description details, and get at least one approval. For example, see this [sample pull request](https://github.com/DataDog/datadog-ci/pull/78).
 4. Merge the Pull Request.
 5. Create a GitHub Release from the [Tags page](https://github.com/DataDog/datadog-ci/tags) with the description of changes introduced.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci",
-  "version": "2.8.1",
+  "version": "2.9.0",
   "description": "Run datadog actions from the CI.",
   "repository": "https://github.com/DataDog/datadog-ci",
   "license": "Apache-2.0",


### PR DESCRIPTION
### What and why?

Release `v2.9.0`, update release doc to remove deprecated `yarn version`

- https://github.com/DataDog/datadog-ci/pull/845
- https://github.com/DataDog/datadog-ci/pull/846
- https://github.com/DataDog/datadog-ci/pull/847
- https://github.com/DataDog/datadog-ci/pull/835
- https://github.com/DataDog/datadog-ci/pull/848
