### PR TITLE
[lambda][flare] Obfuscate secrets

### DIFF
--- a/src/commands/lambda/__tests__/__snapshots__/flare.test.ts.snap
+++ b/src/commands/lambda/__tests__/__snapshots__/flare.test.ts.snap
@@ -13,7 +13,7 @@ exports[`lambda flare AWS Lambda configuration prints config when running as a d
 {
   Environment: {
     Variables: {
-      DD_API_KEY: '02aeb762fff59ac0d5ad1536cd9633bd',
+      DD_API_KEY: '02**************************33bd',
       DD_SITE: 'datadoghq.com',
       DD_LOG_LEVEL: 'debug'
     }
@@ -55,7 +55,7 @@ exports[`lambda flare AWS credentials continues when getAWSCredentials() returns
 {
   Environment: {
     Variables: {
-      DD_API_KEY: '02aeb762fff59ac0d5ad1536cd9633bd',
+      DD_API_KEY: '02**************************33bd',
       DD_SITE: 'datadoghq.com',
       DD_LOG_LEVEL: 'debug'
     }
@@ -86,7 +86,7 @@ exports[`lambda flare AWS credentials requests AWS credentials when none are fou
 {
   Environment: {
     Variables: {
-      DD_API_KEY: '02aeb762fff59ac0d5ad1536cd9633bd',
+      DD_API_KEY: '02**************************33bd',
       DD_SITE: 'datadoghq.com',
       DD_LOG_LEVEL: 'debug'
     }
@@ -145,7 +145,7 @@ exports[`lambda flare gets CloudWatch Logs does not get logs when --with-logs is
 {
   Environment: {
     Variables: {
-      DD_API_KEY: '02aeb762fff59ac0d5ad1536cd9633bd',
+      DD_API_KEY: '02**************************33bd',
       DD_SITE: 'datadoghq.com',
       DD_LOG_LEVEL: 'debug'
     }
@@ -176,7 +176,7 @@ exports[`lambda flare gets CloudWatch Logs gets logs, saves, and sends correctly
 {
   Environment: {
     Variables: {
-      DD_API_KEY: '02aeb762fff59ac0d5ad1536cd9633bd',
+      DD_API_KEY: '02**************************33bd',
       DD_SITE: 'datadoghq.com',
       DD_LOG_LEVEL: 'debug'
     }
@@ -217,7 +217,7 @@ exports[`lambda flare gets CloudWatch Logs prints error when getLogEvents throws
 {
   Environment: {
     Variables: {
-      DD_API_KEY: '02aeb762fff59ac0d5ad1536cd9633bd',
+      DD_API_KEY: '02**************************33bd',
       DD_SITE: 'datadoghq.com',
       DD_LOG_LEVEL: 'debug'
     }
@@ -244,7 +244,7 @@ exports[`lambda flare gets CloudWatch Logs prints error when getLogStreamNames t
 {
   Environment: {
     Variables: {
-      DD_API_KEY: '02aeb762fff59ac0d5ad1536cd9633bd',
+      DD_API_KEY: '02**************************33bd',
       DD_SITE: 'datadoghq.com',
       DD_LOG_LEVEL: 'debug'
     }
@@ -271,7 +271,7 @@ exports[`lambda flare gets CloudWatch Logs warns and skips getting logs when get
 {
   Environment: {
     Variables: {
-      DD_API_KEY: '02aeb762fff59ac0d5ad1536cd9633bd',
+      DD_API_KEY: '02**************************33bd',
       DD_SITE: 'datadoghq.com',
       DD_LOG_LEVEL: 'debug'
     }
@@ -305,7 +305,7 @@ exports[`lambda flare gets CloudWatch Logs warns and skips log when getLogEvents
 {
   Environment: {
     Variables: {
-      DD_API_KEY: '02aeb762fff59ac0d5ad1536cd9633bd',
+      DD_API_KEY: '02**************************33bd',
       DD_SITE: 'datadoghq.com',
       DD_LOG_LEVEL: 'debug'
     }
@@ -328,6 +328,20 @@ exports[`lambda flare gets CloudWatch Logs warns and skips log when getLogEvents
 
 ✅ Successfully sent flare file to Datadog Support!
 "
+`;
+
+exports[`lambda flare obfuscateConfig should obfuscate API key but not whitelisted environment variables 1`] = `
+Object {
+  "Environment": Object {
+    "Variables": Object {
+      "DD_API_KEY": "02**************************33bd",
+      "DD_LOG_LEVEL": "debug",
+      "DD_SITE": "datadoghq.com",
+    },
+  },
+  "FunctionArn": "arn:aws:lambda:us-east-1:123456789012:function:some-function",
+  "FunctionName": "some-function",
+}
 `;
 
 exports[`lambda flare prints correct headers prints dry-run header 1`] = `
@@ -357,7 +371,7 @@ exports[`lambda flare send to Datadog does not send request to Datadog when a dr
 {
   Environment: {
     Variables: {
-      DD_API_KEY: '02aeb762fff59ac0d5ad1536cd9633bd',
+      DD_API_KEY: '02**************************33bd',
       DD_SITE: 'datadoghq.com',
       DD_LOG_LEVEL: 'debug'
     }
@@ -388,7 +402,7 @@ exports[`lambda flare send to Datadog successfully adds zip file to FormData 1`]
 {
   Environment: {
     Variables: {
-      DD_API_KEY: '02aeb762fff59ac0d5ad1536cd9633bd',
+      DD_API_KEY: '02**************************33bd',
       DD_SITE: 'datadoghq.com',
       DD_LOG_LEVEL: 'debug'
     }
@@ -419,7 +433,7 @@ exports[`lambda flare send to Datadog successfully sends request to Datadog 1`] 
 {
   Environment: {
     Variables: {
-      DD_API_KEY: '02aeb762fff59ac0d5ad1536cd9633bd',
+      DD_API_KEY: '02**************************33bd',
       DD_SITE: 'datadoghq.com',
       DD_LOG_LEVEL: 'debug'
     }
@@ -450,7 +464,7 @@ exports[`lambda flare validates required flags extracts region from function nam
 {
   Environment: {
     Variables: {
-      DD_API_KEY: '02aeb762fff59ac0d5ad1536cd9633bd',
+      DD_API_KEY: '02**************************33bd',
       DD_SITE: 'datadoghq.com',
       DD_LOG_LEVEL: 'debug'
     }
@@ -516,7 +530,7 @@ exports[`lambda flare validates required flags runs successfully with all requir
 {
   Environment: {
     Variables: {
-      DD_API_KEY: '02aeb762fff59ac0d5ad1536cd9633bd',
+      DD_API_KEY: '02**************************33bd',
       DD_SITE: 'datadoghq.com',
       DD_LOG_LEVEL: 'debug'
     }
@@ -547,7 +561,7 @@ exports[`lambda flare validates required flags uses API key ENV variable and run
 {
   Environment: {
     Variables: {
-      DD_API_KEY: '02aeb762fff59ac0d5ad1536cd9633bd',
+      DD_API_KEY: '02**************************33bd',
       DD_SITE: 'datadoghq.com',
       DD_LOG_LEVEL: 'debug'
     }
@@ -578,7 +592,7 @@ exports[`lambda flare validates required flags uses API key ENV variable and run
 {
   Environment: {
     Variables: {
-      DD_API_KEY: '02aeb762fff59ac0d5ad1536cd9633bd',
+      DD_API_KEY: '02**************************33bd',
       DD_SITE: 'datadoghq.com',
       DD_LOG_LEVEL: 'debug'
     }
@@ -605,7 +619,7 @@ exports[`lambda flare validates required flags uses API key ENV variable and run
 {
   Environment: {
     Variables: {
-      DD_API_KEY: '02aeb762fff59ac0d5ad1536cd9633bd',
+      DD_API_KEY: '02**************************33bd',
       DD_SITE: 'datadoghq.com',
       DD_LOG_LEVEL: 'debug'
     }
@@ -636,7 +650,7 @@ exports[`lambda flare validates required flags uses region ENV variable when no 
 {
   Environment: {
     Variables: {
-      DD_API_KEY: '02aeb762fff59ac0d5ad1536cd9633bd',
+      DD_API_KEY: '02**************************33bd',
       DD_SITE: 'datadoghq.com',
       DD_LOG_LEVEL: 'debug'
     }

--- a/src/commands/lambda/__tests__/__snapshots__/flare.test.ts.snap
+++ b/src/commands/lambda/__tests__/__snapshots__/flare.test.ts.snap
@@ -13,7 +13,7 @@ exports[`lambda flare AWS Lambda configuration prints config when running as a d
 {
   Environment: {
     Variables: {
-      DD_API_KEY: '02**************************33bd',
+      DD_API_KEY: '02**********33bd',
       DD_SITE: 'datadoghq.com',
       DD_LOG_LEVEL: 'debug'
     }
@@ -55,7 +55,7 @@ exports[`lambda flare AWS credentials continues when getAWSCredentials() returns
 {
   Environment: {
     Variables: {
-      DD_API_KEY: '02**************************33bd',
+      DD_API_KEY: '02**********33bd',
       DD_SITE: 'datadoghq.com',
       DD_LOG_LEVEL: 'debug'
     }
@@ -86,7 +86,7 @@ exports[`lambda flare AWS credentials requests AWS credentials when none are fou
 {
   Environment: {
     Variables: {
-      DD_API_KEY: '02**************************33bd',
+      DD_API_KEY: '02**********33bd',
       DD_SITE: 'datadoghq.com',
       DD_LOG_LEVEL: 'debug'
     }
@@ -145,7 +145,7 @@ exports[`lambda flare gets CloudWatch Logs does not get logs when --with-logs is
 {
   Environment: {
     Variables: {
-      DD_API_KEY: '02**************************33bd',
+      DD_API_KEY: '02**********33bd',
       DD_SITE: 'datadoghq.com',
       DD_LOG_LEVEL: 'debug'
     }
@@ -176,7 +176,7 @@ exports[`lambda flare gets CloudWatch Logs gets logs, saves, and sends correctly
 {
   Environment: {
     Variables: {
-      DD_API_KEY: '02**************************33bd',
+      DD_API_KEY: '02**********33bd',
       DD_SITE: 'datadoghq.com',
       DD_LOG_LEVEL: 'debug'
     }
@@ -217,7 +217,7 @@ exports[`lambda flare gets CloudWatch Logs prints error when getLogEvents throws
 {
   Environment: {
     Variables: {
-      DD_API_KEY: '02**************************33bd',
+      DD_API_KEY: '02**********33bd',
       DD_SITE: 'datadoghq.com',
       DD_LOG_LEVEL: 'debug'
     }
@@ -244,7 +244,7 @@ exports[`lambda flare gets CloudWatch Logs prints error when getLogStreamNames t
 {
   Environment: {
     Variables: {
-      DD_API_KEY: '02**************************33bd',
+      DD_API_KEY: '02**********33bd',
       DD_SITE: 'datadoghq.com',
       DD_LOG_LEVEL: 'debug'
     }
@@ -271,7 +271,7 @@ exports[`lambda flare gets CloudWatch Logs warns and skips getting logs when get
 {
   Environment: {
     Variables: {
-      DD_API_KEY: '02**************************33bd',
+      DD_API_KEY: '02**********33bd',
       DD_SITE: 'datadoghq.com',
       DD_LOG_LEVEL: 'debug'
     }
@@ -305,7 +305,7 @@ exports[`lambda flare gets CloudWatch Logs warns and skips log when getLogEvents
 {
   Environment: {
     Variables: {
-      DD_API_KEY: '02**************************33bd',
+      DD_API_KEY: '02**********33bd',
       DD_SITE: 'datadoghq.com',
       DD_LOG_LEVEL: 'debug'
     }
@@ -334,7 +334,7 @@ exports[`lambda flare obfuscateConfig should obfuscate API key but not whitelist
 Object {
   "Environment": Object {
     "Variables": Object {
-      "DD_API_KEY": "02**************************33bd",
+      "DD_API_KEY": "02**********33bd",
       "DD_LOG_LEVEL": "debug",
       "DD_SITE": "datadoghq.com",
     },
@@ -371,7 +371,7 @@ exports[`lambda flare send to Datadog does not send request to Datadog when a dr
 {
   Environment: {
     Variables: {
-      DD_API_KEY: '02**************************33bd',
+      DD_API_KEY: '02**********33bd',
       DD_SITE: 'datadoghq.com',
       DD_LOG_LEVEL: 'debug'
     }
@@ -402,7 +402,7 @@ exports[`lambda flare send to Datadog successfully adds zip file to FormData 1`]
 {
   Environment: {
     Variables: {
-      DD_API_KEY: '02**************************33bd',
+      DD_API_KEY: '02**********33bd',
       DD_SITE: 'datadoghq.com',
       DD_LOG_LEVEL: 'debug'
     }
@@ -433,7 +433,7 @@ exports[`lambda flare send to Datadog successfully sends request to Datadog 1`] 
 {
   Environment: {
     Variables: {
-      DD_API_KEY: '02**************************33bd',
+      DD_API_KEY: '02**********33bd',
       DD_SITE: 'datadoghq.com',
       DD_LOG_LEVEL: 'debug'
     }
@@ -464,7 +464,7 @@ exports[`lambda flare validates required flags extracts region from function nam
 {
   Environment: {
     Variables: {
-      DD_API_KEY: '02**************************33bd',
+      DD_API_KEY: '02**********33bd',
       DD_SITE: 'datadoghq.com',
       DD_LOG_LEVEL: 'debug'
     }
@@ -530,7 +530,7 @@ exports[`lambda flare validates required flags runs successfully with all requir
 {
   Environment: {
     Variables: {
-      DD_API_KEY: '02**************************33bd',
+      DD_API_KEY: '02**********33bd',
       DD_SITE: 'datadoghq.com',
       DD_LOG_LEVEL: 'debug'
     }
@@ -561,7 +561,7 @@ exports[`lambda flare validates required flags uses API key ENV variable and run
 {
   Environment: {
     Variables: {
-      DD_API_KEY: '02**************************33bd',
+      DD_API_KEY: '02**********33bd',
       DD_SITE: 'datadoghq.com',
       DD_LOG_LEVEL: 'debug'
     }
@@ -592,7 +592,7 @@ exports[`lambda flare validates required flags uses API key ENV variable and run
 {
   Environment: {
     Variables: {
-      DD_API_KEY: '02**************************33bd',
+      DD_API_KEY: '02**********33bd',
       DD_SITE: 'datadoghq.com',
       DD_LOG_LEVEL: 'debug'
     }
@@ -619,7 +619,7 @@ exports[`lambda flare validates required flags uses API key ENV variable and run
 {
   Environment: {
     Variables: {
-      DD_API_KEY: '02**************************33bd',
+      DD_API_KEY: '02**********33bd',
       DD_SITE: 'datadoghq.com',
       DD_LOG_LEVEL: 'debug'
     }
@@ -650,7 +650,7 @@ exports[`lambda flare validates required flags uses region ENV variable when no 
 {
   Environment: {
     Variables: {
-      DD_API_KEY: '02**************************33bd',
+      DD_API_KEY: '02**********33bd',
       DD_SITE: 'datadoghq.com',
       DD_LOG_LEVEL: 'debug'
     }

--- a/src/commands/lambda/__tests__/__snapshots__/flare.test.ts.snap
+++ b/src/commands/lambda/__tests__/__snapshots__/flare.test.ts.snap
@@ -330,7 +330,7 @@ exports[`lambda flare gets CloudWatch Logs warns and skips log when getLogEvents
 "
 `;
 
-exports[`lambda flare obfuscateConfig should obfuscate API key but not whitelisted environment variables 1`] = `
+exports[`lambda flare maskConfig should mask API key but not whitelisted environment variables 1`] = `
 Object {
   "Environment": Object {
     "Variables": Object {

--- a/src/commands/lambda/__tests__/flare.test.ts
+++ b/src/commands/lambda/__tests__/flare.test.ts
@@ -247,11 +247,11 @@ describe('lambda flare', () => {
   })
 
   describe('getObfuscation', () => {
-    it('should obfuscate the entire string if its length is less than 32', () => {
+    it('should obfuscate the entire string if its length is less than 12', () => {
       expect(getObfuscation('shortString')).toEqual('****************')
     })
 
-    it('should keep the first two and last four characters for strings longer than 32 characters', () => {
+    it('should keep the first two and last four characters for strings longer than 12 characters', () => {
       const original = 'abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz'
       const obfuscated = 'ab**********wxyz'
       expect(getObfuscation(original)).toEqual(obfuscated)
@@ -259,12 +259,6 @@ describe('lambda flare', () => {
 
     it('should return empty string if input is empty', () => {
       expect(getObfuscation('')).toEqual('')
-    })
-
-    it('should correctly handle strings of exactly 32 characters', () => {
-      const original = 'abcd1234567890123456789012345678'
-      const obfuscated = 'ab**********5678'
-      expect(getObfuscation(original)).toEqual(obfuscated)
     })
 
     it('should not obfuscate booleans', () => {

--- a/src/commands/lambda/__tests__/flare.test.ts
+++ b/src/commands/lambda/__tests__/flare.test.ts
@@ -248,12 +248,12 @@ describe('lambda flare', () => {
 
   describe('getObfuscation', () => {
     it('should obfuscate the entire string if its length is less than 32', () => {
-      expect(getObfuscation('shortString')).toEqual('***********')
+      expect(getObfuscation('shortString')).toEqual('****************')
     })
 
     it('should keep the first two and last four characters for strings longer than 32 characters', () => {
       const original = 'abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz'
-      const obfuscated = 'ab**********************************************wxyz'
+      const obfuscated = 'ab**********wxyz'
       expect(getObfuscation(original)).toEqual(obfuscated)
     })
 
@@ -262,8 +262,8 @@ describe('lambda flare', () => {
     })
 
     it('should correctly handle strings of exactly 32 characters', () => {
-      const original = '12345678901234567890123456789012'
-      const obfuscated = '12**************************9012'
+      const original = 'abcd1234567890123456789012345678'
+      const obfuscated = 'ab**********5678'
       expect(getObfuscation(original)).toEqual(obfuscated)
     })
 
@@ -272,7 +272,7 @@ describe('lambda flare', () => {
       expect(getObfuscation('TrUe')).toEqual('TrUe')
       expect(getObfuscation('false')).toEqual('false')
       expect(getObfuscation('FALSE')).toEqual('FALSE')
-      expect(getObfuscation('trueee')).toEqual('******')
+      expect(getObfuscation('trueee')).toEqual('****************')
     })
   })
 

--- a/src/commands/lambda/__tests__/flare.test.ts
+++ b/src/commands/lambda/__tests__/flare.test.ts
@@ -23,8 +23,8 @@ import {
   getAllLogs,
   getLogEvents,
   getLogStreamNames,
-  getObfuscation,
-  obfuscateConfig,
+  getMasking,
+  maskConfig,
   writeFile,
   zipContents,
 } from '../flare'
@@ -246,41 +246,41 @@ describe('lambda flare', () => {
     })
   })
 
-  describe('getObfuscation', () => {
-    it('should obfuscate the entire string if its length is less than 12', () => {
-      expect(getObfuscation('shortString')).toEqual('****************')
+  describe('getMasking', () => {
+    it('should mask the entire string if its length is less than 12', () => {
+      expect(getMasking('shortString')).toEqual('****************')
     })
 
     it('should keep the first two and last four characters for strings longer than 12 characters', () => {
       const original = 'abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz'
-      const obfuscated = 'ab**********wxyz'
-      expect(getObfuscation(original)).toEqual(obfuscated)
+      const masked = 'ab**********wxyz'
+      expect(getMasking(original)).toEqual(masked)
     })
 
     it('should return empty string if input is empty', () => {
-      expect(getObfuscation('')).toEqual('')
+      expect(getMasking('')).toEqual('')
     })
 
-    it('should not obfuscate booleans', () => {
-      expect(getObfuscation('true')).toEqual('true')
-      expect(getObfuscation('TrUe')).toEqual('TrUe')
-      expect(getObfuscation('false')).toEqual('false')
-      expect(getObfuscation('FALSE')).toEqual('FALSE')
-      expect(getObfuscation('trueee')).toEqual('****************')
+    it('should not mask booleans', () => {
+      expect(getMasking('true')).toEqual('true')
+      expect(getMasking('TrUe')).toEqual('TrUe')
+      expect(getMasking('false')).toEqual('false')
+      expect(getMasking('FALSE')).toEqual('FALSE')
+      expect(getMasking('trueee')).toEqual('****************')
     })
   })
 
-  describe('obfuscateConfig', () => {
-    it('should obfuscate API key but not whitelisted environment variables', () => {
-      const obfuscatedConfig = obfuscateConfig(MOCK_CONFIG)
-      expect(obfuscatedConfig).toMatchSnapshot()
+  describe('maskConfig', () => {
+    it('should mask API key but not whitelisted environment variables', () => {
+      const maskedConfig = maskConfig(MOCK_CONFIG)
+      expect(maskedConfig).toMatchSnapshot()
     })
 
     it('should return the original config if there are no environment variables', () => {
       const config: any = {...MOCK_CONFIG}
       config.Environment = undefined
-      const obfuscatedConfig = obfuscateConfig(config)
-      expect(obfuscatedConfig).toEqual(config)
+      const maskedConfig = maskConfig(config)
+      expect(maskedConfig).toEqual(config)
     })
   })
 

--- a/src/commands/lambda/constants.ts
+++ b/src/commands/lambda/constants.ts
@@ -118,7 +118,8 @@ export const AWS_SECRET_ARN_REG_EXP = /arn:aws:secretsmanager:[\w-]+:\d{12}:secr
 export const DATADOG_API_KEY_REG_EXP = /(?<![a-f0-9])[a-f0-9]{32}(?![a-f0-9])/g
 export const DATADOG_APP_KEY_REG_EXP = /(?<![a-f0-9])[a-f0-9]{40}(?![a-f0-9])/g
 
-// Lambda Flare environment variables
+// Environment Variables whose values don't need to be
+// masked in a Flare
 export const SKIP_MASKING_ENV_VARS = new Set([
   AWS_LAMBDA_EXEC_WRAPPER_VAR,
   SITE_ENV_VAR,
@@ -128,8 +129,7 @@ export const SKIP_MASKING_ENV_VARS = new Set([
   VERSION_ENV_VAR,
   ENVIRONMENT_ENV_VAR,
   EXTRA_TAGS_ENV_VAR,
+  PROFILER_ENV_VAR,
   PROFILER_PATH_ENV_VAR,
   DOTNET_TRACER_HOME_ENV_VAR,
-  CI_SITE_ENV_VAR,
-  AWS_DEFAULT_REGION_ENV_VAR,
 ])

--- a/src/commands/lambda/constants.ts
+++ b/src/commands/lambda/constants.ts
@@ -117,3 +117,19 @@ export const AWS_SECRET_ACCESS_KEY_REG_EXP = /(?<![A-Za-z0-9/+=])[A-Za-z0-9/+=]{
 export const AWS_SECRET_ARN_REG_EXP = /arn:aws:secretsmanager:[\w-]+:\d{12}:secret:.+/
 export const DATADOG_API_KEY_REG_EXP = /(?<![a-f0-9])[a-f0-9]{32}(?![a-f0-9])/g
 export const DATADOG_APP_KEY_REG_EXP = /(?<![a-f0-9])[a-f0-9]{40}(?![a-f0-9])/g
+
+// Lambda Flare environment variables
+export const SKIP_MASKING_ENV_VARS = new Set([
+  AWS_LAMBDA_EXEC_WRAPPER_VAR,
+  SITE_ENV_VAR,
+  LOG_LEVEL_ENV_VAR,
+  LAMBDA_HANDLER_ENV_VAR,
+  SERVICE_ENV_VAR,
+  VERSION_ENV_VAR,
+  ENVIRONMENT_ENV_VAR,
+  EXTRA_TAGS_ENV_VAR,
+  PROFILER_PATH_ENV_VAR,
+  DOTNET_TRACER_HOME_ENV_VAR,
+  CI_SITE_ENV_VAR,
+  AWS_DEFAULT_REGION_ENV_VAR,
+])

--- a/src/commands/lambda/flare.ts
+++ b/src/commands/lambda/flare.ts
@@ -30,6 +30,8 @@ const LOGS_DIRECTORY = 'logs'
 const FUNCTION_CONFIG_FILE_NAME = 'function_config.json'
 const ZIP_FILE_NAME = 'lambda-flare-output.zip'
 const LOG_STREAM_COUNT = 3
+const FULL_OBFUSCATION = '****************'
+const MIDDLE_OBFUSCATION = '**********'
 const NON_OBFUSCATED_ENV_VARS = new Set([
   constants.SITE_ENV_VAR,
   constants.LOG_LEVEL_ENV_VAR,
@@ -286,16 +288,15 @@ export const getObfuscation = (original: string) => {
   }
 
   // Obfuscate entire string if it's short
-  if (original.length < 20) {
-    return '*'.repeat(original.length)
+  if (original.length < 12) {
+    return FULL_OBFUSCATION
   }
 
   // Keep first two and last four characters if it's long
   const front = original.substring(0, 2)
-  const middle = '*'.repeat(original.length - 6)
   const end = original.substring(original.length - 4)
 
-  return front + middle + end
+  return front + MIDDLE_OBFUSCATION + end
 }
 
 /**

--- a/src/commands/lambda/flare.ts
+++ b/src/commands/lambda/flare.ts
@@ -40,7 +40,6 @@ const NON_OBFUSCATED_ENV_VARS = new Set([
   constants.VERSION_ENV_VAR,
   constants.ENVIRONMENT_ENV_VAR,
   constants.EXTRA_TAGS_ENV_VAR,
-  constants.APM_FLUSH_DEADLINE_MILLISECONDS_ENV_VAR,
   constants.DOTNET_TRACER_HOME_ENV_VAR,
 ])
 


### PR DESCRIPTION
### What and why?

For more context on what Lambda Flare is, please read the description in this PR: https://github.com/DataDog/datadog-ci/pull/924

We want to obfuscate secrets (passwords, API keys, and other unknown environment variables) in Lambda function configuration so customers don't send private information to Datadog support. Any non-Datadog environment variables should also be obfuscated.

### How?

1. Create a whitelist of 'allowed' environment variables to not be obfuscated. These are stored in a set in the constant `NON_OBFUSCATED_ENV_VARS` for O(1) lookup.
2. If an environment variable is not in this set, we will pass it to the `getObfuscation` function which returns an obfuscated version of the string.
3. Short strings (<12 characters) will be entirely obfuscated and replaced with `*`'s. Longer strings will preserve the first 2 and last 4 characters of the string, but obfuscate everything in between.
4. Numbers and boolean values are unlikely to be secrets, so they can be skipped and returned as-is
5. Obfuscate the function config before logging to console, saving the file, and sending to Datadog support

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
