### PR TITLE
[lambda][flare] Get resource tags

### DIFF
--- a/src/commands/lambda/__tests__/__snapshots__/flare.test.ts.snap
+++ b/src/commands/lambda/__tests__/__snapshots__/flare.test.ts.snap
@@ -22,8 +22,8 @@ exports[`lambda flare AWS Lambda configuration prints config when running as a d
   FunctionName: 'some-function'
 }
 
-🏷️ Getting Resource Tags...
-✅ Found 0 resource tags.
+🏷 Getting Resource Tags...
+[!] No resource tags were found, so the \`tags.json\` file will not be created or sent.
 
 💾 Saving files...
 • Saved function config to mock-folder/.datadog-ci/function_config.json
@@ -67,8 +67,8 @@ exports[`lambda flare AWS credentials continues when getAWSCredentials() returns
   FunctionName: 'some-function'
 }
 
-🏷️ Getting Resource Tags...
-✅ Found 0 resource tags.
+🏷 Getting Resource Tags...
+[!] No resource tags were found, so the \`tags.json\` file will not be created or sent.
 
 💾 Saving files...
 • Saved function config to mock-folder/.datadog-ci/function_config.json
@@ -102,8 +102,8 @@ exports[`lambda flare AWS credentials requests AWS credentials when none are fou
   FunctionName: 'some-function'
 }
 
-🏷️ Getting Resource Tags...
-✅ Found 0 resource tags.
+🏷 Getting Resource Tags...
+[!] No resource tags were found, so the \`tags.json\` file will not be created or sent.
 
 💾 Saving files...
 • Saved function config to mock-folder/.datadog-ci/function_config.json
@@ -172,8 +172,8 @@ exports[`lambda flare gets CloudWatch Logs does not get logs when --with-logs is
   FunctionName: 'some-function'
 }
 
-🏷️ Getting Resource Tags...
-✅ Found 0 resource tags.
+🏷 Getting Resource Tags...
+[!] No resource tags were found, so the \`tags.json\` file will not be created or sent.
 
 💾 Saving files...
 • Saved function config to mock-folder/.datadog-ci/function_config.json
@@ -207,8 +207,8 @@ exports[`lambda flare gets CloudWatch Logs gets logs, saves, and sends correctly
   FunctionName: 'some-function'
 }
 
-🏷️ Getting Resource Tags...
-✅ Found 0 resource tags.
+🏷 Getting Resource Tags...
+[!] No resource tags were found, so the \`tags.json\` file will not be created or sent.
 
 ☁️ Getting CloudWatch logs...
 
@@ -252,8 +252,8 @@ exports[`lambda flare gets CloudWatch Logs prints error when getLogEvents throws
   FunctionName: 'some-function'
 }
 
-🏷️ Getting Resource Tags...
-✅ Found 0 resource tags.
+🏷 Getting Resource Tags...
+[!] No resource tags were found, so the \`tags.json\` file will not be created or sent.
 
 ☁️ Getting CloudWatch logs...
 [Error] Unable to get log events for stream Stream1: MOCK ERROR: Unable to get log events
@@ -282,8 +282,8 @@ exports[`lambda flare gets CloudWatch Logs prints error when getLogStreamNames t
   FunctionName: 'some-function'
 }
 
-🏷️ Getting Resource Tags...
-✅ Found 0 resource tags.
+🏷 Getting Resource Tags...
+[!] No resource tags were found, so the \`tags.json\` file will not be created or sent.
 
 ☁️ Getting CloudWatch logs...
 [Error] Unable to get log streams: MOCK ERROR: Unable to get log stream names
@@ -312,8 +312,8 @@ exports[`lambda flare gets CloudWatch Logs warns and skips getting logs when get
   FunctionName: 'some-function'
 }
 
-🏷️ Getting Resource Tags...
-✅ Found 0 resource tags.
+🏷 Getting Resource Tags...
+[!] No resource tags were found, so the \`tags.json\` file will not be created or sent.
 
 ☁️ Getting CloudWatch logs...
 [!] No CloudWatch log streams were found. Logs will not be retrieved or sent.
@@ -350,8 +350,8 @@ exports[`lambda flare gets CloudWatch Logs warns and skips log when getLogEvents
   FunctionName: 'some-function'
 }
 
-🏷️ Getting Resource Tags...
-✅ Found 0 resource tags.
+🏷 Getting Resource Tags...
+[!] No resource tags were found, so the \`tags.json\` file will not be created or sent.
 
 ☁️ Getting CloudWatch logs...
 
@@ -418,8 +418,8 @@ exports[`lambda flare prompts for confirmation before sending does not send when
   FunctionName: 'some-function'
 }
 
-🏷️ Getting Resource Tags...
-✅ Found 0 resource tags.
+🏷 Getting Resource Tags...
+[!] No resource tags were found, so the \`tags.json\` file will not be created or sent.
 
 💾 Saving files...
 • Saved function config to mock-folder/.datadog-ci/function_config.json
@@ -451,8 +451,8 @@ exports[`lambda flare prompts for confirmation before sending sends when user an
   FunctionName: 'some-function'
 }
 
-🏷️ Getting Resource Tags...
-✅ Found 0 resource tags.
+🏷 Getting Resource Tags...
+[!] No resource tags were found, so the \`tags.json\` file will not be created or sent.
 
 💾 Saving files...
 • Saved function config to mock-folder/.datadog-ci/function_config.json
@@ -486,8 +486,8 @@ exports[`lambda flare send to Datadog does not send request to Datadog when a dr
   FunctionName: 'some-function'
 }
 
-🏷️ Getting Resource Tags...
-✅ Found 0 resource tags.
+🏷 Getting Resource Tags...
+[!] No resource tags were found, so the \`tags.json\` file will not be created or sent.
 
 💾 Saving files...
 • Saved function config to mock-folder/.datadog-ci/function_config.json
@@ -520,8 +520,8 @@ exports[`lambda flare send to Datadog successfully adds zip file to FormData 1`]
   FunctionName: 'some-function'
 }
 
-🏷️ Getting Resource Tags...
-✅ Found 0 resource tags.
+🏷 Getting Resource Tags...
+[!] No resource tags were found, so the \`tags.json\` file will not be created or sent.
 
 💾 Saving files...
 • Saved function config to mock-folder/.datadog-ci/function_config.json
@@ -555,8 +555,8 @@ exports[`lambda flare send to Datadog successfully sends request to Datadog 1`] 
   FunctionName: 'some-function'
 }
 
-🏷️ Getting Resource Tags...
-✅ Found 0 resource tags.
+🏷 Getting Resource Tags...
+[!] No resource tags were found, so the \`tags.json\` file will not be created or sent.
 
 💾 Saving files...
 • Saved function config to mock-folder/.datadog-ci/function_config.json
@@ -590,8 +590,8 @@ exports[`lambda flare validates required flags extracts region from function nam
   FunctionName: 'some-function'
 }
 
