### PR TITLE
[dep] Bump `dd-trace` to `3.29.0`

### DIFF
--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
     "@typescript-eslint/parser": "^4.33.0",
     "aws-sdk-client-mock": "^2.1.1",
     "aws-sdk-client-mock-jest": "^2.1.1",
-    "dd-trace": "3.20.0",
+    "dd-trace": "3.29.0",
     "eslint": "^7.32.0",
     "eslint-config-prettier": "^8.5.0",
     "eslint-import-resolver-typescript": "2.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2789,7 +2789,7 @@ __metadata:
     chalk: 3.0.0
     clipanion: 2.2.2
     datadog-metrics: 0.9.3
-    dd-trace: 3.20.0
+    dd-trace: 3.29.0
     deep-extend: 0.6.0
     deep-object-diff: ^1.1.9
     eslint: ^7.32.0
@@ -2833,13 +2833,13 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@datadog/native-appsec@npm:^3.1.0":
-  version: 3.1.0
-  resolution: "@datadog/native-appsec@npm:3.1.0"
+"@datadog/native-appsec@npm:^3.2.0":
+  version: 3.2.0
+  resolution: "@datadog/native-appsec@npm:3.2.0"
   dependencies:
     node-gyp: latest
     node-gyp-build: ^3.9.0
-  checksum: 9a28721dbe87cc899f3265a3e2eba243e52653bf55c972a7abbfe3ad139a7f4d36fba598e814ce4f4e58312767e854503e1c4b2b2cedd153223b9a7ec5facb8d
+  checksum: 60635bc0379a130178a1f6e2d70c63e4198f5397730b1182a08c1fb2a4095a452bb5923e12e3859ea5786bcbd2b8d84e4058d0676913419100b0d8ac4df43b88
   languageName: node
   linkType: hard
 
@@ -2852,39 +2852,38 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@datadog/native-iast-taint-tracking@npm:^1.4.0":
-  version: 1.4.0
-  resolution: "@datadog/native-iast-taint-tracking@npm:1.4.0"
+"@datadog/native-iast-taint-tracking@npm:1.5.0":
+  version: 1.5.0
+  resolution: "@datadog/native-iast-taint-tracking@npm:1.5.0"
   dependencies:
     node-gyp: latest
     node-gyp-build: ^3.9.0
-  checksum: ba7b6b530638afd06af1d4880b4dea16acbbf93b1f31f55a7cd1cffaf137879350d5423bde528df6a2a0d402dae19e883945df90cbd026a93d8c6a3c6860d05c
+  checksum: b5d8e9e615218c32b9e39c5050ff6471acf12c528459f93955944ed0d59ff77e9a54c628b5e7b2dfb264cc0fb59eb24093da624f7e456b4a1dba2b5aad33210c
   languageName: node
   linkType: hard
 
-"@datadog/native-metrics@npm:^1.6.0":
-  version: 1.6.0
-  resolution: "@datadog/native-metrics@npm:1.6.0"
+"@datadog/native-metrics@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "@datadog/native-metrics@npm:2.0.0"
   dependencies:
+    node-addon-api: ^6.1.0
     node-gyp: latest
     node-gyp-build: ^3.9.0
-  checksum: aad021e79687683d1b058b1534387f998cd090a60b786d4996cf1f7408a2b11e246a7486e5dffd3f7cf723f5cfde8763ad3928e521e7c0f51a33a12db03af9c0
+  checksum: 3975904bebb6a073158d8e3fbee35208d3d98c9c03c8ed5e9dac02e31bfdc165b1d87452ac2e888bbbf0674a66567486493353cc1a9b4ec67e24347b323b530e
   languageName: node
   linkType: hard
 
-"@datadog/pprof@npm:^2.2.0":
-  version: 2.2.0
-  resolution: "@datadog/pprof@npm:2.2.0"
+"@datadog/pprof@npm:3.1.0":
+  version: 3.1.0
+  resolution: "@datadog/pprof@npm:3.1.0"
   dependencies:
     delay: ^5.0.0
     node-gyp: latest
-    node-gyp-build: ^3.9.0
+    node-gyp-build: <4.0
     p-limit: ^3.1.0
