### PR TITLE
https://datadoghq.atlassian.net/browse/SLS-3589

### DIFF
--- a/src/commands/lambda/constants.ts
+++ b/src/commands/lambda/constants.ts
@@ -47,7 +47,7 @@ export const RUNTIME_LOOKUP = {
 
 export type Runtime = keyof typeof RUNTIME_LOOKUP
 export type LayerKey = keyof typeof LAYER_LOOKUP
-export const ARM_LAYERS = [EXTENSION_LAYER_KEY, 'dotnet6', 'python3.8', 'python3.9', 'python3.10', 'ruby2.']
+export const ARM_LAYERS = [EXTENSION_LAYER_KEY, 'dotnet6', 'python3.8', 'python3.9', 'python3.10', 'ruby2.7']
 export const ARM64_ARCHITECTURE = 'arm64'
 export const ARM_LAYER_SUFFIX = '-ARM'
 


### PR DESCRIPTION
Fix ruby2.7 ARM layer typo

### What and why?

The ruby ARM layer had a typo

### How?

`ruby2.`  -> `ruby2.7`