-🏷️ Getting Resource Tags...
-✅ Found 0 resource tags.
+🏷 Getting Resource Tags...
+[!] No resource tags were found, so the \`tags.json\` file will not be created or sent.
 
 💾 Saving files...
 • Saved function config to mock-folder/.datadog-ci/function_config.json
@@ -660,8 +660,8 @@ exports[`lambda flare validates required flags runs successfully with all requir
   FunctionName: 'some-function'
 }
 
-🏷️ Getting Resource Tags...
-✅ Found 0 resource tags.
+🏷 Getting Resource Tags...
+[!] No resource tags were found, so the \`tags.json\` file will not be created or sent.
 
 💾 Saving files...
 • Saved function config to mock-folder/.datadog-ci/function_config.json
@@ -695,8 +695,8 @@ exports[`lambda flare validates required flags uses API key ENV variable and run
   FunctionName: 'some-function'
 }
 
-🏷️ Getting Resource Tags...
-✅ Found 0 resource tags.
+🏷 Getting Resource Tags...
+[!] No resource tags were found, so the \`tags.json\` file will not be created or sent.
 
 💾 Saving files...
 • Saved function config to mock-folder/.datadog-ci/function_config.json
@@ -730,8 +730,8 @@ exports[`lambda flare validates required flags uses API key ENV variable and run
   FunctionName: 'some-function'
 }
 
-🏷️ Getting Resource Tags...
-✅ Found 0 resource tags.
+🏷 Getting Resource Tags...
+[!] No resource tags were found, so the \`tags.json\` file will not be created or sent.
 
 💾 Saving files...
 • Saved function config to mock-folder/.datadog-ci/function_config.json
@@ -761,8 +761,8 @@ exports[`lambda flare validates required flags uses API key ENV variable and run
   FunctionName: 'some-function'
 }
 
-🏷️ Getting Resource Tags...
-✅ Found 0 resource tags.
+🏷 Getting Resource Tags...
+[!] No resource tags were found, so the \`tags.json\` file will not be created or sent.
 
 💾 Saving files...
 • Saved function config to mock-folder/.datadog-ci/function_config.json
@@ -796,8 +796,8 @@ exports[`lambda flare validates required flags uses region ENV variable when no 
   FunctionName: 'some-function'
 }
 
-🏷️ Getting Resource Tags...
-✅ Found 0 resource tags.
+🏷 Getting Resource Tags...
+[!] No resource tags were found, so the \`tags.json\` file will not be created or sent.
 
 💾 Saving files...
 • Saved function config to mock-folder/.datadog-ci/function_config.json

--- a/src/commands/lambda/__tests__/__snapshots__/flare.test.ts.snap
+++ b/src/commands/lambda/__tests__/__snapshots__/flare.test.ts.snap
@@ -23,7 +23,7 @@ exports[`lambda flare AWS Lambda configuration prints config when running as a d
 }
 
 🏷 Getting Resource Tags...
-[!] No resource tags were found, so the \`tags.json\` file will not be created or sent.
+[!] No resource tags were found.
 
 💾 Saving files...
 • Saved function config to mock-folder/.datadog-ci/function_config.json
@@ -68,7 +68,7 @@ exports[`lambda flare AWS credentials continues when getAWSCredentials() returns
 }
 
 🏷 Getting Resource Tags...
-[!] No resource tags were found, so the \`tags.json\` file will not be created or sent.
+[!] No resource tags were found.
 
 💾 Saving files...
 • Saved function config to mock-folder/.datadog-ci/function_config.json
@@ -103,7 +103,7 @@ exports[`lambda flare AWS credentials requests AWS credentials when none are fou
 }
 
 🏷 Getting Resource Tags...
-[!] No resource tags were found, so the \`tags.json\` file will not be created or sent.
+[!] No resource tags were found.
 
 💾 Saving files...
 • Saved function config to mock-folder/.datadog-ci/function_config.json
@@ -173,7 +173,7 @@ exports[`lambda flare gets CloudWatch Logs does not get logs when --with-logs is
 }
 
 🏷 Getting Resource Tags...
-[!] No resource tags were found, so the \`tags.json\` file will not be created or sent.
+[!] No resource tags were found.
 
 💾 Saving files...
 • Saved function config to mock-folder/.datadog-ci/function_config.json
@@ -208,7 +208,7 @@ exports[`lambda flare gets CloudWatch Logs gets logs, saves, and sends correctly
 }
 
 🏷 Getting Resource Tags...
-[!] No resource tags were found, so the \`tags.json\` file will not be created or sent.
+[!] No resource tags were found.
 
 ☁️ Getting CloudWatch logs...
 
@@ -253,7 +253,7 @@ exports[`lambda flare gets CloudWatch Logs prints error when getLogEvents throws
 }
 
 🏷 Getting Resource Tags...
-[!] No resource tags were found, so the \`tags.json\` file will not be created or sent.
+[!] No resource tags were found.
 
 ☁️ Getting CloudWatch logs...
 [Error] Unable to get log events for stream Stream1: MOCK ERROR: Unable to get log events
@@ -283,7 +283,7 @@ exports[`lambda flare gets CloudWatch Logs prints error when getLogStreamNames t
 }
 
 🏷 Getting Resource Tags...
-[!] No resource tags were found, so the \`tags.json\` file will not be created or sent.
+[!] No resource tags were found.
 
 ☁️ Getting CloudWatch logs...
 [Error] Unable to get log streams: MOCK ERROR: Unable to get log stream names
@@ -313,7 +313,7 @@ exports[`lambda flare gets CloudWatch Logs warns and skips getting logs when get
 }
 
 🏷 Getting Resource Tags...
-[!] No resource tags were found, so the \`tags.json\` file will not be created or sent.
+[!] No resource tags were found.
 
 ☁️ Getting CloudWatch logs...
 [!] No CloudWatch log streams were found. Logs will not be retrieved or sent.
@@ -351,7 +351,7 @@ exports[`lambda flare gets CloudWatch Logs warns and skips log when getLogEvents
 }
 
 🏷 Getting Resource Tags...
-[!] No resource tags were found, so the \`tags.json\` file will not be created or sent.
+[!] No resource tags were found.
 
 ☁️ Getting CloudWatch logs...
 
@@ -419,7 +419,7 @@ exports[`lambda flare prompts for confirmation before sending does not send when
 }
 
 🏷 Getting Resource Tags...
-[!] No resource tags were found, so the \`tags.json\` file will not be created or sent.
+[!] No resource tags were found.
 
 💾 Saving files...
 • Saved function config to mock-folder/.datadog-ci/function_config.json
@@ -452,7 +452,7 @@ exports[`lambda flare prompts for confirmation before sending sends when user an
 }
 
 🏷 Getting Resource Tags...
