### PR TITLE
Make rum-browser owner of the sourcemaps upload command

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -18,8 +18,7 @@ src/commands/sbom    @DataDog/static-analysis-core
 src/commands/dsyms            @DataDog/rum-mobile
 src/commands/flutter-symbols  @DataDog/rum-mobile
 src/commands/react-native     @DataDog/rum-mobile
-### Related to RUM, but maintained by Source Code Integration for legacy reasons
-src/commands/sourcemaps       @DataDog/source-code-integration
+src/commands/sourcemaps       @DataDog/rum-browser
 
 ## Serverless
 src/commands/lambda         @DataDog/serverless


### PR DESCRIPTION
This command is now maintained by the RUM Browser SDK team.