### PR TITLE
v2.11.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci",
-  "version": "2.10.0",
+  "version": "2.11.0",
   "description": "Run datadog actions from the CI.",
   "repository": "https://github.com/DataDog/datadog-ci",
   "license": "Apache-2.0",


### PR DESCRIPTION
## What's Changed

- [lambda] update how AWS credentials are handled #841 
- [lambda] add java17 in layer and runtime lookup #877 
- [static-analysis] Show validation errors on SARIF command #874 
- [synthetics-mobile] Compute and forward application size to getMobileApplicationPresignedURL #857 
- [lambda] fix tags regex to comply with Datadog tagging #863
- [lambda] Only change handler path when a layer version is specified #862 
- [lambda] Add python 3.10 instrumentation support #858 
- [ci-visibility] Add --metrics and DD_METRICS options #787 

**Full Changelog**: https://github.com/DataDog/datadog-ci/compare/v2.10.0...v2.11.0