### PR TITLE
[Flutter] Add JavaScript sourcemap upload

### DIFF
--- a/src/commands/flutter-symbols/README.md
+++ b/src/commands/flutter-symbols/README.md
@@ -45,6 +45,9 @@ datadog-ci flutter-symbols upload --dart-symbols-location ./debug-info --service
 | `--ios-dsyms-location` | Optional | Specify the location of iOS dSYM files. By default, these are located at `./build/ios/archive/Runner.xcarchive/dSYMs`. Adding this parameter automatically sets `--ios-dsyms`. |
 | `--android-mapping` | Optional | Upload Android Proguard mapping file. This is usually only necessary if you specify `--obfuscate` as a parameter to `flutter build`. |
 | `--android-mapping-location` | Optional | Specify the location of your Android Proguard mapping file. By default, this is located at `./build/app/outputs/mapping/[flavor]/mapping.txt`. Adding this parameter automatically sets `--android-mapping`. |
+| `--web-sourcemaps` | Optional | Upload a JavaScript mapping file to Datadog. |
+| `--web-sourcemaps-location` | Optional | Specify the directory of your Flutter Web source maps. Defaults to `./build/web` |
+| `--minified-path-prefix` | Optional | For Flutter Web, a prefix common to all your source files, depending on the URL they are served from. Required if `--web-sourcemaps` is specified |
 | `--pubspec` | Optional | The location of the pubspec for this application. The pubspec is used to automatically determine the version number of the application. Defaults to the current directory. |
 | `--version` | Optional | The version of your application. This defaults to the version specified in your pubspec. Only one upload is needed for a specific `version`, `service`, and `flavor` combination. Subsequent uploads are ignored until one parameter changes. |
 | `--dry-run` | Optional | It runs the command without the final step of uploading. All other checks are performed. |

--- a/src/commands/flutter-symbols/__tests__/upload.test.ts
+++ b/src/commands/flutter-symbols/__tests__/upload.test.ts
@@ -136,6 +136,18 @@ describe('flutter-symbol upload', () => {
       expect(exitCode).toBe(1)
       expect(errorOutput).toBe(renderMinifiedPathPrefixRequired())
     })