-    pify: ^5.0.0
-    pprof-format: ^2.0.6
-    source-map: ^0.7.3
-    split: ^1.0.1
-  checksum: ca33f54ad1147c84de9e3a731d2e08be80c316456ca3f84071f1b6a3ad8911d606db860ae58e84871fdcb6a6655b605bed5359eb77861420d9dfb405969972de
+    pprof-format: ^2.0.7
+    source-map: ^0.7.4
+  checksum: a86fe8c25895ee80870c3416270e3ad683607a7bdb4bc1c1523942b652b1e6eebc0db04cc7b076dab6c0b1b217a1d78b8af6610fffcf16818cad3a5e38cec561
   languageName: node
   linkType: hard
 
@@ -3357,6 +3356,34 @@ __metadata:
     mkdirp: ^1.0.4
     rimraf: ^3.0.2
   checksum: 52dc02259d98da517fae4cb3a0a3850227bdae4939dda1980b788a7670636ca2b4a01b58df03dd5f65c1e3cb70c50fa8ce5762b582b3f499ec30ee5ce1fd9380
+  languageName: node
+  linkType: hard
+
+"@opentelemetry/api@npm:^1.0.0":
+  version: 1.4.1
+  resolution: "@opentelemetry/api@npm:1.4.1"
+  checksum: e783c40d1a518abf9c4c5d65223237c1392cd9a6c53ac6e2c3ef0c05ff7266e3dfc4fd9874316dae0dcb7a97950878deb513bcbadfaad653d48f0215f2a0911b
+  languageName: node
+  linkType: hard
+
+"@opentelemetry/core@npm:^1.14.0":
+  version: 1.15.0
+  resolution: "@opentelemetry/core@npm:1.15.0"
+  dependencies:
+    "@opentelemetry/semantic-conventions": 1.15.0
+    tslib: ^2.3.1
+  peerDependencies:
+    "@opentelemetry/api": ">=1.0.0 <1.5.0"
+  checksum: 4fc99d1ecb4497d711e70b626b57b13272667fa54e15aea1f8249104b00d0906459594cf7dc4395ebc00be3dd8a9bf7d1df32cb2caa39a4a014a8f34809d647c
+  languageName: node
+  linkType: hard
+
+"@opentelemetry/semantic-conventions@npm:1.15.0":
+  version: 1.15.0
+  resolution: "@opentelemetry/semantic-conventions@npm:1.15.0"
+  dependencies:
+    tslib: ^2.3.1
+  checksum: 3254ff166d08d52ebbaa9711cdbc29718b431c04b8116423e68e20ca3df4c63206f2be52b471b3a0ed4e475b613e85cc447681d145b5c46ecf1c4aee77edd381
   languageName: node
   linkType: hard
 
@@ -5020,20 +5047,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dd-trace@npm:3.20.0":
-  version: 3.20.0
-  resolution: "dd-trace@npm:3.20.0"
+"dd-trace@npm:3.29.0":
+  version: 3.29.0
+  resolution: "dd-trace@npm:3.29.0"
   dependencies:
-    "@datadog/native-appsec": ^3.1.0
+    "@datadog/native-appsec": ^3.2.0
     "@datadog/native-iast-rewriter": 2.0.1
-    "@datadog/native-iast-taint-tracking": ^1.4.0
-    "@datadog/native-metrics": ^1.6.0
-    "@datadog/pprof": ^2.2.0
+    "@datadog/native-iast-taint-tracking": 1.5.0
+    "@datadog/native-metrics": ^2.0.0
+    "@datadog/pprof": 3.1.0
     "@datadog/sketches-js": ^2.1.0
+    "@opentelemetry/api": ^1.0.0
+    "@opentelemetry/core": ^1.14.0
     crypto-randomuuid: ^1.0.0
     diagnostics_channel: ^1.1.0
     ignore: ^5.2.0
     import-in-the-middle: ^1.3.5
+    int64-buffer: ^0.1.9
     ipaddr.js: ^2.0.1
     istanbul-lib-coverage: 3.2.0
     koalas: ^1.0.2
@@ -5045,13 +5075,14 @@ __metadata:
     lru-cache: ^7.14.0
     methods: ^1.1.2
     module-details-from-path: ^1.0.3
+    msgpack-lite: ^0.1.26
     node-abort-controller: ^3.0.1
     opentracing: ">=0.12.1"
     path-to-regexp: ^0.1.2
-    protobufjs: ^7.1.2
+    protobufjs: ^7.2.4
     retry: ^0.10.1
     semver: ^7.3.8
