### PR TITLE
Update release process in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ To release a new version of `datadog-ci`:
 1. Create a new branch for the version upgrade.
 2. Update the `package.json` version, commit the change `vX.X.X` and tag it with `git tag vX.X.X`, based on the version you are upgrading to. You may refer to [Semantic Versioning](https://semver.org/#summary) to determine what level to increment.
 3. Push the branch along with the tag to the upstream (GitHub) with `git push --tags origin name-of-the-branch`, create a Pull Request with the changes introduced in the description details, and get at least one approval. For example, see this [sample pull request](https://github.com/DataDog/datadog-ci/pull/78).
-4. Merge the Pull Request **with the rebase and merge strategy**.
+4. Once you've received at least one approval, merge the Pull Request **with the "Create a merge commit" strategy**.
 5. Create a GitHub Release from the [Tags page](https://github.com/DataDog/datadog-ci/tags) with the description of changes introduced.
 6. Once the release has been created, a GitHub Action publishes the package. Make sure the job succeeds.
 7. When the package has been published, go to the [Datadog GitLab pipelines](https://gitlab.ddbuild.io/DataDog/datadog-ci/-/pipelines), find the pipeline for your tag, and start the `build` stage to run the Docker image build jobs. Once the jobs pass, the `release` stage automatically triggers. Make sure all the jobs succeed.
@@ -166,14 +166,14 @@ To create a pre-release or releasing in a different channel:
 
 1. Create a new branch for the channel you want to release to (`alpha`, `beta`, and more).
 2. Create a PR for your feature branch with the channel branch as a base.
-3. Pick a version following this format: `version-channel`. For example, `0.10.9-alpha`, `1-beta`, and more.
+3. Pick a version following this format: `<version>-<channel>`. For example, `0.10.9-alpha`, `1-beta`, and more.
 4. Update the `version` field in `package.json`.
-5. Once you've received at least one approval, merge the Pull Request **with the rebase and merge strategy**.
+5. Once you've received at least one approval, merge the Pull Request **with the "Create a merge commit" strategy**.
 6. Create a [GitHub Release](https://github.com/DataDog/datadog-ci/releases/new?target=alpha&tag=0.10.9-alpha&prerelease=1&title=Alpha+prerelease):
    - Target the channel branch.
-   - Pick a tag based on your version `version-channel`.
+   - Pick a tag based on your version `<version>-<channel>`.
    - Check the `This is a pre-release` checkbox.
-7. Publish the release and an action publishes it on npm.
+7. Publish the release and an action will publish it on npm.
 
 <img src="./assets/pre-release.png" width="500"/>
 

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ To create a pre-release or releasing in a different channel:
    - Target the channel branch.
    - Pick a tag based on your version `<version>-<channel>`.
    - Check the `This is a pre-release` checkbox.
-7. Publish the release and an action will publish it on npm.
+7. Publish the release and an action publishes it on npm.
 
 <img src="./assets/pre-release.png" width="500"/>
 


### PR DESCRIPTION
### What and why?

I tried to release v2.12.0 with "Rebase and merge strategy" (according to #881) and weirdly, GitHub generates a new commit instead of just rebasing and pushing the exact same commit (same commit SHA).

- Commit that used to be on my branch: https://github.com/DataDog/datadog-ci/commit/9b91ed809a9c6cc560d6dd8ba5e0b8b08b471735 (pushed in https://github.com/DataDog/datadog-ci/pull/890)
- Commit once merged: https://github.com/DataDog/datadog-ci/commit/9b7e1d188030d42ef9edb86b6bae37c428b4e232

Since no version was published on NPM yet, and no Docker image was built, I'll overwrite the v2.12.0 tag. So for the record (before it's overwritten), here is a proof that the tag was pointing to my [branch commit](https://github.com/DataDog/datadog-ci/commit/9b91ed809a9c6cc560d6dd8ba5e0b8b08b471735).

![image](https://github.com/DataDog/datadog-ci/assets/9317502/699ef542-d74a-4a31-80d8-0f9fa8cd2c7f)

cc. @juan-fernandez 

### How?

Update the instructions.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