-[!] No resource tags were found, so the \`tags.json\` file will not be created or sent.
+[!] No resource tags were found.
 
 💾 Saving files...
 • Saved function config to mock-folder/.datadog-ci/function_config.json
@@ -487,7 +487,7 @@ exports[`lambda flare send to Datadog does not send request to Datadog when a dr
 }
 
 🏷 Getting Resource Tags...
-[!] No resource tags were found, so the \`tags.json\` file will not be created or sent.
+[!] No resource tags were found.
 
 💾 Saving files...
 • Saved function config to mock-folder/.datadog-ci/function_config.json
@@ -521,7 +521,7 @@ exports[`lambda flare send to Datadog successfully adds zip file to FormData 1`]
 }
 
 🏷 Getting Resource Tags...
-[!] No resource tags were found, so the \`tags.json\` file will not be created or sent.
+[!] No resource tags were found.
 
 💾 Saving files...
 • Saved function config to mock-folder/.datadog-ci/function_config.json
@@ -556,7 +556,7 @@ exports[`lambda flare send to Datadog successfully sends request to Datadog 1`] 
 }
 
 🏷 Getting Resource Tags...
-[!] No resource tags were found, so the \`tags.json\` file will not be created or sent.
+[!] No resource tags were found.
 
 💾 Saving files...
 • Saved function config to mock-folder/.datadog-ci/function_config.json
@@ -591,7 +591,7 @@ exports[`lambda flare validates required flags extracts region from function nam
 }
 
 🏷 Getting Resource Tags...
-[!] No resource tags were found, so the \`tags.json\` file will not be created or sent.
+[!] No resource tags were found.
 
 💾 Saving files...
 • Saved function config to mock-folder/.datadog-ci/function_config.json
@@ -661,7 +661,7 @@ exports[`lambda flare validates required flags runs successfully with all requir
 }
 
 🏷 Getting Resource Tags...
-[!] No resource tags were found, so the \`tags.json\` file will not be created or sent.
+[!] No resource tags were found.
 
 💾 Saving files...
 • Saved function config to mock-folder/.datadog-ci/function_config.json
@@ -696,7 +696,7 @@ exports[`lambda flare validates required flags uses API key ENV variable and run
 }
 
 🏷 Getting Resource Tags...
-[!] No resource tags were found, so the \`tags.json\` file will not be created or sent.
+[!] No resource tags were found.
 
 💾 Saving files...
 • Saved function config to mock-folder/.datadog-ci/function_config.json
@@ -731,7 +731,7 @@ exports[`lambda flare validates required flags uses API key ENV variable and run
 }
 
 🏷 Getting Resource Tags...
-[!] No resource tags were found, so the \`tags.json\` file will not be created or sent.
+[!] No resource tags were found.
 
 💾 Saving files...
 • Saved function config to mock-folder/.datadog-ci/function_config.json
@@ -762,7 +762,7 @@ exports[`lambda flare validates required flags uses API key ENV variable and run
 }
 
 🏷 Getting Resource Tags...
-[!] No resource tags were found, so the \`tags.json\` file will not be created or sent.
+[!] No resource tags were found.
 
 💾 Saving files...
 • Saved function config to mock-folder/.datadog-ci/function_config.json
@@ -797,7 +797,7 @@ exports[`lambda flare validates required flags uses region ENV variable when no 
 }
 
 🏷 Getting Resource Tags...
-[!] No resource tags were found, so the \`tags.json\` file will not be created or sent.
+[!] No resource tags were found.
 
 💾 Saving files...
 • Saved function config to mock-folder/.datadog-ci/function_config.json

--- a/src/commands/lambda/__tests__/__snapshots__/flare.test.ts.snap
+++ b/src/commands/lambda/__tests__/__snapshots__/flare.test.ts.snap
@@ -22,6 +22,9 @@ exports[`lambda flare AWS Lambda configuration prints config when running as a d
   FunctionName: 'some-function'
 }
 
+🏷️ Getting Resource Tags...
+✅ Found 0 resource tags.
+
 💾 Saving files...
 • Saved function config to mock-folder/.datadog-ci/function_config.json
 
@@ -64,6 +67,9 @@ exports[`lambda flare AWS credentials continues when getAWSCredentials() returns
   FunctionName: 'some-function'
 }
 
+🏷️ Getting Resource Tags...
+✅ Found 0 resource tags.
+
 💾 Saving files...
 • Saved function config to mock-folder/.datadog-ci/function_config.json
 
@@ -95,6 +101,9 @@ exports[`lambda flare AWS credentials requests AWS credentials when none are fou
   FunctionArn: 'arn:aws:lambda:us-east-1:123456789012:function:some-function',
   FunctionName: 'some-function'
 }
+
+🏷️ Getting Resource Tags...
+✅ Found 0 resource tags.
 
 💾 Saving files...
 • Saved function config to mock-folder/.datadog-ci/function_config.json
