### PR TITLE
[lambda] Only change handler path when a layer version is specified

### DIFF
--- a/src/commands/lambda/__tests__/__snapshots__/instrument.test.ts.snap
+++ b/src/commands/lambda/__tests__/__snapshots__/instrument.test.ts.snap
@@ -18,7 +18,6 @@ Will apply the following updates:
 UpdateFunctionConfiguration -> arn:aws:lambda:us-east-1:123456789012:function:lambda-1-us-east-1
 {
   \\"FunctionName\\": \\"arn:aws:lambda:us-east-1:123456789012:function:lambda-1-us-east-1\\",
-  \\"Handler\\": \\"/opt/nodejs/node_modules/datadog-lambda-js/handler.handler\\",
   \\"Environment\\": {
     \\"Variables\\": {
       \\"DD_LAMBDA_HANDLER\\": \\"index.handler\\",
@@ -37,7 +36,6 @@ TagResource -> arn:aws:lambda:us-east-1:123456789012:function:lambda-1-us-east-1
 UpdateFunctionConfiguration -> arn:aws:lambda:us-east-2:123456789012:function:lambda-1-us-east-2
 {
   \\"FunctionName\\": \\"arn:aws:lambda:us-east-2:123456789012:function:lambda-1-us-east-2\\",
-  \\"Handler\\": \\"/opt/nodejs/node_modules/datadog-lambda-js/handler.handler\\",
   \\"Environment\\": {
     \\"Variables\\": {
       \\"DD_LAMBDA_HANDLER\\": \\"index.handler\\",
@@ -167,7 +165,6 @@ Will apply the following updates:
 UpdateFunctionConfiguration -> arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world
 {
   \\"FunctionName\\": \\"arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world\\",
-  \\"Handler\\": \\"/opt/nodejs/node_modules/datadog-lambda-js/handler.handler\\",
   \\"Environment\\": {
     \\"Variables\\": {
       \\"DD_LAMBDA_HANDLER\\": \\"index.handler\\",
@@ -191,7 +188,6 @@ TagResource -> arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world
 UpdateFunctionConfiguration -> arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world-2
 {
   \\"FunctionName\\": \\"arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world-2\\",
-  \\"Handler\\": \\"/opt/nodejs/node_modules/datadog-lambda-js/handler.handler\\",
   \\"Environment\\": {
     \\"Variables\\": {
       \\"DD_LAMBDA_HANDLER\\": \\"index.handler\\",
@@ -242,7 +238,6 @@ Will apply the following updates:
 UpdateFunctionConfiguration -> arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world
 {
   \\"FunctionName\\": \\"arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world\\",
-  \\"Handler\\": \\"/opt/nodejs/node_modules/datadog-lambda-js/handler.handler\\",
   \\"Environment\\": {
     \\"Variables\\": {
       \\"DD_LAMBDA_HANDLER\\": \\"index.handler\\",
@@ -266,7 +261,6 @@ TagResource -> arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world
 UpdateFunctionConfiguration -> arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world-2
 {
   \\"FunctionName\\": \\"arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world-2\\",
-  \\"Handler\\": \\"/opt/nodejs/node_modules/datadog-lambda-js/handler.handler\\",
   \\"Environment\\": {
     \\"Variables\\": {
       \\"DD_LAMBDA_HANDLER\\": \\"index.handler\\",
@@ -349,7 +343,6 @@ exports[`lambda instrument execute prints dry run data for lambda extension laye
 UpdateFunctionConfiguration -> arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world
 {
   \\"FunctionName\\": \\"arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world\\",
-  \\"Handler\\": \\"/opt/nodejs/node_modules/datadog-lambda-js/handler.handler\\",
   \\"Environment\\": {
     \\"Variables\\": {
       \\"DD_LAMBDA_HANDLER\\": \\"index.handler\\",
@@ -478,7 +471,6 @@ Will apply the following updates:
 UpdateFunctionConfiguration -> arn:aws:lambda:us-east-1:123456789012:function:lambda-1-us-east-1
 {
   \\"FunctionName\\": \\"arn:aws:lambda:us-east-1:123456789012:function:lambda-1-us-east-1\\",
-  \\"Handler\\": \\"/opt/nodejs/node_modules/datadog-lambda-js/handler.handler\\",
   \\"Environment\\": {
     \\"Variables\\": {
       \\"DD_LAMBDA_HANDLER\\": \\"index.handler\\",
@@ -497,7 +489,6 @@ TagResource -> arn:aws:lambda:us-east-1:123456789012:function:lambda-1-us-east-1
 UpdateFunctionConfiguration -> arn:aws:lambda:us-east-1:123456789012:function:lambda-2-us-east-1
 {
   \\"FunctionName\\": \\"arn:aws:lambda:us-east-1:123456789012:function:lambda-2-us-east-1\\",
-  \\"Handler\\": \\"/opt/nodejs/node_modules/datadog-lambda-js/handler.handler\\",
   \\"Environment\\": {
     \\"Variables\\": {
       \\"DD_LAMBDA_HANDLER\\": \\"index.handler\\",
@@ -516,7 +507,6 @@ TagResource -> arn:aws:lambda:us-east-1:123456789012:function:lambda-2-us-east-1
 UpdateFunctionConfiguration -> arn:aws:lambda:us-east-1:123456789012:function:lambda-3-us-east-1
 {
   \\"FunctionName\\": \\"arn:aws:lambda:us-east-1:123456789012:function:lambda-3-us-east-1\\",
-  \\"Handler\\": \\"/opt/nodejs/node_modules/datadog-lambda-js/handler.handler\\",
   \\"Environment\\": {
     \\"Variables\\": {
       \\"DD_LAMBDA_HANDLER\\": \\"index.handler\\",
@@ -535,7 +525,6 @@ TagResource -> arn:aws:lambda:us-east-1:123456789012:function:lambda-3-us-east-1
 UpdateFunctionConfiguration -> arn:aws:lambda:us-east-2:123456789012:function:lambda-1-us-east-2
 {
   \\"FunctionName\\": \\"arn:aws:lambda:us-east-2:123456789012:function:lambda-1-us-east-2\\",
-  \\"Handler\\": \\"/opt/nodejs/node_modules/datadog-lambda-js/handler.handler\\",
   \\"Environment\\": {
     \\"Variables\\": {
       \\"DD_LAMBDA_HANDLER\\": \\"index.handler\\",
@@ -554,7 +543,6 @@ TagResource -> arn:aws:lambda:us-east-2:123456789012:function:lambda-1-us-east-2
 UpdateFunctionConfiguration -> arn:aws:lambda:us-east-2:123456789012:function:lambda-2-us-east-2
 {
   \\"FunctionName\\": \\"arn:aws:lambda:us-east-2:123456789012:function:lambda-2-us-east-2\\",
-  \\"Handler\\": \\"/opt/nodejs/node_modules/datadog-lambda-js/handler.handler\\",
   \\"Environment\\": {
     \\"Variables\\": {
       \\"DD_LAMBDA_HANDLER\\": \\"index.handler\\",
@@ -573,7 +561,6 @@ TagResource -> arn:aws:lambda:us-east-2:123456789012:function:lambda-2-us-east-2
 UpdateFunctionConfiguration -> arn:aws:lambda:us-east-2:123456789012:function:lambda-3-us-east-2
 {
   \\"FunctionName\\": \\"arn:aws:lambda:us-east-2:123456789012:function:lambda-3-us-east-2\\",
-  \\"Handler\\": \\"/opt/nodejs/node_modules/datadog-lambda-js/handler.handler\\",
   \\"Environment\\": {
     \\"Variables\\": {
       \\"DD_LAMBDA_HANDLER\\": \\"index.handler\\",
@@ -618,7 +605,6 @@ Will apply the following updates:
 UpdateFunctionConfiguration -> arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world
 {
   \\"FunctionName\\": \\"arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world\\",
-  \\"Handler\\": \\"/opt/nodejs/node_modules/datadog-lambda-js/handler.handler\\",
   \\"Environment\\": {
     \\"Variables\\": {
       \\"DD_LAMBDA_HANDLER\\": \\"index.handler\\",
@@ -665,7 +651,6 @@ Will apply the following updates:
 UpdateFunctionConfiguration -> arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world
 {
   \\"FunctionName\\": \\"arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world\\",
-  \\"Handler\\": \\"/opt/nodejs/node_modules/datadog-lambda-js/handler.handler\\",
   \\"Environment\\": {
     \\"Variables\\": {
       \\"DD_LAMBDA_HANDLER\\": \\"index.handler\\",

--- a/src/commands/lambda/__tests__/__snapshots__/uninstrument.test.ts.snap
+++ b/src/commands/lambda/__tests__/__snapshots__/uninstrument.test.ts.snap
@@ -18,7 +18,6 @@ Will apply the following updates:
 UpdateFunctionConfiguration -> arn:aws:lambda:us-east-1:123456789012:function:lambda-1-us-east-1
 {
   \\"FunctionName\\": \\"arn:aws:lambda:us-east-1:123456789012:function:lambda-1-us-east-1\\",
-  \\"Handler\\": \\"/opt/nodejs/node_modules/datadog-lambda-js/handler.handler\\",
   \\"Environment\\": {
     \\"Variables\\": {
       \\"DD_LAMBDA_HANDLER\\": \\"index.handler\\",
@@ -37,7 +36,6 @@ TagResource -> arn:aws:lambda:us-east-1:123456789012:function:lambda-1-us-east-1
 UpdateFunctionConfiguration -> arn:aws:lambda:us-east-2:123456789012:function:lambda-1-us-east-2
 {
   \\"FunctionName\\": \\"arn:aws:lambda:us-east-2:123456789012:function:lambda-1-us-east-2\\",
-  \\"Handler\\": \\"/opt/nodejs/node_modules/datadog-lambda-js/handler.handler\\",
   \\"Environment\\": {
     \\"Variables\\": {
       \\"DD_LAMBDA_HANDLER\\": \\"index.handler\\",
@@ -82,7 +80,6 @@ Will apply the following updates:
 UpdateFunctionConfiguration -> arn:aws:lambda:us-east-1:123456789012:function:lambda-1-us-east-1
 {
   \\"FunctionName\\": \\"arn:aws:lambda:us-east-1:123456789012:function:lambda-1-us-east-1\\",
-  \\"Handler\\": \\"/opt/nodejs/node_modules/datadog-lambda-js/handler.handler\\",
   \\"Environment\\": {
     \\"Variables\\": {
       \\"DD_LAMBDA_HANDLER\\": \\"index.handler\\",
@@ -101,7 +98,6 @@ TagResource -> arn:aws:lambda:us-east-1:123456789012:function:lambda-1-us-east-1
 UpdateFunctionConfiguration -> arn:aws:lambda:us-east-1:123456789012:function:lambda-2-us-east-1
 {
   \\"FunctionName\\": \\"arn:aws:lambda:us-east-1:123456789012:function:lambda-2-us-east-1\\",
-  \\"Handler\\": \\"/opt/nodejs/node_modules/datadog-lambda-js/handler.handler\\",
   \\"Environment\\": {
     \\"Variables\\": {
       \\"DD_LAMBDA_HANDLER\\": \\"index.handler\\",
@@ -120,7 +116,6 @@ TagResource -> arn:aws:lambda:us-east-1:123456789012:function:lambda-2-us-east-1
 UpdateFunctionConfiguration -> arn:aws:lambda:us-east-1:123456789012:function:lambda-3-us-east-1
 {
   \\"FunctionName\\": \\"arn:aws:lambda:us-east-1:123456789012:function:lambda-3-us-east-1\\",
-  \\"Handler\\": \\"/opt/nodejs/node_modules/datadog-lambda-js/handler.handler\\",
   \\"Environment\\": {
     \\"Variables\\": {
       \\"DD_LAMBDA_HANDLER\\": \\"index.handler\\",
@@ -139,7 +134,6 @@ TagResource -> arn:aws:lambda:us-east-1:123456789012:function:lambda-3-us-east-1
 UpdateFunctionConfiguration -> arn:aws:lambda:us-east-2:123456789012:function:lambda-1-us-east-2
 {
   \\"FunctionName\\": \\"arn:aws:lambda:us-east-2:123456789012:function:lambda-1-us-east-2\\",
-  \\"Handler\\": \\"/opt/nodejs/node_modules/datadog-lambda-js/handler.handler\\",
   \\"Environment\\": {
     \\"Variables\\": {
       \\"DD_LAMBDA_HANDLER\\": \\"index.handler\\",
@@ -158,7 +152,6 @@ TagResource -> arn:aws:lambda:us-east-2:123456789012:function:lambda-1-us-east-2
 UpdateFunctionConfiguration -> arn:aws:lambda:us-east-2:123456789012:function:lambda-2-us-east-2
 {
   \\"FunctionName\\": \\"arn:aws:lambda:us-east-2:123456789012:function:lambda-2-us-east-2\\",
-  \\"Handler\\": \\"/opt/nodejs/node_modules/datadog-lambda-js/handler.handler\\",
   \\"Environment\\": {
     \\"Variables\\": {
       \\"DD_LAMBDA_HANDLER\\": \\"index.handler\\",
@@ -177,7 +170,6 @@ TagResource -> arn:aws:lambda:us-east-2:123456789012:function:lambda-2-us-east-2
 UpdateFunctionConfiguration -> arn:aws:lambda:us-east-2:123456789012:function:lambda-3-us-east-2
 {
   \\"FunctionName\\": \\"arn:aws:lambda:us-east-2:123456789012:function:lambda-3-us-east-2\\",
-  \\"Handler\\": \\"/opt/nodejs/node_modules/datadog-lambda-js/handler.handler\\",
   \\"Environment\\": {
     \\"Variables\\": {
       \\"DD_LAMBDA_HANDLER\\": \\"index.handler\\",

--- a/src/commands/lambda/__tests__/functions/instrument.part1.test.ts
+++ b/src/commands/lambda/__tests__/functions/instrument.part1.test.ts
@@ -45,6 +45,37 @@ describe('instrument', () => {
     afterAll(() => {
       process.env = OLD_ENV
     })
+
+    test('does not redirect handler when no version is specified', async () => {
+      const functionConfiguration: LFunctionConfiguration = {
+        FunctionArn: 'arn:aws:lambda:us-east-1:000000000000:function:autoinstrument',
+        Handler: 'index.handler',
+        Runtime: 'nodejs12.x',
+      }
+      mockLambdaConfigurations(lambdaClientMock, {
+        'arn:aws:lambda:us-east-1:000000000000:function:autoinstrument': {
+          config: functionConfiguration,
+        },
+      })
+
+      const settings = {
+        flushMetricsToLogs: false,
+        // No layerVersion specified
+        mergeXrayTraces: false,
+        tracingEnabled: false,
+      }
+
+      const result = await getInstrumentedFunctionConfig(
+        lambdaClientMock as any,
+        cloudWatchLogsClientMock as any,
+        functionConfiguration,
+        'us-east-1',
+        settings
+      )
+
+      expect(result.updateFunctionConfigurationCommandInput?.Handler).toEqual('index.handler')
+    })
+
     test('throws an error when it encounters an unsupported runtime', async () => {
       mockLambdaConfigurations(lambdaClientMock, {
         'arn:aws:lambda:us-east-1:000000000000:function:autoinstrument': {

--- a/src/commands/lambda/__tests__/functions/instrument.part1.test.ts
+++ b/src/commands/lambda/__tests__/functions/instrument.part1.test.ts
@@ -73,7 +73,8 @@ describe('instrument', () => {
         settings
       )
 
-      expect(result.updateFunctionConfigurationCommandInput?.Handler).toEqual('index.handler')
+      // No change to Handler needed so it's not in the update params
+      expect(result.updateFunctionConfigurationCommandInput?.Handler).toBeUndefined()
     })
 
     test('throws an error when it encounters an unsupported runtime', async () => {

--- a/src/commands/lambda/__tests__/functions/instrument.part2.test.ts
+++ b/src/commands/lambda/__tests__/functions/instrument.part2.test.ts
@@ -279,7 +279,6 @@ describe('instrument', () => {
             },
           },
           "FunctionName": "arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world",
-          "Handler": "datadog_lambda.handler.handler",
         }
       `)
     })
@@ -313,7 +312,6 @@ describe('instrument', () => {
             },
           },
           "FunctionName": "arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world",
-          "Handler": "datadog_lambda.handler.handler",
           "Layers": Array [
             "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Extension:13",
           ],
@@ -350,7 +348,6 @@ describe('instrument', () => {
             },
           },
           "FunctionName": "arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world",
-          "Handler": "datadog_lambda.handler.handler",
         }
       `)
     })
@@ -384,7 +381,6 @@ describe('instrument', () => {
             },
           },
           "FunctionName": "arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world",
-          "Handler": "datadog_lambda.handler.handler",
         }
       `)
     })

--- a/src/commands/lambda/functions/instrument.ts
+++ b/src/commands/lambda/functions/instrument.ts
@@ -182,7 +182,7 @@ export const calculateUpdateRequest = async (
   }
 
   // Update Python Handler
-  if (runtimeType === RuntimeType.PYTHON) {
+  if (runtimeType === RuntimeType.PYTHON && settings.layerVersion !== undefined) {
     const expectedHandler = PYTHON_HANDLER_LOCATION
     if (config.Handler !== expectedHandler) {
       needsUpdate = true
@@ -191,7 +191,7 @@ export const calculateUpdateRequest = async (
   }
 
   // Update Node Handler
-  if (runtimeType === RuntimeType.NODE) {
+  if (runtimeType === RuntimeType.NODE && settings.layerVersion !== undefined) {
     const expectedHandler = NODE_HANDLER_LOCATION
     if (config.Handler !== expectedHandler) {
       needsUpdate = true


### PR DESCRIPTION
### What and why?
We found a bug where the handler path would change incorrectlly when no layer is set

### How?
Checks that a layer version is set before changing the Handler of a function

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
