### PR TITLE
[lambda] [flare] Create lambda flare subcommands

### DIFF
--- a/src/commands/lambda/__tests__/__snapshots__/flare.test.ts.snap
+++ b/src/commands/lambda/__tests__/__snapshots__/flare.test.ts.snap
@@ -3,11 +3,15 @@
 exports[`lambda flare prints dry-run header 1`] = `
 "
 [Dry Run] 🐶 Generating Lambda flare to send your configuration to Datadog
+
+[Error] No functions specified. [-f,--function] or [--allFunctions]
 "
 `;
 
 exports[`lambda flare prints non-dry-run header 1`] = `
 "
 🐶 Generating Lambda flare to send your configuration to Datadog
+
+[Error] No functions specified. [-f,--function] or [--allFunctions]
 "
 `;

--- a/src/commands/lambda/__tests__/flare.test.ts
+++ b/src/commands/lambda/__tests__/flare.test.ts
@@ -6,7 +6,7 @@ describe('lambda flare', () => {
     const context = createMockContext()
     const code = await cli.run(['lambda', 'flare'], context as any)
     const output = context.stdout.toString()
-    expect(code).toBe(0)
+    expect(code).toBe(1)
     expect(output).toMatchSnapshot()
   })
 
@@ -15,7 +15,62 @@ describe('lambda flare', () => {
     const context = createMockContext()
     const code = await cli.run(['lambda', 'flare', '-d'], context as any)
     const output = context.stdout.toString()
-    expect(code).toBe(0)
+    expect(code).toBe(1)
     expect(output).toMatchSnapshot()
+  })
+
+  it('prints error when no functions specified', async () => {
+    const cli = makeCli()
+    const context = createMockContext()
+    const code = await cli.run(
+      ['lambda', 'flare', '-r', 'us-west-2', '--api-key', '123', '-e', 'test@test.com'],
+      context as any
+    )
+    expect(code).toBe(1)
+    const output = context.stdout.toString()
+    expect(output).toContain('No functions specified. [-f,--function] or [--allFunctions]')
+  })
+
+  it('prints error when no region specified', async () => {
+    const cli = makeCli()
+    const context = createMockContext()
+    const code = await cli.run(
+      ['lambda', 'flare', '-f', 'func', '--api-key', '123', '-e', 'test@test.com'],
+      context as any
+    )
+    expect(code).toBe(1)
+    const output = context.stdout.toString()
+    expect(output).toContain('No region specified. [-r,--region]')
+  })
+
+  it('prints error when no apiKey specified', async () => {
+    const cli = makeCli()
+    const context = createMockContext()
+    const code = await cli.run(
+      ['lambda', 'flare', '-f', 'func', '-r', 'us-west-2', '-e', 'test@test.com'],
+      context as any
+    )
+    expect(code).toBe(1)
+    const output = context.stdout.toString()
+    expect(output).toContain('No API key specified. [--api-key]')
+  })
+
+  it('prints error when no email specified', async () => {
+    const cli = makeCli()
+    const context = createMockContext()
+    const code = await cli.run(['lambda', 'flare', '-f', 'func', '-r', 'us-west-2', '--api-key', '123'], context as any)
+    expect(code).toBe(1)
+    const output = context.stdout.toString()
+    expect(output).toContain('No email specified. [-e,--email]')
+  })
+
+  it('runs successfully with all required options specified', async () => {
+    const cli = makeCli()
+    const context = createMockContext()
+    const code = await cli.run(
+      ['lambda', 'flare', '-f', 'func', '-r', 'us-west-2', '--api-key', '123', '-e', 'test@test.com'],
+      context as any
+    )
+    expect(code).toBe(0)
   })
 })

--- a/src/commands/lambda/flare.ts
+++ b/src/commands/lambda/flare.ts
@@ -1,14 +1,57 @@
 import {Command} from 'clipanion'
 
-import {renderLambdaFlareHeader} from './renderers/flare-renderer'
+import {renderError, renderLambdaFlareHeader} from './renderers/flare-renderer'
 
 export class LambdaFlareCommand extends Command {
   private isDryRun = false
+  private isInteractive = false
+  private allFunctions = false
+  private functions: string[] = []
+  private region = ''
+  private apiKey = ''
+  private caseID = ''
+  private email = ''
 
+  /**
+   * @returns 0 if the command ran successfully, 1 otherwise.
+   */
   public async execute() {
     this.context.stdout.write(renderLambdaFlareHeader(this.isDryRun))
+
+    if (!this.validateCommand()) {
+      return 1
+    }
+
+    return 0
+  }
+
+  /**
+   * @returns true if the command is valid, false otherwise.
+   * Prints an error message if the command is invalid.
+   */
+  private validateCommand = () => {
+    if (this.functions.length === 0 && !this.allFunctions) {
+      this.context.stdout.write(renderError('No functions specified. [-f,--function] or [--allFunctions]'))
+    } else if (this.region === '') {
+      this.context.stdout.write(renderError('No region specified. [-r,--region]'))
+    } else if (this.apiKey === '') {
+      this.context.stdout.write(renderError('No API key specified. [--api-key]'))
+    } else if (this.email === '') {
+      this.context.stdout.write(renderError('No email specified. [-e,--email]'))
+    } else {
+      return true
+    }
+
+    return false
   }
 }
 
 LambdaFlareCommand.addPath('lambda', 'flare')
 LambdaFlareCommand.addOption('isDryRun', Command.Boolean('-d,--dry'))
