### PR TITLE
[static analysis][ci-visibility] Add e2e tests to sarif and junit uploads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,15 @@ jobs:
         env:
           DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY_E2E }}
           DATADOG_APP_KEY: ${{ secrets.DATADOG_APP_KEY_E2E }}
+      - name: Run junit upload test
+        run: yarn datadog-ci junit upload --service=datadog-ci-e2e-tests-junit artifacts/e2e/junit-reports 
+        env:
+          DD_API_KEY: ${{ secrets.DD_API_KEY_CI_VISIBILITY }}
+      - name: Run sarif upload test
+        run: yarn datadog-ci sarif upload --service=datadog-ci-e2e-tests-sarif artifacts/e2e/sarif-reports
+        env:
+          DD_API_KEY: ${{ secrets.DD_API_KEY_CI_VISIBILITY }}
+
 
   standalone-binary-test-ubuntu:
     name: Test standalone binary in ubuntu

--- a/.github/workflows/e2e/junit-reports/junit-2.xml
+++ b/.github/workflows/e2e/junit-reports/junit-2.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites duration="50.5">
+    <testsuite failures="0" name="Untitled suite in agent.js" package="tests/suites/casper/agent" tests="3" time="0.256">
+        <testcase classname="tests/suites/casper/agent" name="Default user agent matches /CasperJS/" time="0.103"/>
+        <testcase classname="tests/suites/casper/agent" name="Default user agent matches /plop/" time="0.146"/>
+        <testcase classname="tests/suites/casper/agent" name="Default user agent matches /plop/" time="0.007"/>
+    </testsuite>
+</testsuites>

--- a/.github/workflows/e2e/junit-reports/junit.xml
+++ b/.github/workflows/e2e/junit-reports/junit.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites duration="50.5">
+    <testsuite failures="0" name="Untitled suite in agent.js" package="tests/suites/casper/agent" tests="3" time="0.256">
+        <testcase classname="tests/suites/casper/agent" name="Default user agent matches /CasperJS/" time="0.103"/>
+        <testcase classname="tests/suites/casper/agent" name="Default user agent matches /plop/" time="0.146"/>
+        <testcase classname="tests/suites/casper/agent" name="Default user agent matches /plop/" time="0.007"/>
+    </testsuite>
+</testsuites>

--- a/.github/workflows/e2e/sarif-reports/sarif-report-2.sarif
+++ b/.github/workflows/e2e/sarif-reports/sarif-report-2.sarif
@@ -1,0 +1,60 @@
+{
+  "version": "2.1.0",
+  "$schema": "http://json.schemastore.org/sarif-2.1.0-rtm.5",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "name": "ESLint",
+          "informationUri": "https://eslint.org",
+          "rules": [
+            {
+              "id": "@typescript-eslint/no-unused-vars",
+              "helpUri": "https://github.com/typescript-eslint/typescript-eslint/blob/v4.33.0/packages/eslint-plugin/docs/rules/no-unused-vars.md",
+              "properties": {
+                "category": "Variables"
+              },
+              "shortDescription": {
+                "text": "Disallow unused variables"
+              }
+            }
+          ],
+          "version": "7.32.0"
+        }
+      },
+      "artifacts": [
+        {
+          "location": {
+            "uri": "file:///foo/bar/myfile.test.ts"
+          }
+        }
+      ],
+      "results": [
+        {
+          "level": "error",
+          "message": {
+            "text": "'foobar' is assigned a value but never used. Allowed unused vars must match /_/u."
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "file:///foo/bar/myfile.test.ts",
+                  "index": 0
+                },
+                "region": {
+                  "startLine": 7,
+                  "startColumn": 7,
+                  "endLine": 7,
+                  "endColumn": 14
+                }
+              }
+            }
+          ],
+          "ruleId": "@typescript-eslint/no-unused-vars",
+          "ruleIndex": 0
+        }
+      ]
+    }
+  ]
+}

--- a/.github/workflows/e2e/sarif-reports/sarif-report.sarif
+++ b/.github/workflows/e2e/sarif-reports/sarif-report.sarif
@@ -1,0 +1,60 @@
+{
+  "version": "2.1.0",
+  "$schema": "http://json.schemastore.org/sarif-2.1.0-rtm.5",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "name": "ESLint",
+          "informationUri": "https://eslint.org",
+          "rules": [
+            {
+              "id": "@typescript-eslint/no-unused-vars",
+              "helpUri": "https://github.com/typescript-eslint/typescript-eslint/blob/v4.33.0/packages/eslint-plugin/docs/rules/no-unused-vars.md",
+              "properties": {
+                "category": "Variables"
+              },
+              "shortDescription": {
+                "text": "Disallow unused variables"
+              }
+            }
+          ],
+          "version": "7.32.0"
+        }
+      },
+      "artifacts": [
+        {
+          "location": {
+            "uri": "file:///foo/bar/myfile.test.ts"
+          }
+        }
+      ],
+      "results": [
+        {
+          "level": "error",
+          "message": {
+            "text": "'foobar' is assigned a value but never used. Allowed unused vars must match /_/u."
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "file:///foo/bar/myfile.test.ts",
+                  "index": 0
+                },
+                "region": {
+                  "startLine": 7,
+                  "startColumn": 7,
+                  "endLine": 7,
+                  "endColumn": 14
+                }
+              }
+            }
+          ],
+          "ruleId": "@typescript-eslint/no-unused-vars",
+          "ruleIndex": 0
+        }
+      ]
+    }
+  ]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -80,6 +80,7 @@ src/commands/react-native/__tests__/fixtures/with-sources-content/main.jsbundle.
 !src/commands/sarif/__tests__/fixtures/*.sarif
 !src/commands/sarif/__tests__/fixtures/subfolder/*.sarif
 !src/commands/sarif/__tests__/fixtures/another_subfolder/*.sarif
+!.github/workflows/e2e/sarif-reports/*.sarif
 
 # Yarn non zero-install. See: https://yarnpkg.com/getting-started/qa#which-files-should-be-gitignored
 .pnp.*


### PR DESCRIPTION
### What and why?

Add integration tests to junit and sarif commands, to reduce the likelihood of future incidents. 

### How?

* Add `DD_API_KEY_CI_VISIBILITY` to report to a ci visibility controlled org. 
* Add two steps to `e2e-test` for junit and sarif uploads. 

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
