### PR TITLE
[lambda][flare] Ask for user confirmation before sending files to support

### DIFF
--- a/src/commands/lambda/__tests__/__snapshots__/flare.test.ts.snap
+++ b/src/commands/lambda/__tests__/__snapshots__/flare.test.ts.snap
@@ -67,6 +67,7 @@ exports[`lambda flare AWS credentials continues when getAWSCredentials() returns
 💾 Saving files...
 • Saved function config to mock-folder/.datadog-ci/function_config.json
 
+
 🚀 Sending to Datadog Support...
 
 ✅ Successfully sent flare file to Datadog Support!
@@ -97,6 +98,7 @@ exports[`lambda flare AWS credentials requests AWS credentials when none are fou
 
 💾 Saving files...
 • Saved function config to mock-folder/.datadog-ci/function_config.json
+
 
 🚀 Sending to Datadog Support...
 
@@ -157,6 +159,7 @@ exports[`lambda flare gets CloudWatch Logs does not get logs when --with-logs is
 💾 Saving files...
 • Saved function config to mock-folder/.datadog-ci/function_config.json
 
+
 🚀 Sending to Datadog Support...
 
 ✅ Successfully sent flare file to Datadog Support!
@@ -197,6 +200,7 @@ exports[`lambda flare gets CloudWatch Logs gets logs, saves, and sends correctly
 • Saved logs to mock-folder/.datadog-ci/logs/Stream1.csv
 • Saved logs to mock-folder/.datadog-ci/logs/Stream2.csv
 • Saved logs to mock-folder/.datadog-ci/logs/Stream3.csv
+
 
 🚀 Sending to Datadog Support...
 
@@ -286,6 +290,7 @@ exports[`lambda flare gets CloudWatch Logs warns and skips getting logs when get
 💾 Saving files...
 • Saved function config to mock-folder/.datadog-ci/function_config.json
 
+
 🚀 Sending to Datadog Support...
 
 ✅ Successfully sent flare file to Datadog Support!
@@ -324,6 +329,7 @@ exports[`lambda flare gets CloudWatch Logs warns and skips log when getLogEvents
 💾 Saving files...
 • Saved function config to mock-folder/.datadog-ci/function_config.json
 
+
 🚀 Sending to Datadog Support...
 
 ✅ Successfully sent flare file to Datadog Support!
@@ -355,6 +361,66 @@ exports[`lambda flare prints correct headers prints non-dry-run header 1`] = `
 "
 🐶 Generating Lambda flare to send your configuration to Datadog...
 [Error] No function name specified. [-f,--function]
+"
+`;
+
+exports[`lambda flare prompt to send works as expected does not send when user answers prompt with no 1`] = `
+"
+🐶 Generating Lambda flare to send your configuration to Datadog...
+
+🔑 Getting AWS credentials...
+
+🔍 Fetching Lambda function configuration...
+
+{
+  Environment: {
+    Variables: {
+      DD_API_KEY: '02**********33bd',
+      DD_SITE: 'datadoghq.com',
+      DD_LOG_LEVEL: 'debug'
+    }
+  },
+  FunctionArn: 'arn:aws:lambda:us-east-1:123456789012:function:some-function',
+  FunctionName: 'some-function'
+}
+
+💾 Saving files...
+• Saved function config to mock-folder/.datadog-ci/function_config.json
+
+
+🚫 The flare files were not sent based on your selection.
+ℹ️ Your output files are located at: mock-folder/.datadog-ci
+
+"
+`;
+
+exports[`lambda flare prompt to send works as expected sends when user answers prompt with yes 1`] = `
+"
+🐶 Generating Lambda flare to send your configuration to Datadog...
+
+🔑 Getting AWS credentials...
+
+🔍 Fetching Lambda function configuration...
+
+{
+  Environment: {
+    Variables: {
+      DD_API_KEY: '02**********33bd',
+      DD_SITE: 'datadoghq.com',
+      DD_LOG_LEVEL: 'debug'
+    }
+  },
+  FunctionArn: 'arn:aws:lambda:us-east-1:123456789012:function:some-function',
+  FunctionName: 'some-function'
+}
+
+💾 Saving files...
+• Saved function config to mock-folder/.datadog-ci/function_config.json
+
+
+🚀 Sending to Datadog Support...
+
+✅ Successfully sent flare file to Datadog Support!
 "
 `;
 
@@ -414,6 +480,7 @@ exports[`lambda flare send to Datadog successfully adds zip file to FormData 1`]
 💾 Saving files...
 • Saved function config to mock-folder/.datadog-ci/function_config.json
 
+
 🚀 Sending to Datadog Support...
 
 ✅ Successfully sent flare file to Datadog Support!
@@ -445,6 +512,7 @@ exports[`lambda flare send to Datadog successfully sends request to Datadog 1`] 
 💾 Saving files...
 • Saved function config to mock-folder/.datadog-ci/function_config.json
 
+
 🚀 Sending to Datadog Support...
 
 ✅ Successfully sent flare file to Datadog Support!
@@ -475,6 +543,7 @@ exports[`lambda flare validates required flags extracts region from function nam
 
 💾 Saving files...
 • Saved function config to mock-folder/.datadog-ci/function_config.json
+
 
 🚀 Sending to Datadog Support...
 
@@ -542,6 +611,7 @@ exports[`lambda flare validates required flags runs successfully with all requir
 💾 Saving files...
 • Saved function config to mock-folder/.datadog-ci/function_config.json
 
+
 🚀 Sending to Datadog Support...
 
 ✅ Successfully sent flare file to Datadog Support!
@@ -572,6 +642,7 @@ exports[`lambda flare validates required flags uses API key ENV variable and run
 
 💾 Saving files...
 • Saved function config to mock-folder/.datadog-ci/function_config.json
+
 
 🚀 Sending to Datadog Support...
 
@@ -604,6 +675,7 @@ exports[`lambda flare validates required flags uses API key ENV variable and run
 💾 Saving files...
 • Saved function config to mock-folder/.datadog-ci/function_config.json
 
+
 🚀 Sending to Datadog Support...
 
 ✅ Successfully sent flare file to Datadog Support!
@@ -630,6 +702,7 @@ exports[`lambda flare validates required flags uses API key ENV variable and run
 
 💾 Saving files...
 • Saved function config to mock-folder/.datadog-ci/function_config.json
+
 
 🚀 Sending to Datadog Support...
 
@@ -661,6 +734,7 @@ exports[`lambda flare validates required flags uses region ENV variable when no 
 
 💾 Saving files...
 • Saved function config to mock-folder/.datadog-ci/function_config.json
+
 
 🚀 Sending to Datadog Support...
 

--- a/src/commands/lambda/__tests__/__snapshots__/flare.test.ts.snap
+++ b/src/commands/lambda/__tests__/__snapshots__/flare.test.ts.snap
@@ -364,7 +364,7 @@ exports[`lambda flare prints correct headers prints non-dry-run header 1`] = `
 "
 `;
 
-exports[`lambda flare prompt to send works as expected does not send when user answers prompt with no 1`] = `
+exports[`lambda flare prompts for confirmation before sending does not send when user answers prompt with no 1`] = `
 "
 🐶 Generating Lambda flare to send your configuration to Datadog...
 
@@ -394,7 +394,7 @@ exports[`lambda flare prompt to send works as expected does not send when user a
 "
 `;
 
-exports[`lambda flare prompt to send works as expected sends when user answers prompt with yes 1`] = `
+exports[`lambda flare prompts for confirmation before sending sends when user answers prompt with yes 1`] = `
 "
 🐶 Generating Lambda flare to send your configuration to Datadog...
 

--- a/src/commands/lambda/__tests__/flare.test.ts
+++ b/src/commands/lambda/__tests__/flare.test.ts
@@ -809,7 +809,7 @@ describe('lambda flare', () => {
     })
   })
 
-  describe('prompt to send works as expected', () => {
+  describe('prompts for confirmation before sending', () => {
     beforeEach(() => {
       ;(getAWSCredentials as any).mockResolvedValue(mockAwsCredentials)
     })

--- a/src/commands/lambda/__tests__/flare.test.ts
+++ b/src/commands/lambda/__tests__/flare.test.ts
@@ -13,6 +13,7 @@ import {
 import {mockClient} from 'aws-sdk-client-mock'
 import axios from 'axios'
 import FormData from 'form-data'
+import inquirer from 'inquirer'
 import JSZip from 'jszip'
 
 import {API_KEY_ENV_VAR, AWS_DEFAULT_REGION_ENV_VAR, CI_API_KEY_ENV_VAR} from '../constants'
@@ -73,6 +74,10 @@ jest.mock('../functions/commons', () => ({
   getLambdaFunctionConfig: jest.fn().mockImplementation(() => Promise.resolve(MOCK_CONFIG)),
 }))
 jest.mock('../prompt')
+jest.mock('inquirer', () => ({
+  ...jest.requireActual('inquirer'),
+  prompt: jest.fn().mockResolvedValue({confirmation: true}),
+}))
 jest.mock('util')
 
 // File system mocks
@@ -799,6 +804,32 @@ describe('lambda flare', () => {
       const code = await cli.run(MOCK_REQUIRED_FLAGS, context as any)
       expect(requestAWSCredentials).toHaveBeenCalled()
       expect(code).toBe(1)
+      const output = context.stdout.toString()
+      expect(output).toMatchSnapshot()
+    })
+  })
+
+  describe('prompt to send works as expected', () => {
+    beforeEach(() => {
+      ;(getAWSCredentials as any).mockResolvedValue(mockAwsCredentials)
+    })
+
+    it('sends when user answers prompt with yes', async () => {
+      ;(inquirer.prompt as any).mockResolvedValueOnce({confirmation: true})
+      const cli = makeCli()
+      const context = createMockContext()
+      const code = await cli.run(MOCK_REQUIRED_FLAGS, context as any)
+      expect(code).toBe(0)
+      const output = context.stdout.toString()
+      expect(output).toMatchSnapshot()
+    })
+
+    it('does not send when user answers prompt with no', async () => {
+      ;(inquirer.prompt as any).mockResolvedValueOnce({confirmation: false})
+      const cli = makeCli()
+      const context = createMockContext()
+      const code = await cli.run(MOCK_REQUIRED_FLAGS, context as any)
+      expect(code).toBe(0)
       const output = context.stdout.toString()
       expect(output).toMatchSnapshot()
     })

--- a/src/commands/lambda/flare.ts
+++ b/src/commands/lambda/flare.ts
@@ -14,11 +14,12 @@ import {AwsCredentialIdentity} from '@aws-sdk/types'
 import axios from 'axios'
 import {Command} from 'clipanion'
 import FormData from 'form-data'
+import inquirer from 'inquirer'
 import JSZip from 'jszip'
 
 import {API_KEY_ENV_VAR, AWS_DEFAULT_REGION_ENV_VAR, CI_API_KEY_ENV_VAR, SKIP_MASKING_ENV_VARS} from './constants'
 import {getAWSCredentials, getLambdaFunctionConfig, getRegion} from './functions/commons'
-import {requestAWSCredentials} from './prompt'
+import {confirmationQuestion, requestAWSCredentials} from './prompt'
 import * as commonRenderer from './renderers/common-renderer'
 import * as flareRenderer from './renderers/flare-renderer'
 
@@ -202,9 +203,22 @@ export class LambdaFlareCommand extends Command {
       }
 
       // Exit if dry run
+      const outputMsg = `\nℹ️ Your output files are located at: ${rootFolderPath}\n\n`
       if (this.isDryRun) {
         this.context.stdout.write('\n🚫 The flare files were not sent as it was executed in dry run mode.')
-        this.context.stdout.write(`\nℹ️ Your output files are located at: ${rootFolderPath}\n\n`)
+        this.context.stdout.write(outputMsg)
+
+        return 0
+      }
+
+      // Confirm before sending
+      this.context.stdout.write('\n')
+      const answer = await inquirer.prompt(
+        confirmationQuestion('Are you sure you want to send the flare file to Datadog Support?')
+      )
+      if (!answer.confirmation) {
+        this.context.stdout.write('\n🚫 The flare files were not sent based on your selection.')
+        this.context.stdout.write(outputMsg)
 
         return 0
       }


### PR DESCRIPTION
### What and why?

For more context on what Lambda Flare is, please read the description in this PR: https://github.com/DataDog/datadog-ci/pull/924

We want to ask users for confirmation before sending their files to support.
If they answer `no` or anything other than `y` or `Y`, the flare files are not sent and are deleted
They must answer `y` or `Y` before the files are sent to support.
This is intended to:
1. Give the user an opportunity to check the files and see if there is anything they don't want to send to support
2. Prevent users from accidentally spamming their support ticket with files

<img width="909" alt="Screenshot 2023-07-03 at 2 38 49 PM" src="https://github.com/DataDog/datadog-ci/assets/29668820/8a331976-fa4f-4eb2-bbcd-867688f5ddf7">

<img width="849" alt="Screenshot 2023-07-03 at 2 39 09 PM" src="https://github.com/DataDog/datadog-ci/assets/29668820/5b2f2003-6b65-45ff-8765-c9ec51dfb0f0">

### How?

Use `inquirer` to prompt the user for confirmation.
Exit the program early if they answer `no`, continue otherwise.


### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
