### PR TITLE
[utils] Format all git domains, not only github.com

### DIFF
--- a/src/commands/git-metadata/library.ts
+++ b/src/commands/git-metadata/library.ts
@@ -1,7 +1,7 @@
 import {newApiKeyValidator} from '../../helpers/apikey'
 import {RequestBuilder} from '../../helpers/interfaces'
 import {upload, UploadOptions, UploadStatus} from '../../helpers/upload'
-import {getRequestBuilder, filterAndFormatGithubRemote} from '../../helpers/utils'
+import {getRequestBuilder, filterAndFormatGitRemote} from '../../helpers/utils'
 import {version} from '../../helpers/version'
 
 import {getCommitInfo, newSimpleGit} from './git'
@@ -26,9 +26,9 @@ export const getGitCommitInfo = async (filterAndFormatGitRepoUrl = true): Promis
   const simpleGit = await newSimpleGit()
   const payload = await getCommitInfo(simpleGit)
 
-  const gitRemote = filterAndFormatGitRepoUrl ? filterAndFormatGithubRemote(payload.remote) : payload.remote
+  const gitRemote = filterAndFormatGitRepoUrl ? filterAndFormatGitRemote(payload.remote) : payload.remote
 
-  // gitRemote will never be undefined, as filterAndFormatGithubRemote will ONLY return undefined if it's
+  // gitRemote will never be undefined, as filterAndFormatGitRemote will ONLY return undefined if it's
   // parameter value is also undefined. Added the " gitRemote ?? '' " to make the typechecker happy.
   return [gitRemote ?? '', payload.hash]
 }

--- a/src/commands/lambda/instrument.ts
+++ b/src/commands/lambda/instrument.ts
@@ -7,7 +7,7 @@ import {Cli, Command, Option} from 'clipanion'
 import {ENVIRONMENT_ENV_VAR, SERVICE_ENV_VAR, VERSION_ENV_VAR} from '../../constants'
 import {requestConfirmation} from '../../helpers/prompt'
 import * as helperRenderer from '../../helpers/renderer'
-import {resolveConfigFromFile, filterAndFormatGithubRemote, DEFAULT_CONFIG_PATHS} from '../../helpers/utils'
+import {resolveConfigFromFile, filterAndFormatGitRemote, DEFAULT_CONFIG_PATHS} from '../../helpers/utils'
 
 import {getCommitInfo, newSimpleGit} from '../git-metadata/git'
 import {UploadCommand} from '../git-metadata/upload'
@@ -377,7 +377,7 @@ export class InstrumentCommand extends Command {
       throw Error('Local changes have not been pushed remotely. Aborting git data tagging.')
     }
 
-    const gitRemote = filterAndFormatGithubRemote(currentStatus.remote)
+    const gitRemote = filterAndFormatGitRemote(currentStatus.remote)
 
     return {commitSha: currentStatus.hash, gitRemote}
   }

--- a/src/helpers/__tests__/utils.test.ts
+++ b/src/helpers/__tests__/utils.test.ts
@@ -371,22 +371,22 @@ describe('utils', () => {
     })
   })
 
