### PR TITLE
Add `mergeStepFunctionAndLambdaTraces` option to `stepfunctions` command

### DIFF
--- a/src/commands/stepfunctions/__tests__/awsCommands.test.ts
+++ b/src/commands/stepfunctions/__tests__/awsCommands.test.ts
@@ -26,7 +26,8 @@ import {
   tagResource,
   untagResource,
   createLogsAccessPolicy,
-  attachPolicyToStateMachineIamRole, updateStateMachineDefinition,
+  attachPolicyToStateMachineIamRole,
+  updateStateMachineDefinition,
 } from '../awsCommands'
 import {buildLogAccessPolicyName, StateMachineDefinitionType} from '../helpers'
 

--- a/src/commands/stepfunctions/__tests__/awsCommands.test.ts
+++ b/src/commands/stepfunctions/__tests__/awsCommands.test.ts
@@ -26,9 +26,9 @@ import {
   tagResource,
   untagResource,
   createLogsAccessPolicy,
-  attachPolicyToStateMachineIamRole,
+  attachPolicyToStateMachineIamRole, updateStateMachineDefinition,
 } from '../awsCommands'
-import {buildLogAccessPolicyName} from '../helpers'
+import {buildLogAccessPolicyName, StateMachineDefinitionType} from '../helpers'
 
 import {createMockContext} from './fixtures/aws-resources'
 
@@ -237,6 +237,29 @@ describe('awsCommands test', () => {
       describeStateMachineCommandOutput,
       fakeLogGroupArn,
       fakeStepFunctionArn,
+      mockedContext,
+      false
+    )
+
+    expect(actual).toEqual(expectedResp)
+  })
+
+  test('updateStateMachineDefinition test', async () => {
+    const definitionObj: StateMachineDefinitionType = {
+      Comment: 'no comment',
+      States: {},
+    }
+    const input = {
+      stateMachineArn: fakeStepFunctionArn,
+      definition: JSON.stringify(definitionObj),
+    }
+
+    mockedStepFunctionsClient.on(UpdateStateMachineCommand, input).resolves(expectedResp)
+
+    const actual = await updateStateMachineDefinition(
+      new SFNClient({}),
+      describeStateMachineCommandOutput,
+      definitionObj,
       mockedContext,
       false
     )

--- a/src/commands/stepfunctions/__tests__/instrument.test.ts
+++ b/src/commands/stepfunctions/__tests__/instrument.test.ts
@@ -17,6 +17,7 @@ describe('stepfunctions instrument test', () => {
     aws = require('../awsCommands')
     helpers = require('../helpers')
     helpers.applyChanges = jest.fn().mockImplementation(() => false)
+    helpers.injectContextIntoLambdaPayload = jest.fn().mockImplementation()
     cli = new Cli()
     cli.register(InstrumentStepFunctionsCommand)
   })
@@ -454,6 +455,41 @@ describe('stepfunctions instrument test', () => {
       expect(aws.attachPolicyToStateMachineIamRole).toHaveBeenCalledTimes(0)
       expect(aws.enableStepFunctionLogs).toHaveBeenCalledTimes(1)
       expect(aws.putSubscriptionFilter).toHaveBeenCalledTimes(1)
+      expect(exitCode).toBe(0)
+    })
+  })
+
+  describe('mergeStepFunctionAndLambdaTraces enabled', () => {
+    test('mergeStepFunctionAndLambdaTraces flag is set (to true)', async () => {
+      const exitCode = await cli.run(
+        [
+          'stepfunctions',
+          'instrument',
+          '--forwarder',
+          'arn:aws:lambda:us-east-1:000000000000:function:DatadogForwarder',
+          '--step-function',
+          'arn:aws:states:us-east-1:000000000000:stateMachine:ExampleStepFunction',
+          '--merge-lambda-traces',
+        ],
+        context
+      )
+      expect(helpers.injectContextIntoLambdaPayload).toHaveBeenCalledTimes(1)
+      expect(exitCode).toBe(0)
+    })
+
+    test('mergeStepFunctionAndLambdaTraces flag is not set (default to false)', async () => {
+      const exitCode = await cli.run(
+        [
+          'stepfunctions',
+          'instrument',
+          '--forwarder',
+          'arn:aws:lambda:us-east-1:000000000000:function:DatadogForwarder',
+          '--step-function',
+          'arn:aws:states:us-east-1:000000000000:stateMachine:ExampleStepFunction',
+        ],
+        context
+      )
+      expect(helpers.injectContextIntoLambdaPayload).toHaveBeenCalledTimes(0)
       expect(exitCode).toBe(0)
     })
   })

