### PR TITLE
[SYNTH-11115] Add new resourceUrlSubstitutionRegexes config

### DIFF
--- a/src/commands/synthetics/interfaces.ts
+++ b/src/commands/synthetics/interfaces.ts
@@ -281,6 +281,7 @@ export interface BaseConfigOverride {
   headers?: {[key: string]: string}
   locations?: string[]
   pollingTimeout?: number
+  resourceUrlSubstitutionRegexes?: string[]
   retry?: RetryConfig
   startUrl?: string
   startUrlSubstitutionRegex?: string

--- a/src/commands/synthetics/utils.ts
+++ b/src/commands/synthetics/utils.ts
@@ -100,6 +100,7 @@ export const getOverriddenConfig = (
       'headers',
       'locations',
       'pollingTimeout',
+      'resourceUrlSubstitutionRegexes',
       'retry',
       'startUrlSubstitutionRegex',
       'testTimeout',


### PR DESCRIPTION
### What and why?

Add `resourceUrlSubstitutionRegexes` config to datadog-ci's synthetics command.

https://datadoghq.atlassian.net/browse/SYNTH-11115

### How?

Add it in types, and in what we use from the configuration.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] https://github.com/DataDog/dogweb/pull/103170
- [ ] https://github.com/DataDog/synthetics-worker/pull/4260
