### PR TITLE
[junit] Replace unique filename with just filename

### DIFF
--- a/src/commands/junit/api.ts
+++ b/src/commands/junit/api.ts
@@ -49,17 +49,8 @@ export const uploadJUnitXML = (request: (args: AxiosRequestConfig) => AxiosPromi
 
   form.append('event', JSON.stringify(metadata), {filename: 'event.json'})
 
-  let uniqueFileName = `${fileName}-${jUnitXML.service}-${metadata[GIT_SHA]}`
-
-  if (metadata[CI_PIPELINE_URL]) {
-    uniqueFileName = `${uniqueFileName}-${metadata[CI_PIPELINE_URL]}`
-  }
-  if (metadata[CI_JOB_URL]) {
-    uniqueFileName = `${uniqueFileName}-${metadata[CI_JOB_URL]}`
-  }
-
   form.append('junit_xml_report_file', fs.createReadStream(jUnitXML.xmlPath).pipe(createGzip()), {
-    filename: `${getSafeFileName(uniqueFileName)}.xml.gz`,
+    filename: `${getSafeFileName(fileName)}.xml.gz`,
   })
 
   return request({

--- a/src/helpers/__tests__/file.test.ts
+++ b/src/helpers/__tests__/file.test.ts
@@ -7,7 +7,7 @@ describe('file util', () => {
       expect(safeFileName).toBe('myfilename')
     })
     test('filters unsafe characters out', () => {
-      expect(getSafeFileName('http://gitlab.com/-/pipelines/12345')).toEqual('http___gitlab_com___pipelines_12345')
+      expect(getSafeFileName('http://gitlab.com/-/pipelines/12345')).toEqual('http:\\\\gitlab.com\\-\\pipelines\\12345')
     })
   })
 })

--- a/src/helpers/__tests__/file.test.ts
+++ b/src/helpers/__tests__/file.test.ts
@@ -7,7 +7,7 @@ describe('file util', () => {
       expect(safeFileName).toBe('myfilename')
     })
     test('filters unsafe characters out', () => {
-      expect(getSafeFileName('http://gitlab.com/-/pipelines/12345')).toEqual('http:\\\\gitlab.com\\-\\pipelines\\12345')
+      expect(getSafeFileName('tests/reports/junit/integration.xml')).toEqual('tests\\reports\\junit\\integration.xml')
     })
   })
 })

--- a/src/helpers/file.ts
+++ b/src/helpers/file.ts
@@ -1,4 +1,4 @@
 // We need a unique file name so we use span tags like the pipeline URL,
 // which can contain dots and other unsafe characters for filenames.
 // We filter them out here.
-export const getSafeFileName = (unsafeFileName: string) => unsafeFileName.replace(/[^a-z0-9]/gi, '_')
+export const getSafeFileName = (unsafeFileName: string) => unsafeFileName.replace('/', '\\')

--- a/src/helpers/file.ts
+++ b/src/helpers/file.ts
@@ -1,4 +1,4 @@
 // We need a unique file name so we use span tags like the pipeline URL,
 // which can contain dots and other unsafe characters for filenames.
 // We filter them out here.
-export const getSafeFileName = (unsafeFileName: string) => unsafeFileName.replace('/', '\\')
+export const getSafeFileName = (unsafeFileName: string) => unsafeFileName.replace(/\//g, '\\')

--- a/src/helpers/file.ts
+++ b/src/helpers/file.ts
@@ -1,4 +1,1 @@
-// We need a unique file name so we use span tags like the pipeline URL,
-// which can contain dots and other unsafe characters for filenames.
-// We filter them out here.
 export const getSafeFileName = (unsafeFileName: string) => unsafeFileName.replace(/\//g, '\\')


### PR DESCRIPTION
### What and why?

Replaces the old unique filename with just the filename since we don't need it to be unique anymore on our side.

### How?

Deleting that code and just using the filename

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
