### PR TITLE
Make volta work

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "volta": {
     "node": "14.20.1",
-    "yarn": "3.4.1"
+    "yarn": "1.22.18"
   },
   "packageManager": "yarn@3.4.1",
   "files": [


### PR DESCRIPTION
### What and why?

Make volta work

Currently with volta installed, running `yarn` exits with an error

```
$ yarn
Volta error: Could not download yarn@3.4.1
from https://registry.npmjs.org/yarn/-/yarn-3.4.1.tgz
```

We need to use the yarn cli wrapper version available in npm which in turn will select the correct version at runtime

After the change, volta picks the version correctly: 

```
yarn --version
3.4.1
```

### How?

Update the `volta` conf in `package.json`

### Review checklist

- [x] With volta installed, `yarn --version` yields `3.4.1`