### PR TITLE
[synthetics] hide (last) documentation artifacts in README

### DIFF
--- a/src/commands/synthetics/README.md
+++ b/src/commands/synthetics/README.md
@@ -221,8 +221,8 @@ You can decide to have the CLI auto-discover all your `**/*.synthetics.json` Syn
 
 Run tests by executing the CLI:
 
-{{< tabs >}}
-{{% tab "NPM" %}}
+<!-- xxx tabs xxx -->
+<!-- xxx tab "NPM" xxx -->
 
 Add the following to your `package.json`:
 
@@ -242,8 +242,8 @@ npm run datadog-ci-synthetics
 
 **Note**: If you are launching your tests with a custom global configuration file, append the command associated to your `datadog-ci-synthetics` script with `--config <PATH_TO_GLOBAL_CONFIG_FILE>`.
 
-{{% /tab %}}
-{{% tab "Yarn" %}}
+<!-- xxz tab xxx -->
+<!-- xxx tab "Yarn" xxx -->
 
 The `run-tests` sub-command runs the tests discovered in the folder according to the `files` configuration key. It accepts the `--public-id` (or shorthand `-p`) argument to trigger only the specified test. It can be set multiple times to run multiple tests:
 
@@ -271,8 +271,8 @@ yarn datadog-ci synthetics run-tests -f ./component-1/**/*.synthetics.json -v PA
 
 **Note**: If you are launching your tests with a custom global configuration file, append your command with `--config <PATH_TO_GLOBAL_CONFIG_FILE>`.
 
-{{% /tab %}}
-{{< /tabs >}}
+<!-- xxz tab xxx -->
+<!-- xxz tabs xxx -->
 
 ### Failure modes flags
 


### PR DESCRIPTION
### What and why?

This PR replaces the last internal documentation tags with the GFM compatible alternative.
It allows to keep the features for our internal documentation processor, while hiding the artifacts from the github markdown preview.
It follows a first PR: https://github.com/DataDog/datadog-ci/pull/740

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
