### PR TITLE
synthetics(mobile): Catch invalid application size and add more context in the error message

### DIFF
--- a/src/commands/synthetics/__tests__/mobile.test.ts
+++ b/src/commands/synthetics/__tests__/mobile.test.ts
@@ -151,7 +151,7 @@ describe('uploadMobileApplications', () => {
     })
 
     await expect(mobile.uploadMobileApplications(api, 'new-application-path.api', 'mobileAppUuid')).rejects.toThrow(
-      'Invalid Mobile Application size. Expect a size between 1024B and 1073741824B, got 7B.'
+      `Invalid Mobile Application size. Expect a size between 1 KiB and 1 GiB, got 7 byte(s).`
     )
   })
 })
@@ -194,7 +194,7 @@ describe('shouldUploadApplication', () => {
   })
 })
 
-describe('overrideMobileConfig 1', () => {
+describe('overrideMobileConfig', () => {
   afterAll(() => {
     jest.restoreAllMocks()
   })
@@ -250,7 +250,7 @@ describe('overrideMobileConfig 1', () => {
   })
 })
 
-describe('uploadApplicationAndOverrideConfig 1', () => {
+describe('uploadApplicationAndOverrideConfig', () => {
   const api = getApiHelper()
 
   test('Upload and override for mobile tests', async () => {

--- a/src/commands/synthetics/__tests__/run-test.test.ts
+++ b/src/commands/synthetics/__tests__/run-test.test.ts
@@ -6,6 +6,7 @@ import * as api from '../api'
 import {MAX_TESTS_TO_TRIGGER} from '../command'
 import {CiError, CriticalCiErrorCode, CriticalError} from '../errors'
 import {ExecutionRule, Summary, SyntheticsCIConfig, UserConfigOverride} from '../interfaces'
+import {MIN_APPLICATION_SIZE} from '../mobile'
 import {DefaultReporter} from '../reporters/default'
 import {JUnitReporter} from '../reporters/junit'
 import * as runTests from '../run-test'
@@ -323,8 +324,7 @@ describe('run-test', () => {
       // use /dev/null to create a valid empty fs.ReadStream
       const testStream = fs.createReadStream('/dev/null')
       jest.spyOn(fs, 'createReadStream').mockReturnValue(testStream)
-
-      jest.spyOn(fs.promises, 'readFile').mockImplementation(async () => Buffer.from('aa'))
+      jest.spyOn(fs.promises, 'readFile').mockImplementation(async () => Buffer.alloc(MIN_APPLICATION_SIZE))
 
       const apiHelper = {
         getMobileApplicationPresignedURL: jest.fn(() => MOBILE_PRESIGNED_URL_PAYLOAD),

--- a/src/commands/synthetics/errors.ts
+++ b/src/commands/synthetics/errors.ts
@@ -4,6 +4,7 @@ export type NonCriticalCiErrorCode = typeof nonCriticalErrorCodes[number]
 const criticalErrorCodes = [
   'AUTHORIZATION_ERROR',
   'INVALID_CONFIG',
+  'INVALID_MOBILE_APPLICATION_SIZE',
   'MISSING_API_KEY',
   'MISSING_APP_KEY',
   'POLL_RESULTS_FAILED',

--- a/src/commands/synthetics/mobile.ts
+++ b/src/commands/synthetics/mobile.ts
@@ -34,7 +34,7 @@ export const uploadMobileApplications = async (
   if (fileBufferBytesSize < MIN_APPLICATION_SIZE || MAX_APPLICATION_SIZE < fileBufferBytesSize) {
     throw new CriticalError(
       'INVALID_MOBILE_APPLICATION_SIZE',
-      `Invalid Mobile Application size. Expect a size between ${MIN_APPLICATION_SIZE}B and ${MAX_APPLICATION_SIZE}B, got ${fileBufferBytesSize}B.`
+      `Invalid Mobile Application size. Expect a size between 1 KiB and 1 GiB, got ${fileBufferBytesSize} byte(s).`
     )
   }
 


### PR DESCRIPTION
### What and why?

The synthetics mobile products allow customers to use `mobileApplicationVersionFilePath` option to run tests with custom local application. This option implies an upload to our server via a pre-signed URL. We limit the size of the application to avoid misusage from 1KiB to 1GiB. 

Before this PR, datadog-ci command stops with:

![image](https://user-images.githubusercontent.com/19287532/234861002-741c8058-9c24-48f5-bf25-1b386359d961.png)

This PR adds more context to the error:

![image](https://user-images.githubusercontent.com/19287532/234861151-88cf8ffc-7ba2-4237-b622-b30ff4c7bade.png)

### How?

Add a verification of the size before uploading the application via the pre-signed URL. 

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
