### PR TITLE
[synthetics] Show test runs as they arrive

### DIFF
--- a/src/commands/synthetics/__tests__/reporters/__snapshots__/default.test.ts.snap
+++ b/src/commands/synthetics/__tests__/reporters/__snapshots__/default.test.ts.snap
@@ -5,6 +5,8 @@ exports[`Default reporter resultEnd 1 API test, 1 location, 1 result: success 1`
   ⎋ Total duration: 123 ms - View test run details: [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=1&from_ci=true[39m[22m 
   [1m[32m✓[39m[22m [1m[32m[1mGET[22m[1m - http://fake.url[39m[22m
 
+- Waiting for [1m[36m11[39m[22m tests [90m(abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, …)[39m…
+
 "
 `;
 
@@ -13,17 +15,23 @@ exports[`Default reporter resultEnd 1 API test, 1 location, 3 results: success, 
   ⎋ Total duration: 123 ms - View test run details: [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=1&from_ci=true[39m[22m 
   [1m[32m✓[39m[22m [1m[32m[1mGET[22m[1m - http://fake.url[39m[22m
 
+- Waiting for [1m[36m11[39m[22m tests [90m(abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, …)[39m…
+
 [1m[33m✖[39m[22m [[1m[33mnon-blocking[39m[22m] [[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m - [1m[33mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m
   ⎋ Total duration: 123 ms - View test run details: [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=2&from_ci=true[39m[22m 
   [1m[33m✖[39m[22m [1m[33m[1mGET[22m[1m - http://fake.url[39m[22m
 [1m[33m  - Assertion failed:[39m[22m
 [1m[33m    ▶ responseTime should be less than [4m1000[24m. Actual: [4m1234[24m[39m[22m
 
+- Waiting for [1m[36m11[39m[22m tests [90m(abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, …)[39m…
+
 [1m[31m✖[39m[22m [[1m[31mblocking[39m[22m] [[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m - [1m[31mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m
   ⎋ Total duration: 123 ms - View test run details: [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=3&from_ci=true[39m[22m 
   [1m[31m✖[39m[22m [1m[31m[1mGET[22m[1m - http://fake.url[39m[22m
 [1m[31m  - Assertion failed:[39m[22m
 [1m[31m    ▶ responseTime should be less than [4m1000[24m. Actual: [4m1234[24m[39m[22m
+
+- Waiting for [1m[36m11[39m[22m tests [90m(abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, …)[39m…
 
 "
 `;
@@ -41,13 +49,19 @@ exports[`Default reporter resultEnd 3 Browser test: failed blocking, timed out, 
     [31m[2mStep failure[22m[39m
     [1m[33m⇢[39m[22m | 3 skipped steps
 
+- Waiting for [1m[36m11[39m[22m tests [90m(abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, …)[39m…
+
 [1m[31m✖[39m[22m [[1m[31mblocking[39m[22m] [[1m[2mabc-def-ghi[22m[22m] [1mTest name[22m - [1m[31mlocation: [1mLocation name[22m[1m[39m[22m
   ⎋ View test run details: [2m[36mhttps://app.datadoghq.com/synthetics/details/abc-def-ghi/result/1?from_ci=true[39m[22m (not yet received)
 [31m    [[1mTIMEOUT[22m] - [2mResult timed out[22m[39m
 
+- Waiting for [1m[36m11[39m[22m tests [90m(abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, …)[39m…
+
 [1m[31m✖[39m[22m [[1m[31mblocking[39m[22m] [[1m[2mabc-def-ghi[22m[22m] [1mTest name[22m - [1m[31mlocation: [1mLocation name[22m[1m[39m[22m
   ⎋ View test run details: [2m[36mhttps://app.datadoghq.com/synthetics/details/abc-def-ghi/result/1?from_ci=true[39m[22m 
 [31m    [[1mFAILURE_CODE[22m] - [2mFailure message[22m[39m
+
+- Waiting for [1m[36m11[39m[22m tests [90m(abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, …)[39m…
 
 "
 `;
@@ -176,10 +190,7 @@ exports[`Default reporter testTrigger Skipped test, with 2 config overrides 1`] 
 `;
 
 exports[`Default reporter testsWait outputs triggered tests 1`] = `
-"View pending summary in Datadog: [2m[36mhttps://app.datadoghq.com/synthetics/explorer/ci?batchResultId=123[39m[22m
-
-
-- Waiting for [1m[36m11[39m[22m test results [90m(abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, …)[39m…
+"- Waiting for [1m[36m11[39m[22m tests [90m(abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, …)[39m…
 
 "
 `;

--- a/src/commands/synthetics/__tests__/reporters/__snapshots__/default.test.ts.snap
+++ b/src/commands/synthetics/__tests__/reporters/__snapshots__/default.test.ts.snap
@@ -194,3 +194,20 @@ exports[`Default reporter testsWait outputs triggered tests 1`] = `
 
 "
 `;
+
+exports[`Default reporter testsWait the spinner text is updated and cleared at the end 1`] = `
+"View pending summary in Datadog: [2m[36mhttps://app.datadoghq.com/synthetics/explorer/ci?batchResultId=123[39m[22m
+
+
+ [36m⠋[39m Waiting for [1m[36m2[39m[22m tests [90m(aaa-aaa-aaa, bbb-bbb-bbb)[39m…
+"
+`;
+
+exports[`Default reporter testsWait the spinner text is updated and cleared at the end 2`] = `
+"View pending summary in Datadog: [2m[36mhttps://app.datadoghq.com/synthetics/explorer/ci?batchResultId=123[39m[22m
+
+ [36m⠙[39m Waiting for [1m[36m1[39m[22m test [90m(aaa-aaa-aaa)[39m…
+"
+`;
+
+exports[`Default reporter testsWait the spinner text is updated and cleared at the end 3`] = `"View pending summary in Datadog: [2m[36mhttps://app.datadoghq.com/synthetics/explorer/ci?batchResultId=123[39m[22m"`;

--- a/src/commands/synthetics/__tests__/reporters/__snapshots__/default.test.ts.snap
+++ b/src/commands/synthetics/__tests__/reporters/__snapshots__/default.test.ts.snap
@@ -5,8 +5,6 @@ exports[`Default reporter resultEnd 1 API test, 1 location, 1 result: success 1`
   ⎋ Total duration: 123 ms - View test run details: [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=1&from_ci=true[39m[22m 
   [1m[32m✓[39m[22m [1m[32m[1mGET[22m[1m - http://fake.url[39m[22m
 
-- Waiting for [1m[36m11[39m[22m tests [90m(abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, …)[39m…
-
 "
 `;
 
@@ -15,23 +13,17 @@ exports[`Default reporter resultEnd 1 API test, 1 location, 3 results: success, 
   ⎋ Total duration: 123 ms - View test run details: [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=1&from_ci=true[39m[22m 
   [1m[32m✓[39m[22m [1m[32m[1mGET[22m[1m - http://fake.url[39m[22m
 
-- Waiting for [1m[36m11[39m[22m tests [90m(abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, …)[39m…
-
 [1m[33m✖[39m[22m [[1m[33mnon-blocking[39m[22m] [[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m - [1m[33mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m
   ⎋ Total duration: 123 ms - View test run details: [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=2&from_ci=true[39m[22m 
   [1m[33m✖[39m[22m [1m[33m[1mGET[22m[1m - http://fake.url[39m[22m
 [1m[33m  - Assertion failed:[39m[22m
 [1m[33m    ▶ responseTime should be less than [4m1000[24m. Actual: [4m1234[24m[39m[22m
 
-- Waiting for [1m[36m11[39m[22m tests [90m(abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, …)[39m…
-
 [1m[31m✖[39m[22m [[1m[31mblocking[39m[22m] [[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m - [1m[31mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m
   ⎋ Total duration: 123 ms - View test run details: [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=3&from_ci=true[39m[22m 
   [1m[31m✖[39m[22m [1m[31m[1mGET[22m[1m - http://fake.url[39m[22m
 [1m[31m  - Assertion failed:[39m[22m
 [1m[31m    ▶ responseTime should be less than [4m1000[24m. Actual: [4m1234[24m[39m[22m
-
-- Waiting for [1m[36m11[39m[22m tests [90m(abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, …)[39m…
 
 "
 `;
@@ -49,19 +41,13 @@ exports[`Default reporter resultEnd 3 Browser test: failed blocking, timed out, 
     [31m[2mStep failure[22m[39m
     [1m[33m⇢[39m[22m | 3 skipped steps
 
-- Waiting for [1m[36m11[39m[22m tests [90m(abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, …)[39m…
-
 [1m[31m✖[39m[22m [[1m[31mblocking[39m[22m] [[1m[2mabc-def-ghi[22m[22m] [1mTest name[22m - [1m[31mlocation: [1mLocation name[22m[1m[39m[22m
   ⎋ View test run details: [2m[36mhttps://app.datadoghq.com/synthetics/details/abc-def-ghi/result/1?from_ci=true[39m[22m (not yet received)
 [31m    [[1mTIMEOUT[22m] - [2mResult timed out[22m[39m
 
-- Waiting for [1m[36m11[39m[22m tests [90m(abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, …)[39m…
-
 [1m[31m✖[39m[22m [[1m[31mblocking[39m[22m] [[1m[2mabc-def-ghi[22m[22m] [1mTest name[22m - [1m[31mlocation: [1mLocation name[22m[1m[39m[22m
   ⎋ View test run details: [2m[36mhttps://app.datadoghq.com/synthetics/details/abc-def-ghi/result/1?from_ci=true[39m[22m 
 [31m    [[1mFAILURE_CODE[22m] - [2mFailure message[22m[39m
-
-- Waiting for [1m[36m11[39m[22m tests [90m(abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, …)[39m…
 
 "
 `;
@@ -195,7 +181,7 @@ exports[`Default reporter testsWait outputs triggered tests 1`] = `
 "
 `;
 
-exports[`Default reporter testsWait the spinner text is updated and cleared at the end 1`] = `
+exports[`Default reporter testsWait the spinner text is updated and cleared at the end (in CI: false) 1`] = `
 "View pending summary in Datadog: [2m[36mhttps://app.datadoghq.com/synthetics/explorer/ci?batchResultId=123[39m[22m
 
 
@@ -203,11 +189,83 @@ exports[`Default reporter testsWait the spinner text is updated and cleared at t
 "
 `;
 
-exports[`Default reporter testsWait the spinner text is updated and cleared at the end 2`] = `
+exports[`Default reporter testsWait the spinner text is updated and cleared at the end (in CI: false) 2`] = `
 "View pending summary in Datadog: [2m[36mhttps://app.datadoghq.com/synthetics/explorer/ci?batchResultId=123[39m[22m
+[1m[32m✓[39m[22m [[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m - [1m[32mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m
+  ⎋ Total duration: 123 ms - View test run details: [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=rid&from_ci=true[39m[22m 
+  [1m[32m✓[39m[22m [1m[32m[1mGET[22m[1m - http://fake.url[39m[22m
+
+"
+`;
+
+exports[`Default reporter testsWait the spinner text is updated and cleared at the end (in CI: false) 3`] = `
+"View pending summary in Datadog: [2m[36mhttps://app.datadoghq.com/synthetics/explorer/ci?batchResultId=123[39m[22m
+[1m[32m✓[39m[22m [[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m - [1m[32mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m
+  ⎋ Total duration: 123 ms - View test run details: [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=rid&from_ci=true[39m[22m 
+  [1m[32m✓[39m[22m [1m[32m[1mGET[22m[1m - http://fake.url[39m[22m
 
  [36m⠙[39m Waiting for [1m[36m1[39m[22m test [90m(aaa-aaa-aaa)[39m…
 "
 `;
 
-exports[`Default reporter testsWait the spinner text is updated and cleared at the end 3`] = `"View pending summary in Datadog: [2m[36mhttps://app.datadoghq.com/synthetics/explorer/ci?batchResultId=123[39m[22m"`;
+exports[`Default reporter testsWait the spinner text is updated and cleared at the end (in CI: false) 4`] = `
+"View pending summary in Datadog: [2m[36mhttps://app.datadoghq.com/synthetics/explorer/ci?batchResultId=123[39m[22m
+[1m[32m✓[39m[22m [[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m - [1m[32mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m
+  ⎋ Total duration: 123 ms - View test run details: [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=rid&from_ci=true[39m[22m 
+  [1m[32m✓[39m[22m [1m[32m[1mGET[22m[1m - http://fake.url[39m[22m
+
+ [36m⠙[39m Waiting for [1m[36m1[39m[22m test [90m(aaa-aaa-aaa)[39m…
+"
+`;
+
+exports[`Default reporter testsWait the spinner text is updated and cleared at the end (in CI: true) 1`] = `
+"View pending summary in Datadog: [2m[36mhttps://app.datadoghq.com/synthetics/explorer/ci?batchResultId=123[39m[22m
+
+- Waiting for [1m[36m2[39m[22m tests [90m(aaa-aaa-aaa, bbb-bbb-bbb)[39m…
+
+"
+`;
+
+exports[`Default reporter testsWait the spinner text is updated and cleared at the end (in CI: true) 2`] = `
+"View pending summary in Datadog: [2m[36mhttps://app.datadoghq.com/synthetics/explorer/ci?batchResultId=123[39m[22m
+
+- Waiting for [1m[36m2[39m[22m tests [90m(aaa-aaa-aaa, bbb-bbb-bbb)[39m…
+
+[1m[32m✓[39m[22m [[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m - [1m[32mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m
+  ⎋ Total duration: 123 ms - View test run details: [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=rid&from_ci=true[39m[22m 
+  [1m[32m✓[39m[22m [1m[32m[1mGET[22m[1m - http://fake.url[39m[22m
+
+"
+`;
+
+exports[`Default reporter testsWait the spinner text is updated and cleared at the end (in CI: true) 3`] = `
+"View pending summary in Datadog: [2m[36mhttps://app.datadoghq.com/synthetics/explorer/ci?batchResultId=123[39m[22m
+
+- Waiting for [1m[36m2[39m[22m tests [90m(aaa-aaa-aaa, bbb-bbb-bbb)[39m…
+
+[1m[32m✓[39m[22m [[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m - [1m[32mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m
+  ⎋ Total duration: 123 ms - View test run details: [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=rid&from_ci=true[39m[22m 
+  [1m[32m✓[39m[22m [1m[32m[1mGET[22m[1m - http://fake.url[39m[22m
+
+- Waiting for [1m[36m1[39m[22m test [90m(aaa-aaa-aaa)[39m…
+
+
+ [36m⠋[39m Waiting for [1m[36m1[39m[22m test [90m(aaa-aaa-aaa)[39m…
+"
+`;
+
+exports[`Default reporter testsWait the spinner text is updated and cleared at the end (in CI: true) 4`] = `
+"View pending summary in Datadog: [2m[36mhttps://app.datadoghq.com/synthetics/explorer/ci?batchResultId=123[39m[22m
+
+- Waiting for [1m[36m2[39m[22m tests [90m(aaa-aaa-aaa, bbb-bbb-bbb)[39m…
+
+[1m[32m✓[39m[22m [[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m - [1m[32mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m
+  ⎋ Total duration: 123 ms - View test run details: [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=rid&from_ci=true[39m[22m 
+  [1m[32m✓[39m[22m [1m[32m[1mGET[22m[1m - http://fake.url[39m[22m
+
+- Waiting for [1m[36m1[39m[22m test [90m(aaa-aaa-aaa)[39m…
+
+
+ [36m⠋[39m Waiting for [1m[36m1[39m[22m test [90m(aaa-aaa-aaa)[39m…
+"
+`;

--- a/src/commands/synthetics/__tests__/reporters/default.test.ts
+++ b/src/commands/synthetics/__tests__/reporters/default.test.ts
@@ -4,7 +4,6 @@ import {BaseContext} from 'clipanion/lib/advanced'
 
 import {ExecutionRule, MainReporter, Result, Summary, Test, UserConfigOverride} from '../../interfaces'
 import {DefaultReporter} from '../../reporters/default'
-import {DEFAULT_COMMAND_CONFIG} from '../../run-tests-command'
 
 import {
   getApiResult,
@@ -24,7 +23,6 @@ import {
  */
 
 describe('Default reporter', () => {
-  const baseUrlFixture = 'https://app.datadoghq.com/'
   const writeMock = jest.fn()
   const mockContext: unknown = {
     context: {
@@ -106,10 +104,61 @@ describe('Default reporter', () => {
     })
   })
 
-  test('testsWait outputs triggered tests', async () => {
-    reporter.testsWait(new Array(11).fill(getApiTest()), baseUrlFixture, '123')
-    const output = writeMock.mock.calls.map((c) => c[0]).join('\n')
-    expect(output).toMatchSnapshot()
+  describe('testsWait', () => {
+    test('outputs triggered tests', async () => {
+      reporter.testsWait(Array(11).fill(getApiTest()) as Test[], MOCK_BASE_URL, '123')
+      const output = writeMock.mock.calls.map((c) => c[0]).join('\n')
+      expect(output).toMatchSnapshot()
+    })
+
+    test('the spinner text is updated and cleared at the end', async () => {
+      jest.useFakeTimers()
+
+      let simulatedTerminalOutput = ''
+
+      const write = jest.fn().mockImplementation((text: string) => {
+        // Ignore show/hide cursor ANSI codes.
+        if (text.match(/\u001b\[\?25(l|h)/)) {
+          return
+        }
+
+        simulatedTerminalOutput += text
+      })
+
+      const clearLine = jest.fn().mockImplementation(() => {
+        simulatedTerminalOutput = simulatedTerminalOutput.split('\n').slice(0, -1).join('\n')
+      })
+
+      const ttyContext = {
+        context: {
+          stdout: {
+            isTTY: true,
+            write,
+            clearLine,
+            cursorTo: jest.fn(),
+            moveCursor: jest.fn(),
+          },
+        },
+      }
+
+      const ttyReporter = new DefaultReporter((ttyContext as unknown) as {context: BaseContext})
+
+      ttyReporter.testsWait([getApiTest('aaa-aaa-aaa'), getApiTest('bbb-bbb-bbb')], MOCK_BASE_URL, '123')
+      expect(clearLine).not.toHaveBeenCalled()
+      expect(simulatedTerminalOutput).toMatchSnapshot()
+
+      ttyReporter.testsWait([getApiTest('aaa-aaa-aaa')], MOCK_BASE_URL, '123')
+      ttyReporter['testWaitSpinner']?.render()
+      expect(clearLine).toHaveBeenCalled()
+      expect(simulatedTerminalOutput).toMatchSnapshot()
+
+      ttyReporter.testsWait([], MOCK_BASE_URL, '123')
+      ttyReporter['testWaitSpinner']?.render()
+      expect(clearLine).toHaveBeenCalled()
+      expect(simulatedTerminalOutput).toMatchSnapshot()
+
+      jest.useRealTimers()
+    })
   })
 
   describe('resultEnd', () => {
@@ -143,14 +192,14 @@ describe('Default reporter', () => {
       {
         description: '1 API test, 1 location, 1 result: success',
         fixtures: {
-          baseUrl: baseUrlFixture,
+          baseUrl: MOCK_BASE_URL,
           results: [getApiResult('1', apiTest)],
         },
       },
       {
         description: '1 API test, 1 location, 3 results: success, failed non-blocking, failed blocking',
         fixtures: {
-          baseUrl: baseUrlFixture,
+          baseUrl: MOCK_BASE_URL,
           results: [
             createApiResult('1', true, ExecutionRule.BLOCKING, apiTest),
             createApiResult('2', false, ExecutionRule.NON_BLOCKING, apiTest),
@@ -161,7 +210,7 @@ describe('Default reporter', () => {
       {
         description: '3 Browser test: failed blocking, timed out, global failure',
         fixtures: {
-          baseUrl: baseUrlFixture,
+          baseUrl: MOCK_BASE_URL,
           results: [
             getFailedBrowserResult(),
             getTimedOutBrowserResult(),

--- a/src/commands/synthetics/__tests__/utils.test.ts
+++ b/src/commands/synthetics/__tests__/utils.test.ts
@@ -971,7 +971,10 @@ describe('utils', () => {
     test('results should be timed out if global pollingTimeout is exceeded', async () => {
       mockApi({
         getBatchImplementation: async () => ({
-          results: [batch.results[0], {...batch.results[0], result_id: '3', timed_out: undefined}],
+          results: [
+            {...batch.results[0]},
+            {...batch.results[0], status: 'in_progress', result_id: '3', timed_out: undefined},
+          ],
           status: 'in_progress',
         }),
         pollResultsImplementation: async () => [
@@ -1007,7 +1010,8 @@ describe('utils', () => {
         },
       ])
 
-      expect(mockReporter.resultReceived).toHaveBeenCalledTimes(2)
+      // Residual results are never 'received': we force-end them.
+      expect(mockReporter.resultReceived).toHaveBeenCalledTimes(1)
       expect(mockReporter.resultEnd).toHaveBeenCalledTimes(2)
     })
 
@@ -1122,7 +1126,7 @@ describe('utils', () => {
         ...batch,
         results: [
           batch.results[0],
-          {...batch.results[0], status: 'failed', timed_out: true, result_id: pollTimeoutResult.resultID}, // backend is the source of truth for timeout
+          {...batch.results[0], status: 'failed', timed_out: true, result_id: pollTimeoutResult.resultID},
         ],
       }
 

--- a/src/commands/synthetics/__tests__/utils.test.ts
+++ b/src/commands/synthetics/__tests__/utils.test.ts
@@ -1006,6 +1006,9 @@ describe('utils', () => {
           timedOut: true,
         },
       ])
+
+      expect(mockReporter.resultReceived).toHaveBeenCalledTimes(2)
+      expect(mockReporter.resultEnd).toHaveBeenCalledTimes(2)
     })
 
     test('results failure should ignore if timed-out', async () => {
@@ -1054,7 +1057,7 @@ describe('utils', () => {
     test('results should be timed out if batch result is timed out', async () => {
       const batchWithTimeoutResult: Batch = {
         ...batch,
-        results: [{...batch.results[0], timed_out: true}],
+        results: [{...batch.results[0], status: 'failed', timed_out: true}],
       }
 
       mockApi({getBatchImplementation: async () => batchWithTimeoutResult})
@@ -1119,7 +1122,7 @@ describe('utils', () => {
         ...batch,
         results: [
           batch.results[0],
-          {...batch.results[0], timed_out: true, result_id: pollTimeoutResult.resultID}, // backend is the source of truth for timeout
+          {...batch.results[0], status: 'failed', timed_out: true, result_id: pollTimeoutResult.resultID}, // backend is the source of truth for timeout
         ],
       }
 
@@ -1163,6 +1166,9 @@ describe('utils', () => {
           },
         },
       ])
+
+      expect(mockReporter.resultReceived).toHaveBeenCalledTimes(2)
+      expect(mockReporter.resultEnd).toHaveBeenCalledTimes(2)
     })
 
     test('tunnel failure', async () => {

--- a/src/commands/synthetics/__tests__/utils.test.ts
+++ b/src/commands/synthetics/__tests__/utils.test.ts
@@ -1405,12 +1405,8 @@ describe('utils', () => {
       const exitCode = utils.toExitCode(utils.getExitReason(config, {results: testCase.results}))
 
       expect((mockReporter as MockedReporter).reportStart).toHaveBeenCalledWith({startTime})
-      expect((mockReporter as MockedReporter).resultEnd).toHaveBeenCalledTimes(testCase.results.length)
 
       const baseUrl = `https://${DEFAULT_COMMAND_CONFIG.subdomain}.${DEFAULT_COMMAND_CONFIG.datadogSite}/`
-      for (const result of testCase.results) {
-        expect((mockReporter as MockedReporter).resultEnd).toHaveBeenCalledWith(result, baseUrl)
-      }
 
       expect(testCase.summary).toEqual(testCase.expected.summary)
       expect((mockReporter as MockedReporter).runEnd).toHaveBeenCalledWith(testCase.expected.summary, baseUrl, {

--- a/src/commands/synthetics/interfaces.ts
+++ b/src/commands/synthetics/interfaces.ts
@@ -85,6 +85,23 @@ export interface PollResult {
   timestamp: number
 }
 
+export type PollResultMap = {[resultId: string]: PollResult}
+
+/**
+ * Information required to convert a `PollResult` to a `Result`.
+ */
+export type ResultDisplayInfo = {
+  getLocation: (datacenterId: string, test: Test) => string
+  options: {
+    datadogSite: string
+    failOnCriticalErrors?: boolean
+    failOnTimeout?: boolean
+    maxPollingTimeout: number
+    subdomain: string
+  }
+  tests: Test[]
+}
+
 export interface Result {
   executionRule: ExecutionRule
   location: string

--- a/src/commands/synthetics/utils.ts
+++ b/src/commands/synthetics/utils.ts
@@ -299,11 +299,11 @@ const waitForBatchToFinish = async (
     const current = await getBatch(api, trigger)
     const hasBatchExceededMaxPollingDate = Date.now() >= maxPollingDate
 
-    const receivedResults = reportReceivedResults(current, emittedResultIndexes, reporter)
-
     // The backend is expected to handle the time out of the batch, and change its status to `failed` eventually.
     // But as a safety in case it fails to do that, we also use `hasBatchExceededMaxPollingDate`.
     const shouldContinuePolling = current.status === 'in_progress' && !hasBatchExceededMaxPollingDate
+
+    const receivedResults = reportReceivedResults(current, emittedResultIndexes, reporter)
 
     const resultIdsToFetch = shouldContinuePolling
       ? receivedResults.map((r) => r.result_id)

--- a/src/commands/synthetics/utils.ts
+++ b/src/commands/synthetics/utils.ts
@@ -246,7 +246,7 @@ export const getFilePathRelativeToRepo = async (filePath: string) => {
 
 export const wait = async (duration: number) => new Promise((resolve) => setTimeout(resolve, duration))
 
-const pollBatchAndDisplayUpdates = async (
+const getBatchAndReportUpdates = async (
   api: APIHelper,
   emittedResultIndexes: Set<number>,
   trigger: Trigger,
@@ -338,14 +338,14 @@ const waitForBatchToFinish = async (
   const maxPollingDate = Date.now() + maxPollingTimeout
   const emittedResultIndexes = new Set<number>()
 
-  let current = await pollBatchAndDisplayUpdates(api, emittedResultIndexes, trigger, resultDisplayInfo, reporter)
+  let current = await getBatchAndReportUpdates(api, emittedResultIndexes, trigger, resultDisplayInfo, reporter)
 
   // In theory polling the batch is enough, but in case something goes wrong backend-side
   // let's add a check to ensure it eventually times out.
   let hasBatchExceededMaxPollingDate = Date.now() >= maxPollingDate
   while (current.batch.status === 'in_progress' && !hasBatchExceededMaxPollingDate) {
     await wait(POLLING_INTERVAL)
-    current = await pollBatchAndDisplayUpdates(api, emittedResultIndexes, trigger, resultDisplayInfo, reporter)
+    current = await getBatchAndReportUpdates(api, emittedResultIndexes, trigger, resultDisplayInfo, reporter)
     hasBatchExceededMaxPollingDate = Date.now() >= maxPollingDate
   }
 


### PR DESCRIPTION
### What and why?

This PR changes how often the `run-tests` command displays test runs. Before this PR, we were only showing them once, at the very end.

With this PR, datadog-ci will show each test run as soon as we detect it's failed or passed.

### How?

Before:
- `getBatch()` every 5 seconds
- Use `emittedResultIndexes` to keep track of the in-batch results we emitted with `Reporter.resultReceived()` (minimal information about the result)
- Once the batch is not `in_progress` anymore, use `pollResults()` to get the full information of all results, and display their information with `renderResults()`, which calls `Reporter.resultEnd()` multiple times

After:
- `getBatch()` and `pollResults()` every 5 seconds
- Use `emittedResultIndexes` to keep track of the in-batch results we emitted with `Reporter.resultReceived()` (minimal information about the result) **and** `Reporter.resultEnd()` (full information about the result)
- Once the batch is not `in_progress` anymore, `pollResults()` isn't used an extra time, and `renderResults()` solely display the summary

The output looks exactly the same as before when all results end roughly at the same time:
- [Before](https://github.com/DataDog/datadog-ci/actions/runs/6672701863/job/18137226335#step:6:17) (github action)
- [After](https://github.com/DataDog/datadog-ci/actions/runs/6677903400/job/18148423474#step:6:17) (github action)

Here is how it looks when results arrive later, in a CI environment or not.

When run locally:

https://github.com/DataDog/datadog-ci/assets/9317502/a8aa437a-ea22-43f6-9749-2af14c52db88

When run in a CI environment:

https://github.com/DataDog/datadog-ci/assets/9317502/b3c01cb8-12a6-422e-83eb-53b1c4598eee

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