-  describe('filterAndFormatGithubRemote', () => {
+  describe('filterAndFormatGitRemote', () => {
     test('git remotes get formatted correctly', async () => {
-      expect(ciUtils.filterAndFormatGithubRemote('https://github.com/datadog/test.git')).toEqual(
+      expect(ciUtils.filterAndFormatGitRemote('https://github.com/datadog/test.git')).toEqual(
         'github.com/datadog/test.git'
       )
-      expect(ciUtils.filterAndFormatGithubRemote('git@github.com:datadog/test.git')).toEqual(
+      expect(ciUtils.filterAndFormatGitRemote('git@github.com:datadog/test.git')).toEqual(
         'github.com/datadog/test.git'
       )
-      expect(ciUtils.filterAndFormatGithubRemote('github.com/datadog/test.git')).toEqual('github.com/datadog/test.git')
-      expect(ciUtils.filterAndFormatGithubRemote('https://git.some.domain.com:8080/datadog/test.git')).toEqual(
+      expect(ciUtils.filterAndFormatGitRemote('github.com/datadog/test.git')).toEqual('github.com/datadog/test.git')
+      expect(ciUtils.filterAndFormatGitRemote('https://git.some.domain.com:8080/datadog/test.git')).toEqual(
         'git.some.domain.com/datadog/test.git'
       )
-      expect(ciUtils.filterAndFormatGithubRemote('git@test.domain.com:datadog/test.git')).toEqual(
+      expect(ciUtils.filterAndFormatGitRemote('git@test.domain.com:datadog/test.git')).toEqual(
         'test.domain.com/datadog/test.git'
       )
-      expect(ciUtils.filterAndFormatGithubRemote('example.domain.com/datadog/test.git')).toEqual('example.domain.com/datadog/test.git')
+      expect(ciUtils.filterAndFormatGitRemote('example.domain.com/datadog/test.git')).toEqual('example.domain.com/datadog/test.git')
     })
   })
 

--- a/src/helpers/__tests__/utils.test.ts
+++ b/src/helpers/__tests__/utils.test.ts
@@ -376,9 +376,7 @@ describe('utils', () => {
       expect(ciUtils.filterAndFormatGitRemote('https://github.com/datadog/test.git')).toEqual(
         'github.com/datadog/test.git'
       )
-      expect(ciUtils.filterAndFormatGitRemote('git@github.com:datadog/test.git')).toEqual(
-        'github.com/datadog/test.git'
-      )
+      expect(ciUtils.filterAndFormatGitRemote('git@github.com:datadog/test.git')).toEqual('github.com/datadog/test.git')
       expect(ciUtils.filterAndFormatGitRemote('github.com/datadog/test.git')).toEqual('github.com/datadog/test.git')
       expect(ciUtils.filterAndFormatGitRemote('https://git.some.domain.com:8080/datadog/test.git')).toEqual(
         'git.some.domain.com/datadog/test.git'
@@ -386,7 +384,9 @@ describe('utils', () => {
       expect(ciUtils.filterAndFormatGitRemote('git@test.domain.com:datadog/test.git')).toEqual(
         'test.domain.com/datadog/test.git'
       )
-      expect(ciUtils.filterAndFormatGitRemote('example.domain.com/datadog/test.git')).toEqual('example.domain.com/datadog/test.git')
+      expect(ciUtils.filterAndFormatGitRemote('example.domain.com/datadog/test.git')).toEqual(
+        'example.domain.com/datadog/test.git'
+      )
     })
   })
 

--- a/src/helpers/__tests__/utils.test.ts
+++ b/src/helpers/__tests__/utils.test.ts
@@ -380,6 +380,13 @@ describe('utils', () => {
         'github.com/datadog/test.git'
       )
       expect(ciUtils.filterAndFormatGithubRemote('github.com/datadog/test.git')).toEqual('github.com/datadog/test.git')
+      expect(ciUtils.filterAndFormatGithubRemote('https://git.some.domain.com:8080/datadog/test.git')).toEqual(
+        'git.some.domain.com/datadog/test.git'
+      )
+      expect(ciUtils.filterAndFormatGithubRemote('git@test.domain.com:datadog/test.git')).toEqual(
+        'test.domain.com/datadog/test.git'
+      )
+      expect(ciUtils.filterAndFormatGithubRemote('todo.domain.com/datadog/test.git')).toEqual('todo.domain.com/datadog/test.git')
     })
   })
 

--- a/src/helpers/__tests__/utils.test.ts
+++ b/src/helpers/__tests__/utils.test.ts
@@ -386,7 +386,7 @@ describe('utils', () => {
       expect(ciUtils.filterAndFormatGithubRemote('git@test.domain.com:datadog/test.git')).toEqual(
         'test.domain.com/datadog/test.git'
       )
-      expect(ciUtils.filterAndFormatGithubRemote('todo.domain.com/datadog/test.git')).toEqual('todo.domain.com/datadog/test.git')
+      expect(ciUtils.filterAndFormatGithubRemote('example.domain.com/datadog/test.git')).toEqual('example.domain.com/datadog/test.git')
     })
   })
 

--- a/src/helpers/__tests__/utils.test.ts
+++ b/src/helpers/__tests__/utils.test.ts
@@ -390,6 +390,18 @@ describe('utils', () => {
     })
   })
 
+  describe('filterAndFormatGithubRemote', () => {
+    test('git remotes get formatted correctly', async () => {
+      expect(ciUtils.filterAndFormatGithubRemote('https://github.com/datadog/test.git')).toEqual(
+        'github.com/datadog/test.git'
+      )
+      expect(ciUtils.filterAndFormatGithubRemote('git@github.com:datadog/test.git')).toEqual(
+        'github.com/datadog/test.git'
+      )
+      expect(ciUtils.filterAndFormatGithubRemote('github.com/datadog/test.git')).toEqual('github.com/datadog/test.git')
+    })
+  })
+
   describe('formatBytes', () => {
     it('returns "0 Bytes" when input is 0', () => {
       expect(formatBytes(0)).toEqual('0 Bytes')

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -328,7 +328,7 @@ export const filterAndFormatGithubRemote = (rawRemote: string | undefined): stri
   if (!rawRemote) {
     return rawRemote
   }
-  rawRemote = rawRemote.replace(/git@github\.com:|https:\/\/github\.com\//, 'github.com/')
+  rawRemote = rawRemote.replace(/(git@|https:\/\/)([^/^:]*)(:|\/)/, '$2/')
 
   return rawRemote
 }

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -328,7 +328,7 @@ export const filterAndFormatGithubRemote = (rawRemote: string | undefined): stri
   if (!rawRemote) {
     return rawRemote
   }
-  rawRemote = rawRemote.replace(/(git@|https:\/\/)([^/^:]*)(:|\/)/, '$2/')
+  rawRemote = rawRemote.replace(/(git@|https:\/\/)([^/^:]+)(:([\d]+))?(:|\/)/, '$2/')
 
   return rawRemote
 }

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -333,6 +333,11 @@ export const filterAndFormatGitRemote = (rawRemote: string | undefined): string 
   return rawRemote
 }
 
+/**
+ * @deprecated Use filterAndFormatGitRemote instead
+ */
+export const filterAndFormatGithubRemote = filterAndFormatGitRemote
+
 export const timedExecAsync = async <I, O>(f: (input: I) => Promise<O>, input: I): Promise<number> => {
   const initialTime = Date.now()
   await f(input)

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -323,7 +323,7 @@ export const filterSensitiveInfoFromRepository = (repositoryUrl: string | undefi
 
 // Removes sensitive info from the given git remote url and normalizes the url prefix.
 // "git@github.com:" and "https://github.com/" prefixes will be normalized into "github.com/"
-export const filterAndFormatGithubRemote = (rawRemote: string | undefined): string | undefined => {
+export const filterAndFormatGitRemote = (rawRemote: string | undefined): string | undefined => {
   rawRemote = filterSensitiveInfoFromRepository(rawRemote)
   if (!rawRemote) {
     return rawRemote


### PR DESCRIPTION
### What and why?

Enabled formatting of all git remotes, not only github.com to fix datadog serverless plugin tags, while using in projects with repos that are not hosted on github

### How?

updated regular expression to replace fix remote urls with any domain name
