### PR TITLE
Fix default react native xcode script path

### DIFF
--- a/src/commands/react-native/__tests__/fixtures/react-native/scripts/react-native-xcode.sh
+++ b/src/commands/react-native/__tests__/fixtures/react-native/scripts/react-native-xcode.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+echo "Starting successful script"


### PR DESCRIPTION
### What and why?

After the clipanion v3 migration, the `react-native xcode` command started to fail when no script path was provided (which is the default case).
This was detected by our E2E tests that started failing right after the `2.19.0` release.

This happens as when we are in the constructor, `Option.String({ required: false })` returns an object (so the default is never applied) that is later changed (how?) to `undefined` when we access the attribute inside the `execute` context.

This wasn't tested so it was hard to catch during the migration, I've adapted the code to make it more testable as well.

### How?
 
We now apply the default when accessing the `scriptPath` attribute.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
