### PR TITLE
[synthetics] Make `failOnMissingTests` fail on "No tests to run"

### DIFF
--- a/src/commands/synthetics/__tests__/__snapshots__/utils.test.ts.snap
+++ b/src/commands/synthetics/__tests__/__snapshots__/utils.test.ts.snap
@@ -18,3 +18,63 @@ exports[`utils getTestsToTrigger too many tests to trigger trim and warn if from
   ],
 }
 `;
+
+exports[`utils reportCiError should report  error 1`] = `
+[MockFunction] {
+  "calls": [
+    [
+      "
+[41m[1m ERROR: No tests to run [22m[49m
+
+
+",
+    ],
+  ],
+  "results": [
+    {
+      "type": "return",
+      "value": undefined,
+    },
+  ],
+}
+`;
+
+exports[`utils reportCiError should report NO_TESTS_TO_RUN error 1`] = `
+[MockFunction] {
+  "calls": [
+    [
+      "
+[41m[1m ERROR: No tests to run [22m[49m
+
+
+",
+    ],
+  ],
+  "results": [
+    {
+      "type": "return",
+      "value": undefined,
+    },
+  ],
+}
+`;
+
+exports[`utils reportCiError should report error 1`] = `
+[MockFunction] {
+  "calls": [
+    [
+      "
+[41m[1m ERROR: No tests to run [22m[49m
+
+
+",
+    ],
+  ],
+  "results": [
+    {
+      "type": "return",
+      "value": undefined,
+    },
+  ],
+}
+`;

--- a/src/commands/synthetics/__tests__/__snapshots__/utils.test.ts.snap
+++ b/src/commands/synthetics/__tests__/__snapshots__/utils.test.ts.snap
@@ -253,7 +253,7 @@ exports[`utils reportCiError should report UNAVAILABLE_TUNNEL_CONFIG error 1`] =
 }
 `;
 
-exports[`utils reportCiError should report default Error if it no other CiError was matched 1`] = `
+exports[`utils reportCiError should report default Error if no CiError was matched 1`] = `
 [MockFunction] {
   "calls": [
     [

--- a/src/commands/synthetics/__tests__/__snapshots__/utils.test.ts.snap
+++ b/src/commands/synthetics/__tests__/__snapshots__/utils.test.ts.snap
@@ -19,12 +19,86 @@ exports[`utils getTestsToTrigger too many tests to trigger trim and warn if from
 }
 `;
 
-exports[`utils reportCiError should report  error 1`] = `
+exports[`utils reportCiError should report AUTHORIZATION_ERROR error 1`] = `
 [MockFunction] {
   "calls": [
     [
       "
-[41m[1m ERROR: No tests to run [22m[49m
+[41m[1m ERROR: authorization error [22m[49m
+
+
+",
+    ],
+  ],
+  "results": [
+    {
+      "type": "return",
+      "value": undefined,
+    },
+  ],
+}
+`;
+
+exports[`utils reportCiError should report INVALID_CONFIG error 1`] = `
+[MockFunction] {
+  "calls": [
+    [
+      "
+[41m[1m ERROR: invalid config [22m[49m
+
+
+",
+    ],
+  ],
+  "results": [
+    {
+      "type": "return",
+      "value": undefined,
+    },
+  ],
+}
+`;
+
+exports[`utils reportCiError should report MISSING_API_KEY error 1`] = `
+[MockFunction] {
+  "calls": [
+    [
+      "Missing [31m[1mDATADOG_API_KEY[22m[39m in your environment.
+",
+    ],
+  ],
+  "results": [
+    {
+      "type": "return",
+      "value": undefined,
+    },
+  ],
+}
+`;
+
+exports[`utils reportCiError should report MISSING_APP_KEY error 1`] = `
+[MockFunction] {
+  "calls": [
+    [
+      "Missing [31m[1mDATADOG_APP_KEY[22m[39m in your environment.
+",
+    ],
+  ],
+  "results": [
+    {
+      "type": "return",
+      "value": undefined,
+    },
+  ],
+}
+`;
+
+exports[`utils reportCiError should report MISSING_TESTS error 1`] = `
+[MockFunction] {
+  "calls": [
+    [
+      "
+[41m[1m ERROR: some tests are missing [22m[49m
 
 
 ",
@@ -59,12 +133,132 @@ exports[`utils reportCiError should report NO_TESTS_TO_RUN error 1`] = `
 }
 `;
 
-exports[`utils reportCiError should report error 1`] = `
+exports[`utils reportCiError should report POLL_RESULTS_FAILED error 1`] = `
 [MockFunction] {
   "calls": [
     [
       "
-[41m[1m ERROR: No tests to run [22m[49m
+[41m[1m ERROR: unable to poll test results [22m[49m
+
+
+",
+    ],
+  ],
+  "results": [
+    {
+      "type": "return",
+      "value": undefined,
+    },
+  ],
+}
+`;
+
+exports[`utils reportCiError should report TOO_MANY_TESTS_TO_TRIGGER error 1`] = `
+[MockFunction] {
+  "calls": [
+    [
+      "
+[41m[1m ERROR: too many tests to trigger [22m[49m
+
+
+",
+    ],
+  ],
+  "results": [
+    {
+      "type": "return",
+      "value": undefined,
+    },
+  ],
+}
+`;
+
+exports[`utils reportCiError should report TRIGGER_TESTS_FAILED error 1`] = `
+[MockFunction] {
+  "calls": [
+    [
+      "
+[41m[1m ERROR: unable to trigger tests [22m[49m
+
+
+",
+    ],
+  ],
+  "results": [
+    {
+      "type": "return",
+      "value": undefined,
+    },
+  ],
+}
+`;
+
+exports[`utils reportCiError should report TUNNEL_START_FAILED error 1`] = `
+[MockFunction] {
+  "calls": [
+    [
+      "
+[41m[1m ERROR: unable to start tunnel [22m[49m
+
+
+",
+    ],
+  ],
+  "results": [
+    {
+      "type": "return",
+      "value": undefined,
+    },
+  ],
+}
+`;
+
+exports[`utils reportCiError should report UNAVAILABLE_TEST_CONFIG error 1`] = `
+[MockFunction] {
+  "calls": [
+    [
+      "
+[41m[1m ERROR: unable to obtain test configurations with search query [22m[49m
+
+
+",
+    ],
+  ],
+  "results": [
+    {
+      "type": "return",
+      "value": undefined,
+    },
+  ],
+}
+`;
+
+exports[`utils reportCiError should report UNAVAILABLE_TUNNEL_CONFIG error 1`] = `
+[MockFunction] {
+  "calls": [
+    [
+      "
+[41m[1m ERROR: unable to get tunnel configuration [22m[49m
+
+
+",
+    ],
+  ],
+  "results": [
+    {
+      "type": "return",
+      "value": undefined,
+    },
+  ],
+}
+`;
+
+exports[`utils reportCiError should report default Error if it no other CiError was matched 1`] = `
+[MockFunction] {
+  "calls": [
+    [
+      "
+[41m[1m ERROR [22m[49m
 
 
 ",

--- a/src/commands/synthetics/__tests__/utils.test.ts
+++ b/src/commands/synthetics/__tests__/utils.test.ts
@@ -1585,18 +1585,18 @@ describe('utils', () => {
     })
 
     test.each([
-      {failOnMissingTestsFlag: true, errorCode: 'NO_TESTS_TO_RUN', exitReason: 'missing-tests'},
-      {failOnMissingTestsFlag: true, errorCode: 'MISSING_TESTS', exitReason: 'missing-tests'},
-      {failOnMissingTestsFlag: false, errorCode: 'NO_TESTS_TO_RUN', exitReason: 'passed'},
-      {failOnMissingTestsFlag: false, errorCode: 'MISSING_TESTS', exitReason: 'passed'},
+      {failOnMissingTests: true, errorCode: 'NO_TESTS_TO_RUN', expectedExitReason: 'missing-tests'} as const,
+      {failOnMissingTests: true, errorCode: 'MISSING_TESTS', expectedExitReason: 'missing-tests'} as const,
+      {failOnMissingTests: false, errorCode: 'NO_TESTS_TO_RUN', expectedExitReason: 'passed'} as const,
+      {failOnMissingTests: false, errorCode: 'MISSING_TESTS', expectedExitReason: 'passed'} as const,
     ])(
-      'should return $exitReason when $errorCode if failOnMissingTests flag is $failOnMissingTestsFlag',
-      ({failOnMissingTestsFlag, errorCode, exitReason}) => {
+      'should return $expectedExitReason when $errorCode if failOnMissingTests flag is $failOnMissingTests',
+      ({failOnMissingTests, errorCode, expectedExitReason: exitReason}) => {
         const config = {
           ...DEFAULT_COMMAND_CONFIG,
-          failOnMissingTests: failOnMissingTestsFlag,
+          failOnMissingTests,
         }
-        const error = new CiError(errorCode as CiErrorCode)
+        const error = new CiError(errorCode)
 
         expect(utils.getExitReason(config, {error})).toBe(exitReason)
       }
@@ -1697,13 +1697,13 @@ describe('utils', () => {
       'TRIGGER_TESTS_FAILED',
       'UNAVAILABLE_TEST_CONFIG',
       'UNAVAILABLE_TUNNEL_CONFIG',
-    ])('should report %s error', async (errorCode) => {
-      const error = new CiError(errorCode as CiErrorCode)
+    ] as const)('should report %s error', async (errorCode) => {
+      const error = new CiError(errorCode)
       utils.reportCiError(error, mockReporter)
       expect(mockReporter.error).toMatchSnapshot()
     })
 
-    test('should report default Error if it no other CiError was matched', async () => {
+    test('should report default Error if no CiError was matched', async () => {
       const error = new CiError('ERROR' as CiErrorCode)
       utils.reportCiError(error, mockReporter)
       expect(mockReporter.error).toMatchSnapshot()

--- a/src/commands/synthetics/__tests__/utils.test.ts
+++ b/src/commands/synthetics/__tests__/utils.test.ts
@@ -1585,11 +1585,11 @@ describe('utils', () => {
     })
 
     test.each([
-      {failOnMissingTests: true, errorCode: 'NO_TESTS_TO_RUN', expectedExitReason: 'missing-tests'} as const,
-      {failOnMissingTests: true, errorCode: 'MISSING_TESTS', expectedExitReason: 'missing-tests'} as const,
-      {failOnMissingTests: false, errorCode: 'NO_TESTS_TO_RUN', expectedExitReason: 'passed'} as const,
-      {failOnMissingTests: false, errorCode: 'MISSING_TESTS', expectedExitReason: 'passed'} as const,
-    ])(
+      {failOnMissingTests: true, errorCode: 'NO_TESTS_TO_RUN', expectedExitReason: 'missing-tests'},
+      {failOnMissingTests: true, errorCode: 'MISSING_TESTS', expectedExitReason: 'missing-tests'},
+      {failOnMissingTests: false, errorCode: 'NO_TESTS_TO_RUN', expectedExitReason: 'passed'},
+      {failOnMissingTests: false, errorCode: 'MISSING_TESTS', expectedExitReason: 'passed'},
+    ] as const)(
       'should return $expectedExitReason when $errorCode if failOnMissingTests flag is $failOnMissingTests',
       ({failOnMissingTests, errorCode, expectedExitReason: exitReason}) => {
         const config = {

--- a/src/commands/synthetics/__tests__/utils.test.ts
+++ b/src/commands/synthetics/__tests__/utils.test.ts
@@ -1576,6 +1576,28 @@ describe('utils', () => {
     })
   })
 
+  describe('getExitReason', () => {
+    test('should return missing-tests when no tests to run if failOnMissingTests flag is on', () => {
+      const config = {
+        ...DEFAULT_COMMAND_CONFIG,
+        failOnMissingTests: true,
+      }
+      const error = new CiError('NO_TESTS_TO_RUN')
+
+      expect(utils.getExitReason(config, {error})).toBe('missing-tests')
+    })
+
+    test('should return passed when no tests to run if failOnMissingTests flag is off', () => {
+      const config = {
+        ...DEFAULT_COMMAND_CONFIG,
+        failOnMissingTests: false,
+      }
+      const error = new CiError('NO_TESTS_TO_RUN')
+
+      expect(utils.getExitReason(config, {error})).toBe('passed')
+    })
+  })
+
   describe('getDatadogHost', () => {
     test('should default to datadog us api', async () => {
       process.env = {}
@@ -1630,6 +1652,14 @@ describe('utils', () => {
 
       const config = (apiConfiguration as unknown) as SyntheticsCIConfig
       expect(await utils.getOrgSettings(mockReporter, config)).toBeUndefined()
+    })
+  })
+
+  describe('reportCiError', () => {
+    test('should report NO_TESTS_TO_RUN error', async () => {
+      const error = new CiError('NO_TESTS_TO_RUN')
+      utils.reportCiError(error, mockReporter)
+      expect(mockReporter.error).toMatchSnapshot()
     })
   })
 })

--- a/src/commands/synthetics/utils.ts
+++ b/src/commands/synthetics/utils.ts
@@ -937,7 +937,8 @@ export const getExitReason = (
   }
 
   if (error instanceof CiError) {
-    if (config.failOnMissingTests && error.code === 'MISSING_TESTS') {
+    // Ensure the command fails if search query starts returning no results
+    if (config.failOnMissingTests && ['MISSING_TESTS', 'NO_TESTS_TO_RUN'].includes(error.code)) {
       return 'missing-tests'
     }
 

--- a/src/commands/synthetics/utils.ts
+++ b/src/commands/synthetics/utils.ts
@@ -983,7 +983,7 @@ export const pluralize = (word: string, count: number): string => (count === 1 ?
 export const reportCiError = (error: CiError, reporter: MainReporter) => {
   switch (error.code) {
     case 'NO_TESTS_TO_RUN':
-      reporter.log('No test to run.\n')
+      reporter.error(`\n${chalk.bgRed.bold(' ERROR: No tests to run ')}\n${error.message}\n\n`)
       break
     case 'MISSING_TESTS':
       reporter.error(`\n${chalk.bgRed.bold(' ERROR: some tests are missing ')}\n${error.message}\n\n`)


### PR DESCRIPTION
### What and why?

We received this [issue](https://github.com/DataDog/datadog-ci/issues/1103). The problem is that if the --failOnMissingTests flag is present and there were no tests found to be run, we should exit with an error.

### How?

I included the 'NO_TESTS_TO_RUN' as a reason to fail and also changed the messaging to be an error instead of a log

before:
<img width="955" alt="image" src="https://github.com/DataDog/datadog-ci/assets/25252536/7377f614-814e-4a88-85ff-df9e16ac4cb0">
after:
<img width="956" alt="image" src="https://github.com/DataDog/datadog-ci/assets/25252536/a90e3ada-a50b-435c-afee-f2b423089bc0">


### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
