### PR TITLE
[ci-visibility] Add trace id to git requests when using `junit upload`

### DIFF
--- a/src/commands/junit/__tests__/id.test.ts
+++ b/src/commands/junit/__tests__/id.test.ts
@@ -1,0 +1,23 @@
+import id from '../id'
+
+jest.mock('crypto', () => ({
+  ...jest.requireActual('crypto'),
+  randomFillSync: (data: number[]) => {
+    for (let i = 0; i < data.length; i += 8) {
+      data[i] = 0xff
+      data[i + 1] = 0x00
+      data[i + 2] = 0xff
+      data[i + 3] = 0x00
+      data[i + 4] = 0xff
+      data[i + 5] = 0x00
+      data[i + 6] = 0xff
+      data[i + 7] = 0x00
+    }
+  },
+}))
+
+describe('id', () => {
+  it('should return a random 63bit integer', () => {
+    expect(id()).toEqual('9151594822560186112')
+  })
+})

--- a/src/commands/junit/__tests__/upload.test.ts
+++ b/src/commands/junit/__tests__/upload.test.ts
@@ -4,8 +4,11 @@ import {Cli} from 'clipanion/lib/advanced'
 
 import {SpanTags} from '../../../helpers/interfaces'
 
+import id from '../id'
 import {renderInvalidFile} from '../renderer'
 import {UploadJUnitXMLCommand} from '../upload'
+
+jest.mock('../id', () => jest.fn())
 
 const makeCli = () => {
   const cli = new Cli()
@@ -341,6 +344,7 @@ describe('execute', () => {
       process.cwd() + '/src/commands/junit/__tests__/fixtures/single_file.xml',
     ])
     const output = context.stdout.toString().split(os.EOL)
+    expect(id).not.toHaveBeenCalled()
     expect(code).toBe(0)
     expect(output[5]).toContain('Not syncing git metadata (skip git upload flag detected)')
   })
@@ -354,6 +358,14 @@ describe('execute', () => {
     expect(code).toBe(0)
     expect(output[5]).toContain('Syncing git metadata')
   })
+
+  test('id headers are added when git metadata is uploaded', async () => {
+    await runCLI([
+      '--skip-git-metadata-upload=0',
+      process.cwd() + '/src/commands/junit/__tests__/fixtures/single_file.xml',
+    ])
+    expect(id).toHaveBeenCalled()
+  }, 10000000)
 })
 
 interface ExpectedOutput {

--- a/src/commands/junit/id.ts
+++ b/src/commands/junit/id.ts
@@ -1,0 +1,64 @@
+/* eslint-disable */
+// Eslint disabled because we're doing bitwise logic, which isn't allowed by the linter
+// From https://github.com/DataDog/dd-trace-js/blob/e4b9a268f0429b6f1e92c384b61a0d104aeb1259/packages/dd-trace/src/id.js
+import {randomFillSync} from 'crypto'
+
+const UINT_MAX = 4294967296
+
+const data = new Uint8Array(8 * 8192)
+
+let batch = 0
+
+// Convert a buffer to a numerical string.
+const toNumberString = (buffer: number[]) => {
+  const radix = 10
+  let high = readInt32(buffer, buffer.length - 8)
+  let low = readInt32(buffer, buffer.length - 4)
+  let str = ''
+
+  while (true) {
+    const mod = (high % radix) * UINT_MAX + low
+
+    high = Math.floor(high / radix)
+    low = Math.floor(mod / radix)
+    str = (mod % radix).toString(radix) + str
+
+    if (!high && !low) {
+      break
+    }
+  }
+
+  return str
+}
+
+// Simple pseudo-random 64-bit ID generator.
+const pseudoRandom = () => {
+  if (batch === 0) {
+    randomFillSync(data)
+  }
+
+  batch = (batch + 1) % 8192
+
+  const offset = batch * 8
+
+  return [
+    data[offset] & 0x7F, // only positive int64,
+    data[offset + 1],
+    data[offset + 2],
+    data[offset + 3],
+    data[offset + 4],
+    data[offset + 5],
+    data[offset + 6],
+    data[offset + 7],
+  ]
+}
+
+// Read a buffer to unsigned integer bytes.
+const readInt32 = (buffer: number[], offset: number) => {
+  return (buffer[offset + 0] * 16777216) +
+    (buffer[offset + 1] << 16) +
+    (buffer[offset + 2] << 8) +
+    buffer[offset + 3]
+}
+
+export default () => toNumberString(pseudoRandom())

--- a/src/commands/junit/upload.ts
+++ b/src/commands/junit/upload.ts
@@ -1,4 +1,3 @@
-import {randomBytes} from 'crypto'
 import fs from 'fs'
 import os from 'os'
 import path from 'path'
@@ -24,6 +23,7 @@ import {uploadToGitDB} from '../git-metadata/gitdb'
 import {isGitRepo} from '../git-metadata/library'
 
 import {apiConstructor, apiUrl, intakeUrl} from './api'
+import id from './id'
 import {APIHelper, Payload} from './interfaces'
 import {
   renderCommandInfo,
@@ -184,7 +184,7 @@ export class UploadJUnitXMLCommand extends Command {
 
     if (!this.skipGitMetadataUpload) {
       if (await isGitRepo()) {
-        const traceId = randomBytes(8).toString('hex')
+        const traceId = id()
 
         const requestBuilder = getRequestBuilder({
           baseUrl: apiUrl,

--- a/src/commands/junit/upload.ts
+++ b/src/commands/junit/upload.ts
@@ -1,3 +1,4 @@
+import {randomBytes} from 'crypto'
 import fs from 'fs'
 import os from 'os'
 import path from 'path'
@@ -183,7 +184,16 @@ export class UploadJUnitXMLCommand extends Command {
 
     if (!this.skipGitMetadataUpload) {
       if (await isGitRepo()) {
-        const requestBuilder = getRequestBuilder({baseUrl: apiUrl, apiKey: this.config.apiKey!})
+        const traceId = randomBytes(8).toString('hex')
+
+        const requestBuilder = getRequestBuilder({
+          baseUrl: apiUrl,
+          apiKey: this.config.apiKey!,
+          headers: new Map([
+            ['x-datadog-trace-id', traceId],
+            ['x-datadog-parent-id', traceId],
+          ]),
+        })
         try {
           this.logger.info(`${this.dryRun ? '[DRYRUN] ' : ''}Syncing git metadata...`)
           let elapsed = 0

--- a/src/commands/junit/upload.ts
+++ b/src/commands/junit/upload.ts
@@ -39,6 +39,8 @@ import {
 } from './renderer'
 import {isFalse} from './utils'
 
+const TRACE_ID_HTTP_HEADER = 'x-datadog-trace-id'
+const PARENT_ID_HTTP_HEADER = 'x-datadog-parent-id'
 const errorCodesStopUpload = [400, 403]
 
 const validateXml = (xmlFilePath: string) => {
@@ -190,8 +192,8 @@ export class UploadJUnitXMLCommand extends Command {
           baseUrl: apiUrl,
           apiKey: this.config.apiKey!,
           headers: new Map([
-            ['x-datadog-trace-id', traceId],
-            ['x-datadog-parent-id', traceId],
+            [TRACE_ID_HTTP_HEADER, traceId],
+            [PARENT_ID_HTTP_HEADER, traceId],
           ]),
         })
         try {


### PR DESCRIPTION
### What and why?

By adding a trace id in the git metadata upload requests we make sure that we can track the whole process. 

### How?

* Add an `id` module to generate span / trace ids. 
* Set trace id and parent id headers in the git requests. 

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
