### PR TITLE
[ci-visibility] Change default value of git upload

### DIFF
--- a/src/commands/junit/README.md
+++ b/src/commands/junit/README.md
@@ -30,7 +30,7 @@ datadog-ci junit upload --service my-service --tags key1:value1 --tags key2:valu
 - `--max-concurrency` (default: `20`): number of concurrent uploads to the API.
 - `--dry-run` (default: `false`): it will run the command without the final upload step. All other checks are performed.
 - `--logs` (default: `false`): it will enable collecting logs from the content in the XML reports.
-- `--enable-git-metadata-upload` (default: `false`): it will upload git metadata.
+- `--skip-git-metadata-upload` (default: `true`): if you want to upload git metadata, you may pass `--skip-git-metadata-upload=0` or `--skip-git-metadata-upload=false`.
 - `--git-repository-url` is a string with the repository URL to retrieve git metadata from. If this is missing, the URL is retrieved from the local git repository.
 - `--verbose` (default: `false`): it will add extra verbosity to the output of the command.
 

--- a/src/commands/junit/README.md
+++ b/src/commands/junit/README.md
@@ -30,7 +30,7 @@ datadog-ci junit upload --service my-service --tags key1:value1 --tags key2:valu
 - `--max-concurrency` (default: `20`): number of concurrent uploads to the API.
 - `--dry-run` (default: `false`): it will run the command without the final upload step. All other checks are performed.
 - `--logs` (default: `false`): it will enable collecting logs from the content in the XML reports.
-- `--skip-git-metadata-upload` (default: `false`): it will run the command without uploading git metadata.
+- `--enable-git-metadata-upload` (default: `false`): it will upload git metadata.
 - `--git-repository-url` is a string with the repository URL to retrieve git metadata from. If this is missing, the URL is retrieved from the local git repository.
 - `--verbose` (default: `false`): it will add extra verbosity to the output of the command.
 

