### PR TITLE
Improve unshallowing and git metadata upload

### DIFF
--- a/src/commands/git-metadata/__tests__/git.test.ts
+++ b/src/commands/git-metadata/__tests__/git.test.ts
@@ -1,6 +1,6 @@
 import * as simpleGit from 'simple-git'
 
-import {getCommitInfo, gitRemote, newSimpleGit, stripCredentials} from '../git'
+import {getCommitInfo, newSimpleGit, stripCredentials} from '../git'
 
 interface MockConfig {
   hash?: string
@@ -9,6 +9,8 @@ interface MockConfig {
 }
 
 const createMockSimpleGit = (conf: MockConfig) => ({
+  // eslint-disable-next-line no-null/no-null
+  getConfig: (_: string) => ({value: null}),
   getRemotes: async (_: boolean) => {
     if (conf.remotes === undefined) {
       throw Error('Unexpected call to getRemotes')
@@ -32,31 +34,6 @@ const createMockSimpleGit = (conf: MockConfig) => ({
 })
 
 describe('git', () => {
-  describe('gitRemote', () => {
-    test('should choose the remote named origin', async () => {
-      const mock = createMockSimpleGit({
-        remotes: [
-          {name: 'first', refs: {push: 'remote1'}},
-          {name: 'origin', refs: {push: 'remote2'}},
-        ],
-      }) as any
-      const remote = await gitRemote(mock)
-
-      expect(remote).toBe('remote2')
-    })
-    test('should choose the first remote', async () => {
-      const mock = createMockSimpleGit({
-        remotes: [
-          {name: 'first', refs: {push: 'remote1'}},
-          {name: 'second', refs: {push: 'remote2'}},
-        ],
-      }) as any
-      const remote = await gitRemote(mock)
-
-      expect(remote).toBe('remote1')
-    })
-  })
-
   describe('stripCredentials: git protocol', () => {
     test('should return the same value', () => {
       const input = 'git@github.com:user/project.git'
@@ -115,7 +92,7 @@ describe('git', () => {
 
   describe('newSimpleGit', () => {
     test('should throw an error if git is not installed', async () => {
-      jest.spyOn(simpleGit, 'gitP').mockImplementation(() => {
+      jest.spyOn(simpleGit, 'simpleGit').mockImplementation(() => {
         throw Error('gitp error')
       })
       await expect(newSimpleGit()).rejects.toThrow('gitp error')
@@ -123,7 +100,7 @@ describe('git', () => {
 
     test('should throw an error if revparse throws an error', async () => {
       const mock = createMockSimpleGit({}) as any
-      jest.spyOn(simpleGit, 'gitP').mockReturnValue(mock)
+      jest.spyOn(simpleGit, 'simpleGit').mockReturnValue(mock)
       jest.spyOn(mock, 'revparse').mockImplementation(async () => {
         throw Error('revparse error')
       })
@@ -133,7 +110,7 @@ describe('git', () => {
 
     test('should not throw any errors', async () => {
       const mock = createMockSimpleGit({}) as any
-      jest.spyOn(simpleGit, 'gitP').mockReturnValue(mock)
+      jest.spyOn(simpleGit, 'simpleGit').mockReturnValue(mock)
       jest.spyOn(mock, 'revparse').mockResolvedValue('1234')
 
       await expect(newSimpleGit()).resolves.not.toThrow()

--- a/src/commands/git-metadata/__tests__/gitdb.test.ts
+++ b/src/commands/git-metadata/__tests__/gitdb.test.ts
@@ -269,7 +269,7 @@ describe('gitdb', () => {
           input: [
             '--shallow-since="1 month ago"',
             '--update-shallow',
-            '--filter="blob:none"',
+            '--filter=blob:none',
             '--recurse-submodules=no',
             'origin',
             'COMMIT',
@@ -330,7 +330,7 @@ describe('gitdb', () => {
           input: [
             '--shallow-since="1 month ago"',
             '--update-shallow',
-            '--filter="blob:none"',
+            '--filter=blob:none',
             '--recurse-submodules=no',
             'myorigin',
             'COMMIT',
@@ -435,7 +435,7 @@ describe('gitdb', () => {
         },
       ],
       revparse: [{input: '--is-shallow-repository', output: 'false'}],
-      version: [{input: undefined, output: newGitVersion}],
+      version: [],
       execSync: [
         {
           input: `git pack-objects --compression=9 --max-pack-size=3m ${tmpdir}/1000`,
@@ -520,7 +520,7 @@ describe('gitdb', () => {
         },
       ],
       revparse: [{input: '--is-shallow-repository', output: 'false'}],
-      version: [{input: undefined, output: newGitVersion}],
+      version: [],
       execSync: [
         {
           input: `git pack-objects --compression=9 --max-pack-size=3m ${tmpdir}/1000`,
@@ -621,7 +621,7 @@ describe('gitdb', () => {
         },
       ],
       revparse: [{input: '--is-shallow-repository', output: 'false'}],
-      version: [{input: undefined, output: newGitVersion}],
+      version: [],
       execSync: [
         {
           input: `git pack-objects --compression=9 --max-pack-size=3m ${tmpdir}/1000`,
@@ -718,7 +718,7 @@ describe('gitdb', () => {
         },
       ],
       revparse: [{input: '--is-shallow-repository', output: 'false'}],
-      version: [{input: undefined, output: newGitVersion}],
+      version: [],
       execSync: [
         {
           input: `git pack-objects --compression=9 --max-pack-size=3m ${tmpdir}/1000`,
@@ -823,7 +823,7 @@ describe('gitdb', () => {
       ],
       raw: [],
       revparse: [{input: '--is-shallow-repository', output: 'false'}],
-      version: [{input: undefined, output: newGitVersion}],
+      version: [],
       execSync: [],
       axios: [
         {
@@ -928,7 +928,7 @@ describe('gitdb', () => {
       ],
       raw: [],
       revparse: [{input: '--is-shallow-repository', output: 'false'}],
-      version: [{input: undefined, output: newGitVersion}],
+      version: [],
       execSync: [],
       axios: [
         {
@@ -1015,7 +1015,7 @@ describe('gitdb', () => {
         },
       ],
       revparse: [{input: '--is-shallow-repository', output: 'false'}],
-      version: [{input: undefined, output: newGitVersion}],
+      version: [],
       execSync: [],
       axios: [
         {

--- a/src/commands/git-metadata/__tests__/gitdb.test.ts
+++ b/src/commands/git-metadata/__tests__/gitdb.test.ts
@@ -87,6 +87,15 @@ describe('gitdb', () => {
     }
   )
 
+  const defaultRemoteNameNotConfigured = {
+    key: 'clone.defaultRemoteName',
+    paths: [],
+    scopes: new Map<string, string[]>(),
+    // eslint-disable-next-line no-null/no-null
+    value: null,
+    values: [],
+  }
+
   type MockParam<I, O> = {
     input: I | undefined
     output: O | Error
@@ -248,14 +257,11 @@ describe('gitdb', () => {
       getConfig: [
         {
           input: 'clone.defaultRemoteName',
-          output: {
-            key: 'clone.defaultRemoteName',
-            paths: [],
-            scopes: new Map<string, string[]>(),
-            // eslint-disable-next-line no-null/no-null
-            value: null,
-            values: [],
-          },
+          output: defaultRemoteNameNotConfigured,
+        },
+        {
+          input: 'clone.defaultRemoteName',
+          output: defaultRemoteNameNotConfigured,
         },
       ],
       fetch: [
@@ -308,6 +314,16 @@ describe('gitdb', () => {
             values: [],
           },
         },
+        {
+          input: 'clone.defaultRemoteName',
+          output: {
+            key: 'clone.defaultRemoteName',
+            paths: [],
+            scopes: new Map<string, string[]>(),
+            value: 'myorigin',
+            values: [],
+          },
+        },
       ],
       fetch: [
         {
@@ -347,7 +363,12 @@ describe('gitdb', () => {
 
   test('should not unshallow repository if git version is old', async () => {
     const mocks = new MockAll({
-      getConfig: [],
+      getConfig: [
+        {
+          input: 'clone.defaultRemoteName',
+          output: defaultRemoteNameNotConfigured,
+        },
+      ],
       fetch: [],
       getRemotes: [
         {
@@ -371,7 +392,12 @@ describe('gitdb', () => {
 
   test('should send packfiles', async () => {
     const mocks = new MockAll({
-      getConfig: [],
+      getConfig: [
+        {
+          input: 'clone.defaultRemoteName',
+          output: defaultRemoteNameNotConfigured,
+        },
+      ],
       fetch: [],
       getRemotes: [
         {
@@ -552,7 +578,12 @@ describe('gitdb', () => {
 
   test('should omit known commits', async () => {
     const mocks = new MockAll({
-      getConfig: [],
+      getConfig: [
+        {
+          input: 'clone.defaultRemoteName',
+          output: defaultRemoteNameNotConfigured,
+        },
+      ],
       fetch: [],
       getRemotes: [
         {
@@ -644,7 +675,12 @@ describe('gitdb', () => {
 
   test('retries http requests', async () => {
     const mocks = new MockAll({
-      getConfig: [],
+      getConfig: [
+        {
+          input: 'clone.defaultRemoteName',
+          output: defaultRemoteNameNotConfigured,
+        },
+      ],
       fetch: [],
       getRemotes: [
         {
@@ -757,7 +793,12 @@ describe('gitdb', () => {
 
   test('fails after 3 http requests', async () => {
     const mocks = new MockAll({
-      getConfig: [],
+      getConfig: [
+        {
+          input: 'clone.defaultRemoteName',
+          output: defaultRemoteNameNotConfigured,
+        },
+      ],
       fetch: [],
       getRemotes: [
         {
@@ -857,7 +898,12 @@ describe('gitdb', () => {
 
   test('fail immediately if returned format is incorrect', async () => {
     const mocks = new MockAll({
-      getConfig: [],
+      getConfig: [
+        {
+          input: 'clone.defaultRemoteName',
+          output: defaultRemoteNameNotConfigured,
+        },
+      ],
       fetch: [],
       getRemotes: [
         {
@@ -926,7 +972,12 @@ describe('gitdb', () => {
 
   test('all commits are known, no packfile upload', async () => {
     const mocks = new MockAll({
-      getConfig: [],
+      getConfig: [
+        {
+          input: 'clone.defaultRemoteName',
+          output: defaultRemoteNameNotConfigured,
+        },
+      ],
       fetch: [],
       getRemotes: [
         {

--- a/src/commands/git-metadata/__tests__/gitdb.test.ts
+++ b/src/commands/git-metadata/__tests__/gitdb.test.ts
@@ -51,7 +51,7 @@ describe('gitdb', () => {
   // This is a bit hacky but the documentation of simpleGit asks you to depend on
   // a behavior of VersionResult which is not defined in its typings: it has an
   // override on toString. Here I am replicating this toString behavior so that
-  // the tests pass
+  // the tests pass. See https://github.com/steveukx/git-js/blob/d184c13273abca4b6572c260f9625c19f944d4f7/simple-git/src/lib/tasks/version.ts#L15-L39
   const newGitVersion: simpleGit.VersionResult = Object.defineProperty(
     {
       major: 2,

--- a/src/commands/git-metadata/__tests__/gitdb.test.ts
+++ b/src/commands/git-metadata/__tests__/gitdb.test.ts
@@ -49,7 +49,7 @@ describe('gitdb', () => {
   const testError = new Error('call failed')
 
   // This is a bit hacky but the documentation of simpleGit asks you to depend on
-  // a behavior of VersionResult which is not debined in its typings: it has an
+  // a behavior of VersionResult which is not defined in its typings: it has an
   // override on toString. Here I am replicating this toString behavior so that
   // the tests pass
   const newGitVersion: simpleGit.VersionResult = Object.defineProperty(

--- a/src/commands/git-metadata/git.ts
+++ b/src/commands/git-metadata/git.ts
@@ -2,6 +2,8 @@ import {URL} from 'url'
 
 import * as simpleGit from 'simple-git'
 
+import {gitRemote} from '../../helpers/git/get-git-data'
+
 import {CommitInfo} from './interfaces'
 
 // Returns a configured SimpleGit.
@@ -13,29 +15,11 @@ export const newSimpleGit = async (): Promise<simpleGit.SimpleGit> => {
   }
   // Attempt to set the baseDir to the root of the repository so the 'git ls-files' command
   // returns the tracked files paths relative to the root of the repository.
-  const git = simpleGit.gitP(options)
+  const git = simpleGit.simpleGit(options)
   const root = await git.revparse('--show-toplevel')
   options.baseDir = root
 
-  return simpleGit.gitP(options)
-}
-
-// Returns the remote of the current repository.
-export const gitRemote = async (git: simpleGit.SimpleGit): Promise<string> => {
-  const remotes = await git.getRemotes(true)
-  if (remotes.length === 0) {
-    throw new Error('No git remotes available')
-  }
-
-  for (const remote of remotes) {
-    // We're trying to pick the remote called with the default git name 'origin'.
-    if (remote.name === 'origin') {
-      return stripCredentials(remote.refs.push)
-    }
-  }
-
-  // Falling back to picking the first remote in the list if 'origin' is not found.
-  return stripCredentials(remotes[0].refs.push)
+  return simpleGit.simpleGit(options)
 }
 
 // StripCredentials removes credentials from a remote HTTP url.

--- a/src/commands/git-metadata/gitdb.ts
+++ b/src/commands/git-metadata/gitdb.ts
@@ -9,11 +9,10 @@ import FormData from 'form-data'
 import {gte} from 'semver'
 import * as simpleGit from 'simple-git'
 
+import {getDefaultRemoteName, gitRemote as getRepoURL} from '../../helpers/git/get-git-data'
 import {RequestBuilder} from '../../helpers/interfaces'
 import {Logger} from '../../helpers/logger'
 import {retryRequest} from '../../helpers/retry'
-
-import {gitRemote as getRepoURL} from './git'
 
 const API_TIMEOUT = 15000
 
@@ -126,7 +125,7 @@ const unshallowRepositoryWhenNeeded = async (log: Logger, git: simpleGit.SimpleG
   if (isShallow && gte(gitversion, '2.27.0')) {
     log.info('[unshallow] Git repository is a shallow clone, unshallowing it...')
     const headCmdPromise = git.revparse('HEAD')
-    const remoteNameCmdPromise = git.getConfig('clone.defaultRemoteName')
+    const remoteNameCmdPromise = getDefaultRemoteName(git)
     log.info(
       `[unshallow] Running git fetch --shallow-since="${MAX_HISTORY.oldestCommits}" --update-shallow --filter="blob:none" --recurse-submodules=no`
     )
@@ -135,7 +134,7 @@ const unshallowRepositoryWhenNeeded = async (log: Logger, git: simpleGit.SimpleG
       '--update-shallow',
       '--filter="blob:none"',
       '--recurse-submodules=no',
-      (await remoteNameCmdPromise).value ?? 'origin',
+      (await remoteNameCmdPromise) ?? 'origin',
       await headCmdPromise,
     ])
     log.info('[unshallow] Fetch completed.')

--- a/src/commands/git-metadata/gitdb.ts
+++ b/src/commands/git-metadata/gitdb.ts
@@ -6,7 +6,7 @@ import path from 'path'
 
 import {AxiosResponse} from 'axios'
 import FormData from 'form-data'
-import {gte} from 'semver'
+import {lte} from 'semver'
 import * as simpleGit from 'simple-git'
 
 import {getDefaultRemoteName, gitRemote as getRepoURL} from '../../helpers/git/get-git-data'
@@ -127,21 +127,20 @@ const unshallowRepositoryWhenNeeded = async (log: Logger, git: simpleGit.SimpleG
     return
   }
   log.info('[unshallow] Git repository is a shallow clone, unshallowing it...')
-    const headCmdPromise = git.revparse('HEAD')
-    const remoteNameCmdPromise = getDefaultRemoteName(git)
-    log.info(
-      `[unshallow] Running git fetch --shallow-since="${MAX_HISTORY.oldestCommits}" --update-shallow --filter=blob:none --recurse-submodules=no`
-    )
-    await git.fetch([
-      `--shallow-since="${MAX_HISTORY.oldestCommits}"`,
-      '--update-shallow',
-      '--filter=blob:none',
-      '--recurse-submodules=no',
-      (await remoteNameCmdPromise) ?? 'origin',
-      await headCmdPromise,
-    ])
-    log.info('[unshallow] Fetch completed.')
-  }
+  const headCmdPromise = git.revparse('HEAD')
+  const remoteNameCmdPromise = getDefaultRemoteName(git)
+  log.info(
+    `[unshallow] Running git fetch --shallow-since="${MAX_HISTORY.oldestCommits}" --update-shallow --filter=blob:none --recurse-submodules=no`
+  )
+  await git.fetch([
+    `--shallow-since="${MAX_HISTORY.oldestCommits}"`,
+    '--update-shallow',
+    '--filter=blob:none',
+    '--recurse-submodules=no',
+    (await remoteNameCmdPromise) ?? 'origin',
+    await headCmdPromise,
+  ])
+  log.info('[unshallow] Fetch completed.')
 }
 
 // getKnownCommits asks the backend which of the given commits are already known

--- a/src/helpers/git/__tests__/format-git-sourcemaps-data.test.ts
+++ b/src/helpers/git/__tests__/format-git-sourcemaps-data.test.ts
@@ -68,6 +68,7 @@ describe('git', () => {
 
   describe('GetRepositoryData', () => {
     const createMockSimpleGit = () => ({
+      getConfig: (arg: string) => ({value: 'origin'}),
       getRemotes: (arg: boolean) => [{refs: {push: 'git@github.com:user/repository.git'}}],
       raw: (arg: string) => 'src/commands/sourcemaps/__tests__/git.test.ts',
       revparse: (arg: string) => '25da22df90210a40b919debe3f7ebfb0c1811898',

--- a/src/helpers/git/__tests__/get-git-data.test.ts
+++ b/src/helpers/git/__tests__/get-git-data.test.ts
@@ -2,24 +2,46 @@ import {gitRemote, stripCredentials} from '../get-git-data'
 
 describe('git', () => {
   describe('gitRemote', () => {
-    const createMockSimpleGit = (remotes: any[]) => ({
+    const createMockSimpleGit = (remotes: any[], defaultOrigin: string | undefined) => ({
       getRemotes: (arg: boolean) => remotes,
+      getConfig: (arg: string) => ({
+        // eslint-disable-next-line no-null/no-null
+        value: defaultOrigin ?? null,
+      }),
     })
 
-    test('should choose the remote named origin', async () => {
-      const mock = createMockSimpleGit([
-        {name: 'first', refs: {push: 'remote1'}},
-        {name: 'origin', refs: {push: 'remote2'}},
-      ]) as any
+    test('should choose the remote named origin if no default is specified', async () => {
+      const mock = createMockSimpleGit(
+        [
+          {name: 'first', refs: {push: 'remote1'}},
+          {name: 'origin', refs: {push: 'remote2'}},
+        ],
+        undefined
+      ) as any
       const remote = await gitRemote(mock)
 
       expect(remote).toBe('remote2')
     })
+    test('should choose the remote named first if that is the default origin', async () => {
+      const mock = createMockSimpleGit(
+        [
+          {name: 'first', refs: {push: 'remote1'}},
+          {name: 'origin', refs: {push: 'remote2'}},
+        ],
+        'first'
+      ) as any
+      const remote = await gitRemote(mock)
+
+      expect(remote).toBe('remote1')
+    })
     test('should choose the first remote', async () => {
-      const mock = createMockSimpleGit([
-        {name: 'first', refs: {push: 'remote1'}},
-        {name: 'second', refs: {push: 'remote2'}},
-      ]) as any
+      const mock = createMockSimpleGit(
+        [
+          {name: 'first', refs: {push: 'remote1'}},
+          {name: 'second', refs: {push: 'remote2'}},
+        ],
+        undefined
+      ) as any
       const remote = await gitRemote(mock)
 
       expect(remote).toBe('remote1')

--- a/src/helpers/git/format-git-sourcemaps-data.ts
+++ b/src/helpers/git/format-git-sourcemaps-data.ts
@@ -15,14 +15,14 @@ export const newSimpleGit = async (): Promise<simpleGit.SimpleGit> => {
   try {
     // Attempt to set the baseDir to the root of the repository so the 'git ls-files' command
     // returns the tracked files paths relative to the root of the repository.
-    const git = simpleGit.gitP(options)
+    const git = simpleGit.simpleGit(options)
     const root = await git.revparse('--show-toplevel')
     options.baseDir = root
   } catch {
     // Ignore exception as it will fail if we are not inside a git repository.
   }
 
-  return simpleGit.gitP(options)
+  return simpleGit.simpleGit(options)
 }
 
 export interface RepositoryData {

--- a/src/helpers/git/get-git-data.ts
+++ b/src/helpers/git/get-git-data.ts
@@ -9,16 +9,27 @@ export const gitRemote = async (git: simpleGit.SimpleGit): Promise<string> => {
   if (remotes.length === 0) {
     throw new Error('No git remotes available')
   }
+  const defaultRemote = await getDefaultRemoteName(git)
 
   for (const remote of remotes) {
     // We're trying to pick the remote called with the default git name 'origin'.
-    if (remote.name === 'origin') {
+    if (remote.name === defaultRemote) {
       return stripCredentials(remote.refs.push)
     }
   }
 
   // Falling back to picking the first remote in the list if 'origin' is not found.
   return stripCredentials(remotes[0].refs.push)
+}
+
+export const getDefaultRemoteName = async (git: simpleGit.SimpleGit): Promise<string> => {
+  try {
+    const defaultRemoteConfig = (await git.getConfig('clone.defaultRemoteName')) ?? {}
+
+    return defaultRemoteConfig.value ?? 'origin'
+  } catch (e) {
+    return 'origin'
+  }
 }
 
 // StripCredentials removes credentials from a remote HTTP url.

--- a/src/helpers/git/get-git-data.ts
+++ b/src/helpers/git/get-git-data.ts
@@ -12,13 +12,12 @@ export const gitRemote = async (git: simpleGit.SimpleGit): Promise<string> => {
   const defaultRemote = await getDefaultRemoteName(git)
 
   for (const remote of remotes) {
-    // We're trying to pick the remote called with the default git name 'origin'.
     if (remote.name === defaultRemote) {
       return stripCredentials(remote.refs.push)
     }
   }
 
-  // Falling back to picking the first remote in the list if 'origin' is not found.
+  // Falling back to picking the first remote in the list if the default remote is not found.
   return stripCredentials(remotes[0].refs.push)
 }
 

--- a/src/helpers/git/get-git-data.ts
+++ b/src/helpers/git/get-git-data.ts
@@ -23,9 +23,7 @@ export const gitRemote = async (git: simpleGit.SimpleGit): Promise<string> => {
 
 export const getDefaultRemoteName = async (git: simpleGit.SimpleGit): Promise<string> => {
   try {
-    const defaultRemoteConfig = (await git.getConfig('clone.defaultRemoteName')) ?? {}
-
-    return defaultRemoteConfig.value ?? 'origin'
+    return (await git.getConfig('clone.defaultRemoteName'))?.value ?? 'origin'
   } catch (e) {
     return 'origin'
   }


### PR DESCRIPTION
### What and why?

Improve git metadata upload:
- We now work with git repositories whose default remote is not "origin"
- We do not change the git config when doing git metadata upload
- Improved git metadata upload on error conditions
- Reduced code duplication

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