-  checksum: 65c563f065557f8860eff9fe0e16e4e86d7fa7eaab2d464fd1b0656fddd3bd8a13b4246fd359b5490b539ca6e1642a0c93b2759847ab0fd974e92187b9c4240d
+  checksum: c3b686b638329837c15756a9da74936d8fb95a4d33a94bb769745ed07a3ffcdb992b85b557eddaea2ad1d69849b4daeda81f05e89a413b0f5e61467aaf76610b
   languageName: node
   linkType: hard
 
@@ -5885,6 +5916,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"event-lite@npm:^0.1.1":
+  version: 0.1.3
+  resolution: "event-lite@npm:0.1.3"
+  checksum: 8537e6bf218262f32dbd5200bbe0d1466410b40ba8041d96f34d7c5de08b468b453d44694818eb5c842ab13339a16835f2fbcce5784b8c4e916a3f365241bdb2
+  languageName: node
+  linkType: hard
+
 "execa@npm:^5.0.0":
   version: 5.1.1
   resolution: "execa@npm:5.1.1"
@@ -6625,7 +6663,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ieee754@npm:^1.1.13":
+"ieee754@npm:^1.1.13, ieee754@npm:^1.1.8":
   version: 1.2.1
   resolution: "ieee754@npm:1.2.1"
   checksum: 5144c0c9815e54ada181d80a0b810221a253562422e7c6c3a60b1901154184f49326ec239d618c416c1c5945a2e197107aee8d986a3dd836b53dffefd99b5e7e
@@ -6764,6 +6802,13 @@ __metadata:
     through: ^2.3.6
     wrap-ansi: ^7.0.0
   checksum: f13ee4c444187786fb393609dedf6b30870115a57b603f2e6424f29a99abc13446fd45ee22461c33c9c40a92a60a8df62d0d6b25d74fc6676fa4cb211de55b55
+  languageName: node
+  linkType: hard
+
+"int64-buffer@npm:^0.1.9":
+  version: 0.1.10
+  resolution: "int64-buffer@npm:0.1.10"
+  checksum: 9ab029d0ba6f4c454cbbe09219c9b5762af5f6579e0787716824498cab27a7ad824cbe16a8e1a3b154994c08d684a0a9277d0eda339f551310a0fbd08836d375
   languageName: node
   linkType: hard
 
@@ -7035,7 +7080,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"isarray@npm:~1.0.0":
+"isarray@npm:^1.0.0, isarray@npm:~1.0.0":
   version: 1.0.0
   resolution: "isarray@npm:1.0.0"
   checksum: f032df8e02dce8ec565cf2eb605ea939bdccea528dbcf565cdf92bfa2da9110461159d86a537388ef1acef8815a330642d7885b29010e8f7eac967c9993b65ab
@@ -8204,6 +8249,20 @@ jschardet@latest:
   languageName: node
   linkType: hard
 
+"msgpack-lite@npm:^0.1.26":
+  version: 0.1.26
+  resolution: "msgpack-lite@npm:0.1.26"
+  dependencies:
+    event-lite: ^0.1.1
+    ieee754: ^1.1.8
+    int64-buffer: ^0.1.9
+    isarray: ^1.0.0
+  bin:
+    msgpack: ./bin/msgpack
+  checksum: 9ead6b1739fe8fd793258efe3fefb271f406445f3fbbd1b9c64b76a579d171fb509184c020235c833688b67eab635e32dcb0167128136221eb230a4d265e88e8
+  languageName: node
+  linkType: hard
+
 "multistream@npm:^4.1.0":
   version: 4.1.0
   resolution: "multistream@npm:4.1.0"
@@ -8287,6 +8346,15 @@ jschardet@latest:
   languageName: node
   linkType: hard
 
+"node-addon-api@npm:^6.1.0":
+  version: 6.1.0
+  resolution: "node-addon-api@npm:6.1.0"
+  dependencies:
+    node-gyp: latest
+  checksum: 3a539510e677cfa3a833aca5397300e36141aca064cdc487554f2017110709a03a95da937e98c2a14ec3c626af7b2d1b6dabe629a481f9883143d0d5bff07bf2
+  languageName: node
+  linkType: hard
+
 "node-fetch@npm:^2.6.6":
   version: 2.6.7
   resolution: "node-fetch@npm:2.6.7"
@@ -8301,7 +8369,7 @@ jschardet@latest:
   languageName: node
   linkType: hard
 
-"node-gyp-build@npm:^3.9.0":
+"node-gyp-build@npm:<4.0, node-gyp-build@npm:^3.9.0":
   version: 3.9.0
   resolution: "node-gyp-build@npm:3.9.0"
   bin:
