### PR TITLE
[ci-visibility] Update docs to recommend `DD_*` env vars everywhere

### DIFF
--- a/src/commands/junit/README.md
+++ b/src/commands/junit/README.md
@@ -38,14 +38,14 @@ datadog-ci junit upload --service my-service --tags key1:value1 --tags key2:valu
 
 Additionally you might configure the `junit` command with environment variables:
 
-- `DATADOG_API_KEY` or `DD_API_KEY` (**required**): API key used to authenticate the requests.
+- `DD_API_KEY` (**required**): API key used to authenticate the requests.
 - `DD_ENV`: you may choose the environment you want your test results to appear in.
 - `DD_SERVICE`: if you haven't specified a service through `--service` you might do it with this env var.
 - `DD_TAGS`: set global tags applied to all spans. The format must be `key1:value1,key2:value2`.
   - The resulting dictionary will be merged with whatever is in the `--tags` parameter. If a `key` appears both in `--tags` and `DD_TAGS`, whatever value is in `DD_TAGS` will take precedence.
 - `DD_METRICS`: set global numerical tags applied to all spans. The format must be `key1:123,key2:321`.
   - The resulting dictionary will be merged with whatever is in the `--metrics` parameter. If a `key` appears both in `--metrics` and `DD_METRICS`, whatever value is in `DD_METRICS` will take precedence.
-- `DATADOG_SITE`: choose your Datadog site, e.g. datadoghq.com or datadoghq.eu.
+- `DD_SITE`: choose your Datadog site, e.g. datadoghq.com or datadoghq.eu.
 - `DD_CIVISIBILITY_LOGS_ENABLED`: it will enable collecting logs from the content in the XML reports.
 
 ### Optional dependencies
@@ -57,7 +57,7 @@ Additionally you might configure the `junit` command with environment variables:
 To verify this command works as expected, you can use `--dry-run`:
 
 ```bash
-export DATADOG_API_KEY='<API key>'
+export DD_API_KEY='<API key>'
 
 yarn launch junit upload ./src/commands/junit/__tests__/fixtures/java-report.xml --service example-upload --dry-run
 ```

