### PR TITLE
[lambda] fix handler not being set when running interactive mode

### DIFF
--- a/src/commands/lambda/__tests__/__snapshots__/instrument.test.ts.snap
+++ b/src/commands/lambda/__tests__/__snapshots__/instrument.test.ts.snap
@@ -165,6 +165,7 @@ Will apply the following updates:
 UpdateFunctionConfiguration -> arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world
 {
   "FunctionName": "arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world",
+  "Handler": "/opt/nodejs/node_modules/datadog-lambda-js/handler.handler",
   "Environment": {
     "Variables": {
       "DD_LAMBDA_HANDLER": "index.handler",
@@ -188,6 +189,7 @@ TagResource -> arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world
 UpdateFunctionConfiguration -> arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world-2
 {
   "FunctionName": "arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world-2",
+  "Handler": "/opt/nodejs/node_modules/datadog-lambda-js/handler.handler",
   "Environment": {
     "Variables": {
       "DD_LAMBDA_HANDLER": "index.handler",
@@ -238,6 +240,7 @@ Will apply the following updates:
 UpdateFunctionConfiguration -> arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world
 {
   "FunctionName": "arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world",
+  "Handler": "/opt/nodejs/node_modules/datadog-lambda-js/handler.handler",
   "Environment": {
     "Variables": {
       "DD_LAMBDA_HANDLER": "index.handler",
@@ -261,6 +264,7 @@ TagResource -> arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world
 UpdateFunctionConfiguration -> arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world-2
 {
   "FunctionName": "arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world-2",
+  "Handler": "/opt/nodejs/node_modules/datadog-lambda-js/handler.handler",
   "Environment": {
     "Variables": {
       "DD_LAMBDA_HANDLER": "index.handler",
@@ -721,6 +725,7 @@ Will apply the following updates:
 UpdateFunctionConfiguration -> arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world
 {
   "FunctionName": "arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world",
+  "Handler": "/opt/nodejs/node_modules/datadog-lambda-js/handler.handler",
   "Environment": {
     "Variables": {
       "DD_LAMBDA_HANDLER": "index.handler",
@@ -767,6 +772,7 @@ Will apply the following updates:
 UpdateFunctionConfiguration -> arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world
 {
   "FunctionName": "arn:aws:lambda:sa-east-1:123456789012:function:lambda-hello-world",
+  "Handler": "/opt/nodejs/node_modules/datadog-lambda-js/handler.handler",
   "Environment": {
     "Variables": {
       "DD_LAMBDA_HANDLER": "index.handler",

--- a/src/commands/lambda/functions/instrument.ts
+++ b/src/commands/lambda/functions/instrument.ts
@@ -184,7 +184,7 @@ export const calculateUpdateRequest = async (
   }
 
   // Update Python Handler
-  if (runtimeType === RuntimeType.PYTHON && settings.layerVersion !== undefined) {
+  if (runtimeType === RuntimeType.PYTHON && (settings.layerVersion !== undefined || settings.interactive)) {
     const expectedHandler = PYTHON_HANDLER_LOCATION
     if (config.Handler !== expectedHandler) {
       needsUpdate = true
@@ -193,7 +193,7 @@ export const calculateUpdateRequest = async (
   }
 
   // Update Node Handler
-  if (runtimeType === RuntimeType.NODE && settings.layerVersion !== undefined) {
+  if (runtimeType === RuntimeType.NODE && (settings.layerVersion !== undefined || settings.interactive)) {
     const expectedHandler = NODE_HANDLER_LOCATION
     if (config.Handler !== expectedHandler) {
       needsUpdate = true


### PR DESCRIPTION
### What and why?

Handler for NodeJS and Python AWS Lambdas was not being set properly on interactive mode.
Due to not checking if we were running on such mode when deciding to update the handler.

### How?

Check either if layer version is set or we are in interactive mode.

### Review checklist

- [x] Unit tests
- [x] Tested instrumenting an AWS Lambda
