### PR TITLE
[flutter-symbols] Improve message for mapping upload

### DIFF
--- a/src/commands/flutter-symbols/upload.ts
+++ b/src/commands/flutter-symbols/upload.ts
@@ -329,7 +329,7 @@ export class UploadCommand extends Command {
       payload.content.set('repository', this.getGitDataPayload(this.gitData))
     }
 
-    const result = await uploadMultipartHelper(requestBuilder, payload, {
+    const status = await uploadMultipartHelper(requestBuilder, payload, {
       apiKeyValidator,
       onError: (e) => {
         this.context.stdout.write(renderFailedUpload(this.androidMappingLocation!, e.message))
@@ -345,9 +345,14 @@ export class UploadCommand extends Command {
       retries: 5,
       useGzip: true,
     })
-    this.context.stdout.write(`Mapping upload finished: ${result}\n`)
 
-    return result
+    if (status === UploadStatus.Success) {
+      this.context.stdout.write('Mapping upload finished\n')
+    } else {
+      this.context.stdout.write(`Mapping upload failed (exit code: ${status}\n`)
+    }
+
+    return status
   }
 
   private async performDartSymbolsUpload(): Promise<UploadStatus[]> {

--- a/src/commands/flutter-symbols/upload.ts
+++ b/src/commands/flutter-symbols/upload.ts
@@ -349,7 +349,7 @@ export class UploadCommand extends Command {
     if (status === UploadStatus.Success) {
       this.context.stdout.write('Mapping upload finished\n')
     } else {
-      this.context.stdout.write(`Mapping upload failed (exit code: ${status}\n`)
+      this.context.stdout.write(`Mapping upload failed\n`)
     }
 
     return status


### PR DESCRIPTION
### What and why?

Reported in https://github.com/DataDog/datadog-ci/issues/1117

### How?

No need for more information: this PR just removes the reporting of `0` which could be mistaken for a number of uploaded files.

### Review checklist

- ~[ ] Feature or bugfix MUST have appropriate tests (unit, integration)~ (the text output is not unit tested in this command)
