### PR TITLE
Move base URL computation to common package and fix CI Visibility URLs

### DIFF
--- a/src/commands/junit/utils.ts
+++ b/src/commands/junit/utils.ts
@@ -2,20 +2,12 @@ import {lstatSync} from 'fs'
 
 import {SpanTags} from '../../helpers/interfaces'
 import {CI_JOB_URL, CI_PIPELINE_URL, GIT_BRANCH, GIT_REPOSITORY_URL, GIT_SHA} from '../../helpers/tags'
+import {getCommonAppBaseURL} from "../../helpers/app";
 
 export const getBaseUrl = () => {
-  if (process.env.DATADOG_SITE || process.env.DD_SITE) {
-    let site = process.env.DATADOG_SITE || process.env.DD_SITE
-    if (site === 'datadoghq.com') {
-      site = 'app.datadoghq.com'
-    } else if (site === 'datad0g.com') {
-      site = 'dd.datad0g.com'
-    }
-
-    return `https://${site}`
-  }
-
-  return 'https://app.datadoghq.com'
+  const site = process.env.DATADOG_SITE || process.env.DD_SITE || 'datadoghq.com';
+  const subdomain = process.env.DATADOG_SUBDOMAIN || '';
+  return getCommonAppBaseURL(site, subdomain);
 }
 
 export const getTestRunsUrl = (spanTags: SpanTags): string => {

--- a/src/commands/synthetics/__tests__/utils.test.ts
+++ b/src/commands/synthetics/__tests__/utils.test.ts
@@ -1208,36 +1208,6 @@ describe('utils', () => {
     expect(utils.parseVariablesFromCli(undefined, mockLogFunction)).toBeUndefined()
   })
 
-  test('getAppBaseURL', () => {
-    // Usual datadog site.
-    expect(utils.getAppBaseURL({datadogSite: 'datadoghq.com', subdomain: ''})).toBe('https://app.datadoghq.com/')
-    expect(utils.getAppBaseURL({datadogSite: 'datadoghq.com', subdomain: 'app'})).toBe('https://app.datadoghq.com/')
-    expect(utils.getAppBaseURL({datadogSite: 'datadoghq.com', subdomain: 'myorg'})).toBe('https://myorg.datadoghq.com/')
-
-    // Different top-level domain.
-    expect(utils.getAppBaseURL({datadogSite: 'datadoghq.eu', subdomain: ''})).toBe('https://app.datadoghq.eu/')
-    expect(utils.getAppBaseURL({datadogSite: 'datadoghq.eu', subdomain: 'app'})).toBe('https://app.datadoghq.eu/')
-    expect(utils.getAppBaseURL({datadogSite: 'datadoghq.eu', subdomain: 'myorg'})).toBe('https://myorg.datadoghq.eu/')
-
-    // AP1/US3/US5-type datadog site: the datadog site's subdomain is replaced by `subdomain` when `subdomain` is custom.
-    // The correct Main DC (US3 in this case) is resolved automatically.
-    expect(utils.getAppBaseURL({datadogSite: 'ap1.datadoghq.com', subdomain: ''})).toBe('https://ap1.datadoghq.com/')
-    expect(utils.getAppBaseURL({datadogSite: 'ap1.datadoghq.com', subdomain: 'app'})).toBe('https://ap1.datadoghq.com/')
-    expect(utils.getAppBaseURL({datadogSite: 'ap1.datadoghq.com', subdomain: 'myorg'})).toBe(
-      'https://myorg.datadoghq.com/'
-    )
-    expect(utils.getAppBaseURL({datadogSite: 'us3.datadoghq.com', subdomain: ''})).toBe('https://us3.datadoghq.com/')
-    expect(utils.getAppBaseURL({datadogSite: 'us3.datadoghq.com', subdomain: 'app'})).toBe('https://us3.datadoghq.com/')
-    expect(utils.getAppBaseURL({datadogSite: 'us3.datadoghq.com', subdomain: 'myorg'})).toBe(
-      'https://myorg.datadoghq.com/'
-    )
-    expect(utils.getAppBaseURL({datadogSite: 'us5.datadoghq.com', subdomain: ''})).toBe('https://us5.datadoghq.com/')
-    expect(utils.getAppBaseURL({datadogSite: 'us5.datadoghq.com', subdomain: 'app'})).toBe('https://us5.datadoghq.com/')
-    expect(utils.getAppBaseURL({datadogSite: 'us5.datadoghq.com', subdomain: 'myorg'})).toBe(
-      'https://myorg.datadoghq.com/'
-    )
-  })
-
   describe('sortResultsByOutcome', () => {
     const results: Result[] = getResults([
       {executionRule: ExecutionRule.NON_BLOCKING, passed: false},

--- a/src/commands/synthetics/utils.ts
+++ b/src/commands/synthetics/utils.ts
@@ -11,6 +11,7 @@ import glob from 'glob'
 import {getCIMetadata} from '../../helpers/ci'
 import {GIT_COMMIT_MESSAGE} from '../../helpers/tags'
 import {pick} from '../../helpers/utils'
+import {getCommonAppBaseURL} from '../../helpers/app'
 
 import {APIHelper, EndpointError, formatBackendErrors, getApiHelper, isNotFoundError} from './api'
 import {CiError, CriticalError} from './errors'
@@ -750,18 +751,7 @@ export const parseVariablesFromCli = (
 // XXX: `CommandConfig` should be replaced by `SyntheticsCIConfig` here because it's the smallest
 //      interface that we need, and it's better semantically.
 export const getAppBaseURL = ({datadogSite, subdomain}: Pick<RunTestsCommandConfig, 'datadogSite' | 'subdomain'>) => {
-  const validSubdomain = subdomain || DEFAULT_COMMAND_CONFIG.subdomain
-  const datadogSiteParts = datadogSite.split('.')
-
-  if (datadogSiteParts.length === 3) {
-    if (validSubdomain === DEFAULT_COMMAND_CONFIG.subdomain) {
-      return `https://${datadogSite}/`
-    }
-
-    return `https://${validSubdomain}.${datadogSiteParts[1]}.${datadogSiteParts[2]}/`
-  }
-
-  return `https://${validSubdomain}.${datadogSite}/`
+  return getCommonAppBaseURL(datadogSite, subdomain);
 }
 
 export const getBatchUrl = (baseUrl: string, batchId: string) =>

--- a/src/helpers/__tests__/app.test.ts
+++ b/src/helpers/__tests__/app.test.ts
@@ -1,0 +1,33 @@
+import {getCommonAppBaseURL} from "../app";
+
+describe('getCommonAppBaseUrl', () => {
+  test('the base URL that is correct', () => {
+    // Usual datadog site.
+    expect(getCommonAppBaseURL('datadoghq.com', '')).toBe('https://app.datadoghq.com/')
+    expect(getCommonAppBaseURL('datadoghq.com', 'app')).toBe('https://app.datadoghq.com/')
+    expect(getCommonAppBaseURL('datadoghq.com', 'myorg')).toBe('https://myorg.datadoghq.com/')
+
+    // Different top-level domain.
+    expect(getCommonAppBaseURL('datadoghq.eu', '')).toBe('https://app.datadoghq.eu/')
+    expect(getCommonAppBaseURL('datadoghq.eu', 'app')).toBe('https://app.datadoghq.eu/')
+    expect(getCommonAppBaseURL('datadoghq.eu', 'myorg')).toBe('https://myorg.datadoghq.eu/')
+
+    // AP1/US3/US5-type datadog site: the datadog site's subdomain is replaced by `subdomain` when `subdomain` is custom.
+    // The correct Main DC (US3 in this case) is resolved automatically.
+    expect(getCommonAppBaseURL('ap1.datadoghq.com', '')).toBe('https://ap1.datadoghq.com/')
+    expect(getCommonAppBaseURL('ap1.datadoghq.com', 'app')).toBe('https://ap1.datadoghq.com/')
+    expect(getCommonAppBaseURL('ap1.datadoghq.com', 'myorg')).toBe(
+      'https://myorg.datadoghq.com/'
+    )
+    expect(getCommonAppBaseURL('us3.datadoghq.com', '')).toBe('https://us3.datadoghq.com/')
+    expect(getCommonAppBaseURL('us3.datadoghq.com', 'app')).toBe('https://us3.datadoghq.com/')
+    expect(getCommonAppBaseURL('us3.datadoghq.com', 'myorg')).toBe(
+      'https://myorg.datadoghq.com/'
+    )
+    expect(getCommonAppBaseURL('us5.datadoghq.com', '')).toBe('https://us5.datadoghq.com/')
+    expect(getCommonAppBaseURL('us5.datadoghq.com', 'app')).toBe('https://us5.datadoghq.com/')
+    expect(getCommonAppBaseURL('us5.datadoghq.com', 'myorg')).toBe(
+      'https://myorg.datadoghq.com/'
+    )
+  })
+})

--- a/src/helpers/app.ts
+++ b/src/helpers/app.ts
@@ -1,0 +1,16 @@
+const DEFAULT_SUBDOMAIN = 'app';
+
+export const getCommonAppBaseURL = (datadogSite: string, subdomain: string) => {
+  const validSubdomain = subdomain || DEFAULT_SUBDOMAIN
+  const datadogSiteParts = datadogSite.split('.')
+
+  if (datadogSiteParts.length === 3) {
+    if (validSubdomain === DEFAULT_SUBDOMAIN) {
+      return `https://${datadogSite}/`
+    }
+
+    return `https://${validSubdomain}.${datadogSiteParts[1]}.${datadogSiteParts[2]}/`
+  }
+
+  return `https://${validSubdomain}.${datadogSite}/`
+}


### PR DESCRIPTION
### What and why?

We have two issues with the URLs that are displayed once a JunitXML upload is finished:
- the App URL is not correct for all datacenters except US1
- the App URL does not take into account subdomains.

### How?

This PR:
- adds a `getCommonAppBaseURL` helper, copied from Synthetics code, that could be common to all commands.
- this fixes the URLs for all datacenters for the JunitXML upload as well as supporting subdomains.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
