### PR TITLE
[lambda] update instrumentation for Ruby

### DIFF
--- a/src/commands/lambda/__tests__/__snapshots__/instrument.test.ts.snap
+++ b/src/commands/lambda/__tests__/__snapshots__/instrument.test.ts.snap
@@ -288,6 +288,44 @@ TagResource -> arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world
 "
 `;
 
+exports[`lambda instrument execute instruments Ruby application properly 1`] = `
+"
+[Dry Run] 🐶 Instrumenting Lambda function
+
+[Warning] Instrument your Lambda functions in a dev or staging environment first. Should the instrumentation result be unsatisfactory, run \`uninstrument\` with the same arguments to revert the changes.
+
+[!] Functions to be updated:
+	- arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world
+
+[Dry Run] Will apply the following updates:
+UpdateFunctionConfiguration -> arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world
+{
+  \\"FunctionName\\": \\"arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world\\",
+  \\"Environment\\": {
+    \\"Variables\\": {
+      \\"DD_API_KEY\\": \\"1234\\",
+      \\"DD_SITE\\": \\"datadoghq.com\\",
+      \\"DD_CAPTURE_LAMBDA_PAYLOAD\\": \\"false\\",
+      \\"DD_ENV\\": \\"staging\\",
+      \\"DD_TAGS\\": \\"layer:api,team:intake\\",
+      \\"DD_MERGE_XRAY_TRACES\\": \\"false\\",
+      \\"DD_SERVICE\\": \\"middletier\\",
+      \\"DD_TRACE_ENABLED\\": \\"true\\",
+      \\"DD_VERSION\\": \\"0.2\\"
+    }
+  },
+  \\"Layers\\": [
+    \\"arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Extension:40\\",
+    \\"arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Ruby2-7:19\\"
+  ]
+}
+TagResource -> arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world
+{
+  \\"dd_sls_ci\\": \\"vXXXX\\"
+}
+"
+`;
+
 exports[`lambda instrument execute prints dry run data for lambda .NET layer 1`] = `
 "
 [Dry Run] 🐶 Instrumenting Lambda function

--- a/src/commands/lambda/__tests__/instrument.test.ts
+++ b/src/commands/lambda/__tests__/instrument.test.ts
@@ -1073,7 +1073,7 @@ describe('lambda', () => {
 `)
       })
 
-      test('aborts early when a layer version is set for Ruby', async () => {
+      test('instruments Ruby application properly', async () => {
         ;(fs.readFile as any).mockImplementation((a: any, b: any, callback: any) => callback({code: 'ENOENT'}))
         mockLambdaConfigurations(lambdaClientMock, {
           'arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world': {
@@ -1094,8 +1094,10 @@ describe('lambda', () => {
             '-f',
             functionARN,
             '--dry',
-            '-v',
+            '-e',
             '40',
+            '-v',
+            '19',
             '--extra-tags',
             'layer:api,team:intake',
             '--service',
@@ -1109,12 +1111,8 @@ describe('lambda', () => {
           context
         )
         const output = context.stdout.toString()
-        expect(code).toBe(1)
-        expect(output).toMatchInlineSnapshot(`
-"\n[Dry Run] 🐶 Instrumenting Lambda function
-[Error] Couldn't fetch Lambda functions. Error: Only the --extension-version argument should be set for the ruby2.7 runtime. Please remove the --layer-version argument from the instrument command.
-"
-`)
+        expect(code).toBe(0)
+        expect(output).toMatchSnapshot()
       })
 
       test('aborts early when a layer version is set for a Custom runtime', async () => {

--- a/src/commands/lambda/constants.ts
+++ b/src/commands/lambda/constants.ts
@@ -16,7 +16,7 @@ export const LAYER_LOOKUP = {
   'python3.8': 'Datadog-Python38',
   'python3.9': 'Datadog-Python39',
   'python3.10': 'Datadog-Python310',
-  'ruby2.7': 'Datadog-Ruby2-7'
+  'ruby2.7': 'Datadog-Ruby2-7',
 } as const
 
 export enum RuntimeType {

--- a/src/commands/lambda/constants.ts
+++ b/src/commands/lambda/constants.ts
@@ -16,6 +16,7 @@ export const LAYER_LOOKUP = {
   'python3.8': 'Datadog-Python38',
   'python3.9': 'Datadog-Python39',
   'python3.10': 'Datadog-Python310',
+  'ruby2.7': 'Datadog-Ruby2-7'
 } as const
 
 export enum RuntimeType {
@@ -49,7 +50,7 @@ export const RUNTIME_LOOKUP = {
 
 export type Runtime = keyof typeof RUNTIME_LOOKUP
 export type LayerKey = keyof typeof LAYER_LOOKUP
-export const ARM_LAYERS = [EXTENSION_LAYER_KEY, 'dotnet6', 'python3.8', 'python3.9', 'python3.10']
+export const ARM_LAYERS = [EXTENSION_LAYER_KEY, 'dotnet6', 'python3.8', 'python3.9', 'python3.10', 'ruby2.']
 export const ARM64_ARCHITECTURE = 'arm64'
 export const ARM_LAYER_SUFFIX = '-ARM'
 

--- a/src/commands/lambda/functions/instrument.ts
+++ b/src/commands/lambda/functions/instrument.ts
@@ -173,7 +173,7 @@ export const calculateUpdateRequest = async (
   let needsUpdate = false
   const runtimeType = RUNTIME_LOOKUP[runtime]
 
-  if (runtimeType === RuntimeType.CUSTOM || runtimeType === RuntimeType.RUBY) {
+  if (runtimeType === RuntimeType.CUSTOM) {
     if (settings.layerVersion !== undefined) {
       throw new Error(
         `Only the --extension-version argument should be set for the ${runtime} runtime. Please remove the --layer-version argument from the instrument command.`


### PR DESCRIPTION
### What and why?

Instrumentation for Ruby now allows users to use the Extension and the Library Layer.
ARM is now supported for instrumentation too.

– 
Users can still use the forwarder as an option too.

### How?

Adding runtime into layer and architecture lookups.

### Testing

- Added tets
- Tested manually

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
