### PR TITLE
[STAL-898] Enable datadog static analyzer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,6 +171,24 @@ jobs:
       - name: Test generated standalone binary
         run: yarn dist-standalone:test
 
+  datadog-static-analyzer:
+    runs-on: ubuntu-latest
+    name: Datadog Static Analyzer
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Run Datadog static analyzer
+        id: datadog-static-analysis
+        uses: DataDog/datadog-static-analyzer-github-action@v1
+        with:
+          dd_app_key: ${{ secrets.DATADOG_APP_KEY_E2E }}
+          dd_api_key: ${{ secrets.DATADOG_API_KEY_E2E }}
+          dd_service: "datadog-ci"
+          dd_env: "ci"
+          cpu_count: 2
+          enable_performance_statistics: true
+          sca_enabled: true
+
   check-licenses:
     name: Check licenses
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,7 +179,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Run Datadog static analyzer
         id: datadog-static-analysis
-        uses: DataDog/datadog-static-analyzer-github-action@v1
+        uses: DataDog/datadog-static-analyzer-github-action@main
         with:
           dd_app_key: ${{ secrets.DATADOG_APP_KEY_E2E }}
           dd_api_key: ${{ secrets.DATADOG_API_KEY_E2E }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,8 +181,8 @@ jobs:
         id: datadog-static-analysis
         uses: DataDog/datadog-static-analyzer-github-action@main
         with:
-          dd_app_key: ${{ secrets.DATADOG_APP_KEY_E2E }}
-          dd_api_key: ${{ secrets.DATADOG_API_KEY_E2E }}
+          dd_app_key: ${{ secrets.DATADOG_APP_KEY_MAIN_ACCOUNT }}
+          dd_api_key: ${{ secrets.DATADOG_API_KEY_MAIN_ACCOUNT }}
           dd_service: "datadog-ci"
           dd_env: "ci"
           cpu_count: 2


### PR DESCRIPTION
### What and why?

It enables the datadog static analyzer, which allows to:
 - get a list of all violations [here](https://app.datadoghq.com/ci/static-analysis?query=service%3Adatadog-ci&index=cicodescan&start=1701949821395&end=1701953421395&paused=false)
 - reports all dependencies used, with their security and licenses (upcoming)

### How?

Add a CI/CD job to do so.


### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
