### PR TITLE
[lambda] Add Ruby 3.2 support

### DIFF
--- a/src/commands/lambda/__tests__/__snapshots__/instrument.test.ts.snap
+++ b/src/commands/lambda/__tests__/__snapshots__/instrument.test.ts.snap
@@ -297,6 +297,8 @@ exports[`lambda instrument execute instruments Ruby application properly 1`] = `
 [!] Functions to be updated:
 	- arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world
 	- arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world-2
+	- arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world-3
+	- arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world-4
 
 [Dry Run] Will apply the following updates:
 UpdateFunctionConfiguration -> arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world
@@ -346,6 +348,56 @@ UpdateFunctionConfiguration -> arn:aws:lambda:us-east-1:123456789012:function:la
   ]
 }
 TagResource -> arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world-2
+{
+  \\"dd_sls_ci\\": \\"vXXXX\\"
+}
+UpdateFunctionConfiguration -> arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world-3
+{
+  \\"FunctionName\\": \\"arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world-3\\",
+  \\"Environment\\": {
+    \\"Variables\\": {
+      \\"DD_API_KEY\\": \\"1234\\",
+      \\"DD_SITE\\": \\"datadoghq.com\\",
+      \\"DD_CAPTURE_LAMBDA_PAYLOAD\\": \\"false\\",
+      \\"DD_ENV\\": \\"staging\\",
+      \\"DD_TAGS\\": \\"layer:api,team:intake\\",
+      \\"DD_MERGE_XRAY_TRACES\\": \\"false\\",
+      \\"DD_SERVICE\\": \\"middletier\\",
+      \\"DD_TRACE_ENABLED\\": \\"true\\",
+      \\"DD_VERSION\\": \\"0.2\\"
+    }
+  },
+  \\"Layers\\": [
+    \\"arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Extension:40\\",
+    \\"arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Ruby3-2:19\\"
+  ]
+}
+TagResource -> arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world-3
+{
+  \\"dd_sls_ci\\": \\"vXXXX\\"
+}
+UpdateFunctionConfiguration -> arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world-4
+{
+  \\"FunctionName\\": \\"arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world-4\\",
+  \\"Environment\\": {
+    \\"Variables\\": {
+      \\"DD_API_KEY\\": \\"1234\\",
+      \\"DD_SITE\\": \\"datadoghq.com\\",
+      \\"DD_CAPTURE_LAMBDA_PAYLOAD\\": \\"false\\",
+      \\"DD_ENV\\": \\"staging\\",
+      \\"DD_TAGS\\": \\"layer:api,team:intake\\",
+      \\"DD_MERGE_XRAY_TRACES\\": \\"false\\",
+      \\"DD_SERVICE\\": \\"middletier\\",
+      \\"DD_TRACE_ENABLED\\": \\"true\\",
+      \\"DD_VERSION\\": \\"0.2\\"
+    }
+  },
+  \\"Layers\\": [
+    \\"arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Extension-ARM:40\\",
+    \\"arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Ruby3-2-ARM:19\\"
+  ]
+}
+TagResource -> arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world-4
 {
   \\"dd_sls_ci\\": \\"vXXXX\\"
 }

--- a/src/commands/lambda/__tests__/instrument.test.ts
+++ b/src/commands/lambda/__tests__/instrument.test.ts
@@ -1090,6 +1090,19 @@ describe('lambda', () => {
               Architectures: ['arm64'],
             },
           },
+          'arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world-3': {
+            config: {
+              FunctionArn: 'arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world-3',
+              Runtime: 'ruby3.2',
+            },
+          },
+          'arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world-4': {
+            config: {
+              FunctionArn: 'arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world-4',
+              Runtime: 'ruby3.2',
+              Architectures: ['arm64'],
+            },
+          },
         })
 
         const cli = makeCli()
@@ -1103,6 +1116,10 @@ describe('lambda', () => {
             'arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world',
             '-f',
             'arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world-2',
+            '-f',
+            'arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world-3',
+            '-f',
+            'arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world-4',
             '--dry',
             '-e',
             '40',

--- a/src/commands/lambda/constants.ts
+++ b/src/commands/lambda/constants.ts
@@ -16,6 +16,7 @@ export const LAYER_LOOKUP = {
   'python3.9': 'Datadog-Python39',
   'python3.10': 'Datadog-Python310',
   'ruby2.7': 'Datadog-Ruby2-7',
+  'ruby3.2': 'Datadog-Ruby3-2',
 } as const
 
 export enum RuntimeType {
@@ -43,11 +44,12 @@ export const RUNTIME_LOOKUP = {
   'python3.9': RuntimeType.PYTHON,
   'python3.10': RuntimeType.PYTHON,
   'ruby2.7': RuntimeType.RUBY,
+  'ruby3.2': RuntimeType.RUBY,
 }
 
 export type Runtime = keyof typeof RUNTIME_LOOKUP
 export type LayerKey = keyof typeof LAYER_LOOKUP
-export const ARM_LAYERS = [EXTENSION_LAYER_KEY, 'dotnet6', 'python3.8', 'python3.9', 'python3.10', 'ruby2.7']
+export const ARM_LAYERS = [EXTENSION_LAYER_KEY, 'dotnet6', 'python3.8', 'python3.9', 'python3.10', 'ruby2.7', 'ruby3.2']
 export const ARM64_ARCHITECTURE = 'arm64'
 export const ARM_LAYER_SUFFIX = '-ARM'
 


### PR DESCRIPTION
### What and why?

AWS lambda will soon support the Ruby 3.2 runtime.
This change updates the `lambda` command to support instrumentation/uninstrumentation with the runtime.

### How?

Added Ruby 3.2 runtime to the constants

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
