### PR TITLE
Fix sending is_last_retry in the payload

### DIFF
--- a/src/commands/gate/api.ts
+++ b/src/commands/gate/api.ts
@@ -20,6 +20,7 @@ export const evaluateGateRules = (
         options: {
           no_wait: evaluateRequest.options.noWait,
           dry_run: evaluateRequest.options.dryRun,
+          is_last_retry: evaluateRequest.options.isLastRetry,
         },
       },
     },


### PR DESCRIPTION
### What and why?
In the previous [PR](https://github.com/DataDog/datadog-ci/pull/1055) the logic to send `is_last_retry` on the last request to the service was implemented. 
But it doesn't actually send `is_last_retry` option in the payload to the service.
This PR is fixing this issue.

### How?
Encode `is_last_retry` option in the payload.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
