### PR TITLE
SBOM: support ruby, go and maven/java

### DIFF
--- a/src/commands/sbom/__tests__/fixtures/java-go.sbom.json
+++ b/src/commands/sbom/__tests__/fixtures/java-go.sbom.json
@@ -1,0 +1,3206 @@
+{
+  "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.5",
+  "serialNumber": "urn:uuid:6ce8fe38-536c-4daf-94f0-4ebc38cde2d3",
+  "version": 1,
+  "metadata": {
+    "timestamp": "2023-10-24T17:58:47+00:00",
+    "tools": [
+      {
+        "vendor": "aquasecurity",
+        "name": "trivy",
+        "version": "0.46.0"
+      }
+    ],
+    "component": {
+      "bom-ref": "e4eee236-a16b-4458-990a-fcc14def339a",
+      "type": "application",
+      "name": ".",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:SchemaVersion",
+          "value": "2"
+        }
+      ]
+    }
+  },
+  "components": [
+    {
+      "bom-ref": "26e5aec4-4b8c-4652-9eb0-6487c9c3869b",
+      "type": "application",
+      "name": "pom.xml",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:Class",
+          "value": "lang-pkgs"
+        },
+        {
+          "name": "aquasecurity:trivy:Type",
+          "value": "pom"
+        }
+      ]
+    },
+    {
+      "bom-ref": "2c66cf1c-8e66-435e-a8b5-a236f819e1f2",
+      "type": "application",
+      "name": "src/test/fixture/sdkintegration/gocc/sample1/src/github.com/example_cc/vendor/google.golang.org/grpc/go.mod",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:Class",
+          "value": "lang-pkgs"
+        },
+        {
+          "name": "aquasecurity:trivy:Type",
+          "value": "gomod"
+        }
+      ]
+    },
+    {
+      "bom-ref": "2c6d9149-a391-4e09-80bf-0210182efa20",
+      "type": "application",
+      "name": "src/test/fixture/sdkintegration/gocc/sampleIdemix/src/github.com/example_cc/vendor/google.golang.org/grpc/go.mod",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:Class",
+          "value": "lang-pkgs"
+        },
+        {
+          "name": "aquasecurity:trivy:Type",
+          "value": "gomod"
+        }
+      ]
+    },
+    {
+      "bom-ref": "2c8ed45e-e6f4-4343-9391-6d631ffc3ac3",
+      "type": "application",
+      "name": "src/test/fixture/sdkintegration/gocc/sample_11/src/github.com/example_cc/vendor/google.golang.org/grpc/go.mod",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:Class",
+          "value": "lang-pkgs"
+        },
+        {
+          "name": "aquasecurity:trivy:Type",
+          "value": "gomod"
+        }
+      ]
+    },
+    {
+      "bom-ref": "39cc9e82-beee-4164-9827-9f22e58a9f0b",
+      "type": "application",
+      "name": "src/test/fixture/sdkintegration/gocc/sample1NoInit/src/github.com/example_cc/go.mod",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:Class",
+          "value": "lang-pkgs"
+        },
+        {
+          "name": "aquasecurity:trivy:Type",
+          "value": "gomod"
+        }
+      ]
+    },
+    {
+      "bom-ref": "43090543-f1a2-412c-ae01-a8bf569e48f0",
+      "type": "application",
+      "name": "src/test/fixture/sdkintegration/gocc/sample1/src/github.com/example_cc/go.mod",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:Class",
+          "value": "lang-pkgs"
+        },
+        {
+          "name": "aquasecurity:trivy:Type",
+          "value": "gomod"
+        }
+      ]
+    },
+    {
+      "bom-ref": "82f54327-c490-490a-b8b4-4117f81f5570",
+      "type": "application",
+      "name": "src/test/fixture/sdkintegration/gocc/sample1NoInit/src/github.com/example_cc/vendor/google.golang.org/grpc/go.mod",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:Class",
+          "value": "lang-pkgs"
+        },
+        {
+          "name": "aquasecurity:trivy:Type",
+          "value": "gomod"
+        }
+      ]
+    },
+    {
+      "bom-ref": "8b503cd4-e3e6-47d5-8e12-b65bc6cbc84f",
+      "type": "application",
+      "name": "src/test/fixture/sdkintegration/gocc/sample_11/src/github.com/example_cc/go.mod",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:Class",
+          "value": "lang-pkgs"
+        },
+        {
+          "name": "aquasecurity:trivy:Type",
+          "value": "gomod"
+        }
+      ]
+    },
+    {
+      "bom-ref": "92e709f8-e698-4f21-aecb-d51f65aadb58",
+      "type": "application",
+      "name": "src/test/fixture/sdkintegration/gocc/sample_mv/src/github.com/example_cc/go.mod",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:Class",
+          "value": "lang-pkgs"
+        },
+        {
+          "name": "aquasecurity:trivy:Type",
+          "value": "gomod"
+        }
+      ]
+    },
+    {
+      "bom-ref": "da404db5-355a-46f3-9174-5b60588c1c3c",
+      "type": "application",
+      "name": "src/test/fixture/sdkintegration/gocc/samplePrivateData/src/github.com/private_data_cc/go.mod",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:Class",
+          "value": "lang-pkgs"
+        },
+        {
+          "name": "aquasecurity:trivy:Type",
+          "value": "gomod"
+        }
+      ]
+    },
+    {
+      "bom-ref": "e2b30296-4cf4-4c40-b900-f32a78db2efc",
+      "type": "application",
+      "name": "src/test/fixture/sdkintegration/gocc/sampleIdemix/src/github.com/example_cc/go.mod",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:Class",
+          "value": "lang-pkgs"
+        },
+        {
+          "name": "aquasecurity:trivy:Type",
+          "value": "gomod"
+        }
+      ]
+    },
+    {
+      "bom-ref": "e5d2dbc4-cfa5-4c28-a87e-5185437289bc",
+      "type": "application",
+      "name": "src/test/fixture/sdkintegration/gocc/samplePrivateData/src/github.com/private_data_cc/vendor/google.golang.org/grpc/go.mod",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:Class",
+          "value": "lang-pkgs"
+        },
+        {
+          "name": "aquasecurity:trivy:Type",
+          "value": "gomod"
+        }
+      ]
+    },
+    {
+      "bom-ref": "f3ba4d89-ae60-4a8f-bd10-03d4213d419e",
+      "type": "application",
+      "name": "src/test/fixture/sdkintegration/gocc/sample_mv/src/github.com/example_cc/vendor/google.golang.org/grpc/go.mod",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:Class",
+          "value": "lang-pkgs"
+        },
+        {
+          "name": "aquasecurity:trivy:Type",
+          "value": "gomod"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/cloud.google.com/go@0.26.0",
+      "type": "library",
+      "name": "cloud.google.com/go",
+      "version": "0.26.0",
+      "licenses": [
+        {
+          "license": {
+            "name": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:golang/cloud.google.com/go@0.26.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "cloud.google.com/go@v0.26.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "gomod"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/burntsushi/toml@0.3.1",
+      "type": "library",
+      "name": "github.com/BurntSushi/toml",
+      "version": "0.3.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "MIT"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/burntsushi/toml@0.3.1",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "github.com/BurntSushi/toml@v0.3.1"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "gomod"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/client9/misspell@0.3.4",
+      "type": "library",
+      "name": "github.com/client9/misspell",
+      "version": "0.3.4",
+      "licenses": [
+        {
+          "license": {
+            "name": "MIT"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/client9/misspell@0.3.4",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "github.com/client9/misspell@v0.3.4"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "gomod"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/davecgh/go-spew@1.1.1",
+      "type": "library",
+      "name": "github.com/davecgh/go-spew",
+      "version": "1.1.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "ISC"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/davecgh/go-spew@1.1.1",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "github.com/davecgh/go-spew@v1.1.1"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "gomod"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/golang/glog@0.0.0-20160126235308-23def4e6c14b",
+      "type": "library",
+      "name": "github.com/golang/glog",
+      "version": "0.0.0-20160126235308-23def4e6c14b",
+      "licenses": [
+        {
+          "license": {
+            "name": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/golang/glog@0.0.0-20160126235308-23def4e6c14b",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "github.com/golang/glog@v0.0.0-20160126235308-23def4e6c14b"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "gomod"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/golang/mock@1.1.1",
+      "type": "library",
+      "name": "github.com/golang/mock",
+      "version": "1.1.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/golang/mock@1.1.1",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "github.com/golang/mock@v1.1.1"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "gomod"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/golang/protobuf@1.2.0",
+      "type": "library",
+      "name": "github.com/golang/protobuf",
+      "version": "1.2.0",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD-3-Clause"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/golang/protobuf@1.2.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "github.com/golang/protobuf@v1.2.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "gomod"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/golang/protobuf@1.3.2",
+      "type": "library",
+      "name": "github.com/golang/protobuf",
+      "version": "1.3.2",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD-3-Clause"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/golang/protobuf@1.3.2",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "github.com/golang/protobuf@v1.3.2"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "gomod"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/google/go-cmp@0.2.0",
+      "type": "library",
+      "name": "github.com/google/go-cmp",
+      "version": "0.2.0",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD-3-Clause"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/google/go-cmp@0.2.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "github.com/google/go-cmp@v0.2.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "gomod"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/hyperledger/fabric-chaincode-go@0.0.0-20220131132609-1476cf1d3206",
+      "type": "library",
+      "name": "github.com/hyperledger/fabric-chaincode-go",
+      "version": "0.0.0-20220131132609-1476cf1d3206",
+      "purl": "pkg:golang/github.com/hyperledger/fabric-chaincode-go@0.0.0-20220131132609-1476cf1d3206",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "github.com/hyperledger/fabric-chaincode-go@v0.0.0-20220131132609-1476cf1d3206"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "gomod"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/hyperledger/fabric-protos-go@0.0.0-20190919234611-2a87503ac7c9",
+      "type": "library",
+      "name": "github.com/hyperledger/fabric-protos-go",
+      "version": "0.0.0-20190919234611-2a87503ac7c9",
+      "purl": "pkg:golang/github.com/hyperledger/fabric-protos-go@0.0.0-20190919234611-2a87503ac7c9",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "github.com/hyperledger/fabric-protos-go@v0.0.0-20190919234611-2a87503ac7c9"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "gomod"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/kr/pretty@0.1.0",
+      "type": "library",
+      "name": "github.com/kr/pretty",
+      "version": "0.1.0",
+      "licenses": [
+        {
+          "license": {
+            "name": "MIT"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/kr/pretty@0.1.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "github.com/kr/pretty@v0.1.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "gomod"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/kr/pty@1.1.1",
+      "type": "library",
+      "name": "github.com/kr/pty",
+      "version": "1.1.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "MIT"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/kr/pty@1.1.1",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "github.com/kr/pty@v1.1.1"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "gomod"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/kr/text@0.1.0",
+      "type": "library",
+      "name": "github.com/kr/text",
+      "version": "0.1.0",
+      "licenses": [
+        {
+          "license": {
+            "name": "MIT"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/kr/text@0.1.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "github.com/kr/text@v0.1.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "gomod"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/pmezard/go-difflib@1.0.0",
+      "type": "library",
+      "name": "github.com/pmezard/go-difflib",
+      "version": "1.0.0",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD-3-Clause"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/pmezard/go-difflib@1.0.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "github.com/pmezard/go-difflib@v1.0.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "gomod"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/stretchr/objx@0.1.0",
+      "type": "library",
+      "name": "github.com/stretchr/objx",
+      "version": "0.1.0",
+      "licenses": [
+        {
+          "license": {
+            "name": "MIT"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/stretchr/objx@0.1.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "github.com/stretchr/objx@v0.1.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "gomod"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/stretchr/testify@1.7.0",
+      "type": "library",
+      "name": "github.com/stretchr/testify",
+      "version": "1.7.0",
+      "licenses": [
+        {
+          "license": {
+            "name": "MIT"
+          }
+        }
+      ],
+      "purl": "pkg:golang/github.com/stretchr/testify@1.7.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "github.com/stretchr/testify@v1.7.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "gomod"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/golang.org/x/crypto@0.0.0-20190308221718-c2843e01d9a2",
+      "type": "library",
+      "name": "golang.org/x/crypto",
+      "version": "0.0.0-20190308221718-c2843e01d9a2",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD-3-Clause"
+          }
+        }
+      ],
+      "purl": "pkg:golang/golang.org/x/crypto@0.0.0-20190308221718-c2843e01d9a2",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "golang.org/x/crypto@v0.0.0-20190308221718-c2843e01d9a2"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "gomod"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/golang.org/x/lint@0.0.0-20190313153728-d0100b6bd8b3",
+      "type": "library",
+      "name": "golang.org/x/lint",
+      "version": "0.0.0-20190313153728-d0100b6bd8b3",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD-3-Clause"
+          }
+        }
+      ],
+      "purl": "pkg:golang/golang.org/x/lint@0.0.0-20190313153728-d0100b6bd8b3",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "golang.org/x/lint@v0.0.0-20190313153728-d0100b6bd8b3"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "gomod"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/golang.org/x/net@0.0.0-20190311183353-d8887717615a",
+      "type": "library",
+      "name": "golang.org/x/net",
+      "version": "0.0.0-20190311183353-d8887717615a",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD-3-Clause"
+          }
+        }
+      ],
+      "purl": "pkg:golang/golang.org/x/net@0.0.0-20190311183353-d8887717615a",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "golang.org/x/net@v0.0.0-20190311183353-d8887717615a"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "gomod"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/golang.org/x/net@0.0.0-20190522155817-f3200d17e092",
+      "type": "library",
+      "name": "golang.org/x/net",
+      "version": "0.0.0-20190522155817-f3200d17e092",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD-3-Clause"
+          }
+        }
+      ],
+      "purl": "pkg:golang/golang.org/x/net@0.0.0-20190522155817-f3200d17e092",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "golang.org/x/net@v0.0.0-20190522155817-f3200d17e092"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "gomod"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/golang.org/x/oauth2@0.0.0-20180821212333-d2e6202438be",
+      "type": "library",
+      "name": "golang.org/x/oauth2",
+      "version": "0.0.0-20180821212333-d2e6202438be",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD-3-Clause"
+          }
+        }
+      ],
+      "purl": "pkg:golang/golang.org/x/oauth2@0.0.0-20180821212333-d2e6202438be",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "golang.org/x/oauth2@v0.0.0-20180821212333-d2e6202438be"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "gomod"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/golang.org/x/sync@0.0.0-20190423024810-112230192c58",
+      "type": "library",
+      "name": "golang.org/x/sync",
+      "version": "0.0.0-20190423024810-112230192c58",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD-3-Clause"
+          }
+        }
+      ],
+      "purl": "pkg:golang/golang.org/x/sync@0.0.0-20190423024810-112230192c58",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "golang.org/x/sync@v0.0.0-20190423024810-112230192c58"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "gomod"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/golang.org/x/sys@0.0.0-20190215142949-d0b11bdaac8a",
+      "type": "library",
+      "name": "golang.org/x/sys",
+      "version": "0.0.0-20190215142949-d0b11bdaac8a",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD-3-Clause"
+          }
+        }
+      ],
+      "purl": "pkg:golang/golang.org/x/sys@0.0.0-20190215142949-d0b11bdaac8a",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "golang.org/x/sys@v0.0.0-20190215142949-d0b11bdaac8a"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "gomod"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/golang.org/x/sys@0.0.0-20190710143415-6ec70d6a5542",
+      "type": "library",
+      "name": "golang.org/x/sys",
+      "version": "0.0.0-20190710143415-6ec70d6a5542",
+      "purl": "pkg:golang/golang.org/x/sys@0.0.0-20190710143415-6ec70d6a5542",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "golang.org/x/sys@v0.0.0-20190710143415-6ec70d6a5542"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "gomod"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/golang.org/x/text@0.3.0",
+      "type": "library",
+      "name": "golang.org/x/text",
+      "version": "0.3.0",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD-3-Clause"
+          }
+        }
+      ],
+      "purl": "pkg:golang/golang.org/x/text@0.3.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "golang.org/x/text@v0.3.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "gomod"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/golang.org/x/tools@0.0.0-20190524140312-2c0ae7006135",
+      "type": "library",
+      "name": "golang.org/x/tools",
+      "version": "0.0.0-20190524140312-2c0ae7006135",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD-3-Clause"
+          }
+        }
+      ],
+      "purl": "pkg:golang/golang.org/x/tools@0.0.0-20190524140312-2c0ae7006135",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "golang.org/x/tools@v0.0.0-20190524140312-2c0ae7006135"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "gomod"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/google.golang.org/appengine@1.1.0",
+      "type": "library",
+      "name": "google.golang.org/appengine",
+      "version": "1.1.0",
+      "licenses": [
+        {
+          "license": {
+            "name": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:golang/google.golang.org/appengine@1.1.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "google.golang.org/appengine@v1.1.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "gomod"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/google.golang.org/genproto@0.0.0-20180817151627-c66870c02cf8",
+      "type": "library",
+      "name": "google.golang.org/genproto",
+      "version": "0.0.0-20180817151627-c66870c02cf8",
+      "licenses": [
+        {
+          "license": {
+            "name": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:golang/google.golang.org/genproto@0.0.0-20180817151627-c66870c02cf8",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "google.golang.org/genproto@v0.0.0-20180817151627-c66870c02cf8"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "gomod"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/google.golang.org/genproto@0.0.0-20180831171423-11092d34479b",
+      "type": "library",
+      "name": "google.golang.org/genproto",
+      "version": "0.0.0-20180831171423-11092d34479b",
+      "purl": "pkg:golang/google.golang.org/genproto@0.0.0-20180831171423-11092d34479b",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "google.golang.org/genproto@v0.0.0-20180831171423-11092d34479b"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "gomod"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/google.golang.org/grpc@1.23.0",
+      "type": "library",
+      "name": "google.golang.org/grpc",
+      "version": "1.23.0",
+      "licenses": [
+        {
+          "license": {
+            "name": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:golang/google.golang.org/grpc@1.23.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "google.golang.org/grpc@v1.23.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "gomod"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/gopkg.in/check.v1@1.0.0-20180628173108-788fd7840127",
+      "type": "library",
+      "name": "gopkg.in/check.v1",
+      "version": "1.0.0-20180628173108-788fd7840127",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD-2-Clause"
+          }
+        }
+      ],
+      "purl": "pkg:golang/gopkg.in/check.v1@1.0.0-20180628173108-788fd7840127",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "gopkg.in/check.v1@v1.0.0-20180628173108-788fd7840127"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "gomod"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/gopkg.in/yaml.v3@3.0.0-20200313102051-9f266ea9e77c",
+      "type": "library",
+      "name": "gopkg.in/yaml.v3",
+      "version": "3.0.0-20200313102051-9f266ea9e77c",
+      "licenses": [
+        {
+          "license": {
+            "name": "Apache-2.0"
+          }
+        },
+        {
+          "license": {
+            "name": "MIT"
+          }
+        }
+      ],
+      "purl": "pkg:golang/gopkg.in/yaml.v3@3.0.0-20200313102051-9f266ea9e77c",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "gopkg.in/yaml.v3@v3.0.0-20200313102051-9f266ea9e77c"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "gomod"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/honnef.co/go/tools@0.0.0-20190523083050-ea95bdfd59fc",
+      "type": "library",
+      "name": "honnef.co/go/tools",
+      "version": "0.0.0-20190523083050-ea95bdfd59fc",
+      "licenses": [
+        {
+          "license": {
+            "name": "MIT"
+          }
+        }
+      ],
+      "purl": "pkg:golang/honnef.co/go/tools@0.0.0-20190523083050-ea95bdfd59fc",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "honnef.co/go/tools@v0.0.0-20190523083050-ea95bdfd59fc"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "gomod"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/com.google.api.grpc/proto-google-common-protos@2.17.0",
+      "type": "library",
+      "name": "com.google.api.grpc:proto-google-common-protos",
+      "version": "2.17.0",
+      "licenses": [
+        {
+          "license": {
+            "name": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/com.google.api.grpc/proto-google-common-protos@2.17.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "com.google.api.grpc:proto-google-common-protos:2.17.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "pom"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/com.google.api/api-common@2.15.0",
+      "type": "library",
+      "name": "com.google.api:api-common",
+      "version": "2.15.0",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD-3-Clause"
+          }
+        }
+      ],
+      "purl": "pkg:maven/com.google.api/api-common@2.15.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "com.google.api:api-common:2.15.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "pom"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/com.google.auto.value/auto-value-annotations@1.10.2",
+      "type": "library",
+      "name": "com.google.auto.value:auto-value-annotations",
+      "version": "1.10.2",
+      "licenses": [
+        {
+          "license": {
+            "name": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/com.google.auto.value/auto-value-annotations@1.10.2",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "com.google.auto.value:auto-value-annotations:1.10.2"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "pom"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/com.google.code.findbugs/jsr305@3.0.2",
+      "type": "library",
+      "name": "com.google.code.findbugs:jsr305",
+      "version": "3.0.2",
+      "licenses": [
+        {
+          "license": {
+            "name": "The Apache Software License, Version 2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/com.google.code.findbugs/jsr305@3.0.2",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "com.google.code.findbugs:jsr305:3.0.2"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "pom"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/com.google.errorprone/error_prone_annotations@2.18.0",
+      "type": "library",
+      "name": "com.google.errorprone:error_prone_annotations",
+      "version": "2.18.0",
+      "licenses": [
+        {
+          "license": {
+            "name": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/com.google.errorprone/error_prone_annotations@2.18.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "com.google.errorprone:error_prone_annotations:2.18.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "pom"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/com.google.guava/failureaccess@1.0.1",
+      "type": "library",
+      "name": "com.google.guava:failureaccess",
+      "version": "1.0.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "The Apache Software License, Version 2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/com.google.guava/failureaccess@1.0.1",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "com.google.guava:failureaccess:1.0.1"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "pom"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/com.google.guava/guava@32.0.1-android",
+      "type": "library",
+      "name": "com.google.guava:guava",
+      "version": "32.0.1-android",
+      "licenses": [
+        {
+          "license": {
+            "name": "Apache License, Version 2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/com.google.guava/guava@32.0.1-android",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "com.google.guava:guava:32.0.1-android"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "pom"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/com.google.guava/listenablefuture@9999.0-empty-to-avoid-conflict-with-guava",
+      "type": "library",
+      "name": "com.google.guava:listenablefuture",
+      "version": "9999.0-empty-to-avoid-conflict-with-guava",
+      "licenses": [
+        {
+          "license": {
+            "name": "The Apache Software License, Version 2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/com.google.guava/listenablefuture@9999.0-empty-to-avoid-conflict-with-guava",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "pom"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/com.google.j2objc/j2objc-annotations@2.8",
+      "type": "library",
+      "name": "com.google.j2objc:j2objc-annotations",
+      "version": "2.8",
+      "licenses": [
+        {
+          "license": {
+            "name": "Apache License, Version 2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/com.google.j2objc/j2objc-annotations@2.8",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "com.google.j2objc:j2objc-annotations:2.8"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "pom"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/com.google.protobuf/protobuf-java@3.22.5",
+      "type": "library",
+      "name": "com.google.protobuf:protobuf-java",
+      "version": "3.22.5",
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD-3-Clause"
+          }
+        }
+      ],
+      "purl": "pkg:maven/com.google.protobuf/protobuf-java@3.22.5",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "com.google.protobuf:protobuf-java:3.22.5"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "pom"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/com.spotify/futures-extra@4.3.1",
+      "type": "library",
+      "name": "com.spotify:futures-extra",
+      "version": "4.3.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "The Apache Software License, Version 2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/com.spotify/futures-extra@4.3.1",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "com.spotify:futures-extra:4.3.1"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "pom"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/commons-cli/commons-cli@1.5.0",
+      "type": "library",
+      "name": "commons-cli:commons-cli",
+      "version": "1.5.0",
+      "licenses": [
+        {
+          "license": {
+            "name": "Apache License, Version 2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/commons-cli/commons-cli@1.5.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "commons-cli:commons-cli:1.5.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "pom"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/commons-codec/commons-codec@1.11",
+      "type": "library",
+      "name": "commons-codec:commons-codec",
+      "version": "1.11",
+      "licenses": [
+        {
+          "license": {
+            "name": "Apache License, Version 2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/commons-codec/commons-codec@1.11",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "commons-codec:commons-codec:1.11"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "pom"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/commons-io/commons-io@2.13.0",
+      "type": "library",
+      "name": "commons-io:commons-io",
+      "version": "2.13.0",
+      "licenses": [
+        {
+          "license": {
+            "name": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/commons-io/commons-io@2.13.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "commons-io:commons-io:2.13.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "pom"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/commons-logging/commons-logging@1.2",
+      "type": "library",
+      "name": "commons-logging:commons-logging",
+      "version": "1.2",
+      "licenses": [
+        {
+          "license": {
+            "name": "The Apache Software License, Version 2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/commons-logging/commons-logging@1.2",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "commons-logging:commons-logging:1.2"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "pom"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/io.grpc/grpc-api@1.57.2",
+      "type": "library",
+      "name": "io.grpc:grpc-api",
+      "version": "1.57.2",
+      "licenses": [
+        {
+          "license": {
+            "name": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/io.grpc/grpc-api@1.57.2",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "io.grpc:grpc-api:1.57.2"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "pom"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/io.grpc/grpc-core@1.57.2",
+      "type": "library",
+      "name": "io.grpc:grpc-core",
+      "version": "1.57.2",
+      "licenses": [
+        {
+          "license": {
+            "name": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/io.grpc/grpc-core@1.57.2",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "io.grpc:grpc-core:1.57.2"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "pom"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/io.grpc/grpc-netty-shaded@1.57.2",
+      "type": "library",
+      "name": "io.grpc:grpc-netty-shaded",
+      "version": "1.57.2",
+      "licenses": [
+        {
+          "license": {
+            "name": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/io.grpc/grpc-netty-shaded@1.57.2",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "io.grpc:grpc-netty-shaded:1.57.2"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "pom"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/io.grpc/grpc-protobuf-lite@1.57.2",
+      "type": "library",
+      "name": "io.grpc:grpc-protobuf-lite",
+      "version": "1.57.2",
+      "licenses": [
+        {
+          "license": {
+            "name": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/io.grpc/grpc-protobuf-lite@1.57.2",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "io.grpc:grpc-protobuf-lite:1.57.2"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "pom"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/io.grpc/grpc-protobuf@1.57.2",
+      "type": "library",
+      "name": "io.grpc:grpc-protobuf",
+      "version": "1.57.2",
+      "licenses": [
+        {
+          "license": {
+            "name": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/io.grpc/grpc-protobuf@1.57.2",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "io.grpc:grpc-protobuf:1.57.2"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "pom"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/io.grpc/grpc-stub@1.57.2",
+      "type": "library",
+      "name": "io.grpc:grpc-stub",
+      "version": "1.57.2",
+      "licenses": [
+        {
+          "license": {
+            "name": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/io.grpc/grpc-stub@1.57.2",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "io.grpc:grpc-stub:1.57.2"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "pom"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/io.opentelemetry.instrumentation/opentelemetry-grpc-1.6@1.29.0-alpha",
+      "type": "library",
+      "name": "io.opentelemetry.instrumentation:opentelemetry-grpc-1.6",
+      "version": "1.29.0-alpha",
+      "licenses": [
+        {
+          "license": {
+            "name": "The Apache License, Version 2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/io.opentelemetry.instrumentation/opentelemetry-grpc-1.6@1.29.0-alpha",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "io.opentelemetry.instrumentation:opentelemetry-grpc-1.6:1.29.0-alpha"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "pom"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/io.opentelemetry.instrumentation/opentelemetry-instrumentation-api-semconv@1.29.0-alpha",
+      "type": "library",
+      "name": "io.opentelemetry.instrumentation:opentelemetry-instrumentation-api-semconv",
+      "version": "1.29.0-alpha",
+      "licenses": [
+        {
+          "license": {
+            "name": "The Apache License, Version 2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/io.opentelemetry.instrumentation/opentelemetry-instrumentation-api-semconv@1.29.0-alpha",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "io.opentelemetry.instrumentation:opentelemetry-instrumentation-api-semconv:1.29.0-alpha"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "pom"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/io.opentelemetry.instrumentation/opentelemetry-instrumentation-api@1.29.0",
+      "type": "library",
+      "name": "io.opentelemetry.instrumentation:opentelemetry-instrumentation-api",
+      "version": "1.29.0",
+      "licenses": [
+        {
+          "license": {
+            "name": "The Apache License, Version 2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/io.opentelemetry.instrumentation/opentelemetry-instrumentation-api@1.29.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "io.opentelemetry.instrumentation:opentelemetry-instrumentation-api:1.29.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "pom"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/io.opentelemetry.proto/opentelemetry-proto@1.0.0-alpha",
+      "type": "library",
+      "name": "io.opentelemetry.proto:opentelemetry-proto",
+      "version": "1.0.0-alpha",
+      "licenses": [
+        {
+          "license": {
+            "name": "The Apache License, Version 2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/io.opentelemetry.proto/opentelemetry-proto@1.0.0-alpha",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "io.opentelemetry.proto:opentelemetry-proto:1.0.0-alpha"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "pom"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/io.opentelemetry/opentelemetry-api@1.29.0",
+      "type": "library",
+      "name": "io.opentelemetry:opentelemetry-api",
+      "version": "1.29.0",
+      "licenses": [
+        {
+          "license": {
+            "name": "The Apache License, Version 2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/io.opentelemetry/opentelemetry-api@1.29.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "io.opentelemetry:opentelemetry-api:1.29.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "pom"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/io.opentelemetry/opentelemetry-context@1.29.0",
+      "type": "library",
+      "name": "io.opentelemetry:opentelemetry-context",
+      "version": "1.29.0",
+      "licenses": [
+        {
+          "license": {
+            "name": "The Apache License, Version 2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/io.opentelemetry/opentelemetry-context@1.29.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "io.opentelemetry:opentelemetry-context:1.29.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "pom"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/io.opentelemetry/opentelemetry-exporter-otlp@1.29.0",
+      "type": "library",
+      "name": "io.opentelemetry:opentelemetry-exporter-otlp",
+      "version": "1.29.0",
+      "licenses": [
+        {
+          "license": {
+            "name": "The Apache License, Version 2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/io.opentelemetry/opentelemetry-exporter-otlp@1.29.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "io.opentelemetry:opentelemetry-exporter-otlp:1.29.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "pom"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/io.opentelemetry/opentelemetry-extension-trace-propagators@1.29.0",
+      "type": "library",
+      "name": "io.opentelemetry:opentelemetry-extension-trace-propagators",
+      "version": "1.29.0",
+      "licenses": [
+        {
+          "license": {
+            "name": "The Apache License, Version 2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/io.opentelemetry/opentelemetry-extension-trace-propagators@1.29.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "io.opentelemetry:opentelemetry-extension-trace-propagators:1.29.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "pom"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/io.opentelemetry/opentelemetry-sdk-common@1.29.0",
+      "type": "library",
+      "name": "io.opentelemetry:opentelemetry-sdk-common",
+      "version": "1.29.0",
+      "licenses": [
+        {
+          "license": {
+            "name": "The Apache License, Version 2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/io.opentelemetry/opentelemetry-sdk-common@1.29.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "io.opentelemetry:opentelemetry-sdk-common:1.29.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "pom"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure-spi@1.29.0",
+      "type": "library",
+      "name": "io.opentelemetry:opentelemetry-sdk-extension-autoconfigure-spi",
+      "version": "1.29.0",
+      "licenses": [
+        {
+          "license": {
+            "name": "The Apache License, Version 2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure-spi@1.29.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "io.opentelemetry:opentelemetry-sdk-extension-autoconfigure-spi:1.29.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "pom"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure@1.29.0",
+      "type": "library",
+      "name": "io.opentelemetry:opentelemetry-sdk-extension-autoconfigure",
+      "version": "1.29.0",
+      "licenses": [
+        {
+          "license": {
+            "name": "The Apache License, Version 2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure@1.29.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "io.opentelemetry:opentelemetry-sdk-extension-autoconfigure:1.29.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "pom"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/io.opentelemetry/opentelemetry-sdk-logs@1.29.0",
+      "type": "library",
+      "name": "io.opentelemetry:opentelemetry-sdk-logs",
+      "version": "1.29.0",
+      "licenses": [
+        {
+          "license": {
+            "name": "The Apache License, Version 2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/io.opentelemetry/opentelemetry-sdk-logs@1.29.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "io.opentelemetry:opentelemetry-sdk-logs:1.29.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "pom"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/io.opentelemetry/opentelemetry-sdk-metrics@1.29.0",
+      "type": "library",
+      "name": "io.opentelemetry:opentelemetry-sdk-metrics",
+      "version": "1.29.0",
+      "licenses": [
+        {
+          "license": {
+            "name": "The Apache License, Version 2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/io.opentelemetry/opentelemetry-sdk-metrics@1.29.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "io.opentelemetry:opentelemetry-sdk-metrics:1.29.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "pom"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/io.opentelemetry/opentelemetry-sdk-trace@1.29.0",
+      "type": "library",
+      "name": "io.opentelemetry:opentelemetry-sdk-trace",
+      "version": "1.29.0",
+      "licenses": [
+        {
+          "license": {
+            "name": "The Apache License, Version 2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/io.opentelemetry/opentelemetry-sdk-trace@1.29.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "io.opentelemetry:opentelemetry-sdk-trace:1.29.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "pom"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/io.opentelemetry/opentelemetry-sdk@1.29.0",
+      "type": "library",
+      "name": "io.opentelemetry:opentelemetry-sdk",
+      "version": "1.29.0",
+      "licenses": [
+        {
+          "license": {
+            "name": "The Apache License, Version 2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/io.opentelemetry/opentelemetry-sdk@1.29.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "io.opentelemetry:opentelemetry-sdk:1.29.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "pom"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/io.opentelemetry/opentelemetry-semconv@1.29.0-alpha",
+      "type": "library",
+      "name": "io.opentelemetry:opentelemetry-semconv",
+      "version": "1.29.0-alpha",
+      "licenses": [
+        {
+          "license": {
+            "name": "The Apache License, Version 2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/io.opentelemetry/opentelemetry-semconv@1.29.0-alpha",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "io.opentelemetry:opentelemetry-semconv:1.29.0-alpha"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "pom"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/javax.activation/javax.activation-api@1.2.0",
+      "type": "library",
+      "name": "javax.activation:javax.activation-api",
+      "version": "1.2.0",
+      "licenses": [
+        {
+          "license": {
+            "name": "CDDL/GPLv2+CE"
+          }
+        }
+      ],
+      "purl": "pkg:maven/javax.activation/javax.activation-api@1.2.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "javax.activation:javax.activation-api:1.2.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "pom"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/javax.annotation/javax.annotation-api@1.3.2",
+      "type": "library",
+      "name": "javax.annotation:javax.annotation-api",
+      "version": "1.3.2",
+      "licenses": [
+        {
+          "license": {
+            "name": "CDDL + GPLv2 with classpath exception"
+          }
+        }
+      ],
+      "purl": "pkg:maven/javax.annotation/javax.annotation-api@1.3.2",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "javax.annotation:javax.annotation-api:1.3.2"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "pom"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/javax.xml.bind/jaxb-api@2.3.1",
+      "type": "library",
+      "name": "javax.xml.bind:jaxb-api",
+      "version": "2.3.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "CDDL 1.1"
+          }
+        },
+        {
+          "license": {
+            "name": "GPL2 w/ CPE"
+          }
+        }
+      ],
+      "purl": "pkg:maven/javax.xml.bind/jaxb-api@2.3.1",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "javax.xml.bind:jaxb-api:2.3.1"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "pom"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/org.apache.commons/commons-compress@1.24.0",
+      "type": "library",
+      "name": "org.apache.commons:commons-compress",
+      "version": "1.24.0",
+      "licenses": [
+        {
+          "license": {
+            "name": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.apache.commons/commons-compress@1.24.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "org.apache.commons:commons-compress:1.24.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "pom"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/org.apache.commons/commons-math3@3.6.1",
+      "type": "library",
+      "name": "org.apache.commons:commons-math3",
+      "version": "3.6.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "Apache License, Version 2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.apache.commons/commons-math3@3.6.1",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "org.apache.commons:commons-math3:3.6.1"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "pom"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/org.apache.httpcomponents/httpclient@4.5.14",
+      "type": "library",
+      "name": "org.apache.httpcomponents:httpclient",
+      "version": "4.5.14",
+      "licenses": [
+        {
+          "license": {
+            "name": "Apache License, Version 2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.apache.httpcomponents/httpclient@4.5.14",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "org.apache.httpcomponents:httpclient:4.5.14"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "pom"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/org.apache.httpcomponents/httpcore@4.4.16",
+      "type": "library",
+      "name": "org.apache.httpcomponents:httpcore",
+      "version": "4.4.16",
+      "licenses": [
+        {
+          "license": {
+            "name": "Apache License, Version 2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.apache.httpcomponents/httpcore@4.4.16",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "org.apache.httpcomponents:httpcore:4.4.16"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "pom"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/org.apache.logging.log4j/log4j-1.2-api@2.20.0",
+      "type": "library",
+      "name": "org.apache.logging.log4j:log4j-1.2-api",
+      "version": "2.20.0",
+      "licenses": [
+        {
+          "license": {
+            "name": "Apache License, Version 2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.apache.logging.log4j/log4j-1.2-api@2.20.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "org.apache.logging.log4j:log4j-1.2-api:2.20.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "pom"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/org.apache.logging.log4j/log4j-api@2.20.0",
+      "type": "library",
+      "name": "org.apache.logging.log4j:log4j-api",
+      "version": "2.20.0",
+      "licenses": [
+        {
+          "license": {
+            "name": "Apache License, Version 2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.apache.logging.log4j/log4j-api@2.20.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "org.apache.logging.log4j:log4j-api:2.20.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "pom"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/org.apache.logging.log4j/log4j-core@2.20.0",
+      "type": "library",
+      "name": "org.apache.logging.log4j:log4j-core",
+      "version": "2.20.0",
+      "licenses": [
+        {
+          "license": {
+            "name": "Apache License, Version 2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.apache.logging.log4j/log4j-core@2.20.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "org.apache.logging.log4j:log4j-core:2.20.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "pom"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/org.bouncycastle/bcpkix-jdk18on@1.76",
+      "type": "library",
+      "name": "org.bouncycastle:bcpkix-jdk18on",
+      "version": "1.76",
+      "licenses": [
+        {
+          "license": {
+            "name": "Bouncy Castle Licence"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.bouncycastle/bcpkix-jdk18on@1.76",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "org.bouncycastle:bcpkix-jdk18on:1.76"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "pom"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/org.bouncycastle/bcprov-jdk18on@1.76",
+      "type": "library",
+      "name": "org.bouncycastle:bcprov-jdk18on",
+      "version": "1.76",
+      "licenses": [
+        {
+          "license": {
+            "name": "Bouncy Castle Licence"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.bouncycastle/bcprov-jdk18on@1.76",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "org.bouncycastle:bcprov-jdk18on:1.76"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "pom"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/org.bouncycastle/bcutil-jdk18on@1.76",
+      "type": "library",
+      "name": "org.bouncycastle:bcutil-jdk18on",
+      "version": "1.76",
+      "licenses": [
+        {
+          "license": {
+            "name": "Bouncy Castle Licence"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.bouncycastle/bcutil-jdk18on@1.76",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "org.bouncycastle:bcutil-jdk18on:1.76"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "pom"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/org.checkerframework/checker-qual@3.33.0",
+      "type": "library",
+      "name": "org.checkerframework:checker-qual",
+      "version": "3.33.0",
+      "licenses": [
+        {
+          "license": {
+            "name": "The MIT License"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.checkerframework/checker-qual@3.33.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "org.checkerframework:checker-qual:3.33.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "pom"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/org.glassfish/javax.json@1.1.4",
+      "type": "library",
+      "name": "org.glassfish:javax.json",
+      "version": "1.1.4",
+      "licenses": [
+        {
+          "license": {
+            "name": "Dual license consisting of the CDDL v1.1"
+          }
+        },
+        {
+          "license": {
+            "name": "GPL v2"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.glassfish/javax.json@1.1.4",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "org.glassfish:javax.json:1.1.4"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "pom"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/org.hyperledger.fabric-sdk-java/fabric-sdk-java@2.2.25-SNAPSHOT",
+      "type": "library",
+      "name": "org.hyperledger.fabric-sdk-java:fabric-sdk-java",
+      "version": "2.2.25-SNAPSHOT",
+      "licenses": [
+        {
+          "license": {
+            "name": "Apache License, Version 2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.hyperledger.fabric-sdk-java/fabric-sdk-java@2.2.25-SNAPSHOT",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "org.hyperledger.fabric-sdk-java:fabric-sdk-java:2.2.25-SNAPSHOT"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "pom"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/org.miracl.milagro.amcl/milagro-crypto-java@0.4.0",
+      "type": "library",
+      "name": "org.miracl.milagro.amcl:milagro-crypto-java",
+      "version": "0.4.0",
+      "licenses": [
+        {
+          "license": {
+            "name": "The Apache Software License, Version 2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.miracl.milagro.amcl/milagro-crypto-java@0.4.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "org.miracl.milagro.amcl:milagro-crypto-java:0.4.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "pom"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/org.yaml/snakeyaml@2.1",
+      "type": "library",
+      "name": "org.yaml:snakeyaml",
+      "version": "2.1",
+      "licenses": [
+        {
+          "license": {
+            "name": "Apache License, Version 2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.yaml/snakeyaml@2.1",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "org.yaml:snakeyaml:2.1"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "pom"
+        }
+      ]
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "26e5aec4-4b8c-4652-9eb0-6487c9c3869b",
+      "dependsOn": [
+        "pkg:maven/com.google.api/api-common@2.15.0",
+        "pkg:maven/com.google.protobuf/protobuf-java@3.22.5",
+        "pkg:maven/com.spotify/futures-extra@4.3.1",
+        "pkg:maven/commons-cli/commons-cli@1.5.0",
+        "pkg:maven/commons-io/commons-io@2.13.0",
+        "pkg:maven/commons-logging/commons-logging@1.2",
+        "pkg:maven/io.grpc/grpc-netty-shaded@1.57.2",
+        "pkg:maven/io.grpc/grpc-protobuf@1.57.2",
+        "pkg:maven/io.grpc/grpc-stub@1.57.2",
+        "pkg:maven/io.opentelemetry.instrumentation/opentelemetry-grpc-1.6@1.29.0-alpha",
+        "pkg:maven/io.opentelemetry.proto/opentelemetry-proto@1.0.0-alpha",
+        "pkg:maven/io.opentelemetry/opentelemetry-api@1.29.0",
+        "pkg:maven/io.opentelemetry/opentelemetry-exporter-otlp@1.29.0",
+        "pkg:maven/io.opentelemetry/opentelemetry-extension-trace-propagators@1.29.0",
+        "pkg:maven/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure@1.29.0",
+        "pkg:maven/io.opentelemetry/opentelemetry-sdk-trace@1.29.0",
+        "pkg:maven/io.opentelemetry/opentelemetry-sdk@1.29.0",
+        "pkg:maven/javax.xml.bind/jaxb-api@2.3.1",
+        "pkg:maven/org.apache.commons/commons-compress@1.24.0",
+        "pkg:maven/org.apache.httpcomponents/httpclient@4.5.14",
+        "pkg:maven/org.apache.logging.log4j/log4j-1.2-api@2.20.0",
+        "pkg:maven/org.apache.logging.log4j/log4j-core@2.20.0",
+        "pkg:maven/org.bouncycastle/bcpkix-jdk18on@1.76",
+        "pkg:maven/org.bouncycastle/bcprov-jdk18on@1.76",
+        "pkg:maven/org.glassfish/javax.json@1.1.4",
+        "pkg:maven/org.hyperledger.fabric-sdk-java/fabric-sdk-java@2.2.25-SNAPSHOT",
+        "pkg:maven/org.miracl.milagro.amcl/milagro-crypto-java@0.4.0",
+        "pkg:maven/org.yaml/snakeyaml@2.1"
+      ]
+    },
+    {
+      "ref": "2c66cf1c-8e66-435e-a8b5-a236f819e1f2",
+      "dependsOn": [
+        "pkg:golang/cloud.google.com/go@0.26.0",
+        "pkg:golang/github.com/burntsushi/toml@0.3.1",
+        "pkg:golang/github.com/client9/misspell@0.3.4",
+        "pkg:golang/github.com/golang/glog@0.0.0-20160126235308-23def4e6c14b",
+        "pkg:golang/github.com/golang/mock@1.1.1",
+        "pkg:golang/github.com/golang/protobuf@1.2.0",
+        "pkg:golang/github.com/google/go-cmp@0.2.0",
+        "pkg:golang/golang.org/x/lint@0.0.0-20190313153728-d0100b6bd8b3",
+        "pkg:golang/golang.org/x/net@0.0.0-20190311183353-d8887717615a",
+        "pkg:golang/golang.org/x/oauth2@0.0.0-20180821212333-d2e6202438be",
+        "pkg:golang/golang.org/x/sync@0.0.0-20190423024810-112230192c58",
+        "pkg:golang/golang.org/x/sys@0.0.0-20190215142949-d0b11bdaac8a",
+        "pkg:golang/golang.org/x/tools@0.0.0-20190524140312-2c0ae7006135",
+        "pkg:golang/google.golang.org/appengine@1.1.0",
+        "pkg:golang/google.golang.org/genproto@0.0.0-20180817151627-c66870c02cf8",
+        "pkg:golang/honnef.co/go/tools@0.0.0-20190523083050-ea95bdfd59fc"
+      ]
+    },
+    {
+      "ref": "2c6d9149-a391-4e09-80bf-0210182efa20",
+      "dependsOn": [
+        "pkg:golang/cloud.google.com/go@0.26.0",
+        "pkg:golang/github.com/burntsushi/toml@0.3.1",
+        "pkg:golang/github.com/client9/misspell@0.3.4",
+        "pkg:golang/github.com/golang/glog@0.0.0-20160126235308-23def4e6c14b",
+        "pkg:golang/github.com/golang/mock@1.1.1",
+        "pkg:golang/github.com/golang/protobuf@1.2.0",
+        "pkg:golang/github.com/google/go-cmp@0.2.0",
+        "pkg:golang/golang.org/x/crypto@0.0.0-20190308221718-c2843e01d9a2",
+        "pkg:golang/golang.org/x/lint@0.0.0-20190313153728-d0100b6bd8b3",
+        "pkg:golang/golang.org/x/net@0.0.0-20190311183353-d8887717615a",
+        "pkg:golang/golang.org/x/oauth2@0.0.0-20180821212333-d2e6202438be",
+        "pkg:golang/golang.org/x/sync@0.0.0-20190423024810-112230192c58",
+        "pkg:golang/golang.org/x/sys@0.0.0-20190215142949-d0b11bdaac8a",
+        "pkg:golang/golang.org/x/text@0.3.0",
+        "pkg:golang/golang.org/x/tools@0.0.0-20190524140312-2c0ae7006135",
+        "pkg:golang/google.golang.org/appengine@1.1.0",
+        "pkg:golang/google.golang.org/genproto@0.0.0-20180817151627-c66870c02cf8",
+        "pkg:golang/honnef.co/go/tools@0.0.0-20190523083050-ea95bdfd59fc"
+      ]
+    },
+    {
+      "ref": "2c8ed45e-e6f4-4343-9391-6d631ffc3ac3",
+      "dependsOn": [
+        "pkg:golang/cloud.google.com/go@0.26.0",
+        "pkg:golang/github.com/burntsushi/toml@0.3.1",
+        "pkg:golang/github.com/client9/misspell@0.3.4",
+        "pkg:golang/github.com/golang/glog@0.0.0-20160126235308-23def4e6c14b",
+        "pkg:golang/github.com/golang/mock@1.1.1",
+        "pkg:golang/github.com/golang/protobuf@1.2.0",
+        "pkg:golang/github.com/google/go-cmp@0.2.0",
+        "pkg:golang/golang.org/x/crypto@0.0.0-20190308221718-c2843e01d9a2",
+        "pkg:golang/golang.org/x/lint@0.0.0-20190313153728-d0100b6bd8b3",
+        "pkg:golang/golang.org/x/net@0.0.0-20190311183353-d8887717615a",
+        "pkg:golang/golang.org/x/oauth2@0.0.0-20180821212333-d2e6202438be",
+        "pkg:golang/golang.org/x/sync@0.0.0-20190423024810-112230192c58",
+        "pkg:golang/golang.org/x/sys@0.0.0-20190215142949-d0b11bdaac8a",
+        "pkg:golang/golang.org/x/text@0.3.0",
+        "pkg:golang/golang.org/x/tools@0.0.0-20190524140312-2c0ae7006135",
+        "pkg:golang/google.golang.org/appengine@1.1.0",
+        "pkg:golang/google.golang.org/genproto@0.0.0-20180817151627-c66870c02cf8",
+        "pkg:golang/honnef.co/go/tools@0.0.0-20190523083050-ea95bdfd59fc"
+      ]
+    },
+    {
+      "ref": "39cc9e82-beee-4164-9827-9f22e58a9f0b",
+      "dependsOn": [
+        "pkg:golang/cloud.google.com/go@0.26.0",
+        "pkg:golang/github.com/burntsushi/toml@0.3.1",
+        "pkg:golang/github.com/client9/misspell@0.3.4",
+        "pkg:golang/github.com/davecgh/go-spew@1.1.1",
+        "pkg:golang/github.com/golang/glog@0.0.0-20160126235308-23def4e6c14b",
+        "pkg:golang/github.com/golang/mock@1.1.1",
+        "pkg:golang/github.com/golang/protobuf@1.3.2",
+        "pkg:golang/github.com/google/go-cmp@0.2.0",
+        "pkg:golang/github.com/hyperledger/fabric-chaincode-go@0.0.0-20220131132609-1476cf1d3206",
+        "pkg:golang/github.com/hyperledger/fabric-protos-go@0.0.0-20190919234611-2a87503ac7c9",
+        "pkg:golang/github.com/kr/pretty@0.1.0",
+        "pkg:golang/github.com/kr/pty@1.1.1",
+        "pkg:golang/github.com/kr/text@0.1.0",
+        "pkg:golang/github.com/pmezard/go-difflib@1.0.0",
+        "pkg:golang/github.com/stretchr/objx@0.1.0",
+        "pkg:golang/github.com/stretchr/testify@1.7.0",
+        "pkg:golang/golang.org/x/crypto@0.0.0-20190308221718-c2843e01d9a2",
+        "pkg:golang/golang.org/x/lint@0.0.0-20190313153728-d0100b6bd8b3",
+        "pkg:golang/golang.org/x/net@0.0.0-20190522155817-f3200d17e092",
+        "pkg:golang/golang.org/x/oauth2@0.0.0-20180821212333-d2e6202438be",
+        "pkg:golang/golang.org/x/sync@0.0.0-20190423024810-112230192c58",
+        "pkg:golang/golang.org/x/sys@0.0.0-20190710143415-6ec70d6a5542",
+        "pkg:golang/golang.org/x/text@0.3.0",
+        "pkg:golang/golang.org/x/tools@0.0.0-20190524140312-2c0ae7006135",
+        "pkg:golang/google.golang.org/appengine@1.1.0",
+        "pkg:golang/google.golang.org/genproto@0.0.0-20180831171423-11092d34479b",
+        "pkg:golang/google.golang.org/grpc@1.23.0",
+        "pkg:golang/gopkg.in/check.v1@1.0.0-20180628173108-788fd7840127",
+        "pkg:golang/gopkg.in/yaml.v3@3.0.0-20200313102051-9f266ea9e77c",
+        "pkg:golang/honnef.co/go/tools@0.0.0-20190523083050-ea95bdfd59fc"
+      ]
+    },
+    {
+      "ref": "43090543-f1a2-412c-ae01-a8bf569e48f0",
+      "dependsOn": [
+        "pkg:golang/cloud.google.com/go@0.26.0",
+        "pkg:golang/github.com/burntsushi/toml@0.3.1",
+        "pkg:golang/github.com/hyperledger/fabric-chaincode-go@0.0.0-20220131132609-1476cf1d3206",
+        "pkg:golang/github.com/hyperledger/fabric-protos-go@0.0.0-20190919234611-2a87503ac7c9",
+        "pkg:golang/github.com/kr/pretty@0.1.0",
+        "pkg:golang/github.com/stretchr/testify@1.7.0",
+        "pkg:golang/google.golang.org/appengine@1.1.0",
+        "pkg:golang/google.golang.org/grpc@1.23.0"
+      ]
+    },
+    {
+      "ref": "82f54327-c490-490a-b8b4-4117f81f5570",
+      "dependsOn": [
+        "pkg:golang/cloud.google.com/go@0.26.0",
+        "pkg:golang/github.com/burntsushi/toml@0.3.1",
+        "pkg:golang/github.com/client9/misspell@0.3.4",
+        "pkg:golang/github.com/golang/glog@0.0.0-20160126235308-23def4e6c14b",
+        "pkg:golang/github.com/golang/mock@1.1.1",
+        "pkg:golang/github.com/golang/protobuf@1.2.0",
+        "pkg:golang/github.com/google/go-cmp@0.2.0",
+        "pkg:golang/golang.org/x/crypto@0.0.0-20190308221718-c2843e01d9a2",
+        "pkg:golang/golang.org/x/lint@0.0.0-20190313153728-d0100b6bd8b3",
+        "pkg:golang/golang.org/x/net@0.0.0-20190311183353-d8887717615a",
+        "pkg:golang/golang.org/x/oauth2@0.0.0-20180821212333-d2e6202438be",
+        "pkg:golang/golang.org/x/sync@0.0.0-20190423024810-112230192c58",
+        "pkg:golang/golang.org/x/sys@0.0.0-20190215142949-d0b11bdaac8a",
+        "pkg:golang/golang.org/x/text@0.3.0",
+        "pkg:golang/golang.org/x/tools@0.0.0-20190524140312-2c0ae7006135",
+        "pkg:golang/google.golang.org/appengine@1.1.0",
+        "pkg:golang/google.golang.org/genproto@0.0.0-20180817151627-c66870c02cf8",
+        "pkg:golang/honnef.co/go/tools@0.0.0-20190523083050-ea95bdfd59fc"
+      ]
+    },
+    {
+      "ref": "8b503cd4-e3e6-47d5-8e12-b65bc6cbc84f",
+      "dependsOn": [
+        "pkg:golang/cloud.google.com/go@0.26.0",
+        "pkg:golang/github.com/burntsushi/toml@0.3.1",
+        "pkg:golang/github.com/client9/misspell@0.3.4",
+        "pkg:golang/github.com/davecgh/go-spew@1.1.1",
+        "pkg:golang/github.com/golang/glog@0.0.0-20160126235308-23def4e6c14b",
+        "pkg:golang/github.com/golang/mock@1.1.1",
+        "pkg:golang/github.com/golang/protobuf@1.3.2",
+        "pkg:golang/github.com/google/go-cmp@0.2.0",
+        "pkg:golang/github.com/hyperledger/fabric-chaincode-go@0.0.0-20220131132609-1476cf1d3206",
+        "pkg:golang/github.com/hyperledger/fabric-protos-go@0.0.0-20190919234611-2a87503ac7c9",
+        "pkg:golang/github.com/kr/pretty@0.1.0",
+        "pkg:golang/github.com/kr/pty@1.1.1",
+        "pkg:golang/github.com/kr/text@0.1.0",
+        "pkg:golang/github.com/pmezard/go-difflib@1.0.0",
+        "pkg:golang/github.com/stretchr/objx@0.1.0",
+        "pkg:golang/github.com/stretchr/testify@1.7.0",
+        "pkg:golang/golang.org/x/crypto@0.0.0-20190308221718-c2843e01d9a2",
+        "pkg:golang/golang.org/x/lint@0.0.0-20190313153728-d0100b6bd8b3",
+        "pkg:golang/golang.org/x/net@0.0.0-20190522155817-f3200d17e092",
+        "pkg:golang/golang.org/x/oauth2@0.0.0-20180821212333-d2e6202438be",
+        "pkg:golang/golang.org/x/sync@0.0.0-20190423024810-112230192c58",
+        "pkg:golang/golang.org/x/sys@0.0.0-20190710143415-6ec70d6a5542",
+        "pkg:golang/golang.org/x/text@0.3.0",
+        "pkg:golang/golang.org/x/tools@0.0.0-20190524140312-2c0ae7006135",
+        "pkg:golang/google.golang.org/appengine@1.1.0",
+        "pkg:golang/google.golang.org/genproto@0.0.0-20180831171423-11092d34479b",
+        "pkg:golang/google.golang.org/grpc@1.23.0",
+        "pkg:golang/gopkg.in/check.v1@1.0.0-20180628173108-788fd7840127",
+        "pkg:golang/gopkg.in/yaml.v3@3.0.0-20200313102051-9f266ea9e77c",
+        "pkg:golang/honnef.co/go/tools@0.0.0-20190523083050-ea95bdfd59fc"
+      ]
+    },
+    {
+      "ref": "92e709f8-e698-4f21-aecb-d51f65aadb58",
+      "dependsOn": [
+        "pkg:golang/cloud.google.com/go@0.26.0",
+        "pkg:golang/github.com/burntsushi/toml@0.3.1",
+        "pkg:golang/github.com/client9/misspell@0.3.4",
+        "pkg:golang/github.com/davecgh/go-spew@1.1.1",
+        "pkg:golang/github.com/golang/glog@0.0.0-20160126235308-23def4e6c14b",
+        "pkg:golang/github.com/golang/mock@1.1.1",
+        "pkg:golang/github.com/golang/protobuf@1.3.2",
+        "pkg:golang/github.com/google/go-cmp@0.2.0",
+        "pkg:golang/github.com/hyperledger/fabric-chaincode-go@0.0.0-20220131132609-1476cf1d3206",
+        "pkg:golang/github.com/hyperledger/fabric-protos-go@0.0.0-20190919234611-2a87503ac7c9",
+        "pkg:golang/github.com/kr/pretty@0.1.0",
+        "pkg:golang/github.com/kr/pty@1.1.1",
+        "pkg:golang/github.com/kr/text@0.1.0",
+        "pkg:golang/github.com/pmezard/go-difflib@1.0.0",
+        "pkg:golang/github.com/stretchr/objx@0.1.0",
+        "pkg:golang/github.com/stretchr/testify@1.7.0",
+        "pkg:golang/golang.org/x/crypto@0.0.0-20190308221718-c2843e01d9a2",
+        "pkg:golang/golang.org/x/lint@0.0.0-20190313153728-d0100b6bd8b3",
+        "pkg:golang/golang.org/x/net@0.0.0-20190522155817-f3200d17e092",
+        "pkg:golang/golang.org/x/oauth2@0.0.0-20180821212333-d2e6202438be",
+        "pkg:golang/golang.org/x/sync@0.0.0-20190423024810-112230192c58",
+        "pkg:golang/golang.org/x/sys@0.0.0-20190710143415-6ec70d6a5542",
+        "pkg:golang/golang.org/x/text@0.3.0",
+        "pkg:golang/golang.org/x/tools@0.0.0-20190524140312-2c0ae7006135",
+        "pkg:golang/google.golang.org/appengine@1.1.0",
+        "pkg:golang/google.golang.org/genproto@0.0.0-20180831171423-11092d34479b",
+        "pkg:golang/google.golang.org/grpc@1.23.0",
+        "pkg:golang/gopkg.in/check.v1@1.0.0-20180628173108-788fd7840127",
+        "pkg:golang/gopkg.in/yaml.v3@3.0.0-20200313102051-9f266ea9e77c",
+        "pkg:golang/honnef.co/go/tools@0.0.0-20190523083050-ea95bdfd59fc"
+      ]
+    },
+    {
+      "ref": "da404db5-355a-46f3-9174-5b60588c1c3c",
+      "dependsOn": [
+        "pkg:golang/cloud.google.com/go@0.26.0",
+        "pkg:golang/github.com/burntsushi/toml@0.3.1",
+        "pkg:golang/github.com/client9/misspell@0.3.4",
+        "pkg:golang/github.com/davecgh/go-spew@1.1.1",
+        "pkg:golang/github.com/golang/glog@0.0.0-20160126235308-23def4e6c14b",
+        "pkg:golang/github.com/golang/mock@1.1.1",
+        "pkg:golang/github.com/golang/protobuf@1.3.2",
+        "pkg:golang/github.com/google/go-cmp@0.2.0",
+        "pkg:golang/github.com/hyperledger/fabric-chaincode-go@0.0.0-20220131132609-1476cf1d3206",
+        "pkg:golang/github.com/hyperledger/fabric-protos-go@0.0.0-20190919234611-2a87503ac7c9",
+        "pkg:golang/github.com/kr/pretty@0.1.0",
+        "pkg:golang/github.com/kr/pty@1.1.1",
+        "pkg:golang/github.com/kr/text@0.1.0",
+        "pkg:golang/github.com/pmezard/go-difflib@1.0.0",
+        "pkg:golang/github.com/stretchr/objx@0.1.0",
+        "pkg:golang/github.com/stretchr/testify@1.7.0",
+        "pkg:golang/golang.org/x/crypto@0.0.0-20190308221718-c2843e01d9a2",
+        "pkg:golang/golang.org/x/lint@0.0.0-20190313153728-d0100b6bd8b3",
+        "pkg:golang/golang.org/x/net@0.0.0-20190522155817-f3200d17e092",
+        "pkg:golang/golang.org/x/oauth2@0.0.0-20180821212333-d2e6202438be",
+        "pkg:golang/golang.org/x/sync@0.0.0-20190423024810-112230192c58",
+        "pkg:golang/golang.org/x/sys@0.0.0-20190710143415-6ec70d6a5542",
+        "pkg:golang/golang.org/x/text@0.3.0",
+        "pkg:golang/golang.org/x/tools@0.0.0-20190524140312-2c0ae7006135",
+        "pkg:golang/google.golang.org/appengine@1.1.0",
+        "pkg:golang/google.golang.org/genproto@0.0.0-20180831171423-11092d34479b",
+        "pkg:golang/google.golang.org/grpc@1.23.0",
+        "pkg:golang/gopkg.in/check.v1@1.0.0-20180628173108-788fd7840127",
+        "pkg:golang/gopkg.in/yaml.v3@3.0.0-20200313102051-9f266ea9e77c",
+        "pkg:golang/honnef.co/go/tools@0.0.0-20190523083050-ea95bdfd59fc"
+      ]
+    },
+    {
+      "ref": "e2b30296-4cf4-4c40-b900-f32a78db2efc",
+      "dependsOn": [
+        "pkg:golang/cloud.google.com/go@0.26.0",
+        "pkg:golang/github.com/burntsushi/toml@0.3.1",
+        "pkg:golang/github.com/client9/misspell@0.3.4",
+        "pkg:golang/github.com/davecgh/go-spew@1.1.1",
+        "pkg:golang/github.com/golang/glog@0.0.0-20160126235308-23def4e6c14b",
+        "pkg:golang/github.com/golang/mock@1.1.1",
+        "pkg:golang/github.com/golang/protobuf@1.3.2",
+        "pkg:golang/github.com/google/go-cmp@0.2.0",
+        "pkg:golang/github.com/hyperledger/fabric-chaincode-go@0.0.0-20220131132609-1476cf1d3206",
+        "pkg:golang/github.com/hyperledger/fabric-protos-go@0.0.0-20190919234611-2a87503ac7c9",
+        "pkg:golang/github.com/kr/pretty@0.1.0",
+        "pkg:golang/github.com/kr/pty@1.1.1",
+        "pkg:golang/github.com/kr/text@0.1.0",
+        "pkg:golang/github.com/pmezard/go-difflib@1.0.0",
+        "pkg:golang/github.com/stretchr/objx@0.1.0",
+        "pkg:golang/github.com/stretchr/testify@1.7.0",
+        "pkg:golang/golang.org/x/crypto@0.0.0-20190308221718-c2843e01d9a2",
+        "pkg:golang/golang.org/x/lint@0.0.0-20190313153728-d0100b6bd8b3",
+        "pkg:golang/golang.org/x/net@0.0.0-20190522155817-f3200d17e092",
+        "pkg:golang/golang.org/x/oauth2@0.0.0-20180821212333-d2e6202438be",
+        "pkg:golang/golang.org/x/sync@0.0.0-20190423024810-112230192c58",
+        "pkg:golang/golang.org/x/sys@0.0.0-20190710143415-6ec70d6a5542",
+        "pkg:golang/golang.org/x/text@0.3.0",
+        "pkg:golang/golang.org/x/tools@0.0.0-20190524140312-2c0ae7006135",
+        "pkg:golang/google.golang.org/appengine@1.1.0",
+        "pkg:golang/google.golang.org/genproto@0.0.0-20180831171423-11092d34479b",
+        "pkg:golang/google.golang.org/grpc@1.23.0",
+        "pkg:golang/gopkg.in/check.v1@1.0.0-20180628173108-788fd7840127",
+        "pkg:golang/gopkg.in/yaml.v3@3.0.0-20200313102051-9f266ea9e77c",
+        "pkg:golang/honnef.co/go/tools@0.0.0-20190523083050-ea95bdfd59fc"
+      ]
+    },
+    {
+      "ref": "e4eee236-a16b-4458-990a-fcc14def339a",
+      "dependsOn": [
+        "26e5aec4-4b8c-4652-9eb0-6487c9c3869b",
+        "2c66cf1c-8e66-435e-a8b5-a236f819e1f2",
+        "2c6d9149-a391-4e09-80bf-0210182efa20",
+        "2c8ed45e-e6f4-4343-9391-6d631ffc3ac3",
+        "39cc9e82-beee-4164-9827-9f22e58a9f0b",
+        "43090543-f1a2-412c-ae01-a8bf569e48f0",
+        "82f54327-c490-490a-b8b4-4117f81f5570",
+        "8b503cd4-e3e6-47d5-8e12-b65bc6cbc84f",
+        "92e709f8-e698-4f21-aecb-d51f65aadb58",
+        "da404db5-355a-46f3-9174-5b60588c1c3c",
+        "e2b30296-4cf4-4c40-b900-f32a78db2efc",
+        "e5d2dbc4-cfa5-4c28-a87e-5185437289bc",
+        "f3ba4d89-ae60-4a8f-bd10-03d4213d419e"
+      ]
+    },
+    {
+      "ref": "e5d2dbc4-cfa5-4c28-a87e-5185437289bc",
+      "dependsOn": [
+        "pkg:golang/cloud.google.com/go@0.26.0",
+        "pkg:golang/github.com/burntsushi/toml@0.3.1",
+        "pkg:golang/github.com/client9/misspell@0.3.4",
+        "pkg:golang/github.com/golang/glog@0.0.0-20160126235308-23def4e6c14b",
+        "pkg:golang/github.com/golang/mock@1.1.1",
+        "pkg:golang/github.com/golang/protobuf@1.2.0",
+        "pkg:golang/github.com/google/go-cmp@0.2.0",
+        "pkg:golang/golang.org/x/crypto@0.0.0-20190308221718-c2843e01d9a2",
+        "pkg:golang/golang.org/x/lint@0.0.0-20190313153728-d0100b6bd8b3",
+        "pkg:golang/golang.org/x/net@0.0.0-20190311183353-d8887717615a",
+        "pkg:golang/golang.org/x/oauth2@0.0.0-20180821212333-d2e6202438be",
+        "pkg:golang/golang.org/x/sync@0.0.0-20190423024810-112230192c58",
+        "pkg:golang/golang.org/x/sys@0.0.0-20190215142949-d0b11bdaac8a",
+        "pkg:golang/golang.org/x/text@0.3.0",
+        "pkg:golang/golang.org/x/tools@0.0.0-20190524140312-2c0ae7006135",
+        "pkg:golang/google.golang.org/appengine@1.1.0",
+        "pkg:golang/google.golang.org/genproto@0.0.0-20180817151627-c66870c02cf8",
+        "pkg:golang/honnef.co/go/tools@0.0.0-20190523083050-ea95bdfd59fc"
+      ]
+    },
+    {
+      "ref": "f3ba4d89-ae60-4a8f-bd10-03d4213d419e",
+      "dependsOn": [
+        "pkg:golang/cloud.google.com/go@0.26.0",
+        "pkg:golang/github.com/burntsushi/toml@0.3.1",
+        "pkg:golang/github.com/client9/misspell@0.3.4",
+        "pkg:golang/github.com/golang/glog@0.0.0-20160126235308-23def4e6c14b",
+        "pkg:golang/github.com/golang/mock@1.1.1",
+        "pkg:golang/github.com/golang/protobuf@1.2.0",
+        "pkg:golang/github.com/google/go-cmp@0.2.0",
+        "pkg:golang/golang.org/x/crypto@0.0.0-20190308221718-c2843e01d9a2",
+        "pkg:golang/golang.org/x/lint@0.0.0-20190313153728-d0100b6bd8b3",
+        "pkg:golang/golang.org/x/net@0.0.0-20190311183353-d8887717615a",
+        "pkg:golang/golang.org/x/oauth2@0.0.0-20180821212333-d2e6202438be",
+        "pkg:golang/golang.org/x/sync@0.0.0-20190423024810-112230192c58",
+        "pkg:golang/golang.org/x/sys@0.0.0-20190215142949-d0b11bdaac8a",
+        "pkg:golang/golang.org/x/text@0.3.0",
+        "pkg:golang/golang.org/x/tools@0.0.0-20190524140312-2c0ae7006135",
+        "pkg:golang/google.golang.org/appengine@1.1.0",
+        "pkg:golang/google.golang.org/genproto@0.0.0-20180817151627-c66870c02cf8",
+        "pkg:golang/honnef.co/go/tools@0.0.0-20190523083050-ea95bdfd59fc"
+      ]
+    },
+    {
+      "ref": "pkg:golang/cloud.google.com/go@0.26.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/burntsushi/toml@0.3.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/client9/misspell@0.3.4",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/davecgh/go-spew@1.1.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/golang/glog@0.0.0-20160126235308-23def4e6c14b",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/golang/mock@1.1.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/golang/protobuf@1.2.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/golang/protobuf@1.3.2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/google/go-cmp@0.2.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/hyperledger/fabric-chaincode-go@0.0.0-20220131132609-1476cf1d3206",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/hyperledger/fabric-protos-go@0.0.0-20190919234611-2a87503ac7c9",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/kr/pretty@0.1.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/kr/pty@1.1.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/kr/text@0.1.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/pmezard/go-difflib@1.0.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/stretchr/objx@0.1.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/stretchr/testify@1.7.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/crypto@0.0.0-20190308221718-c2843e01d9a2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/lint@0.0.0-20190313153728-d0100b6bd8b3",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/net@0.0.0-20190311183353-d8887717615a",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/net@0.0.0-20190522155817-f3200d17e092",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/oauth2@0.0.0-20180821212333-d2e6202438be",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/sync@0.0.0-20190423024810-112230192c58",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/sys@0.0.0-20190215142949-d0b11bdaac8a",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/sys@0.0.0-20190710143415-6ec70d6a5542",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/text@0.3.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/tools@0.0.0-20190524140312-2c0ae7006135",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/google.golang.org/appengine@1.1.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/google.golang.org/genproto@0.0.0-20180817151627-c66870c02cf8",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/google.golang.org/genproto@0.0.0-20180831171423-11092d34479b",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/google.golang.org/grpc@1.23.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/gopkg.in/check.v1@1.0.0-20180628173108-788fd7840127",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/gopkg.in/yaml.v3@3.0.0-20200313102051-9f266ea9e77c",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/honnef.co/go/tools@0.0.0-20190523083050-ea95bdfd59fc",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/com.google.api.grpc/proto-google-common-protos@2.17.0",
+      "dependsOn": [
+        "pkg:maven/com.google.protobuf/protobuf-java@3.22.5"
+      ]
+    },
+    {
+      "ref": "pkg:maven/com.google.api/api-common@2.15.0",
+      "dependsOn": [
+        "pkg:maven/com.google.auto.value/auto-value-annotations@1.10.2",
+        "pkg:maven/com.google.code.findbugs/jsr305@3.0.2",
+        "pkg:maven/com.google.errorprone/error_prone_annotations@2.18.0",
+        "pkg:maven/com.google.guava/guava@32.0.1-android",
+        "pkg:maven/javax.annotation/javax.annotation-api@1.3.2"
+      ]
+    },
+    {
+      "ref": "pkg:maven/com.google.auto.value/auto-value-annotations@1.10.2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/com.google.code.findbugs/jsr305@3.0.2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/com.google.errorprone/error_prone_annotations@2.18.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/com.google.guava/failureaccess@1.0.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/com.google.guava/guava@32.0.1-android",
+      "dependsOn": [
+        "pkg:maven/com.google.code.findbugs/jsr305@3.0.2",
+        "pkg:maven/com.google.errorprone/error_prone_annotations@2.18.0",
+        "pkg:maven/com.google.guava/failureaccess@1.0.1",
+        "pkg:maven/com.google.guava/listenablefuture@9999.0-empty-to-avoid-conflict-with-guava",
+        "pkg:maven/com.google.j2objc/j2objc-annotations@2.8",
+        "pkg:maven/org.checkerframework/checker-qual@3.33.0"
+      ]
+    },
+    {
+      "ref": "pkg:maven/com.google.guava/listenablefuture@9999.0-empty-to-avoid-conflict-with-guava",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/com.google.j2objc/j2objc-annotations@2.8",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/com.google.protobuf/protobuf-java@3.22.5",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/com.spotify/futures-extra@4.3.1",
+      "dependsOn": [
+        "pkg:maven/com.google.api/api-common@2.15.0",
+        "pkg:maven/com.google.guava/guava@32.0.1-android"
+      ]
+    },
+    {
+      "ref": "pkg:maven/commons-cli/commons-cli@1.5.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/commons-codec/commons-codec@1.11",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/commons-io/commons-io@2.13.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/commons-logging/commons-logging@1.2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/io.grpc/grpc-api@1.57.2",
+      "dependsOn": [
+        "pkg:maven/com.google.code.findbugs/jsr305@3.0.2",
+        "pkg:maven/com.google.errorprone/error_prone_annotations@2.18.0"
+      ]
+    },
+    {
+      "ref": "pkg:maven/io.grpc/grpc-core@1.57.2",
+      "dependsOn": [
+        "pkg:maven/io.grpc/grpc-api@1.57.2"
+      ]
+    },
+    {
+      "ref": "pkg:maven/io.grpc/grpc-netty-shaded@1.57.2",
+      "dependsOn": [
+        "pkg:maven/io.grpc/grpc-core@1.57.2"
+      ]
+    },
+    {
+      "ref": "pkg:maven/io.grpc/grpc-protobuf-lite@1.57.2",
+      "dependsOn": [
+        "pkg:maven/io.grpc/grpc-api@1.57.2"
+      ]
+    },
+    {
+      "ref": "pkg:maven/io.grpc/grpc-protobuf@1.57.2",
+      "dependsOn": [
+        "pkg:maven/com.google.api.grpc/proto-google-common-protos@2.17.0",
+        "pkg:maven/com.google.code.findbugs/jsr305@3.0.2",
+        "pkg:maven/com.google.protobuf/protobuf-java@3.22.5",
+        "pkg:maven/io.grpc/grpc-api@1.57.2",
+        "pkg:maven/io.grpc/grpc-protobuf-lite@1.57.2"
+      ]
+    },
+    {
+      "ref": "pkg:maven/io.grpc/grpc-stub@1.57.2",
+      "dependsOn": [
+        "pkg:maven/com.google.guava/guava@32.0.1-android",
+        "pkg:maven/io.grpc/grpc-api@1.57.2"
+      ]
+    },
+    {
+      "ref": "pkg:maven/io.opentelemetry.instrumentation/opentelemetry-grpc-1.6@1.29.0-alpha",
+      "dependsOn": [
+        "pkg:maven/io.opentelemetry.instrumentation/opentelemetry-instrumentation-api-semconv@1.29.0-alpha",
+        "pkg:maven/io.opentelemetry.instrumentation/opentelemetry-instrumentation-api@1.29.0",
+        "pkg:maven/io.opentelemetry/opentelemetry-api@1.29.0"
+      ]
+    },
+    {
+      "ref": "pkg:maven/io.opentelemetry.instrumentation/opentelemetry-instrumentation-api-semconv@1.29.0-alpha",
+      "dependsOn": [
+        "pkg:maven/io.opentelemetry.instrumentation/opentelemetry-instrumentation-api@1.29.0",
+        "pkg:maven/io.opentelemetry/opentelemetry-semconv@1.29.0-alpha"
+      ]
+    },
+    {
+      "ref": "pkg:maven/io.opentelemetry.instrumentation/opentelemetry-instrumentation-api@1.29.0",
+      "dependsOn": [
+        "pkg:maven/io.opentelemetry/opentelemetry-api@1.29.0"
+      ]
+    },
+    {
+      "ref": "pkg:maven/io.opentelemetry.proto/opentelemetry-proto@1.0.0-alpha",
+      "dependsOn": [
+        "pkg:maven/com.google.protobuf/protobuf-java@3.22.5"
+      ]
+    },
+    {
+      "ref": "pkg:maven/io.opentelemetry/opentelemetry-api@1.29.0",
+      "dependsOn": [
+        "pkg:maven/io.opentelemetry/opentelemetry-context@1.29.0"
+      ]
+    },
+    {
+      "ref": "pkg:maven/io.opentelemetry/opentelemetry-context@1.29.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/io.opentelemetry/opentelemetry-exporter-otlp@1.29.0",
+      "dependsOn": [
+        "pkg:maven/io.opentelemetry/opentelemetry-sdk-logs@1.29.0",
+        "pkg:maven/io.opentelemetry/opentelemetry-sdk-metrics@1.29.0",
+        "pkg:maven/io.opentelemetry/opentelemetry-sdk-trace@1.29.0"
+      ]
+    },
+    {
+      "ref": "pkg:maven/io.opentelemetry/opentelemetry-extension-trace-propagators@1.29.0",
+      "dependsOn": [
+        "pkg:maven/io.opentelemetry/opentelemetry-api@1.29.0"
+      ]
+    },
+    {
+      "ref": "pkg:maven/io.opentelemetry/opentelemetry-sdk-common@1.29.0",
+      "dependsOn": [
+        "pkg:maven/io.opentelemetry/opentelemetry-api@1.29.0"
+      ]
+    },
+    {
+      "ref": "pkg:maven/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure-spi@1.29.0",
+      "dependsOn": [
+        "pkg:maven/io.opentelemetry/opentelemetry-sdk@1.29.0"
+      ]
+    },
+    {
+      "ref": "pkg:maven/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure@1.29.0",
+      "dependsOn": [
+        "pkg:maven/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure-spi@1.29.0",
+        "pkg:maven/io.opentelemetry/opentelemetry-sdk@1.29.0"
+      ]
+    },
+    {
+      "ref": "pkg:maven/io.opentelemetry/opentelemetry-sdk-logs@1.29.0",
+      "dependsOn": [
+        "pkg:maven/io.opentelemetry/opentelemetry-api@1.29.0",
+        "pkg:maven/io.opentelemetry/opentelemetry-sdk-common@1.29.0"
+      ]
+    },
+    {
+      "ref": "pkg:maven/io.opentelemetry/opentelemetry-sdk-metrics@1.29.0",
+      "dependsOn": [
+        "pkg:maven/io.opentelemetry/opentelemetry-api@1.29.0",
+        "pkg:maven/io.opentelemetry/opentelemetry-sdk-common@1.29.0"
+      ]
+    },
+    {
+      "ref": "pkg:maven/io.opentelemetry/opentelemetry-sdk-trace@1.29.0",
+      "dependsOn": [
+        "pkg:maven/io.opentelemetry/opentelemetry-api@1.29.0",
+        "pkg:maven/io.opentelemetry/opentelemetry-sdk-common@1.29.0"
+      ]
+    },
+    {
+      "ref": "pkg:maven/io.opentelemetry/opentelemetry-sdk@1.29.0",
+      "dependsOn": [
+        "pkg:maven/io.opentelemetry/opentelemetry-api@1.29.0",
+        "pkg:maven/io.opentelemetry/opentelemetry-sdk-common@1.29.0",
+        "pkg:maven/io.opentelemetry/opentelemetry-sdk-logs@1.29.0",
+        "pkg:maven/io.opentelemetry/opentelemetry-sdk-metrics@1.29.0",
+        "pkg:maven/io.opentelemetry/opentelemetry-sdk-trace@1.29.0"
+      ]
+    },
+    {
+      "ref": "pkg:maven/io.opentelemetry/opentelemetry-semconv@1.29.0-alpha",
+      "dependsOn": [
+        "pkg:maven/io.opentelemetry/opentelemetry-api@1.29.0"
+      ]
+    },
+    {
+      "ref": "pkg:maven/javax.activation/javax.activation-api@1.2.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/javax.annotation/javax.annotation-api@1.3.2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/javax.xml.bind/jaxb-api@2.3.1",
+      "dependsOn": [
+        "pkg:maven/javax.activation/javax.activation-api@1.2.0"
+      ]
+    },
+    {
+      "ref": "pkg:maven/org.apache.commons/commons-compress@1.24.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.apache.commons/commons-math3@3.6.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.apache.httpcomponents/httpclient@4.5.14",
+      "dependsOn": [
+        "pkg:maven/commons-codec/commons-codec@1.11",
+        "pkg:maven/commons-logging/commons-logging@1.2",
+        "pkg:maven/org.apache.httpcomponents/httpcore@4.4.16"
+      ]
+    },
+    {
+      "ref": "pkg:maven/org.apache.httpcomponents/httpcore@4.4.16",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.apache.logging.log4j/log4j-1.2-api@2.20.0",
+      "dependsOn": [
+        "pkg:maven/org.apache.logging.log4j/log4j-api@2.20.0"
+      ]
+    },
+    {
+      "ref": "pkg:maven/org.apache.logging.log4j/log4j-api@2.20.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.apache.logging.log4j/log4j-core@2.20.0",
+      "dependsOn": [
+        "pkg:maven/org.apache.logging.log4j/log4j-api@2.20.0"
+      ]
+    },
+    {
+      "ref": "pkg:maven/org.bouncycastle/bcpkix-jdk18on@1.76",
+      "dependsOn": [
+        "pkg:maven/org.bouncycastle/bcprov-jdk18on@1.76",
+        "pkg:maven/org.bouncycastle/bcutil-jdk18on@1.76"
+      ]
+    },
+    {
+      "ref": "pkg:maven/org.bouncycastle/bcprov-jdk18on@1.76",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.bouncycastle/bcutil-jdk18on@1.76",
+      "dependsOn": [
+        "pkg:maven/org.bouncycastle/bcprov-jdk18on@1.76"
+      ]
+    },
+    {
+      "ref": "pkg:maven/org.checkerframework/checker-qual@3.33.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.glassfish/javax.json@1.1.4",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:maven/org.hyperledger.fabric-sdk-java/fabric-sdk-java@2.2.25-SNAPSHOT",
+      "dependsOn": [
+        "pkg:maven/com.google.api/api-common@2.15.0",
+        "pkg:maven/com.google.protobuf/protobuf-java@3.22.5",
+        "pkg:maven/com.spotify/futures-extra@4.3.1",
+        "pkg:maven/commons-cli/commons-cli@1.5.0",
+        "pkg:maven/commons-io/commons-io@2.13.0",
+        "pkg:maven/commons-logging/commons-logging@1.2",
+        "pkg:maven/io.grpc/grpc-netty-shaded@1.57.2",
+        "pkg:maven/io.grpc/grpc-protobuf@1.57.2",
+        "pkg:maven/io.grpc/grpc-stub@1.57.2",
+        "pkg:maven/io.opentelemetry.instrumentation/opentelemetry-grpc-1.6@1.29.0-alpha",
+        "pkg:maven/io.opentelemetry.proto/opentelemetry-proto@1.0.0-alpha",
+        "pkg:maven/io.opentelemetry/opentelemetry-api@1.29.0",
+        "pkg:maven/io.opentelemetry/opentelemetry-exporter-otlp@1.29.0",
+        "pkg:maven/io.opentelemetry/opentelemetry-extension-trace-propagators@1.29.0",
+        "pkg:maven/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure@1.29.0",
+        "pkg:maven/io.opentelemetry/opentelemetry-sdk-trace@1.29.0",
+        "pkg:maven/io.opentelemetry/opentelemetry-sdk@1.29.0",
+        "pkg:maven/javax.xml.bind/jaxb-api@2.3.1",
+        "pkg:maven/org.apache.commons/commons-compress@1.24.0",
+        "pkg:maven/org.apache.httpcomponents/httpclient@4.5.14",
+        "pkg:maven/org.apache.logging.log4j/log4j-1.2-api@2.20.0",
+        "pkg:maven/org.apache.logging.log4j/log4j-core@2.20.0",
+        "pkg:maven/org.bouncycastle/bcpkix-jdk18on@1.76",
+        "pkg:maven/org.bouncycastle/bcprov-jdk18on@1.76",
+        "pkg:maven/org.glassfish/javax.json@1.1.4",
+        "pkg:maven/org.miracl.milagro.amcl/milagro-crypto-java@0.4.0",
+        "pkg:maven/org.yaml/snakeyaml@2.1"
+      ]
+    },
+    {
+      "ref": "pkg:maven/org.miracl.milagro.amcl/milagro-crypto-java@0.4.0",
+      "dependsOn": [
+        "pkg:maven/org.apache.commons/commons-math3@3.6.1"
+      ]
+    },
+    {
+      "ref": "pkg:maven/org.yaml/snakeyaml@2.1",
+      "dependsOn": []
+    }
+  ],
+  "vulnerabilities": []
+}

--- a/src/commands/sbom/__tests__/fixtures/ruby.sbom.json
+++ b/src/commands/sbom/__tests__/fixtures/ruby.sbom.json
@@ -1,0 +1,1514 @@
+{
+  "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.5",
+  "serialNumber": "urn:uuid:a213f5ea-133b-4d2e-bb32-8c44d83e41f1",
+  "version": 1,
+  "metadata": {
+    "timestamp": "2023-10-24T18:04:06+00:00",
+    "tools": [
+      {
+        "vendor": "aquasecurity",
+        "name": "trivy",
+        "version": "0.46.0"
+      }
+    ],
+    "component": {
+      "bom-ref": "82ba1ed2-bcbd-4c00-be96-2cdf09fd1c33",
+      "type": "application",
+      "name": ".",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:SchemaVersion",
+          "value": "2"
+        }
+      ]
+    }
+  },
+  "components": [
+    {
+      "bom-ref": "d5035e70-8784-4437-a008-3e9827af62f8",
+      "type": "application",
+      "name": "Gemfile.lock",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:Class",
+          "value": "lang-pkgs"
+        },
+        {
+          "name": "aquasecurity:trivy:Type",
+          "value": "bundler"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:gem/addressable@2.8.1",
+      "type": "library",
+      "name": "addressable",
+      "version": "2.8.1",
+      "purl": "pkg:gem/addressable@2.8.1",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "addressable@2.8.1"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "bundler"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:gem/adsf@1.4.6",
+      "type": "library",
+      "name": "adsf",
+      "version": "1.4.6",
+      "purl": "pkg:gem/adsf@1.4.6",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "adsf@1.4.6"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "bundler"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:gem/builder@3.2.4",
+      "type": "library",
+      "name": "builder",
+      "version": "3.2.4",
+      "purl": "pkg:gem/builder@3.2.4",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "builder@3.2.4"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "bundler"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:gem/coderay@1.1.3",
+      "type": "library",
+      "name": "coderay",
+      "version": "1.1.3",
+      "purl": "pkg:gem/coderay@1.1.3",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "coderay@1.1.3"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "bundler"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:gem/colored@1.2",
+      "type": "library",
+      "name": "colored",
+      "version": "1.2",
+      "purl": "pkg:gem/colored@1.2",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "colored@1.2"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "bundler"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:gem/concurrent-ruby@1.2.2",
+      "type": "library",
+      "name": "concurrent-ruby",
+      "version": "1.2.2",
+      "purl": "pkg:gem/concurrent-ruby@1.2.2",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "concurrent-ruby@1.2.2"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "bundler"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:gem/cri@2.15.11",
+      "type": "library",
+      "name": "cri",
+      "version": "2.15.11",
+      "purl": "pkg:gem/cri@2.15.11",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "cri@2.15.11"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "bundler"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:gem/ddmetrics@1.0.1",
+      "type": "library",
+      "name": "ddmetrics",
+      "version": "1.0.1",
+      "purl": "pkg:gem/ddmetrics@1.0.1",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "ddmetrics@1.0.1"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "bundler"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:gem/ddplugin@1.0.3",
+      "type": "library",
+      "name": "ddplugin",
+      "version": "1.0.3",
+      "purl": "pkg:gem/ddplugin@1.0.3",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "ddplugin@1.0.3"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "bundler"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:gem/diff-lcs@1.5.0",
+      "type": "library",
+      "name": "diff-lcs",
+      "version": "1.5.0",
+      "purl": "pkg:gem/diff-lcs@1.5.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "diff-lcs@1.5.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "bundler"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:gem/em-websocket@0.5.2",
+      "type": "library",
+      "name": "em-websocket",
+      "version": "0.5.2",
+      "purl": "pkg:gem/em-websocket@0.5.2",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "em-websocket@0.5.2"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "bundler"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:gem/eventmachine@1.2.7",
+      "type": "library",
+      "name": "eventmachine",
+      "version": "1.2.7",
+      "purl": "pkg:gem/eventmachine@1.2.7",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "eventmachine@1.2.7"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "bundler"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:gem/ffi@1.15.0",
+      "type": "library",
+      "name": "ffi",
+      "version": "1.15.0",
+      "purl": "pkg:gem/ffi@1.15.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "ffi@1.15.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "bundler"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:gem/formatador@0.2.5",
+      "type": "library",
+      "name": "formatador",
+      "version": "0.2.5",
+      "purl": "pkg:gem/formatador@0.2.5",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "formatador@0.2.5"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "bundler"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:gem/guard-compat@1.2.1",
+      "type": "library",
+      "name": "guard-compat",
+      "version": "1.2.1",
+      "purl": "pkg:gem/guard-compat@1.2.1",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "guard-compat@1.2.1"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "bundler"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:gem/guard-livereload@2.5.2",
+      "type": "library",
+      "name": "guard-livereload",
+      "version": "2.5.2",
+      "purl": "pkg:gem/guard-livereload@2.5.2",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "guard-livereload@2.5.2"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "bundler"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:gem/guard-nanoc@2.1.9",
+      "type": "library",
+      "name": "guard-nanoc",
+      "version": "2.1.9",
+      "purl": "pkg:gem/guard-nanoc@2.1.9",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "guard-nanoc@2.1.9"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "bundler"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:gem/guard@2.16.2",
+      "type": "library",
+      "name": "guard",
+      "version": "2.16.2",
+      "purl": "pkg:gem/guard@2.16.2",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "guard@2.16.2"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "bundler"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:gem/hamster@3.0.0",
+      "type": "library",
+      "name": "hamster",
+      "version": "3.0.0",
+      "purl": "pkg:gem/hamster@3.0.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "hamster@3.0.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "bundler"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:gem/http_parser.rb@0.6.0",
+      "type": "library",
+      "name": "http_parser.rb",
+      "version": "0.6.0",
+      "purl": "pkg:gem/http_parser.rb@0.6.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "http_parser.rb@0.6.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "bundler"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:gem/json_schema@0.21.0",
+      "type": "library",
+      "name": "json_schema",
+      "version": "0.21.0",
+      "purl": "pkg:gem/json_schema@0.21.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "json_schema@0.21.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "bundler"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:gem/kramdown@2.4.0",
+      "type": "library",
+      "name": "kramdown",
+      "version": "2.4.0",
+      "purl": "pkg:gem/kramdown@2.4.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "kramdown@2.4.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "bundler"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:gem/listen@3.4.1",
+      "type": "library",
+      "name": "listen",
+      "version": "3.4.1",
+      "purl": "pkg:gem/listen@3.4.1",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "listen@3.4.1"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "bundler"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:gem/lumberjack@1.2.8",
+      "type": "library",
+      "name": "lumberjack",
+      "version": "1.2.8",
+      "purl": "pkg:gem/lumberjack@1.2.8",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "lumberjack@1.2.8"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "bundler"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:gem/memo_wise@1.7.0",
+      "type": "library",
+      "name": "memo_wise",
+      "version": "1.7.0",
+      "purl": "pkg:gem/memo_wise@1.7.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "memo_wise@1.7.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "bundler"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:gem/method_source@1.0.0",
+      "type": "library",
+      "name": "method_source",
+      "version": "1.0.0",
+      "purl": "pkg:gem/method_source@1.0.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "method_source@1.0.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "bundler"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:gem/mini_portile2@2.8.1",
+      "type": "library",
+      "name": "mini_portile2",
+      "version": "2.8.1",
+      "purl": "pkg:gem/mini_portile2@2.8.1",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "mini_portile2@2.8.1"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "bundler"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:gem/multi_json@1.15.0",
+      "type": "library",
+      "name": "multi_json",
+      "version": "1.15.0",
+      "purl": "pkg:gem/multi_json@1.15.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "multi_json@1.15.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "bundler"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:gem/nanoc-checking@1.0.2",
+      "type": "library",
+      "name": "nanoc-checking",
+      "version": "1.0.2",
+      "purl": "pkg:gem/nanoc-checking@1.0.2",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "nanoc-checking@1.0.2"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "bundler"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:gem/nanoc-cli@4.12.15",
+      "type": "library",
+      "name": "nanoc-cli",
+      "version": "4.12.15",
+      "purl": "pkg:gem/nanoc-cli@4.12.15",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "nanoc-cli@4.12.15"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "bundler"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:gem/nanoc-core@4.12.15",
+      "type": "library",
+      "name": "nanoc-core",
+      "version": "4.12.15",
+      "purl": "pkg:gem/nanoc-core@4.12.15",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "nanoc-core@4.12.15"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "bundler"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:gem/nanoc-deploying@1.0.2",
+      "type": "library",
+      "name": "nanoc-deploying",
+      "version": "1.0.2",
+      "purl": "pkg:gem/nanoc-deploying@1.0.2",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "nanoc-deploying@1.0.2"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "bundler"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:gem/nanoc@4.12.15",
+      "type": "library",
+      "name": "nanoc",
+      "version": "4.12.15",
+      "purl": "pkg:gem/nanoc@4.12.15",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "nanoc@4.12.15"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "bundler"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:gem/nenv@0.3.0",
+      "type": "library",
+      "name": "nenv",
+      "version": "0.3.0",
+      "purl": "pkg:gem/nenv@0.3.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "nenv@0.3.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "bundler"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:gem/nokogiri@1.14.2",
+      "type": "library",
+      "name": "nokogiri",
+      "version": "1.14.2",
+      "purl": "pkg:gem/nokogiri@1.14.2",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "nokogiri@1.14.2"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "bundler"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:gem/notiffany@0.1.3",
+      "type": "library",
+      "name": "notiffany",
+      "version": "0.1.3",
+      "purl": "pkg:gem/notiffany@0.1.3",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "notiffany@0.1.3"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "bundler"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:gem/parallel@1.22.1",
+      "type": "library",
+      "name": "parallel",
+      "version": "1.22.1",
+      "purl": "pkg:gem/parallel@1.22.1",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "parallel@1.22.1"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "bundler"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:gem/pastel@0.8.0",
+      "type": "library",
+      "name": "pastel",
+      "version": "0.8.0",
+      "purl": "pkg:gem/pastel@0.8.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "pastel@0.8.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "bundler"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:gem/pry@0.14.0",
+      "type": "library",
+      "name": "pry",
+      "version": "0.14.0",
+      "purl": "pkg:gem/pry@0.14.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "pry@0.14.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "bundler"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:gem/psych@4.0.6",
+      "type": "library",
+      "name": "psych",
+      "version": "4.0.6",
+      "purl": "pkg:gem/psych@4.0.6",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "psych@4.0.6"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "bundler"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:gem/public_suffix@5.0.1",
+      "type": "library",
+      "name": "public_suffix",
+      "version": "5.0.1",
+      "purl": "pkg:gem/public_suffix@5.0.1",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "public_suffix@5.0.1"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "bundler"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:gem/pygments.rb@2.3.1",
+      "type": "library",
+      "name": "pygments.rb",
+      "version": "2.3.1",
+      "purl": "pkg:gem/pygments.rb@2.3.1",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "pygments.rb@2.3.1"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "bundler"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:gem/racc@1.6.2",
+      "type": "library",
+      "name": "racc",
+      "version": "1.6.2",
+      "purl": "pkg:gem/racc@1.6.2",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "racc@1.6.2"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "bundler"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:gem/rack@2.2.6.4",
+      "type": "library",
+      "name": "rack",
+      "version": "2.2.6.4",
+      "purl": "pkg:gem/rack@2.2.6.4",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "rack@2.2.6.4"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "bundler"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:gem/rb-fchange@0.0.6",
+      "type": "library",
+      "name": "rb-fchange",
+      "version": "0.0.6",
+      "purl": "pkg:gem/rb-fchange@0.0.6",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "rb-fchange@0.0.6"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "bundler"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:gem/rb-fsevent@0.11.2",
+      "type": "library",
+      "name": "rb-fsevent",
+      "version": "0.11.2",
+      "purl": "pkg:gem/rb-fsevent@0.11.2",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "rb-fsevent@0.11.2"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "bundler"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:gem/rb-inotify@0.10.1",
+      "type": "library",
+      "name": "rb-inotify",
+      "version": "0.10.1",
+      "purl": "pkg:gem/rb-inotify@0.10.1",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "rb-inotify@0.10.1"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "bundler"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:gem/redcarpet@3.6.0",
+      "type": "library",
+      "name": "redcarpet",
+      "version": "3.6.0",
+      "purl": "pkg:gem/redcarpet@3.6.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "redcarpet@3.6.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "bundler"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:gem/rexml@3.2.5",
+      "type": "library",
+      "name": "rexml",
+      "version": "3.2.5",
+      "purl": "pkg:gem/rexml@3.2.5",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "rexml@3.2.5"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "bundler"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:gem/rspec-core@3.12.0",
+      "type": "library",
+      "name": "rspec-core",
+      "version": "3.12.0",
+      "purl": "pkg:gem/rspec-core@3.12.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "rspec-core@3.12.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "bundler"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:gem/rspec-expectations@3.12.0",
+      "type": "library",
+      "name": "rspec-expectations",
+      "version": "3.12.0",
+      "purl": "pkg:gem/rspec-expectations@3.12.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "rspec-expectations@3.12.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "bundler"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:gem/rspec-mocks@3.12.0",
+      "type": "library",
+      "name": "rspec-mocks",
+      "version": "3.12.0",
+      "purl": "pkg:gem/rspec-mocks@3.12.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "rspec-mocks@3.12.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "bundler"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:gem/rspec-support@3.12.0",
+      "type": "library",
+      "name": "rspec-support",
+      "version": "3.12.0",
+      "purl": "pkg:gem/rspec-support@3.12.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "rspec-support@3.12.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "bundler"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:gem/rspec@3.12.0",
+      "type": "library",
+      "name": "rspec",
+      "version": "3.12.0",
+      "purl": "pkg:gem/rspec@3.12.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "rspec@3.12.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "bundler"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:gem/semverse@3.0.2",
+      "type": "library",
+      "name": "semverse",
+      "version": "3.0.2",
+      "purl": "pkg:gem/semverse@3.0.2",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "semverse@3.0.2"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "bundler"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:gem/shellany@0.0.1",
+      "type": "library",
+      "name": "shellany",
+      "version": "0.0.1",
+      "purl": "pkg:gem/shellany@0.0.1",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "shellany@0.0.1"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "bundler"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:gem/slow_enumerator_tools@1.1.0",
+      "type": "library",
+      "name": "slow_enumerator_tools",
+      "version": "1.1.0",
+      "purl": "pkg:gem/slow_enumerator_tools@1.1.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "slow_enumerator_tools@1.1.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "bundler"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:gem/stringio@3.0.5",
+      "type": "library",
+      "name": "stringio",
+      "version": "3.0.5",
+      "purl": "pkg:gem/stringio@3.0.5",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "stringio@3.0.5"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "bundler"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:gem/thor@1.1.0",
+      "type": "library",
+      "name": "thor",
+      "version": "1.1.0",
+      "purl": "pkg:gem/thor@1.1.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "thor@1.1.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "bundler"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:gem/tty-color@0.6.0",
+      "type": "library",
+      "name": "tty-color",
+      "version": "0.6.0",
+      "purl": "pkg:gem/tty-color@0.6.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "tty-color@0.6.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "bundler"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:gem/tty-command@0.10.1",
+      "type": "library",
+      "name": "tty-command",
+      "version": "0.10.1",
+      "purl": "pkg:gem/tty-command@0.10.1",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "tty-command@0.10.1"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "bundler"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:gem/tty-platform@0.3.0",
+      "type": "library",
+      "name": "tty-platform",
+      "version": "0.3.0",
+      "purl": "pkg:gem/tty-platform@0.3.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "tty-platform@0.3.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "bundler"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:gem/tty-which@0.5.0",
+      "type": "library",
+      "name": "tty-which",
+      "version": "0.5.0",
+      "purl": "pkg:gem/tty-which@0.5.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "tty-which@0.5.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "bundler"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:gem/zeitwerk@2.6.7",
+      "type": "library",
+      "name": "zeitwerk",
+      "version": "2.6.7",
+      "purl": "pkg:gem/zeitwerk@2.6.7",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "zeitwerk@2.6.7"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "bundler"
+        }
+      ]
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "82ba1ed2-bcbd-4c00-be96-2cdf09fd1c33",
+      "dependsOn": [
+        "d5035e70-8784-4437-a008-3e9827af62f8"
+      ]
+    },
+    {
+      "ref": "d5035e70-8784-4437-a008-3e9827af62f8",
+      "dependsOn": [
+        "pkg:gem/adsf@1.4.6",
+        "pkg:gem/builder@3.2.4",
+        "pkg:gem/guard-livereload@2.5.2",
+        "pkg:gem/guard-nanoc@2.1.9",
+        "pkg:gem/kramdown@2.4.0",
+        "pkg:gem/nanoc@4.12.15",
+        "pkg:gem/nokogiri@1.14.2",
+        "pkg:gem/pygments.rb@2.3.1",
+        "pkg:gem/rb-fchange@0.0.6",
+        "pkg:gem/rb-fsevent@0.11.2",
+        "pkg:gem/rb-inotify@0.10.1",
+        "pkg:gem/redcarpet@3.6.0",
+        "pkg:gem/rspec@3.12.0",
+        "pkg:gem/semverse@3.0.2"
+      ]
+    },
+    {
+      "ref": "pkg:gem/addressable@2.8.1",
+      "dependsOn": [
+        "pkg:gem/public_suffix@5.0.1"
+      ]
+    },
+    {
+      "ref": "pkg:gem/adsf@1.4.6",
+      "dependsOn": [
+        "pkg:gem/rack@2.2.6.4"
+      ]
+    },
+    {
+      "ref": "pkg:gem/builder@3.2.4",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:gem/coderay@1.1.3",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:gem/colored@1.2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:gem/concurrent-ruby@1.2.2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:gem/cri@2.15.11",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:gem/ddmetrics@1.0.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:gem/ddplugin@1.0.3",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:gem/diff-lcs@1.5.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:gem/em-websocket@0.5.2",
+      "dependsOn": [
+        "pkg:gem/eventmachine@1.2.7",
+        "pkg:gem/http_parser.rb@0.6.0"
+      ]
+    },
+    {
+      "ref": "pkg:gem/eventmachine@1.2.7",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:gem/ffi@1.15.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:gem/formatador@0.2.5",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:gem/guard-compat@1.2.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:gem/guard-livereload@2.5.2",
+      "dependsOn": [
+        "pkg:gem/em-websocket@0.5.2",
+        "pkg:gem/guard-compat@1.2.1",
+        "pkg:gem/guard@2.16.2",
+        "pkg:gem/multi_json@1.15.0"
+      ]
+    },
+    {
+      "ref": "pkg:gem/guard-nanoc@2.1.9",
+      "dependsOn": [
+        "pkg:gem/guard-compat@1.2.1",
+        "pkg:gem/guard@2.16.2",
+        "pkg:gem/nanoc-cli@4.12.15",
+        "pkg:gem/nanoc-core@4.12.15"
+      ]
+    },
+    {
+      "ref": "pkg:gem/guard@2.16.2",
+      "dependsOn": [
+        "pkg:gem/formatador@0.2.5",
+        "pkg:gem/listen@3.4.1",
+        "pkg:gem/lumberjack@1.2.8",
+        "pkg:gem/nenv@0.3.0",
+        "pkg:gem/notiffany@0.1.3",
+        "pkg:gem/pry@0.14.0",
+        "pkg:gem/shellany@0.0.1",
+        "pkg:gem/thor@1.1.0"
+      ]
+    },
+    {
+      "ref": "pkg:gem/hamster@3.0.0",
+      "dependsOn": [
+        "pkg:gem/concurrent-ruby@1.2.2"
+      ]
+    },
+    {
+      "ref": "pkg:gem/http_parser.rb@0.6.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:gem/json_schema@0.21.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:gem/kramdown@2.4.0",
+      "dependsOn": [
+        "pkg:gem/rexml@3.2.5"
+      ]
+    },
+    {
+      "ref": "pkg:gem/listen@3.4.1",
+      "dependsOn": [
+        "pkg:gem/rb-fsevent@0.11.2",
+        "pkg:gem/rb-inotify@0.10.1"
+      ]
+    },
+    {
+      "ref": "pkg:gem/lumberjack@1.2.8",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:gem/memo_wise@1.7.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:gem/method_source@1.0.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:gem/mini_portile2@2.8.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:gem/multi_json@1.15.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:gem/nanoc-checking@1.0.2",
+      "dependsOn": [
+        "pkg:gem/nanoc-cli@4.12.15",
+        "pkg:gem/nanoc-core@4.12.15"
+      ]
+    },
+    {
+      "ref": "pkg:gem/nanoc-cli@4.12.15",
+      "dependsOn": [
+        "pkg:gem/cri@2.15.11",
+        "pkg:gem/diff-lcs@1.5.0",
+        "pkg:gem/nanoc-core@4.12.15",
+        "pkg:gem/zeitwerk@2.6.7"
+      ]
+    },
+    {
+      "ref": "pkg:gem/nanoc-core@4.12.15",
+      "dependsOn": [
+        "pkg:gem/concurrent-ruby@1.2.2",
+        "pkg:gem/ddmetrics@1.0.1",
+        "pkg:gem/ddplugin@1.0.3",
+        "pkg:gem/hamster@3.0.0",
+        "pkg:gem/json_schema@0.21.0",
+        "pkg:gem/memo_wise@1.7.0",
+        "pkg:gem/psych@4.0.6",
+        "pkg:gem/slow_enumerator_tools@1.1.0",
+        "pkg:gem/tty-platform@0.3.0",
+        "pkg:gem/zeitwerk@2.6.7"
+      ]
+    },
+    {
+      "ref": "pkg:gem/nanoc-deploying@1.0.2",
+      "dependsOn": [
+        "pkg:gem/nanoc-checking@1.0.2",
+        "pkg:gem/nanoc-cli@4.12.15",
+        "pkg:gem/nanoc-core@4.12.15"
+      ]
+    },
+    {
+      "ref": "pkg:gem/nanoc@4.12.15",
+      "dependsOn": [
+        "pkg:gem/addressable@2.8.1",
+        "pkg:gem/colored@1.2",
+        "pkg:gem/nanoc-checking@1.0.2",
+        "pkg:gem/nanoc-cli@4.12.15",
+        "pkg:gem/nanoc-core@4.12.15",
+        "pkg:gem/nanoc-deploying@1.0.2",
+        "pkg:gem/parallel@1.22.1",
+        "pkg:gem/tty-command@0.10.1",
+        "pkg:gem/tty-which@0.5.0"
+      ]
+    },
+    {
+      "ref": "pkg:gem/nenv@0.3.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:gem/nokogiri@1.14.2",
+      "dependsOn": [
+        "pkg:gem/mini_portile2@2.8.1",
+        "pkg:gem/racc@1.6.2"
+      ]
+    },
+    {
+      "ref": "pkg:gem/notiffany@0.1.3",
+      "dependsOn": [
+        "pkg:gem/nenv@0.3.0",
+        "pkg:gem/shellany@0.0.1"
+      ]
+    },
+    {
+      "ref": "pkg:gem/parallel@1.22.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:gem/pastel@0.8.0",
+      "dependsOn": [
+        "pkg:gem/tty-color@0.6.0"
+      ]
+    },
+    {
+      "ref": "pkg:gem/pry@0.14.0",
+      "dependsOn": [
+        "pkg:gem/coderay@1.1.3",
+        "pkg:gem/method_source@1.0.0"
+      ]
+    },
+    {
+      "ref": "pkg:gem/psych@4.0.6",
+      "dependsOn": [
+        "pkg:gem/stringio@3.0.5"
+      ]
+    },
+    {
+      "ref": "pkg:gem/public_suffix@5.0.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:gem/pygments.rb@2.3.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:gem/racc@1.6.2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:gem/rack@2.2.6.4",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:gem/rb-fchange@0.0.6",
+      "dependsOn": [
+        "pkg:gem/ffi@1.15.0"
+      ]
+    },
+    {
+      "ref": "pkg:gem/rb-fsevent@0.11.2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:gem/rb-inotify@0.10.1",
+      "dependsOn": [
+        "pkg:gem/ffi@1.15.0"
+      ]
+    },
+    {
+      "ref": "pkg:gem/redcarpet@3.6.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:gem/rexml@3.2.5",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:gem/rspec-core@3.12.0",
+      "dependsOn": [
+        "pkg:gem/rspec-support@3.12.0"
+      ]
+    },
+    {
+      "ref": "pkg:gem/rspec-expectations@3.12.0",
+      "dependsOn": [
+        "pkg:gem/diff-lcs@1.5.0",
+        "pkg:gem/rspec-support@3.12.0"
+      ]
+    },
+    {
+      "ref": "pkg:gem/rspec-mocks@3.12.0",
+      "dependsOn": [
+        "pkg:gem/diff-lcs@1.5.0",
+        "pkg:gem/rspec-support@3.12.0"
+      ]
+    },
+    {
+      "ref": "pkg:gem/rspec-support@3.12.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:gem/rspec@3.12.0",
+      "dependsOn": [
+        "pkg:gem/rspec-core@3.12.0",
+        "pkg:gem/rspec-expectations@3.12.0",
+        "pkg:gem/rspec-mocks@3.12.0"
+      ]
+    },
+    {
+      "ref": "pkg:gem/semverse@3.0.2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:gem/shellany@0.0.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:gem/slow_enumerator_tools@1.1.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:gem/stringio@3.0.5",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:gem/thor@1.1.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:gem/tty-color@0.6.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:gem/tty-command@0.10.1",
+      "dependsOn": [
+        "pkg:gem/pastel@0.8.0"
+      ]
+    },
+    {
+      "ref": "pkg:gem/tty-platform@0.3.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:gem/tty-which@0.5.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:gem/zeitwerk@2.6.7",
+      "dependsOn": []
+    }
+  ],
+  "vulnerabilities": []
+}

--- a/src/commands/sbom/__tests__/license.test.ts
+++ b/src/commands/sbom/__tests__/license.test.ts
@@ -14,5 +14,13 @@ describe('licenses', () => {
     expect(getLicensesFromString('foobar OR MIT')).toStrictEqual([DependencyLicense.MIT])
     expect(getLicensesFromString('')).toStrictEqual([])
     expect(getLicensesFromString('foobar')).toStrictEqual([])
+    expect(getLicensesFromString('Apache License, Version 2.0')).toStrictEqual([DependencyLicense.APACHE2])
+    expect(getLicensesFromString('The Apache Software License, Version 2.0')).toStrictEqual([DependencyLicense.APACHE2])
+    expect(getLicensesFromString('GPL v2')).toStrictEqual([DependencyLicense.GPL2_0])
+
+    expect(getLicensesFromString('BSD-3-Clause')).toStrictEqual([DependencyLicense.BSD3CLAUSE])
+    expect(getLicensesFromString('BSD-2-Clause')).toStrictEqual([DependencyLicense.BSD2CLAUSE])
+    expect(getLicensesFromString('ISC')).toStrictEqual([DependencyLicense.ISC])
+    expect(getLicensesFromString('The MIT License')).toStrictEqual([DependencyLicense.MIT])
   })
 })

--- a/src/commands/sbom/__tests__/payload.test.ts
+++ b/src/commands/sbom/__tests__/payload.test.ts
@@ -75,5 +75,51 @@ describe('generation of payload', () => {
     expect(payload?.dependencies.length).toStrictEqual(305)
     const dependenciesWithoutLicense = payload?.dependencies.filter((d) => d.licenses.length === 0)
     expect(dependenciesWithoutLicense?.length).toStrictEqual(3)
+
+    // all languages are detected
+    const dependenciesWithoutLanguage = payload?.dependencies.filter((d) => d.language.length === 0)
+    expect(dependenciesWithoutLanguage?.length).toStrictEqual(0)
+  })
+
+  test('SBOM generated for Ruby from a Gemfile lock', async () => {
+    const sbomFile = './src/commands/sbom/__tests__/fixtures/ruby.sbom.json'
+    const sbomContent = JSON.parse(fs.readFileSync(sbomFile).toString('utf8'))
+    const config: DatadogCiConfig = {
+      apiKey: undefined,
+      env: undefined,
+      envVarTags: undefined,
+    }
+    const tags = await getSpanTags(config, [])
+
+    const payload = generatePayload(sbomContent, tags)
+
+    expect(payload?.dependencies.length).toStrictEqual(64)
+    const dependenciesWithoutLicense = payload?.dependencies.filter((d) => d.licenses.length === 0)
+    expect(dependenciesWithoutLicense?.length).toStrictEqual(64)
+
+    // all languages are detected
+    const dependenciesWithoutLanguage = payload?.dependencies.filter((d) => d.language.length === 0)
+    expect(dependenciesWithoutLanguage?.length).toStrictEqual(0)
+  })
+
+  test('SBOM generated for Java and Go', async () => {
+    const sbomFile = './src/commands/sbom/__tests__/fixtures/java-go.sbom.json'
+    const sbomContent = JSON.parse(fs.readFileSync(sbomFile).toString('utf8'))
+    const config: DatadogCiConfig = {
+      apiKey: undefined,
+      env: undefined,
+      envVarTags: undefined,
+    }
+    const tags = await getSpanTags(config, [])
+
+    const payload = generatePayload(sbomContent, tags)
+
+    expect(payload?.dependencies.length).toStrictEqual(89)
+    const dependenciesWithoutLicense = payload?.dependencies.filter((d) => d.licenses.length === 0)
+    expect(dependenciesWithoutLicense?.length).toStrictEqual(26)
+
+    // all languages are detected
+    const dependenciesWithoutLanguage = payload?.dependencies.filter((d) => d.language.length === 0)
+    expect(dependenciesWithoutLanguage?.length).toStrictEqual(0)
   })
 })

--- a/src/commands/sbom/__tests__/payload.test.ts
+++ b/src/commands/sbom/__tests__/payload.test.ts
@@ -77,7 +77,7 @@ describe('generation of payload', () => {
     expect(dependenciesWithoutLicense?.length).toStrictEqual(3)
 
     // all languages are detected
-    const dependenciesWithoutLanguage = payload?.dependencies.filter((d) => d.language.length === 0)
+    const dependenciesWithoutLanguage = payload?.dependencies.filter((d) => !d.language)
     expect(dependenciesWithoutLanguage?.length).toStrictEqual(0)
   })
 
@@ -98,7 +98,7 @@ describe('generation of payload', () => {
     expect(dependenciesWithoutLicense?.length).toStrictEqual(64)
 
     // all languages are detected
-    const dependenciesWithoutLanguage = payload?.dependencies.filter((d) => d.language.length === 0)
+    const dependenciesWithoutLanguage = payload?.dependencies.filter((d) => !d.language)
     expect(dependenciesWithoutLanguage?.length).toStrictEqual(0)
   })
 
@@ -119,7 +119,11 @@ describe('generation of payload', () => {
     expect(dependenciesWithoutLicense?.length).toStrictEqual(26)
 
     // all languages are detected
-    const dependenciesWithoutLanguage = payload?.dependencies.filter((d) => d.language.length === 0)
+    const dependenciesWithoutLanguage = payload?.dependencies.filter((d) => !d.language)
     expect(dependenciesWithoutLanguage?.length).toStrictEqual(0)
+    const dependenciesWithJava = payload?.dependencies.filter((d) => d.language === DependencyLanguage.JVM)
+    expect(dependenciesWithJava?.length).toStrictEqual(55)
+    const dependenciesWithGo = payload?.dependencies.filter((d) => d.language === DependencyLanguage.GO)
+    expect(dependenciesWithGo?.length).toStrictEqual(34)
   })
 })

--- a/src/commands/sbom/language.ts
+++ b/src/commands/sbom/language.ts
@@ -19,7 +19,7 @@ export const getLanguageFromComponent = (component: any): DependencyLanguage | u
       return DependencyLanguage.RUBY
     }
     if (component['purl'].includes('pkg:maven')) {
-      return DependencyLanguage.RUBY
+      return DependencyLanguage.JVM
     }
     if (component['purl'].includes('pkg:golang')) {
       return DependencyLanguage.GO

--- a/src/commands/sbom/language.ts
+++ b/src/commands/sbom/language.ts
@@ -15,6 +15,15 @@ export const getLanguageFromComponent = (component: any): DependencyLanguage | u
     if (component['purl'].includes('pkg:cargo')) {
       return DependencyLanguage.RUST
     }
+    if (component['purl'].includes('pkg:gem')) {
+      return DependencyLanguage.RUBY
+    }
+    if (component['purl'].includes('pkg:maven')) {
+      return DependencyLanguage.RUBY
+    }
+    if (component['purl'].includes('pkg:golang')) {
+      return DependencyLanguage.GO
+    }
   }
 
   console.debug(`language for component ${componentName} not found`)

--- a/src/commands/sbom/license.ts
+++ b/src/commands/sbom/license.ts
@@ -11,6 +11,8 @@ const getLicenseFromString = (s: string): DependencyLicense | undefined => {
     case '0bsd':
       return DependencyLicense.ZEROBSD
     case 'apache-2.0':
+    case 'apache license, version 2.0':
+    case 'the apache software license, version 2.0':
       return DependencyLicense.APACHE2
     case 'bsd-2-clause':
       return DependencyLicense.BSD2CLAUSE
@@ -18,9 +20,14 @@ const getLicenseFromString = (s: string): DependencyLicense | undefined => {
       return DependencyLicense.BSD3CLAUSE
     case 'bsl-1.0':
       return DependencyLicense.BSL1
+    case 'gpl v2':
+      return DependencyLicense.GPL2_0
+    case 'gpl v3':
+      return DependencyLicense.GPL3_0
     case 'isc':
       return DependencyLicense.ISC
     case 'mit':
+    case 'the mit license':
       return DependencyLicense.MIT
     case 'unlicense':
       return DependencyLicense.UNLICENSE

--- a/src/commands/sbom/types.ts
+++ b/src/commands/sbom/types.ts
@@ -5,6 +5,7 @@ export enum DependencyLanguage {
   RUST = 'rust',
   RUBY = 'ruby',
   GO = 'go',
+  JVM = 'jvm',
 }
 
 // List from https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/licensing-a-repository

--- a/src/commands/sbom/types.ts
+++ b/src/commands/sbom/types.ts
@@ -3,6 +3,8 @@ export enum DependencyLanguage {
   PYPI = 'pypi',
   PHP = 'php',
   RUST = 'rust',
+  RUBY = 'ruby',
+  GO = 'go',
 }
 
 // List from https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/licensing-a-repository


### PR DESCRIPTION
### What and why?

We want to make sure we can parse SBOM for Ruby, Go and Maven/Java

### How?

We are adapting the language and license detection. We are testing by having an SBOM generated for each of those languages.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
