### PR TITLE
[yarn] Fix dev env

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,9 +10,9 @@
   },
   "volta": {
     "node": "14.20.1",
-    "yarn": "3.4.1"
+    "yarn": "1.22.19"
   },
-  "packageManager": "yarn@3.4.1",
+  "packageManager": "yarn@1.22.19",
   "files": [
     "dist/**/*",
     "README",


### PR DESCRIPTION
### What and why?

There was an issue when setting up my dev env for datadog-ci:

yarn `3.4.1` isn't downloadable
![image](https://github.com/DataDog/datadog-ci/assets/597828/b5301cc5-0faa-416d-9dfc-a8149f670c11)

### How?

Instead, we should download latest version (`1.22.19`) which will use the correct release (`3.4.1`) that we embed in the repo at `.yarn/releases/yarn-3.4.1.cjs`.

### QA

- [x] `yarn -v` still outputs the correct version without being stopped by volta.

![image](https://github.com/DataDog/datadog-ci/assets/597828/248d30d1-89fb-4ba5-ac81-0b8c3d7e1922)
