### PR TITLE
Add e2e check for junit xml test data

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,30 +22,29 @@ jobs:
           node-version: ${{ matrix.version }}
       - run: yarn install --immutable
       - run: yarn build
-      # TODO: remove: just for testing faster
-      # - name: Run yarn lint:ci
-      #   run: |
-      #     if ! yarn lint:ci ; then
-      #       echo "ESLint failed with the following errors:"
-      #       jq '.runs[].results' sarif-datadog-ci.sarif
+      - name: Run yarn lint:ci
+        run: |
+          if ! yarn lint:ci ; then
+            echo "ESLint failed with the following errors:"
+            jq '.runs[].results' sarif-datadog-ci.sarif
 
-      #       echo ""
-      #       echo "Find the full SARIF report in the Artifacts section here: https://github.com/DataDog/datadog-ci/actions/runs/${{ github.run_id }}"
-      #       echo "You can fix this by running ==> yarn format <=="
-      #       echo ""
-      #       exit 1
-      #     fi
-      # - run: yarn no-only-in-tests
+            echo ""
+            echo "Find the full SARIF report in the Artifacts section here: https://github.com/DataDog/datadog-ci/actions/runs/${{ github.run_id }}"
+            echo "You can fix this by running ==> yarn format <=="
+            echo ""
+            exit 1
+          fi
+      - run: yarn no-only-in-tests
       
-      # - run: yarn test
-      #   env:
-      #     CI: true
-      #     DD_SERVICE: datadog-ci-tests
-      #     DD_CIVISIBILITY_AGENTLESS_ENABLED: 1
-      #     DD_API_KEY: ${{ secrets.DATADOG_API_KEY_MAIN_ACCOUNT }}
-      #     DD_APP_KEY: ${{ secrets.DATADOG_APP_KEY_MAIN_ACCOUNT }}
-      #     DD_ENV: ci
-      #     NODE_OPTIONS: -r dd-trace/ci/init
+      - run: yarn test
+        env:
+          CI: true
+          DD_SERVICE: datadog-ci-tests
+          DD_CIVISIBILITY_AGENTLESS_ENABLED: 1
+          DD_API_KEY: ${{ secrets.DATADOG_API_KEY_MAIN_ACCOUNT }}
+          DD_APP_KEY: ${{ secrets.DATADOG_APP_KEY_MAIN_ACCOUNT }}
+          DD_ENV: ci
+          NODE_OPTIONS: -r dd-trace/ci/init
       - run: mkdir artifacts
       - run: yarn pack --filename artifacts/datadog-ci-${{ matrix.version }}.tgz
       - run: cp -r .github/workflows/e2e artifacts/
@@ -53,12 +52,12 @@ jobs:
         with:
           name: artifacts
           path: artifacts/
-      # - uses: actions/upload-artifact@v3
-      #   if: always()
-      #   with:
-      #     name: sarif-datadog-ci.sarif
-      #     path: sarif-datadog-ci.sarif
-      #     if-no-files-found: error
+      - uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: sarif-datadog-ci.sarif
+          path: sarif-datadog-ci.sarif
+          if-no-files-found: error
 
   e2e-test:
     strategy:
@@ -79,16 +78,16 @@ jobs:
         with:
           name: artifacts
       - run: yarn add ./artifacts/datadog-ci-${{ matrix.version }}.tgz
-      # - name: Run synthetics test
-      #   run: yarn datadog-ci synthetics run-tests --config artifacts/e2e/global.config.json
-      #   env:
-      #     DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY_E2E }}
-      #     DATADOG_APP_KEY: ${{ secrets.DATADOG_APP_KEY_E2E }}
-      # - name: Run sourcemaps upload test
-      #   run: yarn datadog-ci sourcemaps upload artifacts/e2e/sourcemaps/ --release-version=e2e --service=e2e-tests --minified-path-prefix=https://e2e-tests.datadoghq.com/static/
-      #   env:
-      #     DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY_E2E }}
-      #     DATADOG_APP_KEY: ${{ secrets.DATADOG_APP_KEY_E2E }}
+      - name: Run synthetics test
+        run: yarn datadog-ci synthetics run-tests --config artifacts/e2e/global.config.json
+        env:
+          DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY_E2E }}
+          DATADOG_APP_KEY: ${{ secrets.DATADOG_APP_KEY_E2E }}
+      - name: Run sourcemaps upload test
+        run: yarn datadog-ci sourcemaps upload artifacts/e2e/sourcemaps/ --release-version=e2e --service=e2e-tests --minified-path-prefix=https://e2e-tests.datadoghq.com/static/
+        env:
+          DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY_E2E }}
+          DATADOG_APP_KEY: ${{ secrets.DATADOG_APP_KEY_E2E }}
       - name: Run junit upload test
         run: yarn datadog-ci junit upload --service=datadog-ci-e2e-tests-junit artifacts/e2e/junit-reports
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,14 @@ jobs:
         run: yarn datadog-ci junit upload --service=datadog-ci-e2e-tests-junit artifacts/e2e/junit-reports
         env:
           DD_API_KEY: ${{ secrets.DD_API_KEY_CI_VISIBILITY }}