--- a/src/commands/junit/__tests__/upload.test.ts
+++ b/src/commands/junit/__tests__/upload.test.ts
@@ -45,7 +45,7 @@ describe('upload', () => {
       command.context = {stdout: {write}} as any
 
       expect(command['getApiHelper'].bind(command)).toThrow('API key is missing')
-      expect(write.mock.calls[0][0]).toContain('DATADOG_API_KEY')
+      expect(write.mock.calls[0][0]).toContain('DD_API_KEY')
     })
   })
   describe('getMatchingJUnitXMLFiles', () => {
@@ -287,7 +287,7 @@ describe('execute', () => {
   const runCLI = async (extraArgs: string[]) => {
     const cli = makeCli()
     const context = createMockContext() as any
-    process.env = {DATADOG_API_KEY: 'PLACEHOLDER'}
+    process.env = {DD_API_KEY: 'PLACEHOLDER'}
     const code = await cli.run(
       ['junit', 'upload', '--service', 'test-service', '--dry-run', '--logs', ...extraArgs],
       context

--- a/src/commands/junit/upload.ts
+++ b/src/commands/junit/upload.ts
@@ -81,7 +81,7 @@ export class UploadJUnitXMLCommand extends Command {
       ],
       [
         'Upload all jUnit XML test report files in current directory to the datadoghq.eu site',
-        'DATADOG_SITE=datadoghq.eu datadog-ci junit upload --service my-service .',
+        'DD_SITE=datadoghq.eu datadog-ci junit upload --service my-service .',
       ],
       [
         'Upload all jUnit XML test report files in current directory while also collecting logs',

--- a/src/commands/metric/README.md
+++ b/src/commands/metric/README.md
@@ -23,8 +23,8 @@ datadog-ci metric --level job --metrics binary.size:1024
 
 ### Environment variables
 
-- `DATADOG_API_KEY` or `DD_API_KEY` (**required**): API key used to authenticate the requests.
-- `DATADOG_SITE`: choose your Datadog site, e.g. datadoghq.com or datadoghq.eu.
+- `DD_API_KEY` (**required**): API key used to authenticate the requests.
+- `DD_SITE`: choose your Datadog site, e.g. datadoghq.com or datadoghq.eu.
 
 ### Supported providers
 
@@ -38,7 +38,7 @@ error.
 To verify this command works as expected, you can tag a mock pipeline and validate the command returns 0:
 
 ```bash
-export DATADOG_API_KEY='<API key>'
+export DD_API_KEY='<API key>'
 export BUILDKITE=true
 export BUILDKITE_BUILD_ID=uuid
 

--- a/src/commands/tag/README.md
+++ b/src/commands/tag/README.md
@@ -23,9 +23,9 @@ datadog-ci tag --level job --tags "go.version:`go version`"
 
 ### Environment variables
 
-- `DATADOG_API_KEY` or `DD_API_KEY` (**required**): API key used to authenticate the requests.
+- `DD_API_KEY` (**required**): API key used to authenticate the requests.
 - `DD_TAGS`: set tags applied to the pipeline or job span. The format must be `key1:value1,key2:value2`.
-- `DATADOG_SITE`: choose your Datadog site, e.g. datadoghq.com or datadoghq.eu.
+- `DD_SITE`: choose your Datadog site, e.g. datadoghq.com or datadoghq.eu.
 
 ### Supported providers
 
@@ -39,7 +39,7 @@ error.
 To verify this command works as expected, you can tag a mock pipeline and validate the command returns 0:
 
 ```bash
-export DATADOG_API_KEY='<API key>'
+export DD_API_KEY='<API key>'
 export BUILDKITE=true
 export BUILDKITE_BUILD_ID=uuid
 

--- a/src/commands/trace/README.md
+++ b/src/commands/trace/README.md
@@ -22,10 +22,10 @@ datadog-ci trace --name "Say Hello" -- echo "Hello World"
 
 Additionally you might configure the `trace` command with environment variables:
 
-- `DATADOG_API_KEY` or `DD_API_KEY` (**required**): API key used to authenticate the requests.
+- `DD_API_KEY` (**required**): API key used to authenticate the requests.
 - `DD_ENV`: you may choose the environment you want your test results to appear in.
 - `DD_TAGS`: set global tags applied to all spans. The format must be `key1:value1,key2:value2`.
-- `DATADOG_SITE`: choose your Datadog site, e.g. datadoghq.com or datadoghq.eu.
+- `DD_SITE`: choose your Datadog site, e.g. datadoghq.com or datadoghq.eu.
 
 ### Optional dependencies
 
@@ -36,7 +36,7 @@ Additionally you might configure the `trace` command with environment variables:
 To verify this command works as expected, you can trace a mock command and validate the command returns 0:
 
 ```bash
-export DATADOG_API_KEY='<API key>'
+export DD_API_KEY='<API key>'
 export CIRCLECI=true
 
 yarn launch trace --name "Say Hello" echo "Hello World"

--- a/src/commands/trace/trace.ts
+++ b/src/commands/trace/trace.ts
@@ -32,7 +32,7 @@ export class TraceCommand extends Command {
       ],
       [
         'Trace a command and report to the datadoghq.eu site',
-        'DATADOG_SITE=datadoghq.eu datadog-ci trace -- echo "Hello World"',
+        'DD_SITE=datadoghq.eu datadog-ci trace -- echo "Hello World"',
       ],
     ],
   })


### PR DESCRIPTION
### What and why?

We want to be as consistent as possible. `DD_*` env vars are the standard. We still want to support `DATADOG_*` but at least the documentation should stick with `DD_*`.

### How?

Update docs to recommend using `DD_*`. 

