### PR TITLE
Fix the version to v2.19.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci",
-  "version": "2.19.1",
+  "version": "2.19.0",
   "description": "Run datadog actions from the CI.",
   "repository": "https://github.com/DataDog/datadog-ci",
   "license": "Apache-2.0",


### PR DESCRIPTION
### What and why?

#### datadog-ci
- Add --version and --help root arguments by @Drarig29 in https://github.com/DataDog/datadog-ci/pull/1031 

#### Dependencies
- Bump dd-trace to 3.32.1 to fix https://github.com/DataDog/datadog-ci/security/dependabot/32 (vulnerability of import-in-the-middle) by @Drarig29 in https://github.com/DataDog/datadog-ci/pull/1027

#### Documentation
- [flare] Add cloud-run flare documentation & update lambda flare documentation by @nhulston in https://github.com/DataDog/datadog-ci/pull/1037

#### CI Visibility
- [gate] update the command to wait for the time returned from the service, and add `--timeout` flag by @liashenko in https://github.com/DataDog/datadog-ci/pull/1013
- [gate] add support for `DD_APP_KEY` by @liashenko in https://github.com/DataDog/datadog-ci/pull/1017
- [sbom] add beta sbom upload command by @juli1 in https://github.com/DataDog/datadog-ci/pull/1038

#### Serverless
- [lambda] update `--dry` to `--dry-run` by @Drarig29 in https://github.com/DataDog/datadog-ci/pull/1029
- [lambda] fix handler not being set when running interactive mode by @duncanista in https://github.com/DataDog/datadog-ci/pull/1035
- [cloud-run][flare] update `--dry` to `--dry-run` by @Drarig29 in https://github.com/DataDog/datadog-ci/pull/1029
- [cloud-run][flare] Add optional --start and --end flags when getting logs by @nhulston in https://github.com/DataDog/datadog-ci/pull/1033
- [lambda] Fix api key handling for lambda to accept DD_API_KEY by @hannahqjiang in https://github.com/DataDog/datadog-ci/pull/1041

#### Synthetics
- Add details and examples in --help by @Drarig29 in https://github.com/DataDog/datadog-ci/pull/1032

### How?

A brief description of implementation details of this PR.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
