### PR TITLE
Update CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -19,8 +19,9 @@ src/commands/flutter-symbols  @DataDog/rum-mobile
 src/commands/react-native     @DataDog/rum-mobile
 
 ## Serverless
-src/commands/lambda  @DataDog/serverless
+src/commands/lambda         @DataDog/serverless
 src/commands/stepfunctions  @DataDog/serverless
+src/commands/cloud-run      @DataDog/serverless
 
 ## Source Code Integration
 src/commands/git-metadata  @DataDog/source-code-integration

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,7 @@
 * @DataDog/datadog-ci
 
 
-# Commands
+# Commands (grouped by product)
 
 ## CI Visibility
 src/commands/junit   @DataDog/ci-app-libraries
@@ -17,6 +17,8 @@ src/commands/sarif   @DataDog/static-analysis-core
 src/commands/dsyms            @DataDog/rum-mobile
 src/commands/flutter-symbols  @DataDog/rum-mobile
 src/commands/react-native     @DataDog/rum-mobile
+### Related to RUM, but maintained by Source Code Integration for legacy reasons
+src/commands/sourcemaps       @DataDog/source-code-integration
 
 ## Serverless
 src/commands/lambda         @DataDog/serverless
@@ -25,7 +27,6 @@ src/commands/cloud-run      @DataDog/serverless
 
 ## Source Code Integration
 src/commands/git-metadata  @DataDog/source-code-integration
-src/commands/sourcemaps    @DataDog/source-code-integration
 
 ## Synthetics
 src/commands/synthetics  @DataDog/synthetics-ct


### PR DESCRIPTION
### What and why?

This PR:

- Adds Serverless as the codeowners for the `cloud-run flare` command
- Moves `src/commands/sourcemaps` in the RUM section to illustrate that it's RUM-related, but maintained by another team