@@ -8741,13 +8809,6 @@ jschardet@latest:
   languageName: node
   linkType: hard
 
-"pify@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "pify@npm:5.0.0"
-  checksum: 443e3e198ad6bfa8c0c533764cf75c9d5bc976387a163792fb553ffe6ce923887cf14eebf5aea9b7caa8eab930da8c33612990ae85bd8c2bc18bedb9eae94ecb
-  languageName: node
-  linkType: hard
-
 "pirates@npm:^4.0.4":
   version: 4.0.5
   resolution: "pirates@npm:4.0.5"
@@ -8812,7 +8873,7 @@ jschardet@latest:
   languageName: node
   linkType: hard
 
-"pprof-format@npm:^2.0.6":
+"pprof-format@npm:^2.0.7":
   version: 2.0.7
   resolution: "pprof-format@npm:2.0.7"
   checksum: 0033740ba5ffb9a0d684e7fc3a616d2932d21b908a62a095e88a0091fcd1ef9af379060b303429d9df8698c9f48a789202cc38ba1c71b3c4a6084a5604647367
@@ -8934,9 +8995,9 @@ jschardet@latest:
   languageName: node
   linkType: hard
 
-"protobufjs@npm:^7.1.2":
-  version: 7.1.2
-  resolution: "protobufjs@npm:7.1.2"
+"protobufjs@npm:^7.2.4":
+  version: 7.2.4
+  resolution: "protobufjs@npm:7.2.4"
   dependencies:
     "@protobufjs/aspromise": ^1.1.2
     "@protobufjs/base64": ^1.1.2
@@ -8950,7 +9011,7 @@ jschardet@latest:
     "@protobufjs/utf8": ^1.1.0
     "@types/node": ">=13.7.0"
     long: ^5.0.0
-  checksum: ae41669b1b0372fb1d49f506f2d1f2b0fb3dc3cece85987b17bcb544e4cef7c8d27f480486cdec324146ad0a5d22a327166a7ea864a9b3e49cc3c92a5d3f6500
+  checksum: a952cdf2a5e5250c16ae651b570849b6f5b20a5475c3eef63ffb290ad239aa2916adfc1cc676f7fc93c69f48113df268761c0c246f7f023118c85bdd1a170044
   languageName: node
   linkType: hard
 
@@ -9622,19 +9683,10 @@ jschardet@latest:
   languageName: node
   linkType: hard
 
-"source-map@npm:^0.7.3":
-  version: 0.7.3
-  resolution: "source-map@npm:0.7.3"
-  checksum: cd24efb3b8fa69b64bf28e3c1b1a500de77e84260c5b7f2b873f88284df17974157cc88d386ee9b6d081f08fdd8242f3fc05c953685a6ad81aad94c7393dedea
-  languageName: node
-  linkType: hard
-
-"split@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "split@npm:1.0.1"
-  dependencies:
-    through: 2
-  checksum: 12f4554a5792c7e98bb3e22b53c63bfa5ef89aa704353e1db608a55b51f5b12afaad6e4a8ecf7843c15f273f43cdadd67b3705cc43d48a75c2cf4641d51f7e7a
+"source-map@npm:^0.7.4":
+  version: 0.7.4
+  resolution: "source-map@npm:0.7.4"
+  checksum: 01cc5a74b1f0e1d626a58d36ad6898ea820567e87f18dfc9d24a9843a351aaa2ec09b87422589906d6ff1deed29693e176194dc88bcae7c9a852dc74b311dbf5
   languageName: node
   linkType: hard
 
@@ -10004,7 +10056,7 @@ jschardet@latest:
   languageName: node
   linkType: hard
 
-"through@npm:2, through@npm:^2.3.6":
+"through@npm:^2.3.6":
   version: 2.3.8
   resolution: "through@npm:2.3.8"
   checksum: a38c3e059853c494af95d50c072b83f8b676a9ba2818dcc5b108ef252230735c54e0185437618596c790bbba8fcdaef5b290405981ffa09dce67b1f1bf190cbd


### PR DESCRIPTION
### What and why?

Fixes https://github.com/DataDog/datadog-ci/security/dependabot/28

A bump for `protobufjs` was made in `dd-trace@3.28.0`: https://github.com/DataDog/dd-trace-js/pull/3383/commits

### How?

Update `package.json` and `yarn.lock`.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
