### PR TITLE
[CIAPP-7371] Remove "DATADOG_*" env variables support in the gate command

### DIFF
--- a/src/commands/gate/README.md
+++ b/src/commands/gate/README.md
@@ -33,10 +33,10 @@ datadog-ci gate evaluate --scope team:backend --scope team:frontend --fail-on-em
 
 Additionally, you can configure the `gate` command with the following environment variables:
 
-- `DATADOG_API_KEY` or `DD_API_KEY` (**required**): The API key used to authenticate the requests.
-- `DATADOG_APP_KEY` (**required**): The application key used to authenticate the requests.
+- `DD_API_KEY` (**required**): The API key used to authenticate the requests.
+- `DD_APP_KEY` (**required**): The application key used to authenticate the requests.
 - `DD_TAGS`: Sets global tags applied to all spans. The format must be `key1:value1,key2:value2`. The upload process merges the tags passed on the command line with the tags in the `--tags` parameter. If a key appears in both `--tags` and `DD_TAGS`, the value in `DD_TAGS` takes precedence.
-- `DATADOG_SITE`: Your Datadog site, for example, datadoghq.com or datadoghq.eu.
+- `DD_SITE`: Your Datadog site, for example, datadoghq.com or datadoghq.eu.
 
 ### Dependencies
 
@@ -47,8 +47,8 @@ Additionally, you can configure the `gate` command with the following environmen
 To verify the command works as expected, use `--dry-run`:
 
 ```bash
-export DATADOG_API_KEY='<API key>'
-export DATADOG_APP_KEY='<APP key>'
+export DD_API_KEY='<API key>'
+export DD_APP_KEY='<APP key>'
 
 yarn launch gate evaluate --scope team:backend --dry-run
 ```

--- a/src/commands/gate/__tests__/evaluate.test.ts
+++ b/src/commands/gate/__tests__/evaluate.test.ts
@@ -14,15 +14,15 @@ describe('evaluate', () => {
       const command = createCommand(GateEvaluateCommand, {stdout: {write}} as any)
 
       expect(command['getApiHelper'].bind(command)).toThrow('API key is missing')
-      expect(write.mock.calls[0][0]).toContain('DATADOG_API_KEY')
+      expect(write.mock.calls[0][0]).toContain('DD_API_KEY')
     })
     test('should throw an error if APP key is undefined', () => {
-      process.env = {DATADOG_API_KEY: 'PLACEHOLDER'}
+      process.env = {DD_API_KEY: 'PLACEHOLDER'}
       const write = jest.fn()
       const command = createCommand(GateEvaluateCommand, {stdout: {write}} as any)
 
       expect(command['getApiHelper'].bind(command)).toThrow('APP key is missing')
-      expect(write.mock.calls[0][0]).toContain('DATADOG_APP_KEY')
+      expect(write.mock.calls[0][0]).toContain('DD_APP_KEY')
     })
   })
   describe('handleEvaluationSuccess', () => {
@@ -139,7 +139,7 @@ describe('evaluate', () => {
     })
   })
   describe('evaluateRules', () => {
-    process.env = {DATADOG_API_KEY: 'PLACEHOLDER', DATADOG_APP_KEY: 'PLACEHOLDER'}
+    process.env = {DD_API_KEY: 'PLACEHOLDER', DD_APP_KEY: 'PLACEHOLDER'}
     const api = apiConstructor('', '', '')
     const mockRequest = (): Payload => {
       return {

--- a/src/commands/gate/evaluate.ts
+++ b/src/commands/gate/evaluate.ts
@@ -53,7 +53,7 @@ export class GateEvaluateCommand extends Command {
       ],
       [
         'Evaluate matching quality gate rules in Datadog from the datadoghq.eu site',
-        'DATADOG_SITE=datadoghq.eu datadog-ci gate evaluate',
+        'DD_SITE=datadoghq.eu datadog-ci gate evaluate',
       ],
       [
         'Evaluate matching quality gate rules in Datadog with a timeout of 120 seconds',
@@ -78,8 +78,8 @@ export class GateEvaluateCommand extends Command {
   private tags = Option.Array('--tags')
 
   private config = {
-    apiKey: process.env.DATADOG_API_KEY || process.env.DD_API_KEY,
-    appKey: process.env.DATADOG_APP_KEY || process.env.DD_APP_KEY,
+    apiKey: process.env.DD_API_KEY,
+    appKey: process.env.DD_APP_KEY,
     envVarTags: process.env.DD_TAGS,
   }
 
@@ -105,14 +105,12 @@ export class GateEvaluateCommand extends Command {
 
   private getApiHelper(): APIHelper {
     if (!this.config.apiKey) {
-      this.context.stdout.write(
-        `Neither ${chalk.red.bold('DATADOG_API_KEY')} nor ${chalk.red.bold('DD_API_KEY')} is in your environment.\n`
-      )
+      this.context.stdout.write(`Missing ${chalk.red.bold('DD_API_KEY')} in your environment.\n`)
       throw new Error('API key is missing')
     }
 
     if (!this.config.appKey) {
-      this.context.stdout.write(`Missing ${chalk.red.bold('DATADOG_APP_KEY')} in your environment.\n`)
+      this.context.stdout.write(`Missing ${chalk.red.bold('DD_APP_KEY')} in your environment.\n`)
       throw new Error('APP key is missing')
     }
 

--- a/src/commands/gate/utils.ts
+++ b/src/commands/gate/utils.ts
@@ -1,6 +1,6 @@
 export const getBaseIntakeUrl = () => {
-  if (process.env.DATADOG_SITE || process.env.DD_SITE) {
-    return `https://quality-gates.${process.env.DATADOG_SITE || process.env.DD_SITE}`
+  if (process.env.DD_SITE) {
+    return `https://quality-gates.${process.env.DD_SITE}`
   }
 
   return 'https://quality-gates.datadoghq.com'


### PR DESCRIPTION
### What and why?

Removing `DATADOG_*` environment variables support in the gate command, as these environment variables are deprecated :)

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
