### PR TITLE
s8s(mobile): Compute and forward application size to getMobileApplicationPresignedURL

### DIFF
--- a/src/commands/synthetics/__tests__/api.test.ts
+++ b/src/commands/synthetics/__tests__/api.test.ts
@@ -81,7 +81,7 @@ describe('dd-api', () => {
         shouldBeRetriedOn5xx: true,
       },
       {
-        makeApiRequest: () => api.getMobileApplicationPresignedURL('applicationId', 'md5'),
+        makeApiRequest: () => api.getMobileApplicationPresignedURL('applicationId', 1025, 'md5'),
         name: 'get presigned url' as const,
         shouldBeRetriedOn404: false,
         shouldBeRetriedOn5xx: true,
@@ -157,7 +157,7 @@ describe('dd-api', () => {
       .mockImplementation((() => () => ({data: MOBILE_PRESIGNED_URL_PAYLOAD})) as any)
     const api = apiConstructor(apiConfiguration)
     const {getMobileApplicationPresignedURL} = api
-    const result = await getMobileApplicationPresignedURL('applicationId', 'md5')
+    const result = await getMobileApplicationPresignedURL('applicationId', 1025, 'md5')
     expect(result).toEqual(MOBILE_PRESIGNED_URL_PAYLOAD)
     spy.mockRestore()
   })

--- a/src/commands/synthetics/__tests__/mobile.test.ts
+++ b/src/commands/synthetics/__tests__/mobile.test.ts
@@ -5,15 +5,15 @@ import * as mobile from '../mobile'
 
 import {getApiHelper, getMobileTest, getTestPayload} from './fixtures'
 
-describe('getFileAndMD5HashFromFile', () => {
+describe('getSizeAndMD5HashFromFile', () => {
   test('correctly get size and md5 of a file', async () => {
-    const tmpdir = fs.mkdtempSync('getFileAndMD5HashFromFile')
+    const tmpdir = fs.mkdtempSync('getSizeAndMD5HashFromFile')
     try {
       // write test content to a file in the temporary directory
       const filename = path.join(tmpdir, 'compute_md5_test')
       fs.writeFileSync(filename, '7 bytes')
 
-      expect(await mobile.getFileAndMD5HashFromFile(filename)).toEqual({appSize: 7, md5: 'QCi9PCxLLuyHmU0aRshoeA=='})
+      expect(await mobile.getSizeAndMD5HashFromFile(filename)).toEqual({appSize: 7, md5: 'QCi9PCxLLuyHmU0aRshoeA=='})
     } finally {
       // always clean up created tmpdir
       fs.rmSync(tmpdir, {recursive: true, force: true})

--- a/src/commands/synthetics/__tests__/mobile.test.ts
+++ b/src/commands/synthetics/__tests__/mobile.test.ts
@@ -5,15 +5,15 @@ import * as mobile from '../mobile'
 
 import {getApiHelper, getMobileTest, getTestPayload} from './fixtures'
 
-describe('getMD5HashFromFileBuffer', () => {
-  test('correctly compute md5 of a file', async () => {
-    const tmpdir = fs.mkdtempSync('getMD5HashFromFileBuffer')
+describe('getFileAndMD5HashFromFile', () => {
+  test('correctly get size and md5 of a file', async () => {
+    const tmpdir = fs.mkdtempSync('getFileAndMD5HashFromFile')
     try {
       // write test content to a file in the temporary directory
       const filename = path.join(tmpdir, 'compute_md5_test')
-      fs.writeFileSync(filename, 'Compute md5')
+      fs.writeFileSync(filename, '7 bytes')
 
-      expect(await mobile.getMD5HashFromFile(filename)).toBe('odk1EOlpz16oPIgnco2nfg==')
+      expect(await mobile.getFileAndMD5HashFromFile(filename)).toEqual({appSize: 7, md5: 'QCi9PCxLLuyHmU0aRshoeA=='})
     } finally {
       // always clean up created tmpdir
       fs.rmSync(tmpdir, {recursive: true, force: true})

--- a/src/commands/synthetics/__tests__/run-test.test.ts
+++ b/src/commands/synthetics/__tests__/run-test.test.ts
@@ -308,7 +308,7 @@ describe('run-test', () => {
           global: {mobileApplicationVersionFilePath: 'filePath'},
           publicIds: [mobileTest.public_id],
         })
-      ).rejects.toMatchError(new CriticalError('UPLOAD_MOBILE_APPLICATION_TESTS_FAILED', 'Server Error'))
+      ).rejects.toThrow('Failed to get presigned URL: could not query https://app.datadoghq.com/example')
     })
 
     test('uploadMobileApplication throws', async () => {
@@ -340,7 +340,7 @@ describe('run-test', () => {
           global: {mobileApplicationVersionFilePath: 'filePath'},
           publicIds: [mobileTest.public_id],
         })
-      ).rejects.toMatchError(new CriticalError('UPLOAD_MOBILE_APPLICATION_TESTS_FAILED', 'Server Error'))
+      ).rejects.toThrow('Failed to upload mobile application: could not query https://app.datadoghq.com/example')
     })
 
     test('runTests throws', async () => {

--- a/src/commands/synthetics/api.ts
+++ b/src/commands/synthetics/api.ts
@@ -159,10 +159,10 @@ const getTunnelPresignedURL = (request: (args: AxiosRequestConfig) => AxiosPromi
 
 const getMobileApplicationPresignedURL = (
   request: (args: AxiosRequestConfig) => AxiosPromise<PresignedUrlResponse>
-) => async (applicationId: string, md5: string) => {
+) => async (applicationId: string, appSize: number, md5: string) => {
   const resp = await retryRequest(
     {
-      data: {md5},
+      data: {appSize, md5},
       method: 'POST',
       url: `/synthetics/mobile/applications/${applicationId}/presigned-url`,
     },

--- a/src/commands/synthetics/mobile.ts
+++ b/src/commands/synthetics/mobile.ts
@@ -4,7 +4,7 @@ import fs from 'fs'
 import {APIHelper, EndpointError, formatBackendErrors} from './api'
 import {PresignedUrlResponse, Test, TestPayload, UserConfigOverride} from './interfaces'
 
-export const getFileAndMD5HashFromFile = async (filePath: string): Promise<{appSize: number; md5: string}> => {
+export const getSizeAndMD5HashFromFile = async (filePath: string): Promise<{appSize: number; md5: string}> => {
   const hash = crypto.createHash('md5')
   const fileStream = fs.createReadStream(filePath)
   for await (const chunk of fileStream) {
@@ -19,7 +19,7 @@ export const uploadMobileApplications = async (
   applicationPathToUpload: string,
   mobileApplicationId: string
 ): Promise<string> => {
-  const {appSize, md5} = await getFileAndMD5HashFromFile(applicationPathToUpload)
+  const {appSize, md5} = await getSizeAndMD5HashFromFile(applicationPathToUpload)
 
   let presignedUrlResponse: PresignedUrlResponse
   try {

--- a/src/commands/synthetics/mobile.ts
+++ b/src/commands/synthetics/mobile.ts
@@ -1,17 +1,17 @@
 import * as crypto from 'crypto'
 import fs from 'fs'
 
-import {APIHelper} from './api'
-import {Test, TestPayload, UserConfigOverride} from './interfaces'
+import {APIHelper, EndpointError, formatBackendErrors} from './api'
+import {PresignedUrlResponse, Test, TestPayload, UserConfigOverride} from './interfaces'
 
-export const getMD5HashFromFile = async (file: string): Promise<string> => {
+export const getFileAndMD5HashFromFile = async (filePath: string): Promise<{appSize: number; md5: string}> => {
   const hash = crypto.createHash('md5')
-  const input = fs.createReadStream(file)
-  for await (const chunk of input) {
+  const fileStream = fs.createReadStream(filePath)
+  for await (const chunk of fileStream) {
     hash.update(chunk)
   }
 
-  return hash.digest('base64')
+  return {appSize: fileStream.bytesRead, md5: hash.digest('base64')}
 }
 
 export const uploadMobileApplications = async (
@@ -19,16 +19,23 @@ export const uploadMobileApplications = async (
   applicationPathToUpload: string,
   mobileApplicationId: string
 ): Promise<string> => {
-  const md5 = await getMD5HashFromFile(applicationPathToUpload)
-  const {presigned_url_params: presignedUrl, file_name: fileName} = await api.getMobileApplicationPresignedURL(
-    mobileApplicationId,
-    md5
-  )
+  const {appSize, md5} = await getFileAndMD5HashFromFile(applicationPathToUpload)
+
+  let presignedUrlResponse: PresignedUrlResponse
+  try {
+    presignedUrlResponse = await api.getMobileApplicationPresignedURL(mobileApplicationId, appSize, md5)
+  } catch (e) {
+    throw new EndpointError(`Failed to get presigned URL: ${formatBackendErrors(e)}\n`, e.response?.status)
+  }
 
   const fileBuffer = await fs.promises.readFile(applicationPathToUpload)
-  await api.uploadMobileApplication(fileBuffer, presignedUrl)
+  try {
+    await api.uploadMobileApplication(fileBuffer, presignedUrlResponse.presigned_url_params)
+  } catch (e) {
+    throw new EndpointError(`Failed to upload mobile application: ${formatBackendErrors(e)}\n`, e.response?.status)
+  }
 
-  return fileName
+  return presignedUrlResponse.file_name
 }
 
 export const uploadApplication = async (


### PR DESCRIPTION
### What and why?

- Compute and forward application size to `getMobileApplicationPresignedURL`. The endpoint was changed to verify the app size and send back a pre-signed URL or an error message with context. 
- Add try-catch around `getMobileApplicationPresignedURL` and `uploadMobileApplication`.

### How?

Changing back-end code

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
