### PR TITLE
[sarif] Sanitize characters from filename

### DIFF
--- a/src/commands/sarif/api.ts
+++ b/src/commands/sarif/api.ts
@@ -7,7 +7,7 @@ import type {AxiosPromise, AxiosRequestConfig, AxiosResponse} from 'axios'
 
 import FormData from 'form-data'
 
-import {getSafeFileName} from '../../helpers/file'
+import {getSafeFilename} from '../../helpers/file'
 import {CI_JOB_URL, CI_PIPELINE_URL, GIT_SHA} from '../../helpers/tags'
 import {getRequestBuilder} from '../../helpers/utils'
 
@@ -52,7 +52,7 @@ export const uploadSarifReport = (request: (args: AxiosRequestConfig) => AxiosPr
   }
 
   form.append('sarif_report_file', fs.createReadStream(sarifReport.reportPath).pipe(createGzip()), {
-    filename: `${getSafeFileName(uniqueFileName)}.sarif.gz`,
+    filename: `${getSafeFilename(uniqueFileName)}.sarif.gz`,
   })
 
   return request({

--- a/src/commands/sarif/api.ts
+++ b/src/commands/sarif/api.ts
@@ -7,7 +7,7 @@ import type {AxiosPromise, AxiosRequestConfig, AxiosResponse} from 'axios'
 
 import FormData from 'form-data'
 
-import {replaceForwardSlashes} from '../../helpers/file'
+import {getSafeFileName} from '../../helpers/file'
 import {CI_JOB_URL, CI_PIPELINE_URL, GIT_SHA} from '../../helpers/tags'
 import {getRequestBuilder} from '../../helpers/utils'
 
@@ -52,7 +52,7 @@ export const uploadSarifReport = (request: (args: AxiosRequestConfig) => AxiosPr
   }
 
   form.append('sarif_report_file', fs.createReadStream(sarifReport.reportPath).pipe(createGzip()), {
-    filename: `${replaceForwardSlashes(uniqueFileName)}.sarif.gz`,
+    filename: `${getSafeFileName(uniqueFileName)}.sarif.gz`,
   })
 
   return request({

--- a/src/helpers/__tests__/file.test.ts
+++ b/src/helpers/__tests__/file.test.ts
@@ -1,15 +1,21 @@
-import {replaceForwardSlashes} from '../file'
+import {replaceForwardSlashes, getSafeFileName} from '../file'
 
-describe('file util', () => {
-  describe('getSafeFileName', () => {
-    it('returns same file name if the file name is safe', () => {
-      const safeFileName = replaceForwardSlashes('myfilename')
-      expect(safeFileName).toBe('myfilename')
-    })
-    test('filters unsafe characters out', () => {
-      expect(replaceForwardSlashes('tests/reports/junit/integration.xml')).toEqual(
-        'tests\\reports\\junit\\integration.xml'
-      )
-    })
+describe('replaceForwardSlashes', () => {
+  it('returns same file name if the file name does not include forward slashes', () => {
+    expect(replaceForwardSlashes('myfilename')).toBe('myfilename')
+  })
+  test('replaces forward slashes', () => {
+    expect(replaceForwardSlashes('tests/reports/junit/integration.xml')).toEqual(
+      'tests\\reports\\junit\\integration.xml'
+    )
+  })
+})
+
+describe('getSafeFileName', () => {
+  it('returns same file name if the file name is safe', () => {
+    expect(replaceForwardSlashes('myfilename')).toBe('myfilename')
+  })
+  test('filters unsafe characters out', () => {
+    expect(getSafeFileName('http://gitlab.com/-/pipelines/12345')).toEqual('http___gitlab_com___pipelines_12345')
   })
 })

--- a/src/helpers/__tests__/file.test.ts
+++ b/src/helpers/__tests__/file.test.ts
@@ -1,4 +1,4 @@
-import {replaceForwardSlashes, getSafeFileName} from '../file'
+import {replaceForwardSlashes, getSafeFilename} from '../file'
 
 describe('replaceForwardSlashes', () => {
   it('returns same file name if the file name does not include forward slashes', () => {
@@ -11,11 +11,11 @@ describe('replaceForwardSlashes', () => {
   })
 })
 
-describe('getSafeFileName', () => {
+describe('getSafeFilename', () => {
   it('returns same file name if the file name is safe', () => {
     expect(replaceForwardSlashes('myfilename')).toBe('myfilename')
   })
   test('filters unsafe characters out', () => {
-    expect(getSafeFileName('http://gitlab.com/-/pipelines/12345')).toEqual('http___gitlab_com___pipelines_12345')
+    expect(getSafeFilename('http://gitlab.com/-/pipelines/12345')).toEqual('http___gitlab_com___pipelines_12345')
   })
 })

--- a/src/helpers/file.ts
+++ b/src/helpers/file.ts
@@ -1,1 +1,6 @@
 export const replaceForwardSlashes = (unsafeFileName: string) => unsafeFileName.replace(/\//g, '\\')
+
+// We need a unique file name so we use span tags like the pipeline URL,
+// which can contain dots and other unsafe characters for filenames.
+// We filter them out here.
+export const getSafeFileName = (unsafeFileName: string) => unsafeFileName.replace(/[^a-z0-9]/gi, '_')

--- a/src/helpers/file.ts
+++ b/src/helpers/file.ts
@@ -3,4 +3,4 @@ export const replaceForwardSlashes = (unsafeFileName: string) => unsafeFileName.
 // We need a unique file name so we use span tags like the pipeline URL,
 // which can contain dots and other unsafe characters for filenames.
 // We filter them out here.
-export const getSafeFileName = (unsafeFileName: string) => unsafeFileName.replace(/[^a-z0-9]/gi, '_')
+export const getSafeFilename = (unsafeFileName: string) => unsafeFileName.replace(/[^a-z0-9]/gi, '_')


### PR DESCRIPTION
### What and why?

We replaced `getSafeFileName` by `replaceForwardSlashes` in https://github.com/DataDog/datadog-ci/pull/931/files#diff-d185890b7519424a2afa587baaf3b2ab18edc4710bb53bde9880e20db2896fbeR55

but we shouldn't have. 

### How?

Bring back `getSafeFilename`

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
