### PR TITLE
[ci] Bump datadog-ci in CI integrations on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,31 @@ jobs:
         env:
           YARN_NPM_AUTH_TOKEN: ${{ secrets.YARN_NPM_AUTH_TOKEN }}
 
+  bump-ci-integrations:
+    strategy:
+      fail-fast: false
+      matrix:
+        integration:
+          - synthetics-ci-github-action
+          - datadog-ci-azure-devops
+          - synthetics-test-automation-circleci-orb
+
+    name: Bump datadog-ci in integration
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Create bump datadog-ci PR
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.CROSS_REPOSITORY_GITHUB_TOKEN }}
+          script: |
+            github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: '${{ matrix.integration }}',
+              workflow_id: 'bump-datadog-ci.yml',
+              ref: 'main',
+            });
+
   build-binary-ubuntu:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
### What and why?

All CI integrations now have a workflow to bump datadog-ci. It's now time to do this automatically on each release of datadog-ci.

### How?

Use the github's api to dispatch workflows.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
