### PR TITLE
[dep] Bump `aws-sdk` to fix `fast-xml-parser` vulnerability

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -1,14 +1,14 @@
 Component,Origin,Licence,Copyright
-@aws-sdk/client-cloudwatch-logs,import,Apache-2.0,Copyright (c) 2018 Amazon.com Inc. or its affiliates.
-@aws-sdk/client-iam,import,Apache-2.0,Copyright (c) 2018 Amazon.com Inc. or its affiliates.
-@aws-sdk/client-lambda,import,Apache-2.0,Copyright (c) 2018 Amazon.com Inc. or its affiliates.
-@aws-sdk/client-sfn,import,Apache-2.0,Copyright (c) 2018 Amazon.com Inc. or its affiliates.
-@aws-sdk/credential-providers,import,Apache-2.0,Copyright (c) 2018 Amazon.com Inc. or its affiliates.
-@aws-sdk/types,dev,Apache-2.0,Copyright (c) 2018 Amazon.com Inc. or its affiliates.
+@aws-sdk/client-cloudwatch-logs,import,Apache-2.0,"Copyright 2018-2021 Amazon.com, Inc. or its affiliates."
+@aws-sdk/client-iam,import,Apache-2.0,"Copyright 2018-2021 Amazon.com, Inc. or its affiliates."
+@aws-sdk/client-lambda,import,Apache-2.0,"Copyright 2018-2021 Amazon.com, Inc. or its affiliates."
+@aws-sdk/client-sfn,import,Apache-2.0,"Copyright 2018-2021 Amazon.com, Inc. or its affiliates."
+@aws-sdk/credential-providers,import,Apache-2.0,"Copyright 2018-2021 Amazon.com, Inc. or its affiliates."
+@aws-sdk/types,dev,Apache-2.0,"Copyright 2018-2021 Amazon.com, Inc. or its affiliates."
 @babel/core,dev,MIT,Copyright (c) 2014-present Sebastian McKenzie and other contributors
 @babel/preset-env,dev,MIT,Copyright (c) 2014-present Sebastian McKenzie and other contributors
 @babel/preset-typescript,dev,MIT,Copyright (c) 2014-present Sebastian McKenzie and other contributors
-@smithy/property-provider,import,Apache-2.0,Copyright 2018-2020 Amazon.com, Inc. or its affiliates.
+@smithy/property-provider,import,Apache-2.0,"Copyright 2018-2020 Amazon.com, Inc. or its affiliates."
 @types/async-retry,dev,MIT,Copyright (c) Microsoft Corporation
 @types/datadog-metrics,dev,MIT,Copyright (c) Microsoft Corporation
 @types/tiny-async-pool,dev,MIT,Copyright (c) Microsoft Corporation

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -4,11 +4,11 @@ Component,Origin,Licence,Copyright
 @aws-sdk/client-lambda,import,Apache-2.0,Copyright (c) 2018 Amazon.com Inc. or its affiliates.
 @aws-sdk/client-sfn,import,Apache-2.0,Copyright (c) 2018 Amazon.com Inc. or its affiliates.
 @aws-sdk/credential-providers,import,Apache-2.0,Copyright (c) 2018 Amazon.com Inc. or its affiliates.
-@aws-sdk/property-provider,import,Apache-2.0,Copyright (c) 2018 Amazon.com Inc. or its affiliates.
 @aws-sdk/types,dev,Apache-2.0,Copyright (c) 2018 Amazon.com Inc. or its affiliates.
 @babel/core,dev,MIT,Copyright (c) 2014-present Sebastian McKenzie and other contributors
 @babel/preset-env,dev,MIT,Copyright (c) 2014-present Sebastian McKenzie and other contributors
 @babel/preset-typescript,dev,MIT,Copyright (c) 2014-present Sebastian McKenzie and other contributors
+@smithy/property-provider,import,Apache-2.0,Copyright 2018-2020 Amazon.com, Inc. or its affiliates.
 @types/async-retry,dev,MIT,Copyright (c) Microsoft Corporation
 @types/datadog-metrics,dev,MIT,Copyright (c) Microsoft Corporation
 @types/tiny-async-pool,dev,MIT,Copyright (c) Microsoft Corporation