+
+    test('minified-path-prefix required if web-sourcemaps-location is specified', async () => {
+      const {exitCode, context} = await runCommand((cmd) => {
+        cmd['serviceName'] = 'fake.service'
+        cmd['version'] = '1.0.0+114'
+        cmd['webSourceMapsLocation'] = './fake/location'
+      })
+      const errorOutput = context.stderr.toString()
+
+      expect(exitCode).toBe(1)
+      expect(errorOutput).toBe(renderMinifiedPathPrefixRequired())
+    })
   })
 
   describe('getFlutterSymbolFiles', () => {
@@ -482,6 +494,29 @@ describe('flutter-symbol upload', () => {
         cmd['serviceName'] = 'fake.service'
         cmd['version'] = '1.2.3'
         cmd['webSourceMaps'] = true
+        cmd['webSourceMapsLocation'] = './other/location'
+        cmd['minifiedPathPrefix'] = 'https://localhost'
+      })
+
+      expect(exitCode).toBe(0)
+      expect(performSubCommand).toHaveBeenCalledWith(
+        sourcemaps.UploadCommand,
+        [
+          'sourcemaps',
+          'upload',
+          './other/location',
+          '--service=fake.service',
+          '--release-version=1.2.3',
+          '--minified-path-prefix=https://localhost',
+        ],
+        expect.anything()
+      )
+    })
+
+    test('calls sourcemap sub-command with location only', async () => {
+      const {exitCode} = await runCommand((cmd) => {
+        cmd['serviceName'] = 'fake.service'
+        cmd['version'] = '1.2.3'
         cmd['webSourceMapsLocation'] = './other/location'
         cmd['minifiedPathPrefix'] = 'https://localhost'
       })

--- a/src/commands/flutter-symbols/__tests__/upload.test.ts
+++ b/src/commands/flutter-symbols/__tests__/upload.test.ts
@@ -8,11 +8,13 @@ import {MultipartPayload} from '../../../helpers/upload'
 import {performSubCommand} from '../../../helpers/utils'
 
 import * as dsyms from '../../dsyms/upload'
+import * as sourcemaps from '../../sourcemaps/upload'
 
 import {getArchInfoFromFilename, uploadMultipartHelper} from '../helpers'
 import {
   renderInvalidPubspecError,
   renderInvalidSymbolsDir,
+  renderMinifiedPathPrefixRequired,
   renderMissingAndroidMappingFile,
   renderMissingDartSymbolsDir,
   renderMissingPubspecError,
@@ -121,6 +123,18 @@ describe('flutter-symbol upload', () => {
 
       expect(exitCode).toBe(0)
       expect(errorOutput).toBe('')
+    })
+
+    test('minified-path-prefix required if web-sourcemaps is specified', async () => {
+      const { exitCode, context } = await runCommand((cmd) => {
+        cmd['serviceName'] = 'fake.service' 
+        cmd['version'] = '1.0.0+114'
+        cmd['webSourceMaps'] = true
+      })
+      const errorOutput = context.stderr.toString()
+
+      expect(exitCode).toBe(1)
+      expect(errorOutput).toBe(renderMinifiedPathPrefixRequired());
     })
   })
 
@@ -436,6 +450,58 @@ describe('flutter-symbol upload', () => {
 
       expect(uploadMultipartHelper).not.toHaveBeenCalled()
       expect(exitCode).toBe(0)
+    })
+  })
+
+  describe('web symbols upload', () => {
+    test('calls sourcemap sub-command with proper default parameters', async () => {
+      const {exitCode} = await runCommand((cmd) => {
+        cmd['serviceName'] = 'fake.service'
+        cmd['version'] = '1.2.3'
+        cmd['webSourceMaps'] = true
+        cmd['minifiedPathPrefix'] = 'https://localhost'
+      })
+
+      expect(exitCode).toBe(0)
+      expect(performSubCommand).toHaveBeenCalledWith(
+        sourcemaps.UploadCommand,
+        ['sourcemaps', 'upload', './build/web', '--service=fake.service', '--release-version=1.2.3', '--minified-path-prefix=https://localhost'],
+        expect.anything()
+      )
+    })
+
+    test('calls sourcemap sub-command with overridden location', async () => {
+      const {exitCode} = await runCommand((cmd) => {
+        cmd['serviceName'] = 'fake.service'
+        cmd['version'] = '1.2.3'
+        cmd['webSourceMaps'] = true
+        cmd['webSourceMapsLocation'] = './other/location'
+        cmd['minifiedPathPrefix'] = 'https://localhost'
+      })
+
+      expect(exitCode).toBe(0)
+      expect(performSubCommand).toHaveBeenCalledWith(
+        sourcemaps.UploadCommand,
+        ['sourcemaps', 'upload', './other/location', '--service=fake.service', '--release-version=1.2.3', '--minified-path-prefix=https://localhost'],
+        expect.anything()
+      )
+    })
+
+    test('calls sourcemap sub-command with dry-run', async () => {
+      const {exitCode} = await runCommand((cmd) => {
+        cmd['serviceName'] = 'fake.service'
+        cmd['version'] = '1.2.3'
+        cmd['webSourceMaps'] = true
+        cmd['minifiedPathPrefix'] = 'https://localhost'
+        cmd['dryRun'] = true
+      })
+
+      expect(exitCode).toBe(0)
+      expect(performSubCommand).toHaveBeenCalledWith(
+        sourcemaps.UploadCommand,
+        ['sourcemaps', 'upload', './build/web', '--service=fake.service', '--release-version=1.2.3', '--minified-path-prefix=https://localhost', '--dry-run'],
+        expect.anything()
+      )
     })
   })
 

