### PR TITLE
[lambda][flare] Don't require email or case ID as flags when running in dry mode

### DIFF
--- a/src/commands/lambda/__tests__/__snapshots__/flare.test.ts.snap
+++ b/src/commands/lambda/__tests__/__snapshots__/flare.test.ts.snap
@@ -652,6 +652,40 @@ exports[`lambda flare validates required flags prints error when no region speci
 "
 `;
 
+exports[`lambda flare validates required flags runs successfully when dry run but no email or case ID is specified 1`] = `
+"
+[Dry Run] 🐶 Generating Lambda flare to send your configuration to Datadog...
+
+🔑 Getting AWS credentials...
+
+[!] No AWS credentials found, let's set them up! Or you can re-run the command and supply the AWS credentials in the same way when you invoke the AWS CLI.
+
+🔍 Fetching Lambda function configuration...
+
+{
+  Environment: {
+    Variables: {
+      DD_API_KEY: '02**********33bd',
+      DD_SITE: 'datadoghq.com',
+      DD_LOG_LEVEL: 'debug'
+    }
+  },
+  FunctionArn: 'arn:aws:lambda:us-east-1:123456789012:function:some-function',
+  FunctionName: 'some-function'
+}
+
+🏷 Getting Resource Tags...
+[!] No resource tags were found.
+
+💾 Saving files...
+• Saved function config to mock-folder/.datadog-ci/function_config.json
+
+🚫 The flare files were not sent as it was executed in dry run mode.
+ℹ️ Your output files are located at: mock-folder/.datadog-ci
+
+"
+`;
+
 exports[`lambda flare validates required flags runs successfully with all required options specified 1`] = `
 "
 🐶 Generating Lambda flare to send your configuration to Datadog...

--- a/src/commands/lambda/__tests__/flare.test.ts
+++ b/src/commands/lambda/__tests__/flare.test.ts
@@ -251,6 +251,15 @@ describe('lambda flare', () => {
       expect(output).toMatchSnapshot()
     })
 
+    it('runs successfully when dry run but no email or case ID is specified', async () => {
+      const cli = makeCli()
+      const context = createMockContext()
+      const code = await cli.run(['lambda', 'flare', '-f', 'func', '-r', MOCK_REGION, '-d'], context as any)
+      expect(code).toBe(0)
+      const output = context.stdout.toString()
+      expect(output).toMatchSnapshot()
+    })
+
     it('runs successfully with all required options specified', async () => {
       const cli = makeCli()
       const context = createMockContext()

--- a/src/commands/lambda/flare.ts
+++ b/src/commands/lambda/flare.ts
@@ -77,14 +77,16 @@ export class LambdaFlareCommand extends Command {
       )
     }
 
-    // Validate case ID
-    if (this.caseId === undefined) {
-      errorMessages.push(commonRenderer.renderError('No case ID specified. [-c,--case-id]'))
-    }
+    if (!this.isDryRun) {
+      // Validate case ID
+      if (this.caseId === undefined) {
+        errorMessages.push(commonRenderer.renderError('No case ID specified. [-c,--case-id]'))
+      }
 
-    // Validate email
-    if (this.email === undefined) {
-      errorMessages.push(commonRenderer.renderError('No email specified. [-e,--email]'))
+      // Validate email
+      if (this.email === undefined) {
+        errorMessages.push(commonRenderer.renderError('No email specified. [-e,--email]'))
+      }
     }
 
     if (errorMessages.length > 0) {


### PR DESCRIPTION
### What and why?

Case ID and email are not needed when running in dry mode. Therefore, they should not be required flags. This PR removes the check for case ID and email when `--dry` is specified.

### How?

Wrap the email and case ID check in `if !(this.isDryRun)`

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
