### PR TITLE
[junit] Add support for junit reports without tests

### DIFF
--- a/src/commands/junit/__tests__/fixtures/subfolder/valid-no-tests.xml
+++ b/src/commands/junit/__tests__/fixtures/subfolder/valid-no-tests.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites tests="0" failures="0" disabled="0" errors="0" time="0.001" name="AllTests">
+</testsuites>

--- a/src/commands/junit/__tests__/upload.test.ts
+++ b/src/commands/junit/__tests__/upload.test.ts
@@ -223,6 +223,26 @@ describe('upload', () => {
       expect(firstFile.logsEnabled).toBe(true)
       expect(secondFile.logsEnabled).toBe(true)
     })
+    test('should accept no test report', async () => {
+      process.env.DD_CIVISIBILITY_LOGS_ENABLED = 'true'
+      const context = createMockContext()
+      const command = new UploadJUnitXMLCommand()
+      const files = await command['getMatchingJUnitXMLFiles'].call(
+        {
+          basePaths: ['./src/commands/junit/__tests__/fixtures/subfolder/valid-no-tests.xml'],
+          config: {},
+          context,
+          logs: true,
+          service: 'service',
+        },
+        {},
+        {},
+        {},
+        {},
+        {}
+      )
+      expect(files.length).toEqual(1)
+    })
   })
   describe('getSpanTags', () => {
     test('should parse DD_ENV environment variable', async () => {

--- a/src/commands/junit/upload.ts
+++ b/src/commands/junit/upload.ts
@@ -52,7 +52,7 @@ const validateXml = (xmlFilePath: string) => {
   }
   const xmlParser = new XMLParser()
   const xmlFileJSON = xmlParser.parse(String(xmlFileContentString))
-  if (!xmlFileJSON.testsuites && !xmlFileJSON.testsuite) {
+  if (!("testsuites" in xmlFileJSON) && !("testsuite" in xmlFileJSON)) {
     return 'Neither <testsuites> nor <testsuite> are the root tag.'
   }
 

--- a/src/commands/junit/upload.ts
+++ b/src/commands/junit/upload.ts
@@ -52,7 +52,7 @@ const validateXml = (xmlFilePath: string) => {
   }
   const xmlParser = new XMLParser()
   const xmlFileJSON = xmlParser.parse(String(xmlFileContentString))
-  if (!("testsuites" in xmlFileJSON) && !("testsuite" in xmlFileJSON)) {
+  if (!('testsuites' in xmlFileJSON) && !('testsuite' in xmlFileJSON)) {
     return 'Neither <testsuites> nor <testsuite> are the root tag.'
   }
 


### PR DESCRIPTION
### What and why?

It allows users to send junit xml reports where there are no testcases and instead of showing the misleading error `Neither <testsuites> nor <testsuite> are the root tag`. For example:

```xml
<?xml version="1.0" encoding="UTF-8"?>
<testsuites tests="0" failures="0" disabled="0" errors="0" time="0.001" name="AllTests">
</testsuites>
```

### How?

By modifying the if statement to detect invalid xmls.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
