### PR TITLE
[lambda] deprecate `ruby2.5`

### DIFF
--- a/src/commands/lambda/constants.ts
+++ b/src/commands/lambda/constants.ts
@@ -44,7 +44,6 @@ export const RUNTIME_LOOKUP = {
   'python3.8': RuntimeType.PYTHON,
   'python3.9': RuntimeType.PYTHON,
   'python3.10': RuntimeType.PYTHON,
-  'ruby2.5': RuntimeType.RUBY,
   'ruby2.7': RuntimeType.RUBY,
 }
 


### PR DESCRIPTION
### What and why?

Removes support for `ruby2.5` instrumentation
This runtime has been deprecated by AWS (phase 2).

### How?

Removing it from the runtime lookups.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
