### PR TITLE
[synthetics] Print summary link before waiting for results

### DIFF
--- a/src/commands/synthetics/__tests__/reporters/__snapshots__/default.test.ts.snap
+++ b/src/commands/synthetics/__tests__/reporters/__snapshots__/default.test.ts.snap
@@ -176,7 +176,10 @@ exports[`Default reporter testTrigger Skipped test, with 2 config overrides 1`] 
 `;
 
 exports[`Default reporter testsWait outputs triggered tests 1`] = `
-"- Waiting for [1m[36m11[39m[22m test results [90m(abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, …)[39m…
+"View pending summary in Datadog: [2m[36mhttps://app.datadoghq.com/synthetics/explorer/ci?batchResultId=123[39m[22m
+
+
+- Waiting for [1m[36m11[39m[22m test results [90m(abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, …)[39m…
 
 "
 `;

--- a/src/commands/synthetics/__tests__/utils.test.ts
+++ b/src/commands/synthetics/__tests__/utils.test.ts
@@ -737,7 +737,12 @@ describe('utils', () => {
           api,
           trigger,
           [result.test],
-          {maxPollingTimeout: 120000, failOnCriticalErrors: false},
+          {
+            datadogSite: DEFAULT_COMMAND_CONFIG.datadogSite,
+            failOnCriticalErrors: false,
+            maxPollingTimeout: 120000,
+            subdomain: DEFAULT_COMMAND_CONFIG.subdomain,
+          },
           mockReporter
         )
       ).toEqual([result])
@@ -762,7 +767,12 @@ describe('utils', () => {
         api,
         trigger,
         [result.test, result.test],
-        {maxPollingTimeout: 0, failOnCriticalErrors: false},
+        {
+          datadogSite: DEFAULT_COMMAND_CONFIG.datadogSite,
+          failOnCriticalErrors: false,
+          maxPollingTimeout: 0,
+          subdomain: DEFAULT_COMMAND_CONFIG.subdomain,
+        },
         mockReporter
       )
 
@@ -786,7 +796,12 @@ describe('utils', () => {
           api,
           trigger,
           [result.test, result.test],
-          {maxPollingTimeout: 0, failOnCriticalErrors: false},
+          {
+            datadogSite: DEFAULT_COMMAND_CONFIG.datadogSite,
+            failOnCriticalErrors: false,
+            maxPollingTimeout: 0,
+            subdomain: DEFAULT_COMMAND_CONFIG.subdomain,
+          },
           mockReporter
         )
       ).toEqual([
@@ -830,7 +845,12 @@ describe('utils', () => {
           api,
           trigger,
           [result.test],
-          {maxPollingTimeout: 0, failOnCriticalErrors: false},
+          {
+            datadogSite: DEFAULT_COMMAND_CONFIG.datadogSite,
+            failOnCriticalErrors: false,
+            maxPollingTimeout: 0,
+            subdomain: DEFAULT_COMMAND_CONFIG.subdomain,
+          },
           mockReporter
         )
       ).toStrictEqual([
@@ -855,7 +875,12 @@ describe('utils', () => {
           api,
           trigger,
           [result.test],
-          {maxPollingTimeout: 120000, failOnCriticalErrors: false},
+          {
+            datadogSite: DEFAULT_COMMAND_CONFIG.datadogSite,
+            failOnCriticalErrors: false,
+            maxPollingTimeout: 120000,
+            subdomain: DEFAULT_COMMAND_CONFIG.subdomain,
+          },
           mockReporter
         )
       ).toEqual([
@@ -886,7 +911,12 @@ describe('utils', () => {
           api,
           trigger,
           [result.test],
-          {maxPollingTimeout: 120000, failOnCriticalErrors: false},
+          {
+            datadogSite: DEFAULT_COMMAND_CONFIG.datadogSite,
+            failOnCriticalErrors: false,
+            maxPollingTimeout: 120000,
+            subdomain: DEFAULT_COMMAND_CONFIG.subdomain,
+          },
           mockReporter
         )
       ).toEqual([result])
@@ -912,7 +942,12 @@ describe('utils', () => {
           api,
           trigger,
           [result.test],
-          {maxPollingTimeout: 2000, failOnCriticalErrors: false},
+          {
+            datadogSite: DEFAULT_COMMAND_CONFIG.datadogSite,
+            failOnCriticalErrors: false,
+            maxPollingTimeout: 2000,
+            subdomain: DEFAULT_COMMAND_CONFIG.subdomain,
+          },
           mockReporter
         )
       ).toEqual([result, {...result, resultId: pollTimeoutResult.resultID, timedOut: true}])
@@ -931,7 +966,12 @@ describe('utils', () => {
         api,
         trigger,
         [result.test],
-        {maxPollingTimeout: 2000, failOnCriticalErrors: true},
+        {
+          datadogSite: DEFAULT_COMMAND_CONFIG.datadogSite,
+          failOnCriticalErrors: true,
+          maxPollingTimeout: 2000,
+          subdomain: DEFAULT_COMMAND_CONFIG.subdomain,
+        },
         mockReporter,
         mockTunnel
       )
@@ -948,7 +988,12 @@ describe('utils', () => {
         api,
         trigger,
         [result.test],
-        {maxPollingTimeout: 2000, failOnCriticalErrors: true},
+        {
+          datadogSite: DEFAULT_COMMAND_CONFIG.datadogSite,
+          failOnCriticalErrors: true,
+          maxPollingTimeout: 2000,
+          subdomain: DEFAULT_COMMAND_CONFIG.subdomain,
+        },
         mockReporter,
         mockTunnel
       )
@@ -961,7 +1006,12 @@ describe('utils', () => {
         api,
         trigger,
         [newTest],
-        {maxPollingTimeout: 2000, failOnCriticalErrors: true},
+        {
+          datadogSite: DEFAULT_COMMAND_CONFIG.datadogSite,
+          failOnCriticalErrors: true,
+          maxPollingTimeout: 2000,
+          subdomain: DEFAULT_COMMAND_CONFIG.subdomain,
+        },
         mockReporter,
         mockTunnel
       )
@@ -973,7 +1023,12 @@ describe('utils', () => {
         api,
         trigger,
         [newTest],
-        {failOnCriticalErrors: true, maxPollingTimeout: 2000},
+        {
+          datadogSite: DEFAULT_COMMAND_CONFIG.datadogSite,
+          failOnCriticalErrors: true,
+          maxPollingTimeout: 2000,
+          subdomain: DEFAULT_COMMAND_CONFIG.subdomain,
+        },
         mockReporter,
         mockTunnel
       )
@@ -988,7 +1043,17 @@ describe('utils', () => {
       })
 
       await expect(
-        utils.waitForResults(api, trigger, [result.test], {maxPollingTimeout: 2000}, mockReporter)
+        utils.waitForResults(
+          api,
+          trigger,
+          [result.test],
+          {
+            datadogSite: DEFAULT_COMMAND_CONFIG.datadogSite,
+            maxPollingTimeout: 2000,
+            subdomain: DEFAULT_COMMAND_CONFIG.subdomain,
+          },
+          mockReporter
+        )
       ).rejects.toThrowError(
         'Failed to poll results: could not query https://app.datadoghq.com/example\nPoll results server error\n'
       )
@@ -1004,7 +1069,17 @@ describe('utils', () => {
       })
 
       await expect(
-        utils.waitForResults(api, trigger, [result.test], {maxPollingTimeout: 2000}, mockReporter)
+        utils.waitForResults(
+          api,
+          trigger,
+          [result.test],
+          {
+            datadogSite: DEFAULT_COMMAND_CONFIG.datadogSite,
+            maxPollingTimeout: 2000,
+            subdomain: DEFAULT_COMMAND_CONFIG.subdomain,
+          },
+          mockReporter
+        )
       ).rejects.toThrowError(
         'Failed to get batch: could not query https://app.datadoghq.com/example\nGet batch server error\n'
       )

--- a/src/commands/synthetics/interfaces.ts
+++ b/src/commands/synthetics/interfaces.ts
@@ -13,7 +13,7 @@ export interface MainReporter {
   resultEnd(result: Result, baseUrl: string): void
   resultReceived(result: Batch['results'][0]): void
   runEnd(summary: Summary, baseUrl: string, orgSettings?: SyntheticsOrgSettings): void
-  testsWait(tests: Test[]): void
+  testsWait(tests: Test[], baseUrl: string, batchId: string): void
   testTrigger(test: Test, testId: string, executionRule: ExecutionRule, config: UserConfigOverride): void
   testWait(test: Test): void
 }

--- a/src/commands/synthetics/reporters/default.ts
+++ b/src/commands/synthetics/reporters/default.ts
@@ -363,13 +363,16 @@ export class DefaultReporter implements MainReporter {
     this.write(lines.join('\n'))
   }
 
-  public testsWait(tests: Test[]) {
+  public testsWait(tests: Test[], baseUrl: string, batchId: string) {
     const testsList = tests.map((t) => t.public_id)
     if (testsList.length > 10) {
       testsList.splice(10)
       testsList.push('…')
     }
     const testsDisplay = chalk.gray(`(${testsList.join(', ')})`)
+
+    const batchUrl = getBatchUrl(baseUrl, batchId)
+    this.write(`View pending summary in Datadog: ${chalk.dim.cyan(batchUrl)}\n\n`)
 
     this.testWaitSpinner = ora({
       stream: this.context.stdout,

--- a/src/commands/synthetics/run-tests-lib.ts
+++ b/src/commands/synthetics/run-tests-lib.ts
@@ -145,14 +145,13 @@ export const executeTests = async (
 
   try {
     const maxPollingTimeout = Math.max(...testsToTrigger.map((t) => t.config.pollingTimeout || config.pollingTimeout))
+    const {datadogSite, failOnCriticalErrors, failOnTimeout, subdomain} = config
+
     const results = await waitForResults(
       api,
       trigger,
       tests,
-      {
-        ...config,
-        maxPollingTimeout,
-      },
+      {datadogSite, failOnCriticalErrors, failOnTimeout, subdomain, maxPollingTimeout},
       reporter,
       tunnel
     )

--- a/src/commands/synthetics/run-tests-lib.ts
+++ b/src/commands/synthetics/run-tests-lib.ts
@@ -150,8 +150,7 @@ export const executeTests = async (
       trigger,
       tests,
       {
-        failOnCriticalErrors: config.failOnCriticalErrors,
-        failOnTimeout: config.failOnTimeout,
+        ...config,
         maxPollingTimeout,
       },
       reporter,


### PR DESCRIPTION
### What and why?

Closes https://github.com/DataDog/datadog-ci/issues/864

Without this, the user needs to wait until the end (or timeout) of the batch in order to view it in Datadog.

### How?

- Move the call of `reporter.testsWait()` from `getTestsToTrigger()` to `waitForResults()`.
- Add `baseUrl` and `batchId` to the arguments of `reporter.testsWait()` to craft the summary URL

FYI, the `batchId` is only available after (or in) `runTests()`, but `runTests()` doesn't take a `reporter` currently. And IMO, it's better semantically to give the link of the batch we are waiting for, inside `waitForResults()`.

New output:

```js
[3dq-qkt-ant] Found test "Test title" (1 config override)


View pending summary in Datadog: https://app.datadoghq.com/synthetics/explorer/ci?batchResultId=32cc437d-0a94-4565-8862-23fbec4d552b

  Waiting for 1 test result (3dq-qkt-ant)…


=== REPORT ===
Took 7585ms

✓ [3dq-qkt-ant] Test title - location: Tokyo (AWS)
  ⎋ Total duration: 765 ms - View test run details: https://app.datadoghq.com/synthetics/details/3dq-qkt-ant?resultId=4920761804591194046&from_ci=true
  ✓ GET - http://example.org

✓ [3dq-qkt-ant] Test title - location: Frankfurt (AWS)
  ⎋ Total duration: 25 ms - View test run details: https://app.datadoghq.com/synthetics/details/3dq-qkt-ant?resultId=455958245746826684&from_ci=true
  ✓ GET - http://example.org

View full summary in Datadog: https://app.datadoghq.com/synthetics/explorer/ci?batchResultId=32cc437d-0a94-4565-8862-23fbec4d552b

Continuous Testing Summary:
Test Results: 2 passed, 0 failed
Total Duration: 8s
```

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
