### PR TITLE
[CIAPP] add azure pipelines in the readme

### DIFF
--- a/src/commands/metric/README.md
+++ b/src/commands/metric/README.md
@@ -28,7 +28,7 @@ datadog-ci metric --level job --metrics binary.size:1024
 
 ### Supported providers
 
-The metric command only works for the following CI providers: [Buildkite, CircleCI, GitHub, GitLab]. If used in
+The metric command only works for the following CI providers: [Buildkite, CircleCI, GitHub, GitLab, Azure Pipelines]. If used in
 any other provider it will fail. Note that for GitHub actions only the level `pipeline` is supported. If the
 command is invoked in GitHub actions with level `job` it will exit with status code 1 and return an
 error.

--- a/src/commands/metric/README.md
+++ b/src/commands/metric/README.md
@@ -28,7 +28,7 @@ datadog-ci metric --level job --metrics binary.size:1024
 
 ### Supported providers
 
-The metric command only works for the following CI providers: [Buildkite, CircleCI, GitHub, GitLab, Azure Pipelines]. If used in
+The metric command only works for the following CI providers: [Buildkite, CircleCI, GitHub, GitLab, AzurePipelines]. If used in
 any other provider it will fail. Note that for GitHub actions only the level `pipeline` is supported. If the
 command is invoked in GitHub actions with level `job` it will exit with status code 1 and return an
 error.

--- a/src/commands/tag/README.md
+++ b/src/commands/tag/README.md
@@ -29,7 +29,7 @@ datadog-ci tag --level job --tags "go.version:`go version`"
 
 ### Supported providers
 
-The tag command only works for the following CI providers: [Buildkite, CircleCI, GitHub, GitLab, Azure Pipelines]. If used in
+The tag command only works for the following CI providers: [Buildkite, CircleCI, GitHub, GitLab, AzurePipelines]. If used in
 any other provider it will fail. Note that for GitHub actions only the level `pipeline` is supported. If the
 command is invoked in GitHub actions with level `job` it will exit with status code 1 and return an
 error.

--- a/src/commands/tag/README.md
+++ b/src/commands/tag/README.md
@@ -29,7 +29,7 @@ datadog-ci tag --level job --tags "go.version:`go version`"
 
 ### Supported providers
 
-The tag command only works for the following CI providers: [Buildkite, CircleCI, GitHub, GitLab]. If used in
+The tag command only works for the following CI providers: [Buildkite, CircleCI, GitHub, GitLab, Azure Pipelines]. If used in
 any other provider it will fail. Note that for GitHub actions only the level `pipeline` is supported. If the
 command is invoked in GitHub actions with level `job` it will exit with status code 1 and return an
 error.


### PR DESCRIPTION
### What and why?

The support for Azure pipelines `tag` and `metric` commands was added in https://github.com/DataDog/datadog-ci/pull/847/. However, it was not added to the README. This PR does that.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
