### PR TITLE
[lambda][flare] Add human readable time to CloudWatch CSV files

### DIFF
--- a/src/commands/lambda/__tests__/__snapshots__/flare.test.ts.snap
+++ b/src/commands/lambda/__tests__/__snapshots__/flare.test.ts.snap
@@ -124,6 +124,20 @@ exports[`lambda flare AWS credentials stops and prints error when requestAWSCred
 "
 `;
 
+exports[`lambda flare convertToCSV handles missing timestamp and message in log events 1`] = `
+"timestamp,datetime,message
+\\"\\",,\\"Log 1\\"
+\\"456\\",1970-01-01 00:00:00.456,\\"\\""
+`;
+
+exports[`lambda flare convertToCSV returns a CSV string from an array of log events 1`] = `
+"timestamp,datetime,message
+\\"123\\",1970-01-01 00:00:00.123,\\"Log 1\\"
+\\"456\\",1970-01-01 00:00:00.456,\\"Log 2\\""
+`;
+
+exports[`lambda flare convertToCSV returns a CSV string with only headers when given an empty array 1`] = `"timestamp,datetime,message"`;
+
 exports[`lambda flare createDirectories throws error when unable to create a folder 1`] = `"Unable to create directories: MOCK ERROR: Unable to create folder"`;
 
 exports[`lambda flare deleteFolder throws error when unable to delete a folder 1`] = `"Failed to delete files located at mock-folder/.datadog-ci: MOCK ERROR: Unable to delete folder"`;

--- a/src/commands/lambda/__tests__/flare.test.ts
+++ b/src/commands/lambda/__tests__/flare.test.ts
@@ -550,8 +550,7 @@ describe('lambda flare', () => {
         {timestamp: 456, message: 'Log 2'},
       ]
 
-      const expectedCSV = 'timestamp,message\n"123","Log 1"\n"456","Log 2"'
-      expect(convertToCSV(mockLogEvents)).toBe(expectedCSV)
+      expect(convertToCSV(mockLogEvents)).toMatchSnapshot()
     })
 
     it('handles missing timestamp and message in log events', () => {
@@ -560,14 +559,12 @@ describe('lambda flare', () => {
         {timestamp: 456, message: undefined},
       ]
 
-      const expectedCSV = 'timestamp,message\n"","Log 1"\n"456",""'
-      expect(convertToCSV(mockLogEvents)).toBe(expectedCSV)
+      expect(convertToCSV(mockLogEvents)).toMatchSnapshot()
     })
 
     it('returns a CSV string with only headers when given an empty array', () => {
       const mockLogEvents: OutputLogEvent[] = []
-      const expectedCSV = 'timestamp,message'
-      expect(convertToCSV(mockLogEvents)).toBe(expectedCSV)
+      expect(convertToCSV(mockLogEvents)).toMatchSnapshot()
     })
   })
 

--- a/src/commands/lambda/flare.ts
+++ b/src/commands/lambda/flare.ts
@@ -441,11 +441,15 @@ export const writeFile = (filePath: string, data: string) => {
  * @returns the CSV string
  */
 export const convertToCSV = (logEvents: OutputLogEvent[]) => {
-  const rows = [['timestamp', 'message']]
+  const rows = [['timestamp', 'datetime', 'message']]
   for (const logEvent of logEvents) {
     const timestamp = `"${logEvent.timestamp ?? ''}"`
+    let datetime = ''
+    if (logEvent.timestamp) {
+      datetime = new Date(logEvent.timestamp).toISOString().replace('T', ' ').replace('Z', '')
+    }
     const message = `"${logEvent.message ?? ''}"`
-    rows.push([timestamp, message])
+    rows.push([timestamp, datetime, message])
   }
 
   return rows.join('\n')

--- a/src/commands/lambda/flare.ts
+++ b/src/commands/lambda/flare.ts
@@ -446,7 +446,8 @@ export const convertToCSV = (logEvents: OutputLogEvent[]) => {
     const timestamp = `"${logEvent.timestamp ?? ''}"`
     let datetime = ''
     if (logEvent.timestamp) {
-      datetime = new Date(logEvent.timestamp).toISOString().replace('T', ' ').replace('Z', '')
+      const date = new Date(logEvent.timestamp)
+      datetime = date.toISOString().replace('T', ' ').replace('Z', '')
     }
     const message = `"${logEvent.message ?? ''}"`
     rows.push([timestamp, datetime, message])


### PR DESCRIPTION
### What and why?

For more context on what Lambda Flare is, please read the description in this PR: https://github.com/DataDog/datadog-ci/pull/924

Currently, only the timestamp in milliseconds since UNIX epoch is recorded in the CSV files for CloudWatch logs.
This change adds human readable time as a column in the CSV file in the format `YYYY-MM-DD HH:mm:ss.<milliseconds>`.
This is intended to improve the readability of these CSV files to help the support team.

### How?

1. Convert UNIX milliseconds to Date object using `new Date(timestamp)`
2. Convert Date object to string in the format described above using 
```
date.toISOString().replace('T', ' ').replace('Z', '')
```

<img width="722" alt="Screenshot 2023-07-03 at 2 51 27 PM" src="https://github.com/DataDog/datadog-ci/assets/29668820/795b7d9a-39c8-441a-a0f6-b189fdcdd08f">

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
