### PR TITLE
[SVLS-3931] Adds retry strategy with exponential backoff to AWS requests in Lambda Command

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -9,6 +9,7 @@ Component,Origin,Licence,Copyright
 @babel/preset-env,dev,MIT,Copyright (c) 2014-present Sebastian McKenzie and other contributors
 @babel/preset-typescript,dev,MIT,Copyright (c) 2014-present Sebastian McKenzie and other contributors
 @smithy/property-provider,import,Apache-2.0,"Copyright 2018-2020 Amazon.com, Inc. or its affiliates."
+@smithy/util-retry,import,Apache-2.0,"Copyright 2019 Amazon.com, Inc. or its affiliates."
 @types/async-retry,dev,MIT,Copyright (c) Microsoft Corporation
 @types/datadog-metrics,dev,MIT,Copyright (c) Microsoft Corporation
 @types/tiny-async-pool,dev,MIT,Copyright (c) Microsoft Corporation

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "@google-cloud/logging": "^10.5.0",
     "@google-cloud/run": "^0.6.0",
     "@smithy/property-provider": "^2.0.12",
+    "@smithy/util-retry": "^2.0.4",
     "@types/datadog-metrics": "0.6.1",
     "@types/retry": "0.12.0",
     "ajv": "^8.12.0",

--- a/src/commands/lambda/__tests__/functions/instrument.part1.test.ts
+++ b/src/commands/lambda/__tests__/functions/instrument.part1.test.ts
@@ -456,7 +456,7 @@ describe('instrument', () => {
         settings
       )
 
-      await expect(instrumentedConfig).rejects.toThrow('Max retry count exceeded. Error: ListFunctionsError')
+      await expect(instrumentedConfig).rejects.toThrow('ListFunctionsError')
     })
   })
 })

--- a/src/commands/lambda/__tests__/functions/uninstrument.test.ts
+++ b/src/commands/lambda/__tests__/functions/uninstrument.test.ts
@@ -588,7 +588,7 @@ describe('uninstrument', () => {
         undefined
       )
 
-      await expect(uninstrumentedConfig).rejects.toThrow('Max retry count exceeded. Error: ListFunctionsError')
+      await expect(uninstrumentedConfig).rejects.toThrow('ListFunctionsError')
     })
   })
 })