+      - name: Check that test data can be queried
+        run: |
+          yarn add @datadog/datadog-api-client
+          yarn check-junit-upload
+        env:
+          DD_API_KEY: ${{ secrets.DD_API_KEY_CI_VISIBILITY }}
+          DD_APP_KEY: ${{ secrets.DD_APP_KEY_CI_VISIBILITY }}
+          DD_SERVICE: datadog-ci-e2e-tests-junit
       - name: Run sarif upload test
         run: yarn datadog-ci sarif upload --service=datadog-ci-e2e-tests-sarif artifacts/e2e/sarif-reports
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,28 +22,30 @@ jobs:
           node-version: ${{ matrix.version }}
       - run: yarn install --immutable
       - run: yarn build
-      - name: Run yarn lint:ci
-        run: |
-          if ! yarn lint:ci ; then
-            echo "ESLint failed with the following errors:"
-            jq '.runs[].results' sarif-datadog-ci.sarif
+      # TODO: remove: just for testing faster
+      # - name: Run yarn lint:ci
+      #   run: |
+      #     if ! yarn lint:ci ; then
+      #       echo "ESLint failed with the following errors:"
+      #       jq '.runs[].results' sarif-datadog-ci.sarif
 
-            echo ""
-            echo "Find the full SARIF report in the Artifacts section here: https://github.com/DataDog/datadog-ci/actions/runs/${{ github.run_id }}"
-            echo "You can fix this by running ==> yarn format <=="
-            echo ""
-            exit 1
-          fi
-      - run: yarn no-only-in-tests
-      - run: yarn test
-        env:
-          CI: true
-          DD_SERVICE: datadog-ci-tests
-          DD_CIVISIBILITY_AGENTLESS_ENABLED: 1
-          DD_API_KEY: ${{ secrets.DATADOG_API_KEY_MAIN_ACCOUNT }}
-          DD_APP_KEY: ${{ secrets.DATADOG_APP_KEY_MAIN_ACCOUNT }}
-          DD_ENV: ci
-          NODE_OPTIONS: -r dd-trace/ci/init
+      #       echo ""
+      #       echo "Find the full SARIF report in the Artifacts section here: https://github.com/DataDog/datadog-ci/actions/runs/${{ github.run_id }}"
+      #       echo "You can fix this by running ==> yarn format <=="
+      #       echo ""
+      #       exit 1
+      #     fi
+      # - run: yarn no-only-in-tests
+      
+      # - run: yarn test
+      #   env:
+      #     CI: true
+      #     DD_SERVICE: datadog-ci-tests
+      #     DD_CIVISIBILITY_AGENTLESS_ENABLED: 1
+      #     DD_API_KEY: ${{ secrets.DATADOG_API_KEY_MAIN_ACCOUNT }}
+      #     DD_APP_KEY: ${{ secrets.DATADOG_APP_KEY_MAIN_ACCOUNT }}
+      #     DD_ENV: ci
+      #     NODE_OPTIONS: -r dd-trace/ci/init
       - run: mkdir artifacts
       - run: yarn pack --filename artifacts/datadog-ci-${{ matrix.version }}.tgz
       - run: cp -r .github/workflows/e2e artifacts/
@@ -68,6 +70,7 @@ jobs:
     needs: build-and-test
 
     steps:
+      - uses: actions/checkout@v3
       - name: Install node
         uses: actions/setup-node@v3
         with:
@@ -76,16 +79,16 @@ jobs:
         with:
           name: artifacts
       - run: yarn add ./artifacts/datadog-ci-${{ matrix.version }}.tgz
