### PR TITLE
[lambda][flare] Add initial code for Lambda serverless flare 

### DIFF
--- a/src/commands/lambda/__mocks__/instrument-uninstrument-renderer.js
+++ b/src/commands/lambda/__mocks__/instrument-uninstrument-renderer.js
@@ -1,7 +1,8 @@
-const renderer = jest.requireActual('../renderer')
+const renderer = jest.requireActual('../renderers/instrument-uninstrument-renderer')
 
 const makeMockSpinner = () => {
   const f = jest.fn()
+
   return jest.fn(() => ({
     fail: f,
     start: f,

--- a/src/commands/lambda/__tests__/__snapshots__/flare.test.ts.snap
+++ b/src/commands/lambda/__tests__/__snapshots__/flare.test.ts.snap
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`lambda flare prints dry-run header 1`] = `
+"
+[Dry Run] 🐶 Generating Lambda flare to send your configuration to Datadog
+"
+`;
+
+exports[`lambda flare prints non-dry-run header 1`] = `
+"
+🐶 Generating Lambda flare to send your configuration to Datadog
+"
+`;

--- a/src/commands/lambda/__tests__/fixtures.ts
+++ b/src/commands/lambda/__tests__/fixtures.ts
@@ -25,6 +25,7 @@ import {
 import {AwsStub} from 'aws-sdk-client-mock'
 import {Cli, Command} from 'clipanion/lib/advanced'
 
+import {LambdaFlareCommand} from '../flare'
 import {InstrumentCommand} from '../instrument'
 import {UninstrumentCommand} from '../uninstrument'
 
@@ -45,6 +46,7 @@ export const makeCli = () => {
   const cli = new Cli()
   cli.register(InstrumentCommand)
   cli.register(UninstrumentCommand)
+  cli.register(LambdaFlareCommand)
 
   return cli
 }

--- a/src/commands/lambda/__tests__/flare.test.ts
+++ b/src/commands/lambda/__tests__/flare.test.ts
@@ -1,0 +1,21 @@
+import {createMockContext, makeCli} from './fixtures'
+
+describe('lambda flare', () => {
+  it('prints non-dry-run header', async () => {
+    const cli = makeCli()
+    const context = createMockContext()
+    const code = await cli.run(['lambda', 'flare'], context as any)
+    const output = context.stdout.toString()
+    expect(code).toBe(0)
+    expect(output).toMatchSnapshot()
+  })
+
+  it('prints dry-run header', async () => {
+    const cli = makeCli()
+    const context = createMockContext()
+    const code = await cli.run(['lambda', 'flare', '-d'], context as any)
+    const output = context.stdout.toString()
+    expect(code).toBe(0)
+    expect(output).toMatchSnapshot()
+  })
+})

--- a/src/commands/lambda/__tests__/functions/commons.test.ts
+++ b/src/commands/lambda/__tests__/functions/commons.test.ts
@@ -1,5 +1,7 @@
 jest.mock('fs')
-jest.mock('../../renderer', () => require('../../__mocks__/renderer'))
+jest.mock('../../renderers/instrument-uninstrument-renderer', () =>
+  require('../../__mocks__/instrument-uninstrument-renderer')
+)
 jest.mock('@aws-sdk/credential-providers')
 
 import * as fs from 'fs'

--- a/src/commands/lambda/__tests__/functions/uninstrument.test.ts
+++ b/src/commands/lambda/__tests__/functions/uninstrument.test.ts
@@ -1,5 +1,5 @@
 jest.mock('../../loggroup')
-jest.mock('../../renderer')
+jest.mock('../../renderers/instrument-uninstrument-renderer')
 
 import {CloudWatchLogsClient} from '@aws-sdk/client-cloudwatch-logs'
 import {LambdaClient, ListFunctionsCommand} from '@aws-sdk/client-lambda'

--- a/src/commands/lambda/__tests__/instrument.test.ts
+++ b/src/commands/lambda/__tests__/instrument.test.ts
@@ -4,7 +4,9 @@ jest.mock('@aws-sdk/credential-providers', () => ({
   fromIni: jest.fn(),
 }))
 jest.mock('../prompt')
-jest.mock('../renderer', () => require('../__mocks__/renderer'))
+jest.mock('../renderers/instrument-uninstrument-renderer', () =>
+  require('../__mocks__/instrument-uninstrument-renderer')
+)
 jest.mock('../../../../package.json', () => ({version: 'XXXX'}))
 
 import * as fs from 'fs'

--- a/src/commands/lambda/__tests__/uninstrument.test.ts
+++ b/src/commands/lambda/__tests__/uninstrument.test.ts
@@ -4,7 +4,9 @@ jest.mock('@aws-sdk/credential-providers', () => ({
   fromIni: jest.fn(),
 }))
 jest.mock('../prompt')
-jest.mock('../renderer', () => require('../__mocks__/renderer'))
+jest.mock('../renderers/instrument-uninstrument-renderer', () =>
+  require('../__mocks__/instrument-uninstrument-renderer')
+)
 jest.mock('../../../../package.json', () => ({version: 'XXXX'}))
 
 import * as fs from 'fs'

--- a/src/commands/lambda/cli.ts
+++ b/src/commands/lambda/cli.ts
@@ -1,4 +1,5 @@
+import {LambdaFlareCommand} from './flare'
 import {InstrumentCommand} from './instrument'
 import {UninstrumentCommand} from './uninstrument'
 
-module.exports = [InstrumentCommand, UninstrumentCommand]
+module.exports = [InstrumentCommand, UninstrumentCommand, LambdaFlareCommand]

--- a/src/commands/lambda/flare.ts
+++ b/src/commands/lambda/flare.ts
@@ -1,0 +1,14 @@
+import {Command} from 'clipanion'
+
+import {renderLambdaFlareHeader} from './renderers/flare-renderer'
+
+export class LambdaFlareCommand extends Command {
+  private isDryRun = false
+
+  public async execute() {
+    this.context.stdout.write(renderLambdaFlareHeader(this.isDryRun))
+  }
+}
+
+LambdaFlareCommand.addPath('lambda', 'flare')
+LambdaFlareCommand.addOption('isDryRun', Command.Boolean('-d,--dry'))

--- a/src/commands/lambda/functions/commons.ts
+++ b/src/commands/lambda/functions/commons.ts
@@ -39,7 +39,7 @@ import {
 import {FunctionConfiguration, InstrumentationSettings, InstrumentedConfigurationGroup} from '../interfaces'
 import {applyLogGroupConfig} from '../loggroup'
 import {awsProfileQuestion} from '../prompt'
-import * as renderer from '../renderer'
+import * as renderer from '../renderers/instrument-uninstrument-renderer'
 import {applyTagConfig} from '../tags'
 
 /**

--- a/src/commands/lambda/instrument.ts
+++ b/src/commands/lambda/instrument.ts
@@ -43,7 +43,7 @@ import {
   requestEnvServiceVersion,
   requestFunctionSelection,
 } from './prompt'
-import * as renderer from './renderer'
+import * as renderer from './renderers/instrument-uninstrument-renderer'
 
 export class InstrumentCommand extends Command {
   private apmFlushDeadline?: string

--- a/src/commands/lambda/renderers/common-renderer.ts
+++ b/src/commands/lambda/renderers/common-renderer.ts
@@ -1,0 +1,9 @@
+import {bold, cyan, green, red, yellow} from 'chalk'
+
+export const dryRunTag = bold(cyan('[Dry Run]'))
+export const errorTag = bold(red('[Error]'))
+export const warningTag = bold(yellow('[Warning]'))
+
+export const warningExclamationSignTag = bold(yellow('[!]'))
+export const successCheckmarkTag = bold(green('✔'))
+export const failCrossTag = bold(red('✖'))

--- a/src/commands/lambda/renderers/flare-renderer.ts
+++ b/src/commands/lambda/renderers/flare-renderer.ts
@@ -1,5 +1,3 @@
-import {LambdaFlareCommand} from '../flare'
-
 import {dryRunTag} from './common-renderer'
 
 /**

--- a/src/commands/lambda/renderers/flare-renderer.ts
+++ b/src/commands/lambda/renderers/flare-renderer.ts
@@ -1,0 +1,17 @@
+import {LambdaFlareCommand} from '../flare'
+
+import {dryRunTag} from './common-renderer'
+
+/**
+ * @returns a header indicating which `lambda` subcommand is running.
+ * @param command current selected lambda subcommand.
+ *
+ * ```txt
+ * [Dry Run] 🐶 Instrumenting Lambda function
+ * ```
+ */
+export const renderLambdaFlareHeader = (isDryRun: boolean) => {
+  const prefix = isDryRun ? `${dryRunTag} ` : ''
+
+  return `\n${prefix}🐶 Generating Lambda flare to send your configuration to Datadog\n`
+}

--- a/src/commands/lambda/renderers/instrument-uninstrument-renderer.ts
+++ b/src/commands/lambda/renderers/instrument-uninstrument-renderer.ts
@@ -1,8 +1,17 @@
-import {blueBright, bold, cyan, green, hex, red, underline, yellow} from 'chalk'
+import {blueBright, bold, hex, underline} from 'chalk'
 import ora from 'ora'
 
-import {InstrumentCommand} from './instrument'
-import {UninstrumentCommand} from './uninstrument'
+import {InstrumentCommand} from '../instrument'
+import {UninstrumentCommand} from '../uninstrument'
+
+import {
+  dryRunTag,
+  errorTag,
+  warningTag,
+  warningExclamationSignTag,
+  successCheckmarkTag,
+  failCrossTag,
+} from './common-renderer'
 
 /**
  * @returns a header indicating which `lambda` subcommand is running.
@@ -589,11 +598,3 @@ export const updatingFunctionsConfigFromRegionSpinner = (region: string, functio
     discardStdin: false,
     text: `${bold(`[${region}]`)} Updating ${bold(functions)} ${hex('#FF9900').bold('Lambda')} functions.\n`,
   })
-
-export const dryRunTag = bold(cyan('[Dry Run]'))
-export const errorTag = bold(red('[Error]'))
-export const warningTag = bold(yellow('[Warning]'))
-
-export const warningExclamationSignTag = bold(yellow('[!]'))
-export const successCheckmarkTag = bold(green('✔'))
-export const failCrossTag = bold(red('✖'))

--- a/src/commands/lambda/uninstrument.ts
+++ b/src/commands/lambda/uninstrument.ts
@@ -18,7 +18,7 @@ import {
 import {getUninstrumentedFunctionConfigs, getUninstrumentedFunctionConfigsFromRegEx} from './functions/uninstrument'
 import {FunctionConfiguration} from './interfaces'
 import {requestAWSCredentials, requestChangesConfirmation, requestFunctionSelection} from './prompt'
-import * as renderer from './renderer'
+import * as renderer from './renderers/instrument-uninstrument-renderer'
 
 export class UninstrumentCommand extends Command {
   private config: any = {


### PR DESCRIPTION
### What and why?
Adds the beginning of the code for the Lambda flare that will enable customers to send their Lambda configuration to Datadog for debugging and setting up instrumentation. 

### How?
* Add command header
* Add start of tests
* Refactor some of the instrument / uninstrument code to work with a command

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