@@ -134,6 +143,13 @@ exports[`lambda flare getAllLogs throws an error when unable to get log events 1
 
 exports[`lambda flare getAllLogs throws an error when unable to get log streams 1`] = `[Error: Unable to get log streams: Error getting log streams]`;
 
+exports[`lambda flare getTags should return the tags when they exist 1`] = `
+Object {
+  "Key1": "Value1",
+  "Key2": "Value2",
+}
+`;
+
 exports[`lambda flare gets CloudWatch Logs does not get logs when --with-logs is not included 1`] = `
 "
 🐶 Generating Lambda flare to send your configuration to Datadog...
@@ -155,6 +171,9 @@ exports[`lambda flare gets CloudWatch Logs does not get logs when --with-logs is
   FunctionArn: 'arn:aws:lambda:us-east-1:123456789012:function:some-function',
   FunctionName: 'some-function'
 }
+
+🏷️ Getting Resource Tags...
+✅ Found 0 resource tags.
 
 💾 Saving files...
 • Saved function config to mock-folder/.datadog-ci/function_config.json
@@ -187,6 +206,9 @@ exports[`lambda flare gets CloudWatch Logs gets logs, saves, and sends correctly
   FunctionArn: 'arn:aws:lambda:us-east-1:123456789012:function:some-function',
   FunctionName: 'some-function'
 }
+
+🏷️ Getting Resource Tags...
+✅ Found 0 resource tags.
 
 ☁️ Getting CloudWatch logs...
 
@@ -230,6 +252,9 @@ exports[`lambda flare gets CloudWatch Logs prints error when getLogEvents throws
   FunctionName: 'some-function'
 }
 
+🏷️ Getting Resource Tags...
+✅ Found 0 resource tags.
+
 ☁️ Getting CloudWatch logs...
 [Error] Unable to get log events for stream Stream1: MOCK ERROR: Unable to get log events
 "
@@ -257,6 +282,9 @@ exports[`lambda flare gets CloudWatch Logs prints error when getLogStreamNames t
   FunctionName: 'some-function'
 }
 
+🏷️ Getting Resource Tags...
+✅ Found 0 resource tags.
+
 ☁️ Getting CloudWatch logs...
 [Error] Unable to get log streams: MOCK ERROR: Unable to get log stream names
 "
@@ -283,6 +311,9 @@ exports[`lambda flare gets CloudWatch Logs warns and skips getting logs when get
   FunctionArn: 'arn:aws:lambda:us-east-1:123456789012:function:some-function',
   FunctionName: 'some-function'
 }
+
+🏷️ Getting Resource Tags...
+✅ Found 0 resource tags.
 
 ☁️ Getting CloudWatch logs...
 [!] No CloudWatch log streams were found. Logs will not be retrieved or sent.
@@ -318,6 +349,9 @@ exports[`lambda flare gets CloudWatch Logs warns and skips log when getLogEvents
   FunctionArn: 'arn:aws:lambda:us-east-1:123456789012:function:some-function',
   FunctionName: 'some-function'
 }
+
+🏷️ Getting Resource Tags...
+✅ Found 0 resource tags.
 
 ☁️ Getting CloudWatch logs...
 
@@ -384,6 +418,9 @@ exports[`lambda flare prompts for confirmation before sending does not send when
   FunctionName: 'some-function'
 }
 
+🏷️ Getting Resource Tags...
+✅ Found 0 resource tags.
+
 💾 Saving files...
 • Saved function config to mock-folder/.datadog-ci/function_config.json
 
@@ -413,6 +450,9 @@ exports[`lambda flare prompts for confirmation before sending sends when user an
   FunctionArn: 'arn:aws:lambda:us-east-1:123456789012:function:some-function',
   FunctionName: 'some-function'
 }
+
+🏷️ Getting Resource Tags...
+✅ Found 0 resource tags.
 
 💾 Saving files...
 • Saved function config to mock-folder/.datadog-ci/function_config.json
@@ -446,6 +486,9 @@ exports[`lambda flare send to Datadog does not send request to Datadog when a dr
   FunctionName: 'some-function'
 }
 
+🏷️ Getting Resource Tags...
+✅ Found 0 resource tags.
+
 💾 Saving files...
 • Saved function config to mock-folder/.datadog-ci/function_config.json
 
@@ -476,6 +519,9 @@ exports[`lambda flare send to Datadog successfully adds zip file to FormData 1`]
   FunctionArn: 'arn:aws:lambda:us-east-1:123456789012:function:some-function',
   FunctionName: 'some-function'
 }
+
+🏷️ Getting Resource Tags...
+✅ Found 0 resource tags.
 
 💾 Saving files...
 • Saved function config to mock-folder/.datadog-ci/function_config.json
@@ -509,6 +555,9 @@ exports[`lambda flare send to Datadog successfully sends request to Datadog 1`] 
   FunctionName: 'some-function'
 }
 
+🏷️ Getting Resource Tags...
+✅ Found 0 resource tags.
+
 💾 Saving files...
 • Saved function config to mock-folder/.datadog-ci/function_config.json
 
@@ -540,6 +589,9 @@ exports[`lambda flare validates required flags extracts region from function nam
   FunctionArn: 'arn:aws:lambda:us-east-1:123456789012:function:some-function',
   FunctionName: 'some-function'
 }
+
+🏷️ Getting Resource Tags...
+✅ Found 0 resource tags.
 
 💾 Saving files...
 • Saved function config to mock-folder/.datadog-ci/function_config.json
@@ -608,6 +660,9 @@ exports[`lambda flare validates required flags runs successfully with all requir
   FunctionName: 'some-function'
 }
 
+🏷️ Getting Resource Tags...
+✅ Found 0 resource tags.
+
 💾 Saving files...
 • Saved function config to mock-folder/.datadog-ci/function_config.json
 
@@ -639,6 +694,9 @@ exports[`lambda flare validates required flags uses API key ENV variable and run
   FunctionArn: 'arn:aws:lambda:us-east-1:123456789012:function:some-function',
   FunctionName: 'some-function'
 }
+
+🏷️ Getting Resource Tags...
+✅ Found 0 resource tags.
 
 💾 Saving files...
 • Saved function config to mock-folder/.datadog-ci/function_config.json
@@ -672,6 +730,9 @@ exports[`lambda flare validates required flags uses API key ENV variable and run
   FunctionName: 'some-function'
 }
 
+🏷️ Getting Resource Tags...
+✅ Found 0 resource tags.
+
 💾 Saving files...
 • Saved function config to mock-folder/.datadog-ci/function_config.json
 
@@ -699,6 +760,9 @@ exports[`lambda flare validates required flags uses API key ENV variable and run
   FunctionArn: 'arn:aws:lambda:us-east-1:123456789012:function:some-function',
   FunctionName: 'some-function'
 }
+
+🏷️ Getting Resource Tags...
+✅ Found 0 resource tags.
 
 💾 Saving files...
 • Saved function config to mock-folder/.datadog-ci/function_config.json
@@ -731,6 +795,9 @@ exports[`lambda flare validates required flags uses region ENV variable when no 
   FunctionArn: 'arn:aws:lambda:us-east-1:123456789012:function:some-function',
   FunctionName: 'some-function'
 }
+
+🏷️ Getting Resource Tags...
+✅ Found 0 resource tags.
 
 💾 Saving files...
 • Saved function config to mock-folder/.datadog-ci/function_config.json

--- a/src/commands/lambda/__tests__/fixtures.ts
+++ b/src/commands/lambda/__tests__/fixtures.ts
@@ -199,10 +199,10 @@ export const mockCloudWatchLogEvents = (
 }
 
 export const mockResourceTags = (
-  cloudWatchLogsClientMock: AwsStub<ServiceInputTypes, ServiceOutputTypes>,
+  lambdaClientMock: AwsStub<ServiceInputTypes, ServiceOutputTypes>,
   output: ListTagsCommandOutput
 ) => {
-  cloudWatchLogsClientMock.on(ListTagsCommand).resolves(output)
+  lambdaClientMock.on(ListTagsCommand).resolves(output)
 }
 
 export const mockAwsAccount = '123456789012'

--- a/src/commands/lambda/__tests__/fixtures.ts
+++ b/src/commands/lambda/__tests__/fixtures.ts
@@ -24,7 +24,7 @@ import {
   TagResourceCommand,
   ListTagsCommand,
   ListTagsResponse,
-  GetLayerVersionCommandInput,
+  GetLayerVersionCommandInput, ServiceInputTypes, ServiceOutputTypes, ListTagsCommandOutput,
 } from '@aws-sdk/client-lambda'
 import {AwsStub} from 'aws-sdk-client-mock'
 import {Cli, Command} from 'clipanion/lib/advanced'
@@ -193,6 +193,13 @@ export const mockCloudWatchLogEvents = (
   events: OutputLogEvent[]
 ) => {
   cloudWatchLogsClientMock.on(GetLogEventsCommand).resolves({events})
+}
+
+export const mockResourceTags = (
+  cloudWatchLogsClientMock: AwsStub<ServiceInputTypes, ServiceOutputTypes>,
+  output: ListTagsCommandOutput
+) => {
+  cloudWatchLogsClientMock.on(ListTagsCommand).resolves(output)
 }
 
 export const mockAwsAccount = '123456789012'

--- a/src/commands/lambda/__tests__/fixtures.ts
+++ b/src/commands/lambda/__tests__/fixtures.ts
@@ -24,7 +24,10 @@ import {
   TagResourceCommand,
   ListTagsCommand,
   ListTagsResponse,
-  GetLayerVersionCommandInput, ServiceInputTypes, ServiceOutputTypes, ListTagsCommandOutput,
+  GetLayerVersionCommandInput,
+  ServiceInputTypes,
+  ServiceOutputTypes,
+  ListTagsCommandOutput,
 } from '@aws-sdk/client-lambda'
 import {AwsStub} from 'aws-sdk-client-mock'
 import {Cli, Command} from 'clipanion/lib/advanced'

--- a/src/commands/lambda/__tests__/flare.test.ts
+++ b/src/commands/lambda/__tests__/flare.test.ts
@@ -538,6 +538,11 @@ describe('lambda flare', () => {
 
   describe('getTags', () => {
     const MOCK_ARN = 'arn:aws:lambda:us-east-1:123456789012:function:my-function'
+
+    afterAll(() => {
+      mockResourceTags(lambdaClientMock, MOCK_TAGS)
+    })
+
     it('should return the tags when they exist', async () => {
       const mockTags: any = {Tags: {Key1: 'Value1', Key2: 'Value2'}}
 
@@ -560,7 +565,6 @@ describe('lambda flare', () => {
       lambdaClientMock.on(ListTagsCommand).rejects(new Error('Test Error'))
 
       await expect(getTags(lambdaClientMock, MOCK_REGION, MOCK_ARN)).rejects.toThrow(errorMessage)
-      mockResourceTags(lambdaClientMock, MOCK_TAGS)
     })
   })
 

--- a/src/commands/lambda/__tests__/flare.test.ts
+++ b/src/commands/lambda/__tests__/flare.test.ts
@@ -53,7 +53,8 @@ const MOCK_FOLDER_PATH = path.join(MOCK_CWD, MOCK_FOLDER_NAME)
 const MOCK_FILE_NAME = 'function_config.json'
 const MOCK_FILES = new Set([MOCK_FILE_NAME, 'file1.csv', 'file2.csv', 'file3.csv'])
 const MOCK_ZIP_PATH = 'output.zip'
-const MOCK_REQUIRED_FLAGS = ['lambda', 'flare', '-f', 'func', '-r', 'us-east-1', '-c', '123', '-e', 'test@test.com']
+const MOCK_REGION = 'us-east-1'
+const MOCK_REQUIRED_FLAGS = ['lambda', 'flare', '-f', 'func', '-r', MOCK_REGION, '-c', '123', '-e', 'test@test.com']
 const MOCK_CONFIG = {
   Environment: {
     Variables: {
@@ -68,7 +69,6 @@ const MOCK_CONFIG = {
 const MOCK_LOG_GROUP = 'mockLogGroup'
 const MOCK_OUTPUT_EVENT: OutputLogEvent[] = [{timestamp: 123, message: 'Log 1'}]
 const MOCK_LOGS = new Map().set('log1', MOCK_OUTPUT_EVENT)
-const MOCK_REGION = 'us-east-1'
 const cloudWatchLogsClientMock = mockClient(CloudWatchLogsClient)
 const lambdaClientMock: any = mockClient(LambdaClient)
 

--- a/src/commands/lambda/__tests__/flare.test.ts
+++ b/src/commands/lambda/__tests__/flare.test.ts
@@ -69,6 +69,7 @@ const MOCK_CONFIG = {
 const MOCK_LOG_GROUP = 'mockLogGroup'
 const MOCK_OUTPUT_EVENT: OutputLogEvent[] = [{timestamp: 123, message: 'Log 1'}]
 const MOCK_LOGS = new Map().set('log1', MOCK_OUTPUT_EVENT)
+const MOCK_TAGS: any = {Tags: {}}
 const cloudWatchLogsClientMock = mockClient(CloudWatchLogsClient)
 const lambdaClientMock: any = mockClient(LambdaClient)
 
@@ -109,11 +110,11 @@ const mockJSZip = {
 }
 ;(JSZip as any).mockImplementation(() => mockJSZip)
 
-// Resource tags mock
-const mockTags: any = {Tags: {}}
-mockResourceTags(lambdaClientMock, mockTags)
-
 describe('lambda flare', () => {
+  beforeAll(() => {
+    mockResourceTags(lambdaClientMock, MOCK_TAGS)
+  })
+
   describe('prints correct headers', () => {
     it('prints non-dry-run header', async () => {
       const cli = makeCli()
@@ -538,17 +539,17 @@ describe('lambda flare', () => {
   describe('getTags', () => {
     const MOCK_ARN = 'arn:aws:lambda:us-east-1:123456789012:function:my-function'
     it('should return the tags when they exist', async () => {
-      const expectedTags: any = {Tags: {Key1: 'Value1', Key2: 'Value2'}}
+      const mockTags: any = {Tags: {Key1: 'Value1', Key2: 'Value2'}}
 
-      mockResourceTags(lambdaClientMock, expectedTags)
+      mockResourceTags(lambdaClientMock, mockTags)
 
       const tags = await getTags(lambdaClientMock, MOCK_REGION, MOCK_ARN)
       expect(tags).toMatchSnapshot()
     })
 
     it('should return an empty object when there are no tags', async () => {
-      const expectedTags: any = {Tags: {}}
-      mockResourceTags(lambdaClientMock, expectedTags)
+      const mockTags: any = {Tags: {}}
+      mockResourceTags(lambdaClientMock, mockTags)
 
       const tags = await getTags(lambdaClientMock, MOCK_REGION, MOCK_ARN)
       expect(tags).toEqual({})
@@ -559,7 +560,7 @@ describe('lambda flare', () => {
       lambdaClientMock.on(ListTagsCommand).rejects(new Error('Test Error'))
 
       await expect(getTags(lambdaClientMock, MOCK_REGION, MOCK_ARN)).rejects.toThrow(errorMessage)
-      mockResourceTags(lambdaClientMock, mockTags)
+      mockResourceTags(lambdaClientMock, MOCK_TAGS)
     })
   })
 

--- a/src/commands/lambda/__tests__/flare.test.ts
+++ b/src/commands/lambda/__tests__/flare.test.ts
@@ -71,7 +71,7 @@ const MOCK_OUTPUT_EVENT: OutputLogEvent[] = [{timestamp: 123, message: 'Log 1'}]
 const MOCK_LOGS = new Map().set('log1', MOCK_OUTPUT_EVENT)
 const MOCK_TAGS: any = {Tags: {}}
 const cloudWatchLogsClientMock = mockClient(CloudWatchLogsClient)
-const lambdaClientMock: any = mockClient(LambdaClient)
+const lambdaClientMock = mockClient(LambdaClient)
 
 // Commons mocks
 jest.mock('../functions/commons', () => ({
@@ -548,7 +548,7 @@ describe('lambda flare', () => {
 
       mockResourceTags(lambdaClientMock, mockTags)
 
-      const tags = await getTags(lambdaClientMock, MOCK_REGION, MOCK_ARN)
+      const tags = await getTags(lambdaClientMock as any, MOCK_REGION, MOCK_ARN)
       expect(tags).toMatchSnapshot()
     })
 
@@ -556,7 +556,7 @@ describe('lambda flare', () => {
       const mockTags: any = {Tags: {}}
       mockResourceTags(lambdaClientMock, mockTags)
 
-      const tags = await getTags(lambdaClientMock, MOCK_REGION, MOCK_ARN)
+      const tags = await getTags(lambdaClientMock as any, MOCK_REGION, MOCK_ARN)
       expect(tags).toEqual({})
     })
 
@@ -564,7 +564,7 @@ describe('lambda flare', () => {
       const errorMessage = 'Unable to get resource tags: Test Error'
       lambdaClientMock.on(ListTagsCommand).rejects(new Error('Test Error'))
 
-      await expect(getTags(lambdaClientMock, MOCK_REGION, MOCK_ARN)).rejects.toThrow(errorMessage)
+      await expect(getTags(lambdaClientMock as any, MOCK_REGION, MOCK_ARN)).rejects.toThrow(errorMessage)
     })
   })
 

--- a/src/commands/lambda/__tests__/flare.test.ts
+++ b/src/commands/lambda/__tests__/flare.test.ts
@@ -10,6 +10,7 @@ import {
   LogStream,
   OutputLogEvent,
 } from '@aws-sdk/client-cloudwatch-logs'
+import {LambdaClient, ListTagsCommand} from '@aws-sdk/client-lambda'
 import {mockClient} from 'aws-sdk-client-mock'
 import axios from 'axios'
 import FormData from 'form-data'
@@ -25,6 +26,7 @@ import {
   getLogEvents,
   getLogStreamNames,
   getMasking,
+  getTags,
   maskConfig,
   writeFile,
   zipContents,
@@ -41,6 +43,7 @@ import {
   mockCloudWatchLogsClientCommands,
   mockCloudWatchLogStreams,
   mockDatadogApiKey,
+  mockResourceTags,
 } from './fixtures'
 
 // Constants
@@ -50,7 +53,7 @@ const MOCK_FOLDER_PATH = path.join(MOCK_CWD, MOCK_FOLDER_NAME)
 const MOCK_FILE_NAME = 'function_config.json'
 const MOCK_FILES = new Set([MOCK_FILE_NAME, 'file1.csv', 'file2.csv', 'file3.csv'])
 const MOCK_ZIP_PATH = 'output.zip'
-const MOCK_REQUIRED_FLAGS = ['lambda', 'flare', '-f', 'func', '-r', 'us-west-2', '-c', '123', '-e', 'test@test.com']
+const MOCK_REQUIRED_FLAGS = ['lambda', 'flare', '-f', 'func', '-r', 'us-east-1', '-c', '123', '-e', 'test@test.com']
 const MOCK_CONFIG = {
   Environment: {
     Variables: {
@@ -65,7 +68,9 @@ const MOCK_CONFIG = {
 const MOCK_LOG_GROUP = 'mockLogGroup'
 const MOCK_OUTPUT_EVENT: OutputLogEvent[] = [{timestamp: 123, message: 'Log 1'}]
 const MOCK_LOGS = new Map().set('log1', MOCK_OUTPUT_EVENT)
+const MOCK_REGION = 'us-east-1'
 const cloudWatchLogsClientMock = mockClient(CloudWatchLogsClient)
+const lambdaClientMock: any = mockClient(LambdaClient)
 
 // Commons mocks
 jest.mock('../functions/commons', () => ({
@@ -104,6 +109,10 @@ const mockJSZip = {
 }
 ;(JSZip as any).mockImplementation(() => mockJSZip)
 
+// Resource tags mock
+const mockTags: any = {Tags: {}}
+mockResourceTags(lambdaClientMock, mockTags)
+
 describe('lambda flare', () => {
   describe('prints correct headers', () => {
     it('prints non-dry-run header', async () => {
@@ -134,7 +143,7 @@ describe('lambda flare', () => {
       const cli = makeCli()
       const context = createMockContext()
       const code = await cli.run(
-        ['lambda', 'flare', '-r', 'us-west-2', '-c', '123', '-e', 'test@test.com'],
+        ['lambda', 'flare', '-r', MOCK_REGION, '-c', '123', '-e', 'test@test.com'],
         context as any
       )
       expect(code).toBe(1)
@@ -159,7 +168,7 @@ describe('lambda flare', () => {
           'lambda',
           'flare',
           '-f',
-          'arn:aws:lambda:us-west-2:123456789012:function:my-function',
+          'arn:aws:lambda:us-east-1:123456789012:function:my-function',
           '-c',
           '123',
           '-e',
@@ -187,7 +196,7 @@ describe('lambda flare', () => {
       const cli = makeCli()
       const context = createMockContext()
       const code = await cli.run(
-        ['lambda', 'flare', '-f', 'func', '-r', 'us-west-2', '-c', '123', '-e', 'test@test.com'],
+        ['lambda', 'flare', '-f', 'func', '-r', MOCK_REGION, '-c', '123', '-e', 'test@test.com'],
         context as any
       )
       expect(code).toBe(1)
@@ -202,7 +211,7 @@ describe('lambda flare', () => {
       const cli = makeCli()
       const context = createMockContext()
       let code = await cli.run(
-        ['lambda', 'flare', '-f', 'func', '-r', 'test-region', '-c', '123', '-e', 'test@test.com'],
+        ['lambda', 'flare', '-f', 'func', '-r', MOCK_REGION, '-c', '123', '-e', 'test@test.com'],
         context as any
       )
       expect(code).toBe(0)
@@ -212,7 +221,7 @@ describe('lambda flare', () => {
       process.env[CI_API_KEY_ENV_VAR] = undefined
       process.env[API_KEY_ENV_VAR] = mockDatadogApiKey
       code = await cli.run(
-        ['lambda', 'flare', '-f', 'func', '-r', 'test-region', '-c', '123', '-e', 'test@test.com'],
+        ['lambda', 'flare', '-f', 'func', '-r', MOCK_REGION, '-c', '123', '-e', 'test@test.com'],
         context as any
       )
       expect(code).toBe(0)
@@ -224,7 +233,7 @@ describe('lambda flare', () => {
       const cli = makeCli()
       const context = createMockContext()
       const code = await cli.run(
-        ['lambda', 'flare', '-f', 'func', '-r', 'us-west-2', '-e', 'test@test.com'],
+        ['lambda', 'flare', '-f', 'func', '-r', MOCK_REGION, '-e', 'test@test.com'],
         context as any
       )
       expect(code).toBe(1)
@@ -235,7 +244,7 @@ describe('lambda flare', () => {
     it('prints error when no email specified', async () => {
       const cli = makeCli()
       const context = createMockContext()
-      const code = await cli.run(['lambda', 'flare', '-f', 'func', '-r', 'us-west-2', '-c', '123'], context as any)
+      const code = await cli.run(['lambda', 'flare', '-f', 'func', '-r', MOCK_REGION, '-c', '123'], context as any)
       expect(code).toBe(1)
       const output = context.stdout.toString()
       expect(output).toMatchSnapshot()
@@ -418,7 +427,6 @@ describe('lambda flare', () => {
   })
 
   describe('getAllLogs', () => {
-    const region = 'us-east-1'
     const functionName = 'testFunction'
     const mockStreamName = 'streamName'
 
@@ -431,21 +439,21 @@ describe('lambda flare', () => {
       jest.spyOn(flareModule, 'getLogStreamNames').mockResolvedValue([mockStreamName])
       jest.spyOn(flareModule, 'getLogEvents').mockResolvedValue(mockLogs)
 
-      const result = await getAllLogs(region, functionName)
+      const result = await getAllLogs(MOCK_REGION, functionName)
       expect(result.get(mockStreamName)).toEqual(mockLogs)
     })
 
     it('throws an error when unable to get log streams', async () => {
       jest.spyOn(flareModule, 'getLogStreamNames').mockRejectedValueOnce(new Error('Error getting log streams'))
 
-      await expect(getAllLogs(region, functionName)).rejects.toMatchSnapshot()
+      await expect(getAllLogs(MOCK_REGION, functionName)).rejects.toMatchSnapshot()
     })
 
     it('throws an error when unable to get log events', async () => {
       jest.spyOn(flareModule, 'getLogStreamNames').mockResolvedValueOnce([mockStreamName])
       jest.spyOn(flareModule, 'getLogEvents').mockRejectedValueOnce(new Error('Error getting log events'))
 
-      await expect(getAllLogs(region, functionName)).rejects.toMatchSnapshot()
+      await expect(getAllLogs(MOCK_REGION, functionName)).rejects.toMatchSnapshot()
     })
   })
 
@@ -524,6 +532,34 @@ describe('lambda flare', () => {
       expect(code).toBe(0)
       const output = context.stdout.toString()
       expect(output).toMatchSnapshot()
+    })
+  })
+
+  describe('getTags', () => {
+    const MOCK_ARN = 'arn:aws:lambda:us-east-1:123456789012:function:my-function'
+    it('should return the tags when they exist', async () => {
+      const expectedTags: any = {Tags: {Key1: 'Value1', Key2: 'Value2'}}
+
+      mockResourceTags(lambdaClientMock, expectedTags)
+
+      const tags = await getTags(lambdaClientMock, MOCK_REGION, MOCK_ARN)
+      expect(tags).toMatchSnapshot()
+    })
+
+    it('should return an empty object when there are no tags', async () => {
+      const expectedTags: any = {Tags: {}}
+      mockResourceTags(lambdaClientMock, expectedTags)
+
+      const tags = await getTags(lambdaClientMock, MOCK_REGION, MOCK_ARN)
+      expect(tags).toEqual({})
+    })
+
+    it('should throw an error when the command fails', async () => {
+      const errorMessage = 'Unable to get resource tags: Test Error'
+      lambdaClientMock.on(ListTagsCommand).rejects(new Error('Test Error'))
+
+      await expect(getTags(lambdaClientMock, MOCK_REGION, MOCK_ARN)).rejects.toThrow(errorMessage)
+      mockResourceTags(lambdaClientMock, mockTags)
     })
   })
 

--- a/src/commands/lambda/flare.ts
+++ b/src/commands/lambda/flare.ts
@@ -144,10 +144,9 @@ export class LambdaFlareCommand extends Command {
 
     // Get tags
     this.context.stdout.write('\n🏷 Getting Resource Tags...\n')
-    const arn = config.FunctionArn ?? this.functionName
     let tags: Record<string, string>
     try {
-      tags = await getTags(lambdaClient, region!, arn)
+      tags = await getTags(lambdaClient, region!, config.FunctionArn!)
     } catch (err) {
       if (err instanceof Error) {
         this.context.stderr.write(commonRenderer.renderError(err.message))

--- a/src/commands/lambda/flare.ts
+++ b/src/commands/lambda/flare.ts
@@ -155,15 +155,11 @@ export class LambdaFlareCommand extends Command {
 
       return 1
     }
-    const tagLength = Object.keys(tags).length
-    if (tagLength === 0) {
-      this.context.stdout.write(
-        commonRenderer.renderSoftWarning(
-          `No resource tags were found, so the \`${TAGS_FILE_NAME}\` file will not be created or sent.`
-        )
-      )
+    const tagsLength = Object.keys(tags).length
+    if (tagsLength === 0) {
+      this.context.stdout.write(commonRenderer.renderSoftWarning(`No resource tags were found.`))
     } else {
-      this.context.stdout.write(`✅ Found ${tagLength} resource tags.\n`)
+      this.context.stdout.write(`✅ Found ${tagsLength} resource tags.\n`)
     }
 
     // Get CloudWatch logs
