### PR TITLE
Changing gate command exit status based on gate evaluation result

### DIFF
--- a/src/commands/gate/__tests__/evaluate.test.ts
+++ b/src/commands/gate/__tests__/evaluate.test.ts
@@ -23,7 +23,7 @@ describe('evaluate', () => {
     })
   })
   describe('handleEvaluationResponse', () => {
-    test('Should fail the command if gate evaluation failed', () => {
+    test('should fail the command if gate evaluation failed', () => {
       const write = jest.fn()
       const command = new GateEvaluateCommand()
       command.context = {stdout: {write}} as any
@@ -34,7 +34,7 @@ describe('evaluate', () => {
       }
       expect(command['handleEvaluationResponse'].bind(command).call({}, response)).toEqual(1)
     })
-    test('Should pass the command if gate evaluation passed', () => {
+    test('should pass the command if gate evaluation passed', () => {
       const write = jest.fn()
       const command = new GateEvaluateCommand()
       command.context = {stdout: {write}} as any
@@ -45,7 +45,7 @@ describe('evaluate', () => {
       }
       expect(command['handleEvaluationResponse'].bind(command).call({}, response)).toEqual(0)
     })
-    test('Should pass the command on empty evaluation status by default', () => {
+    test('should pass the command on empty evaluation status by default', () => {
       const write = jest.fn()
       const command = new GateEvaluateCommand()
       command.context = {stdout: {write}} as any
@@ -57,7 +57,7 @@ describe('evaluate', () => {
       expect(command['handleEvaluationResponse'].bind(command).call({}, response)).toEqual(0)
       expect(write.mock.calls[0][0]).toContain('No matching rules were found in Datadog')
     })
-    test('Should fail the command on empty result if the override option is provided', () => {
+    test('should fail the command on empty result if the override option is provided', () => {
       const write = jest.fn()
       const command = new GateEvaluateCommand()
       command['failOnEmpty'] = true

--- a/src/commands/gate/__tests__/evaluate.test.ts
+++ b/src/commands/gate/__tests__/evaluate.test.ts
@@ -1,4 +1,5 @@
 import {GateEvaluateCommand} from '../evaluate'
+import {EvaluationResponse} from '../interfaces'
 
 describe('evaluate', () => {
   describe('getApiHelper', () => {
@@ -21,5 +22,53 @@ describe('evaluate', () => {
       expect(write.mock.calls[0][0]).toContain('DATADOG_APP_KEY')
     })
   })
-  // TODO add tests for the call to evaluate rules
+  describe('handleEvaluationResponse', () => {
+    test('Should fail the command if gate evaluation failed', () => {
+      const write = jest.fn()
+      const command = new GateEvaluateCommand()
+      command.context = {stdout: {write}} as any
+
+      const response: EvaluationResponse = {
+        status: 'failed',
+        rule_evaluations: [],
+      }
+      expect(command['handleEvaluationResponse'].bind(command).call({}, response)).toEqual(1)
+    })
+    test('Should pass the command if gate evaluation passed', () => {
+      const write = jest.fn()
+      const command = new GateEvaluateCommand()
+      command.context = {stdout: {write}} as any
+
+      const response: EvaluationResponse = {
+        status: 'passed',
+        rule_evaluations: [],
+      }
+      expect(command['handleEvaluationResponse'].bind(command).call({}, response)).toEqual(0)
+    })
+    test('Should pass the command on empty evaluation status by default', () => {
+      const write = jest.fn()
+      const command = new GateEvaluateCommand()
+      command.context = {stdout: {write}} as any
+
+      const response: EvaluationResponse = {
+        status: 'empty',
+        rule_evaluations: [],
+      }
+      expect(command['handleEvaluationResponse'].bind(command).call({}, response)).toEqual(0)
+      expect(write.mock.calls[0][0]).toContain('No matching rules were found in Datadog')
+    })
+    test('Should fail the command on empty result if the override option is provided', () => {
+      const write = jest.fn()
+      const command = new GateEvaluateCommand()
+      command['failOnEmpty'] = true
+      command.context = {stdout: {write}} as any
+
+      const response: EvaluationResponse = {
+        status: 'empty',
+        rule_evaluations: [],
+      }
+      expect(command['handleEvaluationResponse'].bind(command).call({}, response)).toEqual(1)
+      expect(write.mock.calls[0][0]).toContain('No matching rules were found in Datadog')
+    })
+  })
 })

--- a/src/commands/gate/renderer.ts
+++ b/src/commands/gate/renderer.ts
@@ -29,7 +29,9 @@ export const renderEvaluationResponse = (evaluationResponse: EvaluationResponse)
 }
 
 export const renderEmptyEvaluation = (): string => {
-  return chalk.yellow('No matching rules were found in Datadog for the current pipeline.\n')
+  return chalk.yellow(
+    `${ICONS.WARNING} No matching rules were found in Datadog. Use the '--fail-on-empty' option to fail the command in this situation.\n`
+  )
 }
 
 export const renderStatus = (result: string): string => {
@@ -65,7 +67,7 @@ export const renderDryRunEvaluation = (): string => {
   return chalk.yellow('Dry run mode is enabled. Not evaluating the rules.')
 }
 
-export const renderGateEvaluation = (spanTags: SpanTags): string => {
+export const renderGateEvaluationInput = (spanTags: SpanTags): string => {
   let fullStr = chalk.bold(`${ICONS.INFO} Evaluating rules matching the following information:\n`)
   fullStr += `Repository: ${spanTags['git.repository_url']}\n`
   fullStr += `Branch: ${spanTags['git.branch']}\n`


### PR DESCRIPTION
### What and why?

Changing the result exit status based on the gate evaluation result:

- Passed -> successful command
- Failed -> failed command
- Empty -> successful command unless `--fail-on-empty` is specified

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
