### PR TITLE
[SBOM] remove duplicate licenses

### DIFF
--- a/src/commands/sbom/__tests__/payload.test.ts
+++ b/src/commands/sbom/__tests__/payload.test.ts
@@ -76,6 +76,14 @@ describe('generation of payload', () => {
     const dependenciesWithoutLicense = payload?.dependencies.filter((d) => d.licenses.length === 0)
     expect(dependenciesWithoutLicense?.length).toStrictEqual(3)
 
+    // Check licenses is correct
+    console.log(payload?.dependencies[0].licenses)
+    expect(payload?.dependencies[0].licenses.length).toStrictEqual(1)
+
+    expect(payload?.dependencies[1].licenses.length).toStrictEqual(2)
+    expect(payload?.dependencies[1].licenses[0]).toStrictEqual(DependencyLicense.MIT)
+    expect(payload?.dependencies[1].licenses[1]).toStrictEqual(DependencyLicense.APACHE2)
+
     // all languages are detected
     const dependenciesWithoutLanguage = payload?.dependencies.filter((d) => !d.language)
     expect(dependenciesWithoutLanguage?.length).toStrictEqual(0)

--- a/src/commands/sbom/license.ts
+++ b/src/commands/sbom/license.ts
@@ -84,12 +84,11 @@ export const getLicensesFromComponent = (component: any): DependencyLicense[] =>
             licenses.push(l)
           }
         }
-
-        // Handle "license": [ {"expression": "MIT"} ]
-        if (license['expression']) {
-          for (const l of getLicensesFromString(license['expression'])) {
-            licenses.push(l)
-          }
+      }
+      // Handle "license": [ {"expression": "MIT"} ]
+      if (license['expression']) {
+        for (const l of getLicensesFromString(license['expression'])) {
+          licenses.push(l)
         }
       }
     }

--- a/src/commands/sbom/license.ts
+++ b/src/commands/sbom/license.ts
@@ -72,7 +72,7 @@ export const getLicensesFromComponent = (component: any): DependencyLicense[] =>
   const elementsForLicense = ['id', 'name']
 
   const componentName = component['name']
-  const licenses: DependencyLicense[] = []
+  const licensesSet: Set<DependencyLicense> = new Set()
 
   // Get the "licenses" attribute of the SBOM component.
   if (component['licenses']) {
@@ -81,22 +81,22 @@ export const getLicensesFromComponent = (component: any): DependencyLicense[] =>
         // Handle "license": [ {"license": {"id": <license>}} ]
         if (license['license']?.[el]) {
           for (const l of getLicensesFromString(license['license'][el])) {
-            licenses.push(l)
+            licensesSet.add(l)
           }
         }
       }
       // Handle "license": [ {"expression": "MIT"} ]
       if (license['expression']) {
         for (const l of getLicensesFromString(license['expression'])) {
-          licenses.push(l)
+          licensesSet.add(l)
         }
       }
     }
   }
 
-  if (licenses.length === 0) {
+  if (licensesSet.size === 0) {
     console.log(`license for component ${componentName} not found`)
   }
 
-  return licenses
+  return Array.from(licensesSet)
 }

--- a/src/commands/sbom/upload.ts
+++ b/src/commands/sbom/upload.ts
@@ -91,7 +91,6 @@ export class UploadSbomCommand extends Command {
         // Upload content
         try {
           const scaPayload = generatePayload(jsonContent, tags)
-          console.log(`sending ${JSON.stringify(scaPayload)}`)
           if (!scaPayload) {
             console.log(`Cannot generate payload for file ${filePath}`)
             continue

--- a/src/commands/sbom/upload.ts
+++ b/src/commands/sbom/upload.ts
@@ -91,7 +91,7 @@ export class UploadSbomCommand extends Command {
         // Upload content
         try {
           const scaPayload = generatePayload(jsonContent, tags)
-
+          console.log(`sending ${JSON.stringify(scaPayload)}`)
           if (!scaPayload) {
             console.log(`Cannot generate payload for file ${filePath}`)
             continue


### PR DESCRIPTION
### What and why?

Remove duplicate licenses in the SBOM payload. Ensure we only send one occurrence of the same license, even if the SBOM file contains it twice.

### How?

Use a `Set` to store the licenses we will send.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
