### PR TITLE
[synthetics] Improve "Finding files" message

### DIFF
--- a/src/commands/synthetics/README.md
+++ b/src/commands/synthetics/README.md
@@ -419,7 +419,7 @@ You can also see the outcome of test executions directly in your CI as your test
   yarn datadog-ci synthetics run-tests --config synthetics.global.json
   yarn run v1.22.4
   $ /Users/demo.user/go/src/github.com/Datadog/tmp/test/testDemo/node_modules/.bin/datadog-ci synthetics run-tests --config synthetics.global.json
-  Finding files in /Users/demo.user/go/src/github.com/Datadog/tmp/test/testDemo/{,!(node_modules)/**/}*.synthetics.json
+  Finding files matching /Users/demo.user/go/src/github.com/Datadog/tmp/test/testDemo/{,!(node_modules)/**/}*.synthetics.json
 
   Got test files:
     - user.synthetics.json

--- a/src/commands/synthetics/__tests__/utils.test.ts
+++ b/src/commands/synthetics/__tests__/utils.test.ts
@@ -119,6 +119,25 @@ describe('utils', () => {
     })
   })
 
+  describe('getGlobForDisplay', () => {
+    test('should return good values', () => {
+      const pathToProject = '/path/to/project'
+      jest.spyOn(process, 'cwd').mockImplementation(() => pathToProject)
+
+      expect(utils.getGlobForDisplay('')).toStrictEqual('/path/to/project')
+      expect(utils.getGlobForDisplay('hello')).toStrictEqual('/path/to/project/hello')
+      expect(utils.getGlobForDisplay('{,!(node_modules)/**/}*.synthetics.json')).toStrictEqual(
+        '/path/to/project/{,!(node_modules)/**/}*.synthetics.json'
+      )
+      expect(utils.getGlobForDisplay('/absolute/glob/*.synthetics.json')).toStrictEqual(
+        '/absolute/glob/*.synthetics.json'
+      )
+      expect(utils.getGlobForDisplay('/absolute/glob/specific-file.synthetics.json')).toStrictEqual(
+        '/absolute/glob/specific-file.synthetics.json'
+      )
+    })
+  })
+
   describe('getFilePathRelativeToRepo', () => {
     test('datadog-ci is not run in a git repository', async () => {
       const pathToProject = '/path/to/project'

--- a/src/commands/synthetics/__tests__/utils.test.ts
+++ b/src/commands/synthetics/__tests__/utils.test.ts
@@ -119,25 +119,6 @@ describe('utils', () => {
     })
   })
 
-  describe('getGlobForDisplay', () => {
-    test('should return good values', () => {
-      const pathToProject = '/path/to/project'
-      jest.spyOn(process, 'cwd').mockImplementation(() => pathToProject)
-
-      expect(utils.getGlobForDisplay('')).toStrictEqual('/path/to/project')
-      expect(utils.getGlobForDisplay('hello')).toStrictEqual('/path/to/project/hello')
-      expect(utils.getGlobForDisplay('{,!(node_modules)/**/}*.synthetics.json')).toStrictEqual(
-        '/path/to/project/{,!(node_modules)/**/}*.synthetics.json'
-      )
-      expect(utils.getGlobForDisplay('/absolute/glob/*.synthetics.json')).toStrictEqual(
-        '/absolute/glob/*.synthetics.json'
-      )
-      expect(utils.getGlobForDisplay('/absolute/glob/specific-file.synthetics.json')).toStrictEqual(
-        '/absolute/glob/specific-file.synthetics.json'
-      )
-    })
-  })
-
   describe('getFilePathRelativeToRepo', () => {
     test('datadog-ci is not run in a git repository', async () => {
       const pathToProject = '/path/to/project'

--- a/src/commands/synthetics/utils.ts
+++ b/src/commands/synthetics/utils.ts
@@ -203,7 +203,7 @@ export const getResultOutcome = (result: Result): ResultOutcome => {
 }
 
 export const getSuites = async (GLOB: string, reporter: MainReporter): Promise<Suite[]> => {
-  reporter.log(`Finding files matching ${getGlobForDisplay(GLOB)}\n`)
+  reporter.log(`Finding files matching ${path.resolve(process.cwd(), GLOB)}\n`)
 
   const files: string[] = await promisify(glob)(GLOB)
   if (files.length) {
@@ -224,14 +224,6 @@ export const getSuites = async (GLOB: string, reporter: MainReporter): Promise<S
       }
     })
   )
-}
-
-export const getGlobForDisplay = (GLOB: string): string => {
-  if (path.isAbsolute(GLOB)) {
-    return GLOB
-  }
-
-  return path.join(process.cwd(), GLOB)
 }
 
 export const getFilePathRelativeToRepo = async (filePath: string) => {

--- a/src/commands/synthetics/utils.ts
+++ b/src/commands/synthetics/utils.ts
@@ -203,7 +203,8 @@ export const getResultOutcome = (result: Result): ResultOutcome => {
 }
 
 export const getSuites = async (GLOB: string, reporter: MainReporter): Promise<Suite[]> => {
-  reporter.log(`Finding files in ${path.join(process.cwd(), GLOB)}\n`)
+  reporter.log(`Finding files matching ${getGlobForDisplay(GLOB)}\n`)
+
   const files: string[] = await promisify(glob)(GLOB)
   if (files.length) {
     reporter.log(`\nGot test files:\n${files.map((file) => `  - ${file}\n`).join('')}\n`)
@@ -223,6 +224,14 @@ export const getSuites = async (GLOB: string, reporter: MainReporter): Promise<S
       }
     })
   )
+}
+
+export const getGlobForDisplay = (GLOB: string): string => {
+  if (path.isAbsolute(GLOB)) {
+    return GLOB
+  }
+
+  return path.join(process.cwd(), GLOB)
 }
 
 export const getFilePathRelativeToRepo = async (filePath: string) => {


### PR DESCRIPTION
### What and why?

Before this PR, when using `datadog-ci synthetics run-tests -f ~/tests.synthetics.json`, the terminal used to interpret `~` and pass `$HOME/tests.synthetics.json` to datadog-ci, which then printed:

```
Finding files in /Users/john.doe/path/to/current/directory/Users/john.doe/tests.synthetics.json
```

if the command was run from `~/path/to/current/directory`.

### How?

"Finding files in" makes it sound like the passed glob is a directory (i.e. something which **contains** files), whereas what we're actually doing is to find files which match a specific glob, which may also be the real path of a single file.

So I changed "in" to "matching". And if the glob is an absolute path, we just show that absolute path.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
