### PR TITLE
[CIVIS-7830] DORA Metrics deployment command

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,6 +9,7 @@ src/commands/gate    @DataDog/ci-app-libraries
 src/commands/metric  @DataDog/ci-app-libraries
 src/commands/tag     @DataDog/ci-app-libraries
 src/commands/trace   @DataDog/ci-app-libraries
+src/commands/dora    @DataDog/ci-app-libraries
 
 ## Static Analysis
 src/commands/sarif   @DataDog/static-analysis-core

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,7 +5,7 @@ import {CommandClass} from 'clipanion/lib/advanced/Command'
 
 import {version} from './helpers/version'
 
-const BETA_COMMANDS = ['gate', 'sbom']
+const BETA_COMMANDS = ['gate', 'sbom', 'dora']
 
 const onError = (err: any) => {
   console.log(err)

--- a/src/commands/dora/README.md
+++ b/src/commands/dora/README.md
@@ -1,4 +1,4 @@
-# DORA Metrics (beta)
+# DORA Metrics
 
 Send deployment events for DORA Metrics from CI.
 
@@ -8,10 +8,12 @@ Send deployment events for DORA Metrics from CI.
 
 #### `deployment`
 
+**Warning:** The `dora deployment` command is in beta. It requires you to set `DD_BETA_COMMANDS_ENABLED=1`.
+
 This command sends details to Datadog about a deployment of a `service`.
 
 ```bash
-$ datadog-ci dora deployment [--service #0] [--env #0] [--dry-run]
+$ DD_BETA_COMMANDS_ENABLED=1 datadog-ci dora deployment [--service #0] [--env #0] [--dry-run]
 
 ━━━ Options ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
@@ -25,6 +27,8 @@ $ datadog-ci dora deployment [--service #0] [--env #0] [--dry-run]
 For example:
 
 ```bash
+export DD_BETA_COMMANDS_ENABLED=1
+
 datadog-ci dora deployment --service my-service --env prod \
     --started-at 1699960648 --finished-at 1699961048 \
     --git-repository-url https://github.com/my-organization/my-repository \
@@ -62,6 +66,7 @@ To verify this command works as expected, you can use `--dry-run`:
 
 ```bash
 export DD_API_KEY='<API key>'
+export DD_BETA_COMMANDS_ENABLED=1
 
 yarn launch dora deployment --service test-service --started-at `date +%s` --dry-run
 ```

--- a/src/commands/dora/README.md
+++ b/src/commands/dora/README.md
@@ -21,7 +21,7 @@ $ DD_BETA_COMMANDS_ENABLED=1 datadog-ci dora deployment [--service #0] [--env #0
   --finished-at #0           In Unix seconds or ISO8601. (Examples: 1699961048, 2023-11-14T11:24:08Z)
   --git-repository-url #0    Example: https://github.com/DataDog/datadog-ci.git
   --git-commit-sha #0        Example: 102836a25f5477e571c73d489b3f0f183687068e
-  --skip-git                 Disables git info attributes. Change Lead Time will not be available
+  --skip-git                 Disables sending git URL and SHA. Change Lead Time will not be available
 ```
 
 For example:
@@ -35,14 +35,15 @@ datadog-ci dora deployment --service my-service --env prod \
     --git-commit-sha 102836a25f5477e571c73d489b3f0f183687068e
 ```
 
-- `--service` (or `DD_SERVICE`) and `--started-at` are always required and `--git-repository-url` and `--git-commit-sha` are necessary for Change Lead Time.
+`--service` (or `DD_SERVICE`) and `--started-at` are always required and `--git-repository-url` and `--git-commit-sha` are necessary for Change Lead Time.
+
 - `--service` (default: `DD_SERVICE` env var) should be set as the name of the service that was deployed.
 - `--env` (default: `DD_ENV` env var) is a string that represents the environment that was targeted by the deployment.
 - `--started-at` (required) is the timestamp in Unix seconds or ISO8601 when the deployment started.
 - `--finished-at` (default: current timestamp) is the timestamp in Unix seconds or ISO8601 when the deployment finished.
-- `--git-repository-url` is a string with the repository URL to retrieve git metadata from. If this is missing, the URL is retrieved from the local git repository.
+- `--git-repository-url` is a string with the repository URL for the deployed service. If this is missing, the URL is retrieved from the local git repository.
 - `--git-commit-sha` is a string with the git commit SHA that has been deployed. If this is missing, the current HEAD is retrieved from the local git repository.
-- `--skip-git` (default: `false`): Set to `true` if you do not want to provide git info. Change Lead Time does not work without git info.
+- `--skip-git` (default: `false`): Disables sending git URL and SHA. Change Lead Time will not be available
 - `--dry-run` (default: `false`): It runs the command without actually sending the event. All other checks are still performed.
 
 
@@ -58,7 +59,7 @@ Additionally, you can configure the `deployment` command with environment variab
 
 ### Optional dependencies
 
-- [`git`](https://git-scm.com/downloads) is used for extracting repository metadata automatically.
+- [`git`](https://git-scm.com/downloads) is used for extracting repository URL and commit SHA automatically.
 
 ### End-to-end testing process
 

--- a/src/commands/dora/README.md
+++ b/src/commands/dora/README.md
@@ -1,4 +1,4 @@
-# DORA Metrics
+# DORA Metrics (beta)
 
 Send deployment events for DORA Metrics from CI.
 

--- a/src/commands/dora/README.md
+++ b/src/commands/dora/README.md
@@ -8,7 +8,7 @@ Send deployment events for DORA Metrics from CI.
 
 #### `deployment`
 
-This command sends a deployment event for a given `service` and `env` to Datadog.
+This command sends details to Datadog about a deployment of a `service`.
 
 ```bash
 $ datadog-ci dora deployment [--service #0] [--env #0] [--dry-run]

--- a/src/commands/dora/README.md
+++ b/src/commands/dora/README.md
@@ -1,6 +1,6 @@
 # DORA Metrics
 
-Send deployment events for DORA Metrics from CI
+Send deployment events for DORA Metrics from CI.
 
 ## Usage
 
@@ -8,7 +8,7 @@ Send deployment events for DORA Metrics from CI
 
 #### `deployment`
 
-This command will send a deployment event for a given service and env to Datadog.
+This command sends a deployment event for a given `service` and `env` to Datadog.
 
 ```bash
 $ datadog-ci dora deployment [--service #0] [--env #0] [--dry-run]
@@ -32,24 +32,24 @@ datadog-ci dora deployment --service my-service --env prod \
 ```
 
 - `--service` (or `DD_SERVICE`) and `--started-at` are always required and `--git-repository-url` and `--git-commit-sha` are necessary for Change Lead Time.
-- `--service` (default: `DD_SERVICE` env var) should be set as the name of the service that was deployed
-- `--env` (default: `DD_ENV` env var) is a string that represents the environment that was targetted by the deployment.
-- `--started-at` (required) timestamp in Unix seconds or ISO8601 when the deployment started.
-- `--finished-at` (default: current timestamp) timestamp in Unix seconds or ISO8601 when the deployment finished.
+- `--service` (default: `DD_SERVICE` env var) should be set as the name of the service that was deployed.
+- `--env` (default: `DD_ENV` env var) is a string that represents the environment that was targeted by the deployment.
+- `--started-at` (required) is the timestamp in Unix seconds or ISO8601 when the deployment started.
+- `--finished-at` (default: current timestamp) is the timestamp in Unix seconds or ISO8601 when the deployment finished.
 - `--git-repository-url` is a string with the repository URL to retrieve git metadata from. If this is missing, the URL is retrieved from the local git repository.
 - `--git-commit-sha` is a string with the git commit SHA that has been deployed. If this is missing, the current HEAD is retrieved from the local git repository.
-- `--skip-git` (default: `false`): if you do not want to provide git info. Change Lead Time will not work without git info
-- `--dry-run` (default: `false`): it will run the command without actually sending the event. All other checks are still performed.
+- `--skip-git` (default: `false`): Set to `true` if you do not want to provide git info. Change Lead Time does not work without git info.
+- `--dry-run` (default: `false`): It runs the command without actually sending the event. All other checks are still performed.
 
 
 #### Environment variables
 
-Additionally you might configure the `deployment` command with environment variables:
+Additionally, you can configure the `deployment` command with environment variables:
 
 - `DD_API_KEY` (**required**): API key used to authenticate the requests.
 - `DD_ENV`: you may choose the environment you that the deployment has targetted
-- `DD_SERVICE`: if you haven't specified a service through `--service` you might do it with this env var.
-- `DD_SITE`: choose your Datadog site, e.g. datadoghq.com or datadoghq.eu.
+- `DD_SERVICE`: If you haven't specified a service through `--service` you can set it with this env var.
+- `DD_SITE`: Set to you your Datadog site. For example, `datadoghq.com` or `datadoghq.eu`.
 
 
 ### Optional dependencies
@@ -66,7 +66,7 @@ export DD_API_KEY='<API key>'
 yarn launch dora deployment --service test-service --started-at `date +%s` --dry-run
 ```
 
-Successful output should look like this:
+This is an example of a successful output:
 
 ```bash
 ⚠️ --git-repository-url or --git-commit-sha not provided.

--- a/src/commands/dora/README.md
+++ b/src/commands/dora/README.md
@@ -1,0 +1,85 @@
+# DORA Metrics
+
+Send deployment events for DORA Metrics from CI
+
+## Usage
+
+### Commands
+
+#### `deployment`
+
+This command will send a deployment event for a given service and env to Datadog.
+
+```bash
+$ datadog-ci dora deployment [--service #0] [--env #0] [--dry-run]
+
+━━━ Options ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  --started-at #0            In Unix seconds or ISO8601. (Examples: 1699960648, 2023-11-14T11:17:28Z)
+  --finished-at #0           In Unix seconds or ISO8601. (Examples: 1699961048, 2023-11-14T11:24:08Z)
+  --git-repository-url #0    Example: https://github.com/DataDog/datadog-ci.git
+  --git-commit-sha #0        Example: 102836a25f5477e571c73d489b3f0f183687068e
+  --skip-git                 Disables git info attributes. Change Lead Time will not be available
+```
+
+For example:
+
+```bash
+datadog-ci dora deployment --service my-service --env prod \
+    --started-at 1699960648 --finished-at 1699961048 \
+    --git-repository-url https://github.com/my-organization/my-repository \
+    --git-commit-sha 102836a25f5477e571c73d489b3f0f183687068e
+```
+
+- `--service` (or `DD_SERVICE`) and `--started-at` are always required and `--git-repository-url` and `--git-commit-sha` are necessary for Change Lead Time.
+- `--service` (default: `DD_SERVICE` env var) should be set as the name of the service that was deployed
+- `--env` (default: `DD_ENV` env var) is a string that represents the environment that was targetted by the deployment.
+- `--started-at` (required) timestamp in Unix seconds or ISO8601 when the deployment started.
+- `--finished-at` (default: current timestamp) timestamp in Unix seconds or ISO8601 when the deployment finished.
+- `--git-repository-url` is a string with the repository URL to retrieve git metadata from. If this is missing, the URL is retrieved from the local git repository.
+- `--git-commit-sha` is a string with the git commit SHA that has been deployed. If this is missing, the current HEAD is retrieved from the local git repository.
+- `--skip-git` (default: `false`): if you do not want to provide git info. Change Lead Time will not work without git info
+- `--dry-run` (default: `false`): it will run the command without actually sending the event. All other checks are still performed.
+
+
+#### Environment variables
+
+Additionally you might configure the `deployment` command with environment variables:
+
+- `DD_API_KEY` (**required**): API key used to authenticate the requests.
+- `DD_ENV`: you may choose the environment you that the deployment has targetted
+- `DD_SERVICE`: if you haven't specified a service through `--service` you might do it with this env var.
+- `DD_SITE`: choose your Datadog site, e.g. datadoghq.com or datadoghq.eu.
+
+
+### Optional dependencies
+
+- [`git`](https://git-scm.com/downloads) is used for extracting repository metadata automatically.
+
+### End-to-end testing process
+
+To verify this command works as expected, you can use `--dry-run`:
+
+```bash
+export DD_API_KEY='<API key>'
+
+yarn launch dora deployment --service test-service --started-at `date +%s` --dry-run
+```
+
+Successful output should look like this:
+
+```bash
+⚠️ --git-repository-url or --git-commit-sha not provided.
+Assuming deployment of the current HEAD commit: git@github.com:DataDog/datadog-ci.git 400beb0f276d923846cf778b9dbe9cf101306e41
+This warning can be disabled with --skip-git but git data is required for Change Lead Time.
+[DRYRUN] Sending DORA deployment event for service: dora-api
+ data: {
+  "service": "dora-api",
+  "startedAt": "2023-11-14T17:14:16.000Z",
+  "finishedAt": "2023-11-14T17:14:18.574Z",
+  "git": {
+    "repoURL": "git@github.com:DataDog/datadog-ci.git",
+    "commitSHA": "400beb0f276d923846cf778b9dbe9cf101306e41"
+  }
+}
+```

--- a/src/commands/dora/README.md
+++ b/src/commands/dora/README.md
@@ -10,7 +10,7 @@ Send deployment events for DORA Metrics from CI.
 
 **Warning:** The `dora deployment` command is in beta. It requires you to set `DD_BETA_COMMANDS_ENABLED=1`.
 
-This command sends details to Datadog about a deployment of a `service`.
+This command sends details to Datadog about a deployment of a service.
 
 ```bash
 $ DD_BETA_COMMANDS_ENABLED=1 datadog-ci dora deployment [--service #0] [--env #0] [--dry-run]

--- a/src/commands/dora/__tests__/deployment.test.ts
+++ b/src/commands/dora/__tests__/deployment.test.ts
@@ -1,0 +1,161 @@
+// import {default as axios} from 'axios'
+import {Cli} from 'clipanion/lib/advanced'
+
+import {createMockContext} from '../../../helpers/__tests__/fixtures'
+import * as gitFunctions from '../../../helpers/git/get-git-data'
+
+import {SendDeploymentEvent} from '../deployment'
+import {DeploymentEvent} from '../interfaces'
+
+describe('deployment', () => {
+  describe('getApiHelper', () => {
+    test('should throw an error if API key is undefined', () => {
+      process.env = {}
+      const write = jest.fn()
+      const command = new SendDeploymentEvent()
+      command.context = {stdout: {write}} as any
+
+      expect(command['getApiHelper'].bind(command)).toThrow('API key is missing')
+      expect(write.mock.calls[0][0]).toContain('DD_API_KEY')
+    })
+  })
+})
+
+const makeCli = () => {
+  const cli = new Cli()
+  cli.register(SendDeploymentEvent)
+
+  return cli
+}
+
+describe('execute', () => {
+  const runCLI = async (extraArgs: string[], extraEnv?: Record<string, string>) => {
+    const cli = makeCli()
+    const context = createMockContext() as any
+    process.env = {DD_API_KEY: 'PLACEHOLDER', ...extraEnv}
+    context.env = process.env
+    const code = await cli.run(['dora', 'deployment', ...extraArgs], context)
+
+    return {context, code}
+  }
+  describe('dry-run', () => {
+    const fakeCurrentDate = new Date(1699960651)
+    beforeAll(() => {
+      jest.useFakeTimers()
+      jest.setSystemTime(fakeCurrentDate)
+    })
+    afterAll(() => {
+      jest.useRealTimers()
+    })
+    test('with all parameters provided', async () => {
+      /* eslint-disable prettier/prettier */
+      const {context, code} = await runCLI([
+        '--dry-run',
+        '--service', 'test-service',
+        '--started-at', '1699960648',
+        '--finished-at', '1699960650',
+        '--env', 'test',
+        '--git-repository-url', 'https://github.com/DataDog/datadog-ci',
+        '--git-commit-sha', '2186e1b0ab2a87e312a8c831d5bc947fa081d4f9',
+      ])
+      /* eslint-enable prettier/prettier */
+      expect(code).toBe(0)
+      checkDryRunConsoleOutput(context.stdout, {
+        service: 'test-service',
+        startedAt: new Date(1699960648000),
+        finishedAt: new Date(1699960650000),
+        env: 'test',
+        git: {
+          repoURL: 'https://github.com/DataDog/datadog-ci',
+          commitSHA: '2186e1b0ab2a87e312a8c831d5bc947fa081d4f9',
+        },
+      })
+    })
+    test('with minimal parameters provided', async () => {
+      /* eslint-disable prettier/prettier */
+      const {context, code} = await runCLI([
+        '--dry-run', '--skip-git',
+        '--service', 'test-service',
+        '--started-at', '1699960648',
+      ])
+      /* eslint-enable prettier/prettier */
+      expect(code).toBe(0)
+      checkDryRunConsoleOutput(context.stdout, {
+        service: 'test-service',
+        startedAt: new Date(1699960648000),
+        finishedAt: fakeCurrentDate,
+      })
+    })
+    test('with parameters from env', async () => {
+      const envVars = {
+        DD_SERVICE: 'different-test-service',
+        DD_ENV: 'test-env',
+      }
+      /* eslint-disable prettier/prettier */
+      const {context, code} = await runCLI([
+        '--dry-run', '--skip-git',
+        '--started-at', '1699960648',
+      ], envVars)
+      /* eslint-enable prettier/prettier */
+      expect(code).toBe(0)
+      checkDryRunConsoleOutput(context.stdout, {
+        service: envVars.DD_SERVICE,
+        startedAt: new Date(1699960648000),
+        finishedAt: fakeCurrentDate,
+        env: envVars.DD_ENV,
+      })
+    })
+    test('with automatic git info', async () => {
+      const mockGitRepositoryURL = jest.spyOn(gitFunctions, 'gitRepositoryURL')
+      const mockGitHash = jest.spyOn(gitFunctions, 'gitHash')
+      const gitInfo = {
+        repoURL: 'https://github.com/DataDog/datadog-ci',
+        commitSHA: '2186e1b0ab2a87e312a8c831d5bc947fa081d4f9',
+      }
+      mockGitRepositoryURL.mockResolvedValue(gitInfo.repoURL)
+      mockGitHash.mockResolvedValue(gitInfo.commitSHA)
+      /* eslint-disable prettier/prettier */
+      const {context, code} = await runCLI([
+        '--dry-run',
+        '--service', 'test-service',
+        '--started-at', '1699960648',
+      ])
+      /* eslint-enable prettier/prettier */
+      expect(code).toBe(0)
+      expect(mockGitRepositoryURL).toHaveBeenCalled()
+      expect(mockGitHash).toHaveBeenCalled()
+      checkDryRunConsoleOutput(context.stdout, {
+        service: 'test-service',
+        startedAt: new Date(1699960648000),
+        finishedAt: fakeCurrentDate,
+        git: gitInfo,
+      })
+    })
+    test('service is required', async () => {
+      /* eslint-disable prettier/prettier */
+      const {context, code} = await runCLI([
+        '--dry-run', '--skip-git',
+        '--started-at', '1699960648',
+      ])
+      /* eslint-enable prettier/prettier */
+      expect(code).not.toBe(0)
+      expect(context.stdout.toString()).toContain('--service')
+    })
+    test('started-at is required', async () => {
+      /* eslint-disable prettier/prettier */
+      const {context, code} = await runCLI([
+        '--dry-run', '--skip-git',
+        '--service', 'test-service',
+      ])
+      /* eslint-enable prettier/prettier */
+      expect(code).not.toBe(0)
+      expect(context.stdout.toString()).toContain('--started-at')
+    })
+  })
+})
+
+const checkDryRunConsoleOutput = (output: any, expectedDeployment: DeploymentEvent) => {
+  const text = output.toString()
+  expect(text).toContain('DRYRUN')
+  expect(text).toContain(JSON.stringify(expectedDeployment, undefined, 2))
+}

--- a/src/commands/dora/__tests__/deployment.test.ts
+++ b/src/commands/dora/__tests__/deployment.test.ts
@@ -38,7 +38,7 @@ describe('execute', () => {
     return {context, code}
   }
   describe('dry-run', () => {
-    const fakeCurrentDate = new Date(1699960651)
+    const fakeCurrentDate = new Date(1699960651000)
     beforeAll(() => {
       jest.useFakeTimers()
       jest.setSystemTime(fakeCurrentDate)
@@ -141,6 +141,16 @@ describe('execute', () => {
       expect(context.stdout.toString()).toContain('--service')
     })
     test('started-at is required', async () => {
+      /* eslint-disable prettier/prettier */
+      const {context, code} = await runCLI([
+        '--dry-run', '--skip-git',
+        '--service', 'test-service',
+      ])
+      /* eslint-enable prettier/prettier */
+      expect(code).not.toBe(0)
+      expect(context.stdout.toString()).toContain('--started-at')
+    })
+    test('timestamps in future are rejected', async () => {
       /* eslint-disable prettier/prettier */
       const {context, code} = await runCLI([
         '--dry-run', '--skip-git',

--- a/src/commands/dora/__tests__/deployment.test.ts
+++ b/src/commands/dora/__tests__/deployment.test.ts
@@ -150,11 +150,12 @@ describe('execute', () => {
       expect(code).not.toBe(0)
       expect(context.stdout.toString()).toContain('--started-at')
     })
-    test('timestamps in future are rejected', async () => {
+    test('started-at after finished-at is rejected', async () => {
       /* eslint-disable prettier/prettier */
       const {context, code} = await runCLI([
         '--dry-run', '--skip-git',
         '--service', 'test-service',
+        '--started-at', '2099-11-14T11:17:28Z',
       ])
       /* eslint-enable prettier/prettier */
       expect(code).not.toBe(0)

--- a/src/commands/dora/__tests__/deployment.test.ts
+++ b/src/commands/dora/__tests__/deployment.test.ts
@@ -1,4 +1,3 @@
-// import {default as axios} from 'axios'
 import {Cli} from 'clipanion/lib/advanced'
 
 import {createMockContext} from '../../../helpers/__tests__/fixtures'

--- a/src/commands/dora/__tests__/deployment.test.ts
+++ b/src/commands/dora/__tests__/deployment.test.ts
@@ -73,7 +73,8 @@ describe('execute', () => {
     test('with minimal parameters provided', async () => {
       /* eslint-disable prettier/prettier */
       const {context, code} = await runCLI([
-        '--dry-run', '--skip-git',
+        '--dry-run',
+        '--skip-git',
         '--service', 'test-service',
         '--started-at', '1699960648',
       ])
@@ -92,7 +93,8 @@ describe('execute', () => {
       }
       /* eslint-disable prettier/prettier */
       const {context, code} = await runCLI([
-        '--dry-run', '--skip-git',
+        '--dry-run',
+        '--skip-git',
         '--started-at', '1699960648',
       ], envVars)
       /* eslint-enable prettier/prettier */
@@ -133,7 +135,8 @@ describe('execute', () => {
     test('service is required', async () => {
       /* eslint-disable prettier/prettier */
       const {context, code} = await runCLI([
-        '--dry-run', '--skip-git',
+        '--dry-run',
+        '--skip-git',
         '--started-at', '1699960648',
       ])
       /* eslint-enable prettier/prettier */
@@ -143,7 +146,8 @@ describe('execute', () => {
     test('started-at is required', async () => {
       /* eslint-disable prettier/prettier */
       const {context, code} = await runCLI([
-        '--dry-run', '--skip-git',
+        '--dry-run',
+        '--skip-git',
         '--service', 'test-service',
       ])
       /* eslint-enable prettier/prettier */
@@ -153,7 +157,8 @@ describe('execute', () => {
     test('started-at after finished-at is rejected', async () => {
       /* eslint-disable prettier/prettier */
       const {context, code} = await runCLI([
-        '--dry-run', '--skip-git',
+        '--dry-run',
+        '--skip-git',
         '--service', 'test-service',
         '--started-at', '2099-11-14T11:17:28Z',
       ])

--- a/src/commands/dora/api.ts
+++ b/src/commands/dora/api.ts
@@ -10,10 +10,31 @@ export const apiUrl = `https://api.${datadogSite}`
 export const sendDeploymentEvent = (request: (args: AxiosRequestConfig) => AxiosPromise<AxiosResponse>) => async (
   deployment: DeploymentEvent
 ) => {
+  const attrs: Record<string, any> = {
+    service: deployment.service,
+    started_at: deployment.startedAt.getTime() * 1000000, // ms to ns
+    finished_at: deployment.finishedAt.getTime() * 1000000, // ms to ns
+  }
+  if (deployment.env) {
+    attrs.env = deployment.env
+  }
+  if (deployment.git) {
+    attrs.git = {
+      repository_url: deployment.git.repoURL,
+      commit_sha: deployment.git.commitSHA,
+    }
+  }
+
+  console.log(attrs)
+
   return request({
     method: 'POST',
     url: 'api/v2/dora/deployment',
-    data: deployment,
+    data: {
+      data: {
+        attributes: attrs,
+      },
+    },
   })
 }
 

--- a/src/commands/dora/api.ts
+++ b/src/commands/dora/api.ts
@@ -25,8 +25,6 @@ export const sendDeploymentEvent = (request: (args: AxiosRequestConfig) => Axios
     }
   }
 
-  console.log(attrs)
-
   return request({
     method: 'POST',
     url: 'api/v2/dora/deployment',

--- a/src/commands/dora/api.ts
+++ b/src/commands/dora/api.ts
@@ -1,0 +1,26 @@
+import type {AxiosPromise, AxiosRequestConfig, AxiosResponse} from 'axios'
+
+import {getRequestBuilder} from '../../helpers/utils'
+
+import {DeploymentEvent} from './interfaces'
+
+export const datadogSite = process.env.DATADOG_SITE || process.env.DD_SITE || 'datadoghq.com'
+export const apiUrl = `https://api.${datadogSite}`
+
+export const sendDeploymentEvent = (request: (args: AxiosRequestConfig) => AxiosPromise<AxiosResponse>) => async (
+  deployment: DeploymentEvent
+) => {
+  return request({
+    method: 'POST',
+    url: 'api/v2/dora/deployment',
+    data: deployment,
+  })
+}
+
+export const apiConstructor = (apiKey: string) => {
+  const requestAPI = getRequestBuilder({baseUrl: apiUrl, apiKey})
+
+  return {
+    sendDeploymentEvent: sendDeploymentEvent(requestAPI),
+  }
+}

--- a/src/commands/dora/api.ts
+++ b/src/commands/dora/api.ts
@@ -4,7 +4,7 @@ import {getRequestBuilder} from '../../helpers/utils'
 
 import {DeploymentEvent} from './interfaces'
 
-export const datadogSite = process.env.DATADOG_SITE || process.env.DD_SITE || 'datadoghq.com'
+export const datadogSite = process.env.DD_SITE || 'datadoghq.com'
 export const apiUrl = `https://api.${datadogSite}`
 
 export const sendDeploymentEvent = (request: (args: AxiosRequestConfig) => AxiosPromise<AxiosResponse>) => async (
@@ -12,8 +12,8 @@ export const sendDeploymentEvent = (request: (args: AxiosRequestConfig) => Axios
 ) => {
   const attrs: Record<string, any> = {
     service: deployment.service,
-    started_at: deployment.startedAt.getTime() * 1000000, // ms to ns
-    finished_at: deployment.finishedAt.getTime() * 1000000, // ms to ns
+    started_at: deployment.startedAt.getTime() * 1e6, // ms to ns
+    finished_at: deployment.finishedAt.getTime() * 1e6, // ms to ns
   }
   if (deployment.env) {
     attrs.env = deployment.env

--- a/src/commands/dora/cli.ts
+++ b/src/commands/dora/cli.ts
@@ -1,0 +1,3 @@
+import {SendDeploymentEvent} from './deployment'
+
+module.exports = [SendDeploymentEvent]

--- a/src/commands/dora/deployment.ts
+++ b/src/commands/dora/deployment.ts
@@ -104,6 +104,12 @@ export class SendDeploymentEvent extends Command {
       return 1
     }
 
+    if (this.startedAt > (this.finishedAt || new Date())) {
+      this.logger.error('--started-at cannot be after --finished-at')
+
+      return 1
+    }
+
     if (this.skipGit) {
       this.gitInfo = undefined
     } else if (this.gitRepoURL && this.gitCommitSHA) {

--- a/src/commands/dora/deployment.ts
+++ b/src/commands/dora/deployment.ts
@@ -1,0 +1,105 @@
+import chalk from 'chalk'
+import {Command, Option} from 'clipanion'
+
+import {Logger, LogLevel} from '../../helpers/logger'
+import {retryRequest} from '../../helpers/retry'
+import {isInteger} from '../../helpers/validation'
+
+import {apiConstructor} from './api'
+import {APIHelper, DeploymentEvent} from './interfaces'
+import {
+  renderDryRun,
+  renderFailedRequest,
+  renderRequest,
+  renderRetriedRequest,
+  renderSuccessfulRequest,
+} from './renderer'
+
+const nonRetriableErrorCodes = [400, 403]
+
+export class SendDeploymentEvent extends Command {
+  public static paths = [['dora', 'deployment']]
+
+  public static usage = Command.Usage({
+    category: 'CI Visibility',
+    description: 'Send a new Deployment event for DORA Metrics to Datadog.',
+    details: `
+      This command will send details about a service Deployment to Datadog.\n
+      See README for details.
+    `,
+    examples: [['TODO', 'datadog-ci dora deployment --service my-service ']],
+  })
+
+  private service = Option.String('--service', {required: true, env: 'DD_SERVICE'})
+  private env = Option.String('--env', {env: 'DD_ENV'})
+  private gitRepositoryURL = Option.String('--repository-url')
+  private gitCommitSha = Option.String('--commit-sha')
+  private startedAt = Option.String('--started-at', {required: true, validator: isInteger()})
+  private finishedAt = Option.String('--finished-at', {required: true, validator: isInteger()})
+  private verbose = Option.Boolean('--verbose', false)
+  private dryRun = Option.Boolean('--dry-run', false)
+
+  private config = {
+    apiKey: process.env.DATADOG_API_KEY || process.env.DD_API_KEY,
+    env: process.env.DD_ENV,
+  }
+
+  private logger: Logger = new Logger((s: string) => this.context.stdout.write(s), LogLevel.INFO)
+
+  public async execute() {
+    this.logger.setLogLevel(this.verbose ? LogLevel.DEBUG : LogLevel.INFO)
+    this.logger.setShouldIncludeTime(this.verbose)
+
+    const api = this.getApiHelper()
+    await this.sendDeploymentEvent(api, this.buildDeploymentEvent())
+
+    if (!this.dryRun) {
+      this.logger.info(renderSuccessfulRequest(this.service))
+    }
+  }
+
+  private getApiHelper(): APIHelper {
+    if (!this.config.apiKey) {
+      this.logger.error(
+        `Neither ${chalk.red.bold('DATADOG_API_KEY')} nor ${chalk.red.bold('DD_API_KEY')} is in your environment.`
+      )
+      throw new Error('API key is missing')
+    }
+
+    return apiConstructor(this.config.apiKey)
+  }
+
+  private buildDeploymentEvent(): DeploymentEvent {
+    // TODO:
+    return {
+      service: 'test-service',
+    }
+  }
+
+  private async sendDeploymentEvent(api: APIHelper, deployment: DeploymentEvent) {
+    if (this.dryRun) {
+      this.logger.info(renderDryRun(this.service))
+
+      return
+    }
+
+    try {
+      this.logger.info(renderRequest(this.service))
+      await retryRequest(() => api.sendDeploymentEvent(deployment), {
+        onRetry: (e, attempt) => {
+          this.context.stderr.write(renderRetriedRequest(this.service, e.message, attempt))
+        },
+        retries: 5,
+      })
+    } catch (error) {
+      this.context.stderr.write(renderFailedRequest(this.service, error))
+      if (error.response) {
+        // If it's an axios error
+        if (!nonRetriableErrorCodes.includes(error.response.status)) {
+          return
+        }
+      }
+      throw error
+    }
+  }
+}

--- a/src/commands/dora/deployment.ts
+++ b/src/commands/dora/deployment.ts
@@ -80,7 +80,7 @@ export class SendDeploymentEvent extends Command {
     description: 'Example: 102836a25f5477e571c73d489b3f0f183687068e',
   })
   private skipGit = Option.Boolean('--skip-git', false, {
-    description: 'Disables git info attributes. Change Lead Time will not be available',
+    description: 'Disables sending git URL and SHA. Change Lead Time will not be available',
   })
 
   private verbose = Option.Boolean('--verbose', false, {hidden: true})

--- a/src/commands/dora/deployment.ts
+++ b/src/commands/dora/deployment.ts
@@ -28,8 +28,8 @@ export class SendDeploymentEvent extends Command {
     category: 'CI Visibility',
     description: 'Send a new Deployment event for DORA Metrics to Datadog.',
     details: `
-      This command will send details about a finished Deployment to Datadog for DORA Metrics.\n
-      See README for more details.
+    This command sends details to Datadog about a deployment of a \`service\`.\n
+    See README for more details.
     `,
     examples: [
       [
@@ -48,7 +48,7 @@ export class SendDeploymentEvent extends Command {
         'DD_SITE=datadoghq.eu datadog-ci dora deployment --service my-service --started-at $deploy_start',
       ],
       [
-        'Send a DORA deployment event with the minimal parameters. Change Lead Time is not available without Git info. The deployment finished-at is set to the current time',
+        'Send a DORA deployment event without git info. Change Lead Time is not available without Git info. The deployment finished-at is set to the current time',
         'datadog-ci dora deployment --service my-service --started-at $deploy_start --skip-git',
       ],
       [

--- a/src/commands/dora/deployment.ts
+++ b/src/commands/dora/deployment.ts
@@ -65,11 +65,11 @@ export class SendDeploymentEvent extends Command {
   private startedAt = Option.String('--started-at', {
     required: true,
     validator: t.isDate(),
-    description: 'In Unix seconds or ISO86001 (Examples: 1699960648, 2023-11-14T11:17:28Z)',
+    description: 'In Unix seconds or ISO8601 (Examples: 1699960648, 2023-11-14T11:17:28Z)',
   })
   private finishedAt = Option.String('--finished-at', {
     validator: t.isDate(),
-    description: 'In Unix seconds or ISO86001 (Examples: 1699961048, 2023-11-14T11:24:08Z)',
+    description: 'In Unix seconds or ISO8601 (Examples: 1699961048, 2023-11-14T11:24:08Z)',
   })
 
   private gitInfo?: GitInfo

--- a/src/commands/dora/deployment.ts
+++ b/src/commands/dora/deployment.ts
@@ -28,7 +28,7 @@ export class SendDeploymentEvent extends Command {
     category: 'CI Visibility',
     description: 'Send a new Deployment event for DORA Metrics to Datadog.',
     details: `
-    This command sends details to Datadog about a deployment of a \`service\`.\n
+    This command sends details to Datadog about a deployment of a service.\n
     See README for more details.
     `,
     examples: [

--- a/src/commands/dora/interfaces.ts
+++ b/src/commands/dora/interfaces.ts
@@ -2,6 +2,15 @@ import {AxiosPromise, AxiosResponse} from 'axios'
 
 export interface DeploymentEvent {
   service: string
+  env?: string
+  startedAt: Date
+  finishedAt: Date
+  git?: GitInfo
+}
+
+export interface GitInfo {
+  repoURL: string
+  commitSHA: string
 }
 
 export interface APIHelper {

--- a/src/commands/dora/interfaces.ts
+++ b/src/commands/dora/interfaces.ts
@@ -1,0 +1,9 @@
+import {AxiosPromise, AxiosResponse} from 'axios'
+
+export interface DeploymentEvent {
+  service: string
+}
+
+export interface APIHelper {
+  sendDeploymentEvent(deployment: DeploymentEvent): AxiosPromise<AxiosResponse>
+}

--- a/src/commands/dora/renderer.ts
+++ b/src/commands/dora/renderer.ts
@@ -25,5 +25,5 @@ export const renderRequest = (service: string): string => `Sending DORA deployme
 
 export const renderGitWarning = (git: GitInfo): string =>
   `${ICONS.WARNING} --git-repository-url or --git-commit-sha not provided.\n` +
-  `Assuming deployment from current git checkout: ${git.repoURL} ${git.commitSHA}\n` +
+  `Assuming deployment of the current HEAD commit: ${git.repoURL} ${git.commitSHA}\n` +
   `This warning can be disabled with --skip-git but git data is required for Change Lead Time.`

--- a/src/commands/dora/renderer.ts
+++ b/src/commands/dora/renderer.ts
@@ -1,4 +1,6 @@
-import chalk from 'chalk'
+import {AxiosError} from 'axios'
+
+import {DeploymentEvent, GitInfo} from './interfaces'
 
 const ICONS = {
   FAILED: '❌',
@@ -6,20 +8,22 @@ const ICONS = {
   WARNING: '⚠️',
 }
 
-export const renderFailedRequest = (service: string, errorMessage: string) => {
-  return chalk.red(`${ICONS.FAILED} Failed to send DORA deployment event for service: ${service}: ${errorMessage}\n`)
-}
+export const renderFailedRequest = (service: string, error: AxiosError) =>
+  `${ICONS.FAILED} Failed to send DORA deployment event for service: ${service}: ` +
+  (error.response ? JSON.stringify(error.response.data, undefined, 2) : '')
 
-export const renderRetriedRequest = (service: string, errorMessage: string, attempt: number) => {
-  return chalk.yellow(
-    `[attempt ${attempt}] Retrying to send DORA deployment event for service: ${service}: ${errorMessage}\n`
-  )
-}
+export const renderRetriedRequest = (service: string, error: Error, attempt: number) =>
+  `[attempt ${attempt}] Retrying to send DORA deployment event for service: ${service}: ${error.message}`
 
-export const renderSuccessfulRequest = (service: string) => {
-  return chalk.green(`${ICONS.SUCCESS} Successfuly sent DORA deployment event for service: ${service}`)
-}
+export const renderSuccessfulRequest = (service: string) =>
+  `${ICONS.SUCCESS} Successfuly sent DORA deployment event for service: ${service}`
 
-export const renderDryRun = (service: string): string => `[DRYRUN] ${renderRequest(service)}`
+export const renderDryRun = (deployment: DeploymentEvent): string =>
+  `[DRYRUN] ${renderRequest(deployment.service)}\n data: ` + JSON.stringify(deployment, undefined, 2)
 
 export const renderRequest = (service: string): string => `Sending DORA deployment event for service: ${service}`
+
+export const renderGitWarning = (git: GitInfo): string =>
+  `${ICONS.WARNING} --git-repository-url or --git-commit-sha not provided.\n` +
+  `Assuming deployment from current git checkout: ${git.repoURL} ${git.commitSHA}\n` +
+  `This warning can be disabled with --skip-git but git data is required for Change Lead Time.`

--- a/src/commands/dora/renderer.ts
+++ b/src/commands/dora/renderer.ts
@@ -1,0 +1,25 @@
+import chalk from 'chalk'
+
+const ICONS = {
+  FAILED: '❌',
+  SUCCESS: '✅',
+  WARNING: '⚠️',
+}
+
+export const renderFailedRequest = (service: string, errorMessage: string) => {
+  return chalk.red(`${ICONS.FAILED} Failed to send DORA deployment event for service: ${service}: ${errorMessage}\n`)
+}
+
+export const renderRetriedRequest = (service: string, errorMessage: string, attempt: number) => {
+  return chalk.yellow(
+    `[attempt ${attempt}] Retrying to send DORA deployment event for service: ${service}: ${errorMessage}\n`
+  )
+}
+
+export const renderSuccessfulRequest = (service: string) => {
+  return chalk.green(`${ICONS.SUCCESS} Successfuly sent DORA deployment event for service: ${service}`)
+}
+
+export const renderDryRun = (service: string): string => `[DRYRUN] ${renderRequest(service)}`
+
+export const renderRequest = (service: string): string => `Sending DORA deployment event for service: ${service}`

--- a/src/helpers/git/__tests__/format-git-span-data.test.ts
+++ b/src/helpers/git/__tests__/format-git-span-data.test.ts
@@ -21,7 +21,7 @@ describe('getGitMetadata', () => {
   it('reads git metadata successfully', async () => {
     ;(simpleGit as any).mockImplementation(() => ({
       branch: () => ({current: 'main'}),
-      listRemote: () => 'repository_url',
+      listRemote: async (git: any): Promise<string> => 'repository_url',
       revparse: () => 'commitSHA',
       show: (input: string[]) => {
         if (input[1] === '--format=%s') {

--- a/src/helpers/git/get-git-data.ts
+++ b/src/helpers/git/get-git-data.ts
@@ -59,4 +59,5 @@ export const gitMessage = async (git: simpleGit.SimpleGit): Promise<string> => g
 export const gitAuthorAndCommitter = async (git: simpleGit.SimpleGit): Promise<string> =>
   git.show(['-s', '--format=%an,%ae,%aI,%cn,%ce,%cI'])
 
-export const gitRepositoryURL = async (git: simpleGit.SimpleGit): Promise<string> => git.listRemote(['--get-url'])
+export const gitRepositoryURL = async (git: simpleGit.SimpleGit): Promise<string> =>
+  git.listRemote(['--get-url']).then((url) => url.trim())


### PR DESCRIPTION
### What and why?
Adds a new command to send deployment events for DORA Metrics

- [RFC](https://docs.google.com/document/d/1b3cQnj0r3KPKfFfEaO2kwuWt0JVAHBfoN14Iu0WrIjo/edit?pli=1#heading=h.rnd972k0hiye)
- [Proposal specific about the command](https://docs.google.com/document/d/1BBvtZyqNY-udLp8EVnNVnaroxHPUWZ4vrpDe52Q9SyU/edit#heading=h.srzhgb6sxwrv)

### How?

It's mostly a shortcut to avoid a curl command. It handles the DD_SITE and retries. It also helps a bit on figuring reasonable defaults some of the attributes for the API and runs some validations:
- Deployment finished-at defaults to now
- Get git info automatically (although it logs a warning in case this is a mistake and the deployment happens from a different repository or commit)

```
Send a new Deployment event for DORA Metrics to Datadog.

━━━ Usage ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

$ datadog-ci dora deployment [--service #0] [--env #0] [--dry-run]

━━━ Options ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

  --started-at #0            In Unix seconds or ISO8601. (Examples: 1699960648, 2023-11-14T11:17:28Z)
  --finished-at #0           In Unix seconds or ISO8601. (Examples: 1699961048, 2023-11-14T11:24:08Z)
  --git-repository-url #0    Example: https://github.com/DataDog/datadog-ci.git
  --git-commit-sha #0        Example: 102836a25f5477e571c73d489b3f0f183687068e
  --skip-git                 Disables git info attributes. Change Lead Time will not be available

━━━ Details ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

This command will send details about a service Deployment to Datadog.

See README for details.

━━━ Examples ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

Send a DORA deployment event for a service to the prod environment
  $ datadog-ci dora deployment --service my-service --env prod \
    --started-at 1699960648 --finished-at 1699961048 \
    --git-repository-url https://github.com/my-organization/my-repository \
    --git-commit-sha 102836a25f5477e571c73d489b3f0f183687068e

Send a DORA deployment event with automatically extracted Git info (for deployments triggered from CI in the same repository as the application). The deployment is assumed to target the current HEAD commit
  $ datadog-ci dora deployment --service my-service --started-at $deploy_start --finished-at `date +%s`

Send a DORA deployment event to the datadoghq.eu site
  $ DD_SITE=datadoghq.eu datadog-ci dora deployment --service my-service --started-at $deploy_start

Send a DORA deployment event with the minimal parameters. Change Lead Time is not available without Git info. The deployment finished-at is set to the current time
  $ datadog-ci dora deployment --service my-service --started-at $deploy_start --skip-git

Send a DORA deployment event providing the service name and env through environment vars
  $ DD_SERVICE=my-service DD_ENV=prod datadog-ci dora deployment --started-at $deploy_start
```

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
