### PR TITLE
[ci] Bump integrations with given version of datadog-ci

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,8 @@ jobs:
           YARN_NPM_AUTH_TOKEN: ${{ secrets.YARN_NPM_AUTH_TOKEN }}
 
   bump-ci-integrations:
+    name: Bump datadog-ci in integration
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
@@ -23,21 +25,22 @@ jobs:
           - synthetics-ci-github-action
           - datadog-ci-azure-devops
           - synthetics-test-automation-circleci-orb
-
-    name: Bump datadog-ci in integration
-    runs-on: ubuntu-latest
-
     steps:
       - name: Create bump datadog-ci PR
         uses: actions/github-script@v6
         with:
           github-token: ${{ secrets.CROSS_REPOSITORY_GITHUB_TOKEN }}
           script: |
+            const tagName = '${{ github.event.release.tag_name }}'.replace('v', '')
+
             github.rest.actions.createWorkflowDispatch({
               owner: context.repo.owner,
               repo: '${{ matrix.integration }}',
               workflow_id: 'bump-datadog-ci.yml',
               ref: 'main',
+              inputs: {
+                datadog_ci_version: tagName,
+              },
             });
 
   build-binary-ubuntu:


### PR DESCRIPTION
### What and why?

This CI job didn't work as expected recently: we released [`v2.16.0`](https://github.com/DataDog/datadog-ci/releases/tag/v2.16.0), but the PRs which were created all targeted `v2.15.0` ([example](https://github.com/DataDog/synthetics-ci-github-action/pull/163)).

I suspect this is because the changes done by [`yarn npm publish`](https://github.com/DataDog/datadog-ci/blob/543578ebe4ea52d562dbf3c74bc8e43248b77c8b/.github/workflows/release.yml#L14) in this repository's CI took time to get propagated.

By default, when no inputs are given to the `bump-datadog-ci.yml` workflows, we default to latest. And I think that[ `npm view @datadog/datadog-ci --json`](https://github.com/DataDog/synthetics-ci-github-action/blob/93319f125c3ee84ad58e394c200a5d79927aa9ce/.github/workflows/bump-datadog-ci.yml#L50) still got a response from cache, so the version wasn't up-to-date.

### How?

Let's see if it works better by specifying the version. If we do this, the workflow will run [`yarn add datadog-ci@^x.x.x`](https://github.com/DataDog/synthetics-ci-github-action/blob/93319f125c3ee84ad58e394c200a5d79927aa9ce/.github/workflows/bump-datadog-ci.yml#L53) directly, which might bypass the cache.

If this doesn't work, then we can move the `bump-ci-integrations` job matrix at the very bottom of `.github/workflows/release.yml`, which should add enough delay.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
