### PR TITLE
[chore] Clean up list of files in standalone binary

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,9 +34,7 @@
   },
   "pkg": {
     "scripts": [
-      "dist/commands/*/*.js",
-      "node_modules/vm2/lib/contextify.js",
-      "node_modules/vm2/lib/setup-sandbox.js"
+      "dist/commands/*/*.js"
     ]
   },
   "scripts": {


### PR DESCRIPTION
### What and why?

Now that `vm2` was removed (https://github.com/DataDog/datadog-ci/pull/993), we don't need to include some of its files in the standalone binary anymore.

### How?

Remove the last references to `vm2` under `pkg.scripts` in `package.json`.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
