### PR TITLE
[synthetics] Fix max parallelization message

### DIFF
--- a/src/commands/synthetics/__tests__/api.test.ts
+++ b/src/commands/synthetics/__tests__/api.test.ts
@@ -202,7 +202,7 @@ describe('dd-api', () => {
   })
 
   test('should receive settings', async () => {
-    const settings = {orgMaxConcurrencyCap: 100}
+    const settings = {onDemandConcurrencyCap: 10}
     const requestMock = jest.fn(() => ({status: 200, data: settings}))
     const spy = jest.spyOn(axios, 'create').mockImplementation((() => requestMock) as any)
 

--- a/src/commands/synthetics/__tests__/reporters/__snapshots__/default.test.ts.snap
+++ b/src/commands/synthetics/__tests__/reporters/__snapshots__/default.test.ts.snap
@@ -78,32 +78,12 @@ Test Results: [32m[1m1[22m passed[39m, [31m[1m0[22m failed[39m
 Total Duration: 9m 28s"
 `;
 
-exports[`Default reporter runEnd communicates 0 parallelization 1`] = `
-"View full summary in Datadog: [2m[36mhttps://app.datadoghq.com/synthetics/explorer/ci?batchResultId=aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa[39m[22m
-
-[1mContinuous Testing Summary:[22m
-Test Results: [32m[1m1[22m passed[39m, [31m[1m0[22m failed[39m
-Total Duration: 9m 28s"
-`;
-
 exports[`Default reporter runEnd communicates 2 tests parallelization 1`] = `
 "View full summary in Datadog: [2m[36mhttps://app.datadoghq.com/synthetics/explorer/ci?batchResultId=aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa[39m[22m
 
 [1mContinuous Testing Summary:[22m
 Test Results: [32m[1m1[22m passed[39m, [31m[1m0[22m failed[39m
 Max parallelization configured: 2 tests running at the same time
-Total Duration: 9m 28s
-
-Increase your parallelization to reduce your total duration: [2m[36mhttps://app.datadoghq.com/synthetics/settings/continuous-testing[39m[22m
-"
-`;
-
-exports[`Default reporter runEnd communicates no (1 test at a time) parallelization 1`] = `
-"View full summary in Datadog: [2m[36mhttps://app.datadoghq.com/synthetics/explorer/ci?batchResultId=aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa[39m[22m
-
-[1mContinuous Testing Summary:[22m
-Test Results: [32m[1m1[22m passed[39m, [31m[1m0[22m failed[39m
-Max parallelization configured: 1 test running at the same time
 Total Duration: 9m 28s
 
 Increase your parallelization to reduce your total duration: [2m[36mhttps://app.datadoghq.com/synthetics/settings/continuous-testing[39m[22m
@@ -123,14 +103,6 @@ Increase your parallelization to reduce your total duration: [2m[36mhttps://ap
 `;
 
 exports[`Default reporter runEnd does not communicate for uncapped orgs 1`] = `
-"View full summary in Datadog: [2m[36mhttps://app.datadoghq.com/synthetics/explorer/ci?batchResultId=aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa[39m[22m
-
-[1mContinuous Testing Summary:[22m
-Test Results: [32m[1m1[22m passed[39m, [31m[1m0[22m failed[39m
-Total Duration: 9m 28s"
-`;
-
-exports[`Default reporter runEnd does not communicate infinite parallelization 1`] = `
 "View full summary in Datadog: [2m[36mhttps://app.datadoghq.com/synthetics/explorer/ci?batchResultId=aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa[39m[22m
 
 [1mContinuous Testing Summary:[22m

--- a/src/commands/synthetics/__tests__/reporters/__snapshots__/default.test.ts.snap
+++ b/src/commands/synthetics/__tests__/reporters/__snapshots__/default.test.ts.snap
@@ -110,6 +110,34 @@ Increase your parallelization to reduce your total duration: [2m[36mhttps://ap
 "
 `;
 
+exports[`Default reporter runEnd communicates no parallelization (1 test at a time) 1`] = `
+"View full summary in Datadog: [2m[36mhttps://app.datadoghq.com/synthetics/explorer/ci?batchResultId=aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa[39m[22m
+
+[1mContinuous Testing Summary:[22m
+Test Results: [32m[1m1[22m passed[39m, [31m[1m0[22m failed[39m
+Max parallelization configured: 1 test running at the same time
+Total Duration: 9m 28s
+
+Increase your parallelization to reduce your total duration: [2m[36mhttps://app.datadoghq.com/synthetics/settings/continuous-testing[39m[22m
+"
+`;
+
+exports[`Default reporter runEnd does not communicate for uncapped orgs 1`] = `
+"View full summary in Datadog: [2m[36mhttps://app.datadoghq.com/synthetics/explorer/ci?batchResultId=aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa[39m[22m
+
+[1mContinuous Testing Summary:[22m
+Test Results: [32m[1m1[22m passed[39m, [31m[1m0[22m failed[39m
+Total Duration: 9m 28s"
+`;
+
+exports[`Default reporter runEnd does not communicate infinite parallelization 1`] = `
+"View full summary in Datadog: [2m[36mhttps://app.datadoghq.com/synthetics/explorer/ci?batchResultId=aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa[39m[22m
+
+[1mContinuous Testing Summary:[22m
+Test Results: [32m[1m1[22m passed[39m, [31m[1m0[22m failed[39m
+Total Duration: 9m 28s"
+`;
+
 exports[`Default reporter testTrigger Blocking test, with 1 config override 1`] = `
 "[[1m[2maaa-bbb-ccc[22m[22m] Found test \\"[32m[1mRequest on example.org[22m[39m\\" [90m(1 config override)[39m
 "

--- a/src/commands/synthetics/__tests__/reporters/default.test.ts
+++ b/src/commands/synthetics/__tests__/reporters/default.test.ts
@@ -237,14 +237,14 @@ describe('Default reporter', () => {
       expect(mostRecentOutput).toMatchSnapshot()
     })
 
-    const orgMaxConcurrencyCaps: {description: string; cap: number}[] = [
-      {cap: 0, description: 'communicates 0 parallelization'},
-      {cap: 1, description: 'communicates no (1 test at a time) parallelization'},
+    const onDemandConcurrencyCaps: {description: string; cap: number}[] = [
+      {cap: 0, description: 'does not communicate for uncapped orgs'},
+      {cap: 1, description: 'communicates no parallelization (1 test at a time)'},
       {cap: 2, description: 'communicates 2 tests parallelization'},
     ]
 
-    test.each(orgMaxConcurrencyCaps)('$description', (testCase) => {
-      reporter.runEnd({...baseSummary, passed: 1}, MOCK_BASE_URL, {orgMaxConcurrencyCap: testCase.cap})
+    test.each(onDemandConcurrencyCaps)('$description', (testCase) => {
+      reporter.runEnd({...baseSummary, passed: 1}, MOCK_BASE_URL, {onDemandConcurrencyCap: testCase.cap})
       const mostRecentOutput = writeMock.mock.calls[writeMock.mock.calls.length - 1][0]
       expect(mostRecentOutput).toMatchSnapshot()
     })

--- a/src/commands/synthetics/__tests__/run-tests-lib.test.ts
+++ b/src/commands/synthetics/__tests__/run-tests-lib.test.ts
@@ -436,7 +436,7 @@ describe('run-test', () => {
         () =>
           ({
             getSyntheticsOrgSettings: () => ({
-              orgMaxConcurrencyCap: 1,
+              onDemandConcurrencyCap: 1,
             }),
           } as any)
       )

--- a/src/commands/synthetics/__tests__/utils.test.ts
+++ b/src/commands/synthetics/__tests__/utils.test.ts
@@ -1360,7 +1360,7 @@ describe('utils', () => {
           ))
       )
 
-      jest.spyOn(api, 'getSyntheticsOrgSettings').mockResolvedValue({orgMaxConcurrencyCap: 1})
+      jest.spyOn(api, 'getSyntheticsOrgSettings').mockResolvedValue({onDemandConcurrencyCap: 1})
 
       const config = {
         ...DEFAULT_COMMAND_CONFIG,
@@ -1374,7 +1374,7 @@ describe('utils', () => {
 
       utils.renderResults({
         config,
-        orgSettings: {orgMaxConcurrencyCap: 1},
+        orgSettings: {onDemandConcurrencyCap: 1},
         reporter: mockReporter,
         results: testCase.results,
         startTime,
@@ -1393,7 +1393,7 @@ describe('utils', () => {
 
       expect(testCase.summary).toEqual(testCase.expected.summary)
       expect((mockReporter as MockedReporter).runEnd).toHaveBeenCalledWith(testCase.expected.summary, baseUrl, {
-        orgMaxConcurrencyCap: 1,
+        onDemandConcurrencyCap: 1,
       })
 
       expect(exitCode).toBe(testCase.expected.exitCode)

--- a/src/commands/synthetics/interfaces.ts
+++ b/src/commands/synthetics/interfaces.ts
@@ -402,9 +402,9 @@ export interface PresignedUrlResponse {
   }
 }
 
-// not the entire response, but only the slice needed
+// Not the entire response, but only what's needed.
 export interface SyntheticsOrgSettings {
-  orgMaxConcurrencyCap: number
+  onDemandConcurrencyCap: number
 }
 
 export interface MobileApplicationVersion {

--- a/src/commands/synthetics/reporters/default.ts
+++ b/src/commands/synthetics/reporters/default.ts
@@ -332,10 +332,10 @@ export class DefaultReporter implements MainReporter {
     lines.push(`\n${b('Continuous Testing Summary:')}`)
     lines.push(`Test Results: ${runSummary.join(', ')}${extraInfoStr}`)
 
-    if (orgSettings && orgSettings.orgMaxConcurrencyCap > 0) {
+    if (orgSettings && orgSettings.onDemandConcurrencyCap > 0) {
       lines.push(
-        `Max parallelization configured: ${orgSettings.orgMaxConcurrencyCap} test${
-          orgSettings.orgMaxConcurrencyCap > 1 ? 's' : ''
+        `Max parallelization configured: ${orgSettings.onDemandConcurrencyCap} test${
+          orgSettings.onDemandConcurrencyCap > 1 ? 's' : ''
         } running at the same time`
       )
     }
@@ -348,11 +348,7 @@ export class DefaultReporter implements MainReporter {
       )
     }
 
-    if (
-      orgSettings &&
-      typeof orgSettings.orgMaxConcurrencyCap !== 'undefined' &&
-      orgSettings.orgMaxConcurrencyCap > 0
-    ) {
+    if (orgSettings && orgSettings.onDemandConcurrencyCap > 0) {
       lines.push(
         `\nIncrease your parallelization to reduce your total duration: ${chalk.dim.cyan(
           baseUrl + 'synthetics/settings/continuous-testing'


### PR DESCRIPTION
### What and why?

Currently, the wrong property is used for the max parallelization message.

### How?

Replace `orgMaxConcurrencyCap` with `onDemandConcurrencyCap`

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
