### PR TITLE
Fix format issue on the stepfunction command README.md

### DIFF
--- a/src/commands/stepfunctions/README.md
+++ b/src/commands/stepfunctions/README.md
@@ -14,12 +14,10 @@ If logging is not enabled on a Step Function, a log group will be created and th
 
 ```bash
 datadog-ci stepfunctions instrument --step-function <step-function-arn> --forwarder <forwarder-arn> [--service] [--env] [--dry-run]
-
-Run the `uninstrument` command to unsubscribe a Step Function log group from the specified Datadog Forwarder. The log group will not be deleted and the Step Function will continue to log to the AWS log group.
 ```
 
 ### `uninstrument`
-Run `uninstrument` command to remove Step Functions log groups subscription filter created by Datadog-CI.
+Run the `uninstrument` command to unsubscribe a Step Function log group from the specified Datadog Forwarder. The log group will not be deleted and the Step Function will continue to log to the AWS log group.
 
 ```bash
 datadog-ci stepfunctions uninstrument --step-function <step-function-arn> --forwarder <forwarder-arn> [--dry-run]

--- a/src/commands/stepfunctions/README.md
+++ b/src/commands/stepfunctions/README.md
@@ -16,11 +16,13 @@ If logging is not enabled on a Step Function, a log group will be created and th
 datadog-ci stepfunctions instrument --step-function <step-function-arn> --forwarder <forwarder-arn> [--service] [--env] [--dry-run]
 
 Run the `uninstrument` command to unsubscribe a Step Function log group from the specified Datadog Forwarder. The log group will not be deleted and the Step Function will continue to log to the AWS log group.
+```
 
 ### uninstrument
 
 ```bash
 datadog-ci stepfunctions uninstrument --step-function <step-function-arn> --forwarder <forwarder-arn> [--dry-run]
+```
 
 ## Arguments
 

--- a/src/commands/stepfunctions/README.md
+++ b/src/commands/stepfunctions/README.md
@@ -6,7 +6,7 @@ You can also add the `stepfunctions instrument` command to your CI/CD pipelines 
 
 ## Usage
 
-### instrument
+### `instrument`
 
 Run the `instrument` command to subscribe a Step Function log group to the specified Datadog Forwarder. In the Step Function logging configuration, if either `logLevel: ALL` or `includeExecutionData: true` is not set, then the Step Function logging configuration will be updated to use those settings.
 
@@ -18,7 +18,8 @@ datadog-ci stepfunctions instrument --step-function <step-function-arn> --forwar
 Run the `uninstrument` command to unsubscribe a Step Function log group from the specified Datadog Forwarder. The log group will not be deleted and the Step Function will continue to log to the AWS log group.
 ```
 
-### uninstrument
+### `uninstrument`
+Run `uninstrument` command to remove Step Functions log groups subscription filter created by Datadog-CI.
 
 ```bash
 datadog-ci stepfunctions uninstrument --step-function <step-function-arn> --forwarder <forwarder-arn> [--dry-run]


### PR DESCRIPTION
This PR fix README.md format issue.

## Before
<img width="1294" alt="image" src="https://github.com/DataDog/datadog-ci/assets/47579703/8be3d6d2-be0c-4032-990f-73ed5feb41f1">

## After 
<img width="1043" alt="image" src="https://github.com/DataDog/datadog-ci/assets/47579703/30b805b8-d181-4edb-b12b-13b409f93ee9">
