### PR TITLE
[lambda] Allow setting site to datad0g.com

### DIFF
--- a/src/helpers/__tests__/validation.test.ts
+++ b/src/helpers/__tests__/validation.test.ts
@@ -21,6 +21,9 @@ describe('validation', () => {
     expect(isValidDatadogSite('us5.datadoghq.com')).toBe(true)
     expect(isValidDatadogSite('US5.datadoghq.com')).toBe(true)
 
+    expect(isValidDatadogSite('datad0g.com')).toBe(true)
+    expect(isValidDatadogSite('myorg.datad0g.com')).toBe(false)
+
     process.env.DD_CI_BYPASS_SITE_VALIDATION = 'true'
 
     expect(isValidDatadogSite('')).toBe(true)

--- a/src/helpers/validation.ts
+++ b/src/helpers/validation.ts
@@ -33,7 +33,11 @@ export const isValidDatadogSite = (site?: string): boolean => {
     return false
   }
 
-  return !!process.env.DD_CI_BYPASS_SITE_VALIDATION || DATADOG_SITES.includes(site.toLowerCase())
+  return (
+    !!process.env.DD_CI_BYPASS_SITE_VALIDATION ||
+    DATADOG_SITES.includes(site.toLowerCase()) ||
+    site.toLowerCase() === 'datad0g.com'
+  )
 }
 
 const renderDuplicateAPIKey = (environmentAPIKey: string) => {


### PR DESCRIPTION
### What and why?

Allow setting site to data0dg.com, the staging site, for testing purposes

### How?

Update the `isValidDatadogSite` function. I didn't want to edit `DATADOG_SITES` in `src/constants.ts` because it would have side effects such as changing the questions asked in interactive mode.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
