### PR TITLE
[flare] Add cloud-run flare documentation & update lambda flare documentation

### DIFF
--- a/src/commands/cloud-run/README.md
+++ b/src/commands/cloud-run/README.md
@@ -12,10 +12,10 @@ You must have valid [GCP credentials][1] configured with access to the Lambda an
 
 Expose these environment variables in the environment where you are running `datadog-ci cloud-run flare`:
 
-| Environment Variable | Description                                                                                                                                                                                                                                      | Example                               |
-|----------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------|
-| `DATADOG_API_KEY`    | Datadog API Key. Used to attach the flare files to your Zendesk ticket. For more information about getting a Datadog API key, see the [API key documentation][2].                                                                                | `export DATADOG_API_KEY=<API_KEY>`    |
-| `DATADOG_SITE`       | Optional. Set which Datadog site to send the flare for lower latency. Possible values are  `datadoghq.com` , `datadoghq.eu` , `us3.datadoghq.com`, `us5.datadoghq.com`, `ap1.datadoghq.com`, and `ddog-gov.com`. The default is `datadoghq.com`. | `export DATADOG_SITE="datadoghq.com"` |
+| Environment Variable | Description                                                                                                                                                                                                                                      | Example                          |
+|----------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------|
+| `DD_API_KEY`         | Datadog API Key. Used to attach the flare files to your Zendesk ticket. For more information about getting a Datadog API key, see the [API key documentation][2].                                                                                | `export DD_API_KEY=<API_KEY>`    |
+| `DD_SITE`            | Optional. Set which Datadog site to send the flare for lower latency. Possible values are  `datadoghq.com` , `datadoghq.eu` , `us3.datadoghq.com`, `us5.datadoghq.com`, `ap1.datadoghq.com`, and `ddog-gov.com`. The default is `datadoghq.com`. | `export DD_SITE="datadoghq.com"` |
 
 ## Flare Command
 

