### PR TITLE
Provide `version` as a shared and exported constant

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,6 +3,8 @@ import fs from 'fs'
 import {Cli} from 'clipanion'
 import {CommandClass} from 'clipanion/lib/advanced/Command'
 
+import {version} from './helpers/version'
+
 const BETA_COMMANDS = ['gate']
 
 const onError = (err: any) => {
@@ -16,7 +18,7 @@ process.on('unhandledRejection', onError)
 const cli = new Cli({
   binaryLabel: 'Datadog CI',
   binaryName: 'datadog-ci',
-  binaryVersion: require('../package.json').version,
+  binaryVersion: version,
 })
 
 const commandsPath = `${__dirname}/commands`
@@ -28,7 +30,8 @@ for (const commandFolder of fs.readdirSync(commandsPath)) {
   }
   const commandPath = `${commandsPath}/${commandFolder}`
   if (fs.statSync(commandPath).isDirectory()) {
-    require(`${commandPath}/cli`).forEach((command: CommandClass) => cli.register(command))
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    ;(require(`${commandPath}/cli`) as CommandClass[]).forEach((command) => cli.register(command))
   }
 }
 

--- a/src/commands/dsyms/upload.ts
+++ b/src/commands/dsyms/upload.ts
@@ -14,6 +14,7 @@ import {upload, UploadStatus} from '../../helpers/upload'
 import {buildPath, getRequestBuilder, resolveConfigFromFileAndEnvironment} from '../../helpers/utils'
 import * as validation from '../../helpers/validation'
 import {checkAPIKeyOverride} from '../../helpers/validation'
