### PR TITLE
Set static analysis team as code owners of `sarif`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,11 +5,13 @@
 
 ## CI Visibility
 src/commands/junit   @DataDog/ci-app-libraries
-src/commands/sarif   @DataDog/ci-app-libraries
 src/commands/gate    @DataDog/ci-app-libraries
 src/commands/metric  @DataDog/ci-app-libraries
 src/commands/tag     @DataDog/ci-app-libraries
 src/commands/trace   @DataDog/ci-app-libraries
+
+## Static Analysis
+src/commands/sarif   @DataDog/static-analysis-core
 
 ## RUM
 src/commands/dsyms            @DataDog/rum-mobile


### PR DESCRIPTION
### What and why?

Change owners of `sarif` command from `ci-app-libraries` to `static-analysis-core`. The reason being, they're the actual owners of the command and should review the PRs affecting it.

### How?

Change row in `CODEOWNERS` file.

