### PR TITLE
[synthetics] Deprecate `pollingTimeout` at root of config file

### DIFF
--- a/src/commands/synthetics/README.md
+++ b/src/commands/synthetics/README.md
@@ -77,17 +77,13 @@ See below for the list of advanced options in the global configuration file. For
 : A boolean flag that fails the CI job if at least one test exceeds the default test timeout. The default is set to `true`.
 
 `files`
-: Glob patterns to detect Synthetic test [configuration files](#test-files).
+: Glob patterns to detect Synthetic [test files](#test-files).
 
 `global`
-: Overrides for Synthetic tests applied to all tests.
+: Overrides for Synthetic tests applied to all tests. They are the same overrides as those documented in the [test files](#test-files) section.
 
 `mobileApplicationVersionFilePath`
 : Override the application version for all Synthetic mobile application tests.
-
-`pollingTimeout`
-: **Type**: integer<br>
-The duration (in milliseconds) after which `datadog-ci` stops polling for test results. The default is 30 minutes. At the CI level, test results completed after this duration are considered failed.
 
 `proxy`
 : The proxy to be used for outgoing connections to Datadog. `host` and `port` keys are mandatory arguments, the `protocol` key defaults to `http`. Supported values for the `protocol` key are `http`, `https`, `socks`, `socks4`, `socks4a`, `socks5`, `socks5h`, `pac+data`, `pac+file`, `pac+ftp`, `pac+http`, and `pac+https`. The library used to configure the proxy is the [proxy-agent][2] library.

--- a/src/commands/synthetics/__tests__/cli.test.ts
+++ b/src/commands/synthetics/__tests__/cli.test.ts
@@ -175,6 +175,7 @@ describe('run-test', () => {
         appKey: 'app_key_config_file',
         datadogSite: 'us5.datadoghq.com',
         global: {
+          pollingTimeout: 111,
           mobileApplicationVersionFilePath: './path/to/application_config_file.apk',
         },
       }))
@@ -187,6 +188,7 @@ describe('run-test', () => {
       const command = new RunTestsCommand()
       command['apiKey'] = 'api_key_cli'
       command['mobileApplicationVersionFilePath'] = './path/to/application_cli.apk'
+      command['pollingTimeout'] = '333'
 
       await command['resolveConfig']()
       expect(command['config']).toEqual({
@@ -195,7 +197,7 @@ describe('run-test', () => {
         appKey: 'app_key_env',
         datadogSite: 'us5.datadoghq.com',
         global: {
-          pollingTimeout: DEFAULT_POLLING_TIMEOUT,
+          pollingTimeout: 333,
           mobileApplicationVersionFilePath: './path/to/application_cli.apk',
         },
       })

--- a/src/commands/synthetics/__tests__/cli.test.ts
+++ b/src/commands/synthetics/__tests__/cli.test.ts
@@ -8,7 +8,7 @@ import {DEFAULT_COMMAND_CONFIG, DEFAULT_POLLING_TIMEOUT, RunTestsCommand} from '
 import {DEFAULT_UPLOAD_COMMAND_CONFIG, UploadApplicationCommand} from '../upload-application-command'
 import * as utils from '../utils'
 
-import {getApiTest, getAxiosHttpError, getTestSuite, mockTestTriggerResponse} from './fixtures'
+import {getApiTest, getAxiosHttpError, getTestSuite, mockReporter, mockTestTriggerResponse} from './fixtures'
 test('all option flags are supported', async () => {
   const options = [
     'apiKey',
@@ -302,15 +302,22 @@ describe('run-test', () => {
 
     test('pass command pollingTimeout as global override if undefined', async () => {
       const command = new RunTestsCommand()
+      command['reporter'] = mockReporter
       command['configPath'] =
         'src/commands/synthetics/__tests__/config-fixtures/config-with-global-polling-timeout.json'
+
       await command['resolveConfig']()
+
       expect(command['config']).toEqual({
         ...DEFAULT_COMMAND_CONFIG,
         configPath: 'src/commands/synthetics/__tests__/config-fixtures/config-with-global-polling-timeout.json',
         global: {followRedirects: false, pollingTimeout: 333},
         pollingTimeout: 333,
       })
+
+      expect(mockReporter.log).toHaveBeenCalledWith(
+        '[DEPRECATED] "pollingTimeout" should be set under the `global` key in the global configuration file or in a test file.\n'
+      )
     })
   })
 

--- a/src/commands/synthetics/__tests__/cli.test.ts
+++ b/src/commands/synthetics/__tests__/cli.test.ts
@@ -94,7 +94,7 @@ describe('run-test', () => {
       }
 
       const command = new RunTestsCommand()
-      command.configPath = 'src/commands/synthetics/__tests__/config-fixtures/config-with-all-keys.json'
+      command['configPath'] = 'src/commands/synthetics/__tests__/config-fixtures/config-with-all-keys.json'
 
       await command['resolveConfig']()
       expect(command['config']).toEqual(overrideConfigFile)
@@ -302,7 +302,8 @@ describe('run-test', () => {
 
     test('pass command pollingTimeout as global override if undefined', async () => {
       const command = new RunTestsCommand()
-      command.configPath = 'src/commands/synthetics/__tests__/config-fixtures/config-with-global-polling-timeout.json'
+      command['configPath'] =
+        'src/commands/synthetics/__tests__/config-fixtures/config-with-global-polling-timeout.json'
       await command['resolveConfig']()
       expect(command['config']).toEqual({
         ...DEFAULT_COMMAND_CONFIG,
@@ -532,7 +533,7 @@ describe('upload-application', () => {
       }
 
       const command = new UploadApplicationCommand()
-      command.configPath = 'src/commands/synthetics/__tests__/config-fixtures/upload-app-config-with-all-keys.json'
+      command['configPath'] = 'src/commands/synthetics/__tests__/config-fixtures/upload-app-config-with-all-keys.json'
 
       await command['resolveConfig']()
       expect(command['config']).toEqual(overrideConfigFile)

--- a/src/commands/synthetics/__tests__/tunnel/websocket.test.ts
+++ b/src/commands/synthetics/__tests__/tunnel/websocket.test.ts
@@ -73,7 +73,7 @@ describe('Proxy configuration', () => {
 
     try {
       const command = new RunTestsCommand()
-      command.configPath = 'src/commands/synthetics/__tests__/config-fixtures/config-with-tunnel-no-proxy.json'
+      command['configPath'] = 'src/commands/synthetics/__tests__/config-fixtures/config-with-tunnel-no-proxy.json'
       command.context = {stdout: {write: jest.fn()}} as any
       jest.spyOn(utils, 'getDatadogHost').mockImplementation(() => 'http://datadoghq.com/')
 

--- a/src/commands/synthetics/run-tests-command.ts
+++ b/src/commands/synthetics/run-tests-command.ts
@@ -44,17 +44,20 @@ export const DEFAULT_COMMAND_CONFIG: RunTestsCommandConfig = {
 }
 
 export class RunTestsCommand extends Command {
-  public configPath?: string
+  // CLI arguments for JUnit reports
   public jUnitReport?: string
   public runName?: string
+
+  // CLI arguments
   private apiKey?: string
   private appKey?: string
-  private config: RunTestsCommandConfig = JSON.parse(JSON.stringify(DEFAULT_COMMAND_CONFIG)) // Deep copy to avoid mutation during unit tests
+  private configPath?: string
   private datadogSite?: string
   private failOnCriticalErrors?: boolean
   private failOnMissingTests?: boolean
   private failOnTimeout?: boolean
   private files?: string[]
+  private mobileApplicationVersionFilePath?: string
   private pollingTimeout?: string
   private publicIds?: string[]
   private reporter?: MainReporter
@@ -62,7 +65,8 @@ export class RunTestsCommand extends Command {
   private testSearchQuery?: string
   private tunnel?: boolean
   private variableStrings?: string[]
-  private mobileApplicationVersionFilePath?: string
+
+  private config = JSON.parse(JSON.stringify(DEFAULT_COMMAND_CONFIG)) as RunTestsCommandConfig // Deep copy to avoid mutation during unit tests
 
   public async execute() {
     const reporters: Reporter[] = [new DefaultReporter(this)]

--- a/src/commands/synthetics/run-tests-command.ts
+++ b/src/commands/synthetics/run-tests-command.ts
@@ -135,6 +135,12 @@ export class RunTestsCommand extends Command {
       }
     }
 
+    if (this.config.pollingTimeout !== DEFAULT_COMMAND_CONFIG.pollingTimeout) {
+      this.reporter?.log(
+        '[DEPRECATED] "pollingTimeout" should be set under the `global` key in the global configuration file or in a test file.\n'
+      )
+    }
+
     // Override with ENV variables
     this.config = deepExtend(
       this.config,
@@ -184,7 +190,7 @@ export class RunTestsCommand extends Command {
     )
 
     if (typeof this.config.files === 'string') {
-      this.reporter!.log('[DEPRECATED] "files" should be an array of string instead of a string.\n')
+      this.reporter?.log('[DEPRECATED] "files" should be an array of string instead of a string.\n')
       this.config.files = [this.config.files]
     }
 

--- a/src/commands/synthetics/upload-application-command.ts
+++ b/src/commands/synthetics/upload-application-command.ts
@@ -22,18 +22,21 @@ export const DEFAULT_UPLOAD_COMMAND_CONFIG: UploadApplicationCommandConfig = {
 }
 
 export class UploadApplicationCommand extends Command {
-  public configPath?: string
+  // CLI arguments
   private apiKey?: string
   private appKey?: string
-  private config: UploadApplicationCommandConfig = JSON.parse(JSON.stringify(DEFAULT_UPLOAD_COMMAND_CONFIG)) // Deep copy to avoid mutation during unit tests
+  private configPath?: string
   private datadogSite?: string
-  private mobileApplicationVersionFilePath?: string
-  private mobileApplicationId?: string
-  private versionName?: string
   private latest?: boolean
+  private mobileApplicationId?: string
+  private mobileApplicationVersionFilePath?: string
+  private versionName?: string
+
   private logger: Logger = new Logger((s: string) => {
     this.context.stdout.write(s)
   }, LogLevel.INFO)
+
+  private config = JSON.parse(JSON.stringify(DEFAULT_UPLOAD_COMMAND_CONFIG)) as UploadApplicationCommandConfig // Deep copy to avoid mutation during unit tests
 
   public async execute() {
     try {

--- a/src/helpers/__tests__/utils.test.ts
+++ b/src/helpers/__tests__/utils.test.ts
@@ -23,6 +23,15 @@ describe('utils', () => {
     expect(Object.keys(resultHash).length).toBe(0)
   })
 
+  test('parseOptionalInteger', () => {
+    expect(ciUtils.parseOptionalInteger(undefined)).toStrictEqual(undefined)
+    expect(ciUtils.parseOptionalInteger('')).toStrictEqual(undefined)
+    expect(() => ciUtils.parseOptionalInteger('1.2')).toThrow('1.2 is not an integer')
+    expect(() => ciUtils.parseOptionalInteger('abc')).toThrow('NaN is not an integer')
+
+    expect(ciUtils.parseOptionalInteger('1')).toStrictEqual(1)
+  })
+
   describe('resolveConfigFromFile', () => {
     test('should read a config file', async () => {
       const config: any = await ciUtils.resolveConfigFromFile(

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -58,6 +58,19 @@ const resolveConfigPath = ({
   return undefined
 }
 
+export const parseOptionalInteger = (value: string | undefined): number | undefined => {
+  if (!value) {
+    return undefined
+  }
+
+  const number = parseFloat(value)
+  if (!Number.isInteger(number)) {
+    throw new Error(`${number} is not an integer`)
+  }
+
+  return number
+}
+
 /**
  * Applies configurations in this order of priority:
  * environment > config file > base config


### PR DESCRIPTION
- https://github.com/DataDog/datadog-ci/pull/970 
- https://github.com/DataDog/datadog-ci/pull/971 ←
---

### What and why?

The `pollingTimeout` can currently be set in two places inside a `datadog-ci.json` file:

```json
{
  "apiKey": "api-key",
  "appKey": "app-key",
  "pollingTimeout": 300000
  "global": {
    "pollingTimeout": 180000
  },
}
```

This is the result of making it possible to override the `pollingTimeout` in test files (we take the maximum in all the `pollingTimeout` values to poll for the batch).

Because the overrides in `global` and in test files are the same, we ended up having `pollingTimeout` both at the root of the config file and in `global`. However, only the latter makes sense.

### How?

- Undocument the option in the README
- Add a deprecation log

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
