### PR TITLE
[dep] Bump aws-sdk to bump fast-xml-parser

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,11 +58,11 @@
     "watch": "tsc -w"
   },
   "dependencies": {
-    "@aws-sdk/client-cloudwatch-logs": "^3.315.0",
-    "@aws-sdk/client-iam": "^3.315.0",
-    "@aws-sdk/client-lambda": "^3.293.0",
-    "@aws-sdk/client-sfn": "^3.315.0",
-    "@aws-sdk/credential-providers": "^3.296.0",
+    "@aws-sdk/client-cloudwatch-logs": "^3.358.0",
+    "@aws-sdk/client-iam": "^3.358.0",
+    "@aws-sdk/client-lambda": "^3.358.0",
+    "@aws-sdk/client-sfn": "^3.358.0",
+    "@aws-sdk/credential-providers": "^3.358.0",
     "@types/datadog-metrics": "0.6.1",
     "ajv": "^8.12.0",
     "ajv-formats": "^2.1.1",
@@ -94,7 +94,7 @@
     "yamux-js": "0.1.2"
   },
   "devDependencies": {
-    "@aws-sdk/types": "^3.292.0",
+    "@aws-sdk/types": "^3.357.0",
     "@babel/core": "7.8.0",
     "@babel/preset-env": "7.4.5",
     "@babel/preset-typescript": "7.3.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15,6 +15,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@aws-crypto/crc32@npm:3.0.0":
+  version: 3.0.0
+  resolution: "@aws-crypto/crc32@npm:3.0.0"
+  dependencies:
+    "@aws-crypto/util": ^3.0.0
+    "@aws-sdk/types": ^3.222.0
+    tslib: ^1.11.1
+  checksum: 9fdb3e837fc54119b017ea34fd0a6d71d2c88075d99e1e818a5158e0ad30ced67ddbcc423a11ceeef6cc465ab5ffd91830acab516470b48237ca7abd51be9642
+  languageName: node
+  linkType: hard
+
 "@aws-crypto/ie11-detection@npm:^3.0.0":
   version: 3.0.0
   resolution: "@aws-crypto/ie11-detection@npm:3.0.0"
@@ -71,818 +82,599 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/abort-controller@npm:3.296.0":
-  version: 3.296.0
-  resolution: "@aws-sdk/abort-controller@npm:3.296.0"
+"@aws-sdk/abort-controller@npm:3.357.0":
+  version: 3.357.0
+  resolution: "@aws-sdk/abort-controller@npm:3.357.0"
   dependencies:
-    "@aws-sdk/types": 3.296.0
+    "@aws-sdk/types": 3.357.0
     tslib: ^2.5.0
-  checksum: bfaf89f703f3be0b2c79574e3bd67f7f8272c88e1f99edaba51fa592a70d82f391380fdec703d8b31eea5488b285797848f7c6d187e87872ec0faf2df8284d47
+  checksum: dee99ea164454db35f5a85deb0cec51b9d7065a1aa551c4ac7c0c8e2a538fd3827f9fd5812bd9576ce5dfd25a98fce1b26252d7a67d9ae864c65b5deb7f35a43
   languageName: node
   linkType: hard
 
-"@aws-sdk/abort-controller@npm:3.310.0":
-  version: 3.310.0
-  resolution: "@aws-sdk/abort-controller@npm:3.310.0"
-  dependencies:
-    "@aws-sdk/types": 3.310.0
-    tslib: ^2.5.0
-  checksum: ca081fbec7419ff7bc03b7fddcfe7be1d5e390290c819069f42672f5a66415b55d90a81de899c384fd3368396390e3573c66345a8f91683e600c6caff64a239f
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/client-cloudwatch-logs@npm:^3.315.0":
-  version: 3.315.0
-  resolution: "@aws-sdk/client-cloudwatch-logs@npm:3.315.0"
+"@aws-sdk/client-cloudwatch-logs@npm:^3.358.0":
+  version: 3.358.0
+  resolution: "@aws-sdk/client-cloudwatch-logs@npm:3.358.0"
   dependencies:
     "@aws-crypto/sha256-browser": 3.0.0
     "@aws-crypto/sha256-js": 3.0.0
-    "@aws-sdk/client-sts": 3.315.0
-    "@aws-sdk/config-resolver": 3.310.0
-    "@aws-sdk/credential-provider-node": 3.315.0
-    "@aws-sdk/fetch-http-handler": 3.310.0
-    "@aws-sdk/hash-node": 3.310.0
-    "@aws-sdk/invalid-dependency": 3.310.0
-    "@aws-sdk/middleware-content-length": 3.310.0
-    "@aws-sdk/middleware-endpoint": 3.310.0
-    "@aws-sdk/middleware-host-header": 3.310.0
-    "@aws-sdk/middleware-logger": 3.310.0
-    "@aws-sdk/middleware-recursion-detection": 3.310.0
-    "@aws-sdk/middleware-retry": 3.310.0
-    "@aws-sdk/middleware-serde": 3.310.0
-    "@aws-sdk/middleware-signing": 3.310.0
-    "@aws-sdk/middleware-stack": 3.310.0
-    "@aws-sdk/middleware-user-agent": 3.310.0
-    "@aws-sdk/node-config-provider": 3.310.0
-    "@aws-sdk/node-http-handler": 3.310.0
-    "@aws-sdk/protocol-http": 3.310.0
-    "@aws-sdk/smithy-client": 3.315.0
-    "@aws-sdk/types": 3.310.0
-    "@aws-sdk/url-parser": 3.310.0
+    "@aws-sdk/client-sts": 3.358.0
+    "@aws-sdk/config-resolver": 3.357.0
+    "@aws-sdk/credential-provider-node": 3.358.0
+    "@aws-sdk/fetch-http-handler": 3.357.0
+    "@aws-sdk/hash-node": 3.357.0
+    "@aws-sdk/invalid-dependency": 3.357.0
+    "@aws-sdk/middleware-content-length": 3.357.0
+    "@aws-sdk/middleware-endpoint": 3.357.0
+    "@aws-sdk/middleware-host-header": 3.357.0
+    "@aws-sdk/middleware-logger": 3.357.0
+    "@aws-sdk/middleware-recursion-detection": 3.357.0
+    "@aws-sdk/middleware-retry": 3.357.0
+    "@aws-sdk/middleware-serde": 3.357.0
+    "@aws-sdk/middleware-signing": 3.357.0
+    "@aws-sdk/middleware-stack": 3.357.0
+    "@aws-sdk/middleware-user-agent": 3.357.0
+    "@aws-sdk/node-config-provider": 3.357.0
+    "@aws-sdk/node-http-handler": 3.357.0
+    "@aws-sdk/smithy-client": 3.358.0
+    "@aws-sdk/types": 3.357.0
+    "@aws-sdk/url-parser": 3.357.0
     "@aws-sdk/util-base64": 3.310.0
     "@aws-sdk/util-body-length-browser": 3.310.0
     "@aws-sdk/util-body-length-node": 3.310.0
-    "@aws-sdk/util-defaults-mode-browser": 3.315.0
-    "@aws-sdk/util-defaults-mode-node": 3.315.0
-    "@aws-sdk/util-endpoints": 3.310.0
-    "@aws-sdk/util-retry": 3.310.0
-    "@aws-sdk/util-user-agent-browser": 3.310.0
-    "@aws-sdk/util-user-agent-node": 3.310.0
+    "@aws-sdk/util-defaults-mode-browser": 3.358.0
+    "@aws-sdk/util-defaults-mode-node": 3.358.0
+    "@aws-sdk/util-endpoints": 3.357.0
+    "@aws-sdk/util-retry": 3.357.0
+    "@aws-sdk/util-user-agent-browser": 3.357.0
+    "@aws-sdk/util-user-agent-node": 3.357.0
     "@aws-sdk/util-utf8": 3.310.0
+    "@smithy/protocol-http": ^1.0.1
+    "@smithy/types": ^1.0.0
     tslib: ^2.5.0
-  checksum: 40ac606b89fb21e3ecbd0a6bbf44e6613883cf53e233a1ea19ffa018b3d944fb3204822be96c06933de003eb43bdd026c929924430d8208e5743f3e22cbcd937
+  checksum: c5d55b6dc921ac2a3568271999faed824b978b0c5c80d61089d0a87e0e8609810b8abc69002d0cac50969cafe6c1eb2d6bbb4d97742f0bb809971aad8b12e72b
   languageName: node
   linkType: hard
 
-"@aws-sdk/client-cognito-identity@npm:3.301.0":
-  version: 3.301.0
-  resolution: "@aws-sdk/client-cognito-identity@npm:3.301.0"
+"@aws-sdk/client-cognito-identity@npm:3.358.0":
+  version: 3.358.0
+  resolution: "@aws-sdk/client-cognito-identity@npm:3.358.0"
   dependencies:
     "@aws-crypto/sha256-browser": 3.0.0
     "@aws-crypto/sha256-js": 3.0.0
-    "@aws-sdk/client-sts": 3.301.0
-    "@aws-sdk/config-resolver": 3.300.0
-    "@aws-sdk/credential-provider-node": 3.301.0
-    "@aws-sdk/fetch-http-handler": 3.296.0
-    "@aws-sdk/hash-node": 3.296.0
-    "@aws-sdk/invalid-dependency": 3.296.0
-    "@aws-sdk/middleware-content-length": 3.296.0
-    "@aws-sdk/middleware-endpoint": 3.299.0
-    "@aws-sdk/middleware-host-header": 3.296.0
-    "@aws-sdk/middleware-logger": 3.296.0
-    "@aws-sdk/middleware-recursion-detection": 3.296.0
-    "@aws-sdk/middleware-retry": 3.300.0
-    "@aws-sdk/middleware-serde": 3.296.0
-    "@aws-sdk/middleware-signing": 3.299.0
-    "@aws-sdk/middleware-stack": 3.296.0
-    "@aws-sdk/middleware-user-agent": 3.299.0
-    "@aws-sdk/node-config-provider": 3.300.0
-    "@aws-sdk/node-http-handler": 3.296.0
-    "@aws-sdk/protocol-http": 3.296.0
-    "@aws-sdk/smithy-client": 3.296.0
-    "@aws-sdk/types": 3.296.0
-    "@aws-sdk/url-parser": 3.296.0
-    "@aws-sdk/util-base64": 3.295.0
-    "@aws-sdk/util-body-length-browser": 3.295.0
-    "@aws-sdk/util-body-length-node": 3.295.0
-    "@aws-sdk/util-defaults-mode-browser": 3.296.0
-    "@aws-sdk/util-defaults-mode-node": 3.300.0
-    "@aws-sdk/util-endpoints": 3.296.0
-    "@aws-sdk/util-retry": 3.296.0
-    "@aws-sdk/util-user-agent-browser": 3.299.0
-    "@aws-sdk/util-user-agent-node": 3.300.0
-    "@aws-sdk/util-utf8": 3.295.0
-    tslib: ^2.5.0
-  checksum: 0a77c20d5be67f2d7abc0d118af0f2bd71b3d2989aa0e2b484e0f5612cb6001c6f54ae3934f827c37e3aad53ea6fba43e4c7f93ea83e9db8ea505b2d167c8553
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/client-iam@npm:^3.315.0":
-  version: 3.315.0
-  resolution: "@aws-sdk/client-iam@npm:3.315.0"
-  dependencies:
-    "@aws-crypto/sha256-browser": 3.0.0
-    "@aws-crypto/sha256-js": 3.0.0
-    "@aws-sdk/client-sts": 3.315.0
-    "@aws-sdk/config-resolver": 3.310.0
-    "@aws-sdk/credential-provider-node": 3.315.0
-    "@aws-sdk/fetch-http-handler": 3.310.0
-    "@aws-sdk/hash-node": 3.310.0
-    "@aws-sdk/invalid-dependency": 3.310.0
-    "@aws-sdk/middleware-content-length": 3.310.0
-    "@aws-sdk/middleware-endpoint": 3.310.0
-    "@aws-sdk/middleware-host-header": 3.310.0
-    "@aws-sdk/middleware-logger": 3.310.0
-    "@aws-sdk/middleware-recursion-detection": 3.310.0
-    "@aws-sdk/middleware-retry": 3.310.0
-    "@aws-sdk/middleware-serde": 3.310.0
-    "@aws-sdk/middleware-signing": 3.310.0
-    "@aws-sdk/middleware-stack": 3.310.0
-    "@aws-sdk/middleware-user-agent": 3.310.0
-    "@aws-sdk/node-config-provider": 3.310.0
-    "@aws-sdk/node-http-handler": 3.310.0
-    "@aws-sdk/protocol-http": 3.310.0
-    "@aws-sdk/smithy-client": 3.315.0
-    "@aws-sdk/types": 3.310.0
-    "@aws-sdk/url-parser": 3.310.0
+    "@aws-sdk/client-sts": 3.358.0
+    "@aws-sdk/config-resolver": 3.357.0
+    "@aws-sdk/credential-provider-node": 3.358.0
+    "@aws-sdk/fetch-http-handler": 3.357.0
+    "@aws-sdk/hash-node": 3.357.0
+    "@aws-sdk/invalid-dependency": 3.357.0
+    "@aws-sdk/middleware-content-length": 3.357.0
+    "@aws-sdk/middleware-endpoint": 3.357.0
+    "@aws-sdk/middleware-host-header": 3.357.0
+    "@aws-sdk/middleware-logger": 3.357.0
+    "@aws-sdk/middleware-recursion-detection": 3.357.0
+    "@aws-sdk/middleware-retry": 3.357.0
+    "@aws-sdk/middleware-serde": 3.357.0
+    "@aws-sdk/middleware-signing": 3.357.0
+    "@aws-sdk/middleware-stack": 3.357.0
+    "@aws-sdk/middleware-user-agent": 3.357.0
+    "@aws-sdk/node-config-provider": 3.357.0
+    "@aws-sdk/node-http-handler": 3.357.0
+    "@aws-sdk/smithy-client": 3.358.0
+    "@aws-sdk/types": 3.357.0
+    "@aws-sdk/url-parser": 3.357.0
     "@aws-sdk/util-base64": 3.310.0
     "@aws-sdk/util-body-length-browser": 3.310.0
     "@aws-sdk/util-body-length-node": 3.310.0
-    "@aws-sdk/util-defaults-mode-browser": 3.315.0
-    "@aws-sdk/util-defaults-mode-node": 3.315.0
-    "@aws-sdk/util-endpoints": 3.310.0
-    "@aws-sdk/util-retry": 3.310.0
-    "@aws-sdk/util-user-agent-browser": 3.310.0
-    "@aws-sdk/util-user-agent-node": 3.310.0
+    "@aws-sdk/util-defaults-mode-browser": 3.358.0
+    "@aws-sdk/util-defaults-mode-node": 3.358.0
+    "@aws-sdk/util-endpoints": 3.357.0
+    "@aws-sdk/util-retry": 3.357.0
+    "@aws-sdk/util-user-agent-browser": 3.357.0
+    "@aws-sdk/util-user-agent-node": 3.357.0
     "@aws-sdk/util-utf8": 3.310.0
-    "@aws-sdk/util-waiter": 3.310.0
-    fast-xml-parser: 4.1.2
+    "@smithy/protocol-http": ^1.0.1
+    "@smithy/types": ^1.0.0
     tslib: ^2.5.0
-  checksum: 1b6a2507e556191fcd84f898d8bd496b7ab2eef3fa354377b8b33190f17c54a1d80116ff72c44371f07b0bd96ab06811b875c91b6e45f5efcc3e8d7c88f5de76
+  checksum: cbc01289edd167250ca93f1b19970499be5a16b328bd8e8225fe7ca8d9774d0115632608130b9d099ba3ac230beb112f9e31f25bef13043424f7eac74b4a3d21
   languageName: node
   linkType: hard
 
-"@aws-sdk/client-lambda@npm:^3.293.0":
-  version: 3.301.0
-  resolution: "@aws-sdk/client-lambda@npm:3.301.0"
+"@aws-sdk/client-iam@npm:^3.358.0":
+  version: 3.358.0
+  resolution: "@aws-sdk/client-iam@npm:3.358.0"
   dependencies:
     "@aws-crypto/sha256-browser": 3.0.0
     "@aws-crypto/sha256-js": 3.0.0
-    "@aws-sdk/client-sts": 3.301.0
-    "@aws-sdk/config-resolver": 3.300.0
-    "@aws-sdk/credential-provider-node": 3.301.0
-    "@aws-sdk/fetch-http-handler": 3.296.0
-    "@aws-sdk/hash-node": 3.296.0
-    "@aws-sdk/invalid-dependency": 3.296.0
-    "@aws-sdk/middleware-content-length": 3.296.0
-    "@aws-sdk/middleware-endpoint": 3.299.0
-    "@aws-sdk/middleware-host-header": 3.296.0
-    "@aws-sdk/middleware-logger": 3.296.0
-    "@aws-sdk/middleware-recursion-detection": 3.296.0
-    "@aws-sdk/middleware-retry": 3.300.0
-    "@aws-sdk/middleware-serde": 3.296.0
-    "@aws-sdk/middleware-signing": 3.299.0
-    "@aws-sdk/middleware-stack": 3.296.0
-    "@aws-sdk/middleware-user-agent": 3.299.0
-    "@aws-sdk/node-config-provider": 3.300.0
-    "@aws-sdk/node-http-handler": 3.296.0
-    "@aws-sdk/protocol-http": 3.296.0
-    "@aws-sdk/smithy-client": 3.296.0
-    "@aws-sdk/types": 3.296.0
-    "@aws-sdk/url-parser": 3.296.0
-    "@aws-sdk/util-base64": 3.295.0
-    "@aws-sdk/util-body-length-browser": 3.295.0
-    "@aws-sdk/util-body-length-node": 3.295.0
-    "@aws-sdk/util-defaults-mode-browser": 3.296.0
-    "@aws-sdk/util-defaults-mode-node": 3.300.0
-    "@aws-sdk/util-endpoints": 3.296.0
-    "@aws-sdk/util-retry": 3.296.0
-    "@aws-sdk/util-user-agent-browser": 3.299.0
-    "@aws-sdk/util-user-agent-node": 3.300.0
-    "@aws-sdk/util-utf8": 3.295.0
-    "@aws-sdk/util-waiter": 3.296.0
-    tslib: ^2.5.0
-  checksum: 4e7ade7bf4e064ae45e36cbe120afb99abc6c8acbe7053ce95f0b80b7b18ae75cbab359a5d2a1fe2682063c514df2321c0f9d2ea647bf0760bb0b12dace73996
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/client-sfn@npm:^3.315.0":
-  version: 3.315.0
-  resolution: "@aws-sdk/client-sfn@npm:3.315.0"
-  dependencies:
-    "@aws-crypto/sha256-browser": 3.0.0
-    "@aws-crypto/sha256-js": 3.0.0
-    "@aws-sdk/client-sts": 3.315.0
-    "@aws-sdk/config-resolver": 3.310.0
-    "@aws-sdk/credential-provider-node": 3.315.0
-    "@aws-sdk/fetch-http-handler": 3.310.0
-    "@aws-sdk/hash-node": 3.310.0
-    "@aws-sdk/invalid-dependency": 3.310.0
-    "@aws-sdk/middleware-content-length": 3.310.0
-    "@aws-sdk/middleware-endpoint": 3.310.0
-    "@aws-sdk/middleware-host-header": 3.310.0
-    "@aws-sdk/middleware-logger": 3.310.0
-    "@aws-sdk/middleware-recursion-detection": 3.310.0
-    "@aws-sdk/middleware-retry": 3.310.0
-    "@aws-sdk/middleware-serde": 3.310.0
-    "@aws-sdk/middleware-signing": 3.310.0
-    "@aws-sdk/middleware-stack": 3.310.0
-    "@aws-sdk/middleware-user-agent": 3.310.0
-    "@aws-sdk/node-config-provider": 3.310.0
-    "@aws-sdk/node-http-handler": 3.310.0
-    "@aws-sdk/protocol-http": 3.310.0
-    "@aws-sdk/smithy-client": 3.315.0
-    "@aws-sdk/types": 3.310.0
-    "@aws-sdk/url-parser": 3.310.0
+    "@aws-sdk/client-sts": 3.358.0
+    "@aws-sdk/config-resolver": 3.357.0
+    "@aws-sdk/credential-provider-node": 3.358.0
+    "@aws-sdk/fetch-http-handler": 3.357.0
+    "@aws-sdk/hash-node": 3.357.0
+    "@aws-sdk/invalid-dependency": 3.357.0
+    "@aws-sdk/middleware-content-length": 3.357.0
+    "@aws-sdk/middleware-endpoint": 3.357.0
+    "@aws-sdk/middleware-host-header": 3.357.0
+    "@aws-sdk/middleware-logger": 3.357.0
+    "@aws-sdk/middleware-recursion-detection": 3.357.0
+    "@aws-sdk/middleware-retry": 3.357.0
+    "@aws-sdk/middleware-serde": 3.357.0
+    "@aws-sdk/middleware-signing": 3.357.0
+    "@aws-sdk/middleware-stack": 3.357.0
+    "@aws-sdk/middleware-user-agent": 3.357.0
+    "@aws-sdk/node-config-provider": 3.357.0
+    "@aws-sdk/node-http-handler": 3.357.0
+    "@aws-sdk/smithy-client": 3.358.0
+    "@aws-sdk/types": 3.357.0
+    "@aws-sdk/url-parser": 3.357.0
     "@aws-sdk/util-base64": 3.310.0
     "@aws-sdk/util-body-length-browser": 3.310.0
     "@aws-sdk/util-body-length-node": 3.310.0
-    "@aws-sdk/util-defaults-mode-browser": 3.315.0
-    "@aws-sdk/util-defaults-mode-node": 3.315.0
-    "@aws-sdk/util-endpoints": 3.310.0
-    "@aws-sdk/util-retry": 3.310.0
-    "@aws-sdk/util-user-agent-browser": 3.310.0
-    "@aws-sdk/util-user-agent-node": 3.310.0
+    "@aws-sdk/util-defaults-mode-browser": 3.358.0
+    "@aws-sdk/util-defaults-mode-node": 3.358.0
+    "@aws-sdk/util-endpoints": 3.357.0
+    "@aws-sdk/util-retry": 3.357.0
+    "@aws-sdk/util-user-agent-browser": 3.357.0
+    "@aws-sdk/util-user-agent-node": 3.357.0
     "@aws-sdk/util-utf8": 3.310.0
+    "@aws-sdk/util-waiter": 3.357.0
+    "@smithy/protocol-http": ^1.0.1
+    "@smithy/types": ^1.0.0
+    fast-xml-parser: 4.2.4
     tslib: ^2.5.0
-  checksum: 1ee81fd879ac15fc46ca403d579adb849cd87dbf1fdd9ba114ba402a790c89a54b6a46a9e7a233f771ce47d4137cb5671f731bd3d944bf67b5bf9c2555ff2365
+  checksum: 64fd984f5290de5edd4e414637f2b755bc63656e55f755c446482c025143532666b51691a1b0d4d5c9aaacddca34283d835754b23a16bbba022dc49d37032aa3
   languageName: node
   linkType: hard
 
-"@aws-sdk/client-sso-oidc@npm:3.301.0":
-  version: 3.301.0
-  resolution: "@aws-sdk/client-sso-oidc@npm:3.301.0"
+"@aws-sdk/client-lambda@npm:^3.358.0":
+  version: 3.358.0
+  resolution: "@aws-sdk/client-lambda@npm:3.358.0"
   dependencies:
     "@aws-crypto/sha256-browser": 3.0.0
     "@aws-crypto/sha256-js": 3.0.0
-    "@aws-sdk/config-resolver": 3.300.0
-    "@aws-sdk/fetch-http-handler": 3.296.0
-    "@aws-sdk/hash-node": 3.296.0
-    "@aws-sdk/invalid-dependency": 3.296.0
-    "@aws-sdk/middleware-content-length": 3.296.0
-    "@aws-sdk/middleware-endpoint": 3.299.0
-    "@aws-sdk/middleware-host-header": 3.296.0
-    "@aws-sdk/middleware-logger": 3.296.0
-    "@aws-sdk/middleware-recursion-detection": 3.296.0
-    "@aws-sdk/middleware-retry": 3.300.0
-    "@aws-sdk/middleware-serde": 3.296.0
-    "@aws-sdk/middleware-stack": 3.296.0
-    "@aws-sdk/middleware-user-agent": 3.299.0
-    "@aws-sdk/node-config-provider": 3.300.0
-    "@aws-sdk/node-http-handler": 3.296.0
-    "@aws-sdk/protocol-http": 3.296.0
-    "@aws-sdk/smithy-client": 3.296.0
-    "@aws-sdk/types": 3.296.0
-    "@aws-sdk/url-parser": 3.296.0
-    "@aws-sdk/util-base64": 3.295.0
-    "@aws-sdk/util-body-length-browser": 3.295.0
-    "@aws-sdk/util-body-length-node": 3.295.0
-    "@aws-sdk/util-defaults-mode-browser": 3.296.0
-    "@aws-sdk/util-defaults-mode-node": 3.300.0
-    "@aws-sdk/util-endpoints": 3.296.0
-    "@aws-sdk/util-retry": 3.296.0
-    "@aws-sdk/util-user-agent-browser": 3.299.0
-    "@aws-sdk/util-user-agent-node": 3.300.0
-    "@aws-sdk/util-utf8": 3.295.0
-    tslib: ^2.5.0
-  checksum: d4bc3b6cf2e870005c474caf699ce739162f077c6d8b5caa846ec9585649e694fd43f50a864355dbf6cf87e2f9a0747ef462492013d3a91843cd194bd9526d56
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/client-sso-oidc@npm:3.315.0":
-  version: 3.315.0
-  resolution: "@aws-sdk/client-sso-oidc@npm:3.315.0"
-  dependencies:
-    "@aws-crypto/sha256-browser": 3.0.0
-    "@aws-crypto/sha256-js": 3.0.0
-    "@aws-sdk/config-resolver": 3.310.0
-    "@aws-sdk/fetch-http-handler": 3.310.0
-    "@aws-sdk/hash-node": 3.310.0
-    "@aws-sdk/invalid-dependency": 3.310.0
-    "@aws-sdk/middleware-content-length": 3.310.0
-    "@aws-sdk/middleware-endpoint": 3.310.0
-    "@aws-sdk/middleware-host-header": 3.310.0
-    "@aws-sdk/middleware-logger": 3.310.0
-    "@aws-sdk/middleware-recursion-detection": 3.310.0
-    "@aws-sdk/middleware-retry": 3.310.0
-    "@aws-sdk/middleware-serde": 3.310.0
-    "@aws-sdk/middleware-stack": 3.310.0
-    "@aws-sdk/middleware-user-agent": 3.310.0
-    "@aws-sdk/node-config-provider": 3.310.0
-    "@aws-sdk/node-http-handler": 3.310.0
-    "@aws-sdk/protocol-http": 3.310.0
-    "@aws-sdk/smithy-client": 3.315.0
-    "@aws-sdk/types": 3.310.0
-    "@aws-sdk/url-parser": 3.310.0
+    "@aws-sdk/client-sts": 3.358.0
+    "@aws-sdk/config-resolver": 3.357.0
+    "@aws-sdk/credential-provider-node": 3.358.0
+    "@aws-sdk/eventstream-serde-browser": 3.357.0
+    "@aws-sdk/eventstream-serde-config-resolver": 3.357.0
+    "@aws-sdk/eventstream-serde-node": 3.357.0
+    "@aws-sdk/fetch-http-handler": 3.357.0
+    "@aws-sdk/hash-node": 3.357.0
+    "@aws-sdk/invalid-dependency": 3.357.0
+    "@aws-sdk/middleware-content-length": 3.357.0
+    "@aws-sdk/middleware-endpoint": 3.357.0
+    "@aws-sdk/middleware-host-header": 3.357.0
+    "@aws-sdk/middleware-logger": 3.357.0
+    "@aws-sdk/middleware-recursion-detection": 3.357.0
+    "@aws-sdk/middleware-retry": 3.357.0
+    "@aws-sdk/middleware-serde": 3.357.0
+    "@aws-sdk/middleware-signing": 3.357.0
+    "@aws-sdk/middleware-stack": 3.357.0
+    "@aws-sdk/middleware-user-agent": 3.357.0
+    "@aws-sdk/node-config-provider": 3.357.0
+    "@aws-sdk/node-http-handler": 3.357.0
+    "@aws-sdk/smithy-client": 3.358.0
+    "@aws-sdk/types": 3.357.0
+    "@aws-sdk/url-parser": 3.357.0
     "@aws-sdk/util-base64": 3.310.0
     "@aws-sdk/util-body-length-browser": 3.310.0
     "@aws-sdk/util-body-length-node": 3.310.0
-    "@aws-sdk/util-defaults-mode-browser": 3.315.0
-    "@aws-sdk/util-defaults-mode-node": 3.315.0
-    "@aws-sdk/util-endpoints": 3.310.0
-    "@aws-sdk/util-retry": 3.310.0
-    "@aws-sdk/util-user-agent-browser": 3.310.0
-    "@aws-sdk/util-user-agent-node": 3.310.0
+    "@aws-sdk/util-defaults-mode-browser": 3.358.0
+    "@aws-sdk/util-defaults-mode-node": 3.358.0
+    "@aws-sdk/util-endpoints": 3.357.0
+    "@aws-sdk/util-retry": 3.357.0
+    "@aws-sdk/util-stream": 3.358.0
+    "@aws-sdk/util-user-agent-browser": 3.357.0
+    "@aws-sdk/util-user-agent-node": 3.357.0
     "@aws-sdk/util-utf8": 3.310.0
+    "@aws-sdk/util-waiter": 3.357.0
+    "@smithy/protocol-http": ^1.0.1
+    "@smithy/types": ^1.0.0
     tslib: ^2.5.0
-  checksum: c51bdac14b208f58f6ebc0e73753bd6b7b4cd5bf9966b770748985a7c4eaae6d8a18685f98db34c7796c2321f37e5926ebd363d654a8354ae5e83f3c6c6558c7
+  checksum: 951793dd1aad9754aa50860b905afcd4f78260ff8e54f385a6441a2eb558efb8ac6d08c0c1f57b0a7bf5d6577c077001d8288a08ae5d3d483f213647434779bc
   languageName: node
   linkType: hard
 
-"@aws-sdk/client-sso@npm:3.301.0":
-  version: 3.301.0
-  resolution: "@aws-sdk/client-sso@npm:3.301.0"
+"@aws-sdk/client-sfn@npm:^3.358.0":
+  version: 3.358.0
+  resolution: "@aws-sdk/client-sfn@npm:3.358.0"
   dependencies:
     "@aws-crypto/sha256-browser": 3.0.0
     "@aws-crypto/sha256-js": 3.0.0
-    "@aws-sdk/config-resolver": 3.300.0
-    "@aws-sdk/fetch-http-handler": 3.296.0
-    "@aws-sdk/hash-node": 3.296.0
-    "@aws-sdk/invalid-dependency": 3.296.0
-    "@aws-sdk/middleware-content-length": 3.296.0
-    "@aws-sdk/middleware-endpoint": 3.299.0
-    "@aws-sdk/middleware-host-header": 3.296.0
-    "@aws-sdk/middleware-logger": 3.296.0
-    "@aws-sdk/middleware-recursion-detection": 3.296.0
-    "@aws-sdk/middleware-retry": 3.300.0
-    "@aws-sdk/middleware-serde": 3.296.0
-    "@aws-sdk/middleware-stack": 3.296.0
-    "@aws-sdk/middleware-user-agent": 3.299.0
-    "@aws-sdk/node-config-provider": 3.300.0
-    "@aws-sdk/node-http-handler": 3.296.0
-    "@aws-sdk/protocol-http": 3.296.0
-    "@aws-sdk/smithy-client": 3.296.0
-    "@aws-sdk/types": 3.296.0
-    "@aws-sdk/url-parser": 3.296.0
-    "@aws-sdk/util-base64": 3.295.0
-    "@aws-sdk/util-body-length-browser": 3.295.0
-    "@aws-sdk/util-body-length-node": 3.295.0
-    "@aws-sdk/util-defaults-mode-browser": 3.296.0
-    "@aws-sdk/util-defaults-mode-node": 3.300.0
-    "@aws-sdk/util-endpoints": 3.296.0
-    "@aws-sdk/util-retry": 3.296.0
-    "@aws-sdk/util-user-agent-browser": 3.299.0
-    "@aws-sdk/util-user-agent-node": 3.300.0
-    "@aws-sdk/util-utf8": 3.295.0
-    tslib: ^2.5.0
-  checksum: 21cb421bb1cbe57f859466ae33a7e46986510c5cab519ba012727ec553ca7e70f351e3fafc1f8b9600235ece352c0d8b209b1943030f34c13f4a70f0e3befdb4
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/client-sso@npm:3.315.0":
-  version: 3.315.0
-  resolution: "@aws-sdk/client-sso@npm:3.315.0"
-  dependencies:
-    "@aws-crypto/sha256-browser": 3.0.0
-    "@aws-crypto/sha256-js": 3.0.0
-    "@aws-sdk/config-resolver": 3.310.0
-    "@aws-sdk/fetch-http-handler": 3.310.0
-    "@aws-sdk/hash-node": 3.310.0
-    "@aws-sdk/invalid-dependency": 3.310.0
-    "@aws-sdk/middleware-content-length": 3.310.0
-    "@aws-sdk/middleware-endpoint": 3.310.0
-    "@aws-sdk/middleware-host-header": 3.310.0
-    "@aws-sdk/middleware-logger": 3.310.0
-    "@aws-sdk/middleware-recursion-detection": 3.310.0
-    "@aws-sdk/middleware-retry": 3.310.0
-    "@aws-sdk/middleware-serde": 3.310.0
-    "@aws-sdk/middleware-stack": 3.310.0
-    "@aws-sdk/middleware-user-agent": 3.310.0
-    "@aws-sdk/node-config-provider": 3.310.0
-    "@aws-sdk/node-http-handler": 3.310.0
-    "@aws-sdk/protocol-http": 3.310.0
-    "@aws-sdk/smithy-client": 3.315.0
-    "@aws-sdk/types": 3.310.0
-    "@aws-sdk/url-parser": 3.310.0
+    "@aws-sdk/client-sts": 3.358.0
+    "@aws-sdk/config-resolver": 3.357.0
+    "@aws-sdk/credential-provider-node": 3.358.0
+    "@aws-sdk/fetch-http-handler": 3.357.0
+    "@aws-sdk/hash-node": 3.357.0
+    "@aws-sdk/invalid-dependency": 3.357.0
+    "@aws-sdk/middleware-content-length": 3.357.0
+    "@aws-sdk/middleware-endpoint": 3.357.0
+    "@aws-sdk/middleware-host-header": 3.357.0
+    "@aws-sdk/middleware-logger": 3.357.0
+    "@aws-sdk/middleware-recursion-detection": 3.357.0
+    "@aws-sdk/middleware-retry": 3.357.0
+    "@aws-sdk/middleware-serde": 3.357.0
+    "@aws-sdk/middleware-signing": 3.357.0
+    "@aws-sdk/middleware-stack": 3.357.0
+    "@aws-sdk/middleware-user-agent": 3.357.0
+    "@aws-sdk/node-config-provider": 3.357.0
+    "@aws-sdk/node-http-handler": 3.357.0
+    "@aws-sdk/smithy-client": 3.358.0
+    "@aws-sdk/types": 3.357.0
+    "@aws-sdk/url-parser": 3.357.0
     "@aws-sdk/util-base64": 3.310.0
     "@aws-sdk/util-body-length-browser": 3.310.0
     "@aws-sdk/util-body-length-node": 3.310.0
-    "@aws-sdk/util-defaults-mode-browser": 3.315.0
-    "@aws-sdk/util-defaults-mode-node": 3.315.0
-    "@aws-sdk/util-endpoints": 3.310.0
-    "@aws-sdk/util-retry": 3.310.0
-    "@aws-sdk/util-user-agent-browser": 3.310.0
-    "@aws-sdk/util-user-agent-node": 3.310.0
+    "@aws-sdk/util-defaults-mode-browser": 3.358.0
+    "@aws-sdk/util-defaults-mode-node": 3.358.0
+    "@aws-sdk/util-endpoints": 3.357.0
+    "@aws-sdk/util-retry": 3.357.0
+    "@aws-sdk/util-user-agent-browser": 3.357.0
+    "@aws-sdk/util-user-agent-node": 3.357.0
     "@aws-sdk/util-utf8": 3.310.0
+    "@smithy/protocol-http": ^1.0.1
+    "@smithy/types": ^1.0.0
     tslib: ^2.5.0
-  checksum: 54b57b65b0bd61ac12f87a7dc037c9b404b54aa99cf5a32f0b5a80e191958f16513c3a271958f84d12db7ac9c51289001bf1e269c324a74315ce7a9924ceaaa4
+  checksum: 5ce15463184d3e5b43773ed80e35c51e06970c21eb0655ed86a16157f32c56ce5d82088053bdac070b293d3acab058d23e4ad8977d5947a4fb9d22f09ecc1861
   languageName: node
   linkType: hard
 
-"@aws-sdk/client-sts@npm:3.301.0":
-  version: 3.301.0
-  resolution: "@aws-sdk/client-sts@npm:3.301.0"
+"@aws-sdk/client-sso-oidc@npm:3.358.0":
+  version: 3.358.0
+  resolution: "@aws-sdk/client-sso-oidc@npm:3.358.0"
   dependencies:
     "@aws-crypto/sha256-browser": 3.0.0
     "@aws-crypto/sha256-js": 3.0.0
-    "@aws-sdk/config-resolver": 3.300.0
-    "@aws-sdk/credential-provider-node": 3.301.0
-    "@aws-sdk/fetch-http-handler": 3.296.0
-    "@aws-sdk/hash-node": 3.296.0
-    "@aws-sdk/invalid-dependency": 3.296.0
-    "@aws-sdk/middleware-content-length": 3.296.0
-    "@aws-sdk/middleware-endpoint": 3.299.0
-    "@aws-sdk/middleware-host-header": 3.296.0
-    "@aws-sdk/middleware-logger": 3.296.0
-    "@aws-sdk/middleware-recursion-detection": 3.296.0
-    "@aws-sdk/middleware-retry": 3.300.0
-    "@aws-sdk/middleware-sdk-sts": 3.299.0
-    "@aws-sdk/middleware-serde": 3.296.0
-    "@aws-sdk/middleware-signing": 3.299.0
-    "@aws-sdk/middleware-stack": 3.296.0
-    "@aws-sdk/middleware-user-agent": 3.299.0
-    "@aws-sdk/node-config-provider": 3.300.0
-    "@aws-sdk/node-http-handler": 3.296.0
-    "@aws-sdk/protocol-http": 3.296.0
-    "@aws-sdk/smithy-client": 3.296.0
-    "@aws-sdk/types": 3.296.0
-    "@aws-sdk/url-parser": 3.296.0
-    "@aws-sdk/util-base64": 3.295.0
-    "@aws-sdk/util-body-length-browser": 3.295.0
-    "@aws-sdk/util-body-length-node": 3.295.0
-    "@aws-sdk/util-defaults-mode-browser": 3.296.0
-    "@aws-sdk/util-defaults-mode-node": 3.300.0
-    "@aws-sdk/util-endpoints": 3.296.0
-    "@aws-sdk/util-retry": 3.296.0
-    "@aws-sdk/util-user-agent-browser": 3.299.0
-    "@aws-sdk/util-user-agent-node": 3.300.0
-    "@aws-sdk/util-utf8": 3.295.0
-    fast-xml-parser: 4.1.2
-    tslib: ^2.5.0
-  checksum: f5ac1755831b8bc596e7d678beff52d086c29d9acef1150c0cb29f4e1f9395a57c21b0106efe7e39aa19eeede4a14d9b9410997490bd0e778ab6e8bf05371454
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/client-sts@npm:3.315.0":
-  version: 3.315.0
-  resolution: "@aws-sdk/client-sts@npm:3.315.0"
-  dependencies:
-    "@aws-crypto/sha256-browser": 3.0.0
-    "@aws-crypto/sha256-js": 3.0.0
-    "@aws-sdk/config-resolver": 3.310.0
-    "@aws-sdk/credential-provider-node": 3.315.0
-    "@aws-sdk/fetch-http-handler": 3.310.0
-    "@aws-sdk/hash-node": 3.310.0
-    "@aws-sdk/invalid-dependency": 3.310.0
-    "@aws-sdk/middleware-content-length": 3.310.0
-    "@aws-sdk/middleware-endpoint": 3.310.0
-    "@aws-sdk/middleware-host-header": 3.310.0
-    "@aws-sdk/middleware-logger": 3.310.0
-    "@aws-sdk/middleware-recursion-detection": 3.310.0
-    "@aws-sdk/middleware-retry": 3.310.0
-    "@aws-sdk/middleware-sdk-sts": 3.310.0
-    "@aws-sdk/middleware-serde": 3.310.0
-    "@aws-sdk/middleware-signing": 3.310.0
-    "@aws-sdk/middleware-stack": 3.310.0
-    "@aws-sdk/middleware-user-agent": 3.310.0
-    "@aws-sdk/node-config-provider": 3.310.0
-    "@aws-sdk/node-http-handler": 3.310.0
-    "@aws-sdk/protocol-http": 3.310.0
-    "@aws-sdk/smithy-client": 3.315.0
-    "@aws-sdk/types": 3.310.0
-    "@aws-sdk/url-parser": 3.310.0
+    "@aws-sdk/config-resolver": 3.357.0
+    "@aws-sdk/fetch-http-handler": 3.357.0
+    "@aws-sdk/hash-node": 3.357.0
+    "@aws-sdk/invalid-dependency": 3.357.0
+    "@aws-sdk/middleware-content-length": 3.357.0
+    "@aws-sdk/middleware-endpoint": 3.357.0
+    "@aws-sdk/middleware-host-header": 3.357.0
+    "@aws-sdk/middleware-logger": 3.357.0
+    "@aws-sdk/middleware-recursion-detection": 3.357.0
+    "@aws-sdk/middleware-retry": 3.357.0
+    "@aws-sdk/middleware-serde": 3.357.0
+    "@aws-sdk/middleware-stack": 3.357.0
+    "@aws-sdk/middleware-user-agent": 3.357.0
+    "@aws-sdk/node-config-provider": 3.357.0
+    "@aws-sdk/node-http-handler": 3.357.0
+    "@aws-sdk/smithy-client": 3.358.0
+    "@aws-sdk/types": 3.357.0
+    "@aws-sdk/url-parser": 3.357.0
     "@aws-sdk/util-base64": 3.310.0
     "@aws-sdk/util-body-length-browser": 3.310.0
     "@aws-sdk/util-body-length-node": 3.310.0
-    "@aws-sdk/util-defaults-mode-browser": 3.315.0
-    "@aws-sdk/util-defaults-mode-node": 3.315.0
-    "@aws-sdk/util-endpoints": 3.310.0
-    "@aws-sdk/util-retry": 3.310.0
-    "@aws-sdk/util-user-agent-browser": 3.310.0
-    "@aws-sdk/util-user-agent-node": 3.310.0
+    "@aws-sdk/util-defaults-mode-browser": 3.358.0
+    "@aws-sdk/util-defaults-mode-node": 3.358.0
+    "@aws-sdk/util-endpoints": 3.357.0
+    "@aws-sdk/util-retry": 3.357.0
+    "@aws-sdk/util-user-agent-browser": 3.357.0
+    "@aws-sdk/util-user-agent-node": 3.357.0
     "@aws-sdk/util-utf8": 3.310.0
-    fast-xml-parser: 4.1.2
+    "@smithy/protocol-http": ^1.0.1
+    "@smithy/types": ^1.0.0
     tslib: ^2.5.0
-  checksum: 5bc2fb75b2568ada3f9c3a849b080068ece5d74851c195cd5aef86539d7c61c44b8585d895ed8a05fd189a78b6d1b31935352be803d473954a50c9ef805bb234
+  checksum: 0453c965fef264f0d73789dbd7288813075e13d91d0992a3871e370f1fb1016c8d8bc0e8d1adef9edc658243047782d0438eac8fabc3e99661b8281858316fa5
   languageName: node
   linkType: hard
 
-"@aws-sdk/config-resolver@npm:3.300.0":
-  version: 3.300.0
-  resolution: "@aws-sdk/config-resolver@npm:3.300.0"
+"@aws-sdk/client-sso@npm:3.358.0":
+  version: 3.358.0
+  resolution: "@aws-sdk/client-sso@npm:3.358.0"
   dependencies:
-    "@aws-sdk/types": 3.296.0
-    "@aws-sdk/util-config-provider": 3.295.0
-    "@aws-sdk/util-middleware": 3.296.0
+    "@aws-crypto/sha256-browser": 3.0.0
+    "@aws-crypto/sha256-js": 3.0.0
+    "@aws-sdk/config-resolver": 3.357.0
+    "@aws-sdk/fetch-http-handler": 3.357.0
+    "@aws-sdk/hash-node": 3.357.0
+    "@aws-sdk/invalid-dependency": 3.357.0
+    "@aws-sdk/middleware-content-length": 3.357.0
+    "@aws-sdk/middleware-endpoint": 3.357.0
+    "@aws-sdk/middleware-host-header": 3.357.0
+    "@aws-sdk/middleware-logger": 3.357.0
+    "@aws-sdk/middleware-recursion-detection": 3.357.0
+    "@aws-sdk/middleware-retry": 3.357.0
+    "@aws-sdk/middleware-serde": 3.357.0
+    "@aws-sdk/middleware-stack": 3.357.0
+    "@aws-sdk/middleware-user-agent": 3.357.0
+    "@aws-sdk/node-config-provider": 3.357.0
+    "@aws-sdk/node-http-handler": 3.357.0
+    "@aws-sdk/smithy-client": 3.358.0
+    "@aws-sdk/types": 3.357.0
+    "@aws-sdk/url-parser": 3.357.0
+    "@aws-sdk/util-base64": 3.310.0
+    "@aws-sdk/util-body-length-browser": 3.310.0
+    "@aws-sdk/util-body-length-node": 3.310.0
+    "@aws-sdk/util-defaults-mode-browser": 3.358.0
+    "@aws-sdk/util-defaults-mode-node": 3.358.0
+    "@aws-sdk/util-endpoints": 3.357.0
+    "@aws-sdk/util-retry": 3.357.0
+    "@aws-sdk/util-user-agent-browser": 3.357.0
+    "@aws-sdk/util-user-agent-node": 3.357.0
+    "@aws-sdk/util-utf8": 3.310.0
+    "@smithy/protocol-http": ^1.0.1
+    "@smithy/types": ^1.0.0
     tslib: ^2.5.0
-  checksum: c8c065520c9b8e628d2971cb3c22f48b35a600a429d8b1031ff732058cb19e6f3d83ce00927c37726ef72c4b5a3e2a385a01fd8e4d3d69526f0808f51e77042f
+  checksum: ee3371ad673ad69bbde5694396d7804a6e2c2a6144a095233e47eec325c17fc5f706909508fa9d7d93c2bef8a1a8849f99486f6c91b230d3fa0a9892135ff93b
   languageName: node
   linkType: hard
 
-"@aws-sdk/config-resolver@npm:3.310.0":
-  version: 3.310.0
-  resolution: "@aws-sdk/config-resolver@npm:3.310.0"
+"@aws-sdk/client-sts@npm:3.358.0":
+  version: 3.358.0
+  resolution: "@aws-sdk/client-sts@npm:3.358.0"
   dependencies:
-    "@aws-sdk/types": 3.310.0
+    "@aws-crypto/sha256-browser": 3.0.0
+    "@aws-crypto/sha256-js": 3.0.0
+    "@aws-sdk/config-resolver": 3.357.0
+    "@aws-sdk/credential-provider-node": 3.358.0
+    "@aws-sdk/fetch-http-handler": 3.357.0
+    "@aws-sdk/hash-node": 3.357.0
+    "@aws-sdk/invalid-dependency": 3.357.0
+    "@aws-sdk/middleware-content-length": 3.357.0
+    "@aws-sdk/middleware-endpoint": 3.357.0
+    "@aws-sdk/middleware-host-header": 3.357.0
+    "@aws-sdk/middleware-logger": 3.357.0
+    "@aws-sdk/middleware-recursion-detection": 3.357.0
+    "@aws-sdk/middleware-retry": 3.357.0
+    "@aws-sdk/middleware-sdk-sts": 3.357.0
+    "@aws-sdk/middleware-serde": 3.357.0
+    "@aws-sdk/middleware-signing": 3.357.0
+    "@aws-sdk/middleware-stack": 3.357.0
+    "@aws-sdk/middleware-user-agent": 3.357.0
+    "@aws-sdk/node-config-provider": 3.357.0
+    "@aws-sdk/node-http-handler": 3.357.0
+    "@aws-sdk/smithy-client": 3.358.0
+    "@aws-sdk/types": 3.357.0
+    "@aws-sdk/url-parser": 3.357.0
+    "@aws-sdk/util-base64": 3.310.0
+    "@aws-sdk/util-body-length-browser": 3.310.0
+    "@aws-sdk/util-body-length-node": 3.310.0
+    "@aws-sdk/util-defaults-mode-browser": 3.358.0
+    "@aws-sdk/util-defaults-mode-node": 3.358.0
+    "@aws-sdk/util-endpoints": 3.357.0
+    "@aws-sdk/util-retry": 3.357.0
+    "@aws-sdk/util-user-agent-browser": 3.357.0
+    "@aws-sdk/util-user-agent-node": 3.357.0
+    "@aws-sdk/util-utf8": 3.310.0
+    "@smithy/protocol-http": ^1.0.1
+    "@smithy/types": ^1.0.0
+    fast-xml-parser: 4.2.4
+    tslib: ^2.5.0
+  checksum: 71da447c9c4f6832fd22350fde9c2aec0cedc74e4e2b1248367960c7c366244e1413a24938f3d418db543b627618278ea5119f58d54e1f10763cb6282dd35715
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/config-resolver@npm:3.357.0":
+  version: 3.357.0
+  resolution: "@aws-sdk/config-resolver@npm:3.357.0"
+  dependencies:
+    "@aws-sdk/types": 3.357.0
     "@aws-sdk/util-config-provider": 3.310.0
-    "@aws-sdk/util-middleware": 3.310.0
+    "@aws-sdk/util-middleware": 3.357.0
     tslib: ^2.5.0
-  checksum: ec80bc867304344d04b6d6bbf369234e7d296540ffb988c3f29bf96ea5e3ac959f86a699c8eecef3fea87491fd413aaed3137e4f7a89544cceedf09cce1c9a15
+  checksum: ea2d608b1a4257a8c70c12fec9bdc0ddc2ea8e2d61597053f8713677426aaf9ea2a2be2fdaea430f4b95c3d1c9830d5994db7c760a40cb066b3646fb14ff5339
   languageName: node
   linkType: hard
 
-"@aws-sdk/credential-provider-cognito-identity@npm:3.301.0":
-  version: 3.301.0
-  resolution: "@aws-sdk/credential-provider-cognito-identity@npm:3.301.0"
+"@aws-sdk/credential-provider-cognito-identity@npm:3.358.0":
+  version: 3.358.0
+  resolution: "@aws-sdk/credential-provider-cognito-identity@npm:3.358.0"
   dependencies:
-    "@aws-sdk/client-cognito-identity": 3.301.0
-    "@aws-sdk/property-provider": 3.296.0
-    "@aws-sdk/types": 3.296.0
+    "@aws-sdk/client-cognito-identity": 3.358.0
+    "@aws-sdk/property-provider": 3.357.0
+    "@aws-sdk/types": 3.357.0
     tslib: ^2.5.0
-  checksum: 6bc9542814e4efb64d42b5ed943293ca4d2dbd5519d4cb027ee22331d1e63f2e00d8e2ffd33bf56bc8171f9abead9dc8e9cc74cc8a049cb442d9969b7c7a32fa
+  checksum: 24c43c647382574fe8762578971a3e58ea3c79ca9bb08f5fe67d141d9c759af05a9b8ae4c3c9ffedbcfd4a49e813a688f88f9f4ffb6c9a62086f2d25e56d6099
   languageName: node
   linkType: hard
 
-"@aws-sdk/credential-provider-env@npm:3.296.0":
-  version: 3.296.0
-  resolution: "@aws-sdk/credential-provider-env@npm:3.296.0"
+"@aws-sdk/credential-provider-env@npm:3.357.0":
+  version: 3.357.0
+  resolution: "@aws-sdk/credential-provider-env@npm:3.357.0"
   dependencies:
-    "@aws-sdk/property-provider": 3.296.0
-    "@aws-sdk/types": 3.296.0
+    "@aws-sdk/property-provider": 3.357.0
+    "@aws-sdk/types": 3.357.0
     tslib: ^2.5.0
-  checksum: 2695b2431f68a0faea47e41bef6ad38a5ccaa48a85729b7b533af63daa30e0645e9aee6d138abfbb2175c361b2afdf6a8acb6bd19a6cc7c2648d7c6a1ca84917
+  checksum: a998ea7661cf1650d8c69f5a910bf921e6e13b8c9c1a7f4c07a6be9f18313cd8946dc67f2d97a3433e319d47fec84becf7913a8b80d97827de7a360b5d19b7f0
   languageName: node
   linkType: hard
 
-"@aws-sdk/credential-provider-env@npm:3.310.0":
-  version: 3.310.0
-  resolution: "@aws-sdk/credential-provider-env@npm:3.310.0"
+"@aws-sdk/credential-provider-imds@npm:3.357.0":
+  version: 3.357.0
+  resolution: "@aws-sdk/credential-provider-imds@npm:3.357.0"
   dependencies:
-    "@aws-sdk/property-provider": 3.310.0
-    "@aws-sdk/types": 3.310.0
+    "@aws-sdk/node-config-provider": 3.357.0
+    "@aws-sdk/property-provider": 3.357.0
+    "@aws-sdk/types": 3.357.0
+    "@aws-sdk/url-parser": 3.357.0
     tslib: ^2.5.0
-  checksum: 646e634e6f8429c1984475100a60066dd5d0c085b3e170dc0c05c55c824edb3b04d4c40496ab4318e9586b9ca1db0b20090d26919b0273351c82372a12cd9958
+  checksum: 96c96d44471aed248a4d4f91a3b5c850fcf02a4cc2074a440ec6da7da56f85ee0a0b4f14e479d204d2228cb3737ecdf637d8b046ab8cc7d038d19a7dae57b0bc
   languageName: node
   linkType: hard
 
-"@aws-sdk/credential-provider-imds@npm:3.300.0":
-  version: 3.300.0
-  resolution: "@aws-sdk/credential-provider-imds@npm:3.300.0"
+"@aws-sdk/credential-provider-ini@npm:3.358.0":
+  version: 3.358.0
+  resolution: "@aws-sdk/credential-provider-ini@npm:3.358.0"
   dependencies:
-    "@aws-sdk/node-config-provider": 3.300.0
-    "@aws-sdk/property-provider": 3.296.0
-    "@aws-sdk/types": 3.296.0
-    "@aws-sdk/url-parser": 3.296.0
+    "@aws-sdk/credential-provider-env": 3.357.0
+    "@aws-sdk/credential-provider-imds": 3.357.0
+    "@aws-sdk/credential-provider-process": 3.357.0
+    "@aws-sdk/credential-provider-sso": 3.358.0
+    "@aws-sdk/credential-provider-web-identity": 3.357.0
+    "@aws-sdk/property-provider": 3.357.0
+    "@aws-sdk/shared-ini-file-loader": 3.357.0
+    "@aws-sdk/types": 3.357.0
     tslib: ^2.5.0
-  checksum: 1fa76d5143ad8738db82ffc62f81218f6dcc42afedf1a95de0c5ad08e76a011204367fb085eab4088e9d3754ae28cd449bafd3b424abd20e86f7144e3235523b
+  checksum: f7637e518ce98654c4c06d3cf01f35d7cdc22893b8a37fc522479b7324ba63f7362ea0b60dbb142573fa1148fa0b900791ad8a8361227170055122fec72e9b78
   languageName: node
   linkType: hard
 
-"@aws-sdk/credential-provider-imds@npm:3.310.0":
-  version: 3.310.0
-  resolution: "@aws-sdk/credential-provider-imds@npm:3.310.0"
+"@aws-sdk/credential-provider-node@npm:3.358.0":
+  version: 3.358.0
+  resolution: "@aws-sdk/credential-provider-node@npm:3.358.0"
   dependencies:
-    "@aws-sdk/node-config-provider": 3.310.0
-    "@aws-sdk/property-provider": 3.310.0
-    "@aws-sdk/types": 3.310.0
-    "@aws-sdk/url-parser": 3.310.0
+    "@aws-sdk/credential-provider-env": 3.357.0
+    "@aws-sdk/credential-provider-imds": 3.357.0
+    "@aws-sdk/credential-provider-ini": 3.358.0
+    "@aws-sdk/credential-provider-process": 3.357.0
+    "@aws-sdk/credential-provider-sso": 3.358.0
+    "@aws-sdk/credential-provider-web-identity": 3.357.0
+    "@aws-sdk/property-provider": 3.357.0
+    "@aws-sdk/shared-ini-file-loader": 3.357.0
+    "@aws-sdk/types": 3.357.0
     tslib: ^2.5.0
-  checksum: 24915e2f108e37bef21b9bec07f7ab38f25bf3ed55c55ad318ae8e030e042123980855b977c13714580232d2c0a514e71efd61848e68c221716c2110c160ab13
+  checksum: 5459a864680bb377a43625ce7af915bd9298251119df693a73324adcd2b3753aed20460a9c6cc146b796db00970d2bc6f3887c0ade217568d0e5dba043f7b21d
   languageName: node
   linkType: hard
 
-"@aws-sdk/credential-provider-ini@npm:3.301.0":
-  version: 3.301.0
-  resolution: "@aws-sdk/credential-provider-ini@npm:3.301.0"
+"@aws-sdk/credential-provider-process@npm:3.357.0":
+  version: 3.357.0
+  resolution: "@aws-sdk/credential-provider-process@npm:3.357.0"
   dependencies:
-    "@aws-sdk/credential-provider-env": 3.296.0
-    "@aws-sdk/credential-provider-imds": 3.300.0
-    "@aws-sdk/credential-provider-process": 3.300.0
-    "@aws-sdk/credential-provider-sso": 3.301.0
-    "@aws-sdk/credential-provider-web-identity": 3.296.0
-    "@aws-sdk/property-provider": 3.296.0
-    "@aws-sdk/shared-ini-file-loader": 3.300.0
-    "@aws-sdk/types": 3.296.0
+    "@aws-sdk/property-provider": 3.357.0
+    "@aws-sdk/shared-ini-file-loader": 3.357.0
+    "@aws-sdk/types": 3.357.0
     tslib: ^2.5.0
-  checksum: 8ff07f5ddabf5b0a1e903b5d7e8932627a21b8ec385bd759ee4bef2d57841c99e52ec10cbea6a0987125c04147562a55eecf079544594c489329b831b4cd3115
+  checksum: 753f6d9ccd40cf4422aae8b5512c9f24fbded6e7e631c68673828214294c507e1322ac2e455fb43458cc97f3185681f555fdbb220ff2cf0a6b3fcfca366fddae
   languageName: node
   linkType: hard
 
-"@aws-sdk/credential-provider-ini@npm:3.315.0":
-  version: 3.315.0
-  resolution: "@aws-sdk/credential-provider-ini@npm:3.315.0"
+"@aws-sdk/credential-provider-sso@npm:3.358.0":
+  version: 3.358.0
+  resolution: "@aws-sdk/credential-provider-sso@npm:3.358.0"
   dependencies:
-    "@aws-sdk/credential-provider-env": 3.310.0
-    "@aws-sdk/credential-provider-imds": 3.310.0
-    "@aws-sdk/credential-provider-process": 3.310.0
-    "@aws-sdk/credential-provider-sso": 3.315.0
-    "@aws-sdk/credential-provider-web-identity": 3.310.0
-    "@aws-sdk/property-provider": 3.310.0
-    "@aws-sdk/shared-ini-file-loader": 3.310.0
-    "@aws-sdk/types": 3.310.0
+    "@aws-sdk/client-sso": 3.358.0
+    "@aws-sdk/property-provider": 3.357.0
+    "@aws-sdk/shared-ini-file-loader": 3.357.0
+    "@aws-sdk/token-providers": 3.358.0
+    "@aws-sdk/types": 3.357.0
     tslib: ^2.5.0
-  checksum: 96dfba673688e468d9df145f5aa4172768b568c6689ae74b56ff8c2bbff8b5716574ccd1dffa7f31a3767fbf70052868bb172a1f918949906872e94459aa51c2
+  checksum: a817f23af990765b511fb63889aa46beb624af7b95ffdef05a98e31b68eb3f8bfd8c7831c7eb92613e90d729e392cc5e6d055181785193c7fad75d65f239b72c
   languageName: node
   linkType: hard
 
-"@aws-sdk/credential-provider-node@npm:3.301.0":
-  version: 3.301.0
-  resolution: "@aws-sdk/credential-provider-node@npm:3.301.0"
+"@aws-sdk/credential-provider-web-identity@npm:3.357.0":
+  version: 3.357.0
+  resolution: "@aws-sdk/credential-provider-web-identity@npm:3.357.0"
   dependencies:
-    "@aws-sdk/credential-provider-env": 3.296.0
-    "@aws-sdk/credential-provider-imds": 3.300.0
-    "@aws-sdk/credential-provider-ini": 3.301.0
-    "@aws-sdk/credential-provider-process": 3.300.0
-    "@aws-sdk/credential-provider-sso": 3.301.0
-    "@aws-sdk/credential-provider-web-identity": 3.296.0
-    "@aws-sdk/property-provider": 3.296.0
-    "@aws-sdk/shared-ini-file-loader": 3.300.0
-    "@aws-sdk/types": 3.296.0
+    "@aws-sdk/property-provider": 3.357.0
+    "@aws-sdk/types": 3.357.0
     tslib: ^2.5.0
-  checksum: 06930d0deb34006845ff12bf9959dbfb35300bf40d062fa8e745bb393402a13bf28be33a6515d42e88aeaff078ee9beba7d5af31f4dd1468c9bcd1ca50fc161a
+  checksum: 75625393c7a54169666eccc713eb7aa1c5d931680034c3785d4fadf70d281ff4e27132af0a6ae074c5d96f797bfe86e1c4bfd4a53865692c8bff1bf67d66271c
   languageName: node
   linkType: hard
 
-"@aws-sdk/credential-provider-node@npm:3.315.0":
-  version: 3.315.0
-  resolution: "@aws-sdk/credential-provider-node@npm:3.315.0"
+"@aws-sdk/credential-providers@npm:^3.358.0":
+  version: 3.358.0
+  resolution: "@aws-sdk/credential-providers@npm:3.358.0"
   dependencies:
-    "@aws-sdk/credential-provider-env": 3.310.0
-    "@aws-sdk/credential-provider-imds": 3.310.0
-    "@aws-sdk/credential-provider-ini": 3.315.0
-    "@aws-sdk/credential-provider-process": 3.310.0
-    "@aws-sdk/credential-provider-sso": 3.315.0
-    "@aws-sdk/credential-provider-web-identity": 3.310.0
-    "@aws-sdk/property-provider": 3.310.0
-    "@aws-sdk/shared-ini-file-loader": 3.310.0
-    "@aws-sdk/types": 3.310.0
+    "@aws-sdk/client-cognito-identity": 3.358.0
+    "@aws-sdk/client-sso": 3.358.0
+    "@aws-sdk/client-sts": 3.358.0
+    "@aws-sdk/credential-provider-cognito-identity": 3.358.0
+    "@aws-sdk/credential-provider-env": 3.357.0
+    "@aws-sdk/credential-provider-imds": 3.357.0
+    "@aws-sdk/credential-provider-ini": 3.358.0
+    "@aws-sdk/credential-provider-node": 3.358.0
+    "@aws-sdk/credential-provider-process": 3.357.0
+    "@aws-sdk/credential-provider-sso": 3.358.0
+    "@aws-sdk/credential-provider-web-identity": 3.357.0
+    "@aws-sdk/property-provider": 3.357.0
+    "@aws-sdk/types": 3.357.0
     tslib: ^2.5.0
-  checksum: 33d0e630a963022e5a08fb7d47587ab246e11dfea65f70a289086618a0f2ca8970e60f09c6325c0b51752912b2afd69f093f146ed5c0c0253c5a77be163260b8
+  checksum: 0e8acaea94d5b0933ba331fbe0155cc5e247c8e2626c1f1c7ff5a42ad8b22f2d6baa82730d68aa2d8077f19ced058db777f1a0af103f06685f13b6eb086d8f15
   languageName: node
   linkType: hard
 
-"@aws-sdk/credential-provider-process@npm:3.300.0":
-  version: 3.300.0
-  resolution: "@aws-sdk/credential-provider-process@npm:3.300.0"
+"@aws-sdk/eventstream-codec@npm:3.357.0":
+  version: 3.357.0
+  resolution: "@aws-sdk/eventstream-codec@npm:3.357.0"
   dependencies:
-    "@aws-sdk/property-provider": 3.296.0
-    "@aws-sdk/shared-ini-file-loader": 3.300.0
-    "@aws-sdk/types": 3.296.0
+    "@aws-crypto/crc32": 3.0.0
+    "@aws-sdk/types": 3.357.0
+    "@aws-sdk/util-hex-encoding": 3.310.0
     tslib: ^2.5.0
-  checksum: 228bf0716beda6c78a13f66ffb02c94da14408d5cdb48edf851c139a6fd851e71c9a2b57ac5c87bc6137f2fb067c6b5800241694bc7aed21c35273a5040a1291
+  checksum: df05de4c42d47f46e3808030f0f190747350218d9a3733958810de2a43e3a4be8458cde27c1f9c7467b0ea65a5d668aa3c72418b3fdf66295c4a91ba07b2ea0e
   languageName: node
   linkType: hard
 
-"@aws-sdk/credential-provider-process@npm:3.310.0":
-  version: 3.310.0
-  resolution: "@aws-sdk/credential-provider-process@npm:3.310.0"
+"@aws-sdk/eventstream-serde-browser@npm:3.357.0":
+  version: 3.357.0
+  resolution: "@aws-sdk/eventstream-serde-browser@npm:3.357.0"
   dependencies:
-    "@aws-sdk/property-provider": 3.310.0
-    "@aws-sdk/shared-ini-file-loader": 3.310.0
-    "@aws-sdk/types": 3.310.0
+    "@aws-sdk/eventstream-serde-universal": 3.357.0
+    "@aws-sdk/types": 3.357.0
     tslib: ^2.5.0
-  checksum: 12c4ab1f34d5a045d56ca22bc6c834292da15d518129133babcbede056adb46f4e898489e1b54e7e5ee3472d1116882217f5a29af0a46cc40d2f3aa00ef6767f
+  checksum: fbd2e71d6ce773f2667adc3d930acc791e83be814274ebd4d019dcad1b818b7625de7b30ab14371a9bdac031e0285d1cc6a1e835dad9801a5888a11e50be134c
   languageName: node
   linkType: hard
 
-"@aws-sdk/credential-provider-sso@npm:3.301.0":
-  version: 3.301.0
-  resolution: "@aws-sdk/credential-provider-sso@npm:3.301.0"
+"@aws-sdk/eventstream-serde-config-resolver@npm:3.357.0":
+  version: 3.357.0
+  resolution: "@aws-sdk/eventstream-serde-config-resolver@npm:3.357.0"
   dependencies:
-    "@aws-sdk/client-sso": 3.301.0
-    "@aws-sdk/property-provider": 3.296.0
-    "@aws-sdk/shared-ini-file-loader": 3.300.0
-    "@aws-sdk/token-providers": 3.301.0
-    "@aws-sdk/types": 3.296.0
+    "@aws-sdk/types": 3.357.0
     tslib: ^2.5.0
-  checksum: a728565b4089c49f98e361d1848454cbb763a8858e9cd6ac82310b1c6edac23806a1e7cd9f3709728f086f02e08f9fabde4db3f73077e34394d03a9f02d454bd
+  checksum: 6e61b9e8191eb9e2c2973701082aaa58f3b57268116ab8d1dab02d24145baa8535443ae749028310fdd80d7347973a633982fb05b38c9cbf79fa2586b5f29dd9
   languageName: node
   linkType: hard
 
-"@aws-sdk/credential-provider-sso@npm:3.315.0":
-  version: 3.315.0
-  resolution: "@aws-sdk/credential-provider-sso@npm:3.315.0"
+"@aws-sdk/eventstream-serde-node@npm:3.357.0":
+  version: 3.357.0
+  resolution: "@aws-sdk/eventstream-serde-node@npm:3.357.0"
   dependencies:
-    "@aws-sdk/client-sso": 3.315.0
-    "@aws-sdk/property-provider": 3.310.0
-    "@aws-sdk/shared-ini-file-loader": 3.310.0
-    "@aws-sdk/token-providers": 3.315.0
-    "@aws-sdk/types": 3.310.0
+    "@aws-sdk/eventstream-serde-universal": 3.357.0
+    "@aws-sdk/types": 3.357.0
     tslib: ^2.5.0
-  checksum: 11dfd154536469bacdb21b533d6f77c95dd0deb570270299ea14e2ca3d4b7d65add0e347308d4f8eea9bfcd6b1389bae5b7961f42a9c704cf4efea218ba6ad69
+  checksum: 1edbecd5c49322ac13e481155751912ec25d078635b50f7c0af40de916e98206a6f668847c73a1d7874526e8ec606a923e610445976a9b29c09ab8221f5a3700
   languageName: node
   linkType: hard
 
-"@aws-sdk/credential-provider-web-identity@npm:3.296.0":
-  version: 3.296.0
-  resolution: "@aws-sdk/credential-provider-web-identity@npm:3.296.0"
+"@aws-sdk/eventstream-serde-universal@npm:3.357.0":
+  version: 3.357.0
+  resolution: "@aws-sdk/eventstream-serde-universal@npm:3.357.0"
   dependencies:
-    "@aws-sdk/property-provider": 3.296.0
-    "@aws-sdk/types": 3.296.0
+    "@aws-sdk/eventstream-codec": 3.357.0
+    "@aws-sdk/types": 3.357.0
     tslib: ^2.5.0
-  checksum: 35fadfbc623cb47eae1b189a6384ae545d4a5d203c70a12e57bb236c645d61d31dd3ffaafc323d878cde6061ec5be5c285c34b3296e7c4a8992c479b4485518a
+  checksum: a733d008599191941f258216581a2260c0acbd223add882c47fc3bd6b912a39977ac1146b151ef78bb01de5adcf3d49bf4365dbe82162538f34b681e3d8da966
   languageName: node
   linkType: hard
 
-"@aws-sdk/credential-provider-web-identity@npm:3.310.0":
-  version: 3.310.0
-  resolution: "@aws-sdk/credential-provider-web-identity@npm:3.310.0"
+"@aws-sdk/fetch-http-handler@npm:3.357.0":
+  version: 3.357.0
+  resolution: "@aws-sdk/fetch-http-handler@npm:3.357.0"
   dependencies:
-    "@aws-sdk/property-provider": 3.310.0
-    "@aws-sdk/types": 3.310.0
-    tslib: ^2.5.0
-  checksum: 62dd9362bb48e010cb84dfcb92461478b2d1fa830e47e078a9bd074999eb231b0ef4e273e585fce5ed0135768b90bafcbe9ca5df83fc6c0bc5d227ec74271a82
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/credential-providers@npm:^3.296.0":
-  version: 3.301.0
-  resolution: "@aws-sdk/credential-providers@npm:3.301.0"
-  dependencies:
-    "@aws-sdk/client-cognito-identity": 3.301.0
-    "@aws-sdk/client-sso": 3.301.0
-    "@aws-sdk/client-sts": 3.301.0
-    "@aws-sdk/credential-provider-cognito-identity": 3.301.0
-    "@aws-sdk/credential-provider-env": 3.296.0
-    "@aws-sdk/credential-provider-imds": 3.300.0
-    "@aws-sdk/credential-provider-ini": 3.301.0
-    "@aws-sdk/credential-provider-node": 3.301.0
-    "@aws-sdk/credential-provider-process": 3.300.0
-    "@aws-sdk/credential-provider-sso": 3.301.0
-    "@aws-sdk/credential-provider-web-identity": 3.296.0
-    "@aws-sdk/property-provider": 3.296.0
-    "@aws-sdk/types": 3.296.0
-    tslib: ^2.5.0
-  checksum: c246080b6c5214e41a64471088fec68ed9f13ffa2bce94e2a12fc249d17c25dbf326251f728d0129dc8298a627587b2a6361770d449bb1e76848cb895641155d
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/fetch-http-handler@npm:3.296.0":
-  version: 3.296.0
-  resolution: "@aws-sdk/fetch-http-handler@npm:3.296.0"
-  dependencies:
-    "@aws-sdk/protocol-http": 3.296.0
-    "@aws-sdk/querystring-builder": 3.296.0
-    "@aws-sdk/types": 3.296.0
-    "@aws-sdk/util-base64": 3.295.0
-    tslib: ^2.5.0
-  checksum: cc57acffff2a1dd96ed752a21f76d35f6c597a09ad2a7d5be5b03dba93386a1c3cfaf6c3c5f41b33e9734005424444892f4a173e58ce06dcf6e78421fb7b511b
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/fetch-http-handler@npm:3.310.0":
-  version: 3.310.0
-  resolution: "@aws-sdk/fetch-http-handler@npm:3.310.0"
-  dependencies:
-    "@aws-sdk/protocol-http": 3.310.0
-    "@aws-sdk/querystring-builder": 3.310.0
-    "@aws-sdk/types": 3.310.0
+    "@aws-sdk/protocol-http": 3.357.0
+    "@aws-sdk/querystring-builder": 3.357.0
+    "@aws-sdk/types": 3.357.0
     "@aws-sdk/util-base64": 3.310.0
     tslib: ^2.5.0
-  checksum: 5daa78ee3e2a0a6bd07c3b8bc658ebd88a063b17025ec23454c2eb433859972d60a550fdc62969754488c3f4d624fbf3e758af8ea891c994998deca0f8e3903e
+  checksum: c72a5e1bca33df01d2b4f827cf45a10c22fcc8d46b2728bfb17f5d1ffc4f6157855668082848969c3bd9930e871767e123d78d4a56e4b989ead97fe544ffb327
   languageName: node
   linkType: hard
 
-"@aws-sdk/hash-node@npm:3.296.0":
-  version: 3.296.0
-  resolution: "@aws-sdk/hash-node@npm:3.296.0"
+"@aws-sdk/hash-node@npm:3.357.0":
+  version: 3.357.0
+  resolution: "@aws-sdk/hash-node@npm:3.357.0"
   dependencies:
-    "@aws-sdk/types": 3.296.0
-    "@aws-sdk/util-buffer-from": 3.295.0
-    "@aws-sdk/util-utf8": 3.295.0
-    tslib: ^2.5.0
-  checksum: 728680b1bc04764dc710003e6b967e176d65ba46c03e53ffebf25f7d87bad2354203e1c1e754ef6b6bcebbc3bde725aac6a1e00cb47118f78419cefed13b5724
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/hash-node@npm:3.310.0":
-  version: 3.310.0
-  resolution: "@aws-sdk/hash-node@npm:3.310.0"
-  dependencies:
-    "@aws-sdk/types": 3.310.0
+    "@aws-sdk/types": 3.357.0
     "@aws-sdk/util-buffer-from": 3.310.0
     "@aws-sdk/util-utf8": 3.310.0
     tslib: ^2.5.0
-  checksum: 379c04c78679d68730272b89fa397cdfcd444ae2f21d7dc51953e9885842469de40593efbb86b2399342e022b2ba17926841ef0a9fb108809296b2df416226c1
+  checksum: 295fbfd2099a393537067a313619d41b2efafae690f252e501c44e75ad4149df67c5e08786cb75f4e3e34b2f16871c4d1603ff8f91dcc9975137bf868e19a2cc
   languageName: node
   linkType: hard
 
-"@aws-sdk/invalid-dependency@npm:3.296.0":
-  version: 3.296.0
-  resolution: "@aws-sdk/invalid-dependency@npm:3.296.0"
+"@aws-sdk/invalid-dependency@npm:3.357.0":
+  version: 3.357.0
+  resolution: "@aws-sdk/invalid-dependency@npm:3.357.0"
   dependencies:
-    "@aws-sdk/types": 3.296.0
+    "@aws-sdk/types": 3.357.0
     tslib: ^2.5.0
-  checksum: 5dc57b4396cbde9f594f14dc2a38e0c12e8cca4557b8e78fb5d23e1429e6dfef0b5ed1382da84862bb19abeaf39b92bc4dc7cba7c7a04dbc212cb6971f0553b0
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/invalid-dependency@npm:3.310.0":
-  version: 3.310.0
-  resolution: "@aws-sdk/invalid-dependency@npm:3.310.0"
-  dependencies:
-    "@aws-sdk/types": 3.310.0
-    tslib: ^2.5.0
-  checksum: e38d09615e273617583e845b2cd3683c9d27d54234a98bec7da1cf959107329f73e62b322479415155016ed62c7d849cd6542d6e9e33572f6ed542013c15821c
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/is-array-buffer@npm:3.295.0":
-  version: 3.295.0
-  resolution: "@aws-sdk/is-array-buffer@npm:3.295.0"
-  dependencies:
-    tslib: ^2.5.0
-  checksum: 23de81a3ab63a51ae61183792db4a9faf74f02c7c9cb5cfa6d4b36781d7832070090bb406dc8591dd74a07fa3d3c27bac11d7a931e75163f8e018987a995f3ce
+  checksum: 203148201ea0957350231cf8c1821e6e11573dfb36c5648f30bf2a89955a754500d228f93a63a08299881be151301cf9fe8417353653fe582d8f4f82d28fc4d1
   languageName: node
   linkType: hard
 
@@ -895,505 +687,268 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-content-length@npm:3.296.0":
-  version: 3.296.0
-  resolution: "@aws-sdk/middleware-content-length@npm:3.296.0"
+"@aws-sdk/middleware-content-length@npm:3.357.0":
+  version: 3.357.0
+  resolution: "@aws-sdk/middleware-content-length@npm:3.357.0"
   dependencies:
-    "@aws-sdk/protocol-http": 3.296.0
-    "@aws-sdk/types": 3.296.0
+    "@aws-sdk/protocol-http": 3.357.0
+    "@aws-sdk/types": 3.357.0
     tslib: ^2.5.0
-  checksum: 649c0d3f0c1ec607ea9558df09f318bffc763f66501263136791571206c148ca7ca691cb3211fe18bd09aacdc69545fdc5ffff4daeac73323864b5cb76b5c072
+  checksum: 308f5d7f1fa2e42c3bf3619d42cfa85ad47e1b219428e01ad21ad1ebc60ac1b416aabec1868f3ea30a81215cf3386c1dadb3b98e5e66280a092da3fa487774cc
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-content-length@npm:3.310.0":
-  version: 3.310.0
-  resolution: "@aws-sdk/middleware-content-length@npm:3.310.0"
+"@aws-sdk/middleware-endpoint@npm:3.357.0":
+  version: 3.357.0
+  resolution: "@aws-sdk/middleware-endpoint@npm:3.357.0"
   dependencies:
-    "@aws-sdk/protocol-http": 3.310.0
-    "@aws-sdk/types": 3.310.0
+    "@aws-sdk/middleware-serde": 3.357.0
+    "@aws-sdk/types": 3.357.0
+    "@aws-sdk/url-parser": 3.357.0
+    "@aws-sdk/util-middleware": 3.357.0
     tslib: ^2.5.0
-  checksum: 66977eac6aa9ce0d7c5640e357608b79eec18919d4e94c37aacf76801ac1b24471a3483755d1ab30a416aa2aa10c9da02fb6241f11e29ea99079ff04bdf012b1
+  checksum: 2085f37d237e33378ecce44703f9dca5b9f66b36b4bbbd4bb39e726ebce745d07ca948b1d6f9a2f832d75b4e67ec3254d89d26ded4596c5cf29aad827a0fa906
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-endpoint@npm:3.299.0":
-  version: 3.299.0
-  resolution: "@aws-sdk/middleware-endpoint@npm:3.299.0"
+"@aws-sdk/middleware-host-header@npm:3.357.0":
+  version: 3.357.0
+  resolution: "@aws-sdk/middleware-host-header@npm:3.357.0"
   dependencies:
-    "@aws-sdk/middleware-serde": 3.296.0
-    "@aws-sdk/types": 3.296.0
-    "@aws-sdk/url-parser": 3.296.0
-    "@aws-sdk/util-middleware": 3.296.0
+    "@aws-sdk/protocol-http": 3.357.0
+    "@aws-sdk/types": 3.357.0
     tslib: ^2.5.0
-  checksum: 7e8c6a85575019871c87dc5c1b19c47999bd5ae3fc2546b72e3e617bf8bdea1392fb385e25a51f382b37d01d171de51dfaf2f53b79fb09adc10049ee571fbc13
+  checksum: e8471d0ca23ca598a042704877069a81576c2fb743c37818cc09c9383431ecb7e2f32f4bdf22094011bec3ece3e8523f2a3a99b8f8b04e4cca0c871d4d7a8194
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-endpoint@npm:3.310.0":
-  version: 3.310.0
-  resolution: "@aws-sdk/middleware-endpoint@npm:3.310.0"
+"@aws-sdk/middleware-logger@npm:3.357.0":
+  version: 3.357.0
+  resolution: "@aws-sdk/middleware-logger@npm:3.357.0"
   dependencies:
-    "@aws-sdk/middleware-serde": 3.310.0
-    "@aws-sdk/types": 3.310.0
-    "@aws-sdk/url-parser": 3.310.0
-    "@aws-sdk/util-middleware": 3.310.0
+    "@aws-sdk/types": 3.357.0
     tslib: ^2.5.0
-  checksum: 7d61ceaff3fb6be779f9b0597fceccbc1d5ebbc83b83d93ac184fc6451e60b4acca9eebb0c83c9e1c6b34400bd39345b498227860892ed51eda2b99f16ff0566
+  checksum: 0ee86f855ccebb31205b5f86e7b2baba71e2127d02d55ff630757d198ae40766458835ae247cae43a33030b6ba2b36f676ae8fc3935601d321bf6cd9515a1b2a
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-host-header@npm:3.296.0":
-  version: 3.296.0
-  resolution: "@aws-sdk/middleware-host-header@npm:3.296.0"
+"@aws-sdk/middleware-recursion-detection@npm:3.357.0":
+  version: 3.357.0
+  resolution: "@aws-sdk/middleware-recursion-detection@npm:3.357.0"
   dependencies:
-    "@aws-sdk/protocol-http": 3.296.0
-    "@aws-sdk/types": 3.296.0
+    "@aws-sdk/protocol-http": 3.357.0
+    "@aws-sdk/types": 3.357.0
     tslib: ^2.5.0
-  checksum: 8b5b2b26b204bcc8587cbd659a052b896c4d76dd1633e99d7c035b7b779d2b90beff4878481b8b5b28deeb363bf276584f371a5f7c88cecda43a18c5ae1ab7aa
+  checksum: 33625801a66eed9dc68ea0ccb4689b5a26ae3e5aa39d790c241f534aa8c1da9650a7fd607333e24f0aa59d9d8c9c57de16e31ff5d100298edb0238aec79b5bb1
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-host-header@npm:3.310.0":
-  version: 3.310.0
-  resolution: "@aws-sdk/middleware-host-header@npm:3.310.0"
+"@aws-sdk/middleware-retry@npm:3.357.0":
+  version: 3.357.0
+  resolution: "@aws-sdk/middleware-retry@npm:3.357.0"
   dependencies:
-    "@aws-sdk/protocol-http": 3.310.0
-    "@aws-sdk/types": 3.310.0
-    tslib: ^2.5.0
-  checksum: 9b1bf8598f9bf44a0cd992f08820ce54fb7ce5f33366796b7328a003c2efc00754a3e0bfd56be87b221ca0f15b4c00f5caf736bf196cb9a4b3ca26dfd3e7f7db
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/middleware-logger@npm:3.296.0":
-  version: 3.296.0
-  resolution: "@aws-sdk/middleware-logger@npm:3.296.0"
-  dependencies:
-    "@aws-sdk/types": 3.296.0
-    tslib: ^2.5.0
-  checksum: c006c03d24e26bbc1f9089987a0987b7627e1f7e1a5215d75e7132d2905f77f867d78806b968bee6e6830ddb94ddae8c1cead785b3fe4762e66da10584218ca9
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/middleware-logger@npm:3.310.0":
-  version: 3.310.0
-  resolution: "@aws-sdk/middleware-logger@npm:3.310.0"
-  dependencies:
-    "@aws-sdk/types": 3.310.0
-    tslib: ^2.5.0
-  checksum: 13014451afaadf11524754f959aaa4c4e7763442dedef841d693159370720e40d20a6113851b87b6cab6c709d92b1e952adede0ec9948dbaa1546dbff1e477d0
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/middleware-recursion-detection@npm:3.296.0":
-  version: 3.296.0
-  resolution: "@aws-sdk/middleware-recursion-detection@npm:3.296.0"
-  dependencies:
-    "@aws-sdk/protocol-http": 3.296.0
-    "@aws-sdk/types": 3.296.0
-    tslib: ^2.5.0
-  checksum: 2d8b8e130b6410e95340bca961e966c36f54154041aba3b0a308b0b6786cea36e026f28b910ac13411f333e445dbcc122801366bb55f64fab5cd76e05bb70257
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/middleware-recursion-detection@npm:3.310.0":
-  version: 3.310.0
-  resolution: "@aws-sdk/middleware-recursion-detection@npm:3.310.0"
-  dependencies:
-    "@aws-sdk/protocol-http": 3.310.0
-    "@aws-sdk/types": 3.310.0
-    tslib: ^2.5.0
-  checksum: a5db6bec59a5232ebc28296d165d09fb94d74e9232d32f49f77bccbbae62cda58215d2f8a17979f1714b9dd07c25a989caae8bc7eee1f57c57d67328788fa401
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/middleware-retry@npm:3.300.0":
-  version: 3.300.0
-  resolution: "@aws-sdk/middleware-retry@npm:3.300.0"
-  dependencies:
-    "@aws-sdk/protocol-http": 3.296.0
-    "@aws-sdk/service-error-classification": 3.296.0
-    "@aws-sdk/types": 3.296.0
-    "@aws-sdk/util-middleware": 3.296.0
-    "@aws-sdk/util-retry": 3.296.0
+    "@aws-sdk/protocol-http": 3.357.0
+    "@aws-sdk/service-error-classification": 3.357.0
+    "@aws-sdk/types": 3.357.0
+    "@aws-sdk/util-middleware": 3.357.0
+    "@aws-sdk/util-retry": 3.357.0
     tslib: ^2.5.0
     uuid: ^8.3.2
-  checksum: 16b76246701eadda581a3a666f27d6100e75cf4d872e83a7e183ab2ec421d689f7c3f86a6dca2b7f0062208340ab578d4285af7d647a279d837891e3ef84b48b
+  checksum: bf9d0143af03431bb28c24d055780711774ef312c710ae4b58d846924a7d35571a7c2bd4e5a7e1ac219b791ba0af259df06ba139df478a2e7a53004e7712ca47
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-retry@npm:3.310.0":
-  version: 3.310.0
-  resolution: "@aws-sdk/middleware-retry@npm:3.310.0"
+"@aws-sdk/middleware-sdk-sts@npm:3.357.0":
+  version: 3.357.0
+  resolution: "@aws-sdk/middleware-sdk-sts@npm:3.357.0"
   dependencies:
-    "@aws-sdk/protocol-http": 3.310.0
-    "@aws-sdk/service-error-classification": 3.310.0
-    "@aws-sdk/types": 3.310.0
-    "@aws-sdk/util-middleware": 3.310.0
-    "@aws-sdk/util-retry": 3.310.0
+    "@aws-sdk/middleware-signing": 3.357.0
+    "@aws-sdk/types": 3.357.0
     tslib: ^2.5.0
-    uuid: ^8.3.2
-  checksum: 7d69c187d4cfad62df01b445596f812157e4028b377f34c40f6b272df3660a48ebbc6a0c86eba98b1b19454ade6be7b1459c62ffe8a1924725a23e330d2814b7
+  checksum: 138a7f8a397529a05c1316bc0c39339678ed6025b9a356126129136e078cfa48b79ead194f5354cb7089cedd787b1a9927e6fb9fd01bd4f42bed78df02204c6e
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-sdk-sts@npm:3.299.0":
-  version: 3.299.0
-  resolution: "@aws-sdk/middleware-sdk-sts@npm:3.299.0"
+"@aws-sdk/middleware-serde@npm:3.357.0":
+  version: 3.357.0
+  resolution: "@aws-sdk/middleware-serde@npm:3.357.0"
   dependencies:
-    "@aws-sdk/middleware-signing": 3.299.0
-    "@aws-sdk/types": 3.296.0
+    "@aws-sdk/types": 3.357.0
     tslib: ^2.5.0
-  checksum: b1e2b28d29d924bbe176203c9a0abbe05a48748845da970a5aa61723b5ad118d50b3790baf63cecb69db63b89dc6e4abca218f14ce258bce87858acf339696de
+  checksum: 259176f253efc144130494f9dcaafdf5ff0a1d60158619ef300146775ab68622289908a15d1131ee8c7f92235a6ce40df4c80fdc930a8e45eb2635a6e241ac9e
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-sdk-sts@npm:3.310.0":
-  version: 3.310.0
-  resolution: "@aws-sdk/middleware-sdk-sts@npm:3.310.0"
+"@aws-sdk/middleware-signing@npm:3.357.0":
+  version: 3.357.0
+  resolution: "@aws-sdk/middleware-signing@npm:3.357.0"
   dependencies:
-    "@aws-sdk/middleware-signing": 3.310.0
-    "@aws-sdk/types": 3.310.0
+    "@aws-sdk/property-provider": 3.357.0
+    "@aws-sdk/protocol-http": 3.357.0
+    "@aws-sdk/signature-v4": 3.357.0
+    "@aws-sdk/types": 3.357.0
+    "@aws-sdk/util-middleware": 3.357.0
     tslib: ^2.5.0
-  checksum: 80debd2f2371f65f7c37f2f0101e9e8ac520ef74d6a8ba54fedfbad6d63653732f7ce6095bae7bf3adbfec61bfa4d9f816b8eb5550cdadec825b400cf74bb2ce
+  checksum: 416c8472606f6139bcf548d3c45582b0cfadf0da114c63a90fc26aa0301ce1743e5ce93517dfccb1e8756f4c9925c3b2e485b7a1a7853c418061c827be01a2c0
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-serde@npm:3.296.0":
-  version: 3.296.0
-  resolution: "@aws-sdk/middleware-serde@npm:3.296.0"
-  dependencies:
-    "@aws-sdk/types": 3.296.0
-    tslib: ^2.5.0
-  checksum: 337bf9c4a621d6ef3a5c5d16273633f098e12e3581e08a9543d48e3a63ba6b70472f26f4e4e46040ed43fc1a498f8f046b66c28fc629f4a3a74b6a331609fd52
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/middleware-serde@npm:3.310.0":
-  version: 3.310.0
-  resolution: "@aws-sdk/middleware-serde@npm:3.310.0"
-  dependencies:
-    "@aws-sdk/types": 3.310.0
-    tslib: ^2.5.0
-  checksum: 95c2c1b15906a93c9869be36563757f08cd53a0f385882759943e59a1fd31be777260fb075feaa1a9bb919cf1696739e7b2da89049cec0bee1a649a838f9184c
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/middleware-signing@npm:3.299.0":
-  version: 3.299.0
-  resolution: "@aws-sdk/middleware-signing@npm:3.299.0"
-  dependencies:
-    "@aws-sdk/property-provider": 3.296.0
-    "@aws-sdk/protocol-http": 3.296.0
-    "@aws-sdk/signature-v4": 3.299.0
-    "@aws-sdk/types": 3.296.0
-    "@aws-sdk/util-middleware": 3.296.0
-    tslib: ^2.5.0
-  checksum: 4eaa0a3b51eefa0f5e839a55ffa98f7cc79644fb7e8e3a3fbbdc4de2e2d10fb07cbd5201f44464a5550462af5efe47977feb6f057e6bd2160eed0904cd9d1752
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/middleware-signing@npm:3.310.0":
-  version: 3.310.0
-  resolution: "@aws-sdk/middleware-signing@npm:3.310.0"
-  dependencies:
-    "@aws-sdk/property-provider": 3.310.0
-    "@aws-sdk/protocol-http": 3.310.0
-    "@aws-sdk/signature-v4": 3.310.0
-    "@aws-sdk/types": 3.310.0
-    "@aws-sdk/util-middleware": 3.310.0
-    tslib: ^2.5.0
-  checksum: f1db11435250075fc563de375c8c513dbaba7b9939ae99c70074d90622f9aea0cc339cd10f0eff63251eba462b73f564389bfb9dcfe6868f36892488dea0494b
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/middleware-stack@npm:3.296.0":
-  version: 3.296.0
-  resolution: "@aws-sdk/middleware-stack@npm:3.296.0"
+"@aws-sdk/middleware-stack@npm:3.357.0":
+  version: 3.357.0
+  resolution: "@aws-sdk/middleware-stack@npm:3.357.0"
   dependencies:
     tslib: ^2.5.0
-  checksum: 1fb787c066aa48612e0f7ddd4932c3a9fbfd37eef5838bd83c06bd113d11af76f098e2b09a431ab039fb3f3628b1b80bdaca1200a10d9ec9cde56134e40b6995
+  checksum: bb5507ee38e60b8a8fbf3fc7215be710d379c54d7132c78005892563b1e3e0169c00187ec482808a7b68edcefb7a2a420a47f7813dc627f2747703cfee9b99e0
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-stack@npm:3.310.0":
-  version: 3.310.0
-  resolution: "@aws-sdk/middleware-stack@npm:3.310.0"
+"@aws-sdk/middleware-user-agent@npm:3.357.0":
+  version: 3.357.0
+  resolution: "@aws-sdk/middleware-user-agent@npm:3.357.0"
   dependencies:
+    "@aws-sdk/protocol-http": 3.357.0
+    "@aws-sdk/types": 3.357.0
+    "@aws-sdk/util-endpoints": 3.357.0
     tslib: ^2.5.0
-  checksum: ad90bb8cf2a8e3211869ed0c08e240e0df7097ff42a9bbfa6dd96ad79a8b741c096199082f1be40a2ae2b1fbeb56a4bc510cdaf431dd90a5db73e32fe7184ee2
+  checksum: e80a6fce7974f79769349ee9c2fc6744a18d1998e7e66b3eb24196390a5605837cf5fd75b4e9636566353d5fb26c840628ea8e451045af66c0112469ce20debb
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-user-agent@npm:3.299.0":
-  version: 3.299.0
-  resolution: "@aws-sdk/middleware-user-agent@npm:3.299.0"
+"@aws-sdk/node-config-provider@npm:3.357.0":
+  version: 3.357.0
+  resolution: "@aws-sdk/node-config-provider@npm:3.357.0"
   dependencies:
-    "@aws-sdk/protocol-http": 3.296.0
-    "@aws-sdk/types": 3.296.0
-    "@aws-sdk/util-endpoints": 3.296.0
+    "@aws-sdk/property-provider": 3.357.0
+    "@aws-sdk/shared-ini-file-loader": 3.357.0
+    "@aws-sdk/types": 3.357.0
     tslib: ^2.5.0
-  checksum: 7ae91b41d2a9ab6d016e749458c30eb99f7fc1b11093410e6e2b0f0258aba8269fd5e22a980eb54bcbf8456679bf65c7e76fbf5bb145a13ff7d31398a82821ae
+  checksum: 39784541ffdabc6298c42f3e4c308c75e92636b1228f6338d9820d2a6ee6ebb77dacd92e42f739004db6299024d85e80c0191f8c49045f1f00451aedc2136786
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-user-agent@npm:3.310.0":
-  version: 3.310.0
-  resolution: "@aws-sdk/middleware-user-agent@npm:3.310.0"
+"@aws-sdk/node-http-handler@npm:3.357.0":
+  version: 3.357.0
+  resolution: "@aws-sdk/node-http-handler@npm:3.357.0"
   dependencies:
-    "@aws-sdk/protocol-http": 3.310.0
-    "@aws-sdk/types": 3.310.0
-    "@aws-sdk/util-endpoints": 3.310.0
+    "@aws-sdk/abort-controller": 3.357.0
+    "@aws-sdk/protocol-http": 3.357.0
+    "@aws-sdk/querystring-builder": 3.357.0
+    "@aws-sdk/types": 3.357.0
     tslib: ^2.5.0
-  checksum: 571ebfce481a2d814270248e728c68030661cb3f0de97908b73e1d446c508d5af06cb088c68c67b23ce9671873c1872ab681b9383d48797b5a1c53a7030085ff
+  checksum: 535fe5699b1013f84c47fdefe99659c9eebda6bdac09a83d486438a3c4a3c2b5985a6e5f9184ba49624615d5886013c1c6bfe5e7bd4063f31b95665797c98fb6
   languageName: node
   linkType: hard
 
-"@aws-sdk/node-config-provider@npm:3.300.0":
-  version: 3.300.0
-  resolution: "@aws-sdk/node-config-provider@npm:3.300.0"
+"@aws-sdk/property-provider@npm:3.357.0":
+  version: 3.357.0
+  resolution: "@aws-sdk/property-provider@npm:3.357.0"
   dependencies:
-    "@aws-sdk/property-provider": 3.296.0
-    "@aws-sdk/shared-ini-file-loader": 3.300.0
-    "@aws-sdk/types": 3.296.0
+    "@aws-sdk/types": 3.357.0
     tslib: ^2.5.0
-  checksum: 1ad2536961b9a735278635f8c1dc5c6c260d4e44d490e189a5115f6a41b5f8ae0643a3b213b66f39be457eb6a65cfcbcca07459608e1ac9876af7b92ebe5fbb2
+  checksum: 311c00ef9c20810ea18b6772d3f37853469453fd31b1b41d841ecfd6a7f34f2ba2189df954bc094c5ff764bd75bc39ce003f208260334b40b8394f8f2665cd93
   languageName: node
   linkType: hard
 
-"@aws-sdk/node-config-provider@npm:3.310.0":
-  version: 3.310.0
-  resolution: "@aws-sdk/node-config-provider@npm:3.310.0"
+"@aws-sdk/protocol-http@npm:3.357.0":
+  version: 3.357.0
+  resolution: "@aws-sdk/protocol-http@npm:3.357.0"
   dependencies:
-    "@aws-sdk/property-provider": 3.310.0
-    "@aws-sdk/shared-ini-file-loader": 3.310.0
-    "@aws-sdk/types": 3.310.0
+    "@aws-sdk/types": 3.357.0
     tslib: ^2.5.0
-  checksum: 95d017aa1bb94e323c288bc0ce5edba5c4605eeabe779249beb5faee958c26f6eebb7f1664328b83d1024e441eb4e4f9fce9c1bb764637f83f7ebf20b8359a77
+  checksum: 2abc03c76b729b98b37a489ee6592d8620e02c17584c304e91161194d7d4273bf9f8a7e330d52be2f8f8c787db63db99d7865494fb85f07327ffc54b99712b07
   languageName: node
   linkType: hard
 
-"@aws-sdk/node-http-handler@npm:3.296.0":
-  version: 3.296.0
-  resolution: "@aws-sdk/node-http-handler@npm:3.296.0"
+"@aws-sdk/querystring-builder@npm:3.357.0":
+  version: 3.357.0
+  resolution: "@aws-sdk/querystring-builder@npm:3.357.0"
   dependencies:
-    "@aws-sdk/abort-controller": 3.296.0
-    "@aws-sdk/protocol-http": 3.296.0
-    "@aws-sdk/querystring-builder": 3.296.0
-    "@aws-sdk/types": 3.296.0
-    tslib: ^2.5.0
-  checksum: 8766f46047f1667363a34433c9a867b4e5b27b400252418df2d5b110b6f85ff46a8aeff8b96132f7b39fc2bafa54fb1ae0e0fe44da84c8222349cea05cc7cc38
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/node-http-handler@npm:3.310.0":
-  version: 3.310.0
-  resolution: "@aws-sdk/node-http-handler@npm:3.310.0"
-  dependencies:
-    "@aws-sdk/abort-controller": 3.310.0
-    "@aws-sdk/protocol-http": 3.310.0
-    "@aws-sdk/querystring-builder": 3.310.0
-    "@aws-sdk/types": 3.310.0
-    tslib: ^2.5.0
-  checksum: 781cc864972bf52f884b580e43b9b659ab34a6ca7d7772d8e76107a51fe0930124c01024bc7ac1c4e99324319c594b809373ebc4752ea0a2e3a984ccf57aa535
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/property-provider@npm:3.296.0":
-  version: 3.296.0
-  resolution: "@aws-sdk/property-provider@npm:3.296.0"
-  dependencies:
-    "@aws-sdk/types": 3.296.0
-    tslib: ^2.5.0
-  checksum: b456e82002c8302b2ebe328446346381c6d34b63d64f797ffd5b24d9f5cb0d739127d21657587c76a351fa6f56f43585d66020df370ae64f7cd9718c26175fff
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/property-provider@npm:3.310.0":
-  version: 3.310.0
-  resolution: "@aws-sdk/property-provider@npm:3.310.0"
-  dependencies:
-    "@aws-sdk/types": 3.310.0
-    tslib: ^2.5.0
-  checksum: 8a906b3f4e482f4d5be0ef1277fcb22fb005e834c916919373187f8cf6b17b0d464f37a12770d152a553b7a505ed9981504a0c30f73f273d251ed93ff29616e1
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/protocol-http@npm:3.296.0":
-  version: 3.296.0
-  resolution: "@aws-sdk/protocol-http@npm:3.296.0"
-  dependencies:
-    "@aws-sdk/types": 3.296.0
-    tslib: ^2.5.0
-  checksum: b283a1e6b6a6ba544bf833929d19f988747a451a1e1232f440b9412918932d099f29c0459dd398163b7f7bbae4c372166cc36a5e5afc1343d3085884e36879bc
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/protocol-http@npm:3.310.0":
-  version: 3.310.0
-  resolution: "@aws-sdk/protocol-http@npm:3.310.0"
-  dependencies:
-    "@aws-sdk/types": 3.310.0
-    tslib: ^2.5.0
-  checksum: 4bfe2b7a93d52ded21472d6347483fb52dfd2414d4ff07d8e3a2869d7676e866a9bfa29e9e7ac4fa3849c7109740a39e3d1e646a02d8bb4b7c7b402f53b18450
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/querystring-builder@npm:3.296.0":
-  version: 3.296.0
-  resolution: "@aws-sdk/querystring-builder@npm:3.296.0"
-  dependencies:
-    "@aws-sdk/types": 3.296.0
-    "@aws-sdk/util-uri-escape": 3.295.0
-    tslib: ^2.5.0
-  checksum: 54028a5087126cdf48cf7abf4cc12c5d761c30aa97b23bab001ae387179cd95974a9332aacc6a74936f3ce818067ded67383231d5839b0456c5ed326bcaeeac5
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/querystring-builder@npm:3.310.0":
-  version: 3.310.0
-  resolution: "@aws-sdk/querystring-builder@npm:3.310.0"
-  dependencies:
-    "@aws-sdk/types": 3.310.0
+    "@aws-sdk/types": 3.357.0
     "@aws-sdk/util-uri-escape": 3.310.0
     tslib: ^2.5.0
-  checksum: c06ba9ec67d6e6a5f4c1099461b9b2d6cb12a278e6ec2fe198f68ba115ce1e05425f29cf6859f8a005ae7123036b6dadc325d18b35165c7049233f9d04670dcb
+  checksum: f3b8b10ff997eade4ec632be937afdd6d44b7eb15b9ff64d21d31ba6c9f64f90263de2ba904660faa20dbb2b73c3a0193744b78ba2b42a757e28fd41be11d63e
   languageName: node
   linkType: hard
 
-"@aws-sdk/querystring-parser@npm:3.296.0":
-  version: 3.296.0
-  resolution: "@aws-sdk/querystring-parser@npm:3.296.0"
+"@aws-sdk/querystring-parser@npm:3.357.0":
+  version: 3.357.0
+  resolution: "@aws-sdk/querystring-parser@npm:3.357.0"
   dependencies:
-    "@aws-sdk/types": 3.296.0
+    "@aws-sdk/types": 3.357.0
     tslib: ^2.5.0
-  checksum: b60b003302b4823609f9f585acdc3b7e48444aeaaf941549626066a6a74579201b473cdaa0ab1d59e63c4c8eec5bc9380464ccfeca47077ec4b5bc20fea4b190
+  checksum: 57097dda2499991efd00c3773c8ecd5d75d0e0d9a5106e3e8f4649f008d47eb87b01b067ceaee1ae73202a3cdf62458b713fa92cdf309e7d73bdcaffed54b4c7
   languageName: node
   linkType: hard
 
-"@aws-sdk/querystring-parser@npm:3.310.0":
-  version: 3.310.0
-  resolution: "@aws-sdk/querystring-parser@npm:3.310.0"
+"@aws-sdk/service-error-classification@npm:3.357.0":
+  version: 3.357.0
+  resolution: "@aws-sdk/service-error-classification@npm:3.357.0"
+  checksum: a29638c7724a94e6a8baf2c6249d647239a5ff3863f677a023a93c40e4658f00a98cd29e68bf9bcede9f4b85cd7970a9e9bfda410708695312d26d71cde6d6cf
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/shared-ini-file-loader@npm:3.357.0":
+  version: 3.357.0
+  resolution: "@aws-sdk/shared-ini-file-loader@npm:3.357.0"
   dependencies:
-    "@aws-sdk/types": 3.310.0
+    "@aws-sdk/types": 3.357.0
     tslib: ^2.5.0
-  checksum: 5e9d8700918db3daa89440f7c0aa9d0ee37e30bab13892f12602267259160ff73eaccd7e01521bf71f4a0f59da9cb632f75e583d927900f2acddc4913e3422f8
+  checksum: c0be3ef2b74e07abdc7e49a1b2997cb22965af92bd1ca45808c19a54ab4c4ac9444dc69008cdae7d4abe74f38b3c32a08bccc218274df377969ea4bf6839dca9
   languageName: node
   linkType: hard
 
-"@aws-sdk/service-error-classification@npm:3.296.0":
-  version: 3.296.0
-  resolution: "@aws-sdk/service-error-classification@npm:3.296.0"
-  checksum: f4f53591c636971bb2766340137a4816619c8ede0955dff37f795f03a0ed18534042f3ab9ec898d9f3fba98309322854b7442caeb919590f241ac21b3b18de74
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/service-error-classification@npm:3.310.0":
-  version: 3.310.0
-  resolution: "@aws-sdk/service-error-classification@npm:3.310.0"
-  checksum: a600a7634fe932b52676ea33851230173ce66b45f4c8350c91616e37f9cbd43e8f6e7e3fc9761fd14ca7ecd2c7ca90ca806fc555e383d0bf0ee2bdb6a4d73888
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/shared-ini-file-loader@npm:3.300.0":
-  version: 3.300.0
-  resolution: "@aws-sdk/shared-ini-file-loader@npm:3.300.0"
+"@aws-sdk/signature-v4@npm:3.357.0":
+  version: 3.357.0
+  resolution: "@aws-sdk/signature-v4@npm:3.357.0"
   dependencies:
-    "@aws-sdk/types": 3.296.0
-    tslib: ^2.5.0
-  checksum: a85fc99d74b8323dd3fa771244aa072c123355a4f895b8a60d23950971bc3463a5826f70eeb4ac78a5c8395579a8828ad3da64db050888c2a900c85ca95d8a97
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/shared-ini-file-loader@npm:3.310.0":
-  version: 3.310.0
-  resolution: "@aws-sdk/shared-ini-file-loader@npm:3.310.0"
-  dependencies:
-    "@aws-sdk/types": 3.310.0
-    tslib: ^2.5.0
-  checksum: aa3ffb5cb4320ee936102be200dbacb95be0bd85088c692de268d56c175dd4329757a83847d1c4e689b98f3810f729596a1a0b726f1ea0a8d00c78516fc10cc3
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/signature-v4@npm:3.299.0":
-  version: 3.299.0
-  resolution: "@aws-sdk/signature-v4@npm:3.299.0"
-  dependencies:
-    "@aws-sdk/is-array-buffer": 3.295.0
-    "@aws-sdk/types": 3.296.0
-    "@aws-sdk/util-hex-encoding": 3.295.0
-    "@aws-sdk/util-middleware": 3.296.0
-    "@aws-sdk/util-uri-escape": 3.295.0
-    "@aws-sdk/util-utf8": 3.295.0
-    tslib: ^2.5.0
-  checksum: 642e49ef1cb87649a0fdceb82c55f5153f9d662d5429d49fb18601c3ff8c12a1b050d8856fb18c041511be9d4d38fa741628c23f4be508cb816be696446139cd
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/signature-v4@npm:3.310.0":
-  version: 3.310.0
-  resolution: "@aws-sdk/signature-v4@npm:3.310.0"
-  dependencies:
+    "@aws-sdk/eventstream-codec": 3.357.0
     "@aws-sdk/is-array-buffer": 3.310.0
-    "@aws-sdk/types": 3.310.0
+    "@aws-sdk/types": 3.357.0
     "@aws-sdk/util-hex-encoding": 3.310.0
-    "@aws-sdk/util-middleware": 3.310.0
+    "@aws-sdk/util-middleware": 3.357.0
     "@aws-sdk/util-uri-escape": 3.310.0
     "@aws-sdk/util-utf8": 3.310.0
     tslib: ^2.5.0
-  checksum: 0adaf05a005a8a468301f24482d25de3a35554debc98ab8eeb0444c529c02a63dc7e7754d990e9464e1a17c1eb1f6ffdcc178bcd7d35c87587e4cc41574c69b3
+  checksum: 8ef865093e6d60a1b6fcb28c4b0a06e34ed1013dedcc0f8aa35d2e300d48c6e6df00564146111b5f1b58197a4f4c68bedcb5330f4a8fc7a24db302eb21e23782
   languageName: node
   linkType: hard
 
-"@aws-sdk/smithy-client@npm:3.296.0":
-  version: 3.296.0
-  resolution: "@aws-sdk/smithy-client@npm:3.296.0"
+"@aws-sdk/smithy-client@npm:3.358.0":
+  version: 3.358.0
+  resolution: "@aws-sdk/smithy-client@npm:3.358.0"
   dependencies:
-    "@aws-sdk/middleware-stack": 3.296.0
-    "@aws-sdk/types": 3.296.0
+    "@aws-sdk/middleware-stack": 3.357.0
+    "@aws-sdk/types": 3.357.0
+    "@aws-sdk/util-stream": 3.358.0
+    "@smithy/types": ^1.0.0
     tslib: ^2.5.0
-  checksum: 8b7a626c1fd8b253f1f5b365c340626a9495aa6ba83d246be50f559d8274259daa6386f6931c9db41d3250ee3fd9d2d63646f4f0d7c2f793fed5aa7c87593676
+  checksum: 3db71a638ef10fb05e5e10d578014594cd77ccd0b6fba5771e7314b6f1e1d1fcee0ba61ffb9dd6f964480764ef9d0b6af091f6522cb8c44754a767c9d0629087
   languageName: node
   linkType: hard
 
-"@aws-sdk/smithy-client@npm:3.315.0":
-  version: 3.315.0
-  resolution: "@aws-sdk/smithy-client@npm:3.315.0"
+"@aws-sdk/token-providers@npm:3.358.0":
+  version: 3.358.0
+  resolution: "@aws-sdk/token-providers@npm:3.358.0"
   dependencies:
-    "@aws-sdk/middleware-stack": 3.310.0
-    "@aws-sdk/types": 3.310.0
+    "@aws-sdk/client-sso-oidc": 3.358.0
+    "@aws-sdk/property-provider": 3.357.0
+    "@aws-sdk/shared-ini-file-loader": 3.357.0
+    "@aws-sdk/types": 3.357.0
     tslib: ^2.5.0
-  checksum: 2367627dc39960d51fa978f2e4a55fc95dc064f4f31146a9e53e9b1bcaa4c0cb4611fbf56c351eb8cbece88200fb898e654860e55727c31c42baceccb7a9f771
+  checksum: 3038d2be78dade462c52761e37154231e5a5a531f732ecb7f7074ea7b7a84af91917113133539c85e08e262dc9d41257c22ca9d2233221e531709413c23b55d1
   languageName: node
   linkType: hard
 
-"@aws-sdk/token-providers@npm:3.301.0":
-  version: 3.301.0
-  resolution: "@aws-sdk/token-providers@npm:3.301.0"
+"@aws-sdk/types@npm:3.357.0, @aws-sdk/types@npm:^3.357.0":
+  version: 3.357.0
+  resolution: "@aws-sdk/types@npm:3.357.0"
   dependencies:
-    "@aws-sdk/client-sso-oidc": 3.301.0
-    "@aws-sdk/property-provider": 3.296.0
-    "@aws-sdk/shared-ini-file-loader": 3.300.0
-    "@aws-sdk/types": 3.296.0
     tslib: ^2.5.0
-  checksum: f8dac8a46272dfd966a285f005ab27f3f60f61bd0afd2cb21317aaa86083a3297e7d8dee5f9528c2f1bf8a186a7e681ab66ba7e5d0e85f7fee14de8c78633474
+  checksum: 41001b0ea7af2e09daca87f2fedb992bddd864f27f70c70acd62f95bc949ae0637f7100f2cff7a5618291d77c2146f157a863a2d7a4d2576ba2d6882fd4a75bd
   languageName: node
   linkType: hard
 
-"@aws-sdk/token-providers@npm:3.315.0":
-  version: 3.315.0
-  resolution: "@aws-sdk/token-providers@npm:3.315.0"
-  dependencies:
-    "@aws-sdk/client-sso-oidc": 3.315.0
-    "@aws-sdk/property-provider": 3.310.0
-    "@aws-sdk/shared-ini-file-loader": 3.310.0
-    "@aws-sdk/types": 3.310.0
-    tslib: ^2.5.0
-  checksum: 6f62d98f9b27e1dd1b7f0b25887014d520833d686b382f204e5346ea66730b6af3bffd16856add907a43660fd4c5fae430cb9013270e9586fecd23554f549ed3
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/types@npm:3.296.0, @aws-sdk/types@npm:^3.222.0, @aws-sdk/types@npm:^3.292.0":
+"@aws-sdk/types@npm:^3.222.0":
   version: 3.296.0
   resolution: "@aws-sdk/types@npm:3.296.0"
   dependencies:
@@ -1402,44 +957,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/types@npm:3.310.0":
-  version: 3.310.0
-  resolution: "@aws-sdk/types@npm:3.310.0"
+"@aws-sdk/url-parser@npm:3.357.0":
+  version: 3.357.0
+  resolution: "@aws-sdk/url-parser@npm:3.357.0"
   dependencies:
+    "@aws-sdk/querystring-parser": 3.357.0
+    "@aws-sdk/types": 3.357.0
     tslib: ^2.5.0
-  checksum: b11a91899614e14d40081ceab39cd3702254a5658c7b5e8862ef0d66dbffaa41c9a0f0d31e415d22f31c791b507699ba3a5fc7d87a540273386eb779be3807e4
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/url-parser@npm:3.296.0":
-  version: 3.296.0
-  resolution: "@aws-sdk/url-parser@npm:3.296.0"
-  dependencies:
-    "@aws-sdk/querystring-parser": 3.296.0
-    "@aws-sdk/types": 3.296.0
-    tslib: ^2.5.0
-  checksum: eb76e25571d9d13f7a335f36dc5f7466a7d7e8a6e26a5a0ea2529cda36d0ad29d0d6c5d418ac8a81a53a480a57a1b8aced93a43a08060eb0fb8e4259ab2e5048
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/url-parser@npm:3.310.0":
-  version: 3.310.0
-  resolution: "@aws-sdk/url-parser@npm:3.310.0"
-  dependencies:
-    "@aws-sdk/querystring-parser": 3.310.0
-    "@aws-sdk/types": 3.310.0
-    tslib: ^2.5.0
-  checksum: a9f5bec1cfa38cf2d244df1f6d7aad0f8e880a285d148678652ba14a3fb03fc0847defdc80a7e3ffb197d91e33d8cfb43325ee39f53c43c40ceb7fbd34f38fda
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/util-base64@npm:3.295.0":
-  version: 3.295.0
-  resolution: "@aws-sdk/util-base64@npm:3.295.0"
-  dependencies:
-    "@aws-sdk/util-buffer-from": 3.295.0
-    tslib: ^2.5.0
-  checksum: 047329e37dd6946f63b47ae415a988c32022b883b9fcf113120973b2d5e97679bc19f5183b264474f3201cb0560d3a4cb4b9d07d4d70b823945387e20869b41d
+  checksum: ff57a09fb603cf2a3f14f3f45bb09fec7ccd8c4afc525ca6a0c3e25858a3afbf1adb4024ff33292d12103207663e7c8a7c0eda03e6701173d5f8ab817e2190f8
   languageName: node
   linkType: hard
 
@@ -1453,15 +978,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/util-body-length-browser@npm:3.295.0":
-  version: 3.295.0
-  resolution: "@aws-sdk/util-body-length-browser@npm:3.295.0"
-  dependencies:
-    tslib: ^2.5.0
-  checksum: 15100fa717f98a58475c934944108f98b811025039a04eeaaed71380bb2d4444fe44af7c527b74bb6ebd5a3ce277e28896d2e60ea73084f2b9e6cce6873b5592
-  languageName: node
-  linkType: hard
-
 "@aws-sdk/util-body-length-browser@npm:3.310.0":
   version: 3.310.0
   resolution: "@aws-sdk/util-body-length-browser@npm:3.310.0"
@@ -1471,31 +987,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/util-body-length-node@npm:3.295.0":
-  version: 3.295.0
-  resolution: "@aws-sdk/util-body-length-node@npm:3.295.0"
-  dependencies:
-    tslib: ^2.5.0
-  checksum: e44fa83139d0e7e61152cce8f7709e772c920996fbd3ae4acc545df75ea3f7f28fd2959c97029411802b3e12277f775f3e2dbb34c797369635d0881bcf6b0a12
-  languageName: node
-  linkType: hard
-
 "@aws-sdk/util-body-length-node@npm:3.310.0":
   version: 3.310.0
   resolution: "@aws-sdk/util-body-length-node@npm:3.310.0"
   dependencies:
     tslib: ^2.5.0
   checksum: 202417ece7078f09f63c4119cb3ab5f321688ea893125f7d97985e8bf7fc61419d8d990f870d9ead3281dc51334975196ef98c50592eca1f9785472bd39b870d
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/util-buffer-from@npm:3.295.0":
-  version: 3.295.0
-  resolution: "@aws-sdk/util-buffer-from@npm:3.295.0"
-  dependencies:
-    "@aws-sdk/is-array-buffer": 3.295.0
-    tslib: ^2.5.0
-  checksum: c93e6f0cf66927230588365995d0e94ee874857dae6753529f44ebd7f2d9c1bc6e8fdef0a6459bd96f0c29a2fdc9eaa35145102d074249f4e8ff8bb070708f24
   languageName: node
   linkType: hard
 
@@ -1509,15 +1006,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/util-config-provider@npm:3.295.0":
-  version: 3.295.0
-  resolution: "@aws-sdk/util-config-provider@npm:3.295.0"
-  dependencies:
-    tslib: ^2.5.0
-  checksum: 2b6cd2b118465a36c9908dfc330f9f107a0a67cbde2293101af8b3ca0cb2d9f29f76394261880535d62da74b10cf89c5433a2d4524272d5b8776ad8085b0489b
-  languageName: node
-  linkType: hard
-
 "@aws-sdk/util-config-provider@npm:3.310.0":
   version: 3.310.0
   resolution: "@aws-sdk/util-config-provider@npm:3.310.0"
@@ -1527,84 +1015,39 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/util-defaults-mode-browser@npm:3.296.0":
-  version: 3.296.0
-  resolution: "@aws-sdk/util-defaults-mode-browser@npm:3.296.0"
+"@aws-sdk/util-defaults-mode-browser@npm:3.358.0":
+  version: 3.358.0
+  resolution: "@aws-sdk/util-defaults-mode-browser@npm:3.358.0"
   dependencies:
-    "@aws-sdk/property-provider": 3.296.0
-    "@aws-sdk/types": 3.296.0
+    "@aws-sdk/property-provider": 3.357.0
+    "@aws-sdk/types": 3.357.0
     bowser: ^2.11.0
     tslib: ^2.5.0
-  checksum: ae8c6b03d9de2fc9c320ae4aa65027604658aff95483d3eccdc87307e683da2c6943f863a98f74af7c7f9cae74d0b1df7e6f83592cd0b5eff0ff8eba48fca127
+  checksum: 39af5ddcac5411cdacbc477f0f9c61c51a73d967c376dc97c0e6b5ef0b5b6948e73d67118b3d8594d0fdbd99a47c62c0a5b3a832bcf64fd7cab8dc4e9fb52a98
   languageName: node
   linkType: hard
 
-"@aws-sdk/util-defaults-mode-browser@npm:3.315.0":
-  version: 3.315.0
-  resolution: "@aws-sdk/util-defaults-mode-browser@npm:3.315.0"
+"@aws-sdk/util-defaults-mode-node@npm:3.358.0":
+  version: 3.358.0
+  resolution: "@aws-sdk/util-defaults-mode-node@npm:3.358.0"
   dependencies:
-    "@aws-sdk/property-provider": 3.310.0
-    "@aws-sdk/types": 3.310.0
-    bowser: ^2.11.0
+    "@aws-sdk/config-resolver": 3.357.0
+    "@aws-sdk/credential-provider-imds": 3.357.0
+    "@aws-sdk/node-config-provider": 3.357.0
+    "@aws-sdk/property-provider": 3.357.0
+    "@aws-sdk/types": 3.357.0
     tslib: ^2.5.0
-  checksum: 91f25329b070d3d447b3875f501923d17cd0dbeaa498b35cee2ff585f974ff32c8c2c8552260c7b885b96e60fd485d1e3160e07ed3f4cd66e5b3a9a3cc1db349
+  checksum: 04c046290b515aec7dd27b1b6a45274922e714d96ffc21b02775e2f1053d907e12080a009d504bf6265df0c9db48b99ea3d06e2e2790c8b6131c7e426b22cb59
   languageName: node
   linkType: hard
 
-"@aws-sdk/util-defaults-mode-node@npm:3.300.0":
-  version: 3.300.0
-  resolution: "@aws-sdk/util-defaults-mode-node@npm:3.300.0"
+"@aws-sdk/util-endpoints@npm:3.357.0":
+  version: 3.357.0
+  resolution: "@aws-sdk/util-endpoints@npm:3.357.0"
   dependencies:
-    "@aws-sdk/config-resolver": 3.300.0
-    "@aws-sdk/credential-provider-imds": 3.300.0
-    "@aws-sdk/node-config-provider": 3.300.0
-    "@aws-sdk/property-provider": 3.296.0
-    "@aws-sdk/types": 3.296.0
+    "@aws-sdk/types": 3.357.0
     tslib: ^2.5.0
-  checksum: a6c4f5cd85485e23032ab45ea05f9cc943f07b23090c527b7ca159031300a3838c2ce4eb0e545f34a5bdbb2ffce494e85ad7cc86b9b631877fd5f21274bd65f4
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/util-defaults-mode-node@npm:3.315.0":
-  version: 3.315.0
-  resolution: "@aws-sdk/util-defaults-mode-node@npm:3.315.0"
-  dependencies:
-    "@aws-sdk/config-resolver": 3.310.0
-    "@aws-sdk/credential-provider-imds": 3.310.0
-    "@aws-sdk/node-config-provider": 3.310.0
-    "@aws-sdk/property-provider": 3.310.0
-    "@aws-sdk/types": 3.310.0
-    tslib: ^2.5.0
-  checksum: 58c6c945fcc201e68bf5bcbe085a1ead8df257d46d71c74ebee52c311bd6e28f213db315da50876541c115cf69bb0b90fc2535e63053aff5aab6870723a2936d
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/util-endpoints@npm:3.296.0":
-  version: 3.296.0
-  resolution: "@aws-sdk/util-endpoints@npm:3.296.0"
-  dependencies:
-    "@aws-sdk/types": 3.296.0
-    tslib: ^2.5.0
-  checksum: 9ff3b1c39123e8a88c2dcc1e81757f99cfd787be2039b9172e6a1a8b48b04d78712c2082dd1762e41b8b0a6c2f8d79aa06c571ea7ee622351634e5c40a069643
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/util-endpoints@npm:3.310.0":
-  version: 3.310.0
-  resolution: "@aws-sdk/util-endpoints@npm:3.310.0"
-  dependencies:
-    "@aws-sdk/types": 3.310.0
-    tslib: ^2.5.0
-  checksum: 3f1c76b4c7662eeaf9dcf782739aa90812ed6920dd602a4a3779c80fbf3215efb15bd1ad82a30d022b577acd6049d35fbf79b45f6ae842e895be94db360d1b03
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/util-hex-encoding@npm:3.295.0":
-  version: 3.295.0
-  resolution: "@aws-sdk/util-hex-encoding@npm:3.295.0"
-  dependencies:
-    tslib: ^2.5.0
-  checksum: 4b85f087de5c2a8317ff13df4947e355b4c4acae1dd283133e53139457252fb83951194c85e07b89a1e12cecec1b3c0dbd11b7d0f9f2a7775d8c6d3d9c21371e
+  checksum: dcbe4a4ee0fe4490c64465c1dbaaf67d1da38fbc2e8d95e44f50dc4cc94c378b5d1e561c77d5d1c30bb89fb39891e24f1d3778dd8b1fda9305bc3529e3174fe5
   languageName: node
   linkType: hard
 
@@ -1626,50 +1069,38 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/util-middleware@npm:3.296.0":
-  version: 3.296.0
-  resolution: "@aws-sdk/util-middleware@npm:3.296.0"
+"@aws-sdk/util-middleware@npm:3.357.0":
+  version: 3.357.0
+  resolution: "@aws-sdk/util-middleware@npm:3.357.0"
   dependencies:
     tslib: ^2.5.0
-  checksum: 9743a6279208cdb25fc6a5d5800477dfa7f10c25e65cfcb7e0721613c0640df21bef7fe6cb18f27ee3ff470c0be2ff06cb6afdefe234d418c7ac17d9a3563301
+  checksum: 62d92b864a0b6843c83b838a5a850adfe551323ef2cf4d7510ff38f552b1483f09e8caa17f6e6eecf963c57302173e38f682016d45d87a68540b7adf3ec9a9a2
   languageName: node
   linkType: hard
 
-"@aws-sdk/util-middleware@npm:3.310.0":
-  version: 3.310.0
-  resolution: "@aws-sdk/util-middleware@npm:3.310.0"
+"@aws-sdk/util-retry@npm:3.357.0":
+  version: 3.357.0
+  resolution: "@aws-sdk/util-retry@npm:3.357.0"
   dependencies:
+    "@aws-sdk/service-error-classification": 3.357.0
     tslib: ^2.5.0
-  checksum: 3c25a83361ce95dd3f66170d67fb39911a3f5bc21627ffaccef1880ad8c3602b6351f5c51e9c0bfef5b4037e5c66b9eadb291a9441db644811cf5640c35c587b
+  checksum: f88181bfd1d03ab765467fdc8912e448d1b838f2852841f69ffd5537f62759bdfed88fbc9a8f8360957f233c6b0c3278eb2694bc742f587a91f5045cd0621c86
   languageName: node
   linkType: hard
 
-"@aws-sdk/util-retry@npm:3.296.0":
-  version: 3.296.0
-  resolution: "@aws-sdk/util-retry@npm:3.296.0"
+"@aws-sdk/util-stream@npm:3.358.0":
+  version: 3.358.0
+  resolution: "@aws-sdk/util-stream@npm:3.358.0"
   dependencies:
-    "@aws-sdk/service-error-classification": 3.296.0
+    "@aws-sdk/fetch-http-handler": 3.357.0
+    "@aws-sdk/node-http-handler": 3.357.0
+    "@aws-sdk/types": 3.357.0
+    "@aws-sdk/util-base64": 3.310.0
+    "@aws-sdk/util-buffer-from": 3.310.0
+    "@aws-sdk/util-hex-encoding": 3.310.0
+    "@aws-sdk/util-utf8": 3.310.0
     tslib: ^2.5.0
-  checksum: f225fc4eb0933eda3df069d2b0028d8eed76be9b7b871b7bf601c4f5f17012ebb6ebb194df26fc141c9e77bad86d5cbdb79113fe5624d3c2c9d3441f96f580b3
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/util-retry@npm:3.310.0":
-  version: 3.310.0
-  resolution: "@aws-sdk/util-retry@npm:3.310.0"
-  dependencies:
-    "@aws-sdk/service-error-classification": 3.310.0
-    tslib: ^2.5.0
-  checksum: a91b53ca40dd7ac423b46a4916a84567de163e84e63919e77d9a0694337323812b662580f6133442eb1c17885d0a2b5663cba9cadce4dabf5517dc34089b3399
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/util-uri-escape@npm:3.295.0":
-  version: 3.295.0
-  resolution: "@aws-sdk/util-uri-escape@npm:3.295.0"
-  dependencies:
-    tslib: ^2.5.0
-  checksum: 2334baedd339161aa2fb6ae880c04730b072a217ed42b40aa0c0df526aba5a663302da50ba550ad657a4b3cf44070696d91501bf2ba33722f452247f5c2d0fde
+  checksum: 6bb0beba2aa7f93e00b304545072529118327f136ddb9a9eafdd36c82626d71435566cb7471547dff56629cd82e501a0451254b510206d568c1ad50ba0a8b2cc
   languageName: node
   linkType: hard
 
@@ -1682,57 +1113,30 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/util-user-agent-browser@npm:3.299.0":
-  version: 3.299.0
-  resolution: "@aws-sdk/util-user-agent-browser@npm:3.299.0"
+"@aws-sdk/util-user-agent-browser@npm:3.357.0":
+  version: 3.357.0
+  resolution: "@aws-sdk/util-user-agent-browser@npm:3.357.0"
   dependencies:
-    "@aws-sdk/types": 3.296.0
+    "@aws-sdk/types": 3.357.0
     bowser: ^2.11.0
     tslib: ^2.5.0
-  checksum: 60ebb1c0f5de624c212f00641fdcc8b667dac6442413d0d882745b660f72a6d1107cd6b04e7a5eee4013f0444b9fedfe151317937ac1f7d333dd3feeefa027b0
+  checksum: ff41369496116bf9c754030a9679e2eac390eeb5ab88cc49b5df06aa564e156c71eace3458b9bf8e62a8f203c7e431475f498c138276649a6f9c549a0c6e252a
   languageName: node
   linkType: hard
 
-"@aws-sdk/util-user-agent-browser@npm:3.310.0":
-  version: 3.310.0
-  resolution: "@aws-sdk/util-user-agent-browser@npm:3.310.0"
+"@aws-sdk/util-user-agent-node@npm:3.357.0":
+  version: 3.357.0
+  resolution: "@aws-sdk/util-user-agent-node@npm:3.357.0"
   dependencies:
-    "@aws-sdk/types": 3.310.0
-    bowser: ^2.11.0
-    tslib: ^2.5.0
-  checksum: 32fc6249e762fcba3f3111ed627b644855e8127bc354911fdcdbd0332ea1915872bb0984f19c049fbc4feaf17e3bb02ff11b13d3792103ee8902d00c7fe3ff84
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/util-user-agent-node@npm:3.300.0":
-  version: 3.300.0
-  resolution: "@aws-sdk/util-user-agent-node@npm:3.300.0"
-  dependencies:
-    "@aws-sdk/node-config-provider": 3.300.0
-    "@aws-sdk/types": 3.296.0
+    "@aws-sdk/node-config-provider": 3.357.0
+    "@aws-sdk/types": 3.357.0
     tslib: ^2.5.0
   peerDependencies:
     aws-crt: ">=1.0.0"
   peerDependenciesMeta:
     aws-crt:
       optional: true
-  checksum: a42670de913d554d9a102a49920f52eb158fec64fb12d83ce610d6259da17d0ce56cf2e96299c35d019109ca514cd94adb9e8e1a103ce844ee8d4c17236dd35e
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/util-user-agent-node@npm:3.310.0":
-  version: 3.310.0
-  resolution: "@aws-sdk/util-user-agent-node@npm:3.310.0"
-  dependencies:
-    "@aws-sdk/node-config-provider": 3.310.0
-    "@aws-sdk/types": 3.310.0
-    tslib: ^2.5.0
-  peerDependencies:
-    aws-crt: ">=1.0.0"
-  peerDependenciesMeta:
-    aws-crt:
-      optional: true
-  checksum: 82d214f814405a538df8afb259f6a3f2d373cd87adbc2895ac93e9d1f4ed9f4f8f6dcc0ae8ba55887e99e45b5ea83c7b1e5ed3efccbcdbbcaee6a863a638d183
+  checksum: ea9578e519be09a43682dc90be3feab4c4d22e027355be059dac9a0df6de75ace7288be8ef9be94fdf70e3d5d510b1118b6c8d5f8becdde14bc9d90fe05b6e90
   languageName: node
   linkType: hard
 
@@ -1742,16 +1146,6 @@ __metadata:
   dependencies:
     tslib: ^2.3.1
   checksum: b6a1e580da1c9b62c749814182a7649a748ca4253edb4063aa521df97d25b76eae3359eb1680b86f71aac668e05cc05c514379bca39ebf4ba998ae4348412da8
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/util-utf8@npm:3.295.0":
-  version: 3.295.0
-  resolution: "@aws-sdk/util-utf8@npm:3.295.0"
-  dependencies:
-    "@aws-sdk/util-buffer-from": 3.295.0
-    tslib: ^2.5.0
-  checksum: 098058651aa48bb2a6652ea6a1a0a1520e9964a91920e67eed023eacc0956b75475d25025e888ee193140aa800ed89faafa67653914b78c7ffb98e8f96f6d54c
   languageName: node
   linkType: hard
 
@@ -1765,25 +1159,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/util-waiter@npm:3.296.0":
-  version: 3.296.0
-  resolution: "@aws-sdk/util-waiter@npm:3.296.0"
+"@aws-sdk/util-waiter@npm:3.357.0":
+  version: 3.357.0
+  resolution: "@aws-sdk/util-waiter@npm:3.357.0"
   dependencies:
-    "@aws-sdk/abort-controller": 3.296.0
-    "@aws-sdk/types": 3.296.0
+    "@aws-sdk/abort-controller": 3.357.0
+    "@aws-sdk/types": 3.357.0
     tslib: ^2.5.0
-  checksum: 9984297149735df1791791c2f02077bab47501113393efbef619f6af9d19fb1c44a6ac79be73dbc6725a9eb3343b77c04068dcdc0797ddc7da7b9f93df810d7c
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/util-waiter@npm:3.310.0":
-  version: 3.310.0
-  resolution: "@aws-sdk/util-waiter@npm:3.310.0"
-  dependencies:
-    "@aws-sdk/abort-controller": 3.310.0
-    "@aws-sdk/types": 3.310.0
-    tslib: ^2.5.0
-  checksum: 51eb9fbb9a21cd02c312f4639e520b934e2d6ea93eb7c0c1c71f3cf415d61b0a681e7f88209f9e49f3e84bba83480d1c14b0c0b069b610bd12753ff1c1d68f42
+  checksum: 5e1b68ba26c0581aacce2f3c1672e77d870b5e800fc4749cc024e20bc904969d012b496b9bb4e0917fad7560ba4255d2eb8f159379e557dcdff49d5e609c2c41
   languageName: node
   linkType: hard
 
@@ -3367,12 +2750,12 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@datadog/datadog-ci@workspace:."
   dependencies:
-    "@aws-sdk/client-cloudwatch-logs": ^3.315.0
-    "@aws-sdk/client-iam": ^3.315.0
-    "@aws-sdk/client-lambda": ^3.293.0
-    "@aws-sdk/client-sfn": ^3.315.0
-    "@aws-sdk/credential-providers": ^3.296.0
-    "@aws-sdk/types": ^3.292.0
+    "@aws-sdk/client-cloudwatch-logs": ^3.358.0
+    "@aws-sdk/client-iam": ^3.358.0
+    "@aws-sdk/client-lambda": ^3.358.0
+    "@aws-sdk/client-sfn": ^3.358.0
+    "@aws-sdk/credential-providers": ^3.358.0
+    "@aws-sdk/types": ^3.357.0
     "@babel/core": 7.8.0
     "@babel/preset-env": 7.4.5
     "@babel/preset-typescript": 7.3.3
@@ -4104,6 +3487,25 @@ __metadata:
   version: 0.7.2
   resolution: "@sinonjs/text-encoding@npm:0.7.2"
   checksum: fe690002a32ba06906cf87e2e8fe84d1590294586f2a7fd180a65355b53660c155c3273d8011a5f2b77209b819aa7306678ae6e4aea0df014bd7ffd4bbbcf1ab
+  languageName: node
+  linkType: hard
+
+"@smithy/protocol-http@npm:^1.0.1":
+  version: 1.1.0
+  resolution: "@smithy/protocol-http@npm:1.1.0"
+  dependencies:
+    "@smithy/types": ^1.1.0
+    tslib: ^2.5.0
+  checksum: f912e085a477664abf38ff4cd0c2ac064ef068afc6cc0a09ce9c2849f07bac8be622edf60f19a91e2701184b63daa85cb2898e243d7a2c6fd1613de705b3152c
+  languageName: node
+  linkType: hard
+
+"@smithy/types@npm:^1.0.0, @smithy/types@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "@smithy/types@npm:1.1.0"
+  dependencies:
+    tslib: ^2.5.0
+  checksum: 8c0589fa973e5c71cf776c28c43aba04ee07139578fd0174aac0d74c3688e3ffa7075cecd65b223b2a155ad711808b1e4ad58a084ba9f24fcb49679272018387
   languageName: node
   linkType: hard
 
@@ -6581,7 +5983,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-xml-parser@npm:4.1.2, fast-xml-parser@npm:^4.2.4":
+"fast-xml-parser@npm:4.2.4, fast-xml-parser@npm:^4.2.4":
   version: 4.2.4
   resolution: "fast-xml-parser@npm:4.2.4"
   dependencies:


### PR DESCRIPTION
### What and why?

Bump @aws to get latest versions of fast-xml-parser.  Current one has a high severity alert.  See https://github.com/NaturalIntelligence/fast-xml-parser/security/advisories/GHSA-6w63-h3fj-q4vw

### How?

Ran some `yarn add` commands.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
