### PR TITLE
[lambda][flare] Update documentation to tell user to run command in project directory

### DIFF
--- a/src/commands/lambda/README.md
+++ b/src/commands/lambda/README.md
@@ -148,7 +148,7 @@ Instead of supplying arguments, you can create a configuration file in your proj
 
 ## Troubleshooting Serverless Instrumentation
 
-To troubleshoot issues you may be encountering with Datadog monitoring on your Lambda functions, use `datadog-ci lambda flare`. This command collects important data about a Lambda function, such as environment variables and the config file. These files will be submitted to Datadog support via a ticket matching the provided Zendesk case ID.
+To troubleshoot issues you may be encountering with Datadog monitoring on your Lambda functions, use the `datadog-ci lambda flare` command in the root of your project directory. This command collects important data about a Lambda function, such as environment variables and the config file. These files will be submitted to Datadog support via a ticket matching the provided Zendesk case ID.
 
 **Note**: This command works whether or not your Lambda functions were instrumented using `datadog-ci lambda instrument`.
 


### PR DESCRIPTION
### What and why?

Now that https://github.com/DataDog/datadog-ci/pull/962 is merged, the `datadog-ci lambda flare` command is expected to be ran in the root of the project directory to autodiscover project files.

If the command is not ran in the correct directory, it will be unable to automatically find project files.

### How?

Update README.md in `lambda/README.md`

### Review checklist

No tests needed
