### PR TITLE
Bump semver from 7.5.2 to 7.5.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "ora": "5.4.1",
     "proxy-agent": "5.0.0",
     "rimraf": "^3.0.2",
-    "semver": "^7.5.2",
+    "semver": "^7.5.3",
     "simple-git": "3.16.0",
     "ssh2": "1.9.0",
     "ssh2-streams": "0.4.10",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2812,7 +2812,7 @@ __metadata:
     proxy: 1.0.2
     proxy-agent: 5.0.0
     rimraf: ^3.0.2
-    semver: ^7.5.2
+    semver: ^7.5.3
     simple-git: 3.16.0
     ssh2: 1.9.0
     ssh2-streams: 0.4.10
@@ -9390,7 +9390,7 @@ jschardet@latest:
   languageName: node
   linkType: hard
 
-"semver@npm:7.x, semver@npm:^7.2.1, semver@npm:^7.3.5, semver@npm:^7.3.8, semver@npm:^7.5.2":
+"semver@npm:7.x, semver@npm:^5.4.1, semver@npm:^5.5.0, semver@npm:^6.0.0, semver@npm:^6.1.1, semver@npm:^6.3.0, semver@npm:^7.2.1, semver@npm:^7.3.5, semver@npm:^7.3.8, semver@npm:^7.5.3":
   version: 7.5.3
   resolution: "semver@npm:7.5.3"
   dependencies:
@@ -9398,24 +9398,6 @@ jschardet@latest:
   bin:
     semver: bin/semver.js
   checksum: 9d58db16525e9f749ad0a696a1f27deabaa51f66e91d2fa2b0db3de3e9644e8677de3b7d7a03f4c15bc81521e0c3916d7369e0572dbde250d9bedf5194e2a8a7
-  languageName: node
-  linkType: hard
-
-"semver@npm:^5.4.1, semver@npm:^5.5.0":
-  version: 5.7.1
-  resolution: "semver@npm:5.7.1"
-  bin:
-    semver: ./bin/semver
-  checksum: 57fd0acfd0bac382ee87cd52cd0aaa5af086a7dc8d60379dfe65fea491fb2489b6016400813930ecd61fd0952dae75c115287a1b16c234b1550887117744dfaf
-  languageName: node
-  linkType: hard
-
-"semver@npm:^6.0.0, semver@npm:^6.1.1, semver@npm:^6.3.0":
-  version: 6.3.0
-  resolution: "semver@npm:6.3.0"
-  bin:
-    semver: ./bin/semver.js
-  checksum: 1b26ecf6db9e8292dd90df4e781d91875c0dcc1b1909e70f5d12959a23c7eebb8f01ea581c00783bbee72ceeaad9505797c381756326073850dc36ed284b21b9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### What and why?

Fixes https://github.com/DataDog/datadog-ci/security/dependabot/26

I thought that only the `7.x` (this major only) were affected by this vulnerability, but apparently it's all of them.

### How?

This PR aligns all the `semver` dependencies to a single one: [`7.5.3`](https://github.com/npm/node-semver/releases/tag/v7.5.3) (which contains another bug fix).

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
