### PR TITLE
[ci-visibility] Do not use extension for checking if a path is a file

### DIFF
--- a/src/commands/junit/__tests__/fixtures/junit.xml/valid-report-2.xml
+++ b/src/commands/junit/__tests__/fixtures/junit.xml/valid-report-2.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites duration="50.5">
+    <testsuite failures="0" name="Untitled suite in agent.js" package="tests/suites/casper/agent" tests="3" time="0.256">
+        <testcase classname="tests/suites/casper/agent" name="Default user agent matches /CasperJS/" time="0.103"/>
+        <testcase classname="tests/suites/casper/agent" name="Default user agent matches /plop/" time="0.146"/>
+        <testcase classname="tests/suites/casper/agent" name="Default user agent matches /plop/" time="0.007"/>
+    </testsuite>
+</testsuites>

--- a/src/commands/junit/__tests__/fixtures/junit.xml/valid-report.xml
+++ b/src/commands/junit/__tests__/fixtures/junit.xml/valid-report.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites duration="50.5">
+    <testsuite failures="0" name="Untitled suite in agent.js" package="tests/suites/casper/agent" tests="3" time="0.256">
+        <testcase classname="tests/suites/casper/agent" name="Default user agent matches /CasperJS/" time="0.103"/>
+        <testcase classname="tests/suites/casper/agent" name="Default user agent matches /plop/" time="0.146"/>
+        <testcase classname="tests/suites/casper/agent" name="Default user agent matches /plop/" time="0.007"/>
+    </testsuite>
+</testsuites>

--- a/src/commands/junit/__tests__/upload.test.ts
+++ b/src/commands/junit/__tests__/upload.test.ts
@@ -145,6 +145,27 @@ describe('upload', () => {
         xmlPath: './src/commands/junit/__tests__/fixtures/subfolder/js-report.xml',
       })
     })
+    test('should allow folders with extensions', async () => {
+      const context = createMockContext()
+      const command = new UploadJUnitXMLCommand()
+      const [firstFile, secondFile] = await command['getMatchingJUnitXMLFiles'].call(
+        {
+          basePaths: ['./src/commands/junit/__tests__/fixtures/junit.xml'],
+          config: {},
+          context,
+          service: 'service',
+        },
+        {}
+      )
+      expect(firstFile).toMatchObject({
+        service: 'service',
+        xmlPath: './src/commands/junit/__tests__/fixtures/junit.xml/valid-report-2.xml',
+      })
+      expect(secondFile).toMatchObject({
+        service: 'service',
+        xmlPath: './src/commands/junit/__tests__/fixtures/junit.xml/valid-report.xml',
+      })
+    })
     test('should not have repeated files', async () => {
       const context = createMockContext()
       const command = new UploadJUnitXMLCommand()

--- a/src/commands/junit/upload.ts
+++ b/src/commands/junit/upload.ts
@@ -37,7 +37,7 @@ import {
   renderSuccessfulUpload,
   renderUpload,
 } from './renderer'
-import {isFalse} from './utils'
+import {isFalse, isFile} from './utils'
 
 const TRACE_ID_HTTP_HEADER = 'x-datadog-trace-id'
 const PARENT_ID_HTTP_HEADER = 'x-datadog-parent-id'
@@ -251,14 +251,16 @@ export class UploadJUnitXMLCommand extends Command {
   }
 
   private async getMatchingJUnitXMLFiles(spanTags: SpanTags): Promise<Payload[]> {
-    const jUnitXMLFiles = (this.basePaths || []).reduce((acc: string[], basePath: string) => {
-      const isFile = !!path.extname(basePath)
-      if (isFile) {
-        return acc.concat(fs.existsSync(basePath) ? [basePath] : [])
-      }
+    const jUnitXMLFiles = (this.basePaths || [])
+      .reduce((acc: string[], basePath: string) => {
+        const isBasePathFile = isFile(basePath)
+        if (isBasePathFile) {
+          return acc.concat(fs.existsSync(basePath) ? [basePath] : [])
+        }
 
-      return acc.concat(glob.sync(buildPath(basePath, '*.xml')))
-    }, [])
+        return acc.concat(glob.sync(buildPath(basePath, '*.xml')))
+      }, [])
+      .filter(isFile)
 
     const validUniqueFiles = [...new Set(jUnitXMLFiles)].filter((jUnitXMLFilePath) => {
       const validationErrorMessage = validateXml(jUnitXMLFilePath)

--- a/src/commands/junit/upload.ts
+++ b/src/commands/junit/upload.ts
@@ -253,8 +253,7 @@ export class UploadJUnitXMLCommand extends Command {
   private async getMatchingJUnitXMLFiles(spanTags: SpanTags): Promise<Payload[]> {
     const jUnitXMLFiles = (this.basePaths || [])
       .reduce((acc: string[], basePath: string) => {
-        const isBasePathFile = isFile(basePath)
-        if (isBasePathFile) {
+        if (isFile(basePath)) {
           return acc.concat(fs.existsSync(basePath) ? [basePath] : [])
         }
 

--- a/src/commands/junit/utils.ts
+++ b/src/commands/junit/utils.ts
@@ -1,3 +1,5 @@
+import {lstatSync} from 'fs'
+
 import {SpanTags} from '../../helpers/interfaces'
 import {CI_JOB_URL, CI_PIPELINE_URL, GIT_BRANCH, GIT_REPOSITORY_URL, GIT_SHA} from '../../helpers/tags'
 
@@ -53,4 +55,12 @@ export const isFalse = (value: string | boolean) => {
   const lowerCaseValue = String(value).toLowerCase()
 
   return lowerCaseValue === '0' || lowerCaseValue === 'false'
+}
+
+export const isFile = (path: string) => {
+  try {
+    return lstatSync(path).isFile()
+  } catch (e) {
+    return false
+  }
 }


### PR DESCRIPTION
### What and why?

When passing folders with this shape: `./reports/junit.xml/`, `datadog-ci` considered that to be a valid file (because it used `path.extname`), so when attempting to read its contents it failed. 

This PR fixes that.

### How?

Using `isFile` util function to check if the input is actually a file or not.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
