### PR TITLE
[STAL-898] Add static analysis rules

### DIFF
--- a/static-analysis.datadog.yml
+++ b/static-analysis.datadog.yml
@@ -1,0 +1,6 @@
+rulesets:
+  - typescript-best-practices
+  - typescript-code-style
+  - typescript-common-security
+  - typescript-inclusive
+  - typescript-node-security


### PR DESCRIPTION
### What and why?

This PR adds support for static analysis rules for the `datadog-ci` repository. It will bring static analysis checks for the repository and works in the IDE and later in the CI/CD pipeline.

### How?

Adding a file in the repo
