### PR TITLE
[synthetics] Add `executeWithDetails()` method

### DIFF
--- a/src/commands/synthetics/__tests__/run-tests-lib.test.ts
+++ b/src/commands/synthetics/__tests__/run-tests-lib.test.ts
@@ -429,7 +429,7 @@ describe('run-test', () => {
     })
   })
 
-  describe('execute', () => {
+  describe('executeWithDetails', () => {
     beforeEach(() => {
       jest.restoreAllMocks()
       jest.spyOn(api, 'getApiHelper').mockImplementation(
@@ -445,14 +445,14 @@ describe('run-test', () => {
     })
 
     test('should call executeTests and renderResults', async () => {
-      await runTests.execute({}, {})
+      await runTests.executeWithDetails({}, {})
       expect(runTests.executeTests).toHaveBeenCalled()
       expect(utils.renderResults).toHaveBeenCalled()
     })
 
     test('should extend config', async () => {
       const runConfig = {apiKey: 'apiKey', appKey: 'appKey'}
-      await runTests.execute(runConfig, {})
+      await runTests.executeWithDetails(runConfig, {})
       expect(runTests.executeTests).toHaveBeenCalledWith(
         expect.anything(),
         expect.objectContaining(runConfig),
@@ -462,7 +462,7 @@ describe('run-test', () => {
 
     test('should bypass files if suite is passed', async () => {
       const suites = [{content: {tests: []}}]
-      await runTests.execute({}, {suites})
+      await runTests.executeWithDetails({}, {suites})
       expect(runTests.executeTests).toHaveBeenCalledWith(
         expect.anything(),
         expect.objectContaining({files: []}),
@@ -476,17 +476,36 @@ describe('run-test', () => {
       })
 
       test('should use default reporter with empty config', async () => {
-        await runTests.execute({}, {})
+        await runTests.executeWithDetails({}, {})
         expect(utils.getReporter).toHaveBeenCalledWith(expect.arrayContaining([expect.any(DefaultReporter)]))
       })
 
       test('should use custom reporters', async () => {
         const CustomReporter = {}
-        await runTests.execute({}, {reporters: ['junit', CustomReporter]})
+        await runTests.executeWithDetails({}, {reporters: ['junit', CustomReporter]})
         expect(utils.getReporter).toHaveBeenCalledWith(
           expect.arrayContaining([expect.any(JUnitReporter), CustomReporter])
         )
       })
+    })
+  })
+
+  describe('execute', () => {
+    beforeEach(() => {
+      jest.restoreAllMocks()
+      jest
+        .spyOn(runTests, 'executeWithDetails')
+        .mockReturnValue(Promise.resolve({results: [], summary: {} as Summary, exitCode: 0}))
+    })
+
+    test('should call executeWithDetails', async () => {
+      await runTests.execute({}, {})
+      expect(runTests.executeWithDetails).toHaveBeenCalled()
+    })
+
+    test('should return the exitCode returned by executeWithDetails', async () => {
+      const returnValue = await runTests.execute({}, {})
+      expect(returnValue).toBe(0)
     })
   })
 

--- a/src/commands/synthetics/__tests__/run-tests-lib.test.ts
+++ b/src/commands/synthetics/__tests__/run-tests-lib.test.ts
@@ -470,6 +470,13 @@ describe('run-test', () => {
       )
     })
 
+    test('should return values returned by executeTests, and an exitCode', async () => {
+      const returnValue = await runTests.executeWithDetails({}, {})
+      expect(returnValue.results).toBeDefined()
+      expect(returnValue.summary).toBeDefined()
+      expect(returnValue.exitCode).toBeDefined()
+    })
+
     describe('reporters', () => {
       beforeEach(() => {
         jest.spyOn(utils, 'getReporter').mockImplementation(jest.fn())

--- a/src/commands/synthetics/run-tests-lib.ts
+++ b/src/commands/synthetics/run-tests-lib.ts
@@ -35,6 +35,13 @@ import {
   reportExitLogs,
 } from './utils'
 
+type ExecuteOptions = {
+  jUnitReport?: string
+  reporters?: (SupportedReporter | Reporter)[]
+  runId?: string
+  suites?: Suite[]
+}
+
 export const executeTests = async (
   reporter: MainReporter,
   config: RunTestsCommandConfig,
@@ -234,17 +241,7 @@ export const getTestsList = async (
 
 export const executeWithDetails = async (
   runConfig: WrapperConfig,
-  {
-    jUnitReport,
-    reporters,
-    runId,
-    suites,
-  }: {
-    jUnitReport?: string
-    reporters?: (SupportedReporter | Reporter)[]
-    runId?: string
-    suites?: Suite[]
-  }
+  {jUnitReport, reporters, runId, suites}: ExecuteOptions
 ): Promise<{
   results: Result[]
   summary: Summary
@@ -313,24 +310,8 @@ export const executeWithDetails = async (
   }
 }
 
-export const execute = async (
-  runConfig: WrapperConfig,
-  {
-    jUnitReport,
-    reporters,
-    runId,
-    suites,
-  }: {
-    jUnitReport?: string
-    reporters?: (SupportedReporter | Reporter)[]
-    runId?: string
-    suites?: Suite[]
-  }
-): Promise<0 | 1> => {
-  return executeWithDetails(runConfig, {
-    jUnitReport,
-    reporters,
-    runId,
-    suites,
-  }).then((value) => value.exitCode)
+export const execute = async (runConfig: WrapperConfig, executeOptions: ExecuteOptions): Promise<0 | 1> => {
+  const {exitCode} = await executeWithDetails(runConfig, executeOptions)
+
+  return exitCode
 }

--- a/src/commands/synthetics/run-tests-lib.ts
+++ b/src/commands/synthetics/run-tests-lib.ts
@@ -232,7 +232,7 @@ export const getTestsList = async (
   return testsToTrigger
 }
 
-export const execute = async (
+export const executeWithDetails = async (
   runConfig: WrapperConfig,
   {
     jUnitReport,
@@ -245,7 +245,11 @@ export const execute = async (
     runId?: string
     suites?: Suite[]
   }
-): Promise<0 | 1> => {
+): Promise<{
+  results: Result[]
+  summary: Summary
+  exitCode: 0 | 1
+}> => {
   const startTime = Date.now()
   const localConfig = {
     ...DEFAULT_COMMAND_CONFIG,
@@ -300,5 +304,33 @@ export const execute = async (
 
   reportExitLogs(mainReporter, localConfig, {results})
 
-  return toExitCode(getExitReason(localConfig, {results}))
+  const exitCode = toExitCode(getExitReason(localConfig, {results}))
+
+  return {
+    results,
+    summary,
+    exitCode,
+  }
+}
+
+export const execute = async (
+  runConfig: WrapperConfig,
+  {
+    jUnitReport,
+    reporters,
+    runId,
+    suites,
+  }: {
+    jUnitReport?: string
+    reporters?: (SupportedReporter | Reporter)[]
+    runId?: string
+    suites?: Suite[]
+  }
+): Promise<0 | 1> => {
+  return executeWithDetails(runConfig, {
+    jUnitReport,
+    reporters,
+    runId,
+    suites,
+  }).then((value) => value.exitCode)
 }


### PR DESCRIPTION
### What and why?

We want to `execute` tests programmatically and benefit from everything that `execute` provides (setting up reports, rendering results etc.), but also gather the results and summary, and process them on our side (log a custom summary in console etc.)

Currently datadog-ci just logs things itself, and returns only a `0 | 1` exit code at the end of execution.

### How?

Instead of returning `0 | 1`, return an object with detailed info.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