+LambdaFlareCommand.addOption('isInteractive', Command.Boolean('-i,--interactive'))
+LambdaFlareCommand.addOption('allFunctions', Command.Boolean('--allFunctions'))
+LambdaFlareCommand.addOption('functions', Command.Array('-f,--function'))
+LambdaFlareCommand.addOption('region', Command.String('-r,--region'))
+LambdaFlareCommand.addOption('apiKey', Command.String('--api-key'))
+LambdaFlareCommand.addOption('caseID', Command.String('-c,--case-id'))
+LambdaFlareCommand.addOption('email', Command.String('-e,--email'))

--- a/src/commands/lambda/flare.ts
+++ b/src/commands/lambda/flare.ts
@@ -30,7 +30,9 @@ export class LambdaFlareCommand extends Command {
    * Prints an error message if the command is invalid.
    */
   private validateCommand = () => {
-    if (this.functions.length === 0 && !this.allFunctions) {
+    if (this.isInteractive) {
+      return true
+    } else if (this.functions.length === 0 && !this.allFunctions) {
       this.context.stdout.write(renderError('No functions specified. [-f,--function] or [--allFunctions]'))
     } else if (this.region === '') {
       this.context.stdout.write(renderError('No region specified. [-r,--region]'))

--- a/src/commands/lambda/renderers/flare-renderer.ts
+++ b/src/commands/lambda/renderers/flare-renderer.ts
@@ -1,8 +1,15 @@
-import {dryRunTag} from './common-renderer'
+import {
+  dryRunTag,
+  errorTag,
+  warningTag,
+  warningExclamationSignTag,
+  successCheckmarkTag,
+  failCrossTag,
+} from './common-renderer'
 
 /**
  * @returns a header indicating which `lambda` subcommand is running.
- * @param command current selected lambda subcommand.
+ * @param isDryRun whether or not the command is a dry run. Defaults to false.
  *
  * ```txt
  * [Dry Run] 🐶 Instrumenting Lambda function
@@ -13,3 +20,53 @@ export const renderLambdaFlareHeader = (isDryRun: boolean) => {
 
   return `\n${prefix}🐶 Generating Lambda flare to send your configuration to Datadog\n`
 }
+
+/**
+ * @param error an error message
+ * @returns the provided error prefixed by {@link errorTag}.
+ *
+ * ```txt
+ * [Error] The provided error goes here!
+ * ```
+ */
+export const renderError = (error: string) => `\n${errorTag} ${error}\n`
+
+/**
+ * @param warning the message to warn about.
+ * @returns the provided warning prefixed by {@link warningTag}.
+ *
+ * ```txt
+ * [Warning] The provided warning goes here!
+ * ```
+ */
+export const renderWarning = (warning: string) => `${warningTag} ${warning}\n`
+
+/**
+ * @param warning the message to warn about.
+ * @returns the provided warning prefixed by {@link warningExclamationSignTag}.
+ *
+ * ```txt
+ * [!] The provided warning goes here!
+ * ```
+ */
+export const renderSoftWarning = (warning: string) => `${warningExclamationSignTag} ${warning}\n`
+
+/**
+ * @param message the message to set with the success tag.
+ * @returns the provided message prefixed by {@link successCheckmarkTag}.
+ *
+ * ```txt
+ * [✔] The provided message goes here!
+ * ```
+ */
+export const renderSuccess = (message: string) => `${successCheckmarkTag} ${message}\n`
+
+/**
+ * @param message the message to set with the fail tag.
+ * @returns the provided message prefixed by {@link failCrossTag}.
+ *
+ * ```txt
+ * [✖] The provided message goes here!
+ * ```
+ */
+export const renderFail = (message: string) => `${failCrossTag} ${message}\n`


### PR DESCRIPTION
### What and why?

Create lambda flare subcommands.
The command will be used to easily gather configuration information from customers to help support staff quickly resolve issues.

### How?

Add the following options:
`--dry, --interactive, --allFunctions, --function, --region, --api-key, --case-id, --email`

Also, have some initial validation to ensure that required options are included.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
