### PR TITLE
[lambda][flare] Ask for user confirmation before sending files to support

### DIFF
--- a/src/commands/lambda/__tests__/__snapshots__/flare.test.ts.snap
+++ b/src/commands/lambda/__tests__/__snapshots__/flare.test.ts.snap
@@ -67,6 +67,7 @@ exports[`lambda flare AWS credentials continues when getAWSCredentials() returns
 💾 Saving files...
 • Saved function config to mock-folder/.datadog-ci/function_config.json
 
+
 🚀 Sending to Datadog Support...
 
 ✅ Successfully sent flare file to Datadog Support!
@@ -98,6 +99,7 @@ exports[`lambda flare AWS credentials requests AWS credentials when none are fou
 💾 Saving files...
 • Saved function config to mock-folder/.datadog-ci/function_config.json
 
+
 🚀 Sending to Datadog Support...
 
 ✅ Successfully sent flare file to Datadog Support!
@@ -128,6 +130,36 @@ exports[`lambda flare createDirectories throws error when unable to create a fol
 
 exports[`lambda flare deleteFolder throws error when unable to delete a folder 1`] = `"Failed to delete files located at mock-folder/.datadog-ci: MOCK ERROR: Unable to delete folder"`;
 
+exports[`lambda flare does not send when user answers prompt with no 1`] = `
+"
+🐶 Generating Lambda flare to send your configuration to Datadog...
+
+🔑 Getting AWS credentials...
+
+🔍 Fetching Lambda function configuration...
+
+{
+  Environment: {
+    Variables: {
+      DD_API_KEY: '02**********33bd',
+      DD_SITE: 'datadoghq.com',
+      DD_LOG_LEVEL: 'debug'
+    }
+  },
+  FunctionArn: 'arn:aws:lambda:us-east-1:123456789012:function:some-function',
+  FunctionName: 'some-function'
+}
+
+💾 Saving files...
+• Saved function config to mock-folder/.datadog-ci/function_config.json
+
+
+🚫 The flare files were not sent based on your selection.
+ℹ️ Your output files are located at: mock-folder/.datadog-ci
+
+"
+`;
+
 exports[`lambda flare getAllLogs throws an error when unable to get log events 1`] = `[Error: Unable to get log events for stream streamName: Error getting log events]`;
 
 exports[`lambda flare getAllLogs throws an error when unable to get log streams 1`] = `[Error: Unable to get log streams: Error getting log streams]`;
@@ -156,6 +188,7 @@ exports[`lambda flare gets CloudWatch Logs does not get logs when --with-logs is
 
 💾 Saving files...
 • Saved function config to mock-folder/.datadog-ci/function_config.json
+
 
 🚀 Sending to Datadog Support...
 
@@ -197,6 +230,7 @@ exports[`lambda flare gets CloudWatch Logs gets logs, saves, and sends correctly
 • Saved logs to mock-folder/.datadog-ci/logs/Stream1.csv
 • Saved logs to mock-folder/.datadog-ci/logs/Stream2.csv
 • Saved logs to mock-folder/.datadog-ci/logs/Stream3.csv
+
 
 🚀 Sending to Datadog Support...
 
@@ -286,6 +320,7 @@ exports[`lambda flare gets CloudWatch Logs warns and skips getting logs when get
 💾 Saving files...
 • Saved function config to mock-folder/.datadog-ci/function_config.json
 
+
 🚀 Sending to Datadog Support...
 
 ✅ Successfully sent flare file to Datadog Support!
@@ -323,6 +358,7 @@ exports[`lambda flare gets CloudWatch Logs warns and skips log when getLogEvents
 
 💾 Saving files...
 • Saved function config to mock-folder/.datadog-ci/function_config.json
+
 
 🚀 Sending to Datadog Support...
 
@@ -400,6 +436,7 @@ exports[`lambda flare send to Datadog successfully adds zip file to FormData 1`]
 💾 Saving files...
 • Saved function config to mock-folder/.datadog-ci/function_config.json
 
+
 🚀 Sending to Datadog Support...
 
 ✅ Successfully sent flare file to Datadog Support!
@@ -431,6 +468,7 @@ exports[`lambda flare send to Datadog successfully sends request to Datadog 1`] 
 💾 Saving files...
 • Saved function config to mock-folder/.datadog-ci/function_config.json
 
+
 🚀 Sending to Datadog Support...
 
 ✅ Successfully sent flare file to Datadog Support!
@@ -461,6 +499,7 @@ exports[`lambda flare validates required flags extracts region from function nam
 
 💾 Saving files...
 • Saved function config to mock-folder/.datadog-ci/function_config.json
+
 
 🚀 Sending to Datadog Support...
 
@@ -528,6 +567,7 @@ exports[`lambda flare validates required flags runs successfully with all requir
 💾 Saving files...
 • Saved function config to mock-folder/.datadog-ci/function_config.json
 
+
 🚀 Sending to Datadog Support...
 
 ✅ Successfully sent flare file to Datadog Support!
@@ -558,6 +598,7 @@ exports[`lambda flare validates required flags uses API key ENV variable and run
 
 💾 Saving files...
 • Saved function config to mock-folder/.datadog-ci/function_config.json
+
 
 🚀 Sending to Datadog Support...
 
@@ -590,6 +631,7 @@ exports[`lambda flare validates required flags uses API key ENV variable and run
 💾 Saving files...
 • Saved function config to mock-folder/.datadog-ci/function_config.json
 
+
 🚀 Sending to Datadog Support...
 
 ✅ Successfully sent flare file to Datadog Support!
@@ -616,6 +658,7 @@ exports[`lambda flare validates required flags uses API key ENV variable and run
 
 💾 Saving files...
 • Saved function config to mock-folder/.datadog-ci/function_config.json
+
 
 🚀 Sending to Datadog Support...
 
@@ -647,6 +690,7 @@ exports[`lambda flare validates required flags uses region ENV variable when no 
 
 💾 Saving files...
 • Saved function config to mock-folder/.datadog-ci/function_config.json
+
 
 🚀 Sending to Datadog Support...
 

--- a/src/commands/lambda/__tests__/flare.test.ts
+++ b/src/commands/lambda/__tests__/flare.test.ts
@@ -13,6 +13,7 @@ import {
 import {mockClient} from 'aws-sdk-client-mock'
 import axios from 'axios'
 import FormData from 'form-data'
+import inquirer from 'inquirer'
 import JSZip from 'jszip'
 
 import {API_KEY_ENV_VAR, AWS_DEFAULT_REGION_ENV_VAR, CI_API_KEY_ENV_VAR} from '../constants'
@@ -71,6 +72,10 @@ jest.mock('../functions/commons', () => ({
   getLambdaFunctionConfig: jest.fn().mockImplementation(() => Promise.resolve(MOCK_CONFIG)),
 }))
 jest.mock('../prompt')
+jest.mock('inquirer', () => ({
+  ...jest.requireActual('inquirer'),
+  prompt: jest.fn().mockResolvedValue({confirmation: true}),
+}))
 jest.mock('util')
 
 // File system mocks
@@ -762,5 +767,17 @@ describe('lambda flare', () => {
       const output = context.stdout.toString()
       expect(output).toMatchSnapshot()
     })
+  })
+
+  it('does not send when user answers prompt with no', async () => {
+    ;(inquirer.prompt as any).mockResolvedValueOnce({confirmation: false})
+    ;(getAWSCredentials as any).mockResolvedValue(mockAwsCredentials)
+
+    const cli = makeCli()
+    const context = createMockContext()
+    const code = await cli.run(MOCK_REQUIRED_FLAGS, context as any)
+    expect(code).toBe(0)
+    const output = context.stdout.toString()
+    expect(output).toMatchSnapshot()
   })
 })


### PR DESCRIPTION
### What and why?

For more context on what Lambda Flare is, please read the description in this PR: https://github.com/DataDog/datadog-ci/pull/924

We want to ask users for confirmation before sending their files to support.
If they answer `no`, the flare files are not sent and are deleted
They must answer `yes` before the files are sent to support.
This is intended to:
1. Give the user an opportunity to check the files and see if there is anything they don't want to send to support
2. Prevent users from accidentally spamming their support ticket with files

### How?

Use `inquirer` to prompt the user for confirmation.
Exit the program early if they answer `no`, continue otherwise.


### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
