### PR TITLE
[lambda][flare] Change config obfuscation to use functions from `commons.ts`

### DIFF
--- a/src/commands/lambda/__tests__/flare.test.ts
+++ b/src/commands/lambda/__tests__/flare.test.ts
@@ -32,7 +32,6 @@ import {
   getEndpointUrl,
   getLogEvents,
   getLogStreamNames,
-  getMasking,
   getTags,
   maskConfig,
   validateStartEndFlags,
@@ -368,30 +367,6 @@ describe('lambda flare', () => {
       expect(start).toBe(0)
       expect(end).toBeGreaterThanOrEqual(now - 1000)
       expect(end).toBeLessThanOrEqual(now + 1000)
-    })
-  })
-
-  describe('getMasking', () => {
-    it('should mask the entire string if its length is less than 12', () => {
-      expect(getMasking('shortString')).toEqual('****************')
-    })
-
-    it('should keep the first two and last four characters for strings longer than 12 characters', () => {
-      const original = 'abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz'
-      const masked = 'ab**********wxyz'
-      expect(getMasking(original)).toEqual(masked)
-    })
-
-    it('should return empty string if input is empty', () => {
-      expect(getMasking('')).toEqual('')
-    })
-
-    it('should not mask booleans', () => {
-      expect(getMasking('true')).toEqual('true')
-      expect(getMasking('TrUe')).toEqual('TrUe')
-      expect(getMasking('false')).toEqual('false')
-      expect(getMasking('FALSE')).toEqual('FALSE')
-      expect(getMasking('trueee')).toEqual('****************')
     })
   })
 


### PR DESCRIPTION
### What and why?

Config obfuscation was using a function in `flare.ts`. However, a function that does the same thing already exists in `commons.ts`.
This PR modifies the `maskConfig()` function to use helper functions from `commons.ts`. It also removes any unused functions and tests.

### How?

Uses `maskStringifiedEnvVar()` in `commons.ts` to obfuscate the config in the form of a string. We then convert the obfuscated string back into type `FunctionConfig` using `JSON.parse()`.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
Existing tests for `maskConfig()` still pass as expected. Unused tests for the now deleted `getMasking()` function have been removed.