@@ -214,7 +210,7 @@ export class LambdaFlareCommand extends Command {
       const configFilePath = path.join(rootFolderPath, FUNCTION_CONFIG_FILE_NAME)
       writeFile(configFilePath, JSON.stringify(config, undefined, 2))
       this.context.stdout.write(`• Saved function config to ${configFilePath}\n`)
-      if (tagLength > 0) {
+      if (tagsLength > 0) {
         const tagsFilePath = path.join(rootFolderPath, TAGS_FILE_NAME)
         writeFile(tagsFilePath, JSON.stringify(tags, undefined, 2))
         this.context.stdout.write(`• Saved tags to ${tagsFilePath}\n`)

--- a/src/commands/lambda/flare.ts
+++ b/src/commands/lambda/flare.ts
@@ -156,7 +156,15 @@ export class LambdaFlareCommand extends Command {
       return 1
     }
     const tagLength = Object.keys(tags).length
-    this.context.stdout.write(`✅ Found ${tagLength} resource tag${tagLength === 1 ? '' : 's'}.\n`)
+    if (tagLength === 0) {
+      this.context.stdout.write(
+        commonRenderer.renderSoftWarning(
+          'No resource tags were found, so the `tags.json` file will not be created or sent.'
+        )
+      )
+    } else {
+      this.context.stdout.write(`✅ Found ${tagLength} resource tags.\n`)
+    }
 
     // Get CloudWatch logs
     let logs: Map<string, OutputLogEvent[]> = new Map()

--- a/src/commands/lambda/flare.ts
+++ b/src/commands/lambda/flare.ts
@@ -159,7 +159,7 @@ export class LambdaFlareCommand extends Command {
     if (tagLength === 0) {
       this.context.stdout.write(
         commonRenderer.renderSoftWarning(
-          'No resource tags were found, so the `tags.json` file will not be created or sent.'
+          `No resource tags were found, so the \`${TAGS_FILE_NAME}\` file will not be created or sent.`
         )
       )
     } else {

--- a/src/commands/lambda/flare.ts
+++ b/src/commands/lambda/flare.ts
@@ -472,6 +472,9 @@ export const getAllLogs = async (region: string, functionName: string) => {
  * @throws Error if the tags cannot be retrieved
  */
 export const getTags = async (lambdaClient: LambdaClient, region: string, arn: string) => {
+  if (!arn.startsWith('arn:aws')) {
+    throw Error(`Invalid function ARN: ${arn}`)
+  }
   const command = new ListTagsCommand({
     Resource: arn,
   })

--- a/src/commands/lambda/flare.ts
+++ b/src/commands/lambda/flare.ts
@@ -9,7 +9,7 @@ import {
   OrderBy,
   OutputLogEvent,
 } from '@aws-sdk/client-cloudwatch-logs'
-import {FunctionConfiguration, LambdaClient, LambdaClientConfig} from '@aws-sdk/client-lambda'
+import {FunctionConfiguration, LambdaClient, LambdaClientConfig, ListTagsCommand} from '@aws-sdk/client-lambda'
 import {AwsCredentialIdentity} from '@aws-sdk/types'
 import axios from 'axios'
 import {Command} from 'clipanion'
@@ -29,6 +29,7 @@ const ENDPOINT_URL = 'https://datad0g.com/api/ui/support/serverless/flare'
 const FLARE_OUTPUT_DIRECTORY = '.datadog-ci'
 const LOGS_DIRECTORY = 'logs'
 const FUNCTION_CONFIG_FILE_NAME = 'function_config.json'
+const TAGS_FILE_NAME = 'tags.json'
 const ZIP_FILE_NAME = 'lambda-flare-output.zip'
 const LOG_STREAM_COUNT = 3
 const FULL_OBFUSCATION = '****************'
@@ -141,6 +142,22 @@ export class LambdaFlareCommand extends Command {
     const configStr = util.inspect(config, false, undefined, true)
     this.context.stdout.write(`\n${configStr}\n`)
 
+    // Get tags
+    this.context.stdout.write('\n🏷 Getting Resource Tags...\n')
+    const arn = config.FunctionArn ?? this.functionName
+    let tags: Record<string, string>
+    try {
+      tags = await getTags(lambdaClient, region!, arn)
+    } catch (err) {
+      if (err instanceof Error) {
+        this.context.stderr.write(commonRenderer.renderError(err.message))
+      }
+
+      return 1
+    }
+    const tagLength = Object.keys(tags).length
+    this.context.stdout.write(`✅ Found ${tagLength} resource tag${tagLength === 1 ? '' : 's'}.\n`)
+
     // Get CloudWatch logs
     let logs: Map<string, OutputLogEvent[]> = new Map()
     if (this.withLogs) {
@@ -189,6 +206,11 @@ export class LambdaFlareCommand extends Command {
       const configFilePath = path.join(rootFolderPath, FUNCTION_CONFIG_FILE_NAME)
       writeFile(configFilePath, JSON.stringify(config, undefined, 2))
       this.context.stdout.write(`• Saved function config to ${configFilePath}\n`)
+      if (tagLength > 0) {
+        const tagsFilePath = path.join(rootFolderPath, TAGS_FILE_NAME)
+        writeFile(tagsFilePath, JSON.stringify(tags, undefined, 2))
+        this.context.stdout.write(`• Saved tags to ${tagsFilePath}\n`)
+      }
       for (const [logStreamName, logEvents] of logs) {
         if (logEvents.length === 0) {
           continue
@@ -431,6 +453,31 @@ export const getAllLogs = async (region: string, functionName: string) => {
   }
 
   return logs
+}
+
+/**
+ * Gets the tags for a function
+ * @param lambdaClient
+ * @param region
+ * @param arn
+ * @returns the tags or an empty object if no tags are found
+ * @throws Error if the tags cannot be retrieved
+ */
+export const getTags = async (lambdaClient: LambdaClient, region: string, arn: string) => {
+  const command = new ListTagsCommand({
+    Resource: arn,
+  })
+  try {
+    const response = await lambdaClient.send(command)
+
+    return response.Tags ?? {}
+  } catch (err) {
+    let message = ''
+    if (err instanceof Error) {
+      message = err.message
+    }
+    throw Error(`Unable to get resource tags: ${message}`)
+  }
 }
 
 /**


### PR DESCRIPTION
### What and why?

For more context on what Lambda Flare is, please read the description in this PR: https://github.com/DataDog/datadog-ci/pull/924

- Get resource tags for an AWS lambda function
- Save them in `tags.json`
- This is because resource tags can be useful to the Datadog support team when resolving customer issues

<img width="454" alt="Screenshot 2023-07-03 at 3 44 15 PM" src="https://github.com/DataDog/datadog-ci/assets/29668820/e649398b-8e7c-40f1-8923-146e4b331627">

<img width="699" alt="Screenshot 2023-07-03 at 3 53 02 PM" src="https://github.com/DataDog/datadog-ci/assets/29668820/ee855fcf-48d1-476f-bc83-c32742e5dbcf">

I also refactored tests a little bit by standardizing `region` in `flare.test.ts` to use `const MOCK_REGION = 'us-east-1'`

### How?

1. Create a `getTags` function to gather resource tags
2. Use `ListTagsCommand` in the AWS SDK to get resource tags for a particular function ARN
3. The function ARN is retrieved from the function config, which is fetched previously in the command
4. Use try/catch statements to ensure human-readable error logging
5. Write to `tags.json` when tags are found using the `writeFile` method. When no tags are found, no file is written.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
