### PR TITLE
[SYNTH-10966] Support blocking IP addresses in the tunnel

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -43,6 +43,8 @@ fuzzy,import,MIT,Copyright (c) 2012 Matt York
 glob,import,ISC,Copyright (c) Isaac Z. Schlueter and Contributors
 inquirer,import,MIT,Copyright (c) 2012 Simon Boudrias
 inquirer-checkbox-plus-prompt,import,MIT,Copyright (c) 2018 Mohammad Anas Fares
+ipaddr.js,import,MIT,github.com/whitequark/ipaddr.js
+is-in-subnet,import,MIT,github.com/natesilva/is-in-subnet
 jest,dev,MIT,"Copyright (c) Facebook, Inc. and its affiliates."
 js-yaml,import,MIT,Copyright (C) 2011-2015 by Vitaly Puzrin
 ora,import,MIT,Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (https://sindresorhus.com)

--- a/package.json
+++ b/package.json
@@ -92,6 +92,8 @@
     "http-proxy-agent": "^7.0.0",
     "inquirer": "^8.2.5",
     "inquirer-checkbox-plus-prompt": "^1.4.2",
+    "ipaddr.js": "^2.1.0",
+    "is-in-subnet": "^4.0.1",
     "js-yaml": "3.13.1",
     "jszip": "^3.10.1",
     "ora": "5.4.1",

--- a/src/commands/synthetics/__tests__/cli.test.ts
+++ b/src/commands/synthetics/__tests__/cli.test.ts
@@ -72,10 +72,19 @@ describe('run-test', () => {
 
     test('override from config file', async () => {
       const overrideConfigFile = {
+        allowedIPRanges: {
+          4: ['127.0.0.1'],
+          6: ['::1'],
+        },
         apiKey: 'fake_api_key',
         appKey: 'fake_app_key',
+        blockedIPRanges: {
+          4: ['127.0.0.1/8'],
+          6: ['::1/8'],
+        },
         configPath: 'src/commands/synthetics/__tests__/config-fixtures/config-with-all-keys.json',
         datadogSite: 'datadoghq.eu',
+        enableDefaultBlockedIPRanges: true,
         failOnCriticalErrors: true,
         failOnMissingTests: true,
         failOnTimeout: false,

--- a/src/commands/synthetics/__tests__/config-fixtures/config-with-all-keys.json
+++ b/src/commands/synthetics/__tests__/config-fixtures/config-with-all-keys.json
@@ -1,8 +1,17 @@
 {
+  "allowedIPRanges": {
+    "4": ["127.0.0.1"],
+    "6": ["::1"]
+  },
   "apiKey": "fake_api_key",
   "appKey": "fake_app_key",
+  "blockedIPRanges": {
+    "4": ["127.0.0.1/8"],
+    "6": ["::1/8"]
+  },
   "configPath": "fake-datadog-ci.json",
   "datadogSite": "datadoghq.eu",
+  "enableDefaultBlockedIPRanges": true,
   "failOnCriticalErrors": true,
   "failOnMissingTests": true,
   "failOnTimeout": false,

--- a/src/commands/synthetics/__tests__/fixtures.ts
+++ b/src/commands/synthetics/__tests__/fixtures.ts
@@ -64,10 +64,13 @@ export const mockReporter: MainReporter = {
 }
 
 export const ciConfig: RunTestsCommandConfig = {
+  allowedIPRanges: {4: [], 6: []},
   apiKey: '',
   appKey: '',
+  blockedIPRanges: {4: [], 6: []},
   configPath: 'datadog-ci.json',
   datadogSite: 'datadoghq.com',
+  enableDefaultBlockedIPRanges: false,
   failOnCriticalErrors: false,
   failOnMissingTests: false,
   failOnTimeout: true,

--- a/src/commands/synthetics/__tests__/tunnel/tunnel.test.ts
+++ b/src/commands/synthetics/__tests__/tunnel/tunnel.test.ts
@@ -3,11 +3,17 @@ import {PassThrough} from 'stream'
 import {getProxyAgent} from '../../../../../src/helpers/utils'
 
 import {getTunnelReporter} from '../../reporters/default'
-import {Tunnel} from '../../tunnel'
+import {Tunnel, getTunnelFirewallRules} from '../../tunnel'
 import {WebSocket} from '../../tunnel/websocket'
 jest.mock('../../tunnel/websocket')
 
 import {mockReporter} from '../fixtures'
+import {RESERVED_ADDRESS_BLOCKS} from '../../tunnel/blockedIPs'
+
+const EMPTY_FIREWALL_RULES = {
+  allowedSubnetsByFamily: {4: [], 6: []},
+  blockedSubnetsByFamily: {4: [], 6: []},
+}
 
 describe('Tunnel', () => {
   const mockConnect = jest.fn()
@@ -32,7 +38,7 @@ describe('Tunnel', () => {
   test('starts by connecting over WebSocket and closes the WebSocket when stopping', async () => {
     mockedWebSocket.mockImplementation(() => mockWebSocket as any)
 
-    const tunnel = new Tunnel(wsPresignedURL, testIDs, undefined, mockTunnelReporter)
+    const tunnel = new Tunnel(wsPresignedURL, testIDs, EMPTY_FIREWALL_RULES, undefined, mockTunnelReporter)
     const connectionInfo = await tunnel.start()
     expect(WebSocket).toHaveBeenCalledWith(wsPresignedURL, undefined)
     expect(mockConnect).toHaveBeenCalled()
@@ -60,7 +66,7 @@ describe('Tunnel', () => {
     mockConnect.mockImplementation(() => {
       throw websocketConnectError
     })
-    const tunnel = new Tunnel(wsPresignedURL, testIDs, undefined, mockTunnelReporter)
+    const tunnel = new Tunnel(wsPresignedURL, testIDs, EMPTY_FIREWALL_RULES, undefined, mockTunnelReporter)
     await expect(tunnel.start()).rejects.toThrow(websocketConnectError)
     expect(mockClose).toHaveBeenCalled()
     mockConnect.mockRestore()
@@ -73,11 +79,34 @@ describe('Tunnel', () => {
       port: 8080,
       protocol: 'http',
     })
-    const tunnel = new Tunnel(wsPresignedURL, testIDs, localProxyAgent, mockTunnelReporter)
+    const tunnel = new Tunnel(wsPresignedURL, testIDs, EMPTY_FIREWALL_RULES, localProxyAgent, mockTunnelReporter)
     await tunnel.start()
     expect(WebSocket).toHaveBeenCalledWith(wsPresignedURL, localProxyAgent)
 
     // Stop the tunnel
     await tunnel.stop()
+  })
+
+  test('blocks default IP addresses', async () => {
+    const defaultBlockedIPs = {
+      allowedSubnetsByFamily: {4: [], 6: []},
+      blockedSubnetsByFamily: RESERVED_ADDRESS_BLOCKS,
+    }
+
+    const tunnel = new Tunnel(wsPresignedURL, testIDs, defaultBlockedIPs, undefined, mockTunnelReporter)
+    expect(tunnel.validateIP('127.0.0.1')).toBe(false)
+    expect(tunnel.validateIP('::1')).toBe(false)
+    expect(tunnel.validateIP('169.254.169.254')).toBe(false)
+    expect(tunnel.validateIP('54.52.123.45')).toBe(true)
+  })
+
+  test('allows localhost IP address', async () => {
+    const defaultBlockedIPs = {
+      allowedSubnetsByFamily: {4: ['127.0.0.1/32'], 6: []},
+      blockedSubnetsByFamily: {4: ['127.0.0.0/8'], 6: []},
+    }
+
+    const tunnel = new Tunnel(wsPresignedURL, testIDs, defaultBlockedIPs, undefined, mockTunnelReporter)
+    expect(tunnel.validateIP('127.0.0.1')).toBe(true)
   })
 })

--- a/src/commands/synthetics/__tests__/tunnel/tunnel.test.ts
+++ b/src/commands/synthetics/__tests__/tunnel/tunnel.test.ts
@@ -3,12 +3,12 @@ import {PassThrough} from 'stream'
 import {getProxyAgent} from '../../../../../src/helpers/utils'
 
 import {getTunnelReporter} from '../../reporters/default'
-import {Tunnel, getTunnelFirewallRules} from '../../tunnel'
+import {Tunnel} from '../../tunnel'
+import {RESERVED_ADDRESS_BLOCKS} from '../../tunnel/blockedIPs'
 import {WebSocket} from '../../tunnel/websocket'
 jest.mock('../../tunnel/websocket')
 
 import {mockReporter} from '../fixtures'
-import {RESERVED_ADDRESS_BLOCKS} from '../../tunnel/blockedIPs'
 
 const EMPTY_FIREWALL_RULES = {
   allowedSubnetsByFamily: {4: [], 6: []},

--- a/src/commands/synthetics/__tests__/tunnel/websocket.test.ts
+++ b/src/commands/synthetics/__tests__/tunnel/websocket.test.ts
@@ -35,8 +35,10 @@ describe('Proxy configuration', () => {
       // Instead we mock the util function that is called in the command.
       jest.spyOn(ciUtils, 'resolveConfigFromFile').mockImplementationOnce(async (config) => ({
         ...(config as Record<string, unknown>),
+        allowedIPRanges: {4: [], 6: []},
         apiKey: '123',
         appKey: '123',
+        blockedIPRanges: {4: [], 6: []},
         proxy: proxyOpts,
         publicIds: ['123-456-789'],
         tunnel: true,

--- a/src/commands/synthetics/interfaces.ts
+++ b/src/commands/synthetics/interfaces.ts
@@ -2,6 +2,7 @@ import {Metadata} from '../../helpers/interfaces'
 import {ProxyConfiguration} from '../../helpers/utils'
 
 import {TunnelInfo} from './tunnel'
+import {RESERVED_ADDRESS_BLOCKS} from './tunnel/blockedIPs'
 
 export type SupportedReporter = 'junit' | 'default'
 
@@ -370,7 +371,10 @@ export interface APIHelperConfig {
 export interface SyntheticsCIConfig extends APIHelperConfig {}
 
 export interface RunTestsCommandConfig extends SyntheticsCIConfig {
+  allowedIPRanges: typeof RESERVED_ADDRESS_BLOCKS
+  blockedIPRanges: typeof RESERVED_ADDRESS_BLOCKS
   configPath: string
+  enableDefaultBlockedIPRanges: boolean
   failOnCriticalErrors: boolean
   failOnMissingTests: boolean
   failOnTimeout: boolean

--- a/src/commands/synthetics/run-tests-command.ts
+++ b/src/commands/synthetics/run-tests-command.ts
@@ -246,16 +246,16 @@ export class RunTestsCommand extends Command {
         ...(this.allowedIPv4Ranges || this.allowedIPv6Ranges
           ? {
               allowedIPRanges: {
-                [IpFamily.v4]: this.allowedIPv4Ranges,
-                [IpFamily.v6]: this.allowedIPv6Ranges,
+                [IpFamily.v4]: this.allowedIPv4Ranges ?? [],
+                [IpFamily.v6]: this.allowedIPv6Ranges ?? [],
               },
             }
           : {}),
-        ...(this.blockedIPv4Ranges && this.blockedIPv6Ranges
+        ...(this.blockedIPv4Ranges || this.blockedIPv6Ranges
           ? {
               blockedIPRanges: {
-                [IpFamily.v4]: this.blockedIPv4Ranges,
-                [IpFamily.v6]: this.blockedIPv6Ranges,
+                [IpFamily.v4]: this.blockedIPv4Ranges ?? [],
+                [IpFamily.v6]: this.blockedIPv6Ranges ?? [],
               },
             }
           : {}),

--- a/src/commands/synthetics/run-tests-command.ts
+++ b/src/commands/synthetics/run-tests-command.ts
@@ -11,6 +11,7 @@ import {MainReporter, Reporter, Result, RunTestsCommandConfig, Summary} from './
 import {DefaultReporter} from './reporters/default'
 import {JUnitReporter} from './reporters/junit'
 import {executeTests} from './run-tests-lib'
+import {hasValidRanges, IpFamily, RESERVED_ADDRESS_BLOCKS} from './tunnel/blockedIPs'
 import {
   getExitReason,
   getOrgSettings,
@@ -27,10 +28,13 @@ export const MAX_TESTS_TO_TRIGGER = 100
 export const DEFAULT_POLLING_TIMEOUT = 30 * 60 * 1000
 
 export const DEFAULT_COMMAND_CONFIG: RunTestsCommandConfig = {
+  allowedIPRanges: {[IpFamily.v4]: [], [IpFamily.v6]: []} as typeof RESERVED_ADDRESS_BLOCKS,
   apiKey: '',
   appKey: '',
+  blockedIPRanges: {[IpFamily.v4]: [], [IpFamily.v6]: []} as typeof RESERVED_ADDRESS_BLOCKS,
   configPath: 'datadog-ci.json',
   datadogSite: 'datadoghq.com',
+  enableDefaultBlockedIPRanges: false,
   failOnCriticalErrors: false,
   failOnMissingTests: false,
   failOnTimeout: true,
@@ -123,6 +127,23 @@ export class RunTestsCommand extends Command {
   })
   private variableStrings = Option.Array('-v,--variable', {description: 'Pass a variable override.'})
 
+  private enableDefaultBlockedIPRanges = Option.Boolean('--enableDefaultBlockedIPRanges', {
+    description:
+      'Deny access to reserved IP ranges (IANA [IPv4](https://www.iana.org/assignments/iana-ipv4-special-registry/iana-ipv4-special-registry.xhtml) and [IPv6](https://www.iana.org/assignments/iana-ipv6-special-registry/iana-ipv6-special-registry.xhtml) Special-Purpose Address Registry), except for those explicitly set in --allowedIPRanges.',
+  })
+  private allowedIPv4Ranges = Option.Array('--allowedIPRanges.4', {
+    description: 'Grant access to IPv4 ranges while using the tunnel (has precedence over --blockedIPRanges.4).',
+  })
+  private allowedIPv6Ranges = Option.Array('--allowedIPRanges.6', {
+    description: 'Grant access to IPv6 ranges while using the tunnel (has precedence over --blockedIPRanges.6).',
+  })
+  private blockedIPv4Ranges = Option.Array('--blockedIPRanges.4', {
+    description: 'Deny access to IP ranges while using the tunnel. (such as --blockedIPRanges.4="127.0.0.0/8").',
+  })
+  private blockedIPv6Ranges = Option.Array('--blockedIPRanges.6', {
+    description: 'Deny access to IP ranges while using the tunnel. (such as --blockedIPRanges.6="::1/128").',
+  })
+
   private reporter?: MainReporter
   private config: RunTestsCommandConfig = JSON.parse(JSON.stringify(DEFAULT_COMMAND_CONFIG)) // Deep copy to avoid mutation during unit tests
 
@@ -213,6 +234,7 @@ export class RunTestsCommand extends Command {
         appKey: this.appKey,
         configPath: this.configPath,
         datadogSite: this.datadogSite,
+        enableDefaultBlockedIPRanges: this.enableDefaultBlockedIPRanges,
         failOnCriticalErrors: this.failOnCriticalErrors,
         failOnMissingTests: this.failOnMissingTests,
         failOnTimeout: this.failOnTimeout,
@@ -221,6 +243,22 @@ export class RunTestsCommand extends Command {
         subdomain: this.subdomain,
         testSearchQuery: this.testSearchQuery,
         tunnel: this.tunnel,
+        ...(this.allowedIPv4Ranges || this.allowedIPv6Ranges
+          ? {
+              allowedIPRanges: {
+                [IpFamily.v4]: this.allowedIPv4Ranges,
+                [IpFamily.v6]: this.allowedIPv6Ranges,
+              },
+            }
+          : {}),
+        ...(this.blockedIPv4Ranges && this.blockedIPv6Ranges
+          ? {
+              blockedIPRanges: {
+                [IpFamily.v4]: this.blockedIPv4Ranges,
+                [IpFamily.v6]: this.blockedIPv6Ranges,
+              },
+            }
+          : {}),
       })
     )
 
@@ -246,6 +284,12 @@ export class RunTestsCommand extends Command {
           this.config.datadogSite
         )}) must match one of the sites supported by Datadog.\nFor more information, see "Site parameter" in our documentation: https://docs.datadoghq.com/getting_started/site/#access-the-datadog-site`
       )
+    }
+
+    for (const range of [this.config.allowedIPRanges, this.config.blockedIPRanges]) {
+      if (!hasValidRanges(range)) {
+        throw new CiError('INVALID_CONFIG', `Invalid IP range (${JSON.stringify(range)})`)
+      }
     }
   }
 }

--- a/src/commands/synthetics/run-tests-lib.ts
+++ b/src/commands/synthetics/run-tests-lib.ts
@@ -20,7 +20,7 @@ import {
 import {DefaultReporter, getTunnelReporter} from './reporters/default'
 import {JUnitReporter} from './reporters/junit'
 import {DEFAULT_COMMAND_CONFIG, MAX_TESTS_TO_TRIGGER} from './run-tests-command'
-import {Tunnel} from './tunnel'
+import {getTunnelFirewallRules, Tunnel} from './tunnel'
 import {
   getReporter,
   getOrgSettings,
@@ -123,7 +123,8 @@ export const executeTests = async (
     try {
       const tunnelProxyAgent = getProxyAgent(config.proxy)
       const tunnelReporter = getTunnelReporter(reporter)
-      tunnel = new Tunnel(presignedURL, publicIdsToTrigger, tunnelProxyAgent, tunnelReporter)
+      const tunnelFirewallRules = getTunnelFirewallRules(config)
+      tunnel = new Tunnel(presignedURL, publicIdsToTrigger, tunnelFirewallRules, tunnelProxyAgent, tunnelReporter)
 
       const tunnelInfo = await tunnel.start()
       overriddenTestsToTrigger.forEach((testToTrigger) => {

--- a/src/commands/synthetics/tunnel/blockedIPs.ts
+++ b/src/commands/synthetics/tunnel/blockedIPs.ts
@@ -1,0 +1,80 @@
+import * as ipaddr from 'ipaddr.js'
+
+// Taken from https://www.iana.org/assignments/iana-ipv4-special-registry/iana-ipv4-special-registry.xhtml
+// and https://www.iana.org/assignments/iana-ipv6-special-registry/iana-ipv6-special-registry.xhtml",
+export const RESERVED_ADDRESS_BLOCKS: {[ipType in IpFamily]: string[]} = {
+  4: [
+    '0.0.0.0/8',
+    '10.0.0.0/8',
+    '100.64.0.0/10',
+    '127.0.0.0/8',
+    '169.254.0.0/16',
+    '172.16.0.0/12',
+    '192.0.0.0/24',
+    '192.0.0.0/29',
+    '192.0.0.8/32',
+    '192.0.0.9/32',
+    '192.0.0.10/32',
+    '192.0.0.170/32',
+    '192.0.0.171/32',
+    '192.0.2.0/24',
+    '192.31.196.0/24',
+    '192.52.193.0/24',
+    '192.88.99.0/24',
+    '192.168.0.0/16',
+    '192.175.48.0/24',
+    '198.18.0.0/15',
+    '198.51.100.0/24',
+    '203.0.113.0/24',
+    '240.0.0.0/4',
+    '224.0.0.0/4',
+    '255.255.255.255/32',
+  ],
+  6: [
+    '::1/128',
+    '::/128',
+    '::ffff:0:0/96',
+    '64:ff9b::/96',
+    '64:ff9b:1::/48',
+    '100::/64',
+    '2001::/23',
+    '2001::/32',
+    '2001:1::1/128',
+    '2001:1::2/128',
+    '2001:2::/48',
+    '2001:3::/32',
+    '2001:4:112::/48',
+    '2001:5::/32',
+    '2001:10::/28',
+    '2001:20::/28',
+    '2001:db8::/32',
+    '2002::/16',
+    '2620:4f:8000::/48',
+    'fc00::/7',
+    'fe80::/10',
+  ],
+}
+
+export enum IpFamily {
+  v4 = 4,
+  v6 = 6,
+}
+
+export type IpFamilyType = IpFamily
+
+export const hasValidRanges = (firewallRanges: typeof RESERVED_ADDRESS_BLOCKS) =>
+  [IpFamily.v4, IpFamily.v6].every((family) =>
+    (firewallRanges[family] || []).every((ipRange) => {
+      if (ipaddr.isValid(ipRange)) {
+        return true
+      } else {
+        try {
+          ipaddr.parseCIDR(ipRange)
+
+          return true
+        } catch (error) {
+          return false
+        }
+      }
+    })
+  )

--- a/src/commands/synthetics/tunnel/index.ts
+++ b/src/commands/synthetics/tunnel/index.ts
@@ -1,1 +1,1 @@
-export {Tunnel, TunnelInfo, TunnelReporter} from './tunnel'
+export {getTunnelFirewallRules, Tunnel, TunnelInfo, TunnelReporter} from './tunnel'

--- a/src/commands/synthetics/tunnel/tunnel.ts
+++ b/src/commands/synthetics/tunnel/tunnel.ts
@@ -74,9 +74,9 @@ export const getTunnelFirewallRules = (config: RunTestsCommandConfig): TunnelFir
   return firewallRules
 }
 
-const getIPFamily = (ipAddress: string): 4 | 6 => {
+const getIPFamily = (ipAddress: string): IpFamily.v4 | IpFamily.v6 => {
   const ipFamily = isIP(ipAddress)
-  if (ipFamily === 4 || ipFamily === 6) {
+  if (ipFamily === IpFamily.v4 || ipFamily === IpFamily.v6) {
     return ipFamily
   } else {
     throw new Error('invalid IP address')

--- a/src/commands/synthetics/tunnel/tunnel.ts
+++ b/src/commands/synthetics/tunnel/tunnel.ts
@@ -177,6 +177,21 @@ export class Tunnel {
     await this.ws.close()
   }
 
+  public validateIP(ip: string): boolean {
+    const ipFamily = getIPFamily(ip)
+    const {allowedSubnetsByFamily, blockedSubnetsByFamily} = this.tunnelFirewallRules
+
+    if (isInSubnet(ip, allowedSubnetsByFamily[ipFamily])) {
+      return true
+    }
+
+    if (isInSubnet(ip, blockedSubnetsByFamily[ipFamily])) {
+      return false
+    }
+
+    return true
+  }
+
   // Authenticate SSH with key authentication - username should be the test ID
   private authenticateSSHConnection(ctx: AuthContext) {
     const allowedUsers = this.testIDs.map((testId) => Buffer.from(testId))
@@ -213,21 +228,6 @@ export class Tunnel {
       this.reporter?.log('Successfully connected')
     }
     ctx.accept()
-  }
-
-  public validateIP(ip: string): boolean {
-    const ipFamily = getIPFamily(ip)
-    const {allowedSubnetsByFamily, blockedSubnetsByFamily} = this.tunnelFirewallRules
-
-    if (isInSubnet(ip, allowedSubnetsByFamily[ipFamily])) {
-      return true
-    }
-
-    if (isInSubnet(ip, blockedSubnetsByFamily[ipFamily])) {
-      return false
-    }
-
-    return true
   }
 
   private forwardProxiedPacketsFromSSH(client: SSHConnection) {

--- a/src/commands/synthetics/tunnel/tunnel.ts
+++ b/src/commands/synthetics/tunnel/tunnel.ts
@@ -1,9 +1,10 @@
 import {timingSafeEqual} from 'crypto'
-import {Socket} from 'net'
+import {Socket, isIP} from 'net'
 import {Duplex, pipeline} from 'stream'
 
 import type {ProxyAgent} from 'proxy-agent'
 
+import {isInSubnet} from 'is-in-subnet'
 import {
   AuthContext,
   Connection as SSHConnection,
@@ -14,6 +15,9 @@ import {
 } from 'ssh2'
 import {Config as MultiplexerConfig, Server as Multiplexer} from 'yamux-js'
 
+import {RunTestsCommandConfig} from '../interfaces'
+
+import {IpFamily, RESERVED_ADDRESS_BLOCKS} from './blockedIPs'
 import {generateOpenSSHKeys, parseSSHKey} from './crypto'
 import {WebSocket} from './websocket'
 
@@ -34,6 +38,51 @@ export interface TunnelReporter {
   warn(message: string): void
 }
 
+export interface TunnelFirewallRules {
+  allowedSubnetsByFamily: typeof RESERVED_ADDRESS_BLOCKS
+  blockedSubnetsByFamily: typeof RESERVED_ADDRESS_BLOCKS
+}
+
+export const getTunnelFirewallRules = (config: RunTestsCommandConfig): TunnelFirewallRules => {
+  const {allowedIPRanges, blockedIPRanges, enableDefaultBlockedIPRanges} = config
+  const firewallRules: TunnelFirewallRules = {
+    allowedSubnetsByFamily: {
+      [IpFamily.v4]: [],
+      [IpFamily.v6]: [],
+    },
+    blockedSubnetsByFamily: {
+      [IpFamily.v4]: [],
+      [IpFamily.v6]: [],
+    },
+  }
+
+  const hasDefinedRanges = (firewallRanges: typeof RESERVED_ADDRESS_BLOCKS) =>
+    [IpFamily.v4, IpFamily.v6].some((family) => (firewallRanges[family] || []).length !== 0)
+
+  if (enableDefaultBlockedIPRanges) {
+    firewallRules.blockedSubnetsByFamily[IpFamily.v4].push(...(RESERVED_ADDRESS_BLOCKS[IpFamily.v4] || []))
+    firewallRules.blockedSubnetsByFamily[IpFamily.v6].push(...(RESERVED_ADDRESS_BLOCKS[IpFamily.v6] || []))
+  }
+
+  if (hasDefinedRanges(allowedIPRanges) || hasDefinedRanges(blockedIPRanges) || enableDefaultBlockedIPRanges) {
+    firewallRules.allowedSubnetsByFamily[IpFamily.v4].push(...(allowedIPRanges[IpFamily.v4] || []))
+    firewallRules.allowedSubnetsByFamily[IpFamily.v6].push(...(allowedIPRanges[IpFamily.v6] || []))
+    firewallRules.blockedSubnetsByFamily[IpFamily.v4].push(...(blockedIPRanges[IpFamily.v4] || []))
+    firewallRules.blockedSubnetsByFamily[IpFamily.v6].push(...(blockedIPRanges[IpFamily.v6] || []))
+  }
+
+  return firewallRules
+}
+
+const getIPFamily = (ipAddress: string): 4 | 6 => {
+  const ipFamily = isIP(ipAddress)
+  if (ipFamily === 4 || ipFamily === 6) {
+    return ipFamily
+  } else {
+    throw new Error('invalid IP address')
+  }
+}
+
 export class Tunnel {
   private FORWARDING_TIMEOUT = 40000 as const
 
@@ -49,6 +98,7 @@ export class Tunnel {
   constructor(
     private url: string,
     private testIDs: string[],
+    private tunnelFirewallRules: TunnelFirewallRules,
     proxyAgent?: ProxyAgent,
     private reporter?: TunnelReporter
   ) {
@@ -165,6 +215,21 @@ export class Tunnel {
     ctx.accept()
   }
 
+  public validateIP(ip: string): boolean {
+    const ipFamily = getIPFamily(ip)
+    const {allowedSubnetsByFamily, blockedSubnetsByFamily} = this.tunnelFirewallRules
+
+    if (isInSubnet(ip, allowedSubnetsByFamily[ipFamily])) {
+      return true
+    }
+
+    if (isInSubnet(ip, blockedSubnetsByFamily[ipFamily])) {
+      return false
+    }
+
+    return true
+  }
+
   private forwardProxiedPacketsFromSSH(client: SSHConnection) {
     client
       .on('session', (accept) => {
@@ -173,6 +238,11 @@ export class Tunnel {
         })
       })
       .on('tcpip', (accept, reject, {destIP, destPort}) => {
+        // Perform IP blocking
+        if (!this.validateIP(destIP)) {
+          this.reporter?.warn(`Requested blocked IP address (${destIP})`)
+          reject()
+        }
         // Forward packets
         // See https://github.com/mscdex/ssh2/issues/479#issuecomment-250416559
         let src: SSHServerChannel

--- a/yarn.lock
+++ b/yarn.lock
@@ -1878,6 +1878,8 @@ __metadata:
     http-proxy-agent: ^7.0.0
     inquirer: ^8.2.5
     inquirer-checkbox-plus-prompt: ^1.4.2
+    ipaddr.js: ^2.1.0
+    is-in-subnet: ^4.0.1
     jest: 29.6.2
     js-yaml: 3.13.1
     jszip: ^3.10.1
@@ -6955,6 +6957,13 @@ __metadata:
   dependencies:
     is-extglob: ^2.1.1
   checksum: d381c1319fcb69d341cc6e6c7cd588e17cd94722d9a32dbd60660b993c4fb7d0f19438674e68dfec686d09b7c73139c9166b47597f846af387450224a8101ab4
+  languageName: node
+  linkType: hard
+
+"is-in-subnet@npm:^4.0.1":
+  version: 4.0.1
+  resolution: "is-in-subnet@npm:4.0.1"
+  checksum: eb0613ed8620aa4ccc26d6067f873e6484f1b8f0e637b38500dfb2be213adc238ec4c2aa15b4d9b14481d2dd4fd026639b26a825f726629a8cb01c61182666b2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### What and why?

Adds support for blocking/allowing particular IP addresses in synthetics tests that use the tunnel. Also includes default blocked IP addresses that align with the IANA recommended blocked IP addresses.

### How?

Adds a few things:

1. The options `allowedIPRanges`, `blockedIPRanges` and `enableDefaultBlockedIPRanges`
2. Logic to perform IP validation on individual requests made through the tunnel to particular IP addresses.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