--- a/src/commands/junit/__tests__/upload.test.ts
+++ b/src/commands/junit/__tests__/upload.test.ts
@@ -347,7 +347,7 @@ describe('execute', () => {
 
   test('with git metadata', async () => {
     const {context, code} = await runCLI([
-      '--enable-git-metadata-upload',
+      '--skip-git-metadata-upload=0',
       process.cwd() + '/src/commands/junit/__tests__/fixtures/single_file.xml',
     ])
     const output = context.stdout.toString().split(os.EOL)

--- a/src/commands/junit/__tests__/upload.test.ts
+++ b/src/commands/junit/__tests__/upload.test.ts
@@ -335,22 +335,24 @@ describe('execute', () => {
     expect(output[3]).toContain('service: test-service')
   })
 
-  test('with git metadata', async () => {
-    const {context, code} = await runCLI([process.cwd() + '/src/commands/junit/__tests__/fixtures/single_file.xml'])
-    const output = context.stdout.toString().split(os.EOL)
-    expect(code).toBe(0)
-    expect(output[5]).toContain('Syncing git metadata')
-  })
-
   test('without git metadata', async () => {
     const {context, code} = await runCLI([
-      '--skip-git-metadata-upload',
       '--verbose',
       process.cwd() + '/src/commands/junit/__tests__/fixtures/single_file.xml',
     ])
     const output = context.stdout.toString().split(os.EOL)
     expect(code).toBe(0)
-    expect(output[5]).toContain('Not syncing git metadata (skip git upload flag detected)')
+    expect(output[5]).toContain('Not syncing git metadata (no enable git upload flag detected)')
+  })
+
+  test('with git metadata', async () => {
+    const {context, code} = await runCLI([
+      '--enable-git-metadata-upload',
+      process.cwd() + '/src/commands/junit/__tests__/fixtures/single_file.xml',
+    ])
+    const output = context.stdout.toString().split(os.EOL)
+    expect(code).toBe(0)
+    expect(output[5]).toContain('Syncing git metadata')
   })
 })
 

--- a/src/commands/junit/__tests__/upload.test.ts
+++ b/src/commands/junit/__tests__/upload.test.ts
@@ -342,7 +342,7 @@ describe('execute', () => {
     ])
     const output = context.stdout.toString().split(os.EOL)
     expect(code).toBe(0)
-    expect(output[5]).toContain('Not syncing git metadata (no enable git upload flag detected)')
+    expect(output[5]).toContain('Not syncing git metadata (skip git upload flag detected)')
   })
 
   test('with git metadata', async () => {

--- a/src/commands/junit/upload.ts
+++ b/src/commands/junit/upload.ts
@@ -116,7 +116,7 @@ export class UploadJUnitXMLCommand extends Command {
   private rawXPathTags?: string[]
   private xpathTags?: Record<string, string>
   private gitRepositoryURL?: string
-  private skipGitMetadataUpload?: boolean
+  private enableGitMetadataUpload?: boolean
   private logger: Logger = new Logger((s: string) => this.context.stdout.write(s), LogLevel.INFO)
 
   public async execute() {
@@ -174,7 +174,7 @@ export class UploadJUnitXMLCommand extends Command {
     const totalTimeSeconds = (Date.now() - initialTime) / 1000
     this.logger.info(renderSuccessfulUpload(this.dryRun, payloads.length, totalTimeSeconds))
 
-    if (!this.skipGitMetadataUpload) {
+    if (this.enableGitMetadataUpload) {
       if (await isGitRepo()) {
         const requestBuilder = getRequestBuilder({baseUrl: apiUrl, apiKey: this.config.apiKey!})
         try {
@@ -191,7 +191,7 @@ export class UploadJUnitXMLCommand extends Command {
         this.logger.info(`${this.dryRun ? '[DRYRUN] ' : ''}Not syncing git metadata (not a git repo)`)
       }
     } else {
-      this.logger.debug('Not syncing git metadata (skip git upload flag detected)')
+      this.logger.debug('Not syncing git metadata (no enable git upload flag detected)')
     }
 
     if (!this.dryRun) {
@@ -322,6 +322,6 @@ UploadJUnitXMLCommand.addOption('basePaths', Command.Rest({required: 1}))
 UploadJUnitXMLCommand.addOption('maxConcurrency', Command.String('--max-concurrency'))
 UploadJUnitXMLCommand.addOption('logs', Command.Boolean('--logs'))
 UploadJUnitXMLCommand.addOption('rawXPathTags', Command.Array('--xpath-tag'))
-UploadJUnitXMLCommand.addOption('skipGitMetadataUpload', Command.Boolean('--skip-git-metadata-upload'))
+UploadJUnitXMLCommand.addOption('enableGitMetadataUpload', Command.Boolean('--enable-git-metadata-upload'))
 UploadJUnitXMLCommand.addOption('gitRepositoryURL', Command.String('--git-repository-url'))
 UploadJUnitXMLCommand.addOption('verbose', Command.Boolean('--verbose'))

--- a/src/commands/junit/upload.ts
+++ b/src/commands/junit/upload.ts
@@ -198,7 +198,7 @@ export class UploadJUnitXMLCommand extends Command {
         this.logger.info(`${this.dryRun ? '[DRYRUN] ' : ''}Not syncing git metadata (not a git repo)`)
       }
     } else {
-      this.logger.debug('Not syncing git metadata (no enable git upload flag detected)')
+      this.logger.debug('Not syncing git metadata (skip git upload flag detected)')
     }
 
     if (!this.dryRun) {

--- a/src/commands/junit/utils.ts
+++ b/src/commands/junit/utils.ts
@@ -48,3 +48,9 @@ export const getTestCommitRedirectURL = (spanTags: SpanTags, service?: string, e
 
   return url
 }
+
+export const isFalse = (value: string | boolean) => {
+  const lowerCaseValue = String(value).toLowerCase()
+
+  return lowerCaseValue === '0' || lowerCaseValue === 'false'
+}


### PR DESCRIPTION
### What and why?

We've had some issues with slowness doing this git upload operation. Until we have proper metrics reporting in place, it's safer to turn this into opt-in rather than opt-out.

### How?

* Change `--skip-git-metadata-upload` to `--enable-git-metadata-upload`. Now, only if you're passing it will `datadog-ci junit upload` attempt to upload your data. 

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
