### PR TITLE
[test] Fix flaky test for `validateStartEndFlags()`

### DIFF
--- a/src/helpers/__tests__/flare.test.ts
+++ b/src/helpers/__tests__/flare.test.ts
@@ -236,7 +236,8 @@ describe('flare', () => {
       expect(res).not.toBeUndefined()
       const [start, end] = res
       expect(start).toBe(0)
-      expect(end).toEqual(now)
+      expect(end).toBeLessThan(9999999999999)
+      expect(end).toStrictEqual(now)
     })
   })
 })

--- a/src/helpers/__tests__/flare.test.ts
+++ b/src/helpers/__tests__/flare.test.ts
@@ -195,6 +195,14 @@ describe('flare', () => {
   })
 
   describe('validateStartEndFlags', () => {
+    beforeEach(() => {
+      jest.useFakeTimers({now: new Date(Date.UTC(2023, 0))})
+    })
+
+    afterEach(() => {
+      jest.useRealTimers()
+    })
+
     it('returns [undefined, undefined] when start and end flags are not specified', () => {
       const errorMessages: string[] = []
       const res = validateStartEndFlags(undefined, undefined)


### PR DESCRIPTION
### What and why?

This unit test sometimes fail because `Math.min('9999999999999', Date.now())` always returns `Date.now()`, which may be different than a previous `Date.now()`.

### How?

- Use fake timers to get rid of the flakiness

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
