### PR TITLE
[synthetics] Add `--selectiveRerun` input

### DIFF
--- a/src/commands/synthetics/README.md
+++ b/src/commands/synthetics/README.md
@@ -92,6 +92,9 @@ The duration (in milliseconds) after which `datadog-ci` stops polling for test r
 `proxy`
 : The proxy to be used for outgoing connections to Datadog. `host` and `port` keys are mandatory arguments, the `protocol` key defaults to `http`. Supported values for the `protocol` key are `http`, `https`, `socks`, `socks4`, `socks4a`, `socks5`, `socks5h`, `pac+data`, `pac+file`, `pac+ftp`, `pac+http`, and `pac+https`. The library used to configure the proxy is the [proxy-agent][2] library.
 
+`selectiveRerun`
+: A boolean flag to only run the tests which failed in the previous test batches. Use the `--no-selectiveRerun` CLI flag to force a full run if your configuration enables it by default.
+
 `subdomain`
 : The name of the custom subdomain set to access your Datadog application. If the URL used to access Datadog is `myorg.datadoghq.com`, the `subdomain` value needs to be set to `myorg`.
 

--- a/src/commands/synthetics/__tests__/cli.test.ts
+++ b/src/commands/synthetics/__tests__/cli.test.ts
@@ -89,6 +89,7 @@ describe('run-test', () => {
         pollingTimeout: 1,
         proxy: {protocol: 'https'},
         publicIds: ['ran-dom-id'],
+        selectiveRerun: false,
         subdomain: 'ppa',
         tunnel: true,
         variableStrings: [],

--- a/src/commands/synthetics/__tests__/fixtures.ts
+++ b/src/commands/synthetics/__tests__/fixtures.ts
@@ -77,6 +77,7 @@ export const ciConfig: RunTestsCommandConfig = {
   pollingTimeout: 2 * 60 * 1000,
   proxy: {protocol: 'http'},
   publicIds: [],
+  selectiveRerun: false,
   subdomain: 'app',
   tunnel: false,
   variableStrings: [],

--- a/src/commands/synthetics/interfaces.ts
+++ b/src/commands/synthetics/interfaces.ts
@@ -300,6 +300,7 @@ export interface ServerConfigOverride extends BaseConfigOverride {
 
 export interface Payload {
   metadata?: Metadata
+  selective_rerun?: boolean
   tests: TestPayload[]
 }
 
@@ -378,6 +379,7 @@ export interface RunTestsCommandConfig extends SyntheticsCIConfig {
   locations: string[]
   pollingTimeout: number
   publicIds: string[]
+  selectiveRerun: boolean
   subdomain: string
   testSearchQuery?: string
   tunnel: boolean

--- a/src/commands/synthetics/interfaces.ts
+++ b/src/commands/synthetics/interfaces.ts
@@ -298,10 +298,14 @@ export interface ServerConfigOverride extends BaseConfigOverride {
   mobileApplication?: MobileApplication
 }
 
+export interface BatchOptions {
+  selective_rerun?: boolean
+}
+
 export interface Payload {
   metadata?: Metadata
-  selective_rerun?: boolean
   tests: TestPayload[]
+  options?: BatchOptions
 }
 
 export interface TestPayload extends ServerConfigOverride {

--- a/src/commands/synthetics/run-tests-command.ts
+++ b/src/commands/synthetics/run-tests-command.ts
@@ -40,6 +40,7 @@ export const DEFAULT_COMMAND_CONFIG: RunTestsCommandConfig = {
   pollingTimeout: DEFAULT_POLLING_TIMEOUT,
   proxy: {protocol: 'http'},
   publicIds: [],
+  selectiveRerun: false,
   subdomain: 'app',
   tunnel: false,
   variableStrings: [],
@@ -111,6 +112,10 @@ export class RunTestsCommand extends Command {
     validator: validation.isInteger(),
   })
   private publicIds = Option.Array('-p,--public-id', {description: 'Specify a test to run.'})
+  private selectiveRerun = Option.Boolean('--selectiveRerun', false, {
+    description:
+      'A boolean flag to only run the tests which failed in the previous test batches. Use `--no-selectiveRerun` to force a full run if your configuration enables it by default.',
+  })
   private subdomain = Option.String('--subdomain', {
     description:
       'The name of the custom subdomain set to access your Datadog application. If the URL used to access Datadog is `myorg.datadoghq.com`, the `subdomain` value needs to be set to `myorg`.',
@@ -218,6 +223,7 @@ export class RunTestsCommand extends Command {
         failOnTimeout: this.failOnTimeout,
         files: this.files,
         publicIds: this.publicIds,
+        selectiveRerun: this.selectiveRerun,
         subdomain: this.subdomain,
         testSearchQuery: this.testSearchQuery,
         tunnel: this.tunnel,

--- a/src/commands/synthetics/run-tests-lib.ts
+++ b/src/commands/synthetics/run-tests-lib.ts
@@ -137,7 +137,7 @@ export const executeTests = async (
 
   let trigger: Trigger
   try {
-    trigger = await runTests(api, overriddenTestsToTrigger)
+    trigger = await runTests(api, overriddenTestsToTrigger, config.selectiveRerun)
   } catch (error) {
     await stopTunnel()
     throw new CriticalError('TRIGGER_TESTS_FAILED', error.message)

--- a/src/commands/synthetics/utils.ts
+++ b/src/commands/synthetics/utils.ts
@@ -678,7 +678,12 @@ export const runTests = async (
   testsToTrigger: TestPayload[],
   selectiveRerun = false
 ): Promise<Trigger> => {
-  const payload: Payload = {selective_rerun: selectiveRerun, tests: testsToTrigger}
+  const payload: Payload = {
+    tests: testsToTrigger,
+    options: {
+      selective_rerun: selectiveRerun,
+    },
+  }
   const tagsToLimit = {
     [GIT_COMMIT_MESSAGE]: 500,
   }

--- a/src/commands/synthetics/utils.ts
+++ b/src/commands/synthetics/utils.ts
@@ -673,8 +673,12 @@ export const getTestsToTrigger = async (
 }
 
 // XXX: We shouldn't export functions that take an `APIHelper` because the `utils` module is exported while `api` is not.
-export const runTests = async (api: APIHelper, testsToTrigger: TestPayload[]): Promise<Trigger> => {
-  const payload: Payload = {tests: testsToTrigger}
+export const runTests = async (
+  api: APIHelper,
+  testsToTrigger: TestPayload[],
+  selectiveRerun = false
+): Promise<Trigger> => {
+  const payload: Payload = {selective_rerun: selectiveRerun, tests: testsToTrigger}
   const tagsToLimit = {
     [GIT_COMMIT_MESSAGE]: 500,
   }


### PR DESCRIPTION
### What and why?

This PR adds a `--selectiveRerun` input, which is disabled by default.

When using this flag to trigger Synthetics tests, only the tests which previously failed for the same commit will be retried.

### How?

- Pass a `selective_rerun` boolean in the trigger payload.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
