### PR TITLE
[lambda][flare] Add optional start and end flags for getting CloudWatch logs

### DIFF
--- a/src/commands/lambda/__tests__/__snapshots__/flare.test.ts.snap
+++ b/src/commands/lambda/__tests__/__snapshots__/flare.test.ts.snap
@@ -707,9 +707,6 @@ exports[`lambda flare validates required flags prints error when start time is s
 "
 `;
 
-exports[`lambda flare validates required flags runs successfully when start and end times are valid 1`] = `
-"
-🐶 Generating Lambda flare to send your configuration to Datadog...
 exports[`lambda flare validates required flags runs successfully when dry run but no email or case ID is specified 1`] = `
 "
 [Dry Run] 🐶 Generating Lambda flare to send your configuration to Datadog...
@@ -738,13 +735,44 @@ exports[`lambda flare validates required flags runs successfully when dry run bu
 💾 Saving files...
 • Saved function config to mock-folder/.datadog-ci/function_config.json
 
-🚀 Sending to Datadog Support...
-
-✅ Successfully sent flare file to Datadog Support!
-
 🚫 The flare files were not sent as it was executed in dry run mode.
 ℹ️ Your output files are located at: mock-folder/.datadog-ci
 
+"
+`;
+
+exports[`lambda flare validates required flags runs successfully when start and end times are valid 1`] = `
+"
+🐶 Generating Lambda flare to send your configuration to Datadog...
+
+🔑 Getting AWS credentials...
+
+[!] No AWS credentials found, let's set them up! Or you can re-run the command and supply the AWS credentials in the same way when you invoke the AWS CLI.
+
+🔍 Fetching Lambda function configuration...
+
+{
+  Environment: {
+    Variables: {
+      DD_API_KEY: '02**********33bd',
+      DD_SITE: 'datadoghq.com',
+      DD_LOG_LEVEL: 'debug'
+    }
+  },
+  FunctionArn: 'arn:aws:lambda:us-east-1:123456789012:function:some-function',
+  FunctionName: 'some-function'
+}
+
+🏷 Getting Resource Tags...
+[!] No resource tags were found.
+
+💾 Saving files...
+• Saved function config to mock-folder/.datadog-ci/function_config.json
+
+
+🚀 Sending to Datadog Support...
+
+✅ Successfully sent flare file to Datadog Support!
 "
 `;
 

--- a/src/commands/lambda/__tests__/__snapshots__/flare.test.ts.snap
+++ b/src/commands/lambda/__tests__/__snapshots__/flare.test.ts.snap
@@ -719,6 +719,9 @@ exports[`lambda flare validates required flags runs successfully when start and 
   FunctionName: 'some-function'
 }
 
+🏷 Getting Resource Tags...
+[!] No resource tags were found.
+
 💾 Saving files...
 • Saved function config to mock-folder/.datadog-ci/function_config.json
 

--- a/src/commands/lambda/__tests__/__snapshots__/flare.test.ts.snap
+++ b/src/commands/lambda/__tests__/__snapshots__/flare.test.ts.snap
@@ -533,40 +533,15 @@ exports[`lambda flare send to Datadog successfully sends request to Datadog 1`] 
 "
 `;
 
-exports[`lambda flare validateStartEndFlags returns undefined when end is invalid 1`] = `
-Array [
-  "[Error] End time must be a time in milliseconds since Unix Epoch. [--end]
-",
-]
-`;
+exports[`lambda flare validateStartEndFlags throws error when end is invalid 1`] = `"End time must be a time in milliseconds since Unix Epoch. '234abc' is not a number."`;
 
-exports[`lambda flare validateStartEndFlags returns undefined when end is specified but start is not specified 1`] = `
-Array [
-  "[Error] Start time is required when end time is specified. [--start]
-",
-]
-`;
+exports[`lambda flare validateStartEndFlags throws error when end is specified but start is not specified 1`] = `"Start time is required when end time is specified. [--start]"`;
 
-exports[`lambda flare validateStartEndFlags returns undefined when start is invalid 1`] = `
-Array [
-  "[Error] Start time must be a time in milliseconds since Unix Epoch. [--start]
-",
-]
-`;
+exports[`lambda flare validateStartEndFlags throws error when start is invalid 1`] = `"Start time must be a time in milliseconds since Unix Epoch. '123abc' is not a number."`;
 
-exports[`lambda flare validateStartEndFlags returns undefined when start is not before the end time 1`] = `
-Array [
-  "[Error] Start time must be before end time.
-",
-]
-`;
+exports[`lambda flare validateStartEndFlags throws error when start is not before the end time 1`] = `"Start time must be before end time."`;
 
-exports[`lambda flare validateStartEndFlags returns undefined when start is specified but end is not specified 1`] = `
-Array [
-  "[Error] End time is required when start time is specified. [--end]
-",
-]
-`;
+exports[`lambda flare validateStartEndFlags throws error when start is specified but end is not specified 1`] = `"End time is required when start time is specified. [--end]"`;
 
 exports[`lambda flare validates required flags extracts region from function name when given a function ARN 1`] = `
 "
@@ -603,7 +578,7 @@ exports[`lambda flare validates required flags extracts region from function nam
 exports[`lambda flare validates required flags prints error when end time is invalid 1`] = `
 "
 🐶 Generating Lambda flare to send your configuration to Datadog...
-[Error] End time must be a time in milliseconds since Unix Epoch. [--end]
+[Error] End time must be a time in milliseconds since Unix Epoch. '123abc' is not a number.
 "
 `;
 
@@ -659,7 +634,7 @@ exports[`lambda flare validates required flags prints error when start time is a
 exports[`lambda flare validates required flags prints error when start time is invalid 1`] = `
 "
 🐶 Generating Lambda flare to send your configuration to Datadog...
-[Error] Start time must be a time in milliseconds since Unix Epoch. [--start]
+[Error] Start time must be a time in milliseconds since Unix Epoch. '123abc' is not a number.
 "
 `;
 

--- a/src/commands/lambda/__tests__/__snapshots__/flare.test.ts.snap
+++ b/src/commands/lambda/__tests__/__snapshots__/flare.test.ts.snap
@@ -533,41 +533,6 @@ exports[`lambda flare send to Datadog successfully sends request to Datadog 1`] 
 "
 `;
 
-exports[`lambda flare validateStartEndFlags returns [0, 0] when end is invalid 1`] = `
-Array [
-  "[Error] End time must be a time in milliseconds since Unix Epoch. [--end]
-",
-]
-`;
-
-exports[`lambda flare validateStartEndFlags returns [0, 0] when end is specified but start is not specified 1`] = `
-Array [
-  "[Error] Start time is required when end time is specified. [--start]
-",
-]
-`;
-
-exports[`lambda flare validateStartEndFlags returns [0, 0] when start is invalid 1`] = `
-Array [
-  "[Error] Start time must be a time in milliseconds since Unix Epoch. [--start]
-",
-]
-`;
-
-exports[`lambda flare validateStartEndFlags returns [0, 0] when start is not before the end time 1`] = `
-Array [
-  "[Error] Start time must be before end time.
-",
-]
-`;
-
-exports[`lambda flare validateStartEndFlags returns [0, 0] when start is specified but end is not specified 1`] = `
-Array [
-  "[Error] End time is required when start time is specified. [--end]
-",
-]
-`;
-
 exports[`lambda flare validateStartEndFlags returns undefined when end is invalid 1`] = `
 Array [
   "[Error] End time must be a time in milliseconds since Unix Epoch. [--end]

--- a/src/commands/lambda/__tests__/__snapshots__/flare.test.ts.snap
+++ b/src/commands/lambda/__tests__/__snapshots__/flare.test.ts.snap
@@ -533,6 +533,41 @@ exports[`lambda flare send to Datadog successfully sends request to Datadog 1`] 
 "
 `;
 
+exports[`lambda flare validateStartEndFlags returns [0, 0] when end is invalid 1`] = `
+Array [
+  "[Error] End time must be a time in milliseconds since Unix Epoch. [--end]
+",
+]
+`;
+
+exports[`lambda flare validateStartEndFlags returns [0, 0] when end is specified but start is not specified 1`] = `
+Array [
+  "[Error] Start time is required when end time is specified. [--start]
+",
+]
+`;
+
+exports[`lambda flare validateStartEndFlags returns [0, 0] when start is invalid 1`] = `
+Array [
+  "[Error] Start time must be a time in milliseconds since Unix Epoch. [--start]
+",
+]
+`;
+
+exports[`lambda flare validateStartEndFlags returns [0, 0] when start is not before the end time 1`] = `
+Array [
+  "[Error] Start time must be before end time.
+",
+]
+`;
+
+exports[`lambda flare validateStartEndFlags returns [0, 0] when start is specified but end is not specified 1`] = `
+Array [
+  "[Error] End time is required when start time is specified. [--end]
+",
+]
+`;
+
 exports[`lambda flare validates required flags extracts region from function name when given a function ARN 1`] = `
 "
 🐶 Generating Lambda flare to send your configuration to Datadog...
@@ -562,6 +597,20 @@ exports[`lambda flare validates required flags extracts region from function nam
 🚀 Sending to Datadog Support...
 
 ✅ Successfully sent flare file to Datadog Support!
+"
+`;
+
+exports[`lambda flare validates required flags prints error when end time is invalid 1`] = `
+"
+🐶 Generating Lambda flare to send your configuration to Datadog...
+[Error] End time must be a time in milliseconds since Unix Epoch. [--end]
+"
+`;
+
+exports[`lambda flare validates required flags prints error when end time is specified but start time is not 1`] = `
+"
+🐶 Generating Lambda flare to send your configuration to Datadog...
+[Error] Start time is required when end time is specified. [--start]
 "
 `;
 
@@ -597,6 +646,59 @@ exports[`lambda flare validates required flags prints error when no region speci
 "
 🐶 Generating Lambda flare to send your configuration to Datadog...
 [Error] No default region specified. [-r,--region]
+"
+`;
+
+exports[`lambda flare validates required flags prints error when start time is after end time 1`] = `
+"
+🐶 Generating Lambda flare to send your configuration to Datadog...
+[Error] Start time must be before end time.
+"
+`;
+
+exports[`lambda flare validates required flags prints error when start time is invalid 1`] = `
+"
+🐶 Generating Lambda flare to send your configuration to Datadog...
+[Error] Start time must be a time in milliseconds since Unix Epoch. [--start]
+"
+`;
+
+exports[`lambda flare validates required flags prints error when start time is specified but end time is not 1`] = `
+"
+🐶 Generating Lambda flare to send your configuration to Datadog...
+[Error] End time is required when start time is specified. [--end]
+"
+`;
+
+exports[`lambda flare validates required flags runs successfully when start and end times are valid 1`] = `
+"
+🐶 Generating Lambda flare to send your configuration to Datadog...
+
+🔑 Getting AWS credentials...
+
+[!] No AWS credentials found, let's set them up! Or you can re-run the command and supply the AWS credentials in the same way when you invoke the AWS CLI.
+
+🔍 Fetching Lambda function configuration...
+
+{
+  Environment: {
+    Variables: {
+      DD_API_KEY: '02**********33bd',
+      DD_SITE: 'datadoghq.com',
+      DD_LOG_LEVEL: 'debug'
+    }
+  },
+  FunctionArn: 'arn:aws:lambda:us-east-1:123456789012:function:some-function',
+  FunctionName: 'some-function'
+}
+
+💾 Saving files...
+• Saved function config to mock-folder/.datadog-ci/function_config.json
+
+
+🚀 Sending to Datadog Support...
+
+✅ Successfully sent flare file to Datadog Support!
 "
 `;
 

--- a/src/commands/lambda/__tests__/__snapshots__/flare.test.ts.snap
+++ b/src/commands/lambda/__tests__/__snapshots__/flare.test.ts.snap
@@ -568,6 +568,41 @@ Array [
 ]
 `;
 
+exports[`lambda flare validateStartEndFlags returns undefined when end is invalid 1`] = `
+Array [
+  "[Error] End time must be a time in milliseconds since Unix Epoch. [--end]
+",
+]
+`;
+
+exports[`lambda flare validateStartEndFlags returns undefined when end is specified but start is not specified 1`] = `
+Array [
+  "[Error] Start time is required when end time is specified. [--start]
+",
+]
+`;
+
+exports[`lambda flare validateStartEndFlags returns undefined when start is invalid 1`] = `
+Array [
+  "[Error] Start time must be a time in milliseconds since Unix Epoch. [--start]
+",
+]
+`;
+
+exports[`lambda flare validateStartEndFlags returns undefined when start is not before the end time 1`] = `
+Array [
+  "[Error] Start time must be before end time.
+",
+]
+`;
+
+exports[`lambda flare validateStartEndFlags returns undefined when start is specified but end is not specified 1`] = `
+Array [
+  "[Error] End time is required when start time is specified. [--end]
+",
+]
+`;
+
 exports[`lambda flare validates required flags extracts region from function name when given a function ARN 1`] = `
 "
 🐶 Generating Lambda flare to send your configuration to Datadog...

--- a/src/commands/lambda/__tests__/flare.test.ts
+++ b/src/commands/lambda/__tests__/flare.test.ts
@@ -307,53 +307,38 @@ describe('lambda flare', () => {
   })
 
   describe('validateStartEndFlags', () => {
-    it('returns undefined when start and end flags are not specified', () => {
+    it('returns [0, 0] when start and end flags are not specified', () => {
       const errorMessages: string[] = []
-      const res = validateStartEndFlags(undefined, undefined, errorMessages)
-      expect(res).toBeUndefined()
+      const res = validateStartEndFlags(undefined, undefined)
+      expect(res).toEqual([0, 0])
       expect(errorMessages).toEqual([])
     })
 
-    it('returns undefined when start is specified but end is not specified', () => {
-      const errorMessages: string[] = []
-      const res = validateStartEndFlags('123', undefined, errorMessages)
-      expect(res).toBeUndefined()
-      expect(errorMessages).toMatchSnapshot()
+    it('throws error when start is specified but end is not specified', () => {
+      expect(() => validateStartEndFlags('123', undefined)).toThrowErrorMatchingSnapshot()
     })
 
-    it('returns undefined when end is specified but start is not specified', () => {
-      const errorMessages: string[] = []
-      const res = validateStartEndFlags(undefined, '123', errorMessages)
-      expect(res).toBeUndefined()
-      expect(errorMessages).toMatchSnapshot()
+    it('throws error when end is specified but start is not specified', () => {
+      expect(() => validateStartEndFlags(undefined, '123')).toThrowErrorMatchingSnapshot()
     })
 
-    it('returns undefined when start is invalid', () => {
-      const errorMessages: string[] = []
-      const res = validateStartEndFlags('123abc', '200', errorMessages)
-      expect(res).toBeUndefined()
-      expect(errorMessages).toMatchSnapshot()
+    it('throws error when start is invalid', () => {
+      expect(() => validateStartEndFlags('123abc', '200')).toThrowErrorMatchingSnapshot()
     })
 
-    it('returns undefined when end is invalid', () => {
-      const errorMessages: string[] = []
-      const res = validateStartEndFlags('100', '234abc', errorMessages)
-      expect(res).toBeUndefined()
-      expect(errorMessages).toMatchSnapshot()
+    it('throws error when end is invalid', () => {
+      expect(() => validateStartEndFlags('100', '234abc')).toThrowErrorMatchingSnapshot()
     })
 
-    it('returns undefined when start is not before the end time', () => {
-      const errorMessages: string[] = []
-      const res = validateStartEndFlags('200', '100', errorMessages)
-      expect(res).toBeUndefined()
-      expect(errorMessages).toMatchSnapshot()
+    it('throws error when start is not before the end time', () => {
+      expect(() => validateStartEndFlags('200', '100')).toThrowErrorMatchingSnapshot()
     })
 
     it('sets end time to current time if end time is too large', () => {
       const now = Date.now()
-      const res = validateStartEndFlags('0', '9999999999999', [])
+      const res = validateStartEndFlags('0', '9999999999999')
       expect(res).not.toBeUndefined()
-      const [start, end] = res!
+      const [start, end] = res
       expect(start).toBe(0)
       expect(end).toBeGreaterThanOrEqual(now - 1000)
       expect(end).toBeLessThanOrEqual(now + 1000)

--- a/src/commands/lambda/__tests__/flare.test.ts
+++ b/src/commands/lambda/__tests__/flare.test.ts
@@ -333,10 +333,10 @@ describe('lambda flare', () => {
   })
 
   describe('validateStartEndFlags', () => {
-    it('returns [0, 0] when start and end flags are not specified', () => {
+    it('returns [undefined, undefined] when start and end flags are not specified', () => {
       const errorMessages: string[] = []
       const res = validateStartEndFlags(undefined, undefined)
-      expect(res).toEqual([0, 0])
+      expect(res).toEqual([undefined, undefined])
       expect(errorMessages).toEqual([])
     })
 
@@ -468,7 +468,7 @@ describe('lambda flare', () => {
       mockCloudWatchLogStreams(cloudWatchLogsClientMock, mockStreams)
 
       const expectedLogStreams = ['Stream1', 'Stream2', 'Stream3']
-      const logStreams = await getLogStreamNames(new CloudWatchLogsClient({}), MOCK_LOG_GROUP, 0, 0)
+      const logStreams = await getLogStreamNames(new CloudWatchLogsClient({}), MOCK_LOG_GROUP, undefined, undefined)
 
       expect(logStreams).toEqual(expectedLogStreams)
     })
@@ -476,7 +476,7 @@ describe('lambda flare', () => {
     it('returns empty array when no log streams are found', async () => {
       mockCloudWatchLogStreams(cloudWatchLogsClientMock, [])
 
-      const logStreams = await getLogStreamNames(new CloudWatchLogsClient({}), MOCK_LOG_GROUP, 0, 0)
+      const logStreams = await getLogStreamNames(new CloudWatchLogsClient({}), MOCK_LOG_GROUP, undefined, undefined)
 
       expect(logStreams).toEqual([])
     })
@@ -485,7 +485,12 @@ describe('lambda flare', () => {
       cloudWatchLogsClientMock.on(DescribeLogStreamsCommand).rejects('Cannot retrieve log streams')
 
       await expect(
-        getLogStreamNames((cloudWatchLogsClientMock as unknown) as CloudWatchLogsClient, MOCK_LOG_GROUP, 0, 0)
+        getLogStreamNames(
+          (cloudWatchLogsClientMock as unknown) as CloudWatchLogsClient,
+          MOCK_LOG_GROUP,
+          undefined,
+          undefined
+        )
       ).rejects.toThrow('Cannot retrieve log streams')
     })
 
@@ -611,21 +616,21 @@ describe('lambda flare', () => {
       jest.spyOn(flareModule, 'getLogStreamNames').mockResolvedValue([mockStreamName])
       jest.spyOn(flareModule, 'getLogEvents').mockResolvedValue(mockLogs)
 
-      const result = await getAllLogs(MOCK_REGION, functionName, 0, 0)
+      const result = await getAllLogs(MOCK_REGION, functionName, undefined, undefined)
       expect(result.get(mockStreamName)).toEqual(mockLogs)
     })
 
     it('throws an error when unable to get log streams', async () => {
       jest.spyOn(flareModule, 'getLogStreamNames').mockRejectedValueOnce(new Error('Error getting log streams'))
 
-      await expect(getAllLogs(MOCK_REGION, functionName, 0, 0)).rejects.toMatchSnapshot()
+      await expect(getAllLogs(MOCK_REGION, functionName, undefined, undefined)).rejects.toMatchSnapshot()
     })
 
     it('throws an error when unable to get log events', async () => {
       jest.spyOn(flareModule, 'getLogStreamNames').mockResolvedValueOnce([mockStreamName])
       jest.spyOn(flareModule, 'getLogEvents').mockRejectedValueOnce(new Error('Error getting log events'))
 
-      await expect(getAllLogs(MOCK_REGION, functionName, 0, 0)).rejects.toMatchSnapshot()
+      await expect(getAllLogs(MOCK_REGION, functionName, undefined, undefined)).rejects.toMatchSnapshot()
     })
   })
 

--- a/src/commands/lambda/__tests__/flare.test.ts
+++ b/src/commands/lambda/__tests__/flare.test.ts
@@ -307,57 +307,53 @@ describe('lambda flare', () => {
   })
 
   describe('validateStartEndFlags', () => {
-    it('returns [0, 0] when start and end flags are not specified', () => {
+    it('returns undefined when start and end flags are not specified', () => {
       const errorMessages: string[] = []
-      const [start, end] = validateStartEndFlags(undefined, undefined, errorMessages)
-      expect(start).toBe(0)
-      expect(end).toBe(0)
+      const res = validateStartEndFlags(undefined, undefined, errorMessages)
+      expect(res).toBeUndefined()
       expect(errorMessages).toEqual([])
     })
 
-    it('returns [0, 0] when start is specified but end is not specified', () => {
+    it('returns undefined when start is specified but end is not specified', () => {
       const errorMessages: string[] = []
-      const [start, end] = validateStartEndFlags('123', undefined, errorMessages)
-      expect(start).toBe(0)
-      expect(end).toBe(0)
+      const res = validateStartEndFlags('123', undefined, errorMessages)
+      expect(res).toBeUndefined()
       expect(errorMessages).toMatchSnapshot()
     })
 
-    it('returns [0, 0] when end is specified but start is not specified', () => {
+    it('returns undefined when end is specified but start is not specified', () => {
       const errorMessages: string[] = []
-      const [start, end] = validateStartEndFlags(undefined, '123', errorMessages)
-      expect(start).toBe(0)
-      expect(end).toBe(0)
+      const res = validateStartEndFlags(undefined, '123', errorMessages)
+      expect(res).toBeUndefined()
       expect(errorMessages).toMatchSnapshot()
     })
 
-    it('returns [0, 0] when start is invalid', () => {
+    it('returns undefined when start is invalid', () => {
       const errorMessages: string[] = []
-      const [start, end] = validateStartEndFlags('123abc', '200', errorMessages)
-      expect(start).toBe(0)
-      expect(end).toBe(0)
+      const res = validateStartEndFlags('123abc', '200', errorMessages)
+      expect(res).toBeUndefined()
       expect(errorMessages).toMatchSnapshot()
     })
 
-    it('returns [0, 0] when end is invalid', () => {
+    it('returns undefined when end is invalid', () => {
       const errorMessages: string[] = []
-      const [start, end] = validateStartEndFlags('100', '234abc', errorMessages)
-      expect(start).toBe(0)
-      expect(end).toBe(0)
+      const res = validateStartEndFlags('100', '234abc', errorMessages)
+      expect(res).toBeUndefined()
       expect(errorMessages).toMatchSnapshot()
     })
 
-    it('returns [0, 0] when start is not before the end time', () => {
+    it('returns undefined when start is not before the end time', () => {
       const errorMessages: string[] = []
-      const [start, end] = validateStartEndFlags('200', '100', errorMessages)
-      expect(start).toBe(0)
-      expect(end).toBe(0)
+      const res = validateStartEndFlags('200', '100', errorMessages)
+      expect(res).toBeUndefined()
       expect(errorMessages).toMatchSnapshot()
     })
 
     it('sets end time to current time if end time is too large', () => {
       const now = Date.now()
-      const [start, end] = validateStartEndFlags('0', '9999999999999', [])
+      const res = validateStartEndFlags('0', '9999999999999', [])
+      expect(res).not.toBeUndefined()
+      const [start, end] = res!
       expect(start).toBe(0)
       expect(end).toBeGreaterThanOrEqual(now - 1000)
       expect(end).toBeLessThanOrEqual(now + 1000)

--- a/src/commands/lambda/__tests__/flare.test.ts
+++ b/src/commands/lambda/__tests__/flare.test.ts
@@ -576,7 +576,7 @@ describe('lambda flare', () => {
           input: expect.objectContaining({
             logGroupName: MOCK_LOG_GROUP,
             logStreamName: MOCK_LOG_STREAM,
-            limit: 10000,
+            limit: 1000,
             startTime: mockStartTime,
             endTime: mockEndTime,
           }),

--- a/src/commands/lambda/__tests__/flare.test.ts
+++ b/src/commands/lambda/__tests__/flare.test.ts
@@ -532,8 +532,8 @@ describe('lambda flare', () => {
         (cloudWatchLogsClientMock as unknown) as CloudWatchLogsClient,
         MOCK_LOG_GROUP,
         MOCK_LOG_STREAM,
-        0,
-        0
+        undefined,
+        undefined
       )
 
       expect(logEvents).toEqual(expectedEvents)
@@ -546,8 +546,8 @@ describe('lambda flare', () => {
         (cloudWatchLogsClientMock as unknown) as CloudWatchLogsClient,
         MOCK_LOG_GROUP,
         MOCK_LOG_STREAM,
-        0,
-        0
+        undefined,
+        undefined
       )
 
       expect(logEvents).toEqual([])
@@ -560,8 +560,8 @@ describe('lambda flare', () => {
           (cloudWatchLogsClientMock as unknown) as CloudWatchLogsClient,
           MOCK_LOG_GROUP,
           MOCK_LOG_STREAM,
-          0,
-          0
+          undefined,
+          undefined
         )
       ).rejects.toThrow('Cannot retrieve log events')
     })

--- a/src/commands/lambda/__tests__/flare.test.ts
+++ b/src/commands/lambda/__tests__/flare.test.ts
@@ -26,6 +26,7 @@ import {
   getLogStreamNames,
   getMasking,
   maskConfig,
+  validateStartEndFlags,
   writeFile,
   zipContents,
 } from '../flare'
@@ -249,6 +250,118 @@ describe('lambda flare', () => {
       const output = context.stdout.toString()
       expect(output).toMatchSnapshot()
     })
+
+    it('prints error when start time is specified but end time is not', async () => {
+      const cli = makeCli()
+      const context = createMockContext()
+      const code = await cli.run([...MOCK_REQUIRED_FLAGS, '--start', '100'], context as any)
+      expect(code).toBe(1)
+      const output = context.stdout.toString()
+      expect(output).toMatchSnapshot()
+    })
+
+    it('prints error when end time is specified but start time is not', async () => {
+      const cli = makeCli()
+      const context = createMockContext()
+      const code = await cli.run([...MOCK_REQUIRED_FLAGS, '--end', '100'], context as any)
+      expect(code).toBe(1)
+      const output = context.stdout.toString()
+      expect(output).toMatchSnapshot()
+    })
+
+    it('prints error when start time is invalid', async () => {
+      const cli = makeCli()
+      const context = createMockContext()
+      const code = await cli.run([...MOCK_REQUIRED_FLAGS, '--start', '123abc', '--end', '200'], context as any)
+      expect(code).toBe(1)
+      const output = context.stdout.toString()
+      expect(output).toMatchSnapshot()
+    })
+
+    it('prints error when end time is invalid', async () => {
+      const cli = makeCli()
+      const context = createMockContext()
+      const code = await cli.run([...MOCK_REQUIRED_FLAGS, '--start', '100', '--end', '123abc'], context as any)
+      expect(code).toBe(1)
+      const output = context.stdout.toString()
+      expect(output).toMatchSnapshot()
+    })
+
+    it('prints error when start time is after end time', async () => {
+      const cli = makeCli()
+      const context = createMockContext()
+      const code = await cli.run([...MOCK_REQUIRED_FLAGS, '--start', '200', '--end', '100'], context as any)
+      expect(code).toBe(1)
+      const output = context.stdout.toString()
+      expect(output).toMatchSnapshot()
+    })
+
+    it('runs successfully when start and end times are valid', async () => {
+      const cli = makeCli()
+      const context = createMockContext()
+      const code = await cli.run([...MOCK_REQUIRED_FLAGS, '--start', '100', '--end', '200'], context as any)
+      expect(code).toBe(0)
+      const output = context.stdout.toString()
+      expect(output).toMatchSnapshot()
+    })
+  })
+
+  describe('validateStartEndFlags', () => {
+    it('returns [0, 0] when start and end flags are not specified', () => {
+      const errorMessages: string[] = []
+      const [start, end] = validateStartEndFlags(undefined, undefined, errorMessages)
+      expect(start).toBe(0)
+      expect(end).toBe(0)
+      expect(errorMessages).toEqual([])
+    })
+
+    it('returns [0, 0] when start is specified but end is not specified', () => {
+      const errorMessages: string[] = []
+      const [start, end] = validateStartEndFlags('123', undefined, errorMessages)
+      expect(start).toBe(0)
+      expect(end).toBe(0)
+      expect(errorMessages).toMatchSnapshot()
+    })
+
+    it('returns [0, 0] when end is specified but start is not specified', () => {
+      const errorMessages: string[] = []
+      const [start, end] = validateStartEndFlags(undefined, '123', errorMessages)
+      expect(start).toBe(0)
+      expect(end).toBe(0)
+      expect(errorMessages).toMatchSnapshot()
+    })
+
+    it('returns [0, 0] when start is invalid', () => {
+      const errorMessages: string[] = []
+      const [start, end] = validateStartEndFlags('123abc', '200', errorMessages)
+      expect(start).toBe(0)
+      expect(end).toBe(0)
+      expect(errorMessages).toMatchSnapshot()
+    })
+
+    it('returns [0, 0] when end is invalid', () => {
+      const errorMessages: string[] = []
+      const [start, end] = validateStartEndFlags('100', '234abc', errorMessages)
+      expect(start).toBe(0)
+      expect(end).toBe(0)
+      expect(errorMessages).toMatchSnapshot()
+    })
+
+    it('returns [0, 0] when start is not before the end time', () => {
+      const errorMessages: string[] = []
+      const [start, end] = validateStartEndFlags('200', '100', errorMessages)
+      expect(start).toBe(0)
+      expect(end).toBe(0)
+      expect(errorMessages).toMatchSnapshot()
+    })
+
+    it('sets end time to current time if end time is too large', () => {
+      const now = Date.now()
+      const [start, end] = validateStartEndFlags('0', '9999999999999', [])
+      expect(start).toBe(0)
+      expect(end).toBeGreaterThanOrEqual(now - 1000)
+      expect(end).toBeLessThanOrEqual(now + 1000)
+    })
   })
 
   describe('getMasking', () => {
@@ -348,7 +461,7 @@ describe('lambda flare', () => {
       mockCloudWatchLogStreams(cloudWatchLogsClientMock, mockStreams)
 
       const expectedLogStreams = ['Stream1', 'Stream2', 'Stream3']
-      const logStreams = await getLogStreamNames(new CloudWatchLogsClient({}), MOCK_LOG_GROUP)
+      const logStreams = await getLogStreamNames(new CloudWatchLogsClient({}), MOCK_LOG_GROUP, 0, 0)
 
       expect(logStreams).toEqual(expectedLogStreams)
     })
@@ -356,7 +469,7 @@ describe('lambda flare', () => {
     it('returns empty array when no log streams are found', async () => {
       mockCloudWatchLogStreams(cloudWatchLogsClientMock, [])
 
-      const logStreams = await getLogStreamNames(new CloudWatchLogsClient({}), MOCK_LOG_GROUP)
+      const logStreams = await getLogStreamNames(new CloudWatchLogsClient({}), MOCK_LOG_GROUP, 0, 0)
 
       expect(logStreams).toEqual([])
     })
@@ -365,8 +478,23 @@ describe('lambda flare', () => {
       cloudWatchLogsClientMock.on(DescribeLogStreamsCommand).rejects('Cannot retrieve log streams')
 
       await expect(
-        getLogStreamNames((cloudWatchLogsClientMock as unknown) as CloudWatchLogsClient, MOCK_LOG_GROUP)
+        getLogStreamNames((cloudWatchLogsClientMock as unknown) as CloudWatchLogsClient, MOCK_LOG_GROUP, 0, 0)
       ).rejects.toThrow('Cannot retrieve log streams')
+    })
+
+    it('returns log streams within the specified time range', async () => {
+      const mockStreams: LogStream[] = [
+        {logStreamName: 'Stream1', firstEventTimestamp: 100, lastEventTimestamp: 200},
+        {logStreamName: 'Stream2', firstEventTimestamp: 200, lastEventTimestamp: 300},
+        {logStreamName: 'Stream3', firstEventTimestamp: 300, lastEventTimestamp: 400},
+        {logStreamName: 'Stream4', firstEventTimestamp: 400, lastEventTimestamp: 500},
+      ]
+      mockCloudWatchLogStreams(cloudWatchLogsClientMock, mockStreams)
+
+      const expectedLogStreams = ['Stream2', 'Stream1']
+      const logStreams = await getLogStreamNames(new CloudWatchLogsClient({}), MOCK_LOG_GROUP, 0, 250)
+
+      expect(logStreams).toEqual(expectedLogStreams)
     })
   })
 
@@ -391,7 +519,9 @@ describe('lambda flare', () => {
       const logEvents = await getLogEvents(
         (cloudWatchLogsClientMock as unknown) as CloudWatchLogsClient,
         MOCK_LOG_GROUP,
-        MOCK_LOG_STREAM
+        MOCK_LOG_STREAM,
+        0,
+        0
       )
 
       expect(logEvents).toEqual(expectedEvents)
@@ -403,7 +533,9 @@ describe('lambda flare', () => {
       const logEvents = await getLogEvents(
         (cloudWatchLogsClientMock as unknown) as CloudWatchLogsClient,
         MOCK_LOG_GROUP,
-        MOCK_LOG_STREAM
+        MOCK_LOG_STREAM,
+        0,
+        0
       )
 
       expect(logEvents).toEqual([])
@@ -412,8 +544,50 @@ describe('lambda flare', () => {
     it('throws error when log events cannot be retrieved', async () => {
       cloudWatchLogsClientMock.on(GetLogEventsCommand).rejects('Cannot retrieve log events')
       await expect(
-        getLogEvents((cloudWatchLogsClientMock as unknown) as CloudWatchLogsClient, MOCK_LOG_GROUP, MOCK_LOG_STREAM)
+        getLogEvents(
+          (cloudWatchLogsClientMock as unknown) as CloudWatchLogsClient,
+          MOCK_LOG_GROUP,
+          MOCK_LOG_STREAM,
+          0,
+          0
+        )
       ).rejects.toThrow('Cannot retrieve log events')
+    })
+
+    it('sets start and end time when provided', async () => {
+      const mockStartTime = 100
+      const mockEndTime = 200
+
+      const logEvents = [
+        {timestamp: 125, message: 'Log1'},
+        {timestamp: 150, message: 'Log2'},
+        {timestamp: 175, message: 'Log3'},
+      ]
+
+      const sendMock: any = jest.fn().mockResolvedValue({events: logEvents})
+      cloudWatchLogsClientMock.send = sendMock
+
+      const logEventsResult = await getLogEvents(
+        (cloudWatchLogsClientMock as unknown) as CloudWatchLogsClient,
+        MOCK_LOG_GROUP,
+        MOCK_LOG_STREAM,
+        mockStartTime,
+        mockEndTime
+      )
+
+      expect(sendMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          input: expect.objectContaining({
+            logGroupName: MOCK_LOG_GROUP,
+            logStreamName: MOCK_LOG_STREAM,
+            limit: 10000,
+            startTime: mockStartTime,
+            endTime: mockEndTime,
+          }),
+        })
+      )
+
+      expect(logEventsResult).toEqual(logEvents)
     })
   })
 
@@ -431,21 +605,21 @@ describe('lambda flare', () => {
       jest.spyOn(flareModule, 'getLogStreamNames').mockResolvedValue([mockStreamName])
       jest.spyOn(flareModule, 'getLogEvents').mockResolvedValue(mockLogs)
 
-      const result = await getAllLogs(region, functionName)
+      const result = await getAllLogs(region, functionName, 0, 0)
       expect(result.get(mockStreamName)).toEqual(mockLogs)
     })
 
     it('throws an error when unable to get log streams', async () => {
       jest.spyOn(flareModule, 'getLogStreamNames').mockRejectedValueOnce(new Error('Error getting log streams'))
 
-      await expect(getAllLogs(region, functionName)).rejects.toMatchSnapshot()
+      await expect(getAllLogs(region, functionName, 0, 0)).rejects.toMatchSnapshot()
     })
 
     it('throws an error when unable to get log events', async () => {
       jest.spyOn(flareModule, 'getLogStreamNames').mockResolvedValueOnce([mockStreamName])
       jest.spyOn(flareModule, 'getLogEvents').mockRejectedValueOnce(new Error('Error getting log events'))
 
-      await expect(getAllLogs(region, functionName)).rejects.toMatchSnapshot()
+      await expect(getAllLogs(region, functionName, 0, 0)).rejects.toMatchSnapshot()
     })
   })
 

--- a/src/commands/lambda/flare.ts
+++ b/src/commands/lambda/flare.ts
@@ -461,10 +461,10 @@ export const getLogStreamNames = async (
     if (rangeSpecified) {
       const firstEventTime = logStream.firstEventTimestamp
       const lastEventTime = logStream.lastEventTimestamp
-      if (!firstEventTime || !lastEventTime) {
+      if (lastEventTime && lastEventTime < startMillis) {
         continue
       }
-      if (lastEventTime < startMillis || firstEventTime > endMillis) {
+      if (firstEventTime && firstEventTime > endMillis) {
         continue
       }
     }

--- a/src/commands/lambda/flare.ts
+++ b/src/commands/lambda/flare.ts
@@ -91,7 +91,7 @@ export class LambdaFlareCommand extends Command {
     }
 
     // Validate start/end flags if both are specified
-    const [startMillis, endMillis] = validateStartEndFlags(this.start, this.end, errorMessages)
+    const [startMillis, endMillis] = validateStartEndFlags(this.start, this.end, errorMessages) ?? [0, 0]
     if (errorMessages.length > 0) {
       for (const message of errorMessages) {
         this.context.stderr.write(message)
@@ -257,21 +257,21 @@ export class LambdaFlareCommand extends Command {
  * @param start start time as a string
  * @param end end time as a string
  * @param errorMessages array of error messages to add to
- * @returns [startMillis, endMillis] as numbers if valid or [0, 0] otherwise
+ * @returns [startMillis, endMillis] as numbers if valid or undefined otherwise
  */
 export const validateStartEndFlags = (start: string | undefined, end: string | undefined, errorMessages: string[]) => {
   if (!start && !end) {
-    return [0, 0]
+    return
   }
 
   if (!start) {
     errorMessages.push(commonRenderer.renderError('Start time is required when end time is specified. [--start]'))
 
-    return [0, 0]
+    return
   } else if (!end) {
     errorMessages.push(commonRenderer.renderError('End time is required when start time is specified. [--end]'))
 
-    return [0, 0]
+    return
   }
 
   const startMillis = Number(start)
@@ -281,11 +281,11 @@ export const validateStartEndFlags = (start: string | undefined, end: string | u
       commonRenderer.renderError('Start time must be a time in milliseconds since Unix Epoch. [--start]')
     )
 
-    return [0, 0]
+    return
   } else if (isNaN(endMillis)) {
     errorMessages.push(commonRenderer.renderError('End time must be a time in milliseconds since Unix Epoch. [--end]'))
 
-    return [0, 0]
+    return
   }
 
   // Required for AWS SDK to work correctly
@@ -294,7 +294,7 @@ export const validateStartEndFlags = (start: string | undefined, end: string | u
   if (startMillis >= endMillis) {
     errorMessages.push(commonRenderer.renderError('Start time must be before end time.'))
 
-    return [0, 0]
+    return
   }
 
   return [startMillis, endMillis]
@@ -473,6 +473,7 @@ export const getLogEvents = async (
     logStreamName,
     limit: MAX_LOG_EVENTS_PER_STREAM,
   }
+  console.log(startMillis, endMillis)
   if (startMillis !== 0 || endMillis !== 0) {
     config.startTime = startMillis
     config.endTime = endMillis

--- a/src/commands/lambda/flare.ts
+++ b/src/commands/lambda/flare.ts
@@ -30,7 +30,9 @@ const FLARE_OUTPUT_DIRECTORY = '.datadog-ci'
 const LOGS_DIRECTORY = 'logs'
 const FUNCTION_CONFIG_FILE_NAME = 'function_config.json'
 const ZIP_FILE_NAME = 'lambda-flare-output.zip'
-const LOG_STREAM_COUNT = 3
+const MAX_LOG_STREAMS = 50
+const DEFAULT_LOG_STREAMS = 3
+const MAX_LOG_EVENTS_PER_STREAM = 10000
 const FULL_OBFUSCATION = '****************'
 const MIDDLE_OBFUSCATION = '**********'
 
@@ -42,6 +44,8 @@ export class LambdaFlareCommand extends Command {
   private apiKey?: string
   private caseId?: string
   private email?: string
+  private start?: string
+  private end?: string
   private credentials?: AwsCredentialIdentity
 
   /**
@@ -85,6 +89,9 @@ export class LambdaFlareCommand extends Command {
     if (this.email === undefined) {
       errorMessages.push(commonRenderer.renderError('No email specified. [-e,--email]'))
     }
+
+    // Validate start/end flags if both are specified
+    const [startMillis, endMillis] = validateStartEndFlags(this.start, this.end, errorMessages)
 
     if (errorMessages.length > 0) {
       for (const message of errorMessages) {
@@ -146,7 +153,7 @@ export class LambdaFlareCommand extends Command {
     if (this.withLogs) {
       this.context.stdout.write('\n☁️ Getting CloudWatch logs...\n')
       try {
-        logs = await getAllLogs(region!, this.functionName)
+        logs = await getAllLogs(region!, this.functionName, startMillis, endMillis)
       } catch (err) {
         if (err instanceof Error) {
           this.context.stderr.write(commonRenderer.renderError(err.message))
@@ -244,6 +251,54 @@ export class LambdaFlareCommand extends Command {
 
     return 0
   }
+}
+
+/**
+ * Validate the start and end flags and adds error messages if found
+ * @param start start time as a string
+ * @param end end time as a string
+ * @param errorMessages array of error messages to add to
+ * @returns [startMillis, endMillis] as numbers if valid or [0, 0] otherwise
+ */
+export const validateStartEndFlags = (start: string | undefined, end: string | undefined, errorMessages: string[]) => {
+  if (!start && !end) {
+    return [0, 0]
+  }
+
+  if (!start) {
+    errorMessages.push(commonRenderer.renderError('Start time is required when end time is specified. [--start]'))
+
+    return [0, 0]
+  } else if (!end) {
+    errorMessages.push(commonRenderer.renderError('End time is required when start time is specified. [--end]'))
+
+    return [0, 0]
+  }
+
+  const startMillis = Number(start)
+  let endMillis = Number(end)
+  if (isNaN(startMillis)) {
+    errorMessages.push(
+      commonRenderer.renderError('Start time must be a time in milliseconds since Unix Epoch. [--start]')
+    )
+
+    return [0, 0]
+  } else if (isNaN(endMillis)) {
+    errorMessages.push(commonRenderer.renderError('End time must be a time in milliseconds since Unix Epoch. [--end]'))
+
+    return [0, 0]
+  }
+
+  // Required for AWS SDK to work correctly
+  endMillis = Math.min(endMillis, Date.now())
+
+  if (startMillis >= endMillis) {
+    errorMessages.push(commonRenderer.renderError('Start time must be before end time.'))
+
+    return [0, 0]
+  }
+
+  return [startMillis, endMillis]
 }
 
 /**
@@ -346,16 +401,28 @@ export const createDirectories = (
  * Gets the LOG_STREAM_COUNT latest log stream names, sorted by last event time
  * @param cwlClient CloudWatch Logs client
  * @param logGroupName name of the log group
+ * @param startMillis start time in milliseconds or 0 if no start time is specified
+ * @param endMillis end time in milliseconds or 0 if no end time is specified
  * @returns an array of the last LOG_STREAM_COUNT log stream names or an empty array if no log streams are found
  * @throws Error if the log streams cannot be retrieved
  */
-export const getLogStreamNames = async (cwlClient: CloudWatchLogsClient, logGroupName: string) => {
-  const command = new DescribeLogStreamsCommand({
+export const getLogStreamNames = async (
+  cwlClient: CloudWatchLogsClient,
+  logGroupName: string,
+  startMillis: number,
+  endMillis: number
+) => {
+  const config = {
     logGroupName,
-    limit: LOG_STREAM_COUNT,
     descending: true,
     orderBy: OrderBy.LastEventTime,
-  })
+    limit: MAX_LOG_STREAMS,
+  }
+  const rangeSpecified = startMillis !== 0 || endMillis !== 0
+  if (!rangeSpecified) {
+    config.limit = DEFAULT_LOG_STREAMS
+  }
+  const command = new DescribeLogStreamsCommand(config)
   const response = await cwlClient.send(command)
   const logStreams = response.logStreams
   if (logStreams === undefined || logStreams.length === 0) {
@@ -365,9 +432,20 @@ export const getLogStreamNames = async (cwlClient: CloudWatchLogsClient, logGrou
   const output: string[] = []
   for (const logStream of logStreams) {
     const logStreamName = logStream.logStreamName
-    if (logStreamName) {
-      output.push(logStreamName)
+    if (!logStreamName) {
+      continue
     }
+    if (rangeSpecified) {
+      const lastEventTime = logStream.lastEventTimestamp
+      const firstEventTime = logStream.firstEventTimestamp
+      if (!lastEventTime || !firstEventTime) {
+        continue
+      }
+      if (lastEventTime < startMillis || firstEventTime > endMillis) {
+        continue
+      }
+    }
+    output.push(logStreamName)
   }
 
   // Reverse array so the oldest log is created first, so Support Staff can sort by creation time
@@ -379,14 +457,28 @@ export const getLogStreamNames = async (cwlClient: CloudWatchLogsClient, logGrou
  * @param cwlClient
  * @param logGroupName
  * @param logStreamName
+ * @param startMillis
+ * @param endMillis
  * @returns the log events or an empty array if no log events are found
  * @throws Error if the log events cannot be retrieved
  */
-export const getLogEvents = async (cwlClient: CloudWatchLogsClient, logGroupName: string, logStreamName: string) => {
-  const command = new GetLogEventsCommand({
+export const getLogEvents = async (
+  cwlClient: CloudWatchLogsClient,
+  logGroupName: string,
+  logStreamName: string,
+  startMillis: number,
+  endMillis: number
+) => {
+  const config: any = {
     logGroupName,
     logStreamName,
-  })
+    limit: MAX_LOG_EVENTS_PER_STREAM,
+  }
+  if (startMillis !== 0 || endMillis !== 0) {
+    config.startTime = startMillis
+    config.endTime = endMillis
+  }
+  const command = new GetLogEventsCommand(config)
 
   const response = await cwlClient.send(command)
   const logEvents = response.events
@@ -402,9 +494,11 @@ export const getLogEvents = async (cwlClient: CloudWatchLogsClient, logGroupName
  * Gets all CloudWatch logs for a function
  * @param region
  * @param functionName
+ * @param startMillis start time in milliseconds or 0 if no end time is specified
+ * @param endMillis end time in milliseconds or 0 if no end time is specified
  * @returns a map of log stream names to log events or an empty map if no logs are found
  */
-export const getAllLogs = async (region: string, functionName: string) => {
+export const getAllLogs = async (region: string, functionName: string, startMillis: number, endMillis: number) => {
   const logs = new Map<string, OutputLogEvent[]>()
   const cwlClient = new CloudWatchLogsClient({region})
   if (functionName.startsWith('arn:aws')) {
@@ -413,7 +507,7 @@ export const getAllLogs = async (region: string, functionName: string) => {
   const logGroupName = `/aws/lambda/${functionName}`
   let logStreamNames: string[]
   try {
-    logStreamNames = await getLogStreamNames(cwlClient, logGroupName)
+    logStreamNames = await getLogStreamNames(cwlClient, logGroupName, startMillis, endMillis)
   } catch (err) {
     const msg = err instanceof Error ? err.message : ''
     throw new Error(`Unable to get log streams: ${msg}`)
@@ -422,7 +516,7 @@ export const getAllLogs = async (region: string, functionName: string) => {
   for (const logStreamName of logStreamNames) {
     let logEvents
     try {
-      logEvents = await getLogEvents(cwlClient, logGroupName, logStreamName)
+      logEvents = await getLogEvents(cwlClient, logGroupName, logStreamName, startMillis, endMillis)
     } catch (err) {
       const msg = err instanceof Error ? err.message : ''
       throw new Error(`Unable to get log events for stream ${logStreamName}: ${msg}`)
@@ -573,3 +667,5 @@ LambdaFlareCommand.addOption('functionName', Command.String('-f,--function'))
 LambdaFlareCommand.addOption('region', Command.String('-r,--region'))
 LambdaFlareCommand.addOption('caseId', Command.String('-c,--case-id'))
 LambdaFlareCommand.addOption('email', Command.String('-e,--email'))
+LambdaFlareCommand.addOption('start', Command.String('--start'))
+LambdaFlareCommand.addOption('end', Command.String('--end'))

--- a/src/commands/lambda/flare.ts
+++ b/src/commands/lambda/flare.ts
@@ -53,6 +53,7 @@ export class LambdaFlareCommand extends Command {
     this.context.stdout.write(flareRenderer.renderLambdaFlareHeader(this.isDryRun))
 
     // Validate function name
+    const errorMessages = []
     if (this.functionName === undefined) {
       this.context.stderr.write(commonRenderer.renderError('No function name specified. [-f,--function]'))
 
@@ -60,37 +61,36 @@ export class LambdaFlareCommand extends Command {
     }
 
     // Validate region
-    let errorFound = false
     const region = getRegion(this.functionName) ?? this.region ?? process.env[AWS_DEFAULT_REGION_ENV_VAR]
     if (region === undefined) {
-      this.context.stderr.write(commonRenderer.renderNoDefaultRegionSpecifiedError())
-      errorFound = true
+      errorMessages.push(commonRenderer.renderNoDefaultRegionSpecifiedError())
     }
 
     // Validate Datadog API key
     this.apiKey = process.env[CI_API_KEY_ENV_VAR] ?? process.env[API_KEY_ENV_VAR]
     if (this.apiKey === undefined) {
-      this.context.stderr.write(
+      errorMessages.push(
         commonRenderer.renderError(
           'No Datadog API key specified. Set an API key with the DATADOG_API_KEY environment variable.'
         )
       )
-      errorFound = true
     }
 
     // Validate case ID
     if (this.caseId === undefined) {
-      this.context.stderr.write(commonRenderer.renderError('No case ID specified. [-c,--case-id]'))
-      errorFound = true
+      errorMessages.push(commonRenderer.renderError('No case ID specified. [-c,--case-id]'))
     }
 
     // Validate email
     if (this.email === undefined) {
-      this.context.stderr.write(commonRenderer.renderError('No email specified. [-e,--email]'))
-      errorFound = true
+      errorMessages.push(commonRenderer.renderError('No email specified. [-e,--email]'))
     }
 
-    if (errorFound) {
+    if (errorMessages.length > 0) {
+      for (const message of errorMessages) {
+        this.context.stderr.write(message)
+      }
+
       return 1
     }
 

--- a/src/commands/lambda/flare.ts
+++ b/src/commands/lambda/flare.ts
@@ -53,7 +53,7 @@ export class LambdaFlareCommand extends Command {
     this.context.stdout.write(flareRenderer.renderLambdaFlareHeader(this.isDryRun))
 
     // Validate function name
-    const errorMessages = []
+    const errorMessages: string[] = []
     if (this.functionName === undefined) {
       this.context.stderr.write(commonRenderer.renderError('No function name specified. [-f,--function]'))
 

--- a/src/commands/lambda/flare.ts
+++ b/src/commands/lambda/flare.ts
@@ -32,7 +32,7 @@ const FUNCTION_CONFIG_FILE_NAME = 'function_config.json'
 const ZIP_FILE_NAME = 'lambda-flare-output.zip'
 const MAX_LOG_STREAMS = 50
 const DEFAULT_LOG_STREAMS = 3
-const MAX_LOG_EVENTS_PER_STREAM = 10000
+const MAX_LOG_EVENTS_PER_STREAM = 1000
 const FULL_OBFUSCATION = '****************'
 const MIDDLE_OBFUSCATION = '**********'
 

--- a/src/commands/lambda/flare.ts
+++ b/src/commands/lambda/flare.ts
@@ -100,7 +100,6 @@ export class LambdaFlareCommand extends Command {
         errorMessages.push(commonRenderer.renderError(err.message))
       }
     }
-    console.log(startMillis, endMillis)
 
     if (errorMessages.length > 0) {
       for (const message of errorMessages) {

--- a/src/commands/lambda/flare.ts
+++ b/src/commands/lambda/flare.ts
@@ -300,7 +300,8 @@ export const validateStartEndFlags = (start: string | undefined, end: string | u
 
   if (!start) {
     throw Error('Start time is required when end time is specified. [--start]')
-  } else if (!end) {
+  }
+  if (!end) {
     throw Error('End time is required when start time is specified. [--end]')
   }
 
@@ -308,7 +309,8 @@ export const validateStartEndFlags = (start: string | undefined, end: string | u
   let endMillis = Number(end)
   if (isNaN(startMillis)) {
     throw Error(`Start time must be a time in milliseconds since Unix Epoch. '${start}' is not a number.`)
-  } else if (isNaN(endMillis)) {
+  }
+  if (isNaN(endMillis)) {
     throw Error(`End time must be a time in milliseconds since Unix Epoch. '${end}' is not a number.`)
   }
 
@@ -459,10 +461,7 @@ export const getLogStreamNames = async (
     if (rangeSpecified) {
       const lastEventTime = logStream.lastEventTimestamp
       const firstEventTime = logStream.firstEventTimestamp
-      if (!lastEventTime || !firstEventTime) {
-        continue
-      }
-      if (lastEventTime < startMillis || firstEventTime > endMillis) {
+      if (lastEventTime && firstEventTime && (lastEventTime < startMillis || firstEventTime > endMillis)) {
         continue
       }
     }

--- a/src/commands/lambda/flare.ts
+++ b/src/commands/lambda/flare.ts
@@ -473,7 +473,6 @@ export const getLogEvents = async (
     logStreamName,
     limit: MAX_LOG_EVENTS_PER_STREAM,
   }
-  console.log(startMillis, endMillis)
   if (startMillis !== 0 || endMillis !== 0) {
     config.startTime = startMillis
     config.endTime = endMillis

--- a/src/commands/lambda/flare.ts
+++ b/src/commands/lambda/flare.ts
@@ -412,11 +412,11 @@ export const getLogStreamNames = async (
     logGroupName,
     descending: true,
     orderBy: OrderBy.LastEventTime,
-    limit: MAX_LOG_STREAMS,
+    limit: DEFAULT_LOG_STREAMS,
   }
   const rangeSpecified = startMillis !== 0 || endMillis !== 0
-  if (!rangeSpecified) {
-    config.limit = DEFAULT_LOG_STREAMS
+  if (rangeSpecified) {
+    config.limit = MAX_LOG_STREAMS
   }
   const command = new DescribeLogStreamsCommand(config)
   const response = await cwlClient.send(command)

--- a/src/commands/lambda/flare.ts
+++ b/src/commands/lambda/flare.ts
@@ -57,7 +57,6 @@ export class LambdaFlareCommand extends Command {
     this.context.stdout.write(flareRenderer.renderLambdaFlareHeader(this.isDryRun))
 
     // Validate function name
-    const errorMessages: string[] = []
     if (this.functionName === undefined) {
       this.context.stderr.write(commonRenderer.renderError('No function name specified. [-f,--function]'))
 

--- a/src/commands/lambda/flare.ts
+++ b/src/commands/lambda/flare.ts
@@ -459,9 +459,12 @@ export const getLogStreamNames = async (
       continue
     }
     if (rangeSpecified) {
-      const lastEventTime = logStream.lastEventTimestamp
       const firstEventTime = logStream.firstEventTimestamp
-      if (lastEventTime && firstEventTime && (lastEventTime < startMillis || firstEventTime > endMillis)) {
+      const lastEventTime = logStream.lastEventTimestamp
+      if (!firstEventTime || !lastEventTime) {
+        continue
+      }
+      if (lastEventTime < startMillis || firstEventTime > endMillis) {
         continue
       }
     }


### PR DESCRIPTION
### What and why?

This PR adds optional `--start` and `--end` flags to specify a time range for CloudWatch logs.
Only log streams and log events that lie within the range will be saved.
Even though both are optional flags, if one is specified, the other is required.
Each timestamp is in milliseconds since UNIX Epoch.

### How?

1. The `--start` and `--end` validation is complicated, so I created a helper function `validateStartEndFlags()` that handles the validation.
2. The `getLogEvents()` function has been updated to set the `startTime` and `endTime` options in `GetLogEventsCommand`. The logic for this is abstracted and handled by the AWS SDK. If `--start` and `--end` were not specified, then these options won't be added to the `GetLogEventsCommand` config.
3. `DescribeLogStreamsCommand` does not have start or end time config options. Therefore, I had to manually filter the streams. The `getLogStreamNames()` function has been modified to accept `startMillis` and `endMillis` as parameters. We can get the first and last event times for a log stream using `logStream.lastEventTimestamp` and `logStream.firstEventTimestamp`. Then, we can filter the log streams to only include log streams whose range falls inside `[startMillis, endMillis]`

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
