### PR TITLE
[lambda][flare] Update site endpoints

### DIFF
--- a/src/commands/lambda/__tests__/__snapshots__/flare.test.ts.snap
+++ b/src/commands/lambda/__tests__/__snapshots__/flare.test.ts.snap
@@ -159,11 +159,11 @@ exports[`lambda flare getAllLogs throws an error when unable to get log streams 
 
 exports[`lambda flare getEndpointUrl should not throw error if the site is invalid and DD_CI_BYPASS_SITE_VALIDATION is set 1`] = `"https://datad0ge.com/api/ui/support/serverless/flare"`;
 
-exports[`lambda flare getEndpointUrl should return correct endpoint url 1`] = `"https://datadoghq.com/api/ui/support/serverless/flare"`;
+exports[`lambda flare getEndpointUrl should return correct endpoint url 1`] = `"https://app.datadoghq.com/api/ui/support/serverless/flare"`;
 
 exports[`lambda flare getEndpointUrl should throw error if the site is invalid 1`] = `"Invalid site: datad0ge.com. Must be one of: datadoghq.com, datadoghq.eu, us3.datadoghq.com, us5.datadoghq.com, ap1.datadoghq.com, ddog-gov.com"`;
 
-exports[`lambda flare getEndpointUrl should use DEFAULT_DD_SITE if CI_SITE_ENV_VAR and SITE_ENV_VAR are not set 1`] = `"https://datadoghq.com/api/ui/support/serverless/flare"`;
+exports[`lambda flare getEndpointUrl should use DEFAULT_DD_SITE if CI_SITE_ENV_VAR and SITE_ENV_VAR are not set 1`] = `"https://app.datadoghq.com/api/ui/support/serverless/flare"`;
 
 exports[`lambda flare getEndpointUrl should use SITE_ENV_VAR if CI_SITE_ENV_VAR is not set 1`] = `"https://us3.datadoghq.com/api/ui/support/serverless/flare"`;
 

--- a/src/commands/lambda/flare.ts
+++ b/src/commands/lambda/flare.ts
@@ -17,7 +17,7 @@ import FormData from 'form-data'
 import inquirer from 'inquirer'
 import JSZip from 'jszip'
 
-import {DATADOG_SITE_US1, DATADOG_SITES} from '../../constants'
+import {DATADOG_SITE_EU1, DATADOG_SITE_GOV, DATADOG_SITE_US1, DATADOG_SITES} from '../../constants'
 import {isValidDatadogSite} from '../../helpers/validation'
 
 import {
@@ -646,11 +646,18 @@ export const zipContents = async (rootFolderPath: string, zipPath: string) => {
  */
 export const getEndpointUrl = () => {
   const baseUrl = process.env[CI_SITE_ENV_VAR] ?? process.env[SITE_ENV_VAR] ?? DATADOG_SITE_US1
+  // The DNS doesn't redirect to the proper endpoint when a subdomain is not present in the baseUrl.
+  // There is a DNS inconsistency
+  let endpointUrl = baseUrl
+  if ([DATADOG_SITE_US1, DATADOG_SITE_EU1, DATADOG_SITE_GOV].includes(baseUrl)) {
+    endpointUrl = 'app.' + baseUrl
+  }
+
   if (!isValidDatadogSite(baseUrl)) {
     throw Error(`Invalid site: ${baseUrl}. Must be one of: ${DATADOG_SITES.join(', ')}`)
   }
 
-  return 'https://' + baseUrl + ENDPOINT_PATH
+  return 'https://' + endpointUrl + ENDPOINT_PATH
 }
 
 /**


### PR DESCRIPTION
### What and why?

Due to a DNS inconsistency, the lambda flare endpoint doesn't work on sites with no subdomain (for example, US1).
This PR updates sites to append endpoint URL with `app.` when no subdomain is present in the original URL.

### How?

```
if ([DATADOG_SITE_US1, DATADOG_SITE_EU1, DATADOG_SITE_GOV].includes(baseUrl)) {
  endpointUrl = 'app.' + baseUrl
}
```

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
Snapshots have been updated to handle this change
