### PR TITLE
[test] Improve standalone binary test timeout

### DIFF
--- a/standalone-e2e/standalone-binary.test.ts
+++ b/standalone-e2e/standalone-binary.test.ts
@@ -6,21 +6,25 @@ import {version} from '../package.json'
 const execPromise = promisify(exec)
 
 const isWin = process.platform === 'win32'
-
 const os = isWin ? 'win' : process.platform === 'darwin' ? 'darwin' : 'linux'
 
 const STANDALONE_BINARY = `datadog-ci_${os}-x64`
-
 const STANDALONE_BINARY_PATH = `${isWin ? '.\\' : './'}${STANDALONE_BINARY}${isWin ? '.exe' : ''}`
 
 const sanitizeOutput = (output: string) => output.replace(/(\r\n|\n|\r)/gm, '')
 
+const timeoutPerPlatform: Record<typeof os, number> = {
+  // Some macOS agents sometimes run slower, making this test suite flaky on macOS only.
+  // The issue is tracked here: https://github.com/actions/runner-images/issues/3885
+  darwin: 10 * 1000,
+  // Keep the default timeout for Linux.
+  linux: 5 * 1000,
+  // Running the binary on Windows is also slower than on Linux, and sometimes times out by a very small margin.
+  win: 6 * 1000,
+}
+
 describe('standalone binary', () => {
-  if (os === 'darwin') {
-    // Some macOS agents sometimes run slower, making this test suite flaky on macOS only.
-    // The issue is tracked here: https://github.com/actions/runner-images/issues/3885
-    jest.setTimeout(10 * 1000)
-  }
+  jest.setTimeout(timeoutPerPlatform[os])
 
   describe('version', () => {
     it('can be called', async () => {

--- a/standalone-e2e/standalone-binary.test.ts
+++ b/standalone-e2e/standalone-binary.test.ts
@@ -20,7 +20,7 @@ const timeoutPerPlatform: Record<typeof os, number> = {
   // Keep the default timeout for Linux.
   linux: 5 * 1000,
   // Running the binary on Windows is also slower than on Linux, and sometimes times out by a very small margin.
-  win: 6 * 1000,
+  win: 10 * 1000,
 }
 
 describe('standalone binary', () => {


### PR DESCRIPTION
### What and why?

We managed to fix the flakiness on macOS (#893), but Windows can also [occasionally fail](https://github.com/DataDog/datadog-ci/actions/runs/5142676448/jobs/9256709607).

Let's fix this definitely.

### How?

Define timeouts for all platforms.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
