### PR TITLE
[dep] Upgrade axios from 0.21.4 to 1.6.0

### DIFF
--- a/jest.config-standalone.js
+++ b/jest.config-standalone.js
@@ -1,9 +1,12 @@
 module.exports = {
   preset: 'ts-jest',
-  globals: {
-    'ts-jest': {
-      tsconfig: 'tsconfig.json',
-    },
+  transform: {
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: 'tsconfig.json',
+      },
+    ],
   },
   roots: ['standalone-e2e'],
 }

--- a/package.json
+++ b/package.json
@@ -35,6 +35,9 @@
   "pkg": {
     "scripts": [
       "dist/commands/*/*.js"
+    ],
+    "assets": [
+      "node_modules/axios/dist/node/axios.cjs"
     ]
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "ajv": "^8.12.0",
     "ajv-formats": "^2.1.1",
     "async-retry": "1.3.1",
-    "axios": "0.21.4",
+    "axios": "1.6.0",
     "chalk": "3.0.0",
     "clipanion": "^3.2.1",
     "datadog-metrics": "0.9.3",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "deep-extend": "0.6.0",
     "deep-object-diff": "^1.1.9",
     "fast-xml-parser": "^4.2.5",
-    "form-data": "3.0.0",
+    "form-data": "4.0.0",
     "fuzzy": "^0.1.3",
     "glob": "7.1.4",
     "google-auth-library": "^8.9.0",

--- a/src/commands/gate/__tests__/evaluate.test.ts
+++ b/src/commands/gate/__tests__/evaluate.test.ts
@@ -1,4 +1,4 @@
-import {AxiosResponse} from 'axios'
+import type {AxiosResponse, InternalAxiosRequestConfig} from 'axios'
 
 import {createCommand} from '../../../helpers/__tests__/fixtures'
 
@@ -158,7 +158,7 @@ describe('evaluate', () => {
         status: 200,
         statusText: 'OK',
         headers: {},
-        config: {},
+        config: {} as InternalAxiosRequestConfig,
         data: {
           data: {
             attributes: {
@@ -176,7 +176,7 @@ describe('evaluate', () => {
       status: 200,
       statusText: 'OK',
       headers: {},
-      config: {},
+      config: {} as InternalAxiosRequestConfig,
       data: {
         data: {
           attributes: {

--- a/src/commands/gate/api.ts
+++ b/src/commands/gate/api.ts
@@ -1,6 +1,6 @@
 import {Writable} from 'stream'
 
-import {AxiosPromise, AxiosRequestConfig} from 'axios'
+import type {AxiosPromise, AxiosRequestConfig} from 'axios'
 
 import {getRequestBuilder} from '../../helpers/utils'
 

--- a/src/commands/gate/interfaces.ts
+++ b/src/commands/gate/interfaces.ts
@@ -1,6 +1,6 @@
 import {Writable} from 'stream'
 
-import {AxiosPromise} from 'axios'
+import type {AxiosPromise} from 'axios'
 
 import {SpanTags} from '../../helpers/interfaces'
 

--- a/src/commands/git-metadata/gitdb.ts
+++ b/src/commands/git-metadata/gitdb.ts
@@ -4,7 +4,8 @@ import {mkdtemp} from 'fs/promises'
 import os from 'os'
 import path from 'path'
 
-import {AxiosResponse} from 'axios'
+import type {AxiosResponse} from 'axios'
+
 import FormData from 'form-data'
 import {lte} from 'semver'
 import * as simpleGit from 'simple-git'

--- a/src/commands/junit/interfaces.ts
+++ b/src/commands/junit/interfaces.ts
@@ -1,4 +1,4 @@
-import {AxiosPromise, AxiosResponse} from 'axios'
+import type {AxiosPromise, AxiosResponse} from 'axios'
 
 import {SpanTags} from '../../helpers/interfaces'
 

--- a/src/commands/sarif/interfaces.ts
+++ b/src/commands/sarif/interfaces.ts
@@ -1,6 +1,6 @@
 import {Writable} from 'stream'
 
-import {AxiosPromise, AxiosResponse} from 'axios'
+import type {AxiosPromise, AxiosResponse} from 'axios'
 
 import {SpanTags} from '../../helpers/interfaces'
 

--- a/src/commands/sbom/api.ts
+++ b/src/commands/sbom/api.ts
@@ -1,4 +1,4 @@
-import {AxiosPromise, AxiosRequestConfig, AxiosResponse} from 'axios'
+import type {AxiosPromise, AxiosRequestConfig, AxiosResponse} from 'axios'
 
 import {CONTENT_TYPE_HEADER, CONTENT_TYPE_VALUE_PROTOBUF, METHOD_POST} from '../../constants'
 import {getBaseIntakeUrl} from '../../helpers/api'

--- a/src/commands/sbom/upload.ts
+++ b/src/commands/sbom/upload.ts
@@ -1,8 +1,9 @@
 import fs from 'fs'
 import process from 'process'
 
+import type {AxiosPromise, AxiosResponse} from 'axios'
+
 import Ajv from 'ajv'
-import {AxiosPromise, AxiosResponse} from 'axios'
 import chalk from 'chalk'
 import {Command, Option} from 'clipanion'
 

--- a/src/commands/synthetics/__tests__/api.test.ts
+++ b/src/commands/synthetics/__tests__/api.test.ts
@@ -1,4 +1,6 @@
-import {AxiosError, AxiosResponse, default as axios} from 'axios'
+import type {AxiosError, AxiosResponse} from 'axios'
+
+import axios from 'axios'
 
 import {ProxyConfiguration} from '../../../helpers/utils'
 

--- a/src/commands/synthetics/__tests__/fixtures.ts
+++ b/src/commands/synthetics/__tests__/fixtures.ts
@@ -2,7 +2,8 @@ import * as http from 'http'
 import * as net from 'net'
 import {URL} from 'url'
 
-import {AxiosError, AxiosResponse} from 'axios'
+import type {AxiosError, AxiosResponse, InternalAxiosRequestConfig} from 'axios'
+
 import WebSocket, {Server as WebSocketServer} from 'ws'
 
 import {ProxyConfiguration} from '../../../helpers/utils'
@@ -84,8 +85,8 @@ export const ciConfig: RunTestsCommandConfig = {
 }
 
 export const getAxiosHttpError = (status: number, {errors, message}: {errors?: string[]; message?: string}) => {
-  const serverError = new Error(message) as AxiosError
-  serverError.config = {baseURL: MOCK_BASE_URL, url: 'example'}
+  const serverError = new Error(message) as AxiosError<any, any> & {config: InternalAxiosRequestConfig}
+  serverError.config = {baseURL: MOCK_BASE_URL, url: 'example'} as InternalAxiosRequestConfig
   serverError.response = {data: {errors}, status} as AxiosResponse
 
   return serverError

--- a/src/commands/synthetics/api.ts
+++ b/src/commands/synthetics/api.ts
@@ -39,12 +39,8 @@ export class EndpointError extends Error {
 }
 
 export const formatBackendErrors = (requestError: AxiosError<BackendError>) => {
-  if (!requestError.config) {
-    return `config unavailable\n${requestError.message}`
-  }
-
   if (requestError.response?.data?.errors) {
-    const serverHead = `query on ${requestError.config.baseURL}${requestError.config.url} returned:`
+    const serverHead = `query on ${requestError.config?.baseURL}${requestError.config?.url} returned:`
     const errors = requestError.response.data.errors
     if (errors.length > 1) {
       const formattedErrors = errors.map((message: string) => `  - ${message}`)
@@ -53,11 +49,11 @@ export const formatBackendErrors = (requestError: AxiosError<BackendError>) => {
     } else if (errors.length) {
       return `${serverHead} "${errors[0]}"`
     } else {
-      return `error querying ${requestError.config.baseURL}${requestError.config.url}`
+      return `error querying ${requestError.config?.baseURL}${requestError.config?.url}`
     }
   }
 
-  return `could not query ${requestError.config.baseURL}${requestError.config.url}\n${requestError.message}`
+  return `could not query ${requestError.config?.baseURL}${requestError.config?.url}\n${requestError.message}`
 }
 
 const triggerTests = (request: (args: AxiosRequestConfig) => AxiosPromise<Trigger>) => async (data: Payload) => {

--- a/src/commands/synthetics/api.ts
+++ b/src/commands/synthetics/api.ts
@@ -1,6 +1,7 @@
 import {stringify} from 'querystring'
 
-import {AxiosError, AxiosPromise, AxiosRequestConfig} from 'axios'
+import type {AxiosError, AxiosPromise, AxiosRequestConfig} from 'axios'
+
 import FormData from 'form-data'
 
 import {getRequestBuilder} from '../../helpers/utils'
@@ -38,6 +39,10 @@ export class EndpointError extends Error {
 }
 
 export const formatBackendErrors = (requestError: AxiosError<BackendError>) => {
+  if (!requestError.config) {
+    return `config unavailable\n${requestError.message}`
+  }
+
   if (requestError.response?.data?.errors) {
     const serverHead = `query on ${requestError.config.baseURL}${requestError.config.url} returned:`
     const errors = requestError.response.data.errors

--- a/src/commands/trace/interfaces.ts
+++ b/src/commands/trace/interfaces.ts
@@ -1,4 +1,4 @@
-import {AxiosPromise, AxiosResponse} from 'axios'
+import type {AxiosPromise, AxiosResponse} from 'axios'
 
 export const CIRCLECI = 'circleci'
 export const JENKINS = 'jenkins'

--- a/src/helpers/__tests__/retry.test.ts
+++ b/src/helpers/__tests__/retry.test.ts
@@ -1,4 +1,4 @@
-import {AxiosPromise} from 'axios'
+import type {AxiosPromise, AxiosResponseHeaders, InternalAxiosRequestConfig} from 'axios'
 
 import {retryRequest} from '../retry'
 
@@ -11,9 +11,9 @@ describe('retry', () => {
       i = i + 1
       if (errors[i] === undefined) {
         return Promise.resolve({
-          config: {},
+          config: {} as InternalAxiosRequestConfig,
           data: {},
-          headers: undefined,
+          headers: {} as AxiosResponseHeaders,
           status: 200,
           statusText: '',
         })

--- a/src/helpers/__tests__/utils.test.ts
+++ b/src/helpers/__tests__/utils.test.ts
@@ -1,7 +1,9 @@
 import http from 'http'
 import {AddressInfo} from 'net'
 
-import {AxiosPromise, AxiosRequestConfig, default as axios} from 'axios'
+import type {AxiosPromise, AxiosRequestConfig} from 'axios'
+
+import axios from 'axios'
 import {createProxy} from 'proxy'
 import {ProxyAgent} from 'proxy-agent'
 

--- a/src/helpers/interfaces.ts
+++ b/src/helpers/interfaces.ts
@@ -1,6 +1,5 @@
+import type {AxiosPromise, AxiosRequestConfig} from 'axios'
 import type {Writable} from 'stream'
-
-import {AxiosPromise, AxiosRequestConfig} from 'axios'
 
 import {
   CI_ENV_VARS,

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -2,8 +2,9 @@ import fs, {existsSync} from 'fs'
 import {promisify} from 'util'
 
 import type {SpanTag, SpanTags} from './interfaces'
+import type {AxiosRequestConfig} from 'axios'
 
-import {AxiosRequestConfig, default as axios} from 'axios'
+import axios from 'axios'
 import {BaseContext, CommandClass, Cli} from 'clipanion'
 import deepExtend from 'deep-extend'
 import {ProxyAgent} from 'proxy-agent'
@@ -176,7 +177,7 @@ export const getRequestBuilder = (options: RequestOptions) => {
         'DD-API-KEY': apiKey,
         ...(appKey ? {'DD-APPLICATION-KEY': appKey} : {}),
         ...args.headers,
-      },
+      } as NonNullable<typeof args.headers>,
     }
 
     if (overrideUrl !== undefined) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1981,7 +1981,7 @@ __metadata:
     async-retry: 1.3.1
     aws-sdk-client-mock: ^2.1.1
     aws-sdk-client-mock-jest: ^2.1.1
-    axios: 0.21.4
+    axios: 1.6.0
     chalk: 3.0.0
     clipanion: ^3.2.1
     datadog-metrics: 0.9.3
@@ -4400,12 +4400,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios@npm:0.21.4":
-  version: 0.21.4
-  resolution: "axios@npm:0.21.4"
+"axios@npm:1.6.0":
+  version: 1.6.0
+  resolution: "axios@npm:1.6.0"
   dependencies:
-    follow-redirects: ^1.14.0
-  checksum: 44245f24ac971e7458f3120c92f9d66d1fc695e8b97019139de5b0cc65d9b8104647db01e5f46917728edfc0cfd88eb30fc4c55e6053eef4ace76768ce95ff3c
+    follow-redirects: ^1.15.0
+    form-data: ^4.0.0
+    proxy-from-env: ^1.1.0
+  checksum: c7c9f2ae9e0b9bad7d6f9a4dff030930b12ee667dedf54c3c776714f91681feb743c509ac0796ae5c01e12c4ab4a2bee74905068dd200fbc1ab86f9814578fb0
   languageName: node
   linkType: hard
 
@@ -6205,13 +6207,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"follow-redirects@npm:^1.14.0":
-  version: 1.15.2
-  resolution: "follow-redirects@npm:1.15.2"
+"follow-redirects@npm:^1.15.0":
+  version: 1.15.3
+  resolution: "follow-redirects@npm:1.15.3"
   peerDependenciesMeta:
     debug:
       optional: true
-  checksum: faa66059b66358ba65c234c2f2a37fcec029dc22775f35d9ad6abac56003268baf41e55f9ee645957b32c7d9f62baf1f0b906e68267276f54ec4b4c597c2b190
+  checksum: 584da22ec5420c837bd096559ebfb8fe69d82512d5585004e36a3b4a6ef6d5905780e0c74508c7b72f907d1fa2b7bd339e613859e9c304d0dc96af2027fd0231
   languageName: node
   linkType: hard
 
@@ -6242,6 +6244,17 @@ __metadata:
     combined-stream: ^1.0.8
     mime-types: ^2.1.12
   checksum: 60ec3fe7e23154949ab6fef31baedf5afbfb8d6441ea8d19b211b43a5d0448be2918c9bba6218cade56a7cbd43f670d6e75f41f626f8d397d56bf8c60f4a829d
+  languageName: node
+  linkType: hard
+
+"form-data@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "form-data@npm:4.0.0"
+  dependencies:
+    asynckit: ^0.4.0
+    combined-stream: ^1.0.8
+    mime-types: ^2.1.12
+  checksum: 01135bf8675f9d5c61ff18e2e2932f719ca4de964e3be90ef4c36aacfc7b9cb2fceb5eca0b7e0190e3383fe51c5b37f4cb80b62ca06a99aaabfcfd6ac7c9328c
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1997,7 +1997,7 @@ __metadata:
     eslint-plugin-prefer-arrow: ^1.2.3
     eslint-plugin-prettier: 4.0.0
     fast-xml-parser: ^4.2.5
-    form-data: 3.0.0
+    form-data: 4.0.0
     fuzzy: ^0.1.3
     glob: 7.1.4
     google-auth-library: ^8.9.0
@@ -6236,18 +6236,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"form-data@npm:3.0.0":
-  version: 3.0.0
-  resolution: "form-data@npm:3.0.0"
-  dependencies:
-    asynckit: ^0.4.0
-    combined-stream: ^1.0.8
-    mime-types: ^2.1.12
-  checksum: 60ec3fe7e23154949ab6fef31baedf5afbfb8d6441ea8d19b211b43a5d0448be2918c9bba6218cade56a7cbd43f670d6e75f41f626f8d397d56bf8c60f4a829d
-  languageName: node
-  linkType: hard
-
-"form-data@npm:^4.0.0":
+"form-data@npm:4.0.0, form-data@npm:^4.0.0":
   version: 4.0.0
   resolution: "form-data@npm:4.0.0"
   dependencies:


### PR DESCRIPTION
### What and why?

Closes https://github.com/DataDog/datadog-ci/issues/1096

Bumping `axios` to `1.6.0` came with 2 issues:
- https://github.com/axios/axios/discussions/5866, fixed in a5c801aba9fa8131aeefc4ffa75002df67156c8e
- Sending requests with `FormData` (which sends `multipart/form-data` payloads) was failing silently in our backend with only a warning.
  - For reference, the warning was `Decoder has partially decoded field`, which was probably caused by an incorrect boundary. Bumping `form-data` from `3.0.1` to `4.0.0` ([compare changes](https://github.com/form-data/form-data/compare/v3.0.1...v4.0.0)) solved the issue: 41ce71b54e19deacf6953865dd14ee3031cf61c4
  - This bug was caught in [one of our e2e tests](https://github.com/DataDog/datadog-ci/actions/runs/6704428841/job/18217012787#step:9:43), for the `junit upload` command. I ensured this command also works with the standalone binary. I also tested with `synthetics upload-application`, which is another command using the  `form-data` package.

### How?

Bump `axios` and `form-data`, and add `node_modules/axios/dist/node/axios.cjs` to the `pkg.assets` to prevent the following error when running the standalone binary:

```
pkg/prelude/bootstrap.js:1872
      throw error;
      ^

Error: Cannot find module '/snapshot/my_app/node_modules/axios/dist/node/axios.cjs'
1) If you want to compile the package/file into executable, please pay attention to compilation warnings and specify a literal in 'require' call. 2) If you don't want to compile the package/file into executable and want to 'require' it from filesystem (likely plugin), specify an absolute path in 'require' call using process.cwd() or process.execPath.
```

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