+import {version} from '../../helpers/version'
 
 import {ArchSlice, CompressedDsym, Dsym} from './interfaces'
 import {
@@ -61,14 +62,9 @@ export class UploadCommand extends Command {
   private dryRun = Option.Boolean('--dry-run', false)
   private maxConcurrency = Option.String('--max-concurrency', '20', {validator: validation.isInteger()})
 
-  private cliVersion: string
+  private cliVersion = version
   private config: Record<string, string> = {
     datadogSite: 'datadoghq.com',
-  }
-
-  constructor() {
-    super()
-    this.cliVersion = require('../../../package.json').version
   }
 
   public async execute() {

--- a/src/commands/flutter-symbols/__tests__/upload.test.ts
+++ b/src/commands/flutter-symbols/__tests__/upload.test.ts
@@ -7,6 +7,7 @@ import {createCommand} from '../../../helpers/__tests__/fixtures'
 import {TrackedFilesMatcher, getRepositoryData} from '../../../helpers/git/format-git-sourcemaps-data'
 import {MultipartPayload} from '../../../helpers/upload'
 import {performSubCommand} from '../../../helpers/utils'
+import {version} from '../../../helpers/version'
 
 import * as dsyms from '../../dsyms/upload'
 import * as sourcemaps from '../../sourcemaps/upload'
@@ -39,7 +40,7 @@ jest.mock('../../../helpers/git/format-git-sourcemaps-data', () => ({
   getRepositoryData: jest.fn(),
 }))
 
-const cliVersion = require('../../../../package.json').version
+const cliVersion = version
 const fixtureDir = './src/commands/flutter-symbols/__tests__/fixtures'
 
 describe('flutter-symbol upload', () => {

--- a/src/commands/flutter-symbols/upload.ts
+++ b/src/commands/flutter-symbols/upload.ts
@@ -18,6 +18,7 @@ import {
 } from '../../helpers/utils'
 import * as validation from '../../helpers/validation'
 import {checkAPIKeyOverride} from '../../helpers/validation'
+import {version} from '../../helpers/version'
 
 import * as dsyms from '../dsyms/upload'
 import {newSimpleGit} from '../git-metadata/git'
@@ -90,16 +91,11 @@ export class UploadCommand extends Command {
   private serviceName = Option.String('--service-name')
   private version = Option.String('--version')
 
-  private cliVersion: string
+  private cliVersion = version
   private config: Record<string, string> = {
     datadogSite: 'datadoghq.com',
   }
   private gitData?: RepositoryData
-
-  constructor() {
-    super()
-    this.cliVersion = require('../../../package.json').version
-  }
 
   public async execute() {
     if (!(await this.verifyParameters())) {

--- a/src/commands/git-metadata/library.ts
+++ b/src/commands/git-metadata/library.ts
@@ -2,6 +2,7 @@ import {newApiKeyValidator} from '../../helpers/apikey'
 import {RequestBuilder} from '../../helpers/interfaces'
 import {upload, UploadOptions, UploadStatus} from '../../helpers/upload'
 import {getRequestBuilder, filterAndFormatGithubRemote} from '../../helpers/utils'
+import {version} from '../../helpers/version'
 
 import {getCommitInfo, newSimpleGit} from './git'
 import {CommitInfo} from './interfaces'
@@ -33,7 +34,7 @@ export const getGitCommitInfo = async (filterAndFormatGitRepoUrl = true): Promis
 }
 
 // UploadGitCommitHash uploads local git metadata and returns the current [repositoryURL, commitHash].
-// The current repositoryURL can be overriden by specifying the 'repositoryURL' arg.
+// The current repositoryURL can be overridden by specifying the 'repositoryURL' arg.
 export const uploadGitCommitHash = async (
   apiKey: string,
   datadogSite: string,
@@ -46,8 +47,6 @@ export const uploadGitCommitHash = async (
 
   const simpleGit = await newSimpleGit()
   const payload = await getCommitInfo(simpleGit, repositoryURL)
-
-  const version = require('../../../package.json').version
 
   const requestBuilder = getRequestBuilder({
     apiKey,

--- a/src/commands/git-metadata/upload.ts
+++ b/src/commands/git-metadata/upload.ts
@@ -10,6 +10,7 @@ import {Logger, LogLevel} from '../../helpers/logger'
 import {MetricsLogger, getMetricsLogger} from '../../helpers/metrics'
 import {UploadStatus} from '../../helpers/upload'
 import {getRequestBuilder, timedExecAsync} from '../../helpers/utils'
+import {version} from '../../helpers/version'
 
 import {apiHost, datadogSite, getBaseIntakeUrl} from './api'
 import {getCommitInfo, newSimpleGit} from './git'
@@ -46,7 +47,7 @@ export class UploadCommand extends Command {
   private noGitSync = Option.Boolean('--no-gitsync', false)
   private directory = Option.String('--directory', '')
 
-  private cliVersion: string
+  private cliVersion = version
   private config = {
     apiKey: process.env.DATADOG_API_KEY,
   }
@@ -54,11 +55,6 @@ export class UploadCommand extends Command {
   private logger: Logger = new Logger((s: string) => {
     this.context.stdout.write(s)
   }, LogLevel.INFO)
-
-  constructor() {
-    super()
-    this.cliVersion = require('../../../package.json').version
-  }
 
   public async execute() {
     const initialTime = Date.now()

--- a/src/commands/lambda/flare.ts
+++ b/src/commands/lambda/flare.ts
@@ -28,6 +28,7 @@ import {requestConfirmation, requestFilePath} from '../../helpers/prompt'
 import * as helpersRenderer from '../../helpers/renderer'
 import {renderAdditionalFiles, renderProjectFiles} from '../../helpers/renderer'
 import {formatBytes} from '../../helpers/utils'
+import {version} from '../../helpers/version'
 
 import {
   AWS_DEFAULT_REGION_ENV_VAR,
@@ -44,8 +45,6 @@ import {
 } from './functions/commons'
 import {requestAWSCredentials} from './prompt'
 import * as commonRenderer from './renderers/common-renderer'
-
-const version = require('../../../package.json').version
 
 const FUNCTION_CONFIG_FILE_NAME = 'function_config.json'
 const TAGS_FILE_NAME = 'tags.json'

--- a/src/commands/lambda/tags.ts
+++ b/src/commands/lambda/tags.ts
@@ -8,10 +8,10 @@ import {
   ListTagsCommand,
 } from '@aws-sdk/client-lambda'
 
+import {version} from '../../helpers/version'
+
 import {TAG_VERSION_NAME} from './constants'
 import {TagConfiguration} from './interfaces'
-
-const {version} = require('../../../package.json')
 
 export const applyTagConfig = async (lambdaClient: LambdaClient, config: TagConfiguration) => {
   const {tagResourceCommandInput, untagResourceCommandInput} = config

--- a/src/commands/react-native/upload.ts
+++ b/src/commands/react-native/upload.ts
@@ -12,6 +12,7 @@ import {upload, UploadStatus} from '../../helpers/upload'
 import {getRequestBuilder, resolveConfigFromFileAndEnvironment} from '../../helpers/utils'
 import * as validation from '../../helpers/validation'
 import {checkAPIKeyOverride} from '../../helpers/validation'
+import {version} from '../../helpers/version'
 
 import {RNPlatform, RNSourcemap, RN_SUPPORTED_PLATFORMS} from './interfaces'
 import {
@@ -65,14 +66,9 @@ export class UploadCommand extends Command {
   private service = Option.String('--service')
   private sourcemap = Option.String('--sourcemap')
 
-  private cliVersion: string
+  private cliVersion = version
   private config: Record<string, string> = {
     datadogSite: 'datadoghq.com',
-  }
-
-  constructor() {
-    super()
-    this.cliVersion = require('../../../package.json').version
   }
 
   public async execute() {

--- a/src/commands/react-native/utils.ts
+++ b/src/commands/react-native/utils.ts
@@ -8,6 +8,7 @@ export const getReactNativeVersion = (packageJsonPath: string): undefined | stri
   }
 
   try {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-var-requires
     return require(packageJsonPath).version as string
   } catch (e) {
     return undefined

--- a/src/commands/sourcemaps/upload.ts
+++ b/src/commands/sourcemaps/upload.ts
@@ -15,6 +15,7 @@ import {getMetricsLogger, MetricsLogger} from '../../helpers/metrics'
 import {upload, UploadStatus} from '../../helpers/upload'
 import {getRequestBuilder, buildPath} from '../../helpers/utils'
 import * as validation from '../../helpers/validation'
+import {version} from '../../helpers/version'
 
 import {Sourcemap} from './interfaces'
 import {
@@ -63,16 +64,10 @@ export class UploadCommand extends Command {
   private repositoryURL = Option.String('--repository-url')
   private service = Option.String('--service')
 
+  private cliVersion = version
   private config = {
     apiKey: process.env.DATADOG_API_KEY,
     datadogSite: process.env.DATADOG_SITE || 'datadoghq.com',
-  }
-
-  private cliVersion: string
-
-  constructor() {
-    super()
-    this.cliVersion = require('../../../package.json').version
   }
 
   public async execute() {

--- a/src/commands/stepfunctions/instrument.ts
+++ b/src/commands/stepfunctions/instrument.ts
@@ -3,6 +3,8 @@ import {IAMClient} from '@aws-sdk/client-iam'
 import {SFNClient} from '@aws-sdk/client-sfn'
 import {Command, Option} from 'clipanion'
 
+import {version} from '../../helpers/version'
+
 import {
   createLogGroup,
   enableStepFunctionLogs,
@@ -24,7 +26,7 @@ import {
   injectContextIntoLambdaPayload,
 } from './helpers'
 
-const cliVersion = require('../../../package.json').version
+const cliVersion = version
 
 export class InstrumentStepFunctionsCommand extends Command {
   public static paths = [['stepfunctions', 'instrument']]

--- a/src/commands/version/cli.ts
+++ b/src/commands/version/cli.ts
@@ -1,5 +1,7 @@
 import {Command} from 'clipanion'
 
+import {version} from '../../helpers/version'
+
 class VersionCommand extends Command {
   public static paths = [['version']]
 
@@ -9,7 +11,6 @@ class VersionCommand extends Command {
   })
 
   public async execute() {
-    const {version} = require('../../../package.json')
     this.context.stdout.write(`v${version}\n`)
 
     return 0

--- a/src/helpers/flare.ts
+++ b/src/helpers/flare.ts
@@ -21,8 +21,7 @@ import {
 import {deleteFolder} from './fs'
 import * as helpersRenderer from './renderer'
 import {isValidDatadogSite} from './validation'
-
-const {version} = require('../../package.json')
+import {version} from './version'
 
 /**
  * Send the zip file to Datadog support

--- a/src/helpers/version.ts
+++ b/src/helpers/version.ts
@@ -1,0 +1,5 @@
+/**
+ * Current version of `datadog-ci`.
+ */
+// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-var-requires
+export const version = require('../../package.json').version as string

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,4 @@
-import * as gitMetadata from './commands/git-metadata'
-import * as synthetics from './commands/synthetics'
-import * as utils from './helpers/utils'
-
-export {utils, synthetics, gitMetadata}
+export * as gitMetadata from './commands/git-metadata'
+export * as synthetics from './commands/synthetics'
+export * as utils from './helpers/utils'
+export {version} from './helpers/version'


### PR DESCRIPTION
### What and why?

This PR replaces all `require('../path/to/package.json')` to get the package's version by a shared `version` constant.

It also exports that constant for lib users:
```ts
import {version} from '@datadog/datadog-ci`
```

This also fixes a bunch of warnings, and makes all the commands more consistent.

### How?

- Create a new `src/helpers/version.ts` module, which only exports a `version` constant.
- I chose not to change the namings in the commands. They sometimes redeclare the variable globally or as a class field.
- I chose to name it `version` **and not `cliVersion`** because for lib users, what we export is not a CLI, but a "datadog-ci" library.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
