### PR TITLE
[test] Suppress console logs in unit tests

### DIFF
--- a/src/commands/sbom/__tests__/license.test.ts
+++ b/src/commands/sbom/__tests__/license.test.ts
@@ -2,6 +2,11 @@ import {getLicensesFromString} from '../license'
 import {DependencyLicense} from '../types'
 
 describe('licenses', () => {
+  beforeEach(() => {
+    jest.spyOn(console, 'debug').mockImplementation()
+    jest.spyOn(console, 'log').mockImplementation()
+  })
+
   test('should return the correct values', async () => {
     expect(getLicensesFromString('MIT')).toStrictEqual([DependencyLicense.MIT])
     expect(getLicensesFromString('Apache-2.0 OR MIT')).toStrictEqual([DependencyLicense.APACHE2, DependencyLicense.MIT])

--- a/src/commands/sbom/__tests__/payload.test.ts
+++ b/src/commands/sbom/__tests__/payload.test.ts
@@ -7,6 +7,11 @@ import {generatePayload} from '../payload'
 import {DependencyLanguage, DependencyLicense} from '../types'
 
 describe('generation of payload', () => {
+  beforeEach(() => {
+    jest.spyOn(console, 'debug').mockImplementation()
+    jest.spyOn(console, 'log').mockImplementation()
+  })
+
   test('should correctly work with a CycloneDX 1.4 file', async () => {
     const sbomFile = './src/commands/sbom/__tests__/fixtures/sbom.1.4.ok.json'
     const sbomContent = JSON.parse(fs.readFileSync(sbomFile).toString('utf8'))


### PR DESCRIPTION
### What and why?

This [test](https://github.com/DataDog/datadog-ci/actions/runs/6785564730/job/18444174279?pr=1102#step:8:48) is printing logs in the CI and it makes it longer to read the Jest output.

### How?

Mock the implementation of `console.info` and `console.debug`.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