--- a/src/commands/cloud-run/README.md
+++ b/src/commands/cloud-run/README.md
@@ -32,16 +32,7 @@ datadog-ci cloud-run -s <service> -p <project> -r <region/location> -c <case-id>
 
 For product feedback and questions, join the `#serverless` channel in the [Datadog community on Slack](https://chat.datadoghq.com/).
 
-[1]: https://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/setting-credentials-node.html
+[1]: https://cloud.google.com/sdk/gcloud/reference/auth/login
 [2]: https://github.com/DataDog/datadog-ci
-[3]: https://github.com/DataDog/datadog-lambda-layer-js/releases
-[4]: https://github.com/DataDog/datadog-lambda-layer-python/releases
-[5]: https://docs.datadoghq.com/serverless/datadog_lambda_library/extension
-[6]: https://docs.datadoghq.com/account_management/api-app-keys/#api-keys
-[7]: https://docs.datadoghq.com/serverless/troubleshooting/serverless_tagging/#the-env-tag
-[8]: https://docs.datadoghq.com/serverless/troubleshooting/serverless_tagging/#the-version-tag
-[9]: https://docs.datadoghq.com/serverless/troubleshooting/serverless_tagging/#the-service-tag
-[10]: https://docs.datadoghq.com/serverless/forwarder/
-[11]: https://docs.datadoghq.com/serverless/custom_metrics?tab=python#enabling-asynchronous-custom-metrics
-[12]: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html#using-profiles
-[13]: https://docs.datadoghq.com/integrations/guide/source-code-integration
+[3]: https://docs.datadoghq.com/serverless/google_cloud_run
+[4]: https://docs.datadoghq.com/account_management/api-app-keys/#api-keys

--- a/src/commands/cloud-run/README.md
+++ b/src/commands/cloud-run/README.md
@@ -1,0 +1,47 @@
+## Troubleshooting Cloud Run Instrumentation
+
+To troubleshoot issues you may be encountering with Datadog monitoring on your Cloud Run services, use the `datadog-ci cloud-run flare` command in the root of your project directory. This command collects important data about a Cloud Run service, such as environment variables and configuration information. These files will be submitted to Datadog support via a ticket matching the provided Zendesk case ID.
+
+**Examples**
+```bash
+# Collect and send files to Datadog support for a single service
+datadog-ci cloud-run -s <service> -p <project> -r <region/location> -c <case-id> -e <email-on-case-id>
+
+# Include recent logs
+datadog-ci cloud-run -s <service> -p <project> -r <region/location> -c <case-id> -e <email-on-case-id> --with-logs
+
+# Dry run: collect data, but don't send to Datadog support
+datadog-ci cloud-run -s <service> -p <project> -r <region/location> -c <case-id> -e <email-on-case-id> --with-logs --dry-run
+```
+
+**Arguments**
+
+| Argument              | Shorthand | Description                                                                                                                 | Default |
+|-----------------------|-----------|-----------------------------------------------------------------------------------------------------------------------------|---------|
+| `--service`           | `-s`      | The name of the Cloud Run service.                                                                                          |         |
+| `--project`           | `-p`      | The name of the Google Cloud project within which the Cloud Run service is hosted.                                          |         |
+| `--region`            | `-r`      | The region where the Cloud Run service is hosted.                                                                           |         |
+| `--case-id`           | `-c`      | The Datadog case ID to send the files to.                                                                                   |         |
+| `--email`             | `-e`      | The email associated with the specified case ID.                                                                            |         |
+| `--with-logs`         |           | Collect recent logs for the specified service.                                                                              | `false` |
+| `--start` and `--end` |           | Define a time range in milliseconds since the Unix Epoch to gather logs within that range. (`--with-logs` must be included) |         |
+| `--dry-run`           | `-d`      | Preview collected data which would be sent to Datadog support.                                                              | `false` |
+
+
+## Community
+
+For product feedback and questions, join the `#serverless` channel in the [Datadog community on Slack](https://chat.datadoghq.com/).
+
+[1]: https://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/setting-credentials-node.html
+[2]: https://github.com/DataDog/datadog-ci
+[3]: https://github.com/DataDog/datadog-lambda-layer-js/releases
+[4]: https://github.com/DataDog/datadog-lambda-layer-python/releases
+[5]: https://docs.datadoghq.com/serverless/datadog_lambda_library/extension
+[6]: https://docs.datadoghq.com/account_management/api-app-keys/#api-keys
+[7]: https://docs.datadoghq.com/serverless/troubleshooting/serverless_tagging/#the-env-tag
+[8]: https://docs.datadoghq.com/serverless/troubleshooting/serverless_tagging/#the-version-tag
+[9]: https://docs.datadoghq.com/serverless/troubleshooting/serverless_tagging/#the-service-tag
+[10]: https://docs.datadoghq.com/serverless/forwarder/
+[11]: https://docs.datadoghq.com/serverless/custom_metrics?tab=python#enabling-asynchronous-custom-metrics
+[12]: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html#using-profiles
+[13]: https://docs.datadoghq.com/integrations/guide/source-code-integration

--- a/src/commands/cloud-run/README.md
+++ b/src/commands/cloud-run/README.md
@@ -1,6 +1,6 @@
 ## Troubleshooting Cloud Run Instrumentation
 
-To troubleshoot issues you may be encountering with Datadog monitoring on your Cloud Run services, use the `datadog-ci cloud-run flare` command in the root of your project directory. This command collects important data about a Cloud Run service, such as environment variables and configuration information. These files will be submitted to Datadog support via a ticket matching the provided Zendesk case ID.
+To troubleshoot issues you encounter with Datadog monitoring on your Cloud Run services, run the `datadog-ci cloud-run flare` command in the root of your project directory. This command collects important data about the Cloud Run service, such as environment variables and configuration information. These files will be submitted to Datadog support via a ticket matching the provided Zendesk case ID.
 
 **Examples**
 ```bash
@@ -16,16 +16,16 @@ datadog-ci cloud-run -s <service> -p <project> -r <region/location> -c <case-id>
 
 **Arguments**
 
-| Argument              | Shorthand | Description                                                                                                                 | Default |
-|-----------------------|-----------|-----------------------------------------------------------------------------------------------------------------------------|---------|
-| `--service`           | `-s`      | The name of the Cloud Run service.                                                                                          |         |
-| `--project`           | `-p`      | The name of the Google Cloud project within which the Cloud Run service is hosted.                                          |         |
-| `--region`            | `-r`      | The region where the Cloud Run service is hosted.                                                                           |         |
-| `--case-id`           | `-c`      | The Datadog case ID to send the files to.                                                                                   |         |
-| `--email`             | `-e`      | The email associated with the specified case ID.                                                                            |         |
-| `--with-logs`         |           | Collect recent logs for the specified service.                                                                              | `false` |
-| `--start` and `--end` |           | Define a time range in milliseconds since the Unix Epoch to gather logs within that range. (`--with-logs` must be included) |         |
-| `--dry-run`           | `-d`      | Preview collected data which would be sent to Datadog support.                                                              | `false` |
+| Argument              | Shorthand | Description                                                                                                               | Default |
+|-----------------------|-----------|---------------------------------------------------------------------------------------------------------------------------|---------|
+| `--service`           | `-s`      | The name of the Cloud Run service.                                                                                        |         |
+| `--project`           | `-p`      | The name of the Google Cloud project where the Cloud Run service is hosted.                                               |         |
+| `--region`            | `-r`      | The region where the Cloud Run service is hosted.                                                                         |         |
+| `--case-id`           | `-c`      | The Datadog case ID to send the files to.                                                                                 |         |
+| `--email`             | `-e`      | The email associated with the specified case ID.                                                                          |         |
+| `--with-logs`         |           | Collect recent logs for the specified service.                                                                            | `false` |
+| `--start` and `--end` |           | Using numbers in milliseconds since Unix Epoch, only gather logs within the time range. (`--with-logs` must be included.) |         |
+| `--dry-run`           | `-d`      | Preview data that will be sent to Datadog support.                                                                        | `false` |
 
 
 ## Community

--- a/src/commands/cloud-run/README.md
+++ b/src/commands/cloud-run/README.md
@@ -24,7 +24,7 @@ datadog-ci cloud-run -s <service> -p <project> -r <region/location> -c <case-id>
 | `--case-id`           | `-c`      | The Datadog case ID to send the files to.                                                                                 |         |
 | `--email`             | `-e`      | The email associated with the specified case ID.                                                                          |         |
 | `--with-logs`         |           | Collect recent logs for the specified service.                                                                            | `false` |
-| `--start` and `--end` |           | Using numbers in milliseconds since Unix Epoch, only gather logs within the time range. (`--with-logs` must be included.) |         |
+| `--start` and `--end` |           | Only gather logs within the time range (`--with-logs` must be included.) Both arguments are numbers in milliseconds since Unix Epoch. |         |
 | `--dry-run`           | `-d`      | Preview data that will be sent to Datadog support.                                                                        | `false` |
 
 

--- a/src/commands/cloud-run/README.md
+++ b/src/commands/cloud-run/README.md
@@ -2,6 +2,23 @@
 
 To troubleshoot issues you encounter with Datadog monitoring on your Cloud Run services, run the `datadog-ci cloud-run flare` command in the root of your project directory. This command collects important data about the Cloud Run service, such as environment variables and configuration information. These files will be submitted to Datadog support via a ticket matching the provided Zendesk case ID.
 
+## Configuration
+
+### GCP Credentials
+
+You must have valid [GCP credentials][1] configured with access to the Lambda and CloudWatch services where you are running any `datadog-ci lambda` command. You can configure credentials by running `gcloud auth application-default login` and following the prompts in your browser. 
+
+### Environment variables
+
+Expose these environment variables in the environment where you are running `datadog-ci cloud-run flare`:
+
+| Environment Variable | Description                                                                                                                                                                                                                                      | Example                               |
+|----------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------|
+| `DATADOG_API_KEY`    | Datadog API Key. Used to attach the flare files to your Zendesk ticket. For more information about getting a Datadog API key, see the [API key documentation][4].                                                                                | `export DATADOG_API_KEY=<API_KEY>`    |
+| `DATADOG_SITE`       | Optional. Set which Datadog site to send the flare for lower latency. Possible values are  `datadoghq.com` , `datadoghq.eu` , `us3.datadoghq.com`, `us5.datadoghq.com`, `ap1.datadoghq.com`, and `ddog-gov.com`. The default is `datadoghq.com`. | `export DATADOG_SITE="datadoghq.com"` |
+
+## Flare Command
+
 **Examples**
 ```bash
 # Collect and send files to Datadog support for a single service

--- a/src/commands/cloud-run/README.md
+++ b/src/commands/cloud-run/README.md
@@ -14,7 +14,7 @@ Expose these environment variables in the environment where you are running `dat
 
 | Environment Variable | Description                                                                                                                                                                                                                                      | Example                               |
 |----------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------|
-| `DATADOG_API_KEY`    | Datadog API Key. Used to attach the flare files to your Zendesk ticket. For more information about getting a Datadog API key, see the [API key documentation][4].                                                                                | `export DATADOG_API_KEY=<API_KEY>`    |
+| `DATADOG_API_KEY`    | Datadog API Key. Used to attach the flare files to your Zendesk ticket. For more information about getting a Datadog API key, see the [API key documentation][2].                                                                                | `export DATADOG_API_KEY=<API_KEY>`    |
 | `DATADOG_SITE`       | Optional. Set which Datadog site to send the flare for lower latency. Possible values are  `datadoghq.com` , `datadoghq.eu` , `us3.datadoghq.com`, `us5.datadoghq.com`, `ap1.datadoghq.com`, and `ddog-gov.com`. The default is `datadoghq.com`. | `export DATADOG_SITE="datadoghq.com"` |
 
 ## Flare Command
@@ -50,6 +50,4 @@ datadog-ci cloud-run -s <service> -p <project> -r <region/location> -c <case-id>
 For product feedback and questions, join the `#serverless` channel in the [Datadog community on Slack](https://chat.datadoghq.com/).
 
 [1]: https://cloud.google.com/sdk/gcloud/reference/auth/login
-[2]: https://github.com/DataDog/datadog-ci
-[3]: https://docs.datadoghq.com/serverless/google_cloud_run
-[4]: https://docs.datadoghq.com/account_management/api-app-keys/#api-keys
+[2]: https://docs.datadoghq.com/account_management/api-app-keys/#api-keys

--- a/src/commands/lambda/README.md
+++ b/src/commands/lambda/README.md
@@ -148,7 +148,7 @@ Instead of supplying arguments, you can create a configuration file in your proj
 
 ## Troubleshooting Lambda Instrumentation
 
-To troubleshoot issues you may be encountering with Datadog monitoring on your Lambda functions, use the `datadog-ci lambda flare` command in the root of your project directory. This command collects important data about a Lambda function, such as environment variables and the config file. These files will be submitted to Datadog support via a ticket matching the provided Zendesk case ID.
+To troubleshoot issues you encounter with Datadog monitoring on your Lambda functions, run the `datadog-ci lambda flare` command in the root of your project directory. This command collects important data about the Lambda function, such as environment variables and the config file. These files will be submitted to Datadog support via a ticket matching the provided Zendesk case ID.
 
 **Note**: This command works whether or not your Lambda functions were instrumented using `datadog-ci lambda instrument`.
 
@@ -166,15 +166,15 @@ datadog-ci lambda flare -f <function-arn> -c <case-id> -e <email-on-case-id> --w
 
 **Arguments**
 
-| Argument              | Shorthand | Description                                                                                                                 | Default |
-|-----------------------|-----------|-----------------------------------------------------------------------------------------------------------------------------|---------|
-| `--function`          | `-f`      | The ARN of the Lambda function to gather data for, or the name of the Lambda function (`--region` must be defined).         |         |
-| `--region`            | `-r`      | Default region to use, when `--function` is specified by the function name instead of the ARN.                              |         |
-| `--case-id`           | `-c`      | The Datadog case ID to send the files to.                                                                                   |         |
-| `--email`             | `-e`      | The email associated with the specified case ID.                                                                            |         |
-| `--with-logs`         |           | Collect recent CloudWatch logs for the specified function.                                                                  | `false` |
-| `--start` and `--end` |           | Define a time range in milliseconds since the Unix Epoch to gather logs within that range. (`--with-logs` must be included) |         |
-| `--dry-run`           | `-d`      | Preview collected data which would be sent to Datadog support.                                                              | `false` |
+| Argument              | Shorthand | Description                                                                                                               | Default |
+|-----------------------|-----------|---------------------------------------------------------------------------------------------------------------------------|---------|
+| `--function`          | `-f`      | The ARN of the Lambda function to gather data for, or the name of the Lambda function (`--region` must be defined).       |         |
+| `--region`            | `-r`      | Default region to use, when `--function` is specified by the function name instead of the ARN.                            |         |
+| `--case-id`           | `-c`      | The Datadog case ID to send the files to.                                                                                 |         |
+| `--email`             | `-e`      | The email associated with the specified case ID.                                                                          |         |
+| `--with-logs`         |           | Collect recent CloudWatch logs for the specified function.                                                                | `false` |
+| `--start` and `--end` |           | Using numbers in milliseconds since Unix Epoch, only gather logs within the time range. (`--with-logs` must be included.) |         |
+| `--dry-run`           | `-d`      | Preview collected data which would be sent to Datadog support.                                                            | `false` |
 
 
 ## Community

--- a/src/commands/lambda/README.md
+++ b/src/commands/lambda/README.md
@@ -57,7 +57,7 @@ See the configuration section for additional settings.
 
 ### AWS Credentials
 
-You must have valid [AWS credentials](https://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/setting-credentials-node.html) configured with access to the Lambda and CloudWatch services where you are running any `datadog-ci lambda` command.
+You must have valid [AWS credentials][1] configured with access to the Lambda and CloudWatch services where you are running any `datadog-ci lambda` command.
 
 ### Environment variables
 
@@ -65,7 +65,7 @@ You must expose these environment variables in the environment where you are run
 
 | Environment Variable | Description | Example |
 | --- | --- | --- |
-| `DATADOG_API_KEY` | Datadog API Key. Sets the `DD_API_KEY` environment variable on your Lambda function configuration. For more information about getting a Datadog API key, see the [API key documentation][6].  | `export DATADOG_API_KEY=<API_KEY>` |
+| `DATADOG_API_KEY` | Datadog API Key. Sets the `DD_API_KEY` environment variable on your Lambda function configuration. For more information about getting a Datadog API key, see the [API key documentation][5].  | `export DATADOG_API_KEY=<API_KEY>` |
 | `DATADOG_API_KEY_SECRET_ARN` | The ARN of the secret storing the Datadog API key in AWS Secrets Manager. Sets the `DD_API_KEY_SECRET_ARN` on your Lambda function configuration. Notes: `DD_API_KEY_SECRET_ARN` is ignored when `DD_KMS_API_KEY` is set. Add the `secretsmanager:GetSecretValue` permission to the Lambda execution role. | `export DATADOG_API_KEY_SECRET_ARN=<SECRETS_MANAGER_RESOURCE_ARN>` |
 | `DATADOG_KMS_API_KEY` | Datadog API Key encrypted using KMS. Sets the `DD_KMS_API_KEY` environment variable on your Lambda function configuration. Note: `DD_API_KEY` is ignored when `DD_KMS_API_KEY` is set. | `export DATADOG_KMS_API_KEY=<KMS_ENCRYPTED_API_KEY>` |
 | `DATADOG_SITE` | Set which Datadog site to send data. Only needed when using the Datadog Lambda Extension. Possible values are  `datadoghq.com` , `datadoghq.eu` , `us3.datadoghq.com`, `us5.datadoghq.com`, `ap1.datadoghq.com`, and `ddog-gov.com`. The default is `datadoghq.com`. Sets the `DD_SITE` environment variable on your Lambda function configurations. | `export DATADOG_SITE="datadoghq.com"` |
@@ -84,21 +84,21 @@ You can pass the following arguments to `instrument` to specify its behavior. Th
 | `--functions-regex` | | A regex pattern to match with the Lambda function name. | |
 | `--interactive` | `-i` | Allows the user to interactively choose how their function gets instrumented. There is no need to provide any other flags if you choose to use interactive mode since you will be prompted for the information instead. | |
 | `--region` | `-r` | Default region to use, when `--function` is specified by the function name instead of the ARN. | |
-| `--service` | | Use `--service` to group related functions belonging to similar workloads. Learn more about the `service` tag [here][9]. | |
-| `--version` | | Add the `--version` tag to correlate spikes in latency, load or errors to new versions. Learn more about the `version` tag [here][8]. | |
-| `--env` | | Use `--env` to separate out your staging, development, and production environments. Learn more about the `env` tag [here][7]. | |
+| `--service` | | Use `--service` to group related functions belonging to similar workloads. Learn more about the `service` tag [here][8]. | |
+| `--version` | | Add the `--version` tag to correlate spikes in latency, load or errors to new versions. Learn more about the `version` tag [here][7]. | |
+| `--env` | | Use `--env` to separate out your staging, development, and production environments. Learn more about the `env` tag [here][6]. | |
 | `--extra-tags` | | Add custom tags to your Lambda function in Datadog. Must be a list of `<key>:<value>` separated by commas such as: `layer:api,team:intake`. | |
-| `--profile` | | Specify the AWS named profile credentials to use to instrument. Learn more about AWS named profiles [here][12]. |  | 
-| `--layer-version` | `-v` | Version of the Datadog Lambda Library layer to apply. This varies between runtimes. To see the latest layer version check the [JS][3] or [python][4] datadog-lambda-layer repo release notes. | |
-| `--extension-version` | `-e` | Version of the Datadog Lambda Extension layer to apply. When `extension-version` is set, make sure to export `DATADOG_API_KEY` (or if encrypted, `DATADOG_KMS_API_KEY` or `DATADOG_API_KEY_SECRET_ARN`) in your environment as well. While using `extension-version`, leave out `forwarder`. Learn more about the Lambda Extension [here][5]. | |
+| `--profile` | | Specify the AWS named profile credentials to use to instrument. Learn more about AWS named profiles [here][11]. |  | 
+| `--layer-version` | `-v` | Version of the Datadog Lambda Library layer to apply. This varies between runtimes. To see the latest layer version check the [JS][2] or [python][3] datadog-lambda-layer repo release notes. | |
+| `--extension-version` | `-e` | Version of the Datadog Lambda Extension layer to apply. When `extension-version` is set, make sure to export `DATADOG_API_KEY` (or if encrypted, `DATADOG_KMS_API_KEY` or `DATADOG_API_KEY_SECRET_ARN`) in your environment as well. While using `extension-version`, leave out `forwarder`. Learn more about the Lambda Extension [here][4]. | |
 | `--tracing` |  | Whether to enable dd-trace tracing on your Lambda. | `true` |
 | `--merge-xray-traces` | | Whether to join dd-trace traces to AWS X-Ray traces. Useful for tracing API Gateway spans. | `false` |
-| `--flush-metrics-to-logs` | | Whether to send metrics via the Datadog Forwarder [asynchronously][11]. If you disable this parameter, it's required to export `DATADOG_API_KEY` (or if encrypted, `DATADOG_KMS_API_KEY` or `DATADOG_API_KEY_SECRET_ARN`). | `true` |
+| `--flush-metrics-to-logs` | | Whether to send metrics via the Datadog Forwarder [asynchronously][10]. If you disable this parameter, it's required to export `DATADOG_API_KEY` (or if encrypted, `DATADOG_KMS_API_KEY` or `DATADOG_API_KEY_SECRET_ARN`). | `true` |
 | `--capture-lambda-payload` | | Whether to capture and store the payload and response of a lambda invocation. | `false` |
-| `--forwarder` | | The ARN of the [datadog forwarder][10] to attach this function's LogGroup to. | |
+| `--forwarder` | | The ARN of the [datadog forwarder][9] to attach this function's LogGroup to. | |
 | `--dry-run` | `-d` | Preview changes running command would apply. | `false` |
 | `--log-level` | | Set to `debug` to see additional output from the Datadog Lambda Library and/or Lambda Extension for troubleshooting purposes. | |
-| `--source-code-integration` | `-s` | Whether to enable [Datadog Source Code Integration][13]. This will tag your lambda(s) with the Git repository URL and the latest commit hash of the current local directory. **Note**: Git repository must not be ahead of remote, and must not be dirty. | `true` |
+| `--source-code-integration` | `-s` | Whether to enable [Datadog Source Code Integration][12]. This will tag your lambda(s) with the Git repository URL and the latest commit hash of the current local directory. **Note**: Git repository must not be ahead of remote, and must not be dirty. | `true` |
 | `--no-source-code-integration` | | Disables Datadog Source Code Integration. | |
 | `--upload-git-metadata` | `-u` | Whether to enable Git metadata uploading, as a part of source code integration. Git metadata uploading is only required if you don't have the Datadog Github Integration installed. | `true` | 
 | `--no-upload-git-metadata` | | Disables Git metadata uploading, as a part of source code integration. Use this flag if you have the Datadog Github Integration installed, as it renders Git metadata uploading unnecessary. ||
@@ -115,8 +115,8 @@ Any other argument stated on the `instrument` table, but not below, will be igno
 | `--function` | `-f` | The ARN of the Lambda function to be **uninstrumented**, or the name of the Lambda function (`--region` must be defined). | |
 | `--functions-regex` | | A regex pattern to match with the Lambda function name to be **uninstrumented**. | |
 | `--region` | `-r` | Default region to use, when `--function` is specified by the function name instead of the ARN. | |
-| `--profile` | | Specify the AWS named profile credentials to use to uninstrument. Learn more about AWS named profiles [here][12]. |  | 
-| `--forwarder` | | The ARN of the [datadog forwarder][10] to remove from this function. | |
+| `--profile` | | Specify the AWS named profile credentials to use to uninstrument. Learn more about AWS named profiles [here][11]. |  | 
+| `--forwarder` | | The ARN of the [datadog forwarder][9] to remove from this function. | |
 | `--dry-run` | `-d` | Preview changes running command would apply. | `false` |
 
 <br/>
@@ -182,15 +182,14 @@ datadog-ci lambda flare -f <function-arn> -c <case-id> -e <email-on-case-id> --w
 For product feedback and questions, join the `#serverless` channel in the [Datadog community on Slack](https://chat.datadoghq.com/).
 
 [1]: https://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/setting-credentials-node.html
-[2]: https://github.com/DataDog/datadog-ci
-[3]: https://github.com/DataDog/datadog-lambda-layer-js/releases
-[4]: https://github.com/DataDog/datadog-lambda-layer-python/releases
-[5]: https://docs.datadoghq.com/serverless/datadog_lambda_library/extension
-[6]: https://docs.datadoghq.com/account_management/api-app-keys/#api-keys
-[7]: https://docs.datadoghq.com/serverless/troubleshooting/serverless_tagging/#the-env-tag
-[8]: https://docs.datadoghq.com/serverless/troubleshooting/serverless_tagging/#the-version-tag
-[9]: https://docs.datadoghq.com/serverless/troubleshooting/serverless_tagging/#the-service-tag
-[10]: https://docs.datadoghq.com/serverless/forwarder/
-[11]: https://docs.datadoghq.com/serverless/custom_metrics?tab=python#enabling-asynchronous-custom-metrics
-[12]: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html#using-profiles
-[13]: https://docs.datadoghq.com/integrations/guide/source-code-integration
+[2]: https://github.com/DataDog/datadog-lambda-layer-js/releases
+[3]: https://github.com/DataDog/datadog-lambda-layer-python/releases
+[4]: https://docs.datadoghq.com/serverless/datadog_lambda_library/extension
+[5]: https://docs.datadoghq.com/account_management/api-app-keys/#api-keys
+[6]: https://docs.datadoghq.com/serverless/troubleshooting/serverless_tagging/#the-env-tag
+[7]: https://docs.datadoghq.com/serverless/troubleshooting/serverless_tagging/#the-version-tag
+[8]: https://docs.datadoghq.com/serverless/troubleshooting/serverless_tagging/#the-service-tag
+[9]: https://docs.datadoghq.com/serverless/forwarder/
+[10]: https://docs.datadoghq.com/serverless/custom_metrics?tab=python#enabling-asynchronous-custom-metrics
+[11]: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html#using-profiles
+[12]: https://docs.datadoghq.com/integrations/guide/source-code-integration

--- a/src/commands/lambda/README.md
+++ b/src/commands/lambda/README.md
@@ -146,7 +146,7 @@ Instead of supplying arguments, you can create a configuration file in your proj
 }
 ```
 
-## Troubleshooting Serverless Instrumentation
+## Troubleshooting Lambda Instrumentation
 
 To troubleshoot issues you may be encountering with Datadog monitoring on your Lambda functions, use the `datadog-ci lambda flare` command in the root of your project directory. This command collects important data about a Lambda function, such as environment variables and the config file. These files will be submitted to Datadog support via a ticket matching the provided Zendesk case ID.
 
@@ -161,7 +161,7 @@ datadog-ci lambda flare -f <function-arn> -c <case-id> -e <email-on-case-id>
 datadog-ci lambda flare -f <function-name> -r <AWS region> -c <case-id> -e <email-on-case-id> --with-logs
 
 # Dry run: collect data, but don't send to Datadog support
-datadog-ci lambda flare -f <function-arn> --with-logs --dry-run
+datadog-ci lambda flare -f <function-arn> -c <case-id> -e <email-on-case-id> --with-logs --dry-run
 ```
 
 **Arguments**

--- a/src/commands/lambda/README.md
+++ b/src/commands/lambda/README.md
@@ -166,15 +166,15 @@ datadog-ci lambda flare -f <function-arn> -c <case-id> -e <email-on-case-id> --w
 
 **Arguments**
 
-| Argument              | Shorthand | Description                                                                                                               | Default |
-|-----------------------|-----------|---------------------------------------------------------------------------------------------------------------------------|---------|
-| `--function`          | `-f`      | The ARN of the Lambda function to gather data for, or the name of the Lambda function (`--region` must be defined).       |         |
-| `--region`            | `-r`      | Default region to use, when `--function` is specified by the function name instead of the ARN.                            |         |
-| `--case-id`           | `-c`      | The Datadog case ID to send the files to.                                                                                 |         |
-| `--email`             | `-e`      | The email associated with the specified case ID.                                                                          |         |
-| `--with-logs`         |           | Collect recent CloudWatch logs for the specified function.                                                                | `false` |
-| `--start` and `--end` |           | Using numbers in milliseconds since Unix Epoch, only gather logs within the time range. (`--with-logs` must be included.) |         |
-| `--dry-run`           | `-d`      | Preview collected data which would be sent to Datadog support.                                                            | `false` |
+| Argument              | Shorthand | Description                                                                                                                           | Default |
+|-----------------------|-----------|---------------------------------------------------------------------------------------------------------------------------------------|---------|
+| `--function`          | `-f`      | The ARN of the Lambda function to gather data for, or the name of the Lambda function (`--region` must be defined).                   |         |
+| `--region`            | `-r`      | Default region to use, when `--function` is specified by the function name instead of the ARN.                                        |         |
+| `--case-id`           | `-c`      | The Datadog case ID to send the files to.                                                                                             |         |
+| `--email`             | `-e`      | The email associated with the specified case ID.                                                                                      |         |
+| `--with-logs`         |           | Collect recent CloudWatch logs for the specified function.                                                                            | `false` |
+| `--start` and `--end` |           | Only gather logs within the time range (`--with-logs` must be included.) Both arguments are numbers in milliseconds since Unix Epoch. |         |
+| `--dry-run`           | `-d`      | Preview collected data which would be sent to Datadog support.                                                                        | `false` |
 
 
 ## Community


### PR DESCRIPTION
### What and why?

Now that the `datadog-ci cloud-run flare` command is available, we add documentation on how to use the command. This PR also makes some small changes to the `lambda flare` documentation and removes an unused footer link.

### How?

- Create the `src/commands/cloud-run/README.md` file
- Update the `src/commands/lambda/README.md` file

### Review checklist

No tests needed
