### PR TITLE
Creating release 2.23.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci",
-  "version": "2.22.1",
+  "version": "2.23.0",
   "description": "Run datadog actions from the CI.",
   "repository": "https://github.com/DataDog/datadog-ci",
   "license": "Apache-2.0",


### PR DESCRIPTION
### What and why?

Creating the release 2.23.0

### Release notes
CI Visibility:
* Add support for AWSCodePipeline by @albertvaka in https://github.com/DataDog/datadog-ci/pull/1085

Static Analysis:
* adapt SBOM payload by @juli1 in https://github.com/DataDog/datadog-ci/pull/1090
* SBOM: support ruby, go and maven/java by @juli1 in https://github.com/DataDog/datadog-ci/pull/1093

Serverless:
* Add example of instrumenting multiple Lambda functions by ARN by @sfirrin in https://github.com/DataDog/datadog-ci/pull/1092

Dependencies:
* Bump @babel/traverse from 7.22.10 to 7.23.2 by @dependabot in https://github.com/DataDog/datadog-ci/pull/1089

**Full Changelog**: https://github.com/DataDog/datadog-ci/compare/v2.22.1...v2.23.0