--- a/package.json
+++ b/package.json
@@ -64,14 +64,14 @@
     "watch": "tsc -w"
   },
   "dependencies": {
-    "@aws-sdk/client-cloudwatch-logs": "3.427.0",
-    "@aws-sdk/client-iam": "3.427.0",
-    "@aws-sdk/client-lambda": "3.427.0",
-    "@aws-sdk/client-sfn": "3.427.0",
-    "@aws-sdk/credential-providers": "3.427.0",
+    "@aws-sdk/client-cloudwatch-logs": "^3.427.0",
+    "@aws-sdk/client-iam": "^3.427.0",
+    "@aws-sdk/client-lambda": "^3.427.0",
+    "@aws-sdk/client-sfn": "^3.427.0",
+    "@aws-sdk/credential-providers": "^3.427.0",
     "@google-cloud/logging": "^10.5.0",
     "@google-cloud/run": "^0.6.0",
-    "@smithy/property-provider": "2.0.12",
+    "@smithy/property-provider": "^2.0.12",
     "@types/datadog-metrics": "0.6.1",
     "@types/retry": "0.12.0",
     "ajv": "^8.12.0",
@@ -113,7 +113,7 @@
     "yamux-js": "0.1.2"
   },
   "devDependencies": {
-    "@aws-sdk/types": "3.425.0",
+    "@aws-sdk/types": "^3.425.0",
     "@babel/core": "7.8.0",
     "@babel/preset-env": "7.4.5",
     "@babel/preset-typescript": "7.3.3",

--- a/package.json
+++ b/package.json
@@ -64,14 +64,14 @@
     "watch": "tsc -w"
   },
   "dependencies": {
-    "@aws-sdk/client-cloudwatch-logs": "^3.358.0",
-    "@aws-sdk/client-iam": "^3.358.0",
-    "@aws-sdk/client-lambda": "^3.358.0",
-    "@aws-sdk/client-sfn": "^3.358.0",
-    "@aws-sdk/credential-providers": "3.358.0",
-    "@aws-sdk/property-provider": "3.357.0",
+    "@aws-sdk/client-cloudwatch-logs": "3.427.0",
+    "@aws-sdk/client-iam": "3.427.0",
+    "@aws-sdk/client-lambda": "3.427.0",
+    "@aws-sdk/client-sfn": "3.427.0",
+    "@aws-sdk/credential-providers": "3.427.0",
     "@google-cloud/logging": "^10.5.0",
     "@google-cloud/run": "^0.6.0",
+    "@smithy/property-provider": "2.0.12",
     "@types/datadog-metrics": "0.6.1",
     "@types/retry": "0.12.0",
     "ajv": "^8.12.0",
@@ -113,7 +113,7 @@
     "yamux-js": "0.1.2"
   },
   "devDependencies": {
-    "@aws-sdk/types": "^3.357.0",
+    "@aws-sdk/types": "3.425.0",
     "@babel/core": "7.8.0",
     "@babel/preset-env": "7.4.5",
     "@babel/preset-typescript": "7.3.3",

--- a/src/commands/lambda/functions/commons.ts
+++ b/src/commands/lambda/functions/commons.ts
@@ -13,8 +13,8 @@ import {
   UpdateFunctionConfigurationCommandInput,
 } from '@aws-sdk/client-lambda'
 import {FromIniInit, fromIni, fromNodeProviderChain} from '@aws-sdk/credential-providers'
-import {CredentialsProviderError} from '@aws-sdk/property-provider'
 import {AwsCredentialIdentity, AwsCredentialIdentityProvider} from '@aws-sdk/types'
+import {CredentialsProviderError} from '@smithy/property-provider'
 import inquirer from 'inquirer'
 
 import {API_KEY_ENV_VAR, CI_API_KEY_ENV_VAR, CI_SITE_ENV_VAR} from '../../../constants'

--- a/yarn.lock
+++ b/yarn.lock
@@ -89,7 +89,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/client-cloudwatch-logs@npm:3.427.0":
+"@aws-sdk/client-cloudwatch-logs@npm:^3.427.0":
   version: 3.427.0
   resolution: "@aws-sdk/client-cloudwatch-logs@npm:3.427.0"
   dependencies:
@@ -180,7 +180,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/client-iam@npm:3.427.0":
+"@aws-sdk/client-iam@npm:^3.427.0":
   version: 3.427.0
   resolution: "@aws-sdk/client-iam@npm:3.427.0"
   dependencies:
@@ -227,7 +227,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/client-lambda@npm:3.427.0":
+"@aws-sdk/client-lambda@npm:^3.427.0":
   version: 3.427.0
   resolution: "@aws-sdk/client-lambda@npm:3.427.0"
   dependencies:
@@ -277,7 +277,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/client-sfn@npm:3.427.0":
+"@aws-sdk/client-sfn@npm:^3.427.0":
   version: 3.427.0
   resolution: "@aws-sdk/client-sfn@npm:3.427.0"
   dependencies:
@@ -527,7 +527,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/credential-providers@npm:3.427.0":
+"@aws-sdk/credential-providers@npm:^3.427.0":
   version: 3.427.0
   resolution: "@aws-sdk/credential-providers@npm:3.427.0"
   dependencies:
@@ -682,7 +682,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/types@npm:3.425.0":
+"@aws-sdk/types@npm:3.425.0, @aws-sdk/types@npm:^3.425.0":
   version: 3.425.0
   resolution: "@aws-sdk/types@npm:3.425.0"
   dependencies:
@@ -1855,19 +1855,19 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@datadog/datadog-ci@workspace:."
   dependencies:
-    "@aws-sdk/client-cloudwatch-logs": 3.427.0
-    "@aws-sdk/client-iam": 3.427.0
-    "@aws-sdk/client-lambda": 3.427.0
-    "@aws-sdk/client-sfn": 3.427.0
-    "@aws-sdk/credential-providers": 3.427.0
-    "@aws-sdk/types": 3.425.0
+    "@aws-sdk/client-cloudwatch-logs": ^3.427.0
+    "@aws-sdk/client-iam": ^3.427.0
+    "@aws-sdk/client-lambda": ^3.427.0
+    "@aws-sdk/client-sfn": ^3.427.0
+    "@aws-sdk/credential-providers": ^3.427.0
+    "@aws-sdk/types": ^3.425.0
     "@babel/core": 7.8.0
     "@babel/preset-env": 7.4.5
     "@babel/preset-typescript": 7.3.3
     "@google-cloud/logging": ^10.5.0
     "@google-cloud/run": ^0.6.0
     "@microsoft/eslint-formatter-sarif": ^3.0.0
-    "@smithy/property-provider": 2.0.12
+    "@smithy/property-provider": ^2.0.12
     "@types/async-retry": 1.4.2
     "@types/datadog-metrics": 0.6.1
     "@types/deep-extend": 0.4.31
@@ -3053,16 +3053,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/property-provider@npm:2.0.12, @smithy/property-provider@npm:^2.0.12":
-  version: 2.0.12
-  resolution: "@smithy/property-provider@npm:2.0.12"
-  dependencies:
-    "@smithy/types": ^2.3.5
-    tslib: ^2.5.0
-  checksum: 5d7afa158d66f4cd7f9561fbbb9adef987abfc490dfd5f0e5dcae5596611618f83a856273308f70e56347115a0f07ecc2f0eb434b4186725f8dc461b3be3cd5c
-  languageName: node
-  linkType: hard
-
 "@smithy/property-provider@npm:^2.0.0, @smithy/property-provider@npm:^2.0.3":
   version: 2.0.3
   resolution: "@smithy/property-provider@npm:2.0.3"
@@ -3070,6 +3060,16 @@ __metadata:
     "@smithy/types": ^2.2.0
     tslib: ^2.5.0
   checksum: 8b567a43c42f145c8585f4574174cc7a7b045c2d93085ba85abf8559a94787a68536b18c0ce689efc2c3894e7b9ce937cc567085429d3e1275e7e5a57af1f45b
+  languageName: node
+  linkType: hard
+
+"@smithy/property-provider@npm:^2.0.12":
+  version: 2.0.12
+  resolution: "@smithy/property-provider@npm:2.0.12"
+  dependencies:
+    "@smithy/types": ^2.3.5
+    tslib: ^2.5.0
+  checksum: 5d7afa158d66f4cd7f9561fbbb9adef987abfc490dfd5f0e5dcae5596611618f83a856273308f70e56347115a0f07ecc2f0eb434b4186725f8dc461b3be3cd5c
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -89,1123 +89,610 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/abort-controller@npm:3.357.0":
-  version: 3.357.0
-  resolution: "@aws-sdk/abort-controller@npm:3.357.0"
-  dependencies:
-    "@aws-sdk/types": 3.357.0
-    tslib: ^2.5.0
-  checksum: dee99ea164454db35f5a85deb0cec51b9d7065a1aa551c4ac7c0c8e2a538fd3827f9fd5812bd9576ce5dfd25a98fce1b26252d7a67d9ae864c65b5deb7f35a43
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/client-cloudwatch-logs@npm:^3.358.0":
-  version: 3.391.0
-  resolution: "@aws-sdk/client-cloudwatch-logs@npm:3.391.0"
+"@aws-sdk/client-cloudwatch-logs@npm:3.427.0":
+  version: 3.427.0
+  resolution: "@aws-sdk/client-cloudwatch-logs@npm:3.427.0"
   dependencies:
     "@aws-crypto/sha256-browser": 3.0.0
     "@aws-crypto/sha256-js": 3.0.0
-    "@aws-sdk/client-sts": 3.391.0
-    "@aws-sdk/credential-provider-node": 3.391.0
-    "@aws-sdk/middleware-host-header": 3.391.0
-    "@aws-sdk/middleware-logger": 3.391.0
-    "@aws-sdk/middleware-recursion-detection": 3.391.0
-    "@aws-sdk/middleware-signing": 3.391.0
-    "@aws-sdk/middleware-user-agent": 3.391.0
-    "@aws-sdk/types": 3.391.0
-    "@aws-sdk/util-endpoints": 3.391.0
-    "@aws-sdk/util-user-agent-browser": 3.391.0
-    "@aws-sdk/util-user-agent-node": 3.391.0
-    "@smithy/config-resolver": ^2.0.3
-    "@smithy/fetch-http-handler": ^2.0.3
-    "@smithy/hash-node": ^2.0.3
-    "@smithy/invalid-dependency": ^2.0.3
-    "@smithy/middleware-content-length": ^2.0.3
-    "@smithy/middleware-endpoint": ^2.0.3
-    "@smithy/middleware-retry": ^2.0.3
-    "@smithy/middleware-serde": ^2.0.3
-    "@smithy/middleware-stack": ^2.0.0
-    "@smithy/node-config-provider": ^2.0.3
-    "@smithy/node-http-handler": ^2.0.3
-    "@smithy/protocol-http": ^2.0.3
-    "@smithy/smithy-client": ^2.0.3
-    "@smithy/types": ^2.2.0
-    "@smithy/url-parser": ^2.0.3
+    "@aws-sdk/client-sts": 3.427.0
+    "@aws-sdk/credential-provider-node": 3.427.0
+    "@aws-sdk/middleware-host-header": 3.425.0
+    "@aws-sdk/middleware-logger": 3.425.0
+    "@aws-sdk/middleware-recursion-detection": 3.425.0
+    "@aws-sdk/middleware-signing": 3.425.0
+    "@aws-sdk/middleware-user-agent": 3.427.0
+    "@aws-sdk/region-config-resolver": 3.425.0
+    "@aws-sdk/types": 3.425.0
+    "@aws-sdk/util-endpoints": 3.427.0
+    "@aws-sdk/util-user-agent-browser": 3.425.0
+    "@aws-sdk/util-user-agent-node": 3.425.0
+    "@smithy/config-resolver": ^2.0.11
+    "@smithy/fetch-http-handler": ^2.2.1
+    "@smithy/hash-node": ^2.0.10
+    "@smithy/invalid-dependency": ^2.0.10
+    "@smithy/middleware-content-length": ^2.0.12
+    "@smithy/middleware-endpoint": ^2.0.10
+    "@smithy/middleware-retry": ^2.0.13
+    "@smithy/middleware-serde": ^2.0.10
+    "@smithy/middleware-stack": ^2.0.4
+    "@smithy/node-config-provider": ^2.0.13
+    "@smithy/node-http-handler": ^2.1.6
+    "@smithy/protocol-http": ^3.0.6
+    "@smithy/smithy-client": ^2.1.9
+    "@smithy/types": ^2.3.4
+    "@smithy/url-parser": ^2.0.10
     "@smithy/util-base64": ^2.0.0
     "@smithy/util-body-length-browser": ^2.0.0
-    "@smithy/util-body-length-node": ^2.0.0
-    "@smithy/util-defaults-mode-browser": ^2.0.3
-    "@smithy/util-defaults-mode-node": ^2.0.3
-    "@smithy/util-retry": ^2.0.0
+    "@smithy/util-body-length-node": ^2.1.0
+    "@smithy/util-defaults-mode-browser": ^2.0.13
+    "@smithy/util-defaults-mode-node": ^2.0.15
+    "@smithy/util-retry": ^2.0.3
     "@smithy/util-utf8": ^2.0.0
-    tslib: ^2.5.0
-  checksum: 35b73c8ec608da38a23032c95d86980da9bf8433aa5490c556d3fc2dfb29c387226c534f048eec245d6596c2fed04b5814d346949821e9652f361117797b126f
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/client-cognito-identity@npm:3.358.0":
-  version: 3.358.0
-  resolution: "@aws-sdk/client-cognito-identity@npm:3.358.0"
-  dependencies:
-    "@aws-crypto/sha256-browser": 3.0.0
-    "@aws-crypto/sha256-js": 3.0.0
-    "@aws-sdk/client-sts": 3.358.0
-    "@aws-sdk/config-resolver": 3.357.0
-    "@aws-sdk/credential-provider-node": 3.358.0
-    "@aws-sdk/fetch-http-handler": 3.357.0
-    "@aws-sdk/hash-node": 3.357.0
-    "@aws-sdk/invalid-dependency": 3.357.0
-    "@aws-sdk/middleware-content-length": 3.357.0
-    "@aws-sdk/middleware-endpoint": 3.357.0
-    "@aws-sdk/middleware-host-header": 3.357.0
-    "@aws-sdk/middleware-logger": 3.357.0
-    "@aws-sdk/middleware-recursion-detection": 3.357.0
-    "@aws-sdk/middleware-retry": 3.357.0
-    "@aws-sdk/middleware-serde": 3.357.0
-    "@aws-sdk/middleware-signing": 3.357.0
-    "@aws-sdk/middleware-stack": 3.357.0
-    "@aws-sdk/middleware-user-agent": 3.357.0
-    "@aws-sdk/node-config-provider": 3.357.0
-    "@aws-sdk/node-http-handler": 3.357.0
-    "@aws-sdk/smithy-client": 3.358.0
-    "@aws-sdk/types": 3.357.0
-    "@aws-sdk/url-parser": 3.357.0
-    "@aws-sdk/util-base64": 3.310.0
-    "@aws-sdk/util-body-length-browser": 3.310.0
-    "@aws-sdk/util-body-length-node": 3.310.0
-    "@aws-sdk/util-defaults-mode-browser": 3.358.0
-    "@aws-sdk/util-defaults-mode-node": 3.358.0
-    "@aws-sdk/util-endpoints": 3.357.0
-    "@aws-sdk/util-retry": 3.357.0
-    "@aws-sdk/util-user-agent-browser": 3.357.0
-    "@aws-sdk/util-user-agent-node": 3.357.0
-    "@aws-sdk/util-utf8": 3.310.0
-    "@smithy/protocol-http": ^1.0.1
-    "@smithy/types": ^1.0.0
-    tslib: ^2.5.0
-  checksum: cbc01289edd167250ca93f1b19970499be5a16b328bd8e8225fe7ca8d9774d0115632608130b9d099ba3ac230beb112f9e31f25bef13043424f7eac74b4a3d21
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/client-iam@npm:^3.358.0":
-  version: 3.391.0
-  resolution: "@aws-sdk/client-iam@npm:3.391.0"
-  dependencies:
-    "@aws-crypto/sha256-browser": 3.0.0
-    "@aws-crypto/sha256-js": 3.0.0
-    "@aws-sdk/client-sts": 3.391.0
-    "@aws-sdk/credential-provider-node": 3.391.0
-    "@aws-sdk/middleware-host-header": 3.391.0
-    "@aws-sdk/middleware-logger": 3.391.0
-    "@aws-sdk/middleware-recursion-detection": 3.391.0
-    "@aws-sdk/middleware-signing": 3.391.0
-    "@aws-sdk/middleware-user-agent": 3.391.0
-    "@aws-sdk/types": 3.391.0
-    "@aws-sdk/util-endpoints": 3.391.0
-    "@aws-sdk/util-user-agent-browser": 3.391.0
-    "@aws-sdk/util-user-agent-node": 3.391.0
-    "@smithy/config-resolver": ^2.0.3
-    "@smithy/fetch-http-handler": ^2.0.3
-    "@smithy/hash-node": ^2.0.3
-    "@smithy/invalid-dependency": ^2.0.3
-    "@smithy/middleware-content-length": ^2.0.3
-    "@smithy/middleware-endpoint": ^2.0.3
-    "@smithy/middleware-retry": ^2.0.3
-    "@smithy/middleware-serde": ^2.0.3
-    "@smithy/middleware-stack": ^2.0.0
-    "@smithy/node-config-provider": ^2.0.3
-    "@smithy/node-http-handler": ^2.0.3
-    "@smithy/protocol-http": ^2.0.3
-    "@smithy/smithy-client": ^2.0.3
-    "@smithy/types": ^2.2.0
-    "@smithy/url-parser": ^2.0.3
-    "@smithy/util-base64": ^2.0.0
-    "@smithy/util-body-length-browser": ^2.0.0
-    "@smithy/util-body-length-node": ^2.0.0
-    "@smithy/util-defaults-mode-browser": ^2.0.3
-    "@smithy/util-defaults-mode-node": ^2.0.3
-    "@smithy/util-retry": ^2.0.0
-    "@smithy/util-utf8": ^2.0.0
-    "@smithy/util-waiter": ^2.0.3
-    fast-xml-parser: 4.2.5
-    tslib: ^2.5.0
-  checksum: 54d77c5fadbbc863a5fb104cd0d99b837a58cd37f565b1871c5fc95fca074278f42ebe208ce25eb469f88e88657fc241fe03aad9cd807d41f1789f8bab672887
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/client-lambda@npm:^3.358.0":
-  version: 3.391.0
-  resolution: "@aws-sdk/client-lambda@npm:3.391.0"
-  dependencies:
-    "@aws-crypto/sha256-browser": 3.0.0
-    "@aws-crypto/sha256-js": 3.0.0
-    "@aws-sdk/client-sts": 3.391.0
-    "@aws-sdk/credential-provider-node": 3.391.0
-    "@aws-sdk/middleware-host-header": 3.391.0
-    "@aws-sdk/middleware-logger": 3.391.0
-    "@aws-sdk/middleware-recursion-detection": 3.391.0
-    "@aws-sdk/middleware-signing": 3.391.0
-    "@aws-sdk/middleware-user-agent": 3.391.0
-    "@aws-sdk/types": 3.391.0
-    "@aws-sdk/util-endpoints": 3.391.0
-    "@aws-sdk/util-user-agent-browser": 3.391.0
-    "@aws-sdk/util-user-agent-node": 3.391.0
-    "@smithy/config-resolver": ^2.0.3
-    "@smithy/eventstream-serde-browser": ^2.0.3
-    "@smithy/eventstream-serde-config-resolver": ^2.0.3
-    "@smithy/eventstream-serde-node": ^2.0.3
-    "@smithy/fetch-http-handler": ^2.0.3
-    "@smithy/hash-node": ^2.0.3
-    "@smithy/invalid-dependency": ^2.0.3
-    "@smithy/middleware-content-length": ^2.0.3
-    "@smithy/middleware-endpoint": ^2.0.3
-    "@smithy/middleware-retry": ^2.0.3
-    "@smithy/middleware-serde": ^2.0.3
-    "@smithy/middleware-stack": ^2.0.0
-    "@smithy/node-config-provider": ^2.0.3
-    "@smithy/node-http-handler": ^2.0.3
-    "@smithy/protocol-http": ^2.0.3
-    "@smithy/smithy-client": ^2.0.3
-    "@smithy/types": ^2.2.0
-    "@smithy/url-parser": ^2.0.3
-    "@smithy/util-base64": ^2.0.0
-    "@smithy/util-body-length-browser": ^2.0.0
-    "@smithy/util-body-length-node": ^2.0.0
-    "@smithy/util-defaults-mode-browser": ^2.0.3
-    "@smithy/util-defaults-mode-node": ^2.0.3
-    "@smithy/util-retry": ^2.0.0
-    "@smithy/util-stream": ^2.0.3
-    "@smithy/util-utf8": ^2.0.0
-    "@smithy/util-waiter": ^2.0.3
-    tslib: ^2.5.0
-  checksum: 712484fc8057a13db2a04037567c3ff49619b3844d9aef1a41c86406a8aaa1251fd3b8320dc84a63e95647f658ac99ea307fd2838ee075b8cb90b75c4d3cbbb9
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/client-sfn@npm:^3.358.0":
-  version: 3.391.0
-  resolution: "@aws-sdk/client-sfn@npm:3.391.0"
-  dependencies:
-    "@aws-crypto/sha256-browser": 3.0.0
-    "@aws-crypto/sha256-js": 3.0.0
-    "@aws-sdk/client-sts": 3.391.0
-    "@aws-sdk/credential-provider-node": 3.391.0
-    "@aws-sdk/middleware-host-header": 3.391.0
-    "@aws-sdk/middleware-logger": 3.391.0
-    "@aws-sdk/middleware-recursion-detection": 3.391.0
-    "@aws-sdk/middleware-signing": 3.391.0
-    "@aws-sdk/middleware-user-agent": 3.391.0
-    "@aws-sdk/types": 3.391.0
-    "@aws-sdk/util-endpoints": 3.391.0
-    "@aws-sdk/util-user-agent-browser": 3.391.0
-    "@aws-sdk/util-user-agent-node": 3.391.0
-    "@smithy/config-resolver": ^2.0.3
-    "@smithy/fetch-http-handler": ^2.0.3
-    "@smithy/hash-node": ^2.0.3
-    "@smithy/invalid-dependency": ^2.0.3
-    "@smithy/middleware-content-length": ^2.0.3
-    "@smithy/middleware-endpoint": ^2.0.3
-    "@smithy/middleware-retry": ^2.0.3
-    "@smithy/middleware-serde": ^2.0.3
-    "@smithy/middleware-stack": ^2.0.0
-    "@smithy/node-config-provider": ^2.0.3
-    "@smithy/node-http-handler": ^2.0.3
-    "@smithy/protocol-http": ^2.0.3
-    "@smithy/smithy-client": ^2.0.3
-    "@smithy/types": ^2.2.0
-    "@smithy/url-parser": ^2.0.3
-    "@smithy/util-base64": ^2.0.0
-    "@smithy/util-body-length-browser": ^2.0.0
-    "@smithy/util-body-length-node": ^2.0.0
-    "@smithy/util-defaults-mode-browser": ^2.0.3
-    "@smithy/util-defaults-mode-node": ^2.0.3
-    "@smithy/util-retry": ^2.0.0
-    "@smithy/util-utf8": ^2.0.0
-    tslib: ^2.5.0
-  checksum: a52fd4df7a87a38639b48951c59efc402c9256eb287f8bf581c076c30dfc5b75c1bd9c98546e65d442d6254b7a4409c77233e0a86e3a54f1497ea66694710d56
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/client-sso-oidc@npm:3.358.0":
-  version: 3.358.0
-  resolution: "@aws-sdk/client-sso-oidc@npm:3.358.0"
-  dependencies:
-    "@aws-crypto/sha256-browser": 3.0.0
-    "@aws-crypto/sha256-js": 3.0.0
-    "@aws-sdk/config-resolver": 3.357.0
-    "@aws-sdk/fetch-http-handler": 3.357.0
-    "@aws-sdk/hash-node": 3.357.0
-    "@aws-sdk/invalid-dependency": 3.357.0
-    "@aws-sdk/middleware-content-length": 3.357.0
-    "@aws-sdk/middleware-endpoint": 3.357.0
-    "@aws-sdk/middleware-host-header": 3.357.0
-    "@aws-sdk/middleware-logger": 3.357.0
-    "@aws-sdk/middleware-recursion-detection": 3.357.0
-    "@aws-sdk/middleware-retry": 3.357.0
-    "@aws-sdk/middleware-serde": 3.357.0
-    "@aws-sdk/middleware-stack": 3.357.0
-    "@aws-sdk/middleware-user-agent": 3.357.0
-    "@aws-sdk/node-config-provider": 3.357.0
-    "@aws-sdk/node-http-handler": 3.357.0
-    "@aws-sdk/smithy-client": 3.358.0
-    "@aws-sdk/types": 3.357.0
-    "@aws-sdk/url-parser": 3.357.0
-    "@aws-sdk/util-base64": 3.310.0
-    "@aws-sdk/util-body-length-browser": 3.310.0
-    "@aws-sdk/util-body-length-node": 3.310.0
-    "@aws-sdk/util-defaults-mode-browser": 3.358.0
-    "@aws-sdk/util-defaults-mode-node": 3.358.0
-    "@aws-sdk/util-endpoints": 3.357.0
-    "@aws-sdk/util-retry": 3.357.0
-    "@aws-sdk/util-user-agent-browser": 3.357.0
-    "@aws-sdk/util-user-agent-node": 3.357.0
-    "@aws-sdk/util-utf8": 3.310.0
-    "@smithy/protocol-http": ^1.0.1
-    "@smithy/types": ^1.0.0
-    tslib: ^2.5.0
-  checksum: 0453c965fef264f0d73789dbd7288813075e13d91d0992a3871e370f1fb1016c8d8bc0e8d1adef9edc658243047782d0438eac8fabc3e99661b8281858316fa5
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/client-sso@npm:3.358.0":
-  version: 3.358.0
-  resolution: "@aws-sdk/client-sso@npm:3.358.0"
-  dependencies:
-    "@aws-crypto/sha256-browser": 3.0.0
-    "@aws-crypto/sha256-js": 3.0.0
-    "@aws-sdk/config-resolver": 3.357.0
-    "@aws-sdk/fetch-http-handler": 3.357.0
-    "@aws-sdk/hash-node": 3.357.0
-    "@aws-sdk/invalid-dependency": 3.357.0
-    "@aws-sdk/middleware-content-length": 3.357.0
-    "@aws-sdk/middleware-endpoint": 3.357.0
-    "@aws-sdk/middleware-host-header": 3.357.0
-    "@aws-sdk/middleware-logger": 3.357.0
-    "@aws-sdk/middleware-recursion-detection": 3.357.0
-    "@aws-sdk/middleware-retry": 3.357.0
-    "@aws-sdk/middleware-serde": 3.357.0
-    "@aws-sdk/middleware-stack": 3.357.0
-    "@aws-sdk/middleware-user-agent": 3.357.0
-    "@aws-sdk/node-config-provider": 3.357.0
-    "@aws-sdk/node-http-handler": 3.357.0
-    "@aws-sdk/smithy-client": 3.358.0
-    "@aws-sdk/types": 3.357.0
-    "@aws-sdk/url-parser": 3.357.0
-    "@aws-sdk/util-base64": 3.310.0
-    "@aws-sdk/util-body-length-browser": 3.310.0
-    "@aws-sdk/util-body-length-node": 3.310.0
-    "@aws-sdk/util-defaults-mode-browser": 3.358.0
-    "@aws-sdk/util-defaults-mode-node": 3.358.0
-    "@aws-sdk/util-endpoints": 3.357.0
-    "@aws-sdk/util-retry": 3.357.0
-    "@aws-sdk/util-user-agent-browser": 3.357.0
-    "@aws-sdk/util-user-agent-node": 3.357.0
-    "@aws-sdk/util-utf8": 3.310.0
-    "@smithy/protocol-http": ^1.0.1
-    "@smithy/types": ^1.0.0
-    tslib: ^2.5.0
-  checksum: ee3371ad673ad69bbde5694396d7804a6e2c2a6144a095233e47eec325c17fc5f706909508fa9d7d93c2bef8a1a8849f99486f6c91b230d3fa0a9892135ff93b
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/client-sso@npm:3.391.0":
-  version: 3.391.0
-  resolution: "@aws-sdk/client-sso@npm:3.391.0"
-  dependencies:
-    "@aws-crypto/sha256-browser": 3.0.0
-    "@aws-crypto/sha256-js": 3.0.0
-    "@aws-sdk/middleware-host-header": 3.391.0
-    "@aws-sdk/middleware-logger": 3.391.0
-    "@aws-sdk/middleware-recursion-detection": 3.391.0
-    "@aws-sdk/middleware-user-agent": 3.391.0
-    "@aws-sdk/types": 3.391.0
-    "@aws-sdk/util-endpoints": 3.391.0
-    "@aws-sdk/util-user-agent-browser": 3.391.0
-    "@aws-sdk/util-user-agent-node": 3.391.0
-    "@smithy/config-resolver": ^2.0.3
-    "@smithy/fetch-http-handler": ^2.0.3
-    "@smithy/hash-node": ^2.0.3
-    "@smithy/invalid-dependency": ^2.0.3
-    "@smithy/middleware-content-length": ^2.0.3
-    "@smithy/middleware-endpoint": ^2.0.3
-    "@smithy/middleware-retry": ^2.0.3
-    "@smithy/middleware-serde": ^2.0.3
-    "@smithy/middleware-stack": ^2.0.0
-    "@smithy/node-config-provider": ^2.0.3
-    "@smithy/node-http-handler": ^2.0.3
-    "@smithy/protocol-http": ^2.0.3
-    "@smithy/smithy-client": ^2.0.3
-    "@smithy/types": ^2.2.0
-    "@smithy/url-parser": ^2.0.3
-    "@smithy/util-base64": ^2.0.0
-    "@smithy/util-body-length-browser": ^2.0.0
-    "@smithy/util-body-length-node": ^2.0.0
-    "@smithy/util-defaults-mode-browser": ^2.0.3
-    "@smithy/util-defaults-mode-node": ^2.0.3
-    "@smithy/util-retry": ^2.0.0
-    "@smithy/util-utf8": ^2.0.0
-    tslib: ^2.5.0
-  checksum: 6cfcc63d172ede2144924652ceb664839b7c5abe4085caadc878c99137561f0394eecb96c93c51f7ca6aa408bf7dfe4e03409f9e9a4349cef1e62a0e8b4991a8
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/client-sts@npm:3.358.0":
-  version: 3.358.0
-  resolution: "@aws-sdk/client-sts@npm:3.358.0"
-  dependencies:
-    "@aws-crypto/sha256-browser": 3.0.0
-    "@aws-crypto/sha256-js": 3.0.0
-    "@aws-sdk/config-resolver": 3.357.0
-    "@aws-sdk/credential-provider-node": 3.358.0
-    "@aws-sdk/fetch-http-handler": 3.357.0
-    "@aws-sdk/hash-node": 3.357.0
-    "@aws-sdk/invalid-dependency": 3.357.0
-    "@aws-sdk/middleware-content-length": 3.357.0
-    "@aws-sdk/middleware-endpoint": 3.357.0
-    "@aws-sdk/middleware-host-header": 3.357.0
-    "@aws-sdk/middleware-logger": 3.357.0
-    "@aws-sdk/middleware-recursion-detection": 3.357.0
-    "@aws-sdk/middleware-retry": 3.357.0
-    "@aws-sdk/middleware-sdk-sts": 3.357.0
-    "@aws-sdk/middleware-serde": 3.357.0
-    "@aws-sdk/middleware-signing": 3.357.0
-    "@aws-sdk/middleware-stack": 3.357.0
-    "@aws-sdk/middleware-user-agent": 3.357.0
-    "@aws-sdk/node-config-provider": 3.357.0
-    "@aws-sdk/node-http-handler": 3.357.0
-    "@aws-sdk/smithy-client": 3.358.0
-    "@aws-sdk/types": 3.357.0
-    "@aws-sdk/url-parser": 3.357.0
-    "@aws-sdk/util-base64": 3.310.0
-    "@aws-sdk/util-body-length-browser": 3.310.0
-    "@aws-sdk/util-body-length-node": 3.310.0
-    "@aws-sdk/util-defaults-mode-browser": 3.358.0
-    "@aws-sdk/util-defaults-mode-node": 3.358.0
-    "@aws-sdk/util-endpoints": 3.357.0
-    "@aws-sdk/util-retry": 3.357.0
-    "@aws-sdk/util-user-agent-browser": 3.357.0
-    "@aws-sdk/util-user-agent-node": 3.357.0
-    "@aws-sdk/util-utf8": 3.310.0
-    "@smithy/protocol-http": ^1.0.1
-    "@smithy/types": ^1.0.0
-    fast-xml-parser: 4.2.4
-    tslib: ^2.5.0
-  checksum: 71da447c9c4f6832fd22350fde9c2aec0cedc74e4e2b1248367960c7c366244e1413a24938f3d418db543b627618278ea5119f58d54e1f10763cb6282dd35715
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/client-sts@npm:3.391.0":
-  version: 3.391.0
-  resolution: "@aws-sdk/client-sts@npm:3.391.0"
-  dependencies:
-    "@aws-crypto/sha256-browser": 3.0.0
-    "@aws-crypto/sha256-js": 3.0.0
-    "@aws-sdk/credential-provider-node": 3.391.0
-    "@aws-sdk/middleware-host-header": 3.391.0
-    "@aws-sdk/middleware-logger": 3.391.0
-    "@aws-sdk/middleware-recursion-detection": 3.391.0
-    "@aws-sdk/middleware-sdk-sts": 3.391.0
-    "@aws-sdk/middleware-signing": 3.391.0
-    "@aws-sdk/middleware-user-agent": 3.391.0
-    "@aws-sdk/types": 3.391.0
-    "@aws-sdk/util-endpoints": 3.391.0
-    "@aws-sdk/util-user-agent-browser": 3.391.0
-    "@aws-sdk/util-user-agent-node": 3.391.0
-    "@smithy/config-resolver": ^2.0.3
-    "@smithy/fetch-http-handler": ^2.0.3
-    "@smithy/hash-node": ^2.0.3
-    "@smithy/invalid-dependency": ^2.0.3
-    "@smithy/middleware-content-length": ^2.0.3
-    "@smithy/middleware-endpoint": ^2.0.3
-    "@smithy/middleware-retry": ^2.0.3
-    "@smithy/middleware-serde": ^2.0.3
-    "@smithy/middleware-stack": ^2.0.0
-    "@smithy/node-config-provider": ^2.0.3
-    "@smithy/node-http-handler": ^2.0.3
-    "@smithy/protocol-http": ^2.0.3
-    "@smithy/smithy-client": ^2.0.3
-    "@smithy/types": ^2.2.0
-    "@smithy/url-parser": ^2.0.3
-    "@smithy/util-base64": ^2.0.0
-    "@smithy/util-body-length-browser": ^2.0.0
-    "@smithy/util-body-length-node": ^2.0.0
-    "@smithy/util-defaults-mode-browser": ^2.0.3
-    "@smithy/util-defaults-mode-node": ^2.0.3
-    "@smithy/util-retry": ^2.0.0
-    "@smithy/util-utf8": ^2.0.0
-    fast-xml-parser: 4.2.5
-    tslib: ^2.5.0
-  checksum: 5f4d1660a1c614ca89e4d35c440fbc58ed0c254fb0406a7165d3827fe6b0b990615995cd78816f746e985b405863eb7de0cabd085fe395ffb3c2739035913f40
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/config-resolver@npm:3.357.0":
-  version: 3.357.0
-  resolution: "@aws-sdk/config-resolver@npm:3.357.0"
-  dependencies:
-    "@aws-sdk/types": 3.357.0
-    "@aws-sdk/util-config-provider": 3.310.0
-    "@aws-sdk/util-middleware": 3.357.0
-    tslib: ^2.5.0
-  checksum: ea2d608b1a4257a8c70c12fec9bdc0ddc2ea8e2d61597053f8713677426aaf9ea2a2be2fdaea430f4b95c3d1c9830d5994db7c760a40cb066b3646fb14ff5339
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/credential-provider-cognito-identity@npm:3.358.0":
-  version: 3.358.0
-  resolution: "@aws-sdk/credential-provider-cognito-identity@npm:3.358.0"
-  dependencies:
-    "@aws-sdk/client-cognito-identity": 3.358.0
-    "@aws-sdk/property-provider": 3.357.0
-    "@aws-sdk/types": 3.357.0
-    tslib: ^2.5.0
-  checksum: 24c43c647382574fe8762578971a3e58ea3c79ca9bb08f5fe67d141d9c759af05a9b8ae4c3c9ffedbcfd4a49e813a688f88f9f4ffb6c9a62086f2d25e56d6099
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/credential-provider-env@npm:3.357.0":
-  version: 3.357.0
-  resolution: "@aws-sdk/credential-provider-env@npm:3.357.0"
-  dependencies:
-    "@aws-sdk/property-provider": 3.357.0
-    "@aws-sdk/types": 3.357.0
-    tslib: ^2.5.0
-  checksum: a998ea7661cf1650d8c69f5a910bf921e6e13b8c9c1a7f4c07a6be9f18313cd8946dc67f2d97a3433e319d47fec84becf7913a8b80d97827de7a360b5d19b7f0
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/credential-provider-env@npm:3.391.0":
-  version: 3.391.0
-  resolution: "@aws-sdk/credential-provider-env@npm:3.391.0"
-  dependencies:
-    "@aws-sdk/types": 3.391.0
-    "@smithy/property-provider": ^2.0.0
-    "@smithy/types": ^2.2.0
-    tslib: ^2.5.0
-  checksum: 08c797255225d26181687a355f3771d126914e58ed3532087535f88a5185439c273d80530e40540ea142613835f52fb6fe076324d1c356d452a2247a0a17a274
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/credential-provider-imds@npm:3.357.0":
-  version: 3.357.0
-  resolution: "@aws-sdk/credential-provider-imds@npm:3.357.0"
-  dependencies:
-    "@aws-sdk/node-config-provider": 3.357.0
-    "@aws-sdk/property-provider": 3.357.0
-    "@aws-sdk/types": 3.357.0
-    "@aws-sdk/url-parser": 3.357.0
-    tslib: ^2.5.0
-  checksum: 96c96d44471aed248a4d4f91a3b5c850fcf02a4cc2074a440ec6da7da56f85ee0a0b4f14e479d204d2228cb3737ecdf637d8b046ab8cc7d038d19a7dae57b0bc
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/credential-provider-ini@npm:3.358.0":
-  version: 3.358.0
-  resolution: "@aws-sdk/credential-provider-ini@npm:3.358.0"
-  dependencies:
-    "@aws-sdk/credential-provider-env": 3.357.0
-    "@aws-sdk/credential-provider-imds": 3.357.0
-    "@aws-sdk/credential-provider-process": 3.357.0
-    "@aws-sdk/credential-provider-sso": 3.358.0
-    "@aws-sdk/credential-provider-web-identity": 3.357.0
-    "@aws-sdk/property-provider": 3.357.0
-    "@aws-sdk/shared-ini-file-loader": 3.357.0
-    "@aws-sdk/types": 3.357.0
-    tslib: ^2.5.0
-  checksum: f7637e518ce98654c4c06d3cf01f35d7cdc22893b8a37fc522479b7324ba63f7362ea0b60dbb142573fa1148fa0b900791ad8a8361227170055122fec72e9b78
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/credential-provider-ini@npm:3.391.0":
-  version: 3.391.0
-  resolution: "@aws-sdk/credential-provider-ini@npm:3.391.0"
-  dependencies:
-    "@aws-sdk/credential-provider-env": 3.391.0
-    "@aws-sdk/credential-provider-process": 3.391.0
-    "@aws-sdk/credential-provider-sso": 3.391.0
-    "@aws-sdk/credential-provider-web-identity": 3.391.0
-    "@aws-sdk/types": 3.391.0
-    "@smithy/credential-provider-imds": ^2.0.0
-    "@smithy/property-provider": ^2.0.0
-    "@smithy/shared-ini-file-loader": ^2.0.0
-    "@smithy/types": ^2.2.0
-    tslib: ^2.5.0
-  checksum: d1832002b5c61a12bc9139db3a21b1baeaa358684118e518dceab08baccf8c134d32e0397f362357a4a3c468fdb74cc5978287b47d5414ec4fc5e14fe1a16a05
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/credential-provider-node@npm:3.358.0":
-  version: 3.358.0
-  resolution: "@aws-sdk/credential-provider-node@npm:3.358.0"
-  dependencies:
-    "@aws-sdk/credential-provider-env": 3.357.0
-    "@aws-sdk/credential-provider-imds": 3.357.0
-    "@aws-sdk/credential-provider-ini": 3.358.0
-    "@aws-sdk/credential-provider-process": 3.357.0
-    "@aws-sdk/credential-provider-sso": 3.358.0
-    "@aws-sdk/credential-provider-web-identity": 3.357.0
-    "@aws-sdk/property-provider": 3.357.0
-    "@aws-sdk/shared-ini-file-loader": 3.357.0
-    "@aws-sdk/types": 3.357.0
-    tslib: ^2.5.0
-  checksum: 5459a864680bb377a43625ce7af915bd9298251119df693a73324adcd2b3753aed20460a9c6cc146b796db00970d2bc6f3887c0ade217568d0e5dba043f7b21d
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/credential-provider-node@npm:3.391.0":
-  version: 3.391.0
-  resolution: "@aws-sdk/credential-provider-node@npm:3.391.0"
-  dependencies:
-    "@aws-sdk/credential-provider-env": 3.391.0
-    "@aws-sdk/credential-provider-ini": 3.391.0
-    "@aws-sdk/credential-provider-process": 3.391.0
-    "@aws-sdk/credential-provider-sso": 3.391.0
-    "@aws-sdk/credential-provider-web-identity": 3.391.0
-    "@aws-sdk/types": 3.391.0
-    "@smithy/credential-provider-imds": ^2.0.0
-    "@smithy/property-provider": ^2.0.0
-    "@smithy/shared-ini-file-loader": ^2.0.0
-    "@smithy/types": ^2.2.0
-    tslib: ^2.5.0
-  checksum: 92d1cdefdd3b11208ccac18373ea10fee78a3a71e45b8d06a1c5d8cff7e7738277075eeb166a7cdd31b7b6e2d3b28d50a0d17d38db622b392a095b86296a2649
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/credential-provider-process@npm:3.357.0":
-  version: 3.357.0
-  resolution: "@aws-sdk/credential-provider-process@npm:3.357.0"
-  dependencies:
-    "@aws-sdk/property-provider": 3.357.0
-    "@aws-sdk/shared-ini-file-loader": 3.357.0
-    "@aws-sdk/types": 3.357.0
-    tslib: ^2.5.0
-  checksum: 753f6d9ccd40cf4422aae8b5512c9f24fbded6e7e631c68673828214294c507e1322ac2e455fb43458cc97f3185681f555fdbb220ff2cf0a6b3fcfca366fddae
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/credential-provider-process@npm:3.391.0":
-  version: 3.391.0
-  resolution: "@aws-sdk/credential-provider-process@npm:3.391.0"
-  dependencies:
-    "@aws-sdk/types": 3.391.0
-    "@smithy/property-provider": ^2.0.0
-    "@smithy/shared-ini-file-loader": ^2.0.0
-    "@smithy/types": ^2.2.0
-    tslib: ^2.5.0
-  checksum: 67237867667f5f73d7ebc13b92f80f2c9fe58fa764dc7a7f9bb0a6d2c7060c4de014b9b718d07d79744804189f8d39fbe863034d21eda6ecc61f1e551d991532
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/credential-provider-sso@npm:3.358.0":
-  version: 3.358.0
-  resolution: "@aws-sdk/credential-provider-sso@npm:3.358.0"
-  dependencies:
-    "@aws-sdk/client-sso": 3.358.0
-    "@aws-sdk/property-provider": 3.357.0
-    "@aws-sdk/shared-ini-file-loader": 3.357.0
-    "@aws-sdk/token-providers": 3.358.0
-    "@aws-sdk/types": 3.357.0
-    tslib: ^2.5.0
-  checksum: a817f23af990765b511fb63889aa46beb624af7b95ffdef05a98e31b68eb3f8bfd8c7831c7eb92613e90d729e392cc5e6d055181785193c7fad75d65f239b72c
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/credential-provider-sso@npm:3.391.0":
-  version: 3.391.0
-  resolution: "@aws-sdk/credential-provider-sso@npm:3.391.0"
-  dependencies:
-    "@aws-sdk/client-sso": 3.391.0
-    "@aws-sdk/token-providers": 3.391.0
-    "@aws-sdk/types": 3.391.0
-    "@smithy/property-provider": ^2.0.0
-    "@smithy/shared-ini-file-loader": ^2.0.0
-    "@smithy/types": ^2.2.0
-    tslib: ^2.5.0
-  checksum: c6dcb8ccf4644e72f6628ccc1f166585dd5594a2aa6ec0640f3f2b36b254a811482cd5291116ad9f3667b0e536bfd29048f7f366702926b58279af3a580ca3ec
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/credential-provider-web-identity@npm:3.357.0":
-  version: 3.357.0
-  resolution: "@aws-sdk/credential-provider-web-identity@npm:3.357.0"
-  dependencies:
-    "@aws-sdk/property-provider": 3.357.0
-    "@aws-sdk/types": 3.357.0
-    tslib: ^2.5.0
-  checksum: 75625393c7a54169666eccc713eb7aa1c5d931680034c3785d4fadf70d281ff4e27132af0a6ae074c5d96f797bfe86e1c4bfd4a53865692c8bff1bf67d66271c
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/credential-provider-web-identity@npm:3.391.0":
-  version: 3.391.0
-  resolution: "@aws-sdk/credential-provider-web-identity@npm:3.391.0"
-  dependencies:
-    "@aws-sdk/types": 3.391.0
-    "@smithy/property-provider": ^2.0.0
-    "@smithy/types": ^2.2.0
-    tslib: ^2.5.0
-  checksum: e568db62051d848d801f4948ecbf5680926d342fce4c7a608df9f91e3c3ae20b6ff43647a2a24c52b711e324018b0dc02c461d36f679987f6acf9985bc76d737
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/credential-providers@npm:3.358.0":
-  version: 3.358.0
-  resolution: "@aws-sdk/credential-providers@npm:3.358.0"
-  dependencies:
-    "@aws-sdk/client-cognito-identity": 3.358.0
-    "@aws-sdk/client-sso": 3.358.0
-    "@aws-sdk/client-sts": 3.358.0
-    "@aws-sdk/credential-provider-cognito-identity": 3.358.0
-    "@aws-sdk/credential-provider-env": 3.357.0
-    "@aws-sdk/credential-provider-imds": 3.357.0
-    "@aws-sdk/credential-provider-ini": 3.358.0
-    "@aws-sdk/credential-provider-node": 3.358.0
-    "@aws-sdk/credential-provider-process": 3.357.0
-    "@aws-sdk/credential-provider-sso": 3.358.0
-    "@aws-sdk/credential-provider-web-identity": 3.357.0
-    "@aws-sdk/property-provider": 3.357.0
-    "@aws-sdk/types": 3.357.0
-    tslib: ^2.5.0
-  checksum: 0e8acaea94d5b0933ba331fbe0155cc5e247c8e2626c1f1c7ff5a42ad8b22f2d6baa82730d68aa2d8077f19ced058db777f1a0af103f06685f13b6eb086d8f15
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/eventstream-codec@npm:3.357.0":
-  version: 3.357.0
-  resolution: "@aws-sdk/eventstream-codec@npm:3.357.0"
-  dependencies:
-    "@aws-crypto/crc32": 3.0.0
-    "@aws-sdk/types": 3.357.0
-    "@aws-sdk/util-hex-encoding": 3.310.0
-    tslib: ^2.5.0
-  checksum: df05de4c42d47f46e3808030f0f190747350218d9a3733958810de2a43e3a4be8458cde27c1f9c7467b0ea65a5d668aa3c72418b3fdf66295c4a91ba07b2ea0e
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/fetch-http-handler@npm:3.357.0":
-  version: 3.357.0
-  resolution: "@aws-sdk/fetch-http-handler@npm:3.357.0"
-  dependencies:
-    "@aws-sdk/protocol-http": 3.357.0
-    "@aws-sdk/querystring-builder": 3.357.0
-    "@aws-sdk/types": 3.357.0
-    "@aws-sdk/util-base64": 3.310.0
-    tslib: ^2.5.0
-  checksum: c72a5e1bca33df01d2b4f827cf45a10c22fcc8d46b2728bfb17f5d1ffc4f6157855668082848969c3bd9930e871767e123d78d4a56e4b989ead97fe544ffb327
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/hash-node@npm:3.357.0":
-  version: 3.357.0
-  resolution: "@aws-sdk/hash-node@npm:3.357.0"
-  dependencies:
-    "@aws-sdk/types": 3.357.0
-    "@aws-sdk/util-buffer-from": 3.310.0
-    "@aws-sdk/util-utf8": 3.310.0
-    tslib: ^2.5.0
-  checksum: 295fbfd2099a393537067a313619d41b2efafae690f252e501c44e75ad4149df67c5e08786cb75f4e3e34b2f16871c4d1603ff8f91dcc9975137bf868e19a2cc
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/invalid-dependency@npm:3.357.0":
-  version: 3.357.0
-  resolution: "@aws-sdk/invalid-dependency@npm:3.357.0"
-  dependencies:
-    "@aws-sdk/types": 3.357.0
-    tslib: ^2.5.0
-  checksum: 203148201ea0957350231cf8c1821e6e11573dfb36c5648f30bf2a89955a754500d228f93a63a08299881be151301cf9fe8417353653fe582d8f4f82d28fc4d1
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/is-array-buffer@npm:3.310.0":
-  version: 3.310.0
-  resolution: "@aws-sdk/is-array-buffer@npm:3.310.0"
-  dependencies:
-    tslib: ^2.5.0
-  checksum: ddd1536ad16e29186fb5055bc279cfe9790b7c32552e1ee21e31d4e410e1df297b06c94c6117f854ec368d29e60a231dd8cc77e5b604a6260e7602876fd047f8
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/middleware-content-length@npm:3.357.0":
-  version: 3.357.0
-  resolution: "@aws-sdk/middleware-content-length@npm:3.357.0"
-  dependencies:
-    "@aws-sdk/protocol-http": 3.357.0
-    "@aws-sdk/types": 3.357.0
-    tslib: ^2.5.0
-  checksum: 308f5d7f1fa2e42c3bf3619d42cfa85ad47e1b219428e01ad21ad1ebc60ac1b416aabec1868f3ea30a81215cf3386c1dadb3b98e5e66280a092da3fa487774cc
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/middleware-endpoint@npm:3.357.0":
-  version: 3.357.0
-  resolution: "@aws-sdk/middleware-endpoint@npm:3.357.0"
-  dependencies:
-    "@aws-sdk/middleware-serde": 3.357.0
-    "@aws-sdk/types": 3.357.0
-    "@aws-sdk/url-parser": 3.357.0
-    "@aws-sdk/util-middleware": 3.357.0
-    tslib: ^2.5.0
-  checksum: 2085f37d237e33378ecce44703f9dca5b9f66b36b4bbbd4bb39e726ebce745d07ca948b1d6f9a2f832d75b4e67ec3254d89d26ded4596c5cf29aad827a0fa906
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/middleware-host-header@npm:3.357.0":
-  version: 3.357.0
-  resolution: "@aws-sdk/middleware-host-header@npm:3.357.0"
-  dependencies:
-    "@aws-sdk/protocol-http": 3.357.0
-    "@aws-sdk/types": 3.357.0
-    tslib: ^2.5.0
-  checksum: e8471d0ca23ca598a042704877069a81576c2fb743c37818cc09c9383431ecb7e2f32f4bdf22094011bec3ece3e8523f2a3a99b8f8b04e4cca0c871d4d7a8194
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/middleware-host-header@npm:3.391.0":
-  version: 3.391.0
-  resolution: "@aws-sdk/middleware-host-header@npm:3.391.0"
-  dependencies:
-    "@aws-sdk/types": 3.391.0
-    "@smithy/protocol-http": ^2.0.3
-    "@smithy/types": ^2.2.0
-    tslib: ^2.5.0
-  checksum: c8dc6fab8125da76b3f98192d10a15351f2b2afb17a5e9770e7b4039b1f80144c5ff2aaea5cfecdb94890df13fa700c51452e88f2ad2c1eb45445a1d5448ca4a
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/middleware-logger@npm:3.357.0":
-  version: 3.357.0
-  resolution: "@aws-sdk/middleware-logger@npm:3.357.0"
-  dependencies:
-    "@aws-sdk/types": 3.357.0
-    tslib: ^2.5.0
-  checksum: 0ee86f855ccebb31205b5f86e7b2baba71e2127d02d55ff630757d198ae40766458835ae247cae43a33030b6ba2b36f676ae8fc3935601d321bf6cd9515a1b2a
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/middleware-logger@npm:3.391.0":
-  version: 3.391.0
-  resolution: "@aws-sdk/middleware-logger@npm:3.391.0"
-  dependencies:
-    "@aws-sdk/types": 3.391.0
-    "@smithy/types": ^2.2.0
-    tslib: ^2.5.0
-  checksum: 81955beeadfef9e72df6852b9b5b50b79e9358ed4df672f6763ec29a706128cd176a8a02727e225828c6170b325255b14047db421560889e9d5c9e2860f74b02
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/middleware-recursion-detection@npm:3.357.0":
-  version: 3.357.0
-  resolution: "@aws-sdk/middleware-recursion-detection@npm:3.357.0"
-  dependencies:
-    "@aws-sdk/protocol-http": 3.357.0
-    "@aws-sdk/types": 3.357.0
-    tslib: ^2.5.0
-  checksum: 33625801a66eed9dc68ea0ccb4689b5a26ae3e5aa39d790c241f534aa8c1da9650a7fd607333e24f0aa59d9d8c9c57de16e31ff5d100298edb0238aec79b5bb1
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/middleware-recursion-detection@npm:3.391.0":
-  version: 3.391.0
-  resolution: "@aws-sdk/middleware-recursion-detection@npm:3.391.0"
-  dependencies:
-    "@aws-sdk/types": 3.391.0
-    "@smithy/protocol-http": ^2.0.3
-    "@smithy/types": ^2.2.0
-    tslib: ^2.5.0
-  checksum: 3eab16f976594dd25260a6852f207ab83fff27866acef67019dae017d1326af5cf948bd5d8eb5f681add1c9e663adfef1235483dae7208cfa38872b92aef2f57
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/middleware-retry@npm:3.357.0":
-  version: 3.357.0
-  resolution: "@aws-sdk/middleware-retry@npm:3.357.0"
-  dependencies:
-    "@aws-sdk/protocol-http": 3.357.0
-    "@aws-sdk/service-error-classification": 3.357.0
-    "@aws-sdk/types": 3.357.0
-    "@aws-sdk/util-middleware": 3.357.0
-    "@aws-sdk/util-retry": 3.357.0
     tslib: ^2.5.0
     uuid: ^8.3.2
-  checksum: bf9d0143af03431bb28c24d055780711774ef312c710ae4b58d846924a7d35571a7c2bd4e5a7e1ac219b791ba0af259df06ba139df478a2e7a53004e7712ca47
+  checksum: e7054141ecfa42566602a908d9b9e19b1a1fb90d438545ac53530f23b8d9fada15c2fbdbd8543402862230f999a4b88b2cfa646a7692f51b0df248d07bcac530
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-sdk-sts@npm:3.357.0":
-  version: 3.357.0
-  resolution: "@aws-sdk/middleware-sdk-sts@npm:3.357.0"
-  dependencies:
-    "@aws-sdk/middleware-signing": 3.357.0
-    "@aws-sdk/types": 3.357.0
-    tslib: ^2.5.0
-  checksum: 138a7f8a397529a05c1316bc0c39339678ed6025b9a356126129136e078cfa48b79ead194f5354cb7089cedd787b1a9927e6fb9fd01bd4f42bed78df02204c6e
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/middleware-sdk-sts@npm:3.391.0":
-  version: 3.391.0
-  resolution: "@aws-sdk/middleware-sdk-sts@npm:3.391.0"
-  dependencies:
-    "@aws-sdk/middleware-signing": 3.391.0
-    "@aws-sdk/types": 3.391.0
-    "@smithy/types": ^2.2.0
-    tslib: ^2.5.0
-  checksum: dd6f1572ea4306f6add42902743eaa4325ad47e7d497961578d104ae9c96c0bca10521ab2c7e723896ccb85f14ec38d866218c7582a6acd394df75ff5fc8ee24
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/middleware-serde@npm:3.357.0":
-  version: 3.357.0
-  resolution: "@aws-sdk/middleware-serde@npm:3.357.0"
-  dependencies:
-    "@aws-sdk/types": 3.357.0
-    tslib: ^2.5.0
-  checksum: 259176f253efc144130494f9dcaafdf5ff0a1d60158619ef300146775ab68622289908a15d1131ee8c7f92235a6ce40df4c80fdc930a8e45eb2635a6e241ac9e
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/middleware-signing@npm:3.357.0":
-  version: 3.357.0
-  resolution: "@aws-sdk/middleware-signing@npm:3.357.0"
-  dependencies:
-    "@aws-sdk/property-provider": 3.357.0
-    "@aws-sdk/protocol-http": 3.357.0
-    "@aws-sdk/signature-v4": 3.357.0
-    "@aws-sdk/types": 3.357.0
-    "@aws-sdk/util-middleware": 3.357.0
-    tslib: ^2.5.0
-  checksum: 416c8472606f6139bcf548d3c45582b0cfadf0da114c63a90fc26aa0301ce1743e5ce93517dfccb1e8756f4c9925c3b2e485b7a1a7853c418061c827be01a2c0
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/middleware-signing@npm:3.391.0":
-  version: 3.391.0
-  resolution: "@aws-sdk/middleware-signing@npm:3.391.0"
-  dependencies:
-    "@aws-sdk/types": 3.391.0
-    "@smithy/property-provider": ^2.0.0
-    "@smithy/protocol-http": ^2.0.3
-    "@smithy/signature-v4": ^2.0.0
-    "@smithy/types": ^2.2.0
-    "@smithy/util-middleware": ^2.0.0
-    tslib: ^2.5.0
-  checksum: aa76b0aeac670cffc472f7d7197edef2656d155bab38ebcfdb17f7573bdd23ecbf2cb29cbcf97cd15643bdf5cf7ed4cf5fb020db598e42e81e6502140669057e
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/middleware-stack@npm:3.357.0":
-  version: 3.357.0
-  resolution: "@aws-sdk/middleware-stack@npm:3.357.0"
-  dependencies:
-    tslib: ^2.5.0
-  checksum: bb5507ee38e60b8a8fbf3fc7215be710d379c54d7132c78005892563b1e3e0169c00187ec482808a7b68edcefb7a2a420a47f7813dc627f2747703cfee9b99e0
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/middleware-user-agent@npm:3.357.0":
-  version: 3.357.0
-  resolution: "@aws-sdk/middleware-user-agent@npm:3.357.0"
-  dependencies:
-    "@aws-sdk/protocol-http": 3.357.0
-    "@aws-sdk/types": 3.357.0
-    "@aws-sdk/util-endpoints": 3.357.0
-    tslib: ^2.5.0
-  checksum: e80a6fce7974f79769349ee9c2fc6744a18d1998e7e66b3eb24196390a5605837cf5fd75b4e9636566353d5fb26c840628ea8e451045af66c0112469ce20debb
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/middleware-user-agent@npm:3.391.0":
-  version: 3.391.0
-  resolution: "@aws-sdk/middleware-user-agent@npm:3.391.0"
-  dependencies:
-    "@aws-sdk/types": 3.391.0
-    "@aws-sdk/util-endpoints": 3.391.0
-    "@smithy/protocol-http": ^2.0.3
-    "@smithy/types": ^2.2.0
-    tslib: ^2.5.0
-  checksum: 33cda72f937173c6770976c233d627d587d2c943a70126b6eebd6225fb7ee982ad96e0c3125bb231b4b6f5bbd0da392ebded1149194aa952fe325d2cd993386e
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/node-config-provider@npm:3.357.0":
-  version: 3.357.0
-  resolution: "@aws-sdk/node-config-provider@npm:3.357.0"
-  dependencies:
-    "@aws-sdk/property-provider": 3.357.0
-    "@aws-sdk/shared-ini-file-loader": 3.357.0
-    "@aws-sdk/types": 3.357.0
-    tslib: ^2.5.0
-  checksum: 39784541ffdabc6298c42f3e4c308c75e92636b1228f6338d9820d2a6ee6ebb77dacd92e42f739004db6299024d85e80c0191f8c49045f1f00451aedc2136786
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/node-http-handler@npm:3.357.0":
-  version: 3.357.0
-  resolution: "@aws-sdk/node-http-handler@npm:3.357.0"
-  dependencies:
-    "@aws-sdk/abort-controller": 3.357.0
-    "@aws-sdk/protocol-http": 3.357.0
-    "@aws-sdk/querystring-builder": 3.357.0
-    "@aws-sdk/types": 3.357.0
-    tslib: ^2.5.0
-  checksum: 535fe5699b1013f84c47fdefe99659c9eebda6bdac09a83d486438a3c4a3c2b5985a6e5f9184ba49624615d5886013c1c6bfe5e7bd4063f31b95665797c98fb6
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/property-provider@npm:3.357.0":
-  version: 3.357.0
-  resolution: "@aws-sdk/property-provider@npm:3.357.0"
-  dependencies:
-    "@aws-sdk/types": 3.357.0
-    tslib: ^2.5.0
-  checksum: 311c00ef9c20810ea18b6772d3f37853469453fd31b1b41d841ecfd6a7f34f2ba2189df954bc094c5ff764bd75bc39ce003f208260334b40b8394f8f2665cd93
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/protocol-http@npm:3.357.0":
-  version: 3.357.0
-  resolution: "@aws-sdk/protocol-http@npm:3.357.0"
-  dependencies:
-    "@aws-sdk/types": 3.357.0
-    tslib: ^2.5.0
-  checksum: 2abc03c76b729b98b37a489ee6592d8620e02c17584c304e91161194d7d4273bf9f8a7e330d52be2f8f8c787db63db99d7865494fb85f07327ffc54b99712b07
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/querystring-builder@npm:3.357.0":
-  version: 3.357.0
-  resolution: "@aws-sdk/querystring-builder@npm:3.357.0"
-  dependencies:
-    "@aws-sdk/types": 3.357.0
-    "@aws-sdk/util-uri-escape": 3.310.0
-    tslib: ^2.5.0
-  checksum: f3b8b10ff997eade4ec632be937afdd6d44b7eb15b9ff64d21d31ba6c9f64f90263de2ba904660faa20dbb2b73c3a0193744b78ba2b42a757e28fd41be11d63e
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/querystring-parser@npm:3.357.0":
-  version: 3.357.0
-  resolution: "@aws-sdk/querystring-parser@npm:3.357.0"
-  dependencies:
-    "@aws-sdk/types": 3.357.0
-    tslib: ^2.5.0
-  checksum: 57097dda2499991efd00c3773c8ecd5d75d0e0d9a5106e3e8f4649f008d47eb87b01b067ceaee1ae73202a3cdf62458b713fa92cdf309e7d73bdcaffed54b4c7
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/service-error-classification@npm:3.357.0":
-  version: 3.357.0
-  resolution: "@aws-sdk/service-error-classification@npm:3.357.0"
-  checksum: a29638c7724a94e6a8baf2c6249d647239a5ff3863f677a023a93c40e4658f00a98cd29e68bf9bcede9f4b85cd7970a9e9bfda410708695312d26d71cde6d6cf
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/shared-ini-file-loader@npm:3.357.0":
-  version: 3.357.0
-  resolution: "@aws-sdk/shared-ini-file-loader@npm:3.357.0"
-  dependencies:
-    "@aws-sdk/types": 3.357.0
-    tslib: ^2.5.0
-  checksum: c0be3ef2b74e07abdc7e49a1b2997cb22965af92bd1ca45808c19a54ab4c4ac9444dc69008cdae7d4abe74f38b3c32a08bccc218274df377969ea4bf6839dca9
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/signature-v4@npm:3.357.0":
-  version: 3.357.0
-  resolution: "@aws-sdk/signature-v4@npm:3.357.0"
-  dependencies:
-    "@aws-sdk/eventstream-codec": 3.357.0
-    "@aws-sdk/is-array-buffer": 3.310.0
-    "@aws-sdk/types": 3.357.0
-    "@aws-sdk/util-hex-encoding": 3.310.0
-    "@aws-sdk/util-middleware": 3.357.0
-    "@aws-sdk/util-uri-escape": 3.310.0
-    "@aws-sdk/util-utf8": 3.310.0
-    tslib: ^2.5.0
-  checksum: 8ef865093e6d60a1b6fcb28c4b0a06e34ed1013dedcc0f8aa35d2e300d48c6e6df00564146111b5f1b58197a4f4c68bedcb5330f4a8fc7a24db302eb21e23782
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/smithy-client@npm:3.358.0":
-  version: 3.358.0
-  resolution: "@aws-sdk/smithy-client@npm:3.358.0"
-  dependencies:
-    "@aws-sdk/middleware-stack": 3.357.0
-    "@aws-sdk/types": 3.357.0
-    "@aws-sdk/util-stream": 3.358.0
-    "@smithy/types": ^1.0.0
-    tslib: ^2.5.0
-  checksum: 3db71a638ef10fb05e5e10d578014594cd77ccd0b6fba5771e7314b6f1e1d1fcee0ba61ffb9dd6f964480764ef9d0b6af091f6522cb8c44754a767c9d0629087
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/token-providers@npm:3.358.0":
-  version: 3.358.0
-  resolution: "@aws-sdk/token-providers@npm:3.358.0"
-  dependencies:
-    "@aws-sdk/client-sso-oidc": 3.358.0
-    "@aws-sdk/property-provider": 3.357.0
-    "@aws-sdk/shared-ini-file-loader": 3.357.0
-    "@aws-sdk/types": 3.357.0
-    tslib: ^2.5.0
-  checksum: 3038d2be78dade462c52761e37154231e5a5a531f732ecb7f7074ea7b7a84af91917113133539c85e08e262dc9d41257c22ca9d2233221e531709413c23b55d1
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/token-providers@npm:3.391.0":
-  version: 3.391.0
-  resolution: "@aws-sdk/token-providers@npm:3.391.0"
+"@aws-sdk/client-cognito-identity@npm:3.427.0":
+  version: 3.427.0
+  resolution: "@aws-sdk/client-cognito-identity@npm:3.427.0"
   dependencies:
     "@aws-crypto/sha256-browser": 3.0.0
     "@aws-crypto/sha256-js": 3.0.0
-    "@aws-sdk/middleware-host-header": 3.391.0
-    "@aws-sdk/middleware-logger": 3.391.0
-    "@aws-sdk/middleware-recursion-detection": 3.391.0
-    "@aws-sdk/middleware-user-agent": 3.391.0
-    "@aws-sdk/types": 3.391.0
-    "@aws-sdk/util-endpoints": 3.391.0
-    "@aws-sdk/util-user-agent-browser": 3.391.0
-    "@aws-sdk/util-user-agent-node": 3.391.0
-    "@smithy/config-resolver": ^2.0.3
-    "@smithy/fetch-http-handler": ^2.0.3
-    "@smithy/hash-node": ^2.0.3
-    "@smithy/invalid-dependency": ^2.0.3
-    "@smithy/middleware-content-length": ^2.0.3
-    "@smithy/middleware-endpoint": ^2.0.3
-    "@smithy/middleware-retry": ^2.0.3
-    "@smithy/middleware-serde": ^2.0.3
-    "@smithy/middleware-stack": ^2.0.0
-    "@smithy/node-config-provider": ^2.0.3
-    "@smithy/node-http-handler": ^2.0.3
-    "@smithy/property-provider": ^2.0.0
-    "@smithy/protocol-http": ^2.0.3
-    "@smithy/shared-ini-file-loader": ^2.0.0
-    "@smithy/smithy-client": ^2.0.3
-    "@smithy/types": ^2.2.0
-    "@smithy/url-parser": ^2.0.3
+    "@aws-sdk/client-sts": 3.427.0
+    "@aws-sdk/credential-provider-node": 3.427.0
+    "@aws-sdk/middleware-host-header": 3.425.0
+    "@aws-sdk/middleware-logger": 3.425.0
+    "@aws-sdk/middleware-recursion-detection": 3.425.0
+    "@aws-sdk/middleware-signing": 3.425.0
+    "@aws-sdk/middleware-user-agent": 3.427.0
+    "@aws-sdk/region-config-resolver": 3.425.0
+    "@aws-sdk/types": 3.425.0
+    "@aws-sdk/util-endpoints": 3.427.0
+    "@aws-sdk/util-user-agent-browser": 3.425.0
+    "@aws-sdk/util-user-agent-node": 3.425.0
+    "@smithy/config-resolver": ^2.0.11
+    "@smithy/fetch-http-handler": ^2.2.1
+    "@smithy/hash-node": ^2.0.10
+    "@smithy/invalid-dependency": ^2.0.10
+    "@smithy/middleware-content-length": ^2.0.12
+    "@smithy/middleware-endpoint": ^2.0.10
+    "@smithy/middleware-retry": ^2.0.13
+    "@smithy/middleware-serde": ^2.0.10
+    "@smithy/middleware-stack": ^2.0.4
+    "@smithy/node-config-provider": ^2.0.13
+    "@smithy/node-http-handler": ^2.1.6
+    "@smithy/protocol-http": ^3.0.6
+    "@smithy/smithy-client": ^2.1.9
+    "@smithy/types": ^2.3.4
+    "@smithy/url-parser": ^2.0.10
     "@smithy/util-base64": ^2.0.0
     "@smithy/util-body-length-browser": ^2.0.0
-    "@smithy/util-body-length-node": ^2.0.0
-    "@smithy/util-defaults-mode-browser": ^2.0.3
-    "@smithy/util-defaults-mode-node": ^2.0.3
-    "@smithy/util-retry": ^2.0.0
+    "@smithy/util-body-length-node": ^2.1.0
+    "@smithy/util-defaults-mode-browser": ^2.0.13
+    "@smithy/util-defaults-mode-node": ^2.0.15
+    "@smithy/util-retry": ^2.0.3
     "@smithy/util-utf8": ^2.0.0
     tslib: ^2.5.0
-  checksum: 4d929e006519fb25ee337a459f6e0dca6aa0a1e1a839605d8a3857b37b7aa77a032a6810a65023b2802827bf3190940dbee1e585bf86edfb2541be753bea1989
+  checksum: 08d042e3b8082fbe81d673e18f3b4880228910393afacbf1e673fae0210e730c6390fd1029e96babde43486f95a2e7879181d48623b7e046e92a094e2e9a1674
   languageName: node
   linkType: hard
 
-"@aws-sdk/types@npm:3.357.0":
-  version: 3.357.0
-  resolution: "@aws-sdk/types@npm:3.357.0"
+"@aws-sdk/client-iam@npm:3.427.0":
+  version: 3.427.0
+  resolution: "@aws-sdk/client-iam@npm:3.427.0"
   dependencies:
+    "@aws-crypto/sha256-browser": 3.0.0
+    "@aws-crypto/sha256-js": 3.0.0
+    "@aws-sdk/client-sts": 3.427.0
+    "@aws-sdk/credential-provider-node": 3.427.0
+    "@aws-sdk/middleware-host-header": 3.425.0
+    "@aws-sdk/middleware-logger": 3.425.0
+    "@aws-sdk/middleware-recursion-detection": 3.425.0
+    "@aws-sdk/middleware-signing": 3.425.0
+    "@aws-sdk/middleware-user-agent": 3.427.0
+    "@aws-sdk/region-config-resolver": 3.425.0
+    "@aws-sdk/types": 3.425.0
+    "@aws-sdk/util-endpoints": 3.427.0
+    "@aws-sdk/util-user-agent-browser": 3.425.0
+    "@aws-sdk/util-user-agent-node": 3.425.0
+    "@smithy/config-resolver": ^2.0.11
+    "@smithy/fetch-http-handler": ^2.2.1
+    "@smithy/hash-node": ^2.0.10
+    "@smithy/invalid-dependency": ^2.0.10
+    "@smithy/middleware-content-length": ^2.0.12
+    "@smithy/middleware-endpoint": ^2.0.10
+    "@smithy/middleware-retry": ^2.0.13
+    "@smithy/middleware-serde": ^2.0.10
+    "@smithy/middleware-stack": ^2.0.4
+    "@smithy/node-config-provider": ^2.0.13
+    "@smithy/node-http-handler": ^2.1.6
+    "@smithy/protocol-http": ^3.0.6
+    "@smithy/smithy-client": ^2.1.9
+    "@smithy/types": ^2.3.4
+    "@smithy/url-parser": ^2.0.10
+    "@smithy/util-base64": ^2.0.0
+    "@smithy/util-body-length-browser": ^2.0.0
+    "@smithy/util-body-length-node": ^2.1.0
+    "@smithy/util-defaults-mode-browser": ^2.0.13
+    "@smithy/util-defaults-mode-node": ^2.0.15
+    "@smithy/util-retry": ^2.0.3
+    "@smithy/util-utf8": ^2.0.0
+    "@smithy/util-waiter": ^2.0.10
+    fast-xml-parser: 4.2.5
     tslib: ^2.5.0
-  checksum: 41001b0ea7af2e09daca87f2fedb992bddd864f27f70c70acd62f95bc949ae0637f7100f2cff7a5618291d77c2146f157a863a2d7a4d2576ba2d6882fd4a75bd
+  checksum: 2a8a467cec5e5d5421caacbf6c906893c78ad14434bc0d4d51091182fbcb291c4dd13477dddfd7546ff9650f05ae13daebcb8f0fa7205c8482e3ccfa3db33629
   languageName: node
   linkType: hard
 
-"@aws-sdk/types@npm:3.391.0, @aws-sdk/types@npm:^3.222.0, @aws-sdk/types@npm:^3.357.0":
+"@aws-sdk/client-lambda@npm:3.427.0":
+  version: 3.427.0
+  resolution: "@aws-sdk/client-lambda@npm:3.427.0"
+  dependencies:
+    "@aws-crypto/sha256-browser": 3.0.0
+    "@aws-crypto/sha256-js": 3.0.0
+    "@aws-sdk/client-sts": 3.427.0
+    "@aws-sdk/credential-provider-node": 3.427.0
+    "@aws-sdk/middleware-host-header": 3.425.0
+    "@aws-sdk/middleware-logger": 3.425.0
+    "@aws-sdk/middleware-recursion-detection": 3.425.0
+    "@aws-sdk/middleware-signing": 3.425.0
+    "@aws-sdk/middleware-user-agent": 3.427.0
+    "@aws-sdk/region-config-resolver": 3.425.0
+    "@aws-sdk/types": 3.425.0
+    "@aws-sdk/util-endpoints": 3.427.0
+    "@aws-sdk/util-user-agent-browser": 3.425.0
+    "@aws-sdk/util-user-agent-node": 3.425.0
+    "@smithy/config-resolver": ^2.0.11
+    "@smithy/eventstream-serde-browser": ^2.0.10
+    "@smithy/eventstream-serde-config-resolver": ^2.0.10
+    "@smithy/eventstream-serde-node": ^2.0.10
+    "@smithy/fetch-http-handler": ^2.2.1
+    "@smithy/hash-node": ^2.0.10
+    "@smithy/invalid-dependency": ^2.0.10
+    "@smithy/middleware-content-length": ^2.0.12
+    "@smithy/middleware-endpoint": ^2.0.10
+    "@smithy/middleware-retry": ^2.0.13
+    "@smithy/middleware-serde": ^2.0.10
+    "@smithy/middleware-stack": ^2.0.4
+    "@smithy/node-config-provider": ^2.0.13
+    "@smithy/node-http-handler": ^2.1.6
+    "@smithy/protocol-http": ^3.0.6
+    "@smithy/smithy-client": ^2.1.9
+    "@smithy/types": ^2.3.4
+    "@smithy/url-parser": ^2.0.10
+    "@smithy/util-base64": ^2.0.0
+    "@smithy/util-body-length-browser": ^2.0.0
+    "@smithy/util-body-length-node": ^2.1.0
+    "@smithy/util-defaults-mode-browser": ^2.0.13
+    "@smithy/util-defaults-mode-node": ^2.0.15
+    "@smithy/util-retry": ^2.0.3
+    "@smithy/util-stream": ^2.0.14
+    "@smithy/util-utf8": ^2.0.0
+    "@smithy/util-waiter": ^2.0.10
+    tslib: ^2.5.0
+  checksum: 14151f0243359cbd77ca0000cbcefab0141848f8e3a35a710217d1b25907ae7fc343434a1e225ab05ed87f1b14c4715b76ad79bc5264dd9476ad0a0edab80a19
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/client-sfn@npm:3.427.0":
+  version: 3.427.0
+  resolution: "@aws-sdk/client-sfn@npm:3.427.0"
+  dependencies:
+    "@aws-crypto/sha256-browser": 3.0.0
+    "@aws-crypto/sha256-js": 3.0.0
+    "@aws-sdk/client-sts": 3.427.0
+    "@aws-sdk/credential-provider-node": 3.427.0
+    "@aws-sdk/middleware-host-header": 3.425.0
+    "@aws-sdk/middleware-logger": 3.425.0
+    "@aws-sdk/middleware-recursion-detection": 3.425.0
+    "@aws-sdk/middleware-signing": 3.425.0
+    "@aws-sdk/middleware-user-agent": 3.427.0
+    "@aws-sdk/region-config-resolver": 3.425.0
+    "@aws-sdk/types": 3.425.0
+    "@aws-sdk/util-endpoints": 3.427.0
+    "@aws-sdk/util-user-agent-browser": 3.425.0
+    "@aws-sdk/util-user-agent-node": 3.425.0
+    "@smithy/config-resolver": ^2.0.11
+    "@smithy/fetch-http-handler": ^2.2.1
+    "@smithy/hash-node": ^2.0.10
+    "@smithy/invalid-dependency": ^2.0.10
+    "@smithy/middleware-content-length": ^2.0.12
+    "@smithy/middleware-endpoint": ^2.0.10
+    "@smithy/middleware-retry": ^2.0.13
+    "@smithy/middleware-serde": ^2.0.10
+    "@smithy/middleware-stack": ^2.0.4
+    "@smithy/node-config-provider": ^2.0.13
+    "@smithy/node-http-handler": ^2.1.6
+    "@smithy/protocol-http": ^3.0.6
+    "@smithy/smithy-client": ^2.1.9
+    "@smithy/types": ^2.3.4
+    "@smithy/url-parser": ^2.0.10
+    "@smithy/util-base64": ^2.0.0
+    "@smithy/util-body-length-browser": ^2.0.0
+    "@smithy/util-body-length-node": ^2.1.0
+    "@smithy/util-defaults-mode-browser": ^2.0.13
+    "@smithy/util-defaults-mode-node": ^2.0.15
+    "@smithy/util-retry": ^2.0.3
+    "@smithy/util-utf8": ^2.0.0
+    tslib: ^2.5.0
+  checksum: ebb7c5081936544a1b53cf1ce25265e1a90ea6e7631d42280c4d80bc8e30d2da6657820791c6ec02ec3fda5e8c356edbaac36f3525bdc3a8b2f698e5232b7f4c
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/client-sso@npm:3.427.0":
+  version: 3.427.0
+  resolution: "@aws-sdk/client-sso@npm:3.427.0"
+  dependencies:
+    "@aws-crypto/sha256-browser": 3.0.0
+    "@aws-crypto/sha256-js": 3.0.0
+    "@aws-sdk/middleware-host-header": 3.425.0
+    "@aws-sdk/middleware-logger": 3.425.0
+    "@aws-sdk/middleware-recursion-detection": 3.425.0
+    "@aws-sdk/middleware-user-agent": 3.427.0
+    "@aws-sdk/region-config-resolver": 3.425.0
+    "@aws-sdk/types": 3.425.0
+    "@aws-sdk/util-endpoints": 3.427.0
+    "@aws-sdk/util-user-agent-browser": 3.425.0
+    "@aws-sdk/util-user-agent-node": 3.425.0
+    "@smithy/config-resolver": ^2.0.11
+    "@smithy/fetch-http-handler": ^2.2.1
+    "@smithy/hash-node": ^2.0.10
+    "@smithy/invalid-dependency": ^2.0.10
+    "@smithy/middleware-content-length": ^2.0.12
+    "@smithy/middleware-endpoint": ^2.0.10
+    "@smithy/middleware-retry": ^2.0.13
+    "@smithy/middleware-serde": ^2.0.10
+    "@smithy/middleware-stack": ^2.0.4
+    "@smithy/node-config-provider": ^2.0.13
+    "@smithy/node-http-handler": ^2.1.6
+    "@smithy/protocol-http": ^3.0.6
+    "@smithy/smithy-client": ^2.1.9
+    "@smithy/types": ^2.3.4
+    "@smithy/url-parser": ^2.0.10
+    "@smithy/util-base64": ^2.0.0
+    "@smithy/util-body-length-browser": ^2.0.0
+    "@smithy/util-body-length-node": ^2.1.0
+    "@smithy/util-defaults-mode-browser": ^2.0.13
+    "@smithy/util-defaults-mode-node": ^2.0.15
+    "@smithy/util-retry": ^2.0.3
+    "@smithy/util-utf8": ^2.0.0
+    tslib: ^2.5.0
+  checksum: 2f7764167f80b933b6acfd9d0cdceecfb6394f2701dc3bed382e1c76b632a626e2e8e4306b5058ace42346d2fc156ca59d7d4771ba22f2f83e6a6be12d01a0b8
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/client-sts@npm:3.427.0":
+  version: 3.427.0
+  resolution: "@aws-sdk/client-sts@npm:3.427.0"
+  dependencies:
+    "@aws-crypto/sha256-browser": 3.0.0
+    "@aws-crypto/sha256-js": 3.0.0
+    "@aws-sdk/credential-provider-node": 3.427.0
+    "@aws-sdk/middleware-host-header": 3.425.0
+    "@aws-sdk/middleware-logger": 3.425.0
+    "@aws-sdk/middleware-recursion-detection": 3.425.0
+    "@aws-sdk/middleware-sdk-sts": 3.425.0
+    "@aws-sdk/middleware-signing": 3.425.0
+    "@aws-sdk/middleware-user-agent": 3.427.0
+    "@aws-sdk/region-config-resolver": 3.425.0
+    "@aws-sdk/types": 3.425.0
+    "@aws-sdk/util-endpoints": 3.427.0
+    "@aws-sdk/util-user-agent-browser": 3.425.0
+    "@aws-sdk/util-user-agent-node": 3.425.0
+    "@smithy/config-resolver": ^2.0.11
+    "@smithy/fetch-http-handler": ^2.2.1
+    "@smithy/hash-node": ^2.0.10
+    "@smithy/invalid-dependency": ^2.0.10
+    "@smithy/middleware-content-length": ^2.0.12
+    "@smithy/middleware-endpoint": ^2.0.10
+    "@smithy/middleware-retry": ^2.0.13
+    "@smithy/middleware-serde": ^2.0.10
+    "@smithy/middleware-stack": ^2.0.4
+    "@smithy/node-config-provider": ^2.0.13
+    "@smithy/node-http-handler": ^2.1.6
+    "@smithy/protocol-http": ^3.0.6
+    "@smithy/smithy-client": ^2.1.9
+    "@smithy/types": ^2.3.4
+    "@smithy/url-parser": ^2.0.10
+    "@smithy/util-base64": ^2.0.0
+    "@smithy/util-body-length-browser": ^2.0.0
+    "@smithy/util-body-length-node": ^2.1.0
+    "@smithy/util-defaults-mode-browser": ^2.0.13
+    "@smithy/util-defaults-mode-node": ^2.0.15
+    "@smithy/util-retry": ^2.0.3
+    "@smithy/util-utf8": ^2.0.0
+    fast-xml-parser: 4.2.5
+    tslib: ^2.5.0
+  checksum: 7bfa24538fd47b68847c48b39b15aae66b640db44d7689a884587f137d386d67843b5c28e1945adb8fdf007e09ca3ade70e1e5d655175950296b602a8fd90b72
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/credential-provider-cognito-identity@npm:3.427.0":
+  version: 3.427.0
+  resolution: "@aws-sdk/credential-provider-cognito-identity@npm:3.427.0"
+  dependencies:
+    "@aws-sdk/client-cognito-identity": 3.427.0
+    "@aws-sdk/types": 3.425.0
+    "@smithy/property-provider": ^2.0.0
+    "@smithy/types": ^2.3.4
+    tslib: ^2.5.0
+  checksum: e0342f1d1dbc05de538caac5c2f545963306d96bcdaaa8fbcb16bf840bbf46e6667ceae5dd643ac4718ab2f597fba20b52048a87ae62181ab860889b8dbce3df
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/credential-provider-env@npm:3.425.0":
+  version: 3.425.0
+  resolution: "@aws-sdk/credential-provider-env@npm:3.425.0"
+  dependencies:
+    "@aws-sdk/types": 3.425.0
+    "@smithy/property-provider": ^2.0.0
+    "@smithy/types": ^2.3.4
+    tslib: ^2.5.0
+  checksum: 286d372686e7de3fa35f52564db616c50831ab6502fafd4156fd87bf28e0e90db3847a1b4e29499eeb9c38f6145d809c0e693096b5f1076c2a9b0fce56aa9051
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/credential-provider-http@npm:3.425.0":
+  version: 3.425.0
+  resolution: "@aws-sdk/credential-provider-http@npm:3.425.0"
+  dependencies:
+    "@aws-sdk/types": 3.425.0
+    "@smithy/fetch-http-handler": ^2.2.1
+    "@smithy/node-http-handler": ^2.1.6
+    "@smithy/property-provider": ^2.0.0
+    "@smithy/protocol-http": ^3.0.6
+    "@smithy/types": ^2.3.4
+    tslib: ^2.5.0
+  checksum: 59d6cf873ff7df9d4253c3a3a4c954c2ab190a72053468ab1b252235e949c8fa09826c5e382f93702ae3c4753c1386356cc2d80ae2bb42b40da0070010a90db0
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/credential-provider-ini@npm:3.427.0":
+  version: 3.427.0
+  resolution: "@aws-sdk/credential-provider-ini@npm:3.427.0"
+  dependencies:
+    "@aws-sdk/credential-provider-env": 3.425.0
+    "@aws-sdk/credential-provider-process": 3.425.0
+    "@aws-sdk/credential-provider-sso": 3.427.0
+    "@aws-sdk/credential-provider-web-identity": 3.425.0
+    "@aws-sdk/types": 3.425.0
+    "@smithy/credential-provider-imds": ^2.0.0
+    "@smithy/property-provider": ^2.0.0
+    "@smithy/shared-ini-file-loader": ^2.0.6
+    "@smithy/types": ^2.3.4
+    tslib: ^2.5.0
+  checksum: 3a0f92ff5ace8f803c3004fd016e853e035085b936df3b23fb4a847d28166e3fbf9447c743646df79661ec523366c16a9e46b6176526232b82574b59b2bd09a6
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/credential-provider-node@npm:3.427.0":
+  version: 3.427.0
+  resolution: "@aws-sdk/credential-provider-node@npm:3.427.0"
+  dependencies:
+    "@aws-sdk/credential-provider-env": 3.425.0
+    "@aws-sdk/credential-provider-ini": 3.427.0
+    "@aws-sdk/credential-provider-process": 3.425.0
+    "@aws-sdk/credential-provider-sso": 3.427.0
+    "@aws-sdk/credential-provider-web-identity": 3.425.0
+    "@aws-sdk/types": 3.425.0
+    "@smithy/credential-provider-imds": ^2.0.0
+    "@smithy/property-provider": ^2.0.0
+    "@smithy/shared-ini-file-loader": ^2.0.6
+    "@smithy/types": ^2.3.4
+    tslib: ^2.5.0
+  checksum: acd2205d94037523967c5fea3904169d32e907a9da7dab796e413d93c665ddbce1ba4408563c3fe7b2a6726cda39d264b08ca016102e660c75cbf2875dd41ed4
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/credential-provider-process@npm:3.425.0":
+  version: 3.425.0
+  resolution: "@aws-sdk/credential-provider-process@npm:3.425.0"
+  dependencies:
+    "@aws-sdk/types": 3.425.0
+    "@smithy/property-provider": ^2.0.0
+    "@smithy/shared-ini-file-loader": ^2.0.6
+    "@smithy/types": ^2.3.4
+    tslib: ^2.5.0
+  checksum: 010b0d1c11d0c85e7a2ed758eefb968bfb6be96d217f0f7bf5352abb7c019ddcaaa74e15fbd2445ea701ec14a5062c36f639619c7a16a06eea8038b652335ef0
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/credential-provider-sso@npm:3.427.0":
+  version: 3.427.0
+  resolution: "@aws-sdk/credential-provider-sso@npm:3.427.0"
+  dependencies:
+    "@aws-sdk/client-sso": 3.427.0
+    "@aws-sdk/token-providers": 3.427.0
+    "@aws-sdk/types": 3.425.0
+    "@smithy/property-provider": ^2.0.0
+    "@smithy/shared-ini-file-loader": ^2.0.6
+    "@smithy/types": ^2.3.4
+    tslib: ^2.5.0
+  checksum: 265a0000c6d184aca93aeab7740618a934ef7b31e8f5a2750c618984c0bef956b413886dc4886d38dd4595dfea6c95164ae2d6bddfb66febc33144c79fdf4441
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/credential-provider-web-identity@npm:3.425.0":
+  version: 3.425.0
+  resolution: "@aws-sdk/credential-provider-web-identity@npm:3.425.0"
+  dependencies:
+    "@aws-sdk/types": 3.425.0
+    "@smithy/property-provider": ^2.0.0
+    "@smithy/types": ^2.3.4
+    tslib: ^2.5.0
+  checksum: 097474425b56d9d109fffcb2d8ee46289eaf7c31d0629cd8cd9a0d063bd46f0f4a60bcbfc7c7e1a39bb81a3ad6526b414219939da51a776509ca29ddfdcb30d0
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/credential-providers@npm:3.427.0":
+  version: 3.427.0
+  resolution: "@aws-sdk/credential-providers@npm:3.427.0"
+  dependencies:
+    "@aws-sdk/client-cognito-identity": 3.427.0
+    "@aws-sdk/client-sso": 3.427.0
+    "@aws-sdk/client-sts": 3.427.0
+    "@aws-sdk/credential-provider-cognito-identity": 3.427.0
+    "@aws-sdk/credential-provider-env": 3.425.0
+    "@aws-sdk/credential-provider-http": 3.425.0
+    "@aws-sdk/credential-provider-ini": 3.427.0
+    "@aws-sdk/credential-provider-node": 3.427.0
+    "@aws-sdk/credential-provider-process": 3.425.0
+    "@aws-sdk/credential-provider-sso": 3.427.0
+    "@aws-sdk/credential-provider-web-identity": 3.425.0
+    "@aws-sdk/types": 3.425.0
+    "@smithy/credential-provider-imds": ^2.0.0
+    "@smithy/property-provider": ^2.0.0
+    "@smithy/types": ^2.3.4
+    tslib: ^2.5.0
+  checksum: 72b40465f340373f96a843c19b54f4945691be2ac7d90f4ed8ef58cd5a9efc798df35eb3753a9f9f0d0532864dc437e4f7181dae27118684cdc90057da9490c1
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/middleware-host-header@npm:3.425.0":
+  version: 3.425.0
+  resolution: "@aws-sdk/middleware-host-header@npm:3.425.0"
+  dependencies:
+    "@aws-sdk/types": 3.425.0
+    "@smithy/protocol-http": ^3.0.6
+    "@smithy/types": ^2.3.4
+    tslib: ^2.5.0
+  checksum: d9b477b31480ccf7d15d2769411cbed28e08caf5aa7fa5e96c771998325f769154bdf9356e5354d03b77bb459971b9399fec6e3c9fc764e1591964142041bb4c
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/middleware-logger@npm:3.425.0":
+  version: 3.425.0
+  resolution: "@aws-sdk/middleware-logger@npm:3.425.0"
+  dependencies:
+    "@aws-sdk/types": 3.425.0
+    "@smithy/types": ^2.3.4
+    tslib: ^2.5.0
+  checksum: 406622466ba0ed4f531bd2cb27628da83993df1476e3375743cb2ba896e553b4211632034e6b9b290e1c9796067010192fe52c8bf3b73dceab8bbd85cc2a39c0
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/middleware-recursion-detection@npm:3.425.0":
+  version: 3.425.0
+  resolution: "@aws-sdk/middleware-recursion-detection@npm:3.425.0"
+  dependencies:
+    "@aws-sdk/types": 3.425.0
+    "@smithy/protocol-http": ^3.0.6
+    "@smithy/types": ^2.3.4
+    tslib: ^2.5.0
+  checksum: ab845ad59db5bf0048f59d990c5163feb9f5e8dd65792d4a560fd1eff88f10ba7677bb5f71135054e7f0e83f0049e749b5cc62f4e5f37a55d002b552d61c72b3
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/middleware-sdk-sts@npm:3.425.0":
+  version: 3.425.0
+  resolution: "@aws-sdk/middleware-sdk-sts@npm:3.425.0"
+  dependencies:
+    "@aws-sdk/middleware-signing": 3.425.0
+    "@aws-sdk/types": 3.425.0
+    "@smithy/types": ^2.3.4
+    tslib: ^2.5.0
+  checksum: e99e4c7b6e00f0ccfb2c23ec580a3b932dfe8daa7c6f15821714157b34393f96bd7f0576e37a17821dff458ad047820e5837035b6f7b8e0db1fc4d1527dfd76b
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/middleware-signing@npm:3.425.0":
+  version: 3.425.0
+  resolution: "@aws-sdk/middleware-signing@npm:3.425.0"
+  dependencies:
+    "@aws-sdk/types": 3.425.0
+    "@smithy/property-provider": ^2.0.0
+    "@smithy/protocol-http": ^3.0.6
+    "@smithy/signature-v4": ^2.0.0
+    "@smithy/types": ^2.3.4
+    "@smithy/util-middleware": ^2.0.3
+    tslib: ^2.5.0
+  checksum: 34996415395cdbcc67051c21421e70d4648402b745278976d228500885848a7219e37b9ed22d75a94ab594477ca32f59526e763fa6a1458414ae2749f7bb8a70
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/middleware-user-agent@npm:3.427.0":
+  version: 3.427.0
+  resolution: "@aws-sdk/middleware-user-agent@npm:3.427.0"
+  dependencies:
+    "@aws-sdk/types": 3.425.0
+    "@aws-sdk/util-endpoints": 3.427.0
+    "@smithy/protocol-http": ^3.0.6
+    "@smithy/types": ^2.3.4
+    tslib: ^2.5.0
+  checksum: d0ae32f6b5d457931668743842ef93891f1585d467355f6cf65d1e61d987c96fdc463f52101f90231a15ece6c5787e8d62eb90f6f6b490d1ff22f756ead3ccf7
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/region-config-resolver@npm:3.425.0":
+  version: 3.425.0
+  resolution: "@aws-sdk/region-config-resolver@npm:3.425.0"
+  dependencies:
+    "@smithy/node-config-provider": ^2.0.13
+    "@smithy/types": ^2.3.4
+    "@smithy/util-config-provider": ^2.0.0
+    "@smithy/util-middleware": ^2.0.3
+    tslib: ^2.5.0
+  checksum: 00241c54c5ff83f82dc45443c18a67515fe99aff54e7f234b3897551cb90fc6b341afc0a7cc30267463ace6d4ed398782faec584829de23115cb9a8301b74738
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/token-providers@npm:3.427.0":
+  version: 3.427.0
+  resolution: "@aws-sdk/token-providers@npm:3.427.0"
+  dependencies:
+    "@aws-crypto/sha256-browser": 3.0.0
+    "@aws-crypto/sha256-js": 3.0.0
+    "@aws-sdk/middleware-host-header": 3.425.0
+    "@aws-sdk/middleware-logger": 3.425.0
+    "@aws-sdk/middleware-recursion-detection": 3.425.0
+    "@aws-sdk/middleware-user-agent": 3.427.0
+    "@aws-sdk/types": 3.425.0
+    "@aws-sdk/util-endpoints": 3.427.0
+    "@aws-sdk/util-user-agent-browser": 3.425.0
+    "@aws-sdk/util-user-agent-node": 3.425.0
+    "@smithy/config-resolver": ^2.0.11
+    "@smithy/fetch-http-handler": ^2.2.1
+    "@smithy/hash-node": ^2.0.10
+    "@smithy/invalid-dependency": ^2.0.10
+    "@smithy/middleware-content-length": ^2.0.12
+    "@smithy/middleware-endpoint": ^2.0.10
+    "@smithy/middleware-retry": ^2.0.13
+    "@smithy/middleware-serde": ^2.0.10
+    "@smithy/middleware-stack": ^2.0.4
+    "@smithy/node-config-provider": ^2.0.13
+    "@smithy/node-http-handler": ^2.1.6
+    "@smithy/property-provider": ^2.0.0
+    "@smithy/protocol-http": ^3.0.6
+    "@smithy/shared-ini-file-loader": ^2.0.6
+    "@smithy/smithy-client": ^2.1.9
+    "@smithy/types": ^2.3.4
+    "@smithy/url-parser": ^2.0.10
+    "@smithy/util-base64": ^2.0.0
+    "@smithy/util-body-length-browser": ^2.0.0
+    "@smithy/util-body-length-node": ^2.1.0
+    "@smithy/util-defaults-mode-browser": ^2.0.13
+    "@smithy/util-defaults-mode-node": ^2.0.15
+    "@smithy/util-retry": ^2.0.3
+    "@smithy/util-utf8": ^2.0.0
+    tslib: ^2.5.0
+  checksum: d19dabbb575ec416d60112b4c4dd360ddc77231a054d43a91778ca922fbc05d6c25392a0781147322fd463c67362c9240155acd1d9754dbd5d023cb2381fb105
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/types@npm:3.425.0":
+  version: 3.425.0
+  resolution: "@aws-sdk/types@npm:3.425.0"
+  dependencies:
+    "@smithy/types": ^2.3.4
+    tslib: ^2.5.0
+  checksum: 82ab4741179a16cc90ff75549bf07c7174cf4d0db9b3c2e1d7283c7489eb41a1ec49607d4c7bb33975e6424dfb809783ff0e243d721d4544dc21b7b31d94acc0
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/types@npm:^3.222.0":
   version: 3.391.0
   resolution: "@aws-sdk/types@npm:3.391.0"
   dependencies:
@@ -1215,116 +702,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/url-parser@npm:3.357.0":
-  version: 3.357.0
-  resolution: "@aws-sdk/url-parser@npm:3.357.0"
+"@aws-sdk/util-endpoints@npm:3.427.0":
+  version: 3.427.0
+  resolution: "@aws-sdk/util-endpoints@npm:3.427.0"
   dependencies:
-    "@aws-sdk/querystring-parser": 3.357.0
-    "@aws-sdk/types": 3.357.0
+    "@aws-sdk/types": 3.425.0
+    "@smithy/node-config-provider": ^2.0.13
     tslib: ^2.5.0
-  checksum: ff57a09fb603cf2a3f14f3f45bb09fec7ccd8c4afc525ca6a0c3e25858a3afbf1adb4024ff33292d12103207663e7c8a7c0eda03e6701173d5f8ab817e2190f8
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/util-base64@npm:3.310.0":
-  version: 3.310.0
-  resolution: "@aws-sdk/util-base64@npm:3.310.0"
-  dependencies:
-    "@aws-sdk/util-buffer-from": 3.310.0
-    tslib: ^2.5.0
-  checksum: 3c9f7c818401fe8332d2ce438c0660cc9be7db9a5eef68d7fafa30ddcc44b0af3ba9ea58092f0e2b2537a18ec0942ce3c8f12090d3e3b9568b6a94a0713e9de7
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/util-body-length-browser@npm:3.310.0":
-  version: 3.310.0
-  resolution: "@aws-sdk/util-body-length-browser@npm:3.310.0"
-  dependencies:
-    tslib: ^2.5.0
-  checksum: c26136521ccbb59ba83ff29d6e52cb0e4b443b68e830c9dab578556539973573e6892093e5dea39101b1517c28b5d53c80ee38b9a01f9fa9fcd75f3aa5689857
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/util-body-length-node@npm:3.310.0":
-  version: 3.310.0
-  resolution: "@aws-sdk/util-body-length-node@npm:3.310.0"
-  dependencies:
-    tslib: ^2.5.0
-  checksum: 202417ece7078f09f63c4119cb3ab5f321688ea893125f7d97985e8bf7fc61419d8d990f870d9ead3281dc51334975196ef98c50592eca1f9785472bd39b870d
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/util-buffer-from@npm:3.310.0":
-  version: 3.310.0
-  resolution: "@aws-sdk/util-buffer-from@npm:3.310.0"
-  dependencies:
-    "@aws-sdk/is-array-buffer": 3.310.0
-    tslib: ^2.5.0
-  checksum: 9c3bd9c0664a0cbb5270eb285a662274bb9c46ae0d79e0275a85e74659a4b1f094bab900994780fd70dd0152dc6d2d33a8bc681d87f3911fa48eae9f6c3558d6
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/util-config-provider@npm:3.310.0":
-  version: 3.310.0
-  resolution: "@aws-sdk/util-config-provider@npm:3.310.0"
-  dependencies:
-    tslib: ^2.5.0
-  checksum: 958efc58ee492111ad746fe6224b25286da415f8aca1197c742bca063672b858d437d2d6b4df5f90ba770e1af9339b3fb1ffa9cc87f2fa993a7177057eb22caf
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/util-defaults-mode-browser@npm:3.358.0":
-  version: 3.358.0
-  resolution: "@aws-sdk/util-defaults-mode-browser@npm:3.358.0"
-  dependencies:
-    "@aws-sdk/property-provider": 3.357.0
-    "@aws-sdk/types": 3.357.0
-    bowser: ^2.11.0
-    tslib: ^2.5.0
-  checksum: 39af5ddcac5411cdacbc477f0f9c61c51a73d967c376dc97c0e6b5ef0b5b6948e73d67118b3d8594d0fdbd99a47c62c0a5b3a832bcf64fd7cab8dc4e9fb52a98
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/util-defaults-mode-node@npm:3.358.0":
-  version: 3.358.0
-  resolution: "@aws-sdk/util-defaults-mode-node@npm:3.358.0"
-  dependencies:
-    "@aws-sdk/config-resolver": 3.357.0
-    "@aws-sdk/credential-provider-imds": 3.357.0
-    "@aws-sdk/node-config-provider": 3.357.0
-    "@aws-sdk/property-provider": 3.357.0
-    "@aws-sdk/types": 3.357.0
-    tslib: ^2.5.0
-  checksum: 04c046290b515aec7dd27b1b6a45274922e714d96ffc21b02775e2f1053d907e12080a009d504bf6265df0c9db48b99ea3d06e2e2790c8b6131c7e426b22cb59
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/util-endpoints@npm:3.357.0":
-  version: 3.357.0
-  resolution: "@aws-sdk/util-endpoints@npm:3.357.0"
-  dependencies:
-    "@aws-sdk/types": 3.357.0
-    tslib: ^2.5.0
-  checksum: dcbe4a4ee0fe4490c64465c1dbaaf67d1da38fbc2e8d95e44f50dc4cc94c378b5d1e561c77d5d1c30bb89fb39891e24f1d3778dd8b1fda9305bc3529e3174fe5
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/util-endpoints@npm:3.391.0":
-  version: 3.391.0
-  resolution: "@aws-sdk/util-endpoints@npm:3.391.0"
-  dependencies:
-    "@aws-sdk/types": 3.391.0
-    tslib: ^2.5.0
-  checksum: fa2a096d21ea2944e5c0a87e22c78f84c3383941a8b85b7e48ccc9c2a623a458f0e5de8150eede33bbe37b3a7e93d2089824bd1dc4c3d3d49c77b45ffcb412d9
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/util-hex-encoding@npm:3.310.0":
-  version: 3.310.0
-  resolution: "@aws-sdk/util-hex-encoding@npm:3.310.0"
-  dependencies:
-    tslib: ^2.5.0
-  checksum: 97b8d7e0e406189cdbd4fccb0a497dd247a22d54b18caf5a64a63d19d2535b95a64ee79ecf81b13f741bda1d565eb11448d4fd39617e4b86fc8626b05485d98c
+  checksum: 823a8c77f0c31a5075505c0a59b0e9086b395505073e47885358f9d00a3f2cb40576d63b260f31bebb784191cb8b374608b8942d665cd432745e11f819af202a
   languageName: node
   linkType: hard
 
@@ -1337,103 +722,32 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/util-middleware@npm:3.357.0":
-  version: 3.357.0
-  resolution: "@aws-sdk/util-middleware@npm:3.357.0"
+"@aws-sdk/util-user-agent-browser@npm:3.425.0":
+  version: 3.425.0
+  resolution: "@aws-sdk/util-user-agent-browser@npm:3.425.0"
   dependencies:
-    tslib: ^2.5.0
-  checksum: 62d92b864a0b6843c83b838a5a850adfe551323ef2cf4d7510ff38f552b1483f09e8caa17f6e6eecf963c57302173e38f682016d45d87a68540b7adf3ec9a9a2
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/util-retry@npm:3.357.0":
-  version: 3.357.0
-  resolution: "@aws-sdk/util-retry@npm:3.357.0"
-  dependencies:
-    "@aws-sdk/service-error-classification": 3.357.0
-    tslib: ^2.5.0
-  checksum: f88181bfd1d03ab765467fdc8912e448d1b838f2852841f69ffd5537f62759bdfed88fbc9a8f8360957f233c6b0c3278eb2694bc742f587a91f5045cd0621c86
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/util-stream@npm:3.358.0":
-  version: 3.358.0
-  resolution: "@aws-sdk/util-stream@npm:3.358.0"
-  dependencies:
-    "@aws-sdk/fetch-http-handler": 3.357.0
-    "@aws-sdk/node-http-handler": 3.357.0
-    "@aws-sdk/types": 3.357.0
-    "@aws-sdk/util-base64": 3.310.0
-    "@aws-sdk/util-buffer-from": 3.310.0
-    "@aws-sdk/util-hex-encoding": 3.310.0
-    "@aws-sdk/util-utf8": 3.310.0
-    tslib: ^2.5.0
-  checksum: 6bb0beba2aa7f93e00b304545072529118327f136ddb9a9eafdd36c82626d71435566cb7471547dff56629cd82e501a0451254b510206d568c1ad50ba0a8b2cc
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/util-uri-escape@npm:3.310.0":
-  version: 3.310.0
-  resolution: "@aws-sdk/util-uri-escape@npm:3.310.0"
-  dependencies:
-    tslib: ^2.5.0
-  checksum: 614c0a43b238b7371b6655a5961e21c57b708de3e1ce3138bd56284bedc48888e5c7d2a6965544108c3334fcdc45e9ddba86b2470c8e6901559ad7be8e21d418
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/util-user-agent-browser@npm:3.357.0":
-  version: 3.357.0
-  resolution: "@aws-sdk/util-user-agent-browser@npm:3.357.0"
-  dependencies:
-    "@aws-sdk/types": 3.357.0
+    "@aws-sdk/types": 3.425.0
+    "@smithy/types": ^2.3.4
     bowser: ^2.11.0
     tslib: ^2.5.0
-  checksum: ff41369496116bf9c754030a9679e2eac390eeb5ab88cc49b5df06aa564e156c71eace3458b9bf8e62a8f203c7e431475f498c138276649a6f9c549a0c6e252a
+  checksum: 2f75c2bc97d9dc07f50ffe270408aa1d3ebd9e67de8a180e26776f64f9ca397ca9c3ffc21c677dfa4a917f5399f10ae8766f7c94478eaf31e11431d8189e8734
   languageName: node
   linkType: hard
 
-"@aws-sdk/util-user-agent-browser@npm:3.391.0":
-  version: 3.391.0
-  resolution: "@aws-sdk/util-user-agent-browser@npm:3.391.0"
+"@aws-sdk/util-user-agent-node@npm:3.425.0":
+  version: 3.425.0
+  resolution: "@aws-sdk/util-user-agent-node@npm:3.425.0"
   dependencies:
-    "@aws-sdk/types": 3.391.0
-    "@smithy/types": ^2.2.0
-    bowser: ^2.11.0
-    tslib: ^2.5.0
-  checksum: 2cc35bebec3efce878e2ea30571e72d670ed815cf3655928063943f73b1302ad485fd40dd068dfb93e49e9f7283eca2bdc4a13a22ee77fa7fd1c1fd95298abb1
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/util-user-agent-node@npm:3.357.0":
-  version: 3.357.0
-  resolution: "@aws-sdk/util-user-agent-node@npm:3.357.0"
-  dependencies:
-    "@aws-sdk/node-config-provider": 3.357.0
-    "@aws-sdk/types": 3.357.0
+    "@aws-sdk/types": 3.425.0
+    "@smithy/node-config-provider": ^2.0.13
+    "@smithy/types": ^2.3.4
     tslib: ^2.5.0
   peerDependencies:
     aws-crt: ">=1.0.0"
   peerDependenciesMeta:
     aws-crt:
       optional: true
-  checksum: ea9578e519be09a43682dc90be3feab4c4d22e027355be059dac9a0df6de75ace7288be8ef9be94fdf70e3d5d510b1118b6c8d5f8becdde14bc9d90fe05b6e90
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/util-user-agent-node@npm:3.391.0":
-  version: 3.391.0
-  resolution: "@aws-sdk/util-user-agent-node@npm:3.391.0"
-  dependencies:
-    "@aws-sdk/types": 3.391.0
-    "@smithy/node-config-provider": ^2.0.3
-    "@smithy/types": ^2.2.0
-    tslib: ^2.5.0
-  peerDependencies:
-    aws-crt: ">=1.0.0"
-  peerDependenciesMeta:
-    aws-crt:
-      optional: true
-  checksum: 2e59bea8dee6e2a4aaaeec61fbe5bfacb6c3dcebfc2d9e624dc7039855c5793f5d7b064eb08c3a066a954c948ba1f6b6c93c7cf14ceb6713d45fdce110f6a928
+  checksum: ccb8cc91adda5beca5aef4ac9af2c256612d90b284609f731ac1327e31c54b5e994d9224a00e8b25c32a3753c0a34c04e39fbe4b50c3bd3a43bf6d9057917835
   languageName: node
   linkType: hard
 
@@ -1443,16 +757,6 @@ __metadata:
   dependencies:
     tslib: ^2.3.1
   checksum: b6a1e580da1c9b62c749814182a7649a748ca4253edb4063aa521df97d25b76eae3359eb1680b86f71aac668e05cc05c514379bca39ebf4ba998ae4348412da8
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/util-utf8@npm:3.310.0":
-  version: 3.310.0
-  resolution: "@aws-sdk/util-utf8@npm:3.310.0"
-  dependencies:
-    "@aws-sdk/util-buffer-from": 3.310.0
-    tslib: ^2.5.0
-  checksum: 4045e79b8e3593e12233b359ba77d1b4c162fd9fcb4ab3b58b711c41b725552306dd91402b8d57ce5be080c76309f046a7a0c4ff704d12f9ba71e3b25b810086
   languageName: node
   linkType: hard
 
@@ -2551,19 +1855,19 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@datadog/datadog-ci@workspace:."
   dependencies:
-    "@aws-sdk/client-cloudwatch-logs": ^3.358.0
-    "@aws-sdk/client-iam": ^3.358.0
-    "@aws-sdk/client-lambda": ^3.358.0
-    "@aws-sdk/client-sfn": ^3.358.0
-    "@aws-sdk/credential-providers": 3.358.0
-    "@aws-sdk/property-provider": 3.357.0
-    "@aws-sdk/types": ^3.357.0
+    "@aws-sdk/client-cloudwatch-logs": 3.427.0
+    "@aws-sdk/client-iam": 3.427.0
+    "@aws-sdk/client-lambda": 3.427.0
+    "@aws-sdk/client-sfn": 3.427.0
+    "@aws-sdk/credential-providers": 3.427.0
+    "@aws-sdk/types": 3.425.0
     "@babel/core": 7.8.0
     "@babel/preset-env": 7.4.5
     "@babel/preset-typescript": 7.3.3
     "@google-cloud/logging": ^10.5.0
     "@google-cloud/run": ^0.6.0
     "@microsoft/eslint-formatter-sarif": ^3.0.0
+    "@smithy/property-provider": 2.0.12
     "@types/async-retry": 1.4.2
     "@types/datadog-metrics": 0.6.1
     "@types/deep-extend": 0.4.31
@@ -3492,29 +2796,30 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/abort-controller@npm:^2.0.3":
-  version: 2.0.3
-  resolution: "@smithy/abort-controller@npm:2.0.3"
+"@smithy/abort-controller@npm:^2.0.11":
+  version: 2.0.11
+  resolution: "@smithy/abort-controller@npm:2.0.11"
   dependencies:
-    "@smithy/types": ^2.2.0
+    "@smithy/types": ^2.3.5
     tslib: ^2.5.0
-  checksum: 69f8d0e2543eb636dd6b02a04379bab22472db09511d384e7481e9d435efe406b8e9a04a646016bdd7d3a35f068dbbd8316cca892e534de80766950799167d1e
+  checksum: 33a639bb1dd57a4495ef70f3d7ffa6f7eb40256121412e2d1e1d353524d140e483160871653bd9af67a0ec751ffbcae60a3972f85c996569f0c7a88064447dab
   languageName: node
   linkType: hard
 
-"@smithy/config-resolver@npm:^2.0.3":
-  version: 2.0.3
-  resolution: "@smithy/config-resolver@npm:2.0.3"
+"@smithy/config-resolver@npm:^2.0.11, @smithy/config-resolver@npm:^2.0.14":
+  version: 2.0.14
+  resolution: "@smithy/config-resolver@npm:2.0.14"
   dependencies:
-    "@smithy/types": ^2.2.0
+    "@smithy/node-config-provider": ^2.1.1
+    "@smithy/types": ^2.3.5
     "@smithy/util-config-provider": ^2.0.0
-    "@smithy/util-middleware": ^2.0.0
+    "@smithy/util-middleware": ^2.0.4
     tslib: ^2.5.0
-  checksum: 882787c3764829ebca0ba255e8245d2267c26c1d8ebfa273ba40f3264f888f4494419fd692e602df28cecf9f7431dde37711f6d950ac41ed8e5727de8d2150cf
+  checksum: 5fa08a715e20b49db178b22806d79cb43756b7f720007abb018ccf975270529869153ea25b98b99da3ffc80607c19a65ceb147fe908e80301eb51288802ea7b7
   languageName: node
   linkType: hard
 
-"@smithy/credential-provider-imds@npm:^2.0.0, @smithy/credential-provider-imds@npm:^2.0.3":
+"@smithy/credential-provider-imds@npm:^2.0.0":
   version: 2.0.3
   resolution: "@smithy/credential-provider-imds@npm:2.0.3"
   dependencies:
@@ -3524,6 +2829,31 @@ __metadata:
     "@smithy/url-parser": ^2.0.3
     tslib: ^2.5.0
   checksum: 15d73bbff2fd91919cab424246a25e84e7d97011f8990c38c52baf3dd865a64a1b9826f4049d24057c5115b757cdd0f0b51dd04a02003acd39ec2826c3b4d877
+  languageName: node
+  linkType: hard
+
+"@smithy/credential-provider-imds@npm:^2.0.16":
+  version: 2.0.16
+  resolution: "@smithy/credential-provider-imds@npm:2.0.16"
+  dependencies:
+    "@smithy/node-config-provider": ^2.1.1
+    "@smithy/property-provider": ^2.0.12
+    "@smithy/types": ^2.3.5
+    "@smithy/url-parser": ^2.0.11
+    tslib: ^2.5.0
+  checksum: 1079f9b59d60f460bfbc95c722a740664733b5d6c219ff8ac04d85d8af78eccabc71ed08d39cf11ec1e80203e3b65e08eb06a99524c358b2a959e2baa4787fd4
+  languageName: node
+  linkType: hard
+
+"@smithy/eventstream-codec@npm:^2.0.11":
+  version: 2.0.11
+  resolution: "@smithy/eventstream-codec@npm:2.0.11"
+  dependencies:
+    "@aws-crypto/crc32": 3.0.0
+    "@smithy/types": ^2.3.5
+    "@smithy/util-hex-encoding": ^2.0.0
+    tslib: ^2.5.0
+  checksum: beaa818c300986e2d085ab132c835957b674d62df43ece4dd74266d4ba4fcc2d3bf43c474ae724104337da4a1349a710dda49d2975c659ee30e28c7058e31817
   languageName: node
   linkType: hard
 
@@ -3539,81 +2869,81 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/eventstream-serde-browser@npm:^2.0.3":
-  version: 2.0.3
-  resolution: "@smithy/eventstream-serde-browser@npm:2.0.3"
+"@smithy/eventstream-serde-browser@npm:^2.0.10":
+  version: 2.0.11
+  resolution: "@smithy/eventstream-serde-browser@npm:2.0.11"
   dependencies:
-    "@smithy/eventstream-serde-universal": ^2.0.3
-    "@smithy/types": ^2.2.0
+    "@smithy/eventstream-serde-universal": ^2.0.11
+    "@smithy/types": ^2.3.5
     tslib: ^2.5.0
-  checksum: 85b4ab0997bd4598f170639ce91a14b205ebaeade9b8b6437261172b187a6eb8950bbd04f10b21b987c2d2bc46e1d0df67843374bb960b65cee7a68350fb4b58
+  checksum: 40c37d3bdb48e883f459b709bdbdc01cfcf3c3b4b2ddd7b9d02c61feb788fa8a62b76b3a6450c3c84810dc8abb58e3b56db914bb10fa65620ecb44ca5aae81d2
   languageName: node
   linkType: hard
 
-"@smithy/eventstream-serde-config-resolver@npm:^2.0.3":
-  version: 2.0.3
-  resolution: "@smithy/eventstream-serde-config-resolver@npm:2.0.3"
+"@smithy/eventstream-serde-config-resolver@npm:^2.0.10":
+  version: 2.0.11
+  resolution: "@smithy/eventstream-serde-config-resolver@npm:2.0.11"
   dependencies:
-    "@smithy/types": ^2.2.0
+    "@smithy/types": ^2.3.5
     tslib: ^2.5.0
-  checksum: 5e03d15787daef938193167c118cc3829815153e0a0d4e085b0006bf5a0499b544d8d8d09230c5e3323a3777c1a6d748390ce5ee7d812ff00024f7ce197e7bc8
+  checksum: 7d842ab83182a64fa24f5f1c58dd209119ab5f954fc38223b599d5040e66f4d407d36d03fb955378db380120ba2745671ec722f8c1b887c843b24659158ed029
   languageName: node
   linkType: hard
 
-"@smithy/eventstream-serde-node@npm:^2.0.3":
-  version: 2.0.3
-  resolution: "@smithy/eventstream-serde-node@npm:2.0.3"
+"@smithy/eventstream-serde-node@npm:^2.0.10":
+  version: 2.0.11
+  resolution: "@smithy/eventstream-serde-node@npm:2.0.11"
   dependencies:
-    "@smithy/eventstream-serde-universal": ^2.0.3
-    "@smithy/types": ^2.2.0
+    "@smithy/eventstream-serde-universal": ^2.0.11
+    "@smithy/types": ^2.3.5
     tslib: ^2.5.0
-  checksum: 042033c01fe8de7d810e56497e8f150399a89bdd54bfc8782223d6573b226161222af898bfce049c7c68516d44b06f068a1d5ae05d1c472ccbed78db36596ec0
+  checksum: 67dd0fb8dbf411a531cf6a914a73e2ac5c7f13842531b22132c2d1bf2ab1f575e704a33889ed6ef487c2ebd0f58abcff9b319a313cccceefce0e306f1aa961d8
   languageName: node
   linkType: hard
 
-"@smithy/eventstream-serde-universal@npm:^2.0.3":
-  version: 2.0.3
-  resolution: "@smithy/eventstream-serde-universal@npm:2.0.3"
+"@smithy/eventstream-serde-universal@npm:^2.0.11":
+  version: 2.0.11
+  resolution: "@smithy/eventstream-serde-universal@npm:2.0.11"
   dependencies:
-    "@smithy/eventstream-codec": ^2.0.3
-    "@smithy/types": ^2.2.0
+    "@smithy/eventstream-codec": ^2.0.11
+    "@smithy/types": ^2.3.5
     tslib: ^2.5.0
-  checksum: 8e02cc26b0c68a553f2e8df355cffbc82455fe8e8dee49aae40dd1bcb5ab48323ca2e382872d3b4195703278796c1d7ddabc73c8201cc8f7c1bdd7642b5f797e
+  checksum: da9f26a4b6a9cbeed4f017776b6d7455f4cb591ca6a85693a8b1e4de3be25b66d44c93284372ad6f709442a01c9940264da431ad0d998b5c21b7b135ccbd938f
   languageName: node
   linkType: hard
 
-"@smithy/fetch-http-handler@npm:^2.0.3":
-  version: 2.0.3
-  resolution: "@smithy/fetch-http-handler@npm:2.0.3"
+"@smithy/fetch-http-handler@npm:^2.2.1, @smithy/fetch-http-handler@npm:^2.2.2":
+  version: 2.2.2
+  resolution: "@smithy/fetch-http-handler@npm:2.2.2"
   dependencies:
-    "@smithy/protocol-http": ^2.0.3
-    "@smithy/querystring-builder": ^2.0.3
-    "@smithy/types": ^2.2.0
+    "@smithy/protocol-http": ^3.0.7
+    "@smithy/querystring-builder": ^2.0.11
+    "@smithy/types": ^2.3.5
     "@smithy/util-base64": ^2.0.0
     tslib: ^2.5.0
-  checksum: df86d549f510a2499b49976f3c5d9487c4f95c1ade60b99d417dcc294d331be0bcf9ef2a4340f9f6ea2689610af411e3905edd4d329a4fff7baf4f6b8d3bcae3
+  checksum: 598d6869e680d8b8ca827c5a985eb4a0886cc0dca8e3a939f1d0be5c6c386e651d79f5f4ffe0ea3b9ebf871856a5930dcf4c8b01a9ed018046e5e92902c09621
   languageName: node
   linkType: hard
 
-"@smithy/hash-node@npm:^2.0.3":
-  version: 2.0.3
-  resolution: "@smithy/hash-node@npm:2.0.3"
+"@smithy/hash-node@npm:^2.0.10":
+  version: 2.0.11
+  resolution: "@smithy/hash-node@npm:2.0.11"
   dependencies:
-    "@smithy/types": ^2.2.0
+    "@smithy/types": ^2.3.5
     "@smithy/util-buffer-from": ^2.0.0
     "@smithy/util-utf8": ^2.0.0
     tslib: ^2.5.0
-  checksum: 58c122b6a749fe839449c48c643560168d50ee5e08b9d7bdf8d133aa69fbb4f9cb7fbaa80a676ebcf2be14557ac947b1ab317bc75bffc4b9447ad541dc541b9d
+  checksum: 004e3e55ed9397cd551f6ab5fb3164359e5f7ce8c0299993237fe573b47c490ba6cb10da01d006b59c6adb5e972311d7837acd16921772f0b534136c741a2938
   languageName: node
   linkType: hard
 
-"@smithy/invalid-dependency@npm:^2.0.3":
-  version: 2.0.3
-  resolution: "@smithy/invalid-dependency@npm:2.0.3"
+"@smithy/invalid-dependency@npm:^2.0.10":
+  version: 2.0.11
+  resolution: "@smithy/invalid-dependency@npm:2.0.11"
   dependencies:
-    "@smithy/types": ^2.2.0
+    "@smithy/types": ^2.3.5
     tslib: ^2.5.0
-  checksum: 3f65f9807f1e5220cb3d7fff069fa61908e84319f160de7fd5c7868386e78dbb7b9bba030ff2c0d6898be7594ef796cb79f6826c210576acc3793df1e2777150
+  checksum: 672c8aa38f406afb6c8574eab80b619f9444739abadf166c822a1337db6ddccdb0deb5095d5c42eaa3881f37fc689f537888ea188ffc3a090c45be7206990d26
   languageName: node
   linkType: hard
 
@@ -3626,61 +2956,75 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/middleware-content-length@npm:^2.0.3":
-  version: 2.0.3
-  resolution: "@smithy/middleware-content-length@npm:2.0.3"
+"@smithy/middleware-content-length@npm:^2.0.12":
+  version: 2.0.13
+  resolution: "@smithy/middleware-content-length@npm:2.0.13"
   dependencies:
-    "@smithy/protocol-http": ^2.0.3
-    "@smithy/types": ^2.2.0
+    "@smithy/protocol-http": ^3.0.7
+    "@smithy/types": ^2.3.5
     tslib: ^2.5.0
-  checksum: 0d001a72b400ca114b7d1ca3f8481cd399dae8d5ecc7c8411ae8405365780d2d0a20b74af2963b784138d34c4edab71438a8ccb863650aca0e8fe1399e53debe
+  checksum: 153123236c1278fee1857bbc36c92f4fb4c7e35beb755ea13d1acdcdd697c3707eee069fc4999c67c6e009df48165986d778d62bac4251d8f126617c3e3f68f6
   languageName: node
   linkType: hard
 
-"@smithy/middleware-endpoint@npm:^2.0.3":
-  version: 2.0.3
-  resolution: "@smithy/middleware-endpoint@npm:2.0.3"
+"@smithy/middleware-endpoint@npm:^2.0.10":
+  version: 2.0.11
+  resolution: "@smithy/middleware-endpoint@npm:2.0.11"
   dependencies:
-    "@smithy/middleware-serde": ^2.0.3
-    "@smithy/types": ^2.2.0
-    "@smithy/url-parser": ^2.0.3
-    "@smithy/util-middleware": ^2.0.0
+    "@smithy/middleware-serde": ^2.0.11
+    "@smithy/types": ^2.3.5
+    "@smithy/url-parser": ^2.0.11
+    "@smithy/util-middleware": ^2.0.4
     tslib: ^2.5.0
-  checksum: ed0faa6284d60d81331ea3b8beb469e142ca9f5ac836f3366061cb58cba7822c33d9670b7f6f32442bcc5b6ce1f6da0913750b68d4db6e5c5b173f59892e0150
+  checksum: 71f30981733e96a3c5b8e2afea1b2f969c4ff72def41225570420ed43aeafa1e90c85b08811a6f66e43ac7ab5f54441148bce6bb50f6b929705602569ff026c0
   languageName: node
   linkType: hard
 
-"@smithy/middleware-retry@npm:^2.0.3":
-  version: 2.0.3
-  resolution: "@smithy/middleware-retry@npm:2.0.3"
+"@smithy/middleware-retry@npm:^2.0.13":
+  version: 2.0.16
+  resolution: "@smithy/middleware-retry@npm:2.0.16"
   dependencies:
-    "@smithy/protocol-http": ^2.0.3
-    "@smithy/service-error-classification": ^2.0.0
-    "@smithy/types": ^2.2.0
-    "@smithy/util-middleware": ^2.0.0
-    "@smithy/util-retry": ^2.0.0
+    "@smithy/node-config-provider": ^2.1.1
+    "@smithy/protocol-http": ^3.0.7
+    "@smithy/service-error-classification": ^2.0.4
+    "@smithy/types": ^2.3.5
+    "@smithy/util-middleware": ^2.0.4
+    "@smithy/util-retry": ^2.0.4
     tslib: ^2.5.0
     uuid: ^8.3.2
-  checksum: 2675dcf8aa91c085dc97b467eac8438ce023c5e274ea15b6e6ee73b53c4ee6a328a6901ff464835dbd9379c8e5ef00d7df390571e9e8974dcb436f8f03efef33
+  checksum: 9348bf7663ad85469614bda8a672bc8a5a104137caf1f3eb77553462f52044d27b933be177f850abe202fb9b4e060f39982e85565d8caf164de6377ffba82272
   languageName: node
   linkType: hard
 
-"@smithy/middleware-serde@npm:^2.0.3":
-  version: 2.0.3
-  resolution: "@smithy/middleware-serde@npm:2.0.3"
+"@smithy/middleware-serde@npm:^2.0.10, @smithy/middleware-serde@npm:^2.0.11":
+  version: 2.0.11
+  resolution: "@smithy/middleware-serde@npm:2.0.11"
   dependencies:
-    "@smithy/types": ^2.2.0
+    "@smithy/types": ^2.3.5
     tslib: ^2.5.0
-  checksum: d0bd591544dea6e5373be304aa3fc8ff2204a41c34f68acc63d160ccca15b14775d9b3e0bcbec8ad5853b7ed4345c1d549d6d8a31f15c7857472dbd2725e8ad8
+  checksum: 103e90731968036b2f5bc0bd9882d60de8831edafdb0229775c703b0713531829b06664ecf8e3090b915e52298f59415760c2446c3514e878f25acf9fe4008f7
   languageName: node
   linkType: hard
 
-"@smithy/middleware-stack@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "@smithy/middleware-stack@npm:2.0.0"
+"@smithy/middleware-stack@npm:^2.0.4, @smithy/middleware-stack@npm:^2.0.5":
+  version: 2.0.5
+  resolution: "@smithy/middleware-stack@npm:2.0.5"
   dependencies:
+    "@smithy/types": ^2.3.5
     tslib: ^2.5.0
-  checksum: dd23dff4da44964e936c5ae465de9416bb8dd67da2ae72ffe450156ad52e82475836ed5c18d82cef7edeca421b33d363889549e34482008eeb9ca0bb97f061f2
+  checksum: d4bd57206084b01a94306f02b93699d9aeab4753cb6c48bc85824a881a154d1eeeb89e3455568956c2cd82d9742ad2841522ff3d2a45ac70a99ea6d911570057
+  languageName: node
+  linkType: hard
+
+"@smithy/node-config-provider@npm:^2.0.13, @smithy/node-config-provider@npm:^2.1.1":
+  version: 2.1.1
+  resolution: "@smithy/node-config-provider@npm:2.1.1"
+  dependencies:
+    "@smithy/property-provider": ^2.0.12
+    "@smithy/shared-ini-file-loader": ^2.2.0
+    "@smithy/types": ^2.3.5
+    tslib: ^2.5.0
+  checksum: b9bca5ba2b1ef60221f7bf24e876dabba46652ead428ec31a528ef57ee14af559752736317f870d55f1b90c6bb6c52886194475190a05339235ffe123217a9bd
   languageName: node
   linkType: hard
 
@@ -3696,16 +3040,26 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/node-http-handler@npm:^2.0.3":
-  version: 2.0.3
-  resolution: "@smithy/node-http-handler@npm:2.0.3"
+"@smithy/node-http-handler@npm:^2.1.6, @smithy/node-http-handler@npm:^2.1.7":
+  version: 2.1.7
+  resolution: "@smithy/node-http-handler@npm:2.1.7"
   dependencies:
-    "@smithy/abort-controller": ^2.0.3
-    "@smithy/protocol-http": ^2.0.3
-    "@smithy/querystring-builder": ^2.0.3
-    "@smithy/types": ^2.2.0
+    "@smithy/abort-controller": ^2.0.11
+    "@smithy/protocol-http": ^3.0.7
+    "@smithy/querystring-builder": ^2.0.11
+    "@smithy/types": ^2.3.5
     tslib: ^2.5.0
-  checksum: db4305c2214c245664a49e10dc0567cb404d1fe8070f7adb3b907a3a22f7ad9f52c85ec2d338f27c21d11ea947e6fb25fac41eb61f0f803719bd11c14072e930
+  checksum: 2a40f8bcb75eddb682691137a4134f33e97daba775945a45513fdfe2bf1dfafc9d74843f3f698eacf64569baf952d19361b2bb28dd19030a6f3cbe9ee5fdecc3
+  languageName: node
+  linkType: hard
+
+"@smithy/property-provider@npm:2.0.12, @smithy/property-provider@npm:^2.0.12":
+  version: 2.0.12
+  resolution: "@smithy/property-provider@npm:2.0.12"
+  dependencies:
+    "@smithy/types": ^2.3.5
+    tslib: ^2.5.0
+  checksum: 5d7afa158d66f4cd7f9561fbbb9adef987abfc490dfd5f0e5dcae5596611618f83a856273308f70e56347115a0f07ecc2f0eb434b4186725f8dc461b3be3cd5c
   languageName: node
   linkType: hard
 
@@ -3719,34 +3073,34 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/protocol-http@npm:^1.0.1":
-  version: 1.2.0
-  resolution: "@smithy/protocol-http@npm:1.2.0"
+"@smithy/protocol-http@npm:^3.0.6, @smithy/protocol-http@npm:^3.0.7":
+  version: 3.0.7
+  resolution: "@smithy/protocol-http@npm:3.0.7"
   dependencies:
-    "@smithy/types": ^1.2.0
+    "@smithy/types": ^2.3.5
     tslib: ^2.5.0
-  checksum: 39548762da6dbd301d36ef67709ef73ef6f9a4c9bdcc3fafa5d5625eec7dfa71db72898d3eb219a368a79ea5e368a08189519a7512d48e0cdc9db7089c8e9618
+  checksum: bbc13fdddf1891daaa086849c19731e6ca825229b9c90324e50641390f84e957af796464f642f74426038a4d6a0f8d4b05364e0729cf7f8a828328e921ba72cd
   languageName: node
   linkType: hard
 
-"@smithy/protocol-http@npm:^2.0.3":
-  version: 2.0.3
-  resolution: "@smithy/protocol-http@npm:2.0.3"
+"@smithy/querystring-builder@npm:^2.0.11":
+  version: 2.0.11
+  resolution: "@smithy/querystring-builder@npm:2.0.11"
   dependencies:
-    "@smithy/types": ^2.2.0
-    tslib: ^2.5.0
-  checksum: 0fbfe5f63da53eac3c4fdb830591e5a1f400c6c1103a7494f19c59c27e2cd533a33b687cd7c70902429d58f84d6e6a186205043cd896824d802f21f23cb7a50c
-  languageName: node
-  linkType: hard
-
-"@smithy/querystring-builder@npm:^2.0.3":
-  version: 2.0.3
-  resolution: "@smithy/querystring-builder@npm:2.0.3"
-  dependencies:
-    "@smithy/types": ^2.2.0
+    "@smithy/types": ^2.3.5
     "@smithy/util-uri-escape": ^2.0.0
     tslib: ^2.5.0
-  checksum: 32a6cefacee95ecd51c8969adb4b244f55017c080f05cbe1d05fa427b09375b29b1db6d1f5fa43b77a2e7a06c105661c0e54eabe0174cbb43aef94c841e39755
+  checksum: a9ad6389051b24170c178ae0bbac73d224f2ba2c005eca7dfa3c5631e2e7522ffdd17fc1779f80d2480c444e01ba8da9d0553b0b7d68967c1fa283c737dec886
+  languageName: node
+  linkType: hard
+
+"@smithy/querystring-parser@npm:^2.0.11":
+  version: 2.0.11
+  resolution: "@smithy/querystring-parser@npm:2.0.11"
+  dependencies:
+    "@smithy/types": ^2.3.5
+    tslib: ^2.5.0
+  checksum: fc0b384210d06dbe02dc9eb6418d7aba8247cc3cb9eb38bbbdb29470ddc4e9a26a3e7b5eb511382bde62c3be3008771dfe9dcf68f83ec5f4fa99e466684dd224
   languageName: node
   linkType: hard
 
@@ -3760,20 +3114,32 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/service-error-classification@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "@smithy/service-error-classification@npm:2.0.0"
-  checksum: f6f9b869dca8e74871c428e1277dd3700f67b0ca61de69fc838ac55187bbc602193a7d1073113ea6916892babf3f8fe4938b182fc902ce0a415928799a7e3f9a
+"@smithy/service-error-classification@npm:^2.0.4":
+  version: 2.0.4
+  resolution: "@smithy/service-error-classification@npm:2.0.4"
+  dependencies:
+    "@smithy/types": ^2.3.5
+  checksum: e0d90a5daf6af375963ac5521938158124a4df2ae431a08b4cbd40c68d68ca62a5e6f12b17e378ceec9e0023c49114f561e747c9396a513323c987cdcaff68eb
   languageName: node
   linkType: hard
 
-"@smithy/shared-ini-file-loader@npm:^2.0.0, @smithy/shared-ini-file-loader@npm:^2.0.3":
+"@smithy/shared-ini-file-loader@npm:^2.0.3":
   version: 2.0.3
   resolution: "@smithy/shared-ini-file-loader@npm:2.0.3"
   dependencies:
     "@smithy/types": ^2.2.0
     tslib: ^2.5.0
   checksum: 7b07f3dbdd6d3e665b0fd8c0a1c55be0148b1c1cdbf8e9cb95675af90163c59e2cc06e8761d5319ed818f23b760dac37be41e0b1e0691ed3773dc2749a1f4f81
+  languageName: node
+  linkType: hard
+
+"@smithy/shared-ini-file-loader@npm:^2.0.6, @smithy/shared-ini-file-loader@npm:^2.2.0":
+  version: 2.2.0
+  resolution: "@smithy/shared-ini-file-loader@npm:2.2.0"
+  dependencies:
+    "@smithy/types": ^2.3.5
+    tslib: ^2.5.0
+  checksum: 77563b09f961c12d1afe3c5006074be3590fd3b44b096b5b7d5244b6924a5988731c4903d13f13cef4f6139e10735fb04d63e8c78bece1f6594dc3158033a7e2
   languageName: node
   linkType: hard
 
@@ -3793,24 +3159,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/smithy-client@npm:^2.0.3":
-  version: 2.0.3
-  resolution: "@smithy/smithy-client@npm:2.0.3"
+"@smithy/smithy-client@npm:^2.1.10, @smithy/smithy-client@npm:^2.1.9":
+  version: 2.1.10
+  resolution: "@smithy/smithy-client@npm:2.1.10"
   dependencies:
-    "@smithy/middleware-stack": ^2.0.0
-    "@smithy/types": ^2.2.0
-    "@smithy/util-stream": ^2.0.3
+    "@smithy/middleware-stack": ^2.0.5
+    "@smithy/types": ^2.3.5
+    "@smithy/util-stream": ^2.0.15
     tslib: ^2.5.0
-  checksum: 65af55af184e8accfbd3463b49237e51799de7d2135fc76867842556e9a740df97d086ea888035dfb218001cf22c65020cbb407d878f17538bc0554d99ac2913
-  languageName: node
-  linkType: hard
-
-"@smithy/types@npm:^1.0.0, @smithy/types@npm:^1.2.0":
-  version: 1.2.0
-  resolution: "@smithy/types@npm:1.2.0"
-  dependencies:
-    tslib: ^2.5.0
-  checksum: 376a1402d356a8dddd804af66ff2d273e57e332a3e9537a98039b47572684aae044d5fcd879ac6eee5cc08640ea00fbef0725a6a16026db5fb8d189473d44fe6
+  checksum: 9d608b4a4ea4c2be5d42335ca696302f10ddc261e63479f6cc896426a826446396fd0aaf1f58473fb3c9ca7521d0662887da463c5a0964d85743fb9cbdbfd56b
   languageName: node
   linkType: hard
 
@@ -3820,6 +3177,26 @@ __metadata:
   dependencies:
     tslib: ^2.5.0
   checksum: b9bbb35a3d20d4cb26966830d25251f671253aa8f886d23abde71a879486fc5b049a66c44ebd3e724d495772336f13c3034fb35bc62a6db058daaf310e4a013d
+  languageName: node
+  linkType: hard
+
+"@smithy/types@npm:^2.3.4, @smithy/types@npm:^2.3.5":
+  version: 2.3.5
+  resolution: "@smithy/types@npm:2.3.5"
+  dependencies:
+    tslib: ^2.5.0
+  checksum: b758ba1e21132cccc8b612fe56e9c0eb27fe6b00dcc002965a13dae40c172ae3bff2d994dae61e9c8bdadb844fd370a4c4cb031af6d954e4e1fb897ce5d6b54e
+  languageName: node
+  linkType: hard
+
+"@smithy/url-parser@npm:^2.0.10, @smithy/url-parser@npm:^2.0.11":
+  version: 2.0.11
+  resolution: "@smithy/url-parser@npm:2.0.11"
+  dependencies:
+    "@smithy/querystring-parser": ^2.0.11
+    "@smithy/types": ^2.3.5
+    tslib: ^2.5.0
+  checksum: 43702644802c08f493dd0b717af286d584d80b43da2ef033498e94f890dd3d6bc5f80b7e0546ce9d5757eba9c10edf9711c019b7e3aaa6457bfd43661b865c6c
   languageName: node
   linkType: hard
 
@@ -3853,12 +3230,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/util-body-length-node@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "@smithy/util-body-length-node@npm:2.0.0"
+"@smithy/util-body-length-node@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "@smithy/util-body-length-node@npm:2.1.0"
   dependencies:
     tslib: ^2.5.0
-  checksum: 47ded0cc99f880eda353700e10d6131289683164d4ef98a24a2d79449d33f3bbf70c1ce0a66fc457e0c8d14be9fb2a3430fa09302bbc3daa5d23129e11fff478
+  checksum: e4635251898f12e1825f2848e0b7cc9d01ec6635b3f1f71b790734bb702b88e795f6c539d42d95472dad00e50e9ff13fcf396791092b131e5834069cb8f52ed0
   languageName: node
   linkType: hard
 
@@ -3881,29 +3258,31 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/util-defaults-mode-browser@npm:^2.0.3":
-  version: 2.0.3
-  resolution: "@smithy/util-defaults-mode-browser@npm:2.0.3"
+"@smithy/util-defaults-mode-browser@npm:^2.0.13":
+  version: 2.0.14
+  resolution: "@smithy/util-defaults-mode-browser@npm:2.0.14"
   dependencies:
-    "@smithy/property-provider": ^2.0.3
-    "@smithy/types": ^2.2.0
+    "@smithy/property-provider": ^2.0.12
+    "@smithy/smithy-client": ^2.1.10
+    "@smithy/types": ^2.3.5
     bowser: ^2.11.0
     tslib: ^2.5.0
-  checksum: f3fc2f46e629df30598a7bf0a2e0117f342eeaae3761606470ae9608938730c1c7bfbddff4672cbc4da9b3855d5827c8f2160a3db3298d9dd63e393968c9f0b8
+  checksum: 29066a0e04e6ea68be04e11e50ca30fb3f38c18126b761a8335042c472894f8a9c264bb924b7cdebac544e2bd0bcf408aca7cf70929634824ec1214baf0899ca
   languageName: node
   linkType: hard
 
-"@smithy/util-defaults-mode-node@npm:^2.0.3":
-  version: 2.0.3
-  resolution: "@smithy/util-defaults-mode-node@npm:2.0.3"
+"@smithy/util-defaults-mode-node@npm:^2.0.15":
+  version: 2.0.18
+  resolution: "@smithy/util-defaults-mode-node@npm:2.0.18"
   dependencies:
-    "@smithy/config-resolver": ^2.0.3
-    "@smithy/credential-provider-imds": ^2.0.3
-    "@smithy/node-config-provider": ^2.0.3
-    "@smithy/property-provider": ^2.0.3
-    "@smithy/types": ^2.2.0
+    "@smithy/config-resolver": ^2.0.14
+    "@smithy/credential-provider-imds": ^2.0.16
+    "@smithy/node-config-provider": ^2.1.1
+    "@smithy/property-provider": ^2.0.12
+    "@smithy/smithy-client": ^2.1.10
+    "@smithy/types": ^2.3.5
     tslib: ^2.5.0
-  checksum: c3948efd797c6830d30e55fd959d2a0eaf8f841fd55719e446731f3a6c0ca2a8aa51e7e2ac971fe78f19e24ff1610379852856811b107d32f85fad3aea3b698c
+  checksum: 623b46c36e2b45ac3d0957f6e106898e02896981b3637b97de7df446fe9f39f2a50000a84b83d3f4b59856f098efc1f7a2c56b5f9f437362bbf1f9d5fbf8615a
   languageName: node
   linkType: hard
 
@@ -3925,29 +3304,40 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/util-retry@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "@smithy/util-retry@npm:2.0.0"
+"@smithy/util-middleware@npm:^2.0.3, @smithy/util-middleware@npm:^2.0.4":
+  version: 2.0.4
+  resolution: "@smithy/util-middleware@npm:2.0.4"
   dependencies:
-    "@smithy/service-error-classification": ^2.0.0
+    "@smithy/types": ^2.3.5
     tslib: ^2.5.0
-  checksum: d5bfe5e81f41dffce6ba5aaf784f08247602d00f883c10c0de9e34a7f04f5369d7ac43901dd75eecc3864882b7390ad40885d07b3dcb35a366411b639482e673
+  checksum: 8c1fb2351ea1d3283fbf5f14407a2942bed5b78663cd4890fd98b86ec242fbeb55418930dd3b4b39d4bffa455afcbefd822e09ed3d7dbe511e1186c3c3e4ed54
   languageName: node
   linkType: hard
 
-"@smithy/util-stream@npm:^2.0.3":
-  version: 2.0.3
-  resolution: "@smithy/util-stream@npm:2.0.3"
+"@smithy/util-retry@npm:^2.0.3, @smithy/util-retry@npm:^2.0.4":
+  version: 2.0.4
+  resolution: "@smithy/util-retry@npm:2.0.4"
   dependencies:
-    "@smithy/fetch-http-handler": ^2.0.3
-    "@smithy/node-http-handler": ^2.0.3
-    "@smithy/types": ^2.2.0
+    "@smithy/service-error-classification": ^2.0.4
+    "@smithy/types": ^2.3.5
+    tslib: ^2.5.0
+  checksum: 351235e1cc70b836c063c90ee14de29660d2661e412b009d97da6c4633ddd73f5629b37af4646c1d180b0c746c3872a0a561702b8d4ae9d27b8974ecd59e0fcc
+  languageName: node
+  linkType: hard
+
+"@smithy/util-stream@npm:^2.0.14, @smithy/util-stream@npm:^2.0.15":
+  version: 2.0.15
+  resolution: "@smithy/util-stream@npm:2.0.15"
+  dependencies:
+    "@smithy/fetch-http-handler": ^2.2.2
+    "@smithy/node-http-handler": ^2.1.7
+    "@smithy/types": ^2.3.5
     "@smithy/util-base64": ^2.0.0
     "@smithy/util-buffer-from": ^2.0.0
     "@smithy/util-hex-encoding": ^2.0.0
     "@smithy/util-utf8": ^2.0.0
     tslib: ^2.5.0
-  checksum: 7ab1623efcb4b324f583da160604d41d958aa8f979883d3707f4599e874a0d03393b4ea0e694e0428942a0da4a6dd7ec2e7e9c03c97aea6ea463ea4435fa1639
+  checksum: 812e28327c52f4aa359d6876ea9c09e0a3703ce79dc7fbde2c654420ce4040fbf2ab73889d6a2c6af1c5dacc89459b7084c115e08d0df660b028fda3c0f9c86c
   languageName: node
   linkType: hard
 
@@ -3970,14 +3360,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/util-waiter@npm:^2.0.3":
-  version: 2.0.3
-  resolution: "@smithy/util-waiter@npm:2.0.3"
+"@smithy/util-waiter@npm:^2.0.10":
+  version: 2.0.11
+  resolution: "@smithy/util-waiter@npm:2.0.11"
   dependencies:
-    "@smithy/abort-controller": ^2.0.3
-    "@smithy/types": ^2.2.0
+    "@smithy/abort-controller": ^2.0.11
+    "@smithy/types": ^2.3.5
     tslib: ^2.5.0
-  checksum: d4535910fc8c6d48b3bad34e85f9785903753272686362027471ffcbb77f7051f80afb9ab0d661da58acf36f7fccece2db82bb411fd980ae01b0f705da23828b
+  checksum: b72712978c6c71b161f01b363b5e6678edee2013fdbe55ecdd0b10cc4b1bd29ea73cd987fb43ee8275cbb27e6b5c847cbd709bda21ece90934eb41e53d44d78f
   languageName: node
   linkType: hard
 
@@ -6622,17 +6012,6 @@ __metadata:
   version: 1.0.6
   resolution: "fast-text-encoding@npm:1.0.6"
   checksum: 9d58f694314b3283e785bf61954902536da228607ad246905e30256f9ab8331f780ac987e7222c9f5eafd04168d07e12b8054c85cedb76a2c05af0e82387a903
-  languageName: node
-  linkType: hard
-
-"fast-xml-parser@npm:4.2.4":
-  version: 4.2.4
-  resolution: "fast-xml-parser@npm:4.2.4"
-  dependencies:
-    strnum: ^1.0.5
-  bin:
-    fxparser: src/cli/cli.js
-  checksum: d3b4d0c0152c09f98def792769fca6bb3fa1d597f9745d9564451c239089bd86bdf573c9263b4944860028cb7edb81752d64399c1aff8b87c9225ecef96905f7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### What and why?

After [this change](https://github.com/DataDog/datadog-ci/pull/1074/files#diff-51e4f558fae534656963876761c95b83b6ef5da5103c4adef6768219ed76c2deR751-R753) in https://github.com/DataDog/datadog-ci/pull/1074, we reverted our vulnerability fix for:
- https://github.com/DataDog/datadog-ci/security/dependabot/25.

Also, it closes https://github.com/DataDog/datadog-ci/issues/471.

### How?

**Only** bumping `@aws-sdk/credential-providers` from `3.358.0` to `^3.427.0` is required to fix the vulnerability. But it's better to sync all versions.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
