### PR TITLE
[lambda][flare] Refactor flag validation

### DIFF
--- a/src/commands/lambda/flare.ts
+++ b/src/commands/lambda/flare.ts
@@ -53,13 +53,13 @@ export class LambdaFlareCommand extends Command {
     this.context.stdout.write(flareRenderer.renderLambdaFlareHeader(this.isDryRun))
 
     // Validate function name
-    const errorMessages: string[] = []
     if (this.functionName === undefined) {
       this.context.stderr.write(commonRenderer.renderError('No function name specified. [-f,--function]'))
 
       return 1
     }
 
+    const errorMessages: string[] = []
     // Validate region
     const region = getRegion(this.functionName) ?? this.region ?? process.env[AWS_DEFAULT_REGION_ENV_VAR]
     if (region === undefined) {

--- a/src/commands/lambda/flare.ts
+++ b/src/commands/lambda/flare.ts
@@ -53,6 +53,7 @@ export class LambdaFlareCommand extends Command {
     this.context.stdout.write(flareRenderer.renderLambdaFlareHeader(this.isDryRun))
 
     // Validate function name
+    const errorMessages = []
     if (this.functionName === undefined) {
       this.context.stderr.write(commonRenderer.renderError('No function name specified. [-f,--function]'))
 
@@ -60,37 +61,36 @@ export class LambdaFlareCommand extends Command {
     }
 
     // Validate region
-    let errorFound = false
     const region = getRegion(this.functionName) ?? this.region ?? process.env[AWS_DEFAULT_REGION_ENV_VAR]
     if (region === undefined) {
-      this.context.stderr.write(commonRenderer.renderNoDefaultRegionSpecifiedError())
-      errorFound = true
+      errorMessages.push(commonRenderer.renderNoDefaultRegionSpecifiedError())
     }
 
     // Validate Datadog API key
     this.apiKey = process.env[CI_API_KEY_ENV_VAR] ?? process.env[API_KEY_ENV_VAR]
     if (this.apiKey === undefined) {
-      this.context.stderr.write(
+      errorMessages.push(
         commonRenderer.renderError(
           'No Datadog API key specified. Set an API key with the DATADOG_API_KEY environment variable.'
         )
       )
-      errorFound = true
     }
 
     // Validate case ID
     if (this.caseId === undefined) {
-      this.context.stderr.write(commonRenderer.renderError('No case ID specified. [-c,--case-id]'))
-      errorFound = true
+      errorMessages.push(commonRenderer.renderError('No case ID specified. [-c,--case-id]'))
     }
 
     // Validate email
     if (this.email === undefined) {
-      this.context.stderr.write(commonRenderer.renderError('No email specified. [-e,--email]'))
-      errorFound = true
+      errorMessages.push(commonRenderer.renderError('No email specified. [-e,--email]'))
     }
 
-    if (errorFound) {
+    if (errorMessages.length > 0) {
+      for (const message of errorMessages) {
+        this.context.stderr.write(message)
+      }
+
       return 1
     }
 

--- a/src/commands/lambda/flare.ts
+++ b/src/commands/lambda/flare.ts
@@ -53,7 +53,7 @@ export class LambdaFlareCommand extends Command {
     this.context.stdout.write(flareRenderer.renderLambdaFlareHeader(this.isDryRun))
 
     // Validate function name
-    const errorMessages = []
+    const errorMessages: string[] = []
     if (this.functionName === undefined) {
       this.context.stderr.write(commonRenderer.renderError('No function name specified. [-f,--function]'))
 


### PR DESCRIPTION
### What and why?

The code for validating flags in lambda flare was complicated and hard to read.
This PR doesn't change any logic in the code but makes validation more scalable and readable.
This is the strategy used in synthetics: https://github.com/DataDog/datadog-ci/blob/c082a1035d0558da9e6d2d0209c2bace98d78bf1/src/commands/synthetics/utils.ts#L572-L581

### How?

Have an `errorMessages` array and push error messages to the array when encountered.
After all the validation is complete, print any error messages and exit the program if any errors were found.

### Review checklist

- This is not a new feature or bugfix, so no tests were added or changed.
