### PR TITLE
[CIAPP-7523] Mark last retry from datadog-ci gate

### DIFF
--- a/src/commands/gate/interfaces.ts
+++ b/src/commands/gate/interfaces.ts
@@ -15,6 +15,7 @@ export interface Payload {
 export interface PayloadOptions {
   dryRun: boolean
   noWait: boolean
+  isLastRetry?: boolean
 }
 
 export interface EvaluationResponsePayload {


### PR DESCRIPTION
### What and why?
Mark last retry from datadog-ci gate to be able to send failed gate executions to EvP from the service.

We want to provide better visibility in Datadog in the following cases:
* one or more rule evaluations failed during the last request from datadog-ci
* datadog-ci timed out before finishing the evaluation

Currently Quality Gates service is not aware of internal datadog-ci retries, so we can’t send CIGATE events to EvP on the last request for the cases mentioned above.

More context in the [RFC](https://docs.google.com/document/d/1Cj5i5rs_S85AueP7m60gg4iWYVZ-Opr-SB2VpHzvEvE/edit)

### How?
When it's a last retry attempt or the remaining wait time is 0, add `isLastRetry:true` to the API request.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
