### PR TITLE
[synthetics] Support tunneled multi-step tests

### DIFF
--- a/src/commands/synthetics/utils.ts
+++ b/src/commands/synthetics/utils.ts
@@ -29,7 +29,6 @@ import {
   ResultInBatch,
   RunTestsCommandConfig,
   ServerResult,
-  ServerTest,
   Suite,
   Summary,
   SyntheticsCIConfig,
@@ -142,7 +141,7 @@ export const getStrictestExecutionRule = (configRule: ExecutionRule, testRule?: 
   return ExecutionRule.BLOCKING
 }
 
-export const isTestSupportedByTunnel = (test: ServerTest) => {
+export const isTestSupportedByTunnel = (test: Test) => {
   return (
     test.type === 'browser' ||
     test.subtype === 'http' ||


### PR DESCRIPTION
### What and why?

Closes #959 

Currently, multi-step tests are forbidden to run in the tunnel but HTTP steps in multi-step tests are now supported.

### How?

- Refactor the checks on `step.type` and `step.subtype` into a `isTestSupportedByTunnel()` utility function.
- Allow a multi-step test to be tunneled as long as all its steps are `http` steps.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
