### PR TITLE
[lambda] fix tags regex to comply with Datadog tagging

### DIFF
--- a/src/commands/lambda/__tests__/functions/commons.test.ts
+++ b/src/commands/lambda/__tests__/functions/commons.test.ts
@@ -589,7 +589,7 @@ describe('commons', () => {
   })
   describe('sentenceMatchesRegEx', () => {
     const tags: [string, boolean][] = [
-      ['not-complying:regex-should-fail', false],
+      ['not@complying:regex-should-fail', false],
       ['1first-char-is-number:should-fail', false],
       ['_also-not-complying:should-fail', false],
       ['complying_tag:accepted/with/slashes.and.dots,but-empty-tag', false],
@@ -599,6 +599,9 @@ describe('commons', () => {
       ['complying:alone', true],
       ['one_divided_by_two:1/2,one_divided_by_four:0.25,three_minus_one_half:3-1/2', true],
       ['this_is_a_valid_t4g:yes/it.is-42', true],
+      // multiple colons, periods in tag, slashes in tag
+      ['env-staging:east:staging,version.minor:1,version.major:3.4/v3,category/service:not/defined', true],
+      ['email:user@email.com,numb3r:t', true],
     ]
     test.each(tags)('check if the tags match the expected result from the regex', (tag, expectedResult) => {
       const result = !!sentenceMatchesRegEx(tag, EXTRA_TAGS_REG_EXP)

--- a/src/commands/lambda/__tests__/instrument.test.ts
+++ b/src/commands/lambda/__tests__/instrument.test.ts
@@ -1578,7 +1578,7 @@ describe('lambda', () => {
         command['config']['service'] = 'middletier'
         command['config']['environment'] = 'staging'
         command['config']['version'] = '0.2'
-        command['config']['extraTags'] = 'not-complying:illegal-chars-in-key,complies:valid-pair'
+        command['config']['extraTags'] = 'not@complying:illegal-chars-in-key,complies:valid-pair'
         command['getSettings']()
         const output = command.context.stdout.toString()
         expect(output).toMatch('[Error] Extra tags do not comply with the <key>:<value> array.\n')

--- a/src/commands/lambda/constants.ts
+++ b/src/commands/lambda/constants.ts
@@ -109,7 +109,7 @@ export const MAX_LAMBDA_STATE_CHECK_ATTEMPTS = 3
 // This RegExp ensures that the --extra-tags string
 // matches a list of <key>:<value> separated by commas
 // such as: layer:api,team:intake
-export const EXTRA_TAGS_REG_EXP = /^(([a-zA-Z]+)[\w\-\/\.]*:[^,]+)+((\,)([a-zA-Z]+)[\w\-\/\.]*:[^,]+)*$/g
+export const EXTRA_TAGS_REG_EXP = /^(([a-zA-Z]+)[\w\-/\.]*:[^,]+)+((\,)([a-zA-Z]+)[\w\-/\.]*:[^,]+)*$/g
 export const AWS_ACCESS_KEY_ID_REG_EXP = /(?<![A-Z0-9])[A-Z0-9]{20}(?![A-Z0-9])/g
 export const AWS_SECRET_ACCESS_KEY_REG_EXP = /(?<![A-Za-z0-9/+=])[A-Za-z0-9/+=]{40}(?![A-Za-z0-9/+=])/g
 export const AWS_SECRET_ARN_REG_EXP = /arn:aws:secretsmanager:[\w-]+:\d{12}:secret:.+/

--- a/src/commands/lambda/constants.ts
+++ b/src/commands/lambda/constants.ts
@@ -109,7 +109,7 @@ export const MAX_LAMBDA_STATE_CHECK_ATTEMPTS = 3
 // This RegExp ensures that the --extra-tags string
 // matches a list of <key>:<value> separated by commas
 // such as: layer:api,team:intake
-export const EXTRA_TAGS_REG_EXP = /^(([a-zA-Z]+)\w+:[\w\-/\.]+)+((\,)([a-zA-Z]+)\w+:[\w\-/\.]+)*$/g
+export const EXTRA_TAGS_REG_EXP = /^(([a-zA-Z]+)[\w\-\/\.]*:[^,]+)+((\,)([a-zA-Z]+)[\w\-\/\.]*:[^,]+)*$/g
 export const AWS_ACCESS_KEY_ID_REG_EXP = /(?<![A-Z0-9])[A-Z0-9]{20}(?![A-Z0-9])/g
 export const AWS_SECRET_ACCESS_KEY_REG_EXP = /(?<![A-Za-z0-9/+=])[A-Za-z0-9/+=]{40}(?![A-Za-z0-9/+=])/g
 export const AWS_SECRET_ARN_REG_EXP = /arn:aws:secretsmanager:[\w-]+:\d{12}:secret:.+/


### PR DESCRIPTION
### What and why?

Our tag check was not compliant with Datadog's [tag definition](https://docs.datadoghq.com/getting_started/tagging/#define-tags).

This PR changes the regular expression to make sure we allow values as described there.

### How?

Updates the regex. Update test and more use cases.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
