### PR TITLE
add serverless as the codeowner of `stepfunctions` command

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -18,6 +18,7 @@ src/commands/react-native     @DataDog/rum-mobile
 
 ## Serverless
 src/commands/lambda  @DataDog/serverless
+src/commands/stepfunctions  @DataDog/serverless
 
 ## Source Code Integration
 src/commands/git-metadata  @DataDog/source-code-integration


### PR DESCRIPTION
Add serverless as the codeowner of `stepfunctions` command.