### PR TITLE
[git-metadata] Make git sync as default behavior.

### DIFF
--- a/src/commands/git-metadata/upload.ts
+++ b/src/commands/git-metadata/upload.ts
@@ -42,7 +42,7 @@ export class UploadCommand extends Command {
   }
   private dryRun = false
   private verbose = false
-  private gitSync = false
+  private noGitSync = false
   private directory = ''
   private logger: Logger = new Logger((s: string) => {
     this.context.stdout.write(s)
@@ -108,7 +108,7 @@ export class UploadCommand extends Command {
       inError = true
     }
 
-    if (this.gitSync) {
+    if (!this.noGitSync) {
       try {
         this.logger.info('Syncing GitDB...')
         const elapsed = await timedExecAsync(this.uploadToGitDB.bind(this), {
@@ -213,5 +213,5 @@ UploadCommand.addPath('git-metadata', 'upload')
 UploadCommand.addOption('dryRun', Command.Boolean('--dry-run'))
 UploadCommand.addOption('verbose', Command.Boolean('--verbose'))
 UploadCommand.addOption('directory', Command.String('--directory'))
-UploadCommand.addOption('gitSync', Command.Boolean('--git-sync'))
+UploadCommand.addOption('noGitSync', Command.Boolean('--no-git-sync'))
 UploadCommand.addOption('repositoryURL', Command.String('--repository-url'))

--- a/src/commands/git-metadata/upload.ts
+++ b/src/commands/git-metadata/upload.ts
@@ -42,6 +42,7 @@ export class UploadCommand extends Command {
   }
   private dryRun = false
   private verbose = false
+  private gitSync = false
   private noGitSync = false
   private directory = ''
   private logger: Logger = new Logger((s: string) => {
@@ -77,6 +78,10 @@ export class UploadCommand extends Command {
       )
 
       return 1
+    }
+
+    if (this.gitSync) {
+      this.logger.warn('option --git-sync is deprecated as it is now the default behavior')
     }
 
     const metricsLogger = getMetricsLogger({
@@ -212,6 +217,7 @@ export class UploadCommand extends Command {
 UploadCommand.addPath('git-metadata', 'upload')
 UploadCommand.addOption('dryRun', Command.Boolean('--dry-run'))
 UploadCommand.addOption('verbose', Command.Boolean('--verbose'))
+UploadCommand.addOption('gitSync', Command.Boolean('--git-sync'))
+UploadCommand.addOption('noGitSync', Command.Boolean('--no-gitsync'))
 UploadCommand.addOption('directory', Command.String('--directory'))
-UploadCommand.addOption('noGitSync', Command.Boolean('--no-git-sync'))
 UploadCommand.addOption('repositoryURL', Command.String('--repository-url'))

--- a/src/commands/git-metadata/upload.ts
+++ b/src/commands/git-metadata/upload.ts
@@ -84,7 +84,7 @@ export class UploadCommand extends Command {
     }
 
     if (this.gitSync) {
-      this.logger.warn('option --git-sync is deprecated as it is now the default behavior')
+      this.logger.warn('Option --git-sync is deprecated as it is now the default behavior')
     }
 
     const metricsLogger = getMetricsLogger({
@@ -126,11 +126,10 @@ export class UploadCommand extends Command {
         this.logger.info(`${this.dryRun ? '[DRYRUN] ' : ''}Successfully synced git DB in ${elapsed} seconds.`)
       } catch (err) {
         if (!this.isTargetingGov()) {
-          console.log('error writing to git db')
           this.logger.warn(`Could not write to GitDB: ${err}`)
         } else {
           // Skip the warning for Gov DC since git sync is not available there yet.
-          this.logger.warn(`not writing to GitDB: not available for gov`)
+          this.logger.warn(`Not writing to GitDB: not available for gov`)
         }
       }
     }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,8 +1,15 @@
+export const DATADOG_SITE_US1 = 'datadoghq.com'
+export const DATADOG_SITE_EU1 = 'datadoghq.eu'
+export const DATADOG_SITE_US3 = 'us3.datadoghq.com'
+export const DATADOG_SITE_US5 = 'us5.datadoghq.com'
+export const DATADOG_SITE_AP1 = 'ap1.datadoghq.com'
+export const DATADOG_SITE_GOV = 'ddog-gov.com'
+
 export const DATADOG_SITES: string[] = [
-  'datadoghq.com',
-  'datadoghq.eu',
-  'us3.datadoghq.com',
-  'us5.datadoghq.com',
-  'ap1.datadoghq.com',
-  'ddog-gov.com',
+  DATADOG_SITE_US1,
+  DATADOG_SITE_EU1,
+  DATADOG_SITE_US3,
+  DATADOG_SITE_US5,
+  DATADOG_SITE_AP1,
+  DATADOG_SITE_GOV,
 ]


### PR DESCRIPTION
### What and why?

Git sync has been introduced in a previous version as an optional step. After more thorough testing it seems to work fine so the idea is to now release that as a default. There is still the option to disable it through --no-git-sync, just in case this new sync would fail the command in some setups.

Additionally I kept the `--git-sync` option for backward compatibility, and ignore any error for the gov DC as git sync is not available there yet.

### How?

A brief description of implementation details of this PR.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
