### PR TITLE
Add DD_TRACE_ENABLED for stepfunctions instrument and warning for legacy lambda integration

### DIFF
--- a/src/commands/stepfunctions/constants.ts
+++ b/src/commands/stepfunctions/constants.ts
@@ -1,2 +1,3 @@
 export const DD_CI_IDENTIFYING_STRING = 'DdCiLogGroupSubscription'
+export const DD_TRACE_ENABLED = 'DD_TRACE_ENABLED'
 export const TAG_VERSION_NAME = 'dd_sls_ci'

--- a/src/commands/stepfunctions/helpers.ts
+++ b/src/commands/stepfunctions/helpers.ts
@@ -97,9 +97,9 @@ export const injectContextIntoLambdaPayload = async (
       if (shouldUpdateStepForTracesMerging(step)) {
         updateStepObject(step)
         definitionHasBeenUpdated = true
-      } else if (step.Resource.startsWith('arn:aws:lambda')) {
+      } else if (step.Resource?.startsWith('arn:aws:lambda')) {
         context.stdout.write(
-          `\n[Warn] Step ${stepName} may be using the basic legacy integration, which does not support merging lambda trace(s) with Step Functions trace. 
+          `[Warn] Step ${stepName} may be using the basic legacy integration, which does not support merging lambda trace(s) with Step Functions trace. 
           To merge lambda trace(s) with Step Functions trace, please consider using the latest integration. 
           More details can be found on https://docs.aws.amazon.com/step-functions/latest/dg/connect-lambda.html \n`
         )
@@ -152,7 +152,7 @@ export type StatesType = Record<string, StepType>
 export type StepType = {
   Type: string
   Parameters?: ParametersType
-  Resource: string
+  Resource?: string
   Next?: string
   End?: boolean
 }

--- a/src/commands/stepfunctions/helpers.ts
+++ b/src/commands/stepfunctions/helpers.ts
@@ -97,6 +97,12 @@ export const injectContextIntoLambdaPayload = async (
       if (shouldUpdateStepForTracesMerging(step)) {
         updateStepObject(step)
         definitionHasBeenUpdated = true
+      } else if (step.Resource.startsWith('arn:aws:lambda')) {
+        context.stdout.write(
+          `\n[Warn] Step ${stepName} may be using the basic legacy integration, which does not support merging lambda trace(s) with Step Functions trace. 
+          To merge lambda trace(s) with Step Functions trace, please consider using the latest integration. 
+          More details can be found on https://docs.aws.amazon.com/step-functions/latest/dg/connect-lambda.html \n`
+        )
       }
     }
   }

--- a/src/commands/stepfunctions/instrument.ts
+++ b/src/commands/stepfunctions/instrument.ts
@@ -140,7 +140,7 @@ export class InstrumentStepFunctionsCommand extends Command {
       }
 
       if (
-        !listStepFunctionTagsResponse?.tags?.some((tag) => tag.key === 'service') &&
+        !listStepFunctionTagsResponse?.tags?.some((tag) => tag.key === 'service' && tag.value === this.service) &&
         typeof this.service === 'string'
       ) {
         stepFunctionTagsToAdd.push({key: 'service', value: this.service})
@@ -155,7 +155,11 @@ export class InstrumentStepFunctionsCommand extends Command {
         stepFunctionTagsToAdd.push({key: TAG_VERSION_NAME, value: `v${cliVersion}`})
       }
 
-      if (!listStepFunctionTagsResponse?.tags?.some((tag) => tag.key === DD_TRACE_ENABLED)) {
+      if (
+        !listStepFunctionTagsResponse?.tags?.some(
+          (tag) => tag.key === DD_TRACE_ENABLED && tag.value?.toLowerCase() === 'true'
+        )
+      ) {
         stepFunctionTagsToAdd.push({key: DD_TRACE_ENABLED, value: 'true'})
       }
 

--- a/src/commands/stepfunctions/instrument.ts
+++ b/src/commands/stepfunctions/instrument.ts
@@ -13,7 +13,7 @@ import {
   attachPolicyToStateMachineIamRole,
   createLogsAccessPolicy,
 } from './awsCommands'
-import {TAG_VERSION_NAME} from './constants'
+import {DD_TRACE_ENABLED, TAG_VERSION_NAME} from './constants'
 import {
   buildLogGroupName,
   buildArn,
@@ -153,6 +153,10 @@ export class InstrumentStepFunctionsCommand extends Command {
         )
       ) {
         stepFunctionTagsToAdd.push({key: TAG_VERSION_NAME, value: `v${cliVersion}`})
+      }
+
+      if (!listStepFunctionTagsResponse?.tags?.some((tag) => tag.key === DD_TRACE_ENABLED)) {
+        stepFunctionTagsToAdd.push({key: DD_TRACE_ENABLED, value: 'true'})
       }
 
       if (stepFunctionTagsToAdd.length > 0) {


### PR DESCRIPTION
https://datadoghq.atlassian.net/browse/SLS-3822

- To help customers enable step functions tracing when they run instrument command, we add `DD_TRACE_ENABLED=true` tag automatically. 
- If customer enables `mergeStepFunctionAndLambdaTraces` flag but they are using legacy lambda integration, we show warning with instructions to them so that they can know their legacy lambda steps' spans cannot merge with step functions span.


Tested in sandbox
```

======= For arn:aws:states:sa-east-1:425362996713:stateMachine:Kimi-Testing-State-machine =========

Will apply the following change:

TagResource:
{
  "resourceArn": "arn:aws:states:sa-east-1:425362996713:stateMachine:Kimi-Testing-State-machine",
  "tags": [
    {
      "key": "DD_TRACE_ENABLED",
      "value": "true"
    }
  ]
}
TagResource finished successfully!


Will apply the following change:

PutSubscriptionFilter:
{
  "destinationArn": "arn:aws:lambda:sa-east-1:425362996713:function:step-functions-tracing-forwarder-self-monitoring-us1-prod",
  "filterName": "Kimi-Testing-State-machine-DdCiLogGroupSubscription",
  "filterPattern": "",
  "logGroupName": "/aws/vendedlogs/states/Kimi-Testing-State-machine-Logs-dev"
}
Subscription filter Kimi-Testing-State-machine-DdCiLogGroupSubscription is created or the original filter Kimi-Testing-State-machine-DdCiLogGroupSubscription is overwritten.

[Warn] Step InvokeLambda2 may be using the basic legacy integration, which does not support merging lambda trace(s) with Step Functions trace. 
          To merge lambda trace(s) with Step Functions trace, please consider using the latest integration. 
          More details can be found on https://docs.aws.amazon.com/step-functions/latest/dg/connect-lambda.html 

```
<img width="797" alt="image" src="https://github.com/DataDog/datadog-ci/assets/47579703/b08620cc-9b62-4ed1-9fbe-a3062a253221">


### How?


### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