--- a/src/commands/flutter-symbols/__tests__/upload.test.ts
+++ b/src/commands/flutter-symbols/__tests__/upload.test.ts
@@ -126,15 +126,15 @@ describe('flutter-symbol upload', () => {
     })
 
     test('minified-path-prefix required if web-sourcemaps is specified', async () => {
-      const { exitCode, context } = await runCommand((cmd) => {
-        cmd['serviceName'] = 'fake.service' 
+      const {exitCode, context} = await runCommand((cmd) => {
+        cmd['serviceName'] = 'fake.service'
         cmd['version'] = '1.0.0+114'
         cmd['webSourceMaps'] = true
       })
       const errorOutput = context.stderr.toString()
 
       expect(exitCode).toBe(1)
-      expect(errorOutput).toBe(renderMinifiedPathPrefixRequired());
+      expect(errorOutput).toBe(renderMinifiedPathPrefixRequired())
     })
   })
 
@@ -465,7 +465,14 @@ describe('flutter-symbol upload', () => {
       expect(exitCode).toBe(0)
       expect(performSubCommand).toHaveBeenCalledWith(
         sourcemaps.UploadCommand,
-        ['sourcemaps', 'upload', './build/web', '--service=fake.service', '--release-version=1.2.3', '--minified-path-prefix=https://localhost'],
+        [
+          'sourcemaps',
+          'upload',
+          './build/web',
+          '--service=fake.service',
+          '--release-version=1.2.3',
+          '--minified-path-prefix=https://localhost',
+        ],
         expect.anything()
       )
     })
@@ -482,7 +489,14 @@ describe('flutter-symbol upload', () => {
       expect(exitCode).toBe(0)
       expect(performSubCommand).toHaveBeenCalledWith(
         sourcemaps.UploadCommand,
-        ['sourcemaps', 'upload', './other/location', '--service=fake.service', '--release-version=1.2.3', '--minified-path-prefix=https://localhost'],
+        [
+          'sourcemaps',
+          'upload',
+          './other/location',
+          '--service=fake.service',
+          '--release-version=1.2.3',
+          '--minified-path-prefix=https://localhost',
+        ],
         expect.anything()
       )
     })
@@ -499,7 +513,15 @@ describe('flutter-symbol upload', () => {
       expect(exitCode).toBe(0)
       expect(performSubCommand).toHaveBeenCalledWith(
         sourcemaps.UploadCommand,
-        ['sourcemaps', 'upload', './build/web', '--service=fake.service', '--release-version=1.2.3', '--minified-path-prefix=https://localhost', '--dry-run'],
+        [
+          'sourcemaps',
+          'upload',
+          './build/web',
+          '--service=fake.service',
+          '--release-version=1.2.3',
+          '--minified-path-prefix=https://localhost',
+          '--dry-run',
+        ],
         expect.anything()
       )
     })

