### PR TITLE
[junit] Use uuidV4 for filename

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -23,6 +23,7 @@ Component,Origin,Licence,Copyright
 @types/ssh2,dev,MIT,Copyright Microsoft Corporation
 @types/ssh2-streams,dev,MIT,Copyright Microsoft Corporation
 @types/sshpk,dev,MIT,Copyright Microsoft Corporation
+@types/uuid,dev,MIT,Copyright (c) 2010-2020 Robert Kieffer and other contributors
 @types/xml2js,dev,MIT,Copyright Microsoft Corporation
 @types/ws,dev,MIT,Copyright Microsoft Corporation
 async-retry,import,MIT,"Copyright (c) 2017 ZEIT, Inc."
@@ -59,6 +60,7 @@ tiny-async-pool,import,MIT,Copyright (c) 2017 Rafael Xavier de Souza http://rafa
 ts-jest,dev,MIT,Copyright (c) 2016-2018
 ts-node,import,MIT,Copyright (c) 2014 Blake Embrey (hello@blakeembrey.com)
 typescript,dev,Apache-2.0,Copyright (c) Microsoft Corporation.
+uuid,import,MIT,Copyright (c) 2010-2020 Robert Kieffer and other contributors
 xml2js,import,MIT,Copyright (c) Marek Kubica <marek@xivilization.net> (https://xivilization.net)
 ws,import,MIT,Copyright (c) 2011 Einar Otto Stangvik <einaros@gmail.com>
 yamux-js,import,MIT,Copyright (c) 2020 th-ch

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "ssh2-streams": "0.4.10",
     "sshpk": "1.16.1",
     "tiny-async-pool": "1.2.0",
+    "uuid": "^9.0.0",
     "ws": "7.4.6",
     "xml2js": "0.5.0",
     "yamux-js": "0.1.2"
@@ -114,6 +115,7 @@
     "@types/ssh2-streams": "0.1.9",
     "@types/sshpk": "1.10.5",
     "@types/tiny-async-pool": "1.0.0",
+    "@types/uuid": "^9.0.2",
     "@types/ws": "7.2.9",
     "@types/xml2js": "0.4.9",
     "@typescript-eslint/eslint-plugin": "^4.33.0",

--- a/src/commands/junit/api.ts
+++ b/src/commands/junit/api.ts
@@ -6,7 +6,7 @@ import type {AxiosPromise, AxiosRequestConfig, AxiosResponse} from 'axios'
 
 import FormData from 'form-data'
 
-import {replaceForwardSlashes} from '../../helpers/file'
+import {getSafeFilename} from '../../helpers/file'
 import {getRequestBuilder} from '../../helpers/utils'
 
 import {Payload} from './interfaces'
@@ -43,6 +43,7 @@ export const uploadJUnitXML = (request: (args: AxiosRequestConfig) => AxiosPromi
     session: reportTagsAndMetrics,
     '_dd.cireport_version': '3',
     '_dd.hostname': jUnitXML.hostname,
+    '_dd.report_name': fileName,
   }
 
   if (jUnitXML.logsEnabled) {
@@ -56,7 +57,7 @@ export const uploadJUnitXML = (request: (args: AxiosRequestConfig) => AxiosPromi
   form.append('event', JSON.stringify(custom), {filename: 'event.json'})
 
   form.append('junit_xml_report_file', fs.createReadStream(jUnitXML.xmlPath).pipe(createGzip()), {
-    filename: `${replaceForwardSlashes(fileName)}.xml.gz`,
+    filename: `${getSafeFilename(fileName)}.xml.gz`,
   })
 
   return request({

--- a/src/commands/junit/api.ts
+++ b/src/commands/junit/api.ts
@@ -5,11 +5,11 @@ import {createGzip} from 'zlib'
 import type {AxiosPromise, AxiosRequestConfig, AxiosResponse} from 'axios'
 
 import FormData from 'form-data'
+import {v4 as uuidv4} from 'uuid'
 
 import {getRequestBuilder} from '../../helpers/utils'
 
 import {Payload} from './interfaces'
-import { v4 as uuidv4 } from 'uuid';
 
 // Dependency follows-redirects sets a default maxBodyLength of 10 MB https://github.com/follow-redirects/follow-redirects/blob/b774a77e582b97174813b3eaeb86931becba69db/index.js#L391
 // We don't want any hard limit enforced by the CLI, the backend will enforce a max size by returning 413 errors.

--- a/src/commands/junit/api.ts
+++ b/src/commands/junit/api.ts
@@ -6,10 +6,10 @@ import type {AxiosPromise, AxiosRequestConfig, AxiosResponse} from 'axios'
 
 import FormData from 'form-data'
 
-import {getSafeFilename} from '../../helpers/file'
 import {getRequestBuilder} from '../../helpers/utils'
 
 import {Payload} from './interfaces'
+import { v4 as uuidv4 } from 'uuid';
 
 // Dependency follows-redirects sets a default maxBodyLength of 10 MB https://github.com/follow-redirects/follow-redirects/blob/b774a77e582b97174813b3eaeb86931becba69db/index.js#L391
 // We don't want any hard limit enforced by the CLI, the backend will enforce a max size by returning 413 errors.
@@ -57,7 +57,7 @@ export const uploadJUnitXML = (request: (args: AxiosRequestConfig) => AxiosPromi
   form.append('event', JSON.stringify(custom), {filename: 'event.json'})
 
   form.append('junit_xml_report_file', fs.createReadStream(jUnitXML.xmlPath).pipe(createGzip()), {
-    filename: `${getSafeFilename(fileName)}.xml.gz`,
+    filename: `${uuidv4()}.xml.gz`,
   })
 
   return request({

--- a/src/helpers/__tests__/file.test.ts
+++ b/src/helpers/__tests__/file.test.ts
@@ -1,19 +1,8 @@
-import {replaceForwardSlashes, getSafeFilename} from '../file'
-
-describe('replaceForwardSlashes', () => {
-  it('returns same file name if the file name does not include forward slashes', () => {
-    expect(replaceForwardSlashes('myfilename')).toBe('myfilename')
-  })
-  test('replaces forward slashes', () => {
-    expect(replaceForwardSlashes('tests/reports/junit/integration.xml')).toEqual(
-      'tests\\reports\\junit\\integration.xml'
-    )
-  })
-})
+import {getSafeFilename} from '../file'
 
 describe('getSafeFilename', () => {
   it('returns same file name if the file name is safe', () => {
-    expect(replaceForwardSlashes('myfilename')).toBe('myfilename')
+    expect(getSafeFilename('myfilename')).toBe('myfilename')
   })
   test('filters unsafe characters out', () => {
     expect(getSafeFilename('http://gitlab.com/-/pipelines/12345')).toEqual('http___gitlab_com___pipelines_12345')

--- a/src/helpers/file.ts
+++ b/src/helpers/file.ts
@@ -1,5 +1,3 @@
-export const replaceForwardSlashes = (unsafeFileName: string) => unsafeFileName.replace(/\//g, '\\')
-
 // We need a unique file name so we use span tags like the pipeline URL,
 // which can contain dots and other unsafe characters for filenames.
 // We filter them out here.

--- a/yarn.lock
+++ b/yarn.lock
@@ -2775,6 +2775,7 @@ __metadata:
     "@types/ssh2-streams": 0.1.9
     "@types/sshpk": 1.10.5
     "@types/tiny-async-pool": 1.0.0
+    "@types/uuid": ^9.0.2
     "@types/ws": 7.2.9
     "@types/xml2js": 0.4.9
     "@typescript-eslint/eslint-plugin": ^4.33.0
@@ -2823,6 +2824,7 @@ __metadata:
     ts-jest: 28.0.8
     ts-node: 8.8.1
     typescript: 4.3.5
+    uuid: ^9.0.0
     ws: 7.4.6
     xml2js: 0.5.0
     yamux-js: 0.1.2
@@ -3817,6 +3819,13 @@ __metadata:
   version: 1.0.0
   resolution: "@types/tiny-async-pool@npm:1.0.0"
   checksum: 0713cbce33f84f708a54c037cba829b05591998316de16c22b14cd16837322926897f5cbdd5bf3eb69f2c9829dc1c3949762198f10dbef0867a3f24e1cbdfc4b
+  languageName: node
+  linkType: hard
+
+"@types/uuid@npm:^9.0.2":
+  version: 9.0.2
+  resolution: "@types/uuid@npm:9.0.2"
+  checksum: 1754bcf3444e1e3aeadd6e774fc328eb53bc956665e2e8fb6ec127aa8e1f43d9a224c3d22a9a6233dca8dd81a12dc7fed4d84b8876dd5ec82d40f574f7ff8b68
   languageName: node
   linkType: hard
 
@@ -10378,6 +10387,15 @@ jschardet@latest:
   bin:
     uuid: dist/bin/uuid
   checksum: 5575a8a75c13120e2f10e6ddc801b2c7ed7d8f3c8ac22c7ed0c7b2ba6383ec0abda88c905085d630e251719e0777045ae3236f04c812184b7c765f63a70e58df
+  languageName: node
+  linkType: hard
+
+"uuid@npm:^9.0.0":
+  version: 9.0.0
+  resolution: "uuid@npm:9.0.0"
+  bin:
+    uuid: dist/bin/uuid
+  checksum: 8dd2c83c43ddc7e1c71e36b60aea40030a6505139af6bee0f382ebcd1a56f6cd3028f7f06ffb07f8cf6ced320b76aea275284b224b002b289f89fe89c389b028
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### What and why?

If we send the normal filename it can contain some characters that would cause 400 errors at the intake. Now we create a [uuidv4](https://en.wikipedia.org/wiki/Universally_unique_identifier#Version_4_(random)) for the filename and send the original filename somewhere else.

### How?

Use uuid package and send filename somewhere else as `_dd.report_name`

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