-      - name: Run synthetics test
-        run: yarn datadog-ci synthetics run-tests --config artifacts/e2e/global.config.json
-        env:
-          DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY_E2E }}
-          DATADOG_APP_KEY: ${{ secrets.DATADOG_APP_KEY_E2E }}
-      - name: Run sourcemaps upload test
-        run: yarn datadog-ci sourcemaps upload artifacts/e2e/sourcemaps/ --release-version=e2e --service=e2e-tests --minified-path-prefix=https://e2e-tests.datadoghq.com/static/
-        env:
-          DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY_E2E }}
-          DATADOG_APP_KEY: ${{ secrets.DATADOG_APP_KEY_E2E }}
+      # - name: Run synthetics test
+      #   run: yarn datadog-ci synthetics run-tests --config artifacts/e2e/global.config.json
+      #   env:
+      #     DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY_E2E }}
+      #     DATADOG_APP_KEY: ${{ secrets.DATADOG_APP_KEY_E2E }}
+      # - name: Run sourcemaps upload test
+      #   run: yarn datadog-ci sourcemaps upload artifacts/e2e/sourcemaps/ --release-version=e2e --service=e2e-tests --minified-path-prefix=https://e2e-tests.datadoghq.com/static/
+      #   env:
+      #     DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY_E2E }}
+      #     DATADOG_APP_KEY: ${{ secrets.DATADOG_APP_KEY_E2E }}
       - name: Run junit upload test
         run: yarn datadog-ci junit upload --service=datadog-ci-e2e-tests-junit artifacts/e2e/junit-reports
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,12 +53,12 @@ jobs:
         with:
           name: artifacts
           path: artifacts/
-      - uses: actions/upload-artifact@v3
-        if: always()
-        with:
-          name: sarif-datadog-ci.sarif
-          path: sarif-datadog-ci.sarif
-          if-no-files-found: error
+      # - uses: actions/upload-artifact@v3
+      #   if: always()
+      #   with:
+      #     name: sarif-datadog-ci.sarif
+      #     path: sarif-datadog-ci.sarif
+      #     if-no-files-found: error
 
   e2e-test:
     strategy:

