### PR TITLE
[synthetics] Add support for `--pollingTimeout`

### DIFF
--- a/src/commands/synthetics/__tests__/cli.test.ts
+++ b/src/commands/synthetics/__tests__/cli.test.ts
@@ -175,6 +175,7 @@ describe('run-test', () => {
         appKey: 'app_key_config_file',
         datadogSite: 'us5.datadoghq.com',
         global: {
+          pollingTimeout: 111,
           mobileApplicationVersionFilePath: './path/to/application_config_file.apk',
         },
       }))
@@ -187,6 +188,7 @@ describe('run-test', () => {
       const command = new RunTestsCommand()
       command['apiKey'] = 'api_key_cli'
       command['mobileApplicationVersionFilePath'] = './path/to/application_cli.apk'
+      command['pollingTimeout'] = '333'
 
       await command['resolveConfig']()
       expect(command['config']).toEqual({
@@ -195,7 +197,7 @@ describe('run-test', () => {
         appKey: 'app_key_env',
         datadogSite: 'us5.datadoghq.com',
         global: {
-          pollingTimeout: DEFAULT_POLLING_TIMEOUT,
+          pollingTimeout: 333,
           mobileApplicationVersionFilePath: './path/to/application_cli.apk',
         },
       })

--- a/src/helpers/__tests__/utils.test.ts
+++ b/src/helpers/__tests__/utils.test.ts
@@ -23,6 +23,15 @@ describe('utils', () => {
     expect(Object.keys(resultHash).length).toBe(0)
   })
 
+  test('parseOptionalInteger', () => {
+    expect(ciUtils.parseOptionalInteger(undefined)).toStrictEqual(undefined)
+    expect(ciUtils.parseOptionalInteger('')).toStrictEqual(undefined)
+    expect(() => ciUtils.parseOptionalInteger('1.2')).toThrow('1.2 is not an integer')
+    expect(() => ciUtils.parseOptionalInteger('abc')).toThrow('NaN is not an integer')
+
+    expect(ciUtils.parseOptionalInteger('1')).toStrictEqual(1)
+  })
+
   describe('resolveConfigFromFile', () => {
     test('should read a config file', async () => {
       const config: any = await ciUtils.resolveConfigFromFile(

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -58,6 +58,19 @@ const resolveConfigPath = ({
   return undefined
 }
 
+export const parseOptionalInteger = (value: string | undefined): number | undefined => {
+  if (!value) {
+    return undefined
+  }
+
+  const number = parseFloat(value)
+  if (!Number.isInteger(number)) {
+    throw new Error(`${number} is not an integer`)
+  }
+
+  return number
+}
+
 /**
  * Applies configurations in this order of priority:
  * environment > config file > base config


### PR DESCRIPTION
- https://github.com/DataDog/datadog-ci/pull/970 ←
- https://github.com/DataDog/datadog-ci/pull/971
---

### What and why?

This PR adds a `--pollingTimeout` CLI argument.

This will allow us to add a `polling_timeout` input in our [CircleCI orb](https://github.com/DataDog/synthetics-test-automation-circleci-orb).

### How?

- Add a new argument
- Add a utility function to parse an optional integer
  - We can later reuse it in the github action ([here](https://github.com/DataDog/synthetics-ci-github-action/blob/84ab83ecd7f52c6daec005ced8883a461cef51c3/src/resolve-config.ts#L106-L111)) and azure devops extension ([here](https://github.com/DataDog/datadog-ci-azure-devops/blob/main/SyntheticsRunTestsTask/utils.ts#L12-L17))
- Throw an `INVALID_CONFIG` error if the validation fails
- Satisfy this order of precedence:
  - `--pollingTimeout` >> `config.global.pollingTimeout` >> `this.config.pollingTimeout` ([deprecated](https://github.com/DataDog/datadog-ci/pull/971))

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
