### PR TITLE
[synthetics] Use fake timers for api retries unit tests

### DIFF
--- a/src/commands/synthetics/__tests__/api.test.ts
+++ b/src/commands/synthetics/__tests__/api.test.ts
@@ -177,7 +177,7 @@ describe('dd-api', () => {
           await fastForwardRetries()
           await expect(requestPromise).rejects.toThrow()
 
-          expect(requestMock).toHaveBeenCalledTimes(shouldBeRetriedOn5xx ? 4 : 1)
+          expect(requestMock).toHaveBeenCalledTimes(shouldBeRetriedOn5xx ? MAX_ATTEMPTS : MIN_ATTEMPTS)
         }
       }
     )


### PR DESCRIPTION
### What and why?

This PR reduces the duration of the "Retry policy" unit tests by leveraging fake timers.

### How?



### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
