### PR TITLE
add missing @aws-sdk/property-provider

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "@aws-sdk/client-lambda": "^3.358.0",
     "@aws-sdk/client-sfn": "^3.358.0",
     "@aws-sdk/credential-providers": "^3.358.0",
+    "@aws-sdk/property-provider": "^3.357.0",
     "@types/datadog-metrics": "0.6.1",
     "ajv": "^8.12.0",
     "ajv-formats": "^2.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -839,7 +839,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/property-provider@npm:3.357.0":
+"@aws-sdk/property-provider@npm:3.357.0, @aws-sdk/property-provider@npm:^3.357.0":
   version: 3.357.0
   resolution: "@aws-sdk/property-provider@npm:3.357.0"
   dependencies:
@@ -2755,6 +2755,7 @@ __metadata:
     "@aws-sdk/client-lambda": ^3.358.0
     "@aws-sdk/client-sfn": ^3.358.0
     "@aws-sdk/credential-providers": ^3.358.0
+    "@aws-sdk/property-provider": ^3.357.0
     "@aws-sdk/types": ^3.357.0
     "@babel/core": 7.8.0
     "@babel/preset-env": 7.4.5


### PR DESCRIPTION
### What and why?
* Fix: https://github.com/DataDog/datadog-ci/issues/948

Looks like the latest published version of the package `@aws-sdk/property-provider` is 3.357.0 but other aws-sdk package is using 3.358.0: 
https://www.npmjs.com/package/@aws-sdk/property-provider?activeTab=versions


### How?

Add the missing package

### Review checklist

- [x ] Feature or bugfix MUST have appropriate tests (unit, integration)
