### PR TITLE
[synthetics] Fix the reporting of residual results

### DIFF
--- a/src/commands/synthetics/__tests__/reporters/__snapshots__/default.test.ts.snap
+++ b/src/commands/synthetics/__tests__/reporters/__snapshots__/default.test.ts.snap
@@ -208,16 +208,6 @@ exports[`Default reporter testsWait the spinner text is updated and cleared at t
 "
 `;
 
-exports[`Default reporter testsWait the spinner text is updated and cleared at the end (in CI: false) 4`] = `
-"View pending summary in Datadog: [2m[36mhttps://app.datadoghq.com/synthetics/explorer/ci?batchResultId=123[39m[22m
-[1m[32m✓[39m[22m [[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m - [1m[32mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m
-  ⎋ Total duration: 123 ms - View test run details: [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=rid&from_ci=true[39m[22m 
-  [1m[32m✓[39m[22m [1m[32m[1mGET[22m[1m - http://fake.url[39m[22m
-
- [36m⠙[39m Waiting for [1m[36m1[39m[22m test [90m(aaa-aaa-aaa)[39m…
-"
-`;
-
 exports[`Default reporter testsWait the spinner text is updated and cleared at the end (in CI: true) 1`] = `
 "View pending summary in Datadog: [2m[36mhttps://app.datadoghq.com/synthetics/explorer/ci?batchResultId=123[39m[22m
 
@@ -239,22 +229,6 @@ exports[`Default reporter testsWait the spinner text is updated and cleared at t
 `;
 
 exports[`Default reporter testsWait the spinner text is updated and cleared at the end (in CI: true) 3`] = `
-"View pending summary in Datadog: [2m[36mhttps://app.datadoghq.com/synthetics/explorer/ci?batchResultId=123[39m[22m
-
-- Waiting for [1m[36m2[39m[22m tests [90m(aaa-aaa-aaa, bbb-bbb-bbb)[39m…
-
-[1m[32m✓[39m[22m [[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m - [1m[32mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m
-  ⎋ Total duration: 123 ms - View test run details: [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=rid&from_ci=true[39m[22m 
-  [1m[32m✓[39m[22m [1m[32m[1mGET[22m[1m - http://fake.url[39m[22m
-
-- Waiting for [1m[36m1[39m[22m test [90m(aaa-aaa-aaa)[39m…
-
-
- [36m⠋[39m Waiting for [1m[36m1[39m[22m test [90m(aaa-aaa-aaa)[39m…
-"
-`;
-
-exports[`Default reporter testsWait the spinner text is updated and cleared at the end (in CI: true) 4`] = `
 "View pending summary in Datadog: [2m[36mhttps://app.datadoghq.com/synthetics/explorer/ci?batchResultId=123[39m[22m
 
 - Waiting for [1m[36m2[39m[22m tests [90m(aaa-aaa-aaa, bbb-bbb-bbb)[39m…

--- a/src/commands/synthetics/__tests__/reporters/default.test.ts
+++ b/src/commands/synthetics/__tests__/reporters/default.test.ts
@@ -191,10 +191,6 @@ describe('Default reporter', () => {
         expect(clearLine).toHaveBeenCalled()
       }
       expect(simulatedTerminalOutput).toMatchSnapshot()
-
-      // Should do nothing.
-      ttyReporter.testsWait([], MOCK_BASE_URL, '123')
-      expect(simulatedTerminalOutput).toMatchSnapshot()
     })
   })
   /* eslint-enable jest/no-conditional-expect */

--- a/src/commands/synthetics/__tests__/utils.test.ts
+++ b/src/commands/synthetics/__tests__/utils.test.ts
@@ -984,6 +984,17 @@ describe('utils', () => {
         ],
       })
 
+      const expectedTimeoutResult = {
+        ...result,
+        result: {
+          ...result.result,
+          failure: {code: 'TIMEOUT', message: 'Result timed out'},
+          passed: false,
+        },
+        resultId: '3',
+        timedOut: true,
+      }
+
       expect(
         await utils.waitForResults(
           api,
@@ -997,23 +1008,14 @@ describe('utils', () => {
           },
           mockReporter
         )
-      ).toEqual([
-        result,
-        {
-          ...result,
-          result: {
-            ...result.result,
-            failure: {code: 'TIMEOUT', message: 'Result timed out'},
-            passed: false,
-          },
-          resultId: '3',
-          timedOut: true,
-        },
-      ])
+      ).toEqual([result, expectedTimeoutResult])
 
       // Residual results are never 'received': we force-end them.
       expect(mockReporter.resultReceived).toHaveBeenCalledTimes(1)
-      expect(mockReporter.resultEnd).toHaveBeenCalledTimes(2)
+
+      // `resultEnd` should return the same data as `waitForResults`
+      expect(mockReporter.resultEnd).toHaveBeenNthCalledWith(1, result, MOCK_BASE_URL)
+      expect(mockReporter.resultEnd).toHaveBeenNthCalledWith(2, expectedTimeoutResult, MOCK_BASE_URL)
     })
 
     test('results failure should ignore if timed-out', async () => {

--- a/src/commands/synthetics/__tests__/utils.test.ts
+++ b/src/commands/synthetics/__tests__/utils.test.ts
@@ -973,7 +973,7 @@ describe('utils', () => {
         getBatchImplementation: async () => ({
           results: [
             {...batch.results[0]},
-            // eslint-disable-next-line no-null/no-null -- our backend can return null
+            // eslint-disable-next-line no-null/no-null -- the endpoint `/synthetics/ci/batch/:batch_id` can return null
             {...batch.results[0], status: 'in_progress', result_id: '3', timed_out: null},
           ],
           status: 'in_progress',
@@ -1023,7 +1023,7 @@ describe('utils', () => {
       // and retrieving it should be ignored in favor of timeout.
       mockApi({
         getBatchImplementation: async () => ({
-          // eslint-disable-next-line no-null/no-null -- our backend can return null
+          // eslint-disable-next-line no-null/no-null -- the endpoint `/synthetics/ci/batch/:batch_id` can return null
           results: [{...batch.results[0], timed_out: null}],
           status: 'in_progress',
         }),

--- a/src/commands/synthetics/__tests__/utils.test.ts
+++ b/src/commands/synthetics/__tests__/utils.test.ts
@@ -973,7 +973,8 @@ describe('utils', () => {
         getBatchImplementation: async () => ({
           results: [
             {...batch.results[0]},
-            {...batch.results[0], status: 'in_progress', result_id: '3', timed_out: undefined},
+            // eslint-disable-next-line no-null/no-null -- our backend can return null
+            {...batch.results[0], status: 'in_progress', result_id: '3', timed_out: null},
           ],
           status: 'in_progress',
         }),
@@ -1020,7 +1021,8 @@ describe('utils', () => {
       // and retrieving it should be ignored in favor of timeout.
       mockApi({
         getBatchImplementation: async () => ({
-          results: [{...batch.results[0], timed_out: undefined}],
+          // eslint-disable-next-line no-null/no-null -- our backend can return null
+          results: [{...batch.results[0], timed_out: null}],
           status: 'in_progress',
         }),
         pollResultsImplementation: async () => [

--- a/src/commands/synthetics/__tests__/utils.test.ts
+++ b/src/commands/synthetics/__tests__/utils.test.ts
@@ -935,8 +935,8 @@ describe('utils', () => {
         result_id: 'rid-3',
       })
       expect(mockReporter.resultEnd).toHaveBeenNthCalledWith(3, {...result, resultId: 'rid-3'}, MOCK_BASE_URL)
-      // Now waiting for 0 test
-      expect(mockReporter.testsWait).toHaveBeenNthCalledWith(5, [], MOCK_BASE_URL, trigger.batch_id)
+      // Do not report when there are no tests to wait anymore
+      expect(mockReporter.testsWait).toHaveBeenCalledTimes(4)
     })
 
     test('object in each result should be different even if they share the same public ID (config overrides)', async () => {

--- a/src/commands/synthetics/interfaces.ts
+++ b/src/commands/synthetics/interfaces.ts
@@ -123,7 +123,7 @@ export interface ResultInBatch {
   result_id: string
   status: Status
   test_public_id: string
-  timed_out?: boolean
+  timed_out: boolean | null
 }
 
 export interface Batch {

--- a/src/commands/synthetics/reporters/default.ts
+++ b/src/commands/synthetics/reporters/default.ts
@@ -362,10 +362,6 @@ export class DefaultReporter implements MainReporter {
   }
 
   public testsWait(tests: Test[], baseUrl: string, batchId: string) {
-    if (tests.length === 0) {
-      return
-    }
-
     const testsList = tests.map((t) => t.public_id)
     if (testsList.length > 10) {
       testsList.splice(10)

--- a/src/commands/synthetics/utils.ts
+++ b/src/commands/synthetics/utils.ts
@@ -297,46 +297,31 @@ const waitForBatchToFinish = async (
   const emittedResultIndexes = new Set<number>()
 
   while (true) {
-    const current = await getBatch(api, trigger)
+    const batch = await getBatch(api, trigger)
     const hasBatchExceededMaxPollingDate = Date.now() >= maxPollingDate
 
-    // The backend is expected to handle the time out of the batch, and change its status to `failed` eventually.
-    // But as a safety in case it fails to do that, we also use `hasBatchExceededMaxPollingDate`.
-    const shouldContinuePolling = current.status === 'in_progress' && !hasBatchExceededMaxPollingDate
+    // The backend is expected to handle the time out of the batch by eventually changing its status to `failed`.
+    // But `hasBatchExceededMaxPollingDate` is a safety in case it fails to do that.
+    const shouldContinuePolling = batch.status === 'in_progress' && !hasBatchExceededMaxPollingDate
 
-    const receivedResults = reportReceivedResults(current, emittedResultIndexes, reporter)
+    const receivedResults = reportReceivedResults(batch, emittedResultIndexes, reporter)
+    const residualResults = batch.results.filter((_, index) => !emittedResultIndexes.has(index))
 
-    const resultIdsToFetch = shouldContinuePolling
-      ? receivedResults.map((r) => r.result_id)
-      : current.results.map((r) => r.result_id) // Get the full up-to-date data.
-
-    const resultIdsToReport = receivedResults.map((r) => r.result_id)
+    // For the last iteration, the full up-to-date data has to be fetched to compute this function's return value,
+    // while only the [received + residual] results have to be reported.
+    const resultIdsToFetch = (shouldContinuePolling ? receivedResults : batch.results).map((r) => r.result_id)
+    const resultIdsToReport = receivedResults
+      .concat(shouldContinuePolling ? [] : residualResults)
+      .map((r) => r.result_id)
 
     const pollResultMap = await getPollResultMap(api, resultIdsToFetch)
 
-    reportResults(
-      pollResultMap,
-      resultIdsToReport,
-      current,
-      resultDisplayInfo,
-      hasBatchExceededMaxPollingDate,
-      reporter
-    )
+    reportResults(pollResultMap, resultIdsToReport, batch, resultDisplayInfo, hasBatchExceededMaxPollingDate, reporter)
 
-    reportRemainingTests(trigger, current, resultDisplayInfo, reporter)
+    reportRemainingTests(trigger, batch, resultDisplayInfo, reporter)
 
     if (!shouldContinuePolling) {
-      // Break the loop and report any residual results.
-      reportResidualResults(
-        pollResultMap,
-        current,
-        emittedResultIndexes,
-        resultDisplayInfo,
-        hasBatchExceededMaxPollingDate,
-        reporter
-      )
-
-      return current.results.map((r) =>
+      return batch.results.map((r) =>
         getResultFromBatch(r, pollResultMap[r.result_id], resultDisplayInfo, hasBatchExceededMaxPollingDate)
       )
     }
@@ -345,10 +330,10 @@ const waitForBatchToFinish = async (
   }
 }
 
-const reportReceivedResults = (currentBatchState: Batch, emittedResultIndexes: Set<number>, reporter: MainReporter) => {
+const reportReceivedResults = (batch: Batch, emittedResultIndexes: Set<number>, reporter: MainReporter) => {
   const receivedResults: ResultInBatch[] = []
 
-  for (const [index, result] of currentBatchState.results.entries()) {
+  for (const [index, result] of batch.results.entries()) {
     if (result.status !== 'in_progress' && !emittedResultIndexes.has(index)) {
       emittedResultIndexes.add(index)
       reporter.resultReceived(result)
@@ -393,24 +378,6 @@ const reportRemainingTests = (
   const remainingTests = tests.filter((t) => inProgressPublicIds.has(t.public_id))
 
   reporter.testsWait(remainingTests, baseUrl, trigger.batch_id)
-}
-
-const reportResidualResults = (
-  pollResultMap: PollResultMap,
-  batch: Batch,
-  emittedResultIndexes: Set<number>,
-  resultDisplayInfo: ResultDisplayInfo,
-  hasBatchExceededMaxPollingDate: boolean,
-  reporter: MainReporter
-) => {
-  const notEmitted = batch.results.filter((_, index) => !emittedResultIndexes.has(index))
-  if (notEmitted.length === 0) {
-    return
-  }
-
-  const notEmittedResultIds = notEmitted.map((r) => r.result_id)
-
-  reportResults(pollResultMap, notEmittedResultIds, batch, resultDisplayInfo, hasBatchExceededMaxPollingDate, reporter)
 }
 
 const getResultFromBatch = (

--- a/src/commands/synthetics/utils.ts
+++ b/src/commands/synthetics/utils.ts
@@ -330,7 +330,14 @@ const waitForBatchToFinish = async (
       continue
     }
 
-    reportResidualResults(pollResultMap, current, emittedResultIndexes, resultDisplayInfo, reporter)
+    reportResidualResults(
+      pollResultMap,
+      current,
+      emittedResultIndexes,
+      resultDisplayInfo,
+      hasBatchExceededMaxPollingDate,
+      reporter
+    )
 
     return current.results.map((r) =>
       getResultFromBatch(r, pollResultMap[r.result_id], resultDisplayInfo, hasBatchExceededMaxPollingDate)
@@ -393,6 +400,7 @@ const reportResidualResults = (
   batch: Batch,
   emittedResultIndexes: Set<number>,
   resultDisplayInfo: ResultDisplayInfo,
+  hasBatchExceededMaxPollingDate: boolean,
   reporter: MainReporter
 ) => {
   const notEmitted = batch.results.filter((_, index) => !emittedResultIndexes.has(index))
@@ -402,7 +410,7 @@ const reportResidualResults = (
 
   const notEmittedResultIds = notEmitted.map((r) => r.result_id)
 
-  reportResults(pollResultMap, notEmittedResultIds, batch, resultDisplayInfo, false, reporter)
+  reportResults(pollResultMap, notEmittedResultIds, batch, resultDisplayInfo, hasBatchExceededMaxPollingDate, reporter)
 }
 
 const getResultFromBatch = (

--- a/src/commands/synthetics/utils.ts
+++ b/src/commands/synthetics/utils.ts
@@ -413,7 +413,7 @@ const getResultFromBatch = (
 ): Result => {
   const {getLocation, options, tests} = resultDisplayInfo
 
-  const hasTimedOut = resultInBatch.timed_out !== undefined ? resultInBatch.timed_out : hasBatchExceededMaxPollingDate
+  const hasTimedOut = resultInBatch.timed_out ?? hasBatchExceededMaxPollingDate
 
   if (hasTimedOut) {
     pollResult.result.failure = {code: 'TIMEOUT', message: 'Result timed out'}
@@ -427,14 +427,14 @@ const getResultFromBatch = (
     location: getLocation(resultInBatch.location, test),
     passed: hasResultPassed(
       pollResult.result,
-      !!hasTimedOut,
+      hasTimedOut,
       options.failOnCriticalErrors ?? false,
       options.failOnTimeout ?? false
     ),
     result: pollResult.result,
     resultId: resultInBatch.result_id,
     test: deepExtend({}, test, pollResult.check),
-    timedOut: !!hasTimedOut,
+    timedOut: hasTimedOut,
     timestamp: pollResult.timestamp,
   }
 }

--- a/src/commands/synthetics/utils.ts
+++ b/src/commands/synthetics/utils.ts
@@ -318,13 +318,13 @@ const waitForBatchToFinish = async (
 
     reportResults(pollResultMap, resultIdsToReport, batch, resultDisplayInfo, hasBatchExceededMaxPollingDate, reporter)
 
-    reportRemainingTests(trigger, batch, resultDisplayInfo, reporter)
-
     if (!shouldContinuePolling) {
       return batch.results.map((r) =>
         getResultFromBatch(r, pollResultMap[r.result_id], resultDisplayInfo, hasBatchExceededMaxPollingDate)
       )
     }
+
+    reportWaitingTests(trigger, batch, resultDisplayInfo, reporter)
 
     await wait(POLLING_INTERVAL)
   }
@@ -363,7 +363,7 @@ const reportResults = (
   }
 }
 
-const reportRemainingTests = (
+const reportWaitingTests = (
   trigger: Trigger,
   currentBatchState: Batch,
   resultDisplayInfo: ResultDisplayInfo,

--- a/src/commands/synthetics/utils.ts
+++ b/src/commands/synthetics/utils.ts
@@ -427,14 +427,14 @@ const getResultFromBatch = (
     location: getLocation(resultInBatch.location, test),
     passed: hasResultPassed(
       pollResult.result,
-      hasTimedOut,
+      !!hasTimedOut,
       options.failOnCriticalErrors ?? false,
       options.failOnTimeout ?? false
     ),
     result: pollResult.result,
     resultId: resultInBatch.result_id,
     test: deepExtend({}, test, pollResult.check),
-    timedOut: hasTimedOut,
+    timedOut: !!hasTimedOut,
     timestamp: pollResult.timestamp,
   }
 }


### PR DESCRIPTION
### What and why?

💡 _Better reviewed commit by commit_

Our unit tests were incomplete and #1097 broke something when we have residual results, i.e. when datadog-ci stops polling before our backend.

We can reproduce this edge case with a really small value of `--pollingTimeout`, like 1 millisecond:

**Expected:**

![image](https://github.com/DataDog/datadog-ci/assets/9317502/f22ee28b-5fc2-4e16-ae30-21d74befaa8f)

**Actual:**

![image](https://github.com/DataDog/datadog-ci/assets/9317502/f5fbfabb-8b99-4e56-a12b-fe357655794d)

### How?

- Fix the unit tests: 1ef26d01e3f5e04d677645960b35bfb819929f93 and 30d211fc8a3e42991e9c8e3bb88686306dee40dc
- Fix the code: 5e40fc51c918f82ea0ac39ec18eca2082da6f7c1 and a93c75a79390dde14ab0b0709a69e5b3d4b5153d

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
