### PR TITLE
[lambda][flare] Build endpoint URL from environment variables

### DIFF
--- a/src/commands/lambda/__tests__/__snapshots__/flare.test.ts.snap
+++ b/src/commands/lambda/__tests__/__snapshots__/flare.test.ts.snap
@@ -74,7 +74,7 @@ exports[`lambda flare AWS credentials continues when getAWSCredentials() returns
 • Saved function config to mock-folder/.datadog-ci/function_config.json
 
 
-🚀 Sending to Datadog Support...
+🚀 Sending to Datadog Support via https://datadoghq.com/api/ui/support/serverless/flare...
 
 ✅ Successfully sent flare file to Datadog Support!
 "
@@ -109,7 +109,7 @@ exports[`lambda flare AWS credentials requests AWS credentials when none are fou
 • Saved function config to mock-folder/.datadog-ci/function_config.json
 
 
-🚀 Sending to Datadog Support...
+🚀 Sending to Datadog Support via https://datadoghq.com/api/ui/support/serverless/flare...
 
 ✅ Successfully sent flare file to Datadog Support!
 "
@@ -157,6 +157,14 @@ exports[`lambda flare getAllLogs throws an error when unable to get log events 1
 
 exports[`lambda flare getAllLogs throws an error when unable to get log streams 1`] = `[Error: Unable to get log streams: Error getting log streams]`;
 
+exports[`lambda flare getEndpointUrl should return URL with https if the environment variable does not start with http 1`] = `"https://datad0g.com/api/ui/support/serverless/flare"`;
+
+exports[`lambda flare getEndpointUrl should return URL without trailing slash if the environment variable ends with / 1`] = `"https://datadoghq.com/api/ui/support/serverless/flare"`;
+
+exports[`lambda flare getEndpointUrl should use DEFAULT_DD_SITE if CI_SITE_ENV_VAR and SITE_ENV_VAR are not set 1`] = `"https://datadoghq.com/api/ui/support/serverless/flare"`;
+
+exports[`lambda flare getEndpointUrl should use SITE_ENV_VAR if CI_SITE_ENV_VAR is not set 1`] = `"https://us3.datadoghq.com/api/ui/support/serverless/flare"`;
+
 exports[`lambda flare getTags should return the tags when they exist 1`] = `
 Object {
   "Key1": "Value1",
@@ -193,7 +201,7 @@ exports[`lambda flare gets CloudWatch Logs does not get logs when --with-logs is
 • Saved function config to mock-folder/.datadog-ci/function_config.json
 
 
-🚀 Sending to Datadog Support...
+🚀 Sending to Datadog Support via https://datadoghq.com/api/ui/support/serverless/flare...
 
 ✅ Successfully sent flare file to Datadog Support!
 "
@@ -238,7 +246,7 @@ exports[`lambda flare gets CloudWatch Logs gets logs, saves, and sends correctly
 • Saved logs to mock-folder/.datadog-ci/logs/Stream3.csv
 
 
-🚀 Sending to Datadog Support...
+🚀 Sending to Datadog Support via https://datadoghq.com/api/ui/support/serverless/flare...
 
 ✅ Successfully sent flare file to Datadog Support!
 "
@@ -336,7 +344,7 @@ exports[`lambda flare gets CloudWatch Logs warns and skips getting logs when get
 • Saved function config to mock-folder/.datadog-ci/function_config.json
 
 
-🚀 Sending to Datadog Support...
+🚀 Sending to Datadog Support via https://datadoghq.com/api/ui/support/serverless/flare...
 
 ✅ Successfully sent flare file to Datadog Support!
 "
@@ -378,7 +386,7 @@ exports[`lambda flare gets CloudWatch Logs warns and skips log when getLogEvents
 • Saved function config to mock-folder/.datadog-ci/function_config.json
 
 
-🚀 Sending to Datadog Support...
+🚀 Sending to Datadog Support via https://datadoghq.com/api/ui/support/serverless/flare...
 
 ✅ Successfully sent flare file to Datadog Support!
 "
@@ -472,7 +480,7 @@ exports[`lambda flare prompts for confirmation before sending sends when user an
 • Saved function config to mock-folder/.datadog-ci/function_config.json
 
 
-🚀 Sending to Datadog Support...
+🚀 Sending to Datadog Support via https://datadoghq.com/api/ui/support/serverless/flare...
 
 ✅ Successfully sent flare file to Datadog Support!
 "
@@ -541,7 +549,7 @@ exports[`lambda flare send to Datadog successfully adds zip file to FormData 1`]
 • Saved function config to mock-folder/.datadog-ci/function_config.json
 
 
-🚀 Sending to Datadog Support...
+🚀 Sending to Datadog Support via https://datadoghq.com/api/ui/support/serverless/flare...
 
 ✅ Successfully sent flare file to Datadog Support!
 "
@@ -576,7 +584,7 @@ exports[`lambda flare send to Datadog successfully sends request to Datadog 1`] 
 • Saved function config to mock-folder/.datadog-ci/function_config.json
 
 
-🚀 Sending to Datadog Support...
+🚀 Sending to Datadog Support via https://datadoghq.com/api/ui/support/serverless/flare...
 
 ✅ Successfully sent flare file to Datadog Support!
 "
@@ -611,7 +619,7 @@ exports[`lambda flare validates required flags extracts region from function nam
 • Saved function config to mock-folder/.datadog-ci/function_config.json
 
 
-🚀 Sending to Datadog Support...
+🚀 Sending to Datadog Support via https://datadoghq.com/api/ui/support/serverless/flare...
 
 ✅ Successfully sent flare file to Datadog Support!
 "
@@ -681,7 +689,7 @@ exports[`lambda flare validates required flags runs successfully with all requir
 • Saved function config to mock-folder/.datadog-ci/function_config.json
 
 
-🚀 Sending to Datadog Support...
+🚀 Sending to Datadog Support via https://datadoghq.com/api/ui/support/serverless/flare...
 
 ✅ Successfully sent flare file to Datadog Support!
 "
@@ -716,7 +724,7 @@ exports[`lambda flare validates required flags uses API key ENV variable and run
 • Saved function config to mock-folder/.datadog-ci/function_config.json
 
 
-🚀 Sending to Datadog Support...
+🚀 Sending to Datadog Support via https://datadoghq.com/api/ui/support/serverless/flare...
 
 ✅ Successfully sent flare file to Datadog Support!
 "
@@ -751,7 +759,7 @@ exports[`lambda flare validates required flags uses API key ENV variable and run
 • Saved function config to mock-folder/.datadog-ci/function_config.json
 
 
-🚀 Sending to Datadog Support...
+🚀 Sending to Datadog Support via https://datadoghq.com/api/ui/support/serverless/flare...
 
 ✅ Successfully sent flare file to Datadog Support!
 
@@ -782,7 +790,7 @@ exports[`lambda flare validates required flags uses API key ENV variable and run
 • Saved function config to mock-folder/.datadog-ci/function_config.json
 
 
-🚀 Sending to Datadog Support...
+🚀 Sending to Datadog Support via https://datadoghq.com/api/ui/support/serverless/flare...
 
 ✅ Successfully sent flare file to Datadog Support!
 "
@@ -817,7 +825,7 @@ exports[`lambda flare validates required flags uses region ENV variable when no 
 • Saved function config to mock-folder/.datadog-ci/function_config.json
 
 
-🚀 Sending to Datadog Support...
+🚀 Sending to Datadog Support via https://datadoghq.com/api/ui/support/serverless/flare...
 
 ✅ Successfully sent flare file to Datadog Support!
 "

--- a/src/commands/lambda/__tests__/__snapshots__/flare.test.ts.snap
+++ b/src/commands/lambda/__tests__/__snapshots__/flare.test.ts.snap
@@ -74,7 +74,7 @@ exports[`lambda flare AWS credentials continues when getAWSCredentials() returns
 • Saved function config to mock-folder/.datadog-ci/function_config.json
 
 
-🚀 Sending to Datadog Support via https://datadoghq.com/api/ui/support/serverless/flare...
+🚀 Sending to Datadog Support...
 
 ✅ Successfully sent flare file to Datadog Support!
 "
@@ -109,7 +109,7 @@ exports[`lambda flare AWS credentials requests AWS credentials when none are fou
 • Saved function config to mock-folder/.datadog-ci/function_config.json
 
 
-🚀 Sending to Datadog Support via https://datadoghq.com/api/ui/support/serverless/flare...
+🚀 Sending to Datadog Support...
 
 ✅ Successfully sent flare file to Datadog Support!
 "
@@ -157,9 +157,11 @@ exports[`lambda flare getAllLogs throws an error when unable to get log events 1
 
 exports[`lambda flare getAllLogs throws an error when unable to get log streams 1`] = `[Error: Unable to get log streams: Error getting log streams]`;
 
-exports[`lambda flare getEndpointUrl should return URL with https if the environment variable does not start with http 1`] = `"https://datad0g.com/api/ui/support/serverless/flare"`;
+exports[`lambda flare getEndpointUrl should not throw error if the site is invalid and DD_CI_BYPASS_SITE_VALIDATION is set 1`] = `"https://datad0ge.com/api/ui/support/serverless/flare"`;
 
-exports[`lambda flare getEndpointUrl should return URL without trailing slash if the environment variable ends with / 1`] = `"https://datadoghq.com/api/ui/support/serverless/flare"`;
+exports[`lambda flare getEndpointUrl should return correct endpoint url 1`] = `"https://datadoghq.com/api/ui/support/serverless/flare"`;
+
+exports[`lambda flare getEndpointUrl should throw error if the site is invalid 1`] = `"Invalid site: datad0ge.com. Must be one of: datadoghq.com, datadoghq.eu, us3.datadoghq.com, us5.datadoghq.com, ap1.datadoghq.com, ddog-gov.com"`;
 
 exports[`lambda flare getEndpointUrl should use DEFAULT_DD_SITE if CI_SITE_ENV_VAR and SITE_ENV_VAR are not set 1`] = `"https://datadoghq.com/api/ui/support/serverless/flare"`;
 
@@ -201,7 +203,7 @@ exports[`lambda flare gets CloudWatch Logs does not get logs when --with-logs is
 • Saved function config to mock-folder/.datadog-ci/function_config.json
 
 
-🚀 Sending to Datadog Support via https://datadoghq.com/api/ui/support/serverless/flare...
+🚀 Sending to Datadog Support...
 
 ✅ Successfully sent flare file to Datadog Support!
 "
@@ -246,7 +248,7 @@ exports[`lambda flare gets CloudWatch Logs gets logs, saves, and sends correctly
 • Saved logs to mock-folder/.datadog-ci/logs/Stream3.csv
 
 
-🚀 Sending to Datadog Support via https://datadoghq.com/api/ui/support/serverless/flare...
+🚀 Sending to Datadog Support...
 
 ✅ Successfully sent flare file to Datadog Support!
 "
@@ -344,7 +346,7 @@ exports[`lambda flare gets CloudWatch Logs warns and skips getting logs when get
 • Saved function config to mock-folder/.datadog-ci/function_config.json
 
 
-🚀 Sending to Datadog Support via https://datadoghq.com/api/ui/support/serverless/flare...
+🚀 Sending to Datadog Support...
 
 ✅ Successfully sent flare file to Datadog Support!
 "
@@ -386,7 +388,7 @@ exports[`lambda flare gets CloudWatch Logs warns and skips log when getLogEvents
 • Saved function config to mock-folder/.datadog-ci/function_config.json
 
 
-🚀 Sending to Datadog Support via https://datadoghq.com/api/ui/support/serverless/flare...
+🚀 Sending to Datadog Support...
 
 ✅ Successfully sent flare file to Datadog Support!
 "
@@ -480,7 +482,7 @@ exports[`lambda flare prompts for confirmation before sending sends when user an
 • Saved function config to mock-folder/.datadog-ci/function_config.json
 
 
-🚀 Sending to Datadog Support via https://datadoghq.com/api/ui/support/serverless/flare...
+🚀 Sending to Datadog Support...
 
 ✅ Successfully sent flare file to Datadog Support!
 "
@@ -549,7 +551,7 @@ exports[`lambda flare send to Datadog successfully adds zip file to FormData 1`]
 • Saved function config to mock-folder/.datadog-ci/function_config.json
 
 
-🚀 Sending to Datadog Support via https://datadoghq.com/api/ui/support/serverless/flare...
+🚀 Sending to Datadog Support...
 
 ✅ Successfully sent flare file to Datadog Support!
 "
@@ -584,7 +586,7 @@ exports[`lambda flare send to Datadog successfully sends request to Datadog 1`] 
 • Saved function config to mock-folder/.datadog-ci/function_config.json
 
 
-🚀 Sending to Datadog Support via https://datadoghq.com/api/ui/support/serverless/flare...
+🚀 Sending to Datadog Support...
 
 ✅ Successfully sent flare file to Datadog Support!
 "
@@ -619,7 +621,7 @@ exports[`lambda flare validates required flags extracts region from function nam
 • Saved function config to mock-folder/.datadog-ci/function_config.json
 
 
-🚀 Sending to Datadog Support via https://datadoghq.com/api/ui/support/serverless/flare...
+🚀 Sending to Datadog Support...
 
 ✅ Successfully sent flare file to Datadog Support!
 "
@@ -689,7 +691,7 @@ exports[`lambda flare validates required flags runs successfully with all requir
 • Saved function config to mock-folder/.datadog-ci/function_config.json
 
 
-🚀 Sending to Datadog Support via https://datadoghq.com/api/ui/support/serverless/flare...
+🚀 Sending to Datadog Support...
 
 ✅ Successfully sent flare file to Datadog Support!
 "
@@ -724,7 +726,7 @@ exports[`lambda flare validates required flags uses API key ENV variable and run
 • Saved function config to mock-folder/.datadog-ci/function_config.json
 
 
-🚀 Sending to Datadog Support via https://datadoghq.com/api/ui/support/serverless/flare...
+🚀 Sending to Datadog Support...
 
 ✅ Successfully sent flare file to Datadog Support!
 "
@@ -759,7 +761,7 @@ exports[`lambda flare validates required flags uses API key ENV variable and run
 • Saved function config to mock-folder/.datadog-ci/function_config.json
 
 
-🚀 Sending to Datadog Support via https://datadoghq.com/api/ui/support/serverless/flare...
+🚀 Sending to Datadog Support...
 
 ✅ Successfully sent flare file to Datadog Support!
 
@@ -790,7 +792,7 @@ exports[`lambda flare validates required flags uses API key ENV variable and run
 • Saved function config to mock-folder/.datadog-ci/function_config.json
 
 
-🚀 Sending to Datadog Support via https://datadoghq.com/api/ui/support/serverless/flare...
+🚀 Sending to Datadog Support...
 
 ✅ Successfully sent flare file to Datadog Support!
 "
@@ -825,7 +827,7 @@ exports[`lambda flare validates required flags uses region ENV variable when no 
 • Saved function config to mock-folder/.datadog-ci/function_config.json
 
 
-🚀 Sending to Datadog Support via https://datadoghq.com/api/ui/support/serverless/flare...
+🚀 Sending to Datadog Support...
 
 ✅ Successfully sent flare file to Datadog Support!
 "

--- a/src/commands/lambda/__tests__/flare.test.ts
+++ b/src/commands/lambda/__tests__/flare.test.ts
@@ -740,21 +740,28 @@ describe('lambda flare', () => {
       process.env = ORIGINAL_ENV
     })
 
-    it('should return URL with https if the environment variable does not start with http', () => {
-      process.env[CI_SITE_ENV_VAR] = 'datad0g.com'
+    it('should return correct endpoint url', () => {
+      process.env[CI_SITE_ENV_VAR] = 'datadoghq.com'
       const url = getEndpointUrl()
       expect(url).toMatchSnapshot()
     })
 
-    it('should return URL without trailing slash if the environment variable ends with /', () => {
-      process.env[CI_SITE_ENV_VAR] = 'https://datadoghq.com/'
+    it('should throw error if the site is invalid', () => {
+      process.env[CI_SITE_ENV_VAR] = 'datad0ge.com'
+      expect(() => getEndpointUrl()).toThrowErrorMatchingSnapshot()
+    })
+
+    it('should not throw error if the site is invalid and DD_CI_BYPASS_SITE_VALIDATION is set', () => {
+      process.env['DD_CI_BYPASS_SITE_VALIDATION'] = 'true'
+      process.env[CI_SITE_ENV_VAR] = 'datad0ge.com'
       const url = getEndpointUrl()
       expect(url).toMatchSnapshot()
+      delete process.env['DD_CI_BYPASS_SITE_VALIDATION']
     })
 
     it('should use SITE_ENV_VAR if CI_SITE_ENV_VAR is not set', () => {
       delete process.env[CI_SITE_ENV_VAR]
-      process.env[SITE_ENV_VAR] = 'https://us3.datadoghq.com/'
+      process.env[SITE_ENV_VAR] = 'us3.datadoghq.com'
       const url = getEndpointUrl()
       expect(url).toMatchSnapshot()
     })

--- a/src/commands/lambda/flare.ts
+++ b/src/commands/lambda/flare.ts
@@ -589,6 +589,9 @@ export const zipContents = async (rootFolderPath: string, zipPath: string) => {
  */
 export const getEndpointUrl = () => {
   let baseUrl = process.env[CI_SITE_ENV_VAR] ?? process.env[SITE_ENV_VAR] ?? DEFAULT_DD_SITE
+  // These checks cover the case where the environment variables are invalid
+  // For example, the correct endpoint URL will still be returned when the user
+  // sets DATADOG_SITE=https://datadoghq.com/ instead of DATADOG_SITE=datadoghq.com
   if (!baseUrl.startsWith('http')) {
     baseUrl = `https://${baseUrl}`
   }

--- a/src/commands/lambda/flare.ts
+++ b/src/commands/lambda/flare.ts
@@ -17,7 +17,8 @@ import FormData from 'form-data'
 import inquirer from 'inquirer'
 import JSZip from 'jszip'
 
-import {DATADOG_SITE_US1} from '../../constants'
+import {DATADOG_SITE_US1, DATADOG_SITES} from '../../constants'
+import {isValidDatadogSite} from '../../helpers/validation'
 
 import {
   API_KEY_ENV_VAR,
@@ -585,21 +586,16 @@ export const zipContents = async (rootFolderPath: string, zipPath: string) => {
 
 /**
  * Calculates the full endpoint URL
+ * @throws Error if the site is invalid
  * @returns the full endpoint URL
  */
 export const getEndpointUrl = () => {
-  let baseUrl = process.env[CI_SITE_ENV_VAR] ?? process.env[SITE_ENV_VAR] ?? DATADOG_SITE_US1
-  // These checks cover the case where the environment variables are invalid
-  // For example, the correct endpoint URL will still be returned when the user
-  // sets DATADOG_SITE=https://datadoghq.com/ instead of DATADOG_SITE=datadoghq.com
-  if (!baseUrl.startsWith('http')) {
-    baseUrl = `https://${baseUrl}`
-  }
-  if (baseUrl.endsWith('/')) {
-    baseUrl = baseUrl.slice(0, -1)
+  const baseUrl = process.env[CI_SITE_ENV_VAR] ?? process.env[SITE_ENV_VAR] ?? DATADOG_SITE_US1
+  if (!isValidDatadogSite(baseUrl)) {
+    throw Error(`Invalid site: ${baseUrl}. Must be one of: ${DATADOG_SITES.join(', ')}`)
   }
 
-  return baseUrl + ENDPOINT_PATH
+  return 'https://' + baseUrl + ENDPOINT_PATH
 }
 
 /**

--- a/src/commands/lambda/flare.ts
+++ b/src/commands/lambda/flare.ts
@@ -263,7 +263,7 @@ export class LambdaFlareCommand extends Command {
       await zipContents(rootFolderPath, zipPath)
 
       // Send to Datadog
-      this.context.stdout.write(`\n🚀 Sending to Datadog Support...\n`)
+      this.context.stdout.write('\n🚀 Sending to Datadog Support...\n')
       await sendToDatadog(zipPath, this.caseId!, this.email!, this.apiKey!, rootFolderPath)
       this.context.stdout.write('\n✅ Successfully sent flare file to Datadog Support!\n')
 
@@ -600,7 +600,6 @@ export const getEndpointUrl = () => {
 
 /**
  * Send the zip file to Datadog support
- * @param endpointUrl
  * @param zipPath
  * @param caseId
  * @param email


### PR DESCRIPTION
### What and why?

We want to use environment variables `DATADOG_SITE` or `DD_SITE` to build the endpoint URL to send flare files to. This ensures that user experience low latencies.
In the case where neither environment variable is set, we will use `DATADOG_SITE_US1 = 'datadoghq.com'` to default to `US1`.

### How?

- Create the `getEndpointUrl()` function that calculates and returns the full endpoint URL as a string
- Determine the base URL with priority (1) `DATADOG_SITE`, (2) `DD_SITE`, or (3) the default Datadog site `DATADOG_SITE_US1`, if neither environment variable is set.
- Append `https://` to the endpoint

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
