### PR TITLE
Add example of instrumenting multiple Lambda functions by ARN

### DIFF
--- a/src/commands/lambda/README.md
+++ b/src/commands/lambda/README.md
@@ -21,16 +21,19 @@ Run `datadog-ci lambda instrument` to apply Datadog instrumentation to a Lambda.
 
 ```bash
 # Instrument multiple functions specified by names
-datadog-ci lambda instrument -f <function-name> -f <another-function-name> -r us-east-1 -v 46 -e 10
+datadog-ci lambda instrument -f <function-name> -f <another-function-name> -r us-east-1 -v 81 -e 49
+
+# Instrument multiple functions specified by full ARNs
+datadog-ci lambda instrument -f <lambda-arn> -f <another-lambda-arn> -f <a-third-lambda-arn> -v 81 -e 49
 
 # Instrument function(s) in interactive mode
 datadog-ci lambda instrument -i
 
 # Instrument multiple functions that match a regex pattern
-datadog-ci lambda instrument --functions-regex <valid-regex-pattern> -r us-east-1 -v 46 -e 10
+datadog-ci lambda instrument --functions-regex <valid-regex-pattern> -r us-east-1 -v 81 -e 49
 
 # Dry run of all updates
-datadog-ci lambda instrument -f <function-name> -f <another-function-name> -r us-east-1 -v 46 -e 10 --dry-run
+datadog-ci lambda instrument -f <function-name> -f <another-function-name> -r us-east-1 -v 81 -e 49 --dry-run
 ```
 
 ### `uninstrument`


### PR DESCRIPTION
### What and why?
- Adds an example instrumenting multiple Lambda functions by their ARNs
- Updates versions in examples to use latest extension version (49) and latest Python version (81)

### How?
Updates the doc

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