--- a/src/commands/lambda/__tests__/instrument.test.ts
+++ b/src/commands/lambda/__tests__/instrument.test.ts
@@ -1081,7 +1081,7 @@ describe('lambda', () => {
           🐶 Instrumenting Lambda function
 
           [!] Configure AWS region.
-          [Error] Couldn't fetch Lambda functions. Error: Max retry count exceeded. Error: ListFunctionsError
+          [Error] Couldn't fetch Lambda functions. Error: ListFunctionsError
           "
         `)
       })

--- a/src/commands/lambda/__tests__/uninstrument.test.ts
+++ b/src/commands/lambda/__tests__/uninstrument.test.ts
@@ -303,7 +303,7 @@ describe('lambda', () => {
         expect(output).toMatchInlineSnapshot(`
           "
           🐶 Uninstrumenting Lambda function
-          [Error] Couldn't fetch Lambda functions. Error: Max retry count exceeded. Error: ListFunctionsError
+          [Error] Couldn't fetch Lambda functions. Error: ListFunctionsError
           "
         `)
       })
@@ -567,7 +567,7 @@ describe('lambda', () => {
         expect(output).toMatchInlineSnapshot(`
           "
           🐶 Uninstrumenting Lambda function
-          [Error] Couldn't fetch Lambda functions. Error: Max retry count exceeded. Error: ListFunctionsError
+          [Error] Couldn't fetch Lambda functions. Error: ListFunctionsError
           "
         `)
       })

--- a/src/commands/lambda/constants.ts
+++ b/src/commands/lambda/constants.ts
@@ -167,4 +167,7 @@ export const LAMBDA_PROJECT_FILES = [...FLARE_PROJECT_FILES, ...FRAMEWORK_FILES_
 
 // Configures max number of attempts and exponential backoff function for AWS requests
 // First retry is attempt 1
-export const EXPONENTIAL_BACKOFF_RETRY_STRATEGY = new ConfiguredRetryStrategy(4, (attempt: number) => 1000 * 2 ** (attempt - 1))
+export const EXPONENTIAL_BACKOFF_RETRY_STRATEGY = new ConfiguredRetryStrategy(
+  4,
+  (attempt: number) => 1000 * 2 ** (attempt - 1)
+)

--- a/src/commands/lambda/constants.ts
+++ b/src/commands/lambda/constants.ts
@@ -1,5 +1,7 @@
 import type {Runtime} from '@aws-sdk/client-lambda'
 
+import {ConfiguredRetryStrategy} from '@smithy/util-retry'
+
 import {ENVIRONMENT_ENV_VAR, FLARE_PROJECT_FILES, SERVICE_ENV_VAR, SITE_ENV_VAR, VERSION_ENV_VAR} from '../../constants'
 
 export const DD_LAMBDA_EXTENSION_LAYER_NAME = 'Datadog-Extension'
@@ -113,9 +115,6 @@ export const AWS_DEFAULT_REGION_ENV_VAR = 'AWS_DEFAULT_REGION'
 export const AWS_SESSION_TOKEN_ENV_VAR = 'AWS_SESSION_TOKEN'
 export const AWS_SHARED_CREDENTIALS_FILE_ENV_VAR = 'AWS_SHARED_CREDENTIALS_FILE'
 
-export const LIST_FUNCTIONS_MAX_RETRY_COUNT = 2
-export const MAX_LAMBDA_STATE_CHECK_ATTEMPTS = 3
-
 // DD_TAGS Regular Expression
 // This RegExp ensures that the --extra-tags string
 // matches a list of <key>:<value> separated by commas
@@ -165,3 +164,7 @@ export const FRAMEWORK_FILES_MAPPING = new Map([
 ])
 
 export const LAMBDA_PROJECT_FILES = [...FLARE_PROJECT_FILES, ...FRAMEWORK_FILES_MAPPING.keys()]
+
+// Configures max number of attempts and exponential backoff function for AWS requests
+// First retry is attempt 1
+export const RETRY_STRATEGY = new ConfiguredRetryStrategy(4, (attempt: number) => 1000 * 2 ** (attempt - 1))

--- a/src/commands/lambda/constants.ts
+++ b/src/commands/lambda/constants.ts
@@ -167,4 +167,4 @@ export const LAMBDA_PROJECT_FILES = [...FLARE_PROJECT_FILES, ...FRAMEWORK_FILES_
 
 // Configures max number of attempts and exponential backoff function for AWS requests
 // First retry is attempt 1
-export const RETRY_STRATEGY = new ConfiguredRetryStrategy(4, (attempt: number) => 1000 * 2 ** (attempt - 1))
+export const EXPONENTIAL_BACKOFF_RETRY_STRATEGY = new ConfiguredRetryStrategy(4, (attempt: number) => 1000 * 2 ** (attempt - 1))

--- a/src/commands/lambda/flare.ts
+++ b/src/commands/lambda/flare.ts
@@ -36,6 +36,7 @@ import {
   FRAMEWORK_FILES_MAPPING,
   DeploymentFrameworks,
   LAMBDA_PROJECT_FILES,
+  RETRY_STRATEGY,
 } from './constants'
 import {
   getAWSCredentials,
@@ -167,6 +168,7 @@ export class LambdaFlareCommand extends Command {
     const lambdaClientConfig: LambdaClientConfig = {
       region,
       credentials: this.credentials,
+      retryStrategy: RETRY_STRATEGY,
     }
     const lambdaClient = new LambdaClient(lambdaClientConfig)
     let config: FunctionConfiguration
@@ -537,7 +539,7 @@ export const getLogEvents = async (
  */
 export const getAllLogs = async (region: string, functionName: string, startMillis?: number, endMillis?: number) => {
   const logs = new Map<string, OutputLogEvent[]>()
-  const cwlClient = new CloudWatchLogsClient({region})
+  const cwlClient = new CloudWatchLogsClient({region, retryStrategy: RETRY_STRATEGY})
   if (functionName.startsWith('arn:aws')) {
     functionName = functionName.split(':')[6]
   }

--- a/src/commands/lambda/flare.ts
+++ b/src/commands/lambda/flare.ts
@@ -36,7 +36,7 @@ import {
   FRAMEWORK_FILES_MAPPING,
   DeploymentFrameworks,
   LAMBDA_PROJECT_FILES,
-  RETRY_STRATEGY,
+  EXPONENTIAL_BACKOFF_RETRY_STRATEGY,
 } from './constants'
 import {
   getAWSCredentials,
@@ -168,7 +168,7 @@ export class LambdaFlareCommand extends Command {
     const lambdaClientConfig: LambdaClientConfig = {
       region,
       credentials: this.credentials,
-      retryStrategy: RETRY_STRATEGY,
+      retryStrategy: EXPONENTIAL_BACKOFF_RETRY_STRATEGY,
     }
     const lambdaClient = new LambdaClient(lambdaClientConfig)
     let config: FunctionConfiguration
@@ -539,7 +539,7 @@ export const getLogEvents = async (
  */
 export const getAllLogs = async (region: string, functionName: string, startMillis?: number, endMillis?: number) => {
   const logs = new Map<string, OutputLogEvent[]>()
-  const cwlClient = new CloudWatchLogsClient({region, retryStrategy: RETRY_STRATEGY})
+  const cwlClient = new CloudWatchLogsClient({region, retryStrategy: EXPONENTIAL_BACKOFF_RETRY_STRATEGY})
   if (functionName.startsWith('arn:aws')) {
     functionName = functionName.split(':')[6]
   }

--- a/src/commands/lambda/functions/commons.ts
+++ b/src/commands/lambda/functions/commons.ts
@@ -34,7 +34,7 @@ import {
   GOVCLOUD_LAYER_AWS_ACCOUNT,
   LayerKey,
   LAYER_LOOKUP,
-  RETRY_STRATEGY,
+  EXPONENTIAL_BACKOFF_RETRY_STRATEGY,
   RUNTIME_LOOKUP,
   SKIP_MASKING_LAMBDA_ENV_VARS,
 } from '../constants'
@@ -144,7 +144,7 @@ export const findLatestLayerVersion = async (layer: LayerKey, region: string) =>
   const account = region.startsWith('us-gov') ? GOVCLOUD_LAYER_AWS_ACCOUNT : DEFAULT_LAYER_AWS_ACCOUNT
   const layerName = LAYER_LOOKUP[layer]
   let foundLatestVersion = false
-  const lambdaClient = new LambdaClient({region, retryStrategy: RETRY_STRATEGY})
+  const lambdaClient = new LambdaClient({region, retryStrategy: EXPONENTIAL_BACKOFF_RETRY_STRATEGY})
   while (!foundLatestVersion) {
     try {
       // Search next version

--- a/src/commands/lambda/functions/commons.ts
+++ b/src/commands/lambda/functions/commons.ts
@@ -34,7 +34,7 @@ import {
   GOVCLOUD_LAYER_AWS_ACCOUNT,
   LayerKey,
   LAYER_LOOKUP,
-  LIST_FUNCTIONS_MAX_RETRY_COUNT,
+  RETRY_STRATEGY,
   RUNTIME_LOOKUP,
   SKIP_MASKING_LAMBDA_ENV_VARS,
 } from '../constants'
@@ -144,7 +144,7 @@ export const findLatestLayerVersion = async (layer: LayerKey, region: string) =>
   const account = region.startsWith('us-gov') ? GOVCLOUD_LAYER_AWS_ACCOUNT : DEFAULT_LAYER_AWS_ACCOUNT
   const layerName = LAYER_LOOKUP[layer]
   let foundLatestVersion = false
-  const lambdaClient = new LambdaClient({region})
+  const lambdaClient = new LambdaClient({region, retryStrategy: RETRY_STRATEGY})
   while (!foundLatestVersion) {
     try {
       // Search next version
@@ -281,25 +281,16 @@ export const getLambdaFunctionConfigsFromRegex = async (
 ): Promise<LFunctionConfiguration[]> => {
   const regEx = new RegExp(pattern)
   const matchedFunctions: LFunctionConfiguration[] = []
-  let retryCount = 0
   let response: ListFunctionsCommandOutput
   let nextMarker: string | undefined
 
   while (true) {
-    try {
-      const command = new ListFunctionsCommand({Marker: nextMarker})
-      response = await lambdaClient.send(command)
-      response.Functions?.map((fn) => fn.FunctionName?.match(regEx) && matchedFunctions.push(fn))
-      nextMarker = response.NextMarker
-      if (!nextMarker) {
-        break
-      }
-      retryCount = 0
-    } catch (e) {
-      retryCount++
-      if (retryCount > LIST_FUNCTIONS_MAX_RETRY_COUNT) {
-        throw Error(`Max retry count exceeded. ${e}`)
-      }
+    const command = new ListFunctionsCommand({Marker: nextMarker})
+    response = await lambdaClient.send(command)
+    response.Functions?.map((fn) => fn.FunctionName?.match(regEx) && matchedFunctions.push(fn))
+    nextMarker = response.NextMarker
+    if (!nextMarker) {
+      break
     }
   }
 

--- a/src/commands/lambda/instrument.ts
+++ b/src/commands/lambda/instrument.ts
@@ -12,7 +12,7 @@ import {resolveConfigFromFile, filterAndFormatGithubRemote, DEFAULT_CONFIG_PATHS
 import {getCommitInfo, newSimpleGit} from '../git-metadata/git'
 import {UploadCommand} from '../git-metadata/upload'
 
-import {AWS_DEFAULT_REGION_ENV_VAR, EXTRA_TAGS_REG_EXP, RETRY_STRATEGY} from './constants'
+import {AWS_DEFAULT_REGION_ENV_VAR, EXTRA_TAGS_REG_EXP, EXPONENTIAL_BACKOFF_RETRY_STRATEGY} from './constants'
 import {
   checkRuntimeTypesAreUniform,
   coerceBoolean,
@@ -143,7 +143,7 @@ export class InstrumentCommand extends Command {
           const lambdaClientConfig: LambdaClientConfig = {
             region,
             credentials: this.credentials,
-            retryStrategy: RETRY_STRATEGY,
+            retryStrategy: EXPONENTIAL_BACKOFF_RETRY_STRATEGY,
           }
 
           const lambdaClient = new LambdaClient(lambdaClientConfig)
@@ -243,12 +243,12 @@ export class InstrumentCommand extends Command {
 
       const spinner = instrumentRenderer.fetchingFunctionsSpinner()
       try {
-        const cloudWatchLogsClient = new CloudWatchLogsClient({region, retryStrategy: RETRY_STRATEGY})
+        const cloudWatchLogsClient = new CloudWatchLogsClient({region, retryStrategy: EXPONENTIAL_BACKOFF_RETRY_STRATEGY})
 
         const lambdaClientConfig: LambdaClientConfig = {
           region,
           credentials: this.credentials,
-          retryStrategy: RETRY_STRATEGY,
+          retryStrategy: EXPONENTIAL_BACKOFF_RETRY_STRATEGY,
         }
 
         const lambdaClient = new LambdaClient(lambdaClientConfig)
@@ -289,11 +289,11 @@ export class InstrumentCommand extends Command {
         const lambdaClientConfig: LambdaClientConfig = {
           region,
           credentials: this.credentials,
-          retryStrategy: RETRY_STRATEGY,
+          retryStrategy: EXPONENTIAL_BACKOFF_RETRY_STRATEGY,
         }
 
         const lambdaClient = new LambdaClient(lambdaClientConfig)
-        const cloudWatchLogsClient = new CloudWatchLogsClient({region, retryStrategy: RETRY_STRATEGY})
+        const cloudWatchLogsClient = new CloudWatchLogsClient({region, retryStrategy: EXPONENTIAL_BACKOFF_RETRY_STRATEGY})
         try {
           const configs = await getInstrumentedFunctionConfigs(
             lambdaClient,

--- a/src/commands/lambda/instrument.ts
+++ b/src/commands/lambda/instrument.ts
@@ -12,7 +12,7 @@ import {resolveConfigFromFile, filterAndFormatGithubRemote, DEFAULT_CONFIG_PATHS
 import {getCommitInfo, newSimpleGit} from '../git-metadata/git'
 import {UploadCommand} from '../git-metadata/upload'
 
-import {AWS_DEFAULT_REGION_ENV_VAR, EXTRA_TAGS_REG_EXP} from './constants'
+import {AWS_DEFAULT_REGION_ENV_VAR, EXTRA_TAGS_REG_EXP, RETRY_STRATEGY} from './constants'
 import {
   checkRuntimeTypesAreUniform,
   coerceBoolean,
@@ -143,6 +143,7 @@ export class InstrumentCommand extends Command {
           const lambdaClientConfig: LambdaClientConfig = {
             region,
             credentials: this.credentials,
+            retryStrategy: RETRY_STRATEGY,
           }
 
           const lambdaClient = new LambdaClient(lambdaClientConfig)
@@ -242,11 +243,12 @@ export class InstrumentCommand extends Command {
 
       const spinner = instrumentRenderer.fetchingFunctionsSpinner()
       try {
-        const cloudWatchLogsClient = new CloudWatchLogsClient({region})
+        const cloudWatchLogsClient = new CloudWatchLogsClient({region, retryStrategy: RETRY_STRATEGY})
 
         const lambdaClientConfig: LambdaClientConfig = {
           region,
           credentials: this.credentials,
+          retryStrategy: RETRY_STRATEGY,
         }
 
         const lambdaClient = new LambdaClient(lambdaClientConfig)
@@ -287,10 +289,11 @@ export class InstrumentCommand extends Command {
         const lambdaClientConfig: LambdaClientConfig = {
           region,
           credentials: this.credentials,
+          retryStrategy: RETRY_STRATEGY,
         }
 
         const lambdaClient = new LambdaClient(lambdaClientConfig)
-        const cloudWatchLogsClient = new CloudWatchLogsClient({region})
+        const cloudWatchLogsClient = new CloudWatchLogsClient({region, retryStrategy: RETRY_STRATEGY})
         try {
           const configs = await getInstrumentedFunctionConfigs(
             lambdaClient,

--- a/src/commands/lambda/instrument.ts
+++ b/src/commands/lambda/instrument.ts
@@ -243,7 +243,10 @@ export class InstrumentCommand extends Command {
 
       const spinner = instrumentRenderer.fetchingFunctionsSpinner()
       try {
-        const cloudWatchLogsClient = new CloudWatchLogsClient({region, retryStrategy: EXPONENTIAL_BACKOFF_RETRY_STRATEGY})
+        const cloudWatchLogsClient = new CloudWatchLogsClient({
+          region,
+          retryStrategy: EXPONENTIAL_BACKOFF_RETRY_STRATEGY,
+        })
 
         const lambdaClientConfig: LambdaClientConfig = {
           region,
@@ -293,7 +296,10 @@ export class InstrumentCommand extends Command {
         }
 
         const lambdaClient = new LambdaClient(lambdaClientConfig)
-        const cloudWatchLogsClient = new CloudWatchLogsClient({region, retryStrategy: EXPONENTIAL_BACKOFF_RETRY_STRATEGY})
+        const cloudWatchLogsClient = new CloudWatchLogsClient({
+          region,
+          retryStrategy: EXPONENTIAL_BACKOFF_RETRY_STRATEGY,
+        })
         try {
           const configs = await getInstrumentedFunctionConfigs(
             lambdaClient,

--- a/src/commands/lambda/uninstrument.ts
+++ b/src/commands/lambda/uninstrument.ts
@@ -8,7 +8,7 @@ import {requestConfirmation} from '../../helpers/prompt'
 import * as helperRenderer from '../../helpers/renderer'
 import {DEFAULT_CONFIG_PATHS, resolveConfigFromFile} from '../../helpers/utils'
 
-import {AWS_DEFAULT_REGION_ENV_VAR} from './constants'
+import {AWS_DEFAULT_REGION_ENV_VAR, RETRY_STRATEGY} from './constants'
 import {
   collectFunctionsByRegion,
   getAllLambdaFunctionConfigs,
@@ -110,6 +110,7 @@ export class UninstrumentCommand extends Command {
           const lambdaClientConfig: LambdaClientConfig = {
             region,
             credentials: this.credentials,
+            retryStrategy: RETRY_STRATEGY,
           }
 
           const lambdaClient = new LambdaClient(lambdaClientConfig)
@@ -174,11 +175,12 @@ export class UninstrumentCommand extends Command {
 
       const spinner = instrumentRenderer.fetchingFunctionsSpinner()
       try {
-        const cloudWatchLogsClient = new CloudWatchLogsClient({region})
+        const cloudWatchLogsClient = new CloudWatchLogsClient({region, retryStrategy: RETRY_STRATEGY})
 
         const lambdaClientConfig: LambdaClientConfig = {
           region,
           credentials: this.credentials,
+          retryStrategy: RETRY_STRATEGY,
         }
 
         const lambdaClient = new LambdaClient(lambdaClientConfig)
@@ -217,10 +219,11 @@ export class UninstrumentCommand extends Command {
         const lambdaClientConfig: LambdaClientConfig = {
           region,
           credentials: this.credentials,
+          retryStrategy: RETRY_STRATEGY,
         }
 
         const lambdaClient = new LambdaClient(lambdaClientConfig)
-        const cloudWatchLogsClient = new CloudWatchLogsClient({region})
+        const cloudWatchLogsClient = new CloudWatchLogsClient({region, retryStrategy: RETRY_STRATEGY})
         try {
           const configs = await getUninstrumentedFunctionConfigs(
             lambdaClient,

--- a/src/commands/lambda/uninstrument.ts
+++ b/src/commands/lambda/uninstrument.ts
@@ -175,7 +175,10 @@ export class UninstrumentCommand extends Command {
 
       const spinner = instrumentRenderer.fetchingFunctionsSpinner()
       try {
-        const cloudWatchLogsClient = new CloudWatchLogsClient({region, retryStrategy: EXPONENTIAL_BACKOFF_RETRY_STRATEGY})
+        const cloudWatchLogsClient = new CloudWatchLogsClient({
+          region,
+          retryStrategy: EXPONENTIAL_BACKOFF_RETRY_STRATEGY,
+        })
 
         const lambdaClientConfig: LambdaClientConfig = {
           region,
@@ -223,7 +226,10 @@ export class UninstrumentCommand extends Command {
         }
 
         const lambdaClient = new LambdaClient(lambdaClientConfig)
-        const cloudWatchLogsClient = new CloudWatchLogsClient({region, retryStrategy: EXPONENTIAL_BACKOFF_RETRY_STRATEGY})
+        const cloudWatchLogsClient = new CloudWatchLogsClient({
+          region,
+          retryStrategy: EXPONENTIAL_BACKOFF_RETRY_STRATEGY,
+        })
         try {
           const configs = await getUninstrumentedFunctionConfigs(
             lambdaClient,

--- a/src/commands/lambda/uninstrument.ts
+++ b/src/commands/lambda/uninstrument.ts
@@ -8,7 +8,7 @@ import {requestConfirmation} from '../../helpers/prompt'
 import * as helperRenderer from '../../helpers/renderer'
 import {DEFAULT_CONFIG_PATHS, resolveConfigFromFile} from '../../helpers/utils'
 
-import {AWS_DEFAULT_REGION_ENV_VAR, RETRY_STRATEGY} from './constants'
+import {AWS_DEFAULT_REGION_ENV_VAR, EXPONENTIAL_BACKOFF_RETRY_STRATEGY} from './constants'
 import {
   collectFunctionsByRegion,
   getAllLambdaFunctionConfigs,
@@ -110,7 +110,7 @@ export class UninstrumentCommand extends Command {
           const lambdaClientConfig: LambdaClientConfig = {
             region,
             credentials: this.credentials,
-            retryStrategy: RETRY_STRATEGY,
+            retryStrategy: EXPONENTIAL_BACKOFF_RETRY_STRATEGY,
           }
 
           const lambdaClient = new LambdaClient(lambdaClientConfig)
@@ -175,12 +175,12 @@ export class UninstrumentCommand extends Command {
 
       const spinner = instrumentRenderer.fetchingFunctionsSpinner()
       try {
-        const cloudWatchLogsClient = new CloudWatchLogsClient({region, retryStrategy: RETRY_STRATEGY})
+        const cloudWatchLogsClient = new CloudWatchLogsClient({region, retryStrategy: EXPONENTIAL_BACKOFF_RETRY_STRATEGY})
 
         const lambdaClientConfig: LambdaClientConfig = {
           region,
           credentials: this.credentials,
-          retryStrategy: RETRY_STRATEGY,
+          retryStrategy: EXPONENTIAL_BACKOFF_RETRY_STRATEGY,
         }
 
         const lambdaClient = new LambdaClient(lambdaClientConfig)
@@ -219,11 +219,11 @@ export class UninstrumentCommand extends Command {
         const lambdaClientConfig: LambdaClientConfig = {
           region,
           credentials: this.credentials,
-          retryStrategy: RETRY_STRATEGY,
+          retryStrategy: EXPONENTIAL_BACKOFF_RETRY_STRATEGY,
         }
 
         const lambdaClient = new LambdaClient(lambdaClientConfig)
-        const cloudWatchLogsClient = new CloudWatchLogsClient({region, retryStrategy: RETRY_STRATEGY})
+        const cloudWatchLogsClient = new CloudWatchLogsClient({region, retryStrategy: EXPONENTIAL_BACKOFF_RETRY_STRATEGY})
         try {
           const configs = await getUninstrumentedFunctionConfigs(
             lambdaClient,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1984,6 +1984,7 @@ __metadata:
     "@google-cloud/run": ^0.6.0
     "@microsoft/eslint-formatter-sarif": ^3.0.0
     "@smithy/property-provider": ^2.0.12
+    "@smithy/util-retry": ^2.0.4
     "@types/async-retry": 1.4.2
     "@types/datadog-metrics": 0.6.1
     "@types/deep-extend": 0.4.31
@@ -3247,6 +3248,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@smithy/service-error-classification@npm:^2.0.6":
+  version: 2.0.6
+  resolution: "@smithy/service-error-classification@npm:2.0.6"
+  dependencies:
+    "@smithy/types": ^2.5.0
+  checksum: 07be989a2d3e17e14f8c7824bf9342632ec5ed1e4e0b4f2d242442f49a50058db5cbb7b8419b684126bf5c4ba08f6bce3360f43d73bd2def15771a1af7c1c95f
+  languageName: node
+  linkType: hard
+
 "@smithy/shared-ini-file-loader@npm:^2.0.3":
   version: 2.0.3
   resolution: "@smithy/shared-ini-file-loader@npm:2.0.3"
@@ -3329,6 +3339,15 @@ __metadata:
   dependencies:
     tslib: ^2.5.0
   checksum: 936690f8ba9323c05a1046102f83d7ed76c5c2f2405ca22e8bfed8d66a5ba12d74a187c10d93b085d6822b98edaec7b6309a4401f036099bf239a0bf5cdcf00d
+  languageName: node
+  linkType: hard
+
+"@smithy/types@npm:^2.5.0":
+  version: 2.5.0
+  resolution: "@smithy/types@npm:2.5.0"
+  dependencies:
+    tslib: ^2.5.0
+  checksum: 9e03dcf6c9ae7239218ccecae0a04d5f0aaab42e17a326590becfd68f1b15ba1291ed408501efab4a20a0542d995b5a859ab58ca83cd4f3e2dbf430785e207a6
   languageName: node
   linkType: hard
 
@@ -3465,6 +3484,17 @@ __metadata:
     "@smithy/types": ^2.4.0
     tslib: ^2.5.0
   checksum: 9d001723e7472c0d78619320235f66d1de42f16e13d1189697f8e447d05643047ab97965525b147eaafbb0e169563ecb5b806da2d02bd4ce0b652b72df4d9131
+  languageName: node
+  linkType: hard
+
+"@smithy/util-retry@npm:^2.0.4":
+  version: 2.0.6
+  resolution: "@smithy/util-retry@npm:2.0.6"
+  dependencies:
+    "@smithy/service-error-classification": ^2.0.6
+    "@smithy/types": ^2.5.0
+    tslib: ^2.5.0
+  checksum: c37d163f83981ca58c7d924b178a09e18abc915ffb5efb20fcc4e662ad909938296fd295244ed84a209e84e56d66a629a9eba655306ca401c1a3b91c4433ff22
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### What and why?

Adds retries to AWS requests made by the lambda cli due to `Throttling Exception: Rate Exceeded` errors when instrumenting a large number of Lambda functions.

https://datadoghq.atlassian.net/browse/SVLS-3931

### How?

* Uses [@smithy/util-retry](https://github.com/awslabs/smithy-typescript) package to retry failed requests to AWS
* Retries 4 times after initial attempt with exponential backoff starting at 1 second

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)

### Additional Notes

* `getLambdaFunctionConfigsFromRegex` previously had dedicated retry logic but this was removed in favor of the retry strategy being used for all AWS requests
* From manual testing, Throttling Exceptions occur on `ListTagsCommand` requests. However the retry logic is applied to all AWS requests to handle potential Throttling Exceptions in environments different than the one used to test.

Validated the retry behavior by adding debug logs after the `ListTagsCommand` is sent:

```
  if (response.$metadata.attempts !== undefined && response.$metadata.attempts > 1) {
    console.log('ListTagsCommand')
    console.log(`statusCode: ${response.$metadata.httpStatusCode}`)
    console.log(`attempts: ${response.$metadata.attempts}`)
    console.log(`totalRetryDelay: ${response.$metadata.totalRetryDelay}`)
  }
```

```
ListTagsCommand
statusCode: 200
attempts: 2
totalRetryDelay: 1000
ListTagsCommand
statusCode: 200
attempts: 2
totalRetryDelay: 1000
ListTagsCommand
statusCode: 200
attempts: 3
totalRetryDelay: 3000
ListTagsCommand
statusCode: 200
attempts: 2
totalRetryDelay: 1000
ListTagsCommand
statusCode: 200
attempts: 3
totalRetryDelay: 3000
```
