### PR TITLE
[ci] Make `bump-ci-integrations` depend on `build`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,34 +15,6 @@ jobs:
         env:
           YARN_NPM_AUTH_TOKEN: ${{ secrets.YARN_NPM_AUTH_TOKEN }}
 
-  bump-ci-integrations:
-    name: Bump datadog-ci in integration
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        integration:
-          - synthetics-ci-github-action
-          - datadog-ci-azure-devops
-          - synthetics-test-automation-circleci-orb
-    steps:
-      - name: Create bump datadog-ci PR
-        uses: actions/github-script@v6
-        with:
-          github-token: ${{ secrets.CROSS_REPOSITORY_GITHUB_TOKEN }}
-          script: |
-            const tagName = '${{ github.event.release.tag_name }}'.replace('v', '')
-
-            github.rest.actions.createWorkflowDispatch({
-              owner: context.repo.owner,
-              repo: '${{ matrix.integration }}',
-              workflow_id: 'bump-datadog-ci.yml',
-              ref: 'main',
-              inputs: {
-                datadog_ci_version: tagName,
-              },
-            });
-
   build-binary-ubuntu:
     runs-on: ubuntu-latest
     steps:
@@ -120,3 +92,31 @@ jobs:
         with:
           upload_url: ${{ github.event.release.upload_url }}
           asset_path: ./datadog-ci_darwin-x64
+
+  bump-ci-integrations:
+    name: Bump datadog-ci in integration
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        integration:
+          - synthetics-ci-github-action
+          - datadog-ci-azure-devops
+          - synthetics-test-automation-circleci-orb
+    steps:
+      - name: Create bump datadog-ci PR
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.CROSS_REPOSITORY_GITHUB_TOKEN }}
+          script: |
+            const tagName = '${{ github.event.release.tag_name }}'.replace('v', '')
+
+            github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: '${{ matrix.integration }}',
+              workflow_id: 'bump-datadog-ci.yml',
+              ref: 'main',
+              inputs: {
+                datadog_ci_version: tagName,
+              },
+            });

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,35 @@ jobs:
         env:
           YARN_NPM_AUTH_TOKEN: ${{ secrets.YARN_NPM_AUTH_TOKEN }}
 
+  bump-ci-integrations:
+    name: Bump datadog-ci in integration
+    runs-on: ubuntu-latest
+    needs: build
+    strategy:
+      fail-fast: false
+      matrix:
+        integration:
+          - synthetics-ci-github-action
+          - datadog-ci-azure-devops
+          - synthetics-test-automation-circleci-orb
+    steps:
+      - name: Create bump datadog-ci PR
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.CROSS_REPOSITORY_GITHUB_TOKEN }}
+          script: |
+            const tagName = '${{ github.event.release.tag_name }}'.replace('v', '')
+
+            github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: '${{ matrix.integration }}',
+              workflow_id: 'bump-datadog-ci.yml',
+              ref: 'main',
+              inputs: {
+                datadog_ci_version: tagName,
+              },
+            });
+
   build-binary-ubuntu:
     runs-on: ubuntu-latest
     steps:
@@ -92,31 +121,3 @@ jobs:
         with:
           upload_url: ${{ github.event.release.upload_url }}
           asset_path: ./datadog-ci_darwin-x64
-
-  bump-ci-integrations:
-    name: Bump datadog-ci in integration
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        integration:
-          - synthetics-ci-github-action
-          - datadog-ci-azure-devops
-          - synthetics-test-automation-circleci-orb
-    steps:
-      - name: Create bump datadog-ci PR
-        uses: actions/github-script@v6
-        with:
-          github-token: ${{ secrets.CROSS_REPOSITORY_GITHUB_TOKEN }}
-          script: |
-            const tagName = '${{ github.event.release.tag_name }}'.replace('v', '')
-
-            github.rest.actions.createWorkflowDispatch({
-              owner: context.repo.owner,
-              repo: '${{ matrix.integration }}',
-              workflow_id: 'bump-datadog-ci.yml',
-              ref: 'main',
-              inputs: {
-                datadog_ci_version: tagName,
-              },
-            });


### PR DESCRIPTION
### What and why?

In #942, we tried to invalidate the cache by passing a specific version to `yarn add`, but the downstream pipelines still occasionally fail ([example](https://github.com/DataDog/synthetics-ci-github-action/actions/runs/5587506326/job/15132248097)).

### How?

> ~~If this doesn't work, then we can move the `bump-ci-integrations` job matrix at the very bottom of `.github/workflows/release.yml`, which should add enough delay. **Source: #942**~~

Add a `needs:` dependency on `build`.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
