### PR TITLE
[chore] Add `no-extraneous-dependencies` eslint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -165,6 +165,7 @@ module.exports = {
     'guard-for-in': 'error',
     'id-denylist': 'error',
     'id-match': 'error',
+    'import/no-extraneous-dependencies': 'error',
     'import/order': [
       'error',
       {


### PR DESCRIPTION
### What and why?

Typanion was not listed in our dependencies (fixed by #1050). This PR adds an eslint rule so that it doesn't happen again.

Using extraneous (i.e. unlisted) dependencies makes some package managers (e.g. `pnpm`) fail to install the dependencies.

### How?

- Enable an eslint rule provided by `eslint-plugin-import`

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
