### PR TITLE
Fix upload-application marking versions as latest, added docs

### DIFF
--- a/src/commands/synthetics/README.md
+++ b/src/commands/synthetics/README.md
@@ -433,6 +433,41 @@ You can also see the outcome of test executions directly in your CI as your test
   info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
 ```
 
+## Upload Application Command
+
+To upload a new version to an **existing application**, you can use the `synthetics upload-application` command. To use it:
+
+`--mobileApplicationId` - string - the ID of the application you want to upload the new version to
+`--mobileApplicationVersionFilePath` - string - path to the mobile app (.apk/.ipa)
+`--versionName` - string - name of the new version
+`--latest` - bool - if present, marks the application as 'latest'. Any tests that run on the latest version will use this version on their next run 
+ 
+Example:
+```
+datadog-ci synthetics upload-application              \
+--mobileApplicationId '123-123-123'                   \
+--mobileApplicationVersionFilePath 'example/test.apk' \
+--versionName 'example 1.0'                           \
+--latest
+```   
+
+You can also pass these options in a configuration file
+```
+{
+  "apiKey": <YOUR API KEY>,
+  "appKey": <YOUR APP KEY>,
+  "mobileApplicationVersionFilePath": "example_path/example_app.apk",
+  "mobileApplicationId": "example-abc",
+  "versionName": "example",
+  "latest": true
+}
+```
+
+And pass it to the command with the `--config` flag, example:
+```
+datadog-ci synthetics upload-application --config 'datadog-ci.config'
+```
+
 ## Further reading
 
 Additional helpful documentation, links, and articles:

--- a/src/commands/synthetics/__tests__/cli.test.ts
+++ b/src/commands/synthetics/__tests__/cli.test.ts
@@ -5,10 +5,10 @@ import * as ciUtils from '../../../helpers/utils'
 import * as api from '../api'
 import {UserConfigOverride} from '../interfaces'
 import {DEFAULT_COMMAND_CONFIG, DEFAULT_POLLING_TIMEOUT, RunTestsCommand} from '../run-tests-command'
+import {DEFAULT_UPLOAD_COMMAND_CONFIG, UploadApplicationCommand} from '../upload-application-command'
 import * as utils from '../utils'
 
 import {getApiTest, getAxiosHttpError, getTestSuite, mockTestTriggerResponse} from './fixtures'
-
 test('all option flags are supported', async () => {
   const options = [
     'apiKey',
@@ -501,6 +501,104 @@ describe('run-test', () => {
       expect(writeMock).toHaveBeenCalledWith(
         'Credentials refused, make sure `apiKey`, `appKey` and `datadogSite` are correct.\n'
       )
+    })
+  })
+})
+
+describe('upload-application', () => {
+  describe('resolveConfig', () => {
+    beforeEach(() => {
+      process.env = {}
+    })
+
+    test('override from config file', async () => {
+      const overrideConfigFile = {
+        apiKey: 'fake_api_key',
+        appKey: 'fake_app_key',
+        configPath: 'src/commands/synthetics/__tests__/config-fixtures/upload-app-config-with-all-keys.json',
+        datadogSite: 'datadoghq.eu',
+        proxy: {protocol: 'http'},
+        mobileApplicationVersionFilePath: 'fake_path/fake_app.apk',
+        mobileApplicationId: 'fake-abc',
+        versionName: 'new',
+        latest: true,
+      }
+
+      const command = new UploadApplicationCommand()
+      command.configPath = 'src/commands/synthetics/__tests__/config-fixtures/upload-app-config-with-all-keys.json'
+
+      await command['resolveConfig']()
+      expect(command['config']).toEqual(overrideConfigFile)
+    })
+
+    test('override from CLI', async () => {
+      const overrideCLI = {
+        apiKey: 'fake_api_key_cli',
+        appKey: 'fake_app_key_cli',
+        configPath: 'src/commands/synthetics/__tests__/config-fixtures/empty-config-file.json',
+        datadogSite: 'datadoghq.cli',
+        mobileApplicationVersionFilePath: 'fake_path/cli_fake_app.apk',
+        mobileApplicationId: 'fake-abc-cli',
+        versionName: 'new cli',
+        latest: true,
+      }
+
+      const command = new UploadApplicationCommand()
+      command['apiKey'] = overrideCLI.apiKey
+      command['appKey'] = overrideCLI.appKey
+      command['configPath'] = overrideCLI.configPath
+      command['datadogSite'] = overrideCLI.datadogSite
+      command['mobileApplicationVersionFilePath'] = overrideCLI.mobileApplicationVersionFilePath
+      command['mobileApplicationId'] = overrideCLI.mobileApplicationId
+      command['versionName'] = overrideCLI.versionName
+      command['latest'] = overrideCLI.latest
+
+      await command['resolveConfig']()
+      expect(command['config']).toEqual({
+        ...DEFAULT_UPLOAD_COMMAND_CONFIG,
+        apiKey: 'fake_api_key_cli',
+        appKey: 'fake_app_key_cli',
+        configPath: 'src/commands/synthetics/__tests__/config-fixtures/empty-config-file.json',
+        datadogSite: 'datadoghq.cli',
+        mobileApplicationVersionFilePath: 'fake_path/cli_fake_app.apk',
+        mobileApplicationId: 'fake-abc-cli',
+        versionName: 'new cli',
+        latest: true,
+      })
+    })
+
+    test('override from config file < ENV < CLI', async () => {
+      jest.spyOn(ciUtils, 'resolveConfigFromFile').mockImplementationOnce(async <T>(baseConfig: T) => ({
+        ...baseConfig,
+        apiKey: 'api_key_config_file',
+        appKey: 'app_key_config_file',
+        datadogSite: 'us5.datadoghq.com',
+        mobileApplicationVersionFilePath: 'fake_path/fake_app.apk',
+        mobileApplicationId: 'fake-abc',
+        versionName: 'new',
+        latest: true,
+      }))
+
+      process.env = {
+        DATADOG_API_KEY: 'api_key_env',
+        DATADOG_APP_KEY: 'app_key_env',
+      }
+
+      const command = new UploadApplicationCommand()
+      command['apiKey'] = 'api_key_cli'
+      command['mobileApplicationVersionFilePath'] = './path/to/application_cli.apk'
+
+      await command['resolveConfig']()
+      expect(command['config']).toEqual({
+        ...DEFAULT_UPLOAD_COMMAND_CONFIG,
+        apiKey: 'api_key_cli',
+        appKey: 'app_key_env',
+        datadogSite: 'us5.datadoghq.com',
+        mobileApplicationVersionFilePath: './path/to/application_cli.apk',
+        mobileApplicationId: 'fake-abc',
+        versionName: 'new',
+        latest: true,
+      })
     })
   })
 })

--- a/src/commands/synthetics/__tests__/config-fixtures/upload-app-config-with-all-keys.json
+++ b/src/commands/synthetics/__tests__/config-fixtures/upload-app-config-with-all-keys.json
@@ -1,0 +1,10 @@
+{
+  "apiKey": "fake_api_key",
+  "appKey": "fake_app_key",
+  "configPath": "fake-datadog-ci.json",
+  "datadogSite": "datadoghq.eu",
+  "mobileApplicationVersionFilePath": "fake_path/fake_app.apk",
+  "mobileApplicationId": "fake-abc",
+  "versionName": "new",
+  "latest": true
+}

--- a/src/commands/synthetics/__tests__/fixtures.ts
+++ b/src/commands/synthetics/__tests__/fixtures.ts
@@ -562,6 +562,7 @@ export const getMobileVersion = (override?: Partial<MobileApplicationVersion>) =
 export const uploadCommandConfig: UploadApplicationCommandConfig = {
   apiKey: 'foo',
   appKey: 'bar',
+  configPath: 'datadog-ci.json',
   datadogSite: 'datadoghq.com',
   proxy: {protocol: 'http'},
   mobileApplicationVersionFilePath: 'test.apk',

--- a/src/commands/synthetics/__tests__/mobile.test.ts
+++ b/src/commands/synthetics/__tests__/mobile.test.ts
@@ -294,7 +294,7 @@ describe('uploadMobileApplicationVersion', () => {
   })
 
   test('missing mobile application ID', async () => {
-    delete config.mobileApplicationId
+    config.mobileApplicationId = ''
     await expect(mobile.uploadMobileApplicationVersion(config)).rejects.toThrow(CiError)
 
     expect(uploadMobileApplicationSpy).toHaveBeenCalledTimes(0)

--- a/src/commands/synthetics/api.ts
+++ b/src/commands/synthetics/api.ts
@@ -274,10 +274,10 @@ export type APIHelper = ReturnType<typeof apiConstructor>
 
 export const getApiHelper = (config: APIHelperConfig): APIHelper => {
   if (!config.appKey) {
-    throw new CriticalError('MISSING_APP_KEY')
+    throw new CriticalError('MISSING_APP_KEY', 'App key is required')
   }
   if (!config.apiKey) {
-    throw new CriticalError('MISSING_API_KEY')
+    throw new CriticalError('MISSING_API_KEY', 'API key is required')
   }
 
   return apiConstructor({

--- a/src/commands/synthetics/interfaces.ts
+++ b/src/commands/synthetics/interfaces.ts
@@ -386,6 +386,7 @@ export interface RunTestsCommandConfig extends SyntheticsCIConfig {
 export type WrapperConfig = Partial<RunTestsCommandConfig>
 
 export interface UploadApplicationCommandConfig extends SyntheticsCIConfig {
+  configPath: string
   mobileApplicationVersionFilePath?: string
   mobileApplicationId?: string
   versionName?: string

--- a/src/commands/synthetics/mobile.ts
+++ b/src/commands/synthetics/mobile.ts
@@ -155,7 +155,7 @@ export const uploadMobileApplicationVersion = async (
   if (!config.versionName) {
     throw new CiError('MISSING_MOBILE_VERSION_NAME', 'Version name is required')
   }
-  config.latest = config.latest ?? true
+  config.latest = config.latest ?? false
 
   const fileName = await uploadMobileApplications(
     api,


### PR DESCRIPTION
### What and why?

Fix `upload-application` command options so it can mark uploaded versions as latest. Also adds basic usage docs.

### How?

Allowing config override via config files, fixing the `--latest` command option

### Review checklist

- [X] Feature or bugfix MUST have appropriate tests (unit, integration)