--- a/bin/check-junit-upload.js
+++ b/bin/check-junit-upload.js
@@ -30,8 +30,9 @@ function waitFor (waitSeconds) {
 async function checkJunitUpload () {
   let numAttempts = 0
   let isSuccess = false
+  let data = []
   while (numAttempts++ < MAX_NUM_ATTEMPTS && !isSuccess) {
-    const data = await getTestData()
+    data = await getTestData()
     if (data.length > 0) {
       isSuccess = true
     } else {

--- a/bin/check-junit-upload.js
+++ b/bin/check-junit-upload.js
@@ -13,10 +13,10 @@ const params = {
 };
 
 const CHECK_INTERVAL_SECONDS = 10 // 10 seconds
-const MAX_NUM_CHECKS = 10
+const MAX_NUM_ATTEMPTS = 10
 
 function getTestData () {
-  console.log(`Querying CI Visibility tests with ${params.filterQuery}`)
+  console.log(`🔎 Querying CI Visibility tests with ${params.filterQuery}.`)
   return apiInstance
     .listCIAppTestEvents(params)
     .then(data => data.data)
@@ -28,19 +28,27 @@ function waitFor (waitSeconds) {
 } 
 
 async function checkJunitUpload () {
-  let numChecks = 0
+  let numAttempts = 0
   let isSuccess = false
-  while (numChecks++ < MAX_NUM_CHECKS && !isSuccess) {
+  while (numAttempts++ < MAX_NUM_ATTEMPTS && !isSuccess) {
     const data = await getTestData()
     if (data.length > 0) {
       isSuccess = true
-      console.log(`The API returned ${data.length} tests.`)
     } else {
-      console.log(`Attempt number ${numChecks} failed, retrying in ${CHECK_INTERVAL_SECONDS} seconds.`)
-      await waitFor(CHECK_INTERVAL_SECONDS)
+      const isLastAttempt = numAttempts === MAX_NUM_ATTEMPTS
+      if (!isLastAttempt) {
+        console.log(`🔁 Attempt number ${numAttempts} failed, retrying in ${CHECK_INTERVAL_SECONDS} seconds.`)
+        await waitFor(CHECK_INTERVAL_SECONDS)
+      }
     }
   }
-  process.exit(isSuccess ? 0 : 1)
+  if (isSuccess) {
+    console.log(`✅ Successful check: the API returned ${data.length} tests.`)
+    process.exit(0)
+  } else {
+    console.log(`❌ Failed check: the API did not return any test for the given filter.`)
+    process.exit(1)
+  }
 }
 
 checkJunitUpload()

--- a/bin/check-junit-upload.js
+++ b/bin/check-junit-upload.js
@@ -6,7 +6,7 @@ const configuration = client.createConfiguration();
 const apiInstance = new v2.CIVisibilityTestsApi(configuration);
 
 const params = {
-  filterQuery: `@test.service:${process.env.DD_SERVICE} @git.commit.sha:${process.env.GITHUB_SHA}`,
+  filterQuery: `test_level:test @test.service:${process.env.DD_SERVICE} @git.commit.sha:${process.env.GITHUB_SHA}`,
   filterFrom: new Date(new Date().getTime() + -300 * 1000), // Last 5 minutes
   filterTo: new Date(),
   pageLimit: 5,
@@ -16,7 +16,7 @@ const CHECK_INTERVAL_SECONDS = 10 // 10 seconds
 const MAX_NUM_CHECKS = 10
 
 function getTestData () {
-  console.log(`Querying CI tests with ${params.filterQuery}`)
+  console.log(`Querying CI Visibility tests with ${params.filterQuery}`)
   return apiInstance
     .listCIAppTestEvents(params)
     .then(data => data.data)
@@ -34,6 +34,7 @@ async function checkJunitUpload () {
     const data = await getTestData()
     if (data.length > 0) {
       isSuccess = true
+      console.log(`The API returned ${data.length} tests.`)
     } else {
       console.log(`Attempt number ${numChecks} failed, retrying in ${CHECK_INTERVAL_SECONDS} seconds.`)
       await waitFor(CHECK_INTERVAL_SECONDS)

--- a/bin/check-junit-upload.js
+++ b/bin/check-junit-upload.js
@@ -12,7 +12,7 @@ const params = {
   pageLimit: 5,
 };
 
-const CHECK_INTERVAL_SECONDS = 10 // 10 seconds
+const CHECK_INTERVAL_SECONDS = 10
 const MAX_NUM_ATTEMPTS = 10
 
 function getTestData () {

--- a/bin/check-junit-upload.js
+++ b/bin/check-junit-upload.js
@@ -1,0 +1,45 @@
+'use strict'
+
+const { client, v2 } = require("@datadog/datadog-api-client")
+
+const configuration = client.createConfiguration();
+const apiInstance = new v2.CIVisibilityTestsApi(configuration);
+
+const params = {
+  filterQuery: `@test.service:${process.env.DD_SERVICE} @git.commit.sha:${process.env.GITHUB_SHA}`,
+  filterFrom: new Date(new Date().getTime() + -300 * 1000), // Last 5 minutes
+  filterTo: new Date(),
+  pageLimit: 5,
+};
+
+const CHECK_INTERVAL_SECONDS = 10 // 10 seconds
+const MAX_NUM_CHECKS = 10
+
+function getTestData () {
+  console.log(`Querying CI tests with ${params.filterQuery}`)
+  return apiInstance
+    .listCIAppTestEvents(params)
+    .then(data => data.data)
+    .catch(error => console.error(error))
+}
+
+function waitFor (waitSeconds) {
+  return new Promise(resolve => setTimeout(() => resolve(), waitSeconds * 1000))
+} 
+
+async function checkJunitUpload () {
+  let numChecks = 0
+  let isSuccess = false
+  while (numChecks++ < MAX_NUM_CHECKS && !isSuccess) {
+    const data = await getTestData()
+    if (data.length > 0) {
+      isSuccess = true
+    } else {
+      console.log(`Attempt number ${numChecks} failed, retrying in ${CHECK_INTERVAL_SECONDS} seconds.`)
+      await waitFor(CHECK_INTERVAL_SECONDS)
+    }
+  }
+  process.exit(isSuccess ? 0 : 1)
+}
+
+checkJunitUpload()

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "build": "yarn clean; tsc",
     "build:win": "tsc",
     "check-licenses": "node bin/check-licenses.js",
+    "check-junit-upload": "node bin/check-junit-upload.js",
     "clean:win": "rm dist -r",
     "clean": "rm -rf dist/*",
     "dist-standalone": "pkg --compress GZip .",


### PR DESCRIPTION
### What and why?

Add e2e test for JUnit XML report upload: we now not only upload data and check the return status, but query the datadog API to check that test data has actually arrived to the platform. 

### How?

Add a `bin/check-junit-upload.js` script to query the datadog API.

