### PR TITLE
Upload JS sourcemaps with GZIP encoding

### DIFF
--- a/src/commands/sourcemaps/upload.ts
+++ b/src/commands/sourcemaps/upload.ts
@@ -314,6 +314,7 @@ export class UploadCommand extends Command {
           this.context.stdout.write(renderUpload(sourcemap))
         },
         retries: 5,
+        useGzip: true,
       })
     }
   }


### PR DESCRIPTION
### What and why?

This small PR makes upload of JS source maps to use `gzip` encoding, as it was done previously for Flutter and React Native source maps uploads in https://github.com/DataDog/datadog-ci/pull/801.

Note: I didn't test it E2E (that upload is working and mapping file can be processed for the error), I will appreciate if @DataDog/rum-browser does this check.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
