### PR TITLE
Add support for user defined scopes and tags

### DIFF
--- a/src/commands/gate/__tests__/scope.test.ts
+++ b/src/commands/gate/__tests__/scope.test.ts
@@ -18,4 +18,10 @@ describe('parseScope', () => {
       team: ['backend', 'frontend'],
     })
   })
+  test('should remove duplicated values', () => {
+    expect(parseScope(['key1:value1', 'team:backend', 'team:backend'])).toEqual({
+      key1: ['value1'],
+      team: ['backend'],
+    })
+  })
 })

--- a/src/commands/gate/__tests__/scope.test.ts
+++ b/src/commands/gate/__tests__/scope.test.ts
@@ -1,0 +1,21 @@
+import {parseScope} from '../utils'
+
+describe('parseScope', () => {
+  test('falls back to empty object if invalid format', () => {
+    expect(parseScope([''])).toEqual({})
+    expect(parseScope(['not.correct.format'])).toEqual({})
+    expect(parseScope(['not.correct.format,either'])).toEqual({})
+  })
+  test('returns an object with the scope variables with well formatted strings', () => {
+    expect(parseScope(['key1:value1', 'key2:value2'])).toEqual({key1: ['value1'], key2: ['value2']})
+  })
+  test('should not include invalid key:value pairs', () => {
+    expect(parseScope(['key1:value1', 'key2:value2', 'invalidkeyvalue'])).toEqual({key1: ['value1'], key2: ['value2']})
+  })
+  test('should merge values for the same key', () => {
+    expect(parseScope(['key1:value1', 'team:backend', 'team:frontend'])).toEqual({
+      key1: ['value1'],
+      team: ['backend', 'frontend'],
+    })
+  })
+})

--- a/src/commands/gate/api.ts
+++ b/src/commands/gate/api.ts
@@ -14,6 +14,7 @@ export const evaluateGateRules = (
       type: 'gate_evaluation',
       attributes: {
         tags: evaluateRequest.spanTags,
+        user_scope: evaluateRequest.userScope,
       },
     },
   })

--- a/src/commands/gate/interfaces.ts
+++ b/src/commands/gate/interfaces.ts
@@ -6,6 +6,7 @@ import {SpanTags} from '../../helpers/interfaces'
 
 export interface Payload {
   spanTags: SpanTags
+  userScope: Record<string, string[]>
 }
 
 export interface EvaluationResponsePayload {

--- a/src/commands/gate/renderer.ts
+++ b/src/commands/gate/renderer.ts
@@ -72,11 +72,9 @@ export const renderGateEvaluationInput = (evaluateRequest: Payload): string => {
   fullStr += `Repository: ${evaluateRequest.spanTags[GIT_REPOSITORY_URL]}\n`
   fullStr += `Branch: ${evaluateRequest.spanTags[GIT_BRANCH]}\n`
 
-  for (const scopeKey in evaluateRequest.userScope) {
-    if (evaluateRequest.userScope.hasOwnProperty(scopeKey)) {
-      const scopeValue = evaluateRequest.userScope[scopeKey].join(' OR ')
-      fullStr += `${scopeKey}: ${scopeValue}\n`
-    }
+  for (const [scopeKey, scopeValue] of Object.entries(evaluateRequest.userScope)) {
+    const valueString = scopeValue.join(' OR ')
+    fullStr += `${scopeKey}: ${valueString}\n`
   }
 
   fullStr += '\n'

--- a/src/commands/gate/renderer.ts
+++ b/src/commands/gate/renderer.ts
@@ -1,8 +1,8 @@
 import chalk from 'chalk'
 
-import {SpanTags} from '../../helpers/interfaces'
+import {GIT_BRANCH, GIT_REPOSITORY_URL} from '../../helpers/tags'
 
-import {EvaluationResponse, RuleEvaluation} from './interfaces'
+import {EvaluationResponse, Payload, RuleEvaluation} from './interfaces'
 
 const ICONS = {
   FAILED: '❌',
@@ -67,11 +67,18 @@ export const renderDryRunEvaluation = (): string => {
   return chalk.yellow('Dry run mode is enabled. Not evaluating the rules.')
 }
 
-export const renderGateEvaluationInput = (spanTags: SpanTags): string => {
+export const renderGateEvaluationInput = (evaluateRequest: Payload): string => {
   let fullStr = chalk.bold(`${ICONS.INFO} Evaluating rules matching the following information:\n`)
-  fullStr += `Repository: ${spanTags['git.repository_url']}\n`
-  fullStr += `Branch: ${spanTags['git.branch']}\n`
-  fullStr += `Pipeline Name: ${spanTags['ci.pipeline.name']}\n`
+  fullStr += `Repository: ${evaluateRequest.spanTags[GIT_REPOSITORY_URL]}\n`
+  fullStr += `Branch: ${evaluateRequest.spanTags[GIT_BRANCH]}\n`
+
+  for (const scopeKey in evaluateRequest.userScope) {
+    if (evaluateRequest.userScope.hasOwnProperty(scopeKey)) {
+      const scopeValue = evaluateRequest.userScope[scopeKey].join(' OR ')
+      fullStr += `${scopeKey}: ${scopeValue}\n`
+    }
+  }
+
   fullStr += '\n'
 
   return fullStr

--- a/src/commands/gate/utils.ts
+++ b/src/commands/gate/utils.ts
@@ -22,7 +22,9 @@ export const parseScope = (scope: string[]) => {
       const value = keyValuePair.substring(firstColon + 1)
 
       if (acc.hasOwnProperty(key)) {
-        acc[key].push(value)
+        if (!acc[key].includes(value)) {
+          acc[key].push(value)
+        }
       } else {
         acc[key] = [value]
       }

--- a/src/commands/gate/utils.ts
+++ b/src/commands/gate/utils.ts
@@ -5,3 +5,31 @@ export const getBaseIntakeUrl = () => {
 
   return 'https://quality-gates.datadoghq.com'
 }
+
+/**
+ * Receives an array of the form ['key:value', 'key2:value2_1', 'key2:value2_2']
+ * and returns an object of the form {key: ['value'], key2: ['value2_1, value2_2']}
+ */
+export const parseScope = (scope: string[]) => {
+  try {
+    return scope.reduce((acc: {[key: string]: string[]}, keyValuePair) => {
+      if (!keyValuePair.includes(':')) {
+        return acc
+      }
+
+      const firstColon = keyValuePair.indexOf(':')
+      const key = keyValuePair.substring(0, firstColon)
+      const value = keyValuePair.substring(firstColon + 1)
+
+      if (acc.hasOwnProperty(key)) {
+        acc[key].push(value)
+      } else {
+        acc[key] = [value]
+      }
+
+      return acc
+    }, {})
+  } catch (e) {
+    return {}
+  }
+}


### PR DESCRIPTION
### What and why?

Users will be able to provide:

- Scope, via the `--scope` option. They can provide multiple values for the same key (e.g. `--scope=team:backend --scope=team:frontend`). Scope will be used to further filter the rules that are being evaluated.
- Tags, via the `--tags` option. These will work exactly as the other commands.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