--- a/src/commands/flutter-symbols/renderer.ts
+++ b/src/commands/flutter-symbols/renderer.ts
@@ -84,6 +84,9 @@ To ignore this warning use the --disable-git flag.\n`)
 export const renderArgumentMissingError = (argumentName: string) =>
   chalk.red(`${ICONS.FAILED} Error: parameter "${argumentName}" is required.\n`)
 
+export const renderMinifiedPathPrefixRequired = () =>
+  chalk.red(`${ICONS.FAILED} Error: --minified-path-prefix is required when using --web-sourcemaps`);
+  
 export const renderMissingPubspecError = (pubspecLocation: string) =>
   chalk.red(
     `${ICONS.FAILED} Could not find pubspec at '${pubspecLocation}'. A pubspec.yaml is required or the --version argument must be specified.\n`

--- a/src/commands/flutter-symbols/renderer.ts
+++ b/src/commands/flutter-symbols/renderer.ts
@@ -85,8 +85,8 @@ export const renderArgumentMissingError = (argumentName: string) =>
   chalk.red(`${ICONS.FAILED} Error: parameter "${argumentName}" is required.\n`)
 
 export const renderMinifiedPathPrefixRequired = () =>
-  chalk.red(`${ICONS.FAILED} Error: --minified-path-prefix is required when using --web-sourcemaps`);
-  
+  chalk.red(`${ICONS.FAILED} Error: --minified-path-prefix is required when using --web-sourcemaps`)
+
 export const renderMissingPubspecError = (pubspecLocation: string) =>
   chalk.red(
     `${ICONS.FAILED} Could not find pubspec at '${pubspecLocation}'. A pubspec.yaml is required or the --version argument must be specified.\n`

--- a/src/commands/flutter-symbols/upload.ts
+++ b/src/commands/flutter-symbols/upload.ts
@@ -19,8 +19,8 @@ import {
 import {checkAPIKeyOverride} from '../../helpers/validation'
 
 import * as dsyms from '../dsyms/upload'
-import * as sourcemaps from '../sourcemaps/upload'
 import {newSimpleGit} from '../git-metadata/git'
+import * as sourcemaps from '../sourcemaps/upload'
 
 import {getArchInfoFromFilename, getFlutterRequestBuilder, uploadMultipartHelper} from './helpers'
 import {
@@ -128,7 +128,7 @@ export class UploadCommand extends Command {
       uploadInfo.push({
         fileType: 'JavaScript Source Maps',
         location: this.webSourceMapsLocation,
-        platform: 'Browser'
+        platform: 'Browser',
       })
     }
 
@@ -435,12 +435,12 @@ export class UploadCommand extends Command {
 
   private async performSourceMapUpload() {
     const sourceMapUploadCommand = [
-      'sourcemaps', 
-      'upload', 
+      'sourcemaps',
+      'upload',
       this.webSourceMapsLocation!,
       `--service=${this.serviceName}`,
       `--release-version=${this.version}`,
-      `--minified-path-prefix=${this.minifiedPathPrefix}`
+      `--minified-path-prefix=${this.minifiedPathPrefix}`,
     ]
     if (this.dryRun) {
       sourceMapUploadCommand.push('--dry-run')
@@ -491,12 +491,12 @@ export class UploadCommand extends Command {
     }
 
     if (this.webSourceMaps) {
-      if(!this.minifiedPathPrefix) {
+      if (!this.minifiedPathPrefix) {
         this.context.stderr.write(renderMinifiedPathPrefixRequired())
         parametersOkay = false
       }
       if (!this.webSourceMapsLocation) {
-        this.webSourceMapsLocation = './build/web';
+        this.webSourceMapsLocation = './build/web'
       }
     }
 

--- a/src/commands/flutter-symbols/upload.ts
+++ b/src/commands/flutter-symbols/upload.ts
@@ -19,6 +19,7 @@ import {
 import {checkAPIKeyOverride} from '../../helpers/validation'
 
 import * as dsyms from '../dsyms/upload'
+import * as sourcemaps from '../sourcemaps/upload'
 import {newSimpleGit} from '../git-metadata/git'
 
 import {getArchInfoFromFilename, getFlutterRequestBuilder, uploadMultipartHelper} from './helpers'
@@ -40,6 +41,7 @@ import {
   renderGitWarning,
   renderInvalidPubspecError,
   renderInvalidSymbolsDir,
+  renderMinifiedPathPrefixRequired,
   renderMissingAndroidMappingFile,
   renderMissingDartSymbolsDir,
   renderMissingPubspecError,
@@ -69,6 +71,9 @@ export class UploadCommand extends Command {
 
   private androidMapping = false
   private androidMappingLocation?: string
+  private webSourceMaps = false
+  private webSourceMapsLocation?: string
+  private minifiedPathPrefix?: string
   private cliVersion: string
   private config: Record<string, string> = {
     datadogSite: 'datadoghq.com',
@@ -119,6 +124,13 @@ export class UploadCommand extends Command {
         platform: 'Flutter',
       })
     }
+    if (this.webSourceMapsLocation) {
+      uploadInfo.push({
+        fileType: 'JavaScript Source Maps',
+        location: this.webSourceMapsLocation,
+        platform: 'Browser'
+      })
+    }
 
     this.context.stdout.write(renderCommandInfo(this.dryRun, this.version!, this.serviceName, this.flavor, uploadInfo))
 
@@ -153,6 +165,9 @@ export class UploadCommand extends Command {
       }
       if (this.dartSymbolsLocation) {
         callResults.push(...(await this.performDartSymbolsUpload()))
+      }
+      if (this.webSourceMaps) {
+        callResults.push(await this.performSourceMapUpload())
       }
 
       const totalTime = (Date.now() - initialTime) / 1000
@@ -418,6 +433,27 @@ export class UploadCommand extends Command {
     return UploadStatus.Success
   }
 
+  private async performSourceMapUpload() {
+    const sourceMapUploadCommand = [
+      'sourcemaps', 
+      'upload', 
+      this.webSourceMapsLocation!,
+      `--service=${this.serviceName}`,
+      `--release-version=${this.version}`,
+      `--minified-path-prefix=${this.minifiedPathPrefix}`
+    ]
+    if (this.dryRun) {
+      sourceMapUploadCommand.push('--dry-run')
+    }
+
+    const exitCode = await performSubCommand(sourcemaps.UploadCommand, sourceMapUploadCommand, this.context)
+    if (exitCode && exitCode !== 0) {
+      return UploadStatus.Failure
+    }
+
+    return UploadStatus.Success
+  }
+
   private async verifyParameters(): Promise<boolean> {
     let parametersOkay = true
 
@@ -454,6 +490,16 @@ export class UploadCommand extends Command {
       }
     }
 
+    if (this.webSourceMaps) {
+      if(!this.minifiedPathPrefix) {
+        this.context.stderr.write(renderMinifiedPathPrefixRequired())
+        parametersOkay = false
+      }
+      if (!this.webSourceMapsLocation) {
+        this.webSourceMapsLocation = './build/web';
+      }
+    }
+
     if (!this.version && (await this.parsePubspecVersion(this.pubspecLocation))) {
       parametersOkay = false
     }
@@ -469,6 +515,9 @@ UploadCommand.addOption('iosDsyms', Command.Boolean('--ios-dsyms'))
 UploadCommand.addOption('iosDsymsLocation', Command.String('--ios-dsyms-location'))
 UploadCommand.addOption('androidMapping', Command.Boolean('--android-mapping'))
 UploadCommand.addOption('androidMappingLocation', Command.String('--android-mapping-location'))
+UploadCommand.addOption('webSourceMaps', Command.Boolean('--web-sourcemaps'))
+UploadCommand.addOption('webSourceMapsLocation', Command.String('--web-sourcemaps-location'))
+UploadCommand.addOption('minifiedPathPrefix', Command.String('--minified-path-prefix'))
 UploadCommand.addOption('pubspecLocation', Command.String('--pubspec'))
 UploadCommand.addOption('serviceName', Command.String('--service-name'))
 UploadCommand.addOption('maxConcurrency', Command.String('--max-concurrency'))

--- a/src/commands/flutter-symbols/upload.ts
+++ b/src/commands/flutter-symbols/upload.ts
@@ -166,7 +166,7 @@ export class UploadCommand extends Command {
       if (this.dartSymbolsLocation) {
         callResults.push(...(await this.performDartSymbolsUpload()))
       }
-      if (this.webSourceMaps) {
+      if (this.webSourceMapsLocation) {
         callResults.push(await this.performSourceMapUpload())
       }
 
@@ -490,13 +490,14 @@ export class UploadCommand extends Command {
       }
     }
 
-    if (this.webSourceMaps) {
+    if (this.webSourceMaps && !this.webSourceMapsLocation) {
+      this.webSourceMapsLocation = './build/web'
+    }
+
+    if (this.webSourceMapsLocation) {
       if (!this.minifiedPathPrefix) {
         this.context.stderr.write(renderMinifiedPathPrefixRequired())
         parametersOkay = false
-      }
-      if (!this.webSourceMapsLocation) {
-        this.webSourceMapsLocation = './build/web'
       }
     }
 


### PR DESCRIPTION
### What and why?

This adds the ability to upload JavaScript sourcemaps as part of the `flutter-symbols upload` command.

Manual upload of Flutter source maps was already possible using the `sourcemaps upload` command, this just integrates it with the `flutter-symbols` command, allows automatic detection of version (if possible) and allows you to use one command over two.

### How?

I've added several parameters that enable upload of the javascript source maps, and forward those over to the sourcemaps command that's already available, including the default location that Flutter puts the sourcemaps in.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