--- a/src/commands/stepfunctions/awsCommands.ts
+++ b/src/commands/stepfunctions/awsCommands.ts
@@ -276,14 +276,18 @@ export const updateStateMachineDefinition = async (
     `Going to inject Step Function context into lambda payload in steps of ${stepFunction.stateMachineArn}.\n\n`
   )
   if (!dryRun) {
-    const data = await stepFunctionsClient.send(command)
-    context.stdout.write(JSON.stringify(data))
-    context.stdout.write('\n')
-    context.stdout.write(
-      `Step Function context is injected into lambda payload in steps of ${stepFunction.stateMachineArn}\n\n`
-    )
-
-    return data
+    try {
+      await stepFunctionsClient.send(command)
+      context.stdout.write(
+        `Step Function context is injected into lambda payload in steps of ${stepFunction.stateMachineArn}\n\n`
+      )
+    } catch (err) {
+      if (err instanceof Error) {
+        context.stdout.write(
+          `\n[Error] ${err.message}. Failed to inject context into lambda functions' payload of ${stepFunction.stateMachineArn} \n`
+        )
+      }
+    }
   }
 }
 

--- a/src/commands/stepfunctions/awsCommands.ts
+++ b/src/commands/stepfunctions/awsCommands.ts
@@ -277,10 +277,12 @@ export const updateStateMachineDefinition = async (
   )
   if (!dryRun) {
     try {
-      await stepFunctionsClient.send(command)
+      const data = await stepFunctionsClient.send(command)
       context.stdout.write(
         `Step Function context is injected into lambda payload in steps of ${stepFunction.stateMachineArn}\n\n`
       )
+
+      return data
     } catch (err) {
       if (err instanceof Error) {
         context.stdout.write(

--- a/src/commands/stepfunctions/helpers.ts
+++ b/src/commands/stepfunctions/helpers.ts
@@ -14,9 +14,7 @@ export const displayChanges = (
   params: any,
   previousParams?: any
 ): void => {
-  context.stdout.write(`${'='.repeat(50)}`)
-  context.stdout.write(`\n${dryRun ? '\n[Dry Run] Planning for' : 'Will apply'} the following change:\n`)
-  context.stdout.write(`\nChanges for ${stepFunctionArn}\n`)
+  context.stdout.write(`\n${dryRun ? '\nPlanning for' : 'Will apply'} the following change:\n`)
   if (previousParams !== undefined) {
     context.stdout.write(
       `\n${commandName}:\nFrom:\n${JSON.stringify(diff(params, previousParams), undefined, 2)}\nTo:\n${JSON.stringify(

--- a/src/commands/stepfunctions/helpers.ts
+++ b/src/commands/stepfunctions/helpers.ts
@@ -142,15 +142,17 @@ export type StateMachineDefinitionType = {
   States?: StatesType
 }
 
-type StatesType = Record<string, StepType>
-type StepType = {
+export type StatesType = Record<string, StepType>
+export type StepType = {
   Type: string
   Parameters?: ParametersType
   Resource: string
   Next?: string
-  End?: string
+  End?: boolean
 }
 
-type ParametersType = {
+export type ParametersType = {
   'Payload.$'?: string
+  FunctionName?: string
+  TableName?: string
 }

--- a/src/commands/stepfunctions/helpers.ts
+++ b/src/commands/stepfunctions/helpers.ts
@@ -120,7 +120,7 @@ export const updateStepObject = ({Parameters}: StepType): void => {
 export const shouldUpdateStepForTracesMerging = (step: StepType): boolean => {
   // is default lambda api
   if (step.Resource === 'arn:aws:states:::lambda:invoke') {
-    if (step.Parameters === undefined) {
+    if (!step.Parameters) {
       return false
     }
     // payload field not set

--- a/src/commands/stepfunctions/instrument.ts
+++ b/src/commands/stepfunctions/instrument.ts
@@ -90,6 +90,9 @@ export class InstrumentStepFunctionsCommand extends Command {
 
     // loop over step functions passed as parameters and generate a list of requests to make to AWS for each step function
     for (const stepFunctionArn of stepFunctionArns) {
+      this.context.stdout.write(
+        `\n======= ${this.dryRun ? '[Dry Run] Planning for' : 'For'} ${stepFunctionArn} =========\n`
+      )
       // use region from the step function arn to make requests to AWS
       const arnObject = parseArn(stepFunctionArn)
       const region = arnObject.region
@@ -332,8 +335,8 @@ export class InstrumentStepFunctionsCommand extends Command {
       }
 
       if (this.mergeStepFunctionAndLambdaTraces) {
-        // Not putting the update operation into the business logic of logs subscribing to allow
-        // easier testing and cleaner code.
+        // Not putting the update operation into the business logic of logs subscription. This will
+        // add additional API call, but it would also allow easier testing and cleaner code.
         await injectContextIntoLambdaPayload(
           describeStateMachineCommandOutput,
           stepFunctionsClient,

--- a/src/commands/stepfunctions/instrument.ts
+++ b/src/commands/stepfunctions/instrument.ts
@@ -20,7 +20,8 @@ import {
   buildSubscriptionFilterName,
   isValidArn,
   parseArn,
-  getStepFunctionLogGroupArn, updateStateMachineDefinition,
+  getStepFunctionLogGroupArn,
+  injectContextIntoLambdaPayload,
 } from './helpers'
 
 const cliVersion = require('../../../package.json').version
@@ -331,9 +332,14 @@ export class InstrumentStepFunctionsCommand extends Command {
       }
 
       if (this.mergeStepFunctionAndLambdaTraces) {
-        // Not putting the update operation into business log of subscribing to logs to allow
-        // easier testing.
-        updateStateMachineDefinition(describeStateMachineCommandOutput, this.context)
+        // Not putting the update operation into the business logic of logs subscribing to allow
+        // easier testing and cleaner code.
+        await injectContextIntoLambdaPayload(
+          describeStateMachineCommandOutput,
+          stepFunctionsClient,
+          this.context,
+          this.dryRun
+        )
       }
     }
     if (!hasChanges) {


### PR DESCRIPTION
### What and why?
We are asking customers to manually change their step functions definition to inject Step Functions Context Object into Lambda payload. To help customers do this automatically, we add `mergeStepFunctionAndLambdaTraces` flag for customers to opt (default to false) in merging their step functions trace with lambda traces.

Also fixed the issue where the same step functions arn are printed while looping all steps.

### How?
For each step functions' steps, we find all default lambda api steps and check if their lambda step payload has special logic. If not, we change their `Payload.$` to `'States.JsonMerge($$, $, false)'` to inject step functions context (which contains the info that is to be hashed by lambda Python/NodeJS layer) into payload. The scenario that we are updating their payload are:
- without `Payload.$` field
- with `Payload.$` but the value is `$`, which means the original lambda payload.


### Test
Tested in sandbox account. Traces showed up merging as expected.
```bash
aws-vault exec serverless-sandbox-account-admin -- node ./dist/cli.js stepfunctions instrument \
--forwarder arn:aws:lambda:sa-east-1:425362996713:function:step-functions-tracing-forwarder-self-monitoring-us1-prod \
--step-function arn:aws:states:sa-east-1:425362996713:stateMachine:kimi-testing-state-machine \
--env kimi-dev \
--service kimi-dev-service \
--merge-lambda-traces

```

<img width="1055" alt="image" src="https://github.com/DataDog/datadog-ci/assets/47579703/f1acf8fa-b4d7-4d60-9e26-4ea4d6c0a0aa">

<img width="1561" alt="image" src="https://github.com/DataDog/datadog-ci/assets/47579703/ec33f90a-8c0f-44fd-803f-eb7eec7dfff3">


### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
