### PR TITLE
[junit] Update to v3

### DIFF
--- a/src/commands/junit/__tests__/upload.test.ts
+++ b/src/commands/junit/__tests__/upload.test.ts
@@ -56,7 +56,7 @@ describe('upload', () => {
           context,
           service: 'service',
         },
-        {}
+        {},{},{},{},{}
       )
 
       expect(firstFile).toMatchObject({
@@ -89,7 +89,7 @@ describe('upload', () => {
           context,
           service: 'service',
         },
-        {}
+        {},{},{},{},{}
       )
 
       expect(files.length).toEqual(1)
@@ -109,7 +109,7 @@ describe('upload', () => {
           context,
           service: 'service',
         },
-        {}
+        {},{},{},{},{}
       )
 
       expect(files.length).toEqual(0)
@@ -127,7 +127,7 @@ describe('upload', () => {
           context,
           service: 'service',
         },
-        {}
+        {},{},{},{},{}
       )
       expect(firstFile).toMatchObject({
         service: 'service',
@@ -155,7 +155,7 @@ describe('upload', () => {
           context,
           service: 'service',
         },
-        {}
+        {},{},{},{},{}
       )
 
       expect(files.length).toEqual(2)
@@ -170,7 +170,7 @@ describe('upload', () => {
           context,
           service: 'service',
         },
-        {}
+        {},{},{},{},{}
       )
 
       expect(firstFile.hostname).toEqual(os.hostname())
@@ -188,7 +188,7 @@ describe('upload', () => {
           logs: true,
           service: 'service',
         },
-        {}
+        {},{},{},{},{}
       )
       expect(firstFile.logsEnabled).toBe(true)
       expect(secondFile.logsEnabled).toBe(true)

--- a/src/commands/junit/api.ts
+++ b/src/commands/junit/api.ts
@@ -49,17 +49,8 @@ export const uploadJUnitXML = (request: (args: AxiosRequestConfig) => AxiosPromi
 
   form.append('event', JSON.stringify(metadata), {filename: 'event.json'})
 
-  let uniqueFileName = `${fileName}-${jUnitXML.service}-${metadata[GIT_SHA]}`
-
-  if (metadata[CI_PIPELINE_URL]) {
-    uniqueFileName = `${uniqueFileName}-${metadata[CI_PIPELINE_URL]}`
-  }
-  if (metadata[CI_JOB_URL]) {
-    uniqueFileName = `${uniqueFileName}-${metadata[CI_JOB_URL]}`
-  }
-
   form.append('junit_xml_report_file', fs.createReadStream(jUnitXML.xmlPath).pipe(createGzip()), {
-    filename: `${getSafeFileName(uniqueFileName)}.xml.gz`,
+    filename: `${getSafeFileName(fileName)}.xml.gz`,
   })
 
   return request({

--- a/src/commands/junit/api.ts
+++ b/src/commands/junit/api.ts
@@ -7,7 +7,7 @@ import type {AxiosPromise, AxiosRequestConfig, AxiosResponse} from 'axios'
 import FormData from 'form-data'
 
 import {getSafeFileName} from '../../helpers/file'
-import {CI_JOB_URL, CI_PIPELINE_URL, GIT_SHA} from '../../helpers/tags'
+import {CI_JOB_URL, CI_PIPELINE_URL, GIT_SHA, SERVICE} from '../../helpers/tags'
 import {getRequestBuilder} from '../../helpers/utils'
 
 import {Payload} from './interfaces'
@@ -32,10 +32,17 @@ export const uploadJUnitXML = (request: (args: AxiosRequestConfig) => AxiosPromi
     fileName = 'default_file_name'
   }
 
+  const reportTagsAndMetrics: Record<string, any> = { 
+    tags: jUnitXML.reportTags,
+    metrics: jUnitXML.reportMetrics
+  };
+
   const metadata: Record<string, any> = {
-    service: jUnitXML.service,
-    ...jUnitXML.spanTags,
-    '_dd.cireport_version': '2',
+    metadata: jUnitXML.spanTags,
+    tags: jUnitXML.customTags,
+    metrics: jUnitXML.customMetrics,
+    session: reportTagsAndMetrics,
+    '_dd.cireport_version': '3',
     '_dd.hostname': jUnitXML.hostname,
   }
 

--- a/src/commands/junit/interfaces.ts
+++ b/src/commands/junit/interfaces.ts
@@ -5,8 +5,11 @@ import {SpanTags} from '../../helpers/interfaces'
 export interface Payload {
   hostname: string
   logsEnabled: boolean
-  service: string
   spanTags: SpanTags
+  customTags: Record<string, string>
+  customMetrics: Record<string, number>
+  reportTags: Record<string, string>
+  reportMetrics: Record<string, number>
   xmlPath: string
   xpathTags?: Record<string, string>
 }

--- a/src/helpers/__tests__/file.test.ts
+++ b/src/helpers/__tests__/file.test.ts
@@ -7,7 +7,7 @@ describe('file util', () => {
       expect(safeFileName).toBe('myfilename')
     })
     test('filters unsafe characters out', () => {
-      expect(getSafeFileName('http://gitlab.com/-/pipelines/12345')).toEqual('http___gitlab_com___pipelines_12345')
+      expect(getSafeFileName('tests/reports/junit/integration.xml')).toEqual('tests\\reports\\junit\\integration.xml')
     })
   })
 })

--- a/src/helpers/file.ts
+++ b/src/helpers/file.ts
@@ -1,4 +1,1 @@
-// We need a unique file name so we use span tags like the pipeline URL,
-// which can contain dots and other unsafe characters for filenames.
-// We filter them out here.
-export const getSafeFileName = (unsafeFileName: string) => unsafeFileName.replace(/[^a-z0-9]/gi, '_')
+export const getSafeFileName = (unsafeFileName: string) => unsafeFileName.replace(/\//g, '\\')

--- a/src/helpers/interfaces.ts
+++ b/src/helpers/interfaces.ts
@@ -24,6 +24,7 @@ import {
   GIT_REPOSITORY_URL,
   GIT_SHA,
   GIT_TAG,
+  SERVICE,
 } from './tags'
 
 export interface Metadata {
@@ -91,6 +92,7 @@ export type SpanTag =
   | typeof CI_ENV_VARS
   | typeof CI_NODE_NAME
   | typeof CI_NODE_LABELS
+  | typeof SERVICE
 
 export type SpanTags = Partial<Record<SpanTag, string>>
 

--- a/src/helpers/tags.ts
+++ b/src/helpers/tags.ts
@@ -31,6 +31,7 @@ export const GIT_TAG = 'git.tag'
 
 // General
 export const SPAN_TYPE = 'span.type'
+export const SERVICE = 'service'
 
 const parseNumericTag = (numericTag: string | undefined): number | undefined => {
   if (numericTag) {


### PR DESCRIPTION
### What and why?

- Changes the junit upload to v3
  - Adds support for "report tags" that are tags that are only applied to sessions
  - Changes the format that the payload is sent to simplify the backend side.
  - Replaces the unique filename with just the filename https://github.com/DataDog/datadog-ci/pull/926

### How?

Instead of spreading everything into the "spanTags" variable now it is separated into several variables.  Changed the junit payload interface to achieve this.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
