### PR TITLE
[RUMM-3399] Add message stating symbol processing will take 5 minutes

### DIFF
--- a/src/commands/dsyms/__tests__/upload.test.ts
+++ b/src/commands/dsyms/__tests__/upload.test.ts
@@ -302,18 +302,21 @@ describe('execute', () => {
     expect(code).toBe(0)
     expect(output[1]).toContain('Starting upload with concurrency 20. ')
     expect(output[2]).toContain('Will look for dSYMs in src/commands/dsyms/__tests__/fixtures/')
-    expect(output[3]).toContain('Will use temporary intermediate directory: ')
-    expect(output[4]).toContain('Will use temporary upload directory: ')
-    expect(output[5]).toContain(
+    expect(output[3]).toContain(
+      'Once dSYMs upload is successful files will be processed and ready to use within the next 5 minutes.'
+    )
+    expect(output[4]).toContain('Will use temporary intermediate directory: ')
+    expect(output[5]).toContain('Will use temporary upload directory: ')
+    expect(output[6]).toContain(
       'Uploading C8469F85-B060-3085-B69D-E46C645560EA.zip (DDTest, arch: armv7, UUID: C8469F85-B060-3085-B69D-E46C645560EA)'
     )
-    expect(output[6]).toContain(
+    expect(output[7]).toContain(
       'Uploading 06EE3D68-D605-3E92-B92D-2F48C02A505E.zip (DDTest, arch: arm64, UUID: 06EE3D68-D605-3E92-B92D-2F48C02A505E)'
     )
-    expect(output[7]).toContain(
+    expect(output[8]).toContain(
       'Uploading 3BC12422-63CC-30E8-B916-E5006CE3286C.zip (DDTest, arch: arm64, UUID: 3BC12422-63CC-30E8-B916-E5006CE3286C)'
     )
-    expect(output[10]).toContain('Handled 3 dSYMs with success')
+    expect(output[11]).toContain('Handled 3 dSYMs with success')
   })
 
   test('Should succeed with zip file input', async () => {
@@ -325,18 +328,21 @@ describe('execute', () => {
     expect(code).toBe(0)
     expect(output[1]).toContain('Starting upload with concurrency 20. ')
     expect(output[2]).toContain('Will look for dSYMs in src/commands/dsyms/__tests__/fixtures/all.zip')
-    expect(output[3]).toContain('Will use temporary intermediate directory: ')
-    expect(output[4]).toContain('Will use temporary upload directory: ')
-    expect(output[5]).toContain(
+    expect(output[3]).toContain(
+      'Once dSYMs upload is successful files will be processed and ready to use within the next 5 minutes.'
+    )
+    expect(output[4]).toContain('Will use temporary intermediate directory: ')
+    expect(output[5]).toContain('Will use temporary upload directory: ')
+    expect(output[6]).toContain(
       'Uploading C8469F85-B060-3085-B69D-E46C645560EA.zip (DDTest, arch: armv7, UUID: C8469F85-B060-3085-B69D-E46C645560EA)'
     )
-    expect(output[6]).toContain(
+    expect(output[7]).toContain(
       'Uploading 06EE3D68-D605-3E92-B92D-2F48C02A505E.zip (DDTest, arch: arm64, UUID: 06EE3D68-D605-3E92-B92D-2F48C02A505E)'
     )
-    expect(output[7]).toContain(
+    expect(output[8]).toContain(
       'Uploading 3BC12422-63CC-30E8-B916-E5006CE3286C.zip (DDTest, arch: arm64, UUID: 3BC12422-63CC-30E8-B916-E5006CE3286C)'
     )
-    expect(output[10]).toContain('Handled 3 dSYMs with success')
+    expect(output[11]).toContain('Handled 3 dSYMs with success')
   })
 
   test('Should succeed with API key and site from datadog.json file', async () => {
@@ -350,18 +356,21 @@ describe('execute', () => {
     expect(code).toBe(0)
     expect(output[1]).toContain('Starting upload with concurrency 20. ')
     expect(output[2]).toContain('Will look for dSYMs in src/commands/dsyms/__tests__/fixtures/')
-    expect(output[3]).toContain('Will use temporary intermediate directory: ')
-    expect(output[4]).toContain('Will use temporary upload directory: ')
-    expect(output[5]).toContain(
+    expect(output[3]).toContain(
+      'Once dSYMs upload is successful files will be processed and ready to use within the next 5 minutes.'
+    )
+    expect(output[4]).toContain('Will use temporary intermediate directory: ')
+    expect(output[5]).toContain('Will use temporary upload directory: ')
+    expect(output[6]).toContain(
       'Uploading C8469F85-B060-3085-B69D-E46C645560EA.zip (DDTest, arch: armv7, UUID: C8469F85-B060-3085-B69D-E46C645560EA)'
     )
-    expect(output[6]).toContain(
+    expect(output[7]).toContain(
       'Uploading 06EE3D68-D605-3E92-B92D-2F48C02A505E.zip (DDTest, arch: arm64, UUID: 06EE3D68-D605-3E92-B92D-2F48C02A505E)'
     )
-    expect(output[7]).toContain(
+    expect(output[8]).toContain(
       'Uploading 3BC12422-63CC-30E8-B916-E5006CE3286C.zip (DDTest, arch: arm64, UUID: 3BC12422-63CC-30E8-B916-E5006CE3286C)'
     )
-    expect(output[10]).toContain('Handled 3 dSYMs with success')
+    expect(output[11]).toContain('Handled 3 dSYMs with success')
   })
 
   test('Should use API Key from env over config from JSON file', async () => {

--- a/src/commands/dsyms/renderer.ts
+++ b/src/commands/dsyms/renderer.ts
@@ -96,6 +96,10 @@ export const renderCommandInfo = (basePath: string, poolLimit: number, dryRun: b
   const basePathStr = chalk.green(`Will look for dSYMs in ${basePath}\n`)
   fullStr += basePathStr
 
+  fullStr += chalk.green(
+    `Once dSYMs upload is successful files will be processed and ready to use within the next 5 minutes.\n`
+  )
+
   return fullStr
 }
 


### PR DESCRIPTION
### What and why?

Add message stating there might be a delay in processing dsyms as to make it explicit to users that symbolication might not work instantly.

### How?

A brief description of implementation details of this PR.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
