### PR TITLE
[lambda] Fix api key handling for lambda to accept DD_API_KEY

### DIFF
--- a/src/commands/git-metadata/upload.ts
+++ b/src/commands/git-metadata/upload.ts
@@ -50,7 +50,7 @@ export class UploadCommand extends Command {
 
   private cliVersion = version
   private config = {
-    apiKey: process.env.DATADOG_API_KEY,
+    apiKey: process.env.DATADOG_API_KEY ?? process.env.DD_API_KEY,
   }
 
   private logger: Logger = new Logger((s: string) => {

--- a/src/commands/lambda/__tests__/functions/commons.test.ts
+++ b/src/commands/lambda/__tests__/functions/commons.test.ts
@@ -10,7 +10,7 @@ import {fromNodeProviderChain} from '@aws-sdk/credential-providers'
 import {mockClient} from 'aws-sdk-client-mock'
 
 import 'aws-sdk-client-mock-jest'
-import {CI_API_KEY_ENV_VAR, CI_SITE_ENV_VAR} from '../../../../constants'
+import {API_KEY_ENV_VAR, CI_API_KEY_ENV_VAR, CI_SITE_ENV_VAR} from '../../../../constants'
 import {createCommand} from '../../../../helpers/__tests__/fixtures'
 
 import {
@@ -364,6 +364,10 @@ describe('commons', () => {
       expect(isMissingDatadogEnvVars()).toBe(true)
 
       process.env = {}
+      process.env[API_KEY_ENV_VAR] = 'SOME-DATADOG-API-KEY'
+      expect(isMissingDatadogEnvVars()).toBe(true)
+
+      process.env = {}
       process.env[CI_KMS_API_KEY_ENV_VAR] = 'SOME-AWS-KMS-API-KEY-CONTAINING-DATADOG-API-KEY'
       expect(isMissingDatadogEnvVars()).toBe(true)
 
@@ -374,6 +378,12 @@ describe('commons', () => {
 
     test('returns false when Datadog Env Vars are set with DATADOG_API_KEY', () => {
       process.env[CI_API_KEY_ENV_VAR] = 'SOME-DATADOG-API-KEY'
+      process.env[CI_SITE_ENV_VAR] = 'datadoghq.com'
+      expect(isMissingDatadogEnvVars()).toBe(false)
+    })
+
+    test('returns false when Datadog Env Vars are set with DD_API_KEY', () => {
+      process.env[API_KEY_ENV_VAR] = 'SOME-DATADOG-API-KEY'
       process.env[CI_SITE_ENV_VAR] = 'datadoghq.com'
       expect(isMissingDatadogEnvVars()).toBe(false)
     })
@@ -407,6 +417,11 @@ describe('commons', () => {
 
     test('returns false when DATADOG_API_KEY is set', () => {
       process.env[CI_API_KEY_ENV_VAR] = 'SOME-DATADOG-API-KEY'
+      expect(isMissingAnyDatadogApiKeyEnvVar()).toBe(false)
+    })
+
+    test('returns false when DD_API_KEY is set', () => {
+      process.env[API_KEY_ENV_VAR] = 'SOME-DATADOG-API-KEY'
       expect(isMissingAnyDatadogApiKeyEnvVar()).toBe(false)
     })
 

--- a/src/commands/lambda/__tests__/functions/instrument.part2.test.ts
+++ b/src/commands/lambda/__tests__/functions/instrument.part2.test.ts
@@ -218,7 +218,7 @@ describe('instrument', () => {
     })
 
     test('calculates an update request with a lambda library, extension, and DD_API_KEY', async () => {
-      process.env[API_KEY_ENV_VAR] = `dd-api-key${MOCK_DATADOG_API_KEY}`
+      process.env[API_KEY_ENV_VAR] = 'SOME-DD-API-KEY'
       const runtime = 'nodejs12.x'
       const config = {
         FunctionArn: 'arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world',
@@ -241,7 +241,7 @@ describe('instrument', () => {
         {
           "Environment": {
             "Variables": {
-              "DD_API_KEY": "dd-api-key-02aeb762fff59ac0d5ad1536cd9633bf",
+              "DD_API_KEY": "SOME-DD-API-KEY",
               "DD_LAMBDA_HANDLER": "index.handler",
               "DD_MERGE_XRAY_TRACES": "false",
               "DD_SITE": "datadoghq.com",

--- a/src/commands/lambda/functions/commons.ts
+++ b/src/commands/lambda/functions/commons.ts
@@ -251,7 +251,8 @@ export const getAWSCredentials = async () => {
 
 export const isMissingAnyDatadogApiKeyEnvVar = () =>
   !(
-    (process.env[CI_API_KEY_ENV_VAR] && process.env[API_KEY_ENV_VAR]) ||
+    process.env[CI_API_KEY_ENV_VAR] ||
+    process.env[API_KEY_ENV_VAR] ||
     process.env[CI_KMS_API_KEY_ENV_VAR] ||
     process.env[CI_API_KEY_SECRET_ARN_ENV_VAR]
   )

--- a/src/commands/lambda/functions/commons.ts
+++ b/src/commands/lambda/functions/commons.ts
@@ -17,7 +17,7 @@ import {CredentialsProviderError} from '@aws-sdk/property-provider'
 import {AwsCredentialIdentity, AwsCredentialIdentityProvider} from '@aws-sdk/types'
 import inquirer from 'inquirer'
 
-import {CI_API_KEY_ENV_VAR, CI_SITE_ENV_VAR} from '../../../constants'
+import {API_KEY_ENV_VAR, CI_API_KEY_ENV_VAR, CI_SITE_ENV_VAR} from '../../../constants'
 import * as helpersRenderer from '../../../helpers/renderer'
 import {maskString} from '../../../helpers/utils'
 import {isValidDatadogSite} from '../../../helpers/validation'
@@ -251,7 +251,7 @@ export const getAWSCredentials = async () => {
 
 export const isMissingAnyDatadogApiKeyEnvVar = () =>
   !(
-    process.env[CI_API_KEY_ENV_VAR] ||
+    (process.env[CI_API_KEY_ENV_VAR] && process.env[API_KEY_ENV_VAR]) ||
     process.env[CI_KMS_API_KEY_ENV_VAR] ||
     process.env[CI_API_KEY_SECRET_ARN_ENV_VAR]
   )

--- a/src/commands/lambda/functions/instrument.ts
+++ b/src/commands/lambda/functions/instrument.ts
@@ -160,7 +160,7 @@ export const calculateUpdateRequest = async (
   const changedEnvVars: Record<string, string> = {}
   const functionARN = config.FunctionArn
 
-  const apiKey: string | undefined = process.env[CI_API_KEY_ENV_VAR]
+  const apiKey: string | undefined = process.env[CI_API_KEY_ENV_VAR] ?? process.env[API_KEY_ENV_VAR]
   const apiKeySecretArn: string | undefined = process.env[CI_API_KEY_SECRET_ARN_ENV_VAR]
   const apiKmsKey: string | undefined = process.env[CI_KMS_API_KEY_ENV_VAR]
   const site: string | undefined = process.env[CI_SITE_ENV_VAR]


### PR DESCRIPTION
### What and why?
See [ticket](https://datadoghq.atlassian.net/browse/SLS-2713?atlOrigin=eyJpIjoiZTUxZDBiOTgwMGI3NGE2ZWI4MGRjMzEzZWZiYmRiMTAiLCJwIjoiaiJ9) and [issue](https://github.com/DataDog/datadog-ci/issues/737) 

Previously, the `lambda` command only accepted `DATADOG_API_KEY` as an env var. This PR will allow users to pass in both `DD_API_KEY` and `DATADOG_API_KEY`. 

### How?

Set `apiKey` value to either `DD_API_KEY` or `DATADOG_API_KEY` env var

### Review checklist

- [x] Unit tests
- [x] Tested instrumenting an AWS Lambda
