### PR TITLE
[STAL-904] Add purl to the package information to upload

### DIFF
--- a/src/commands/sbom/payload.ts
+++ b/src/commands/sbom/payload.ts
@@ -1,3 +1,4 @@
+import * as console from 'console'
 import crypto from 'crypto'
 
 import {SpanTags} from '../../helpers/interfaces'
@@ -50,11 +51,19 @@ export const generatePayload = (
           continue
         }
 
+        const purl: string | undefined = component['purl']
+
+        if (!purl) {
+          console.error(`cannot find purl for component ${component['name']}`)
+          continue
+        }
+
         const dependency: Dependency = {
           name: component['name'],
           version: component['version'],
           language: lang,
           licenses: getLicensesFromComponent(component),
+          purl,
         }
         dependencies.push(dependency)
       }

--- a/src/commands/sbom/types.ts
+++ b/src/commands/sbom/types.ts
@@ -53,6 +53,7 @@ export interface Dependency {
   version: string
   language: DependencyLanguage
   licenses: DependencyLicense[]
+  purl: string
 }
 
 export interface CommitInformation {


### PR DESCRIPTION
### What and why?

We need to send the `purl` of a package to the backend API.

### How?

1. Add the `purl` in the structure of the payload
2. Extract the `purl` from the SBOM and add it to the payload
