### PR TITLE
Show validation errors on SARIF command

### DIFF
--- a/src/commands/sarif/__tests__/fixtures/invalid-result.sarif
+++ b/src/commands/sarif/__tests__/fixtures/invalid-result.sarif
@@ -1,0 +1,57 @@
+{
+  "version": "2.1.0",
+  "$schema": "http://json.schemastore.org/sarif-2.1.0-rtm.5",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "name": "ESLint",
+          "informationUri": "https://eslint.org",
+          "rules": [
+            {
+              "id": "@typescript-eslint/no-unused-vars",
+              "helpUri": "https://github.com/typescript-eslint/typescript-eslint/blob/v4.33.0/packages/eslint-plugin/docs/rules/no-unused-vars.md",
+              "properties": {
+                "category": "Variables"
+              },
+              "shortDescription": {
+                "text": "Disallow unused variables"
+              }
+            }
+          ],
+          "version": "7.32.0"
+        }
+      },
+      "artifacts": [
+        {
+          "location": {
+            "uri": "file:///foo/bar/myfile.test.ts"
+          }
+        }
+      ],
+      "results": [
+        {
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "file:///foo/bar/myfile.test.ts",
+                  "index": 0
+                },
+                "region": {
+                  "startLine": 7,
+                  "startColumn": 7,
+                  "endLine": 7,
+                  "endColumn": 14
+                }
+              }
+            }
+          ],
+          "ruleId": "@typescript-eslint/no-unused-vars",
+          "ruleIndex": 0
+        }
+      ]
+    }
+  ]
+}

--- a/src/commands/sarif/__tests__/upload.test.ts
+++ b/src/commands/sarif/__tests__/upload.test.ts
@@ -78,6 +78,12 @@ describe('upload', () => {
           'Unexpected token h in JSON at position 1'
         )
       )
+      expect(output).toContain(
+        renderInvalidFile(
+          './src/commands/sarif/__tests__/fixtures/invalid-result.sarif',
+          "/runs/0/results/0: must have required property 'message'"
+        )
+      )
     })
     test('should allow single files', async () => {
       const context = createMockContext()

--- a/src/commands/sarif/upload.ts
+++ b/src/commands/sarif/upload.ts
@@ -1,6 +1,8 @@
 import fs from 'fs'
 import path from 'path'
 
+import type {ErrorObject} from 'ajv'
+
 import Ajv from 'ajv'
 import addFormats from 'ajv-formats'
 import chalk from 'chalk'
@@ -32,7 +34,7 @@ import {getBaseIntakeUrl} from './utils'
 const errorCodesStopUpload = [400, 403]
 
 const validateSarif = (sarifReportPath: string) => {
-  const ajv = new Ajv()
+  const ajv = new Ajv({allErrors: true})
   addFormats(ajv)
   const sarifJsonSchemaValidate = ajv.compile(sarifJsonSchema)
   try {
@@ -40,8 +42,11 @@ const validateSarif = (sarifReportPath: string) => {
     const valid = sarifJsonSchemaValidate(sarifReportContent)
     if (!valid) {
       const errors = sarifJsonSchemaValidate.errors || []
+      const errorMessages = errors.map((error: ErrorObject) => {
+        return `${error.instancePath}: ${error.message}`
+      })
 
-      return errors.toString()
+      return '\n' + errorMessages.join('\n')
     }
   } catch (error) {
     return error.message

--- a/src/commands/sarif/upload.ts
+++ b/src/commands/sarif/upload.ts
@@ -46,7 +46,7 @@ const validateSarif = (sarifReportPath: string) => {
         return `${error.instancePath}: ${error.message}`
       })
 
-      return '\n' + errorMessages.join('\n')
+      return errorMessages.join('\n')
     }
   } catch (error) {
     return error.message


### PR DESCRIPTION
### What and why?

This PR fixes the logic to show the validation errors when the `sarif upload` command is used.

### How?

Join strings composed by `instancePath` and `message` to build the final message.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
