### PR TITLE
[synthetics] Report test level failures

### DIFF
--- a/src/commands/synthetics/__tests__/fixtures.ts
+++ b/src/commands/synthetics/__tests__/fixtures.ts
@@ -305,6 +305,22 @@ export const getMultiStepsServerResult = (): MultiStepsServerResult => ({
   steps: [],
 })
 
+export const getFailedMultiStepsTestLevelServerResult = (): MultiStepsServerResult => ({
+  duration: 2000,
+  failure: {code: 'TEST_TIMEOUT', message: 'Error: Maximum test execution time reached: 2 seconds.'},
+  passed: false,
+  steps: [
+    {
+      ...getMultiStep(),
+      passed: true,
+    },
+    {
+      ...getMultiStep(),
+      skipped: true,
+    },
+  ],
+})
+
 export const getFailedMultiStepsServerResult = (): MultiStepsServerResult => ({
   duration: 123,
   failure: {code: 'INCORRECT_ASSERTION', message: 'incorrect assertion'},

--- a/src/commands/synthetics/__tests__/reporters/__snapshots__/default.test.ts.snap
+++ b/src/commands/synthetics/__tests__/reporters/__snapshots__/default.test.ts.snap
@@ -46,6 +46,7 @@ exports[`Default reporter resultEnd 3 API tests, 2 passed (1 from previous CI ru
 exports[`Default reporter resultEnd 3 Browser test: failed blocking, timed out, global failure 1`] = `
 "[1m[31m✖[39m[22m [[1m[31mblocking[39m[22m] [[1m[2mabc-def-ghi[22m[22m] [1mTest name[22m - [1m[31mlocation: [1mLocation name[22m[1m[39m[22m - [1m[31mdevice: [1mchrome.laptop_large[22m[1m[39m[22m
   ⎋ Total duration: 20000 ms - View test run details: [2m[36mhttps://app.datadoghq.com/synthetics/details/abc-def-ghi/result/1?from_ci=true[39m[22m 
+[31m    [[1mSTEP_TIMEOUT[22m] - [2mStep failed because it took more than 20 seconds.[22m[39m
     [1m[32m✓[39m[22m | [1m1000[22mms - Navigate to start URL
     [2mhttps://example.org/[22m
     [1m[31m✖[39m[22m | [1m1000[22mms - Navigate

--- a/src/commands/synthetics/__tests__/reporters/junit.test.ts
+++ b/src/commands/synthetics/__tests__/reporters/junit.test.ts
@@ -18,6 +18,7 @@ import {
   getBrowserTest,
   getFailedBrowserResult,
   getFailedMultiStepsServerResult,
+  getFailedMultiStepsTestLevelServerResult,
   getMultiStep,
   getMultiStepsServerResult,
   getStep,
@@ -206,6 +207,30 @@ describe('Junit reporter', () => {
         failures: 1,
         skipped: 1, // not 2 because skipped by selective re-run counts as passed
         tests: 3,
+      })
+    })
+
+    it('should fall back to a test level failure', () => {
+      reporter.resultEnd(
+        {
+          ...globalResultMock,
+          passed: false,
+          result: getFailedMultiStepsTestLevelServerResult(),
+          test: {
+            ...globalTestMock,
+            suite: 'suite 1',
+          },
+        },
+        ''
+      )
+
+      const [suiteFailed] = reporter['json'].testsuites.testsuite
+
+      expect(suiteFailed.$).toMatchObject({
+        ...getDefaultSuiteStats(),
+        errors: 0,
+        failures: 1,
+        tests: 1,
       })
     })
 

--- a/src/commands/synthetics/reporters/default.ts
+++ b/src/commands/synthetics/reporters/default.ts
@@ -144,24 +144,24 @@ const renderResultOutcome = (
   }
 
   if (test.type === 'browser') {
+    const lines: string[] = []
+
+    if (result.failure) {
+      lines.push(chalk.red(`    [${chalk.bold(result.failure.code)}] - ${chalk.dim(result.failure.message)}`))
+    }
+
     // We render the step only if the test hasn't passed to avoid cluttering the output.
     if (!result.passed && 'stepDetails' in result) {
       const criticalFailedStepIndex = result.stepDetails.findIndex((s) => s.error && !s.allowFailure) + 1
-      const stepsDisplay = result.stepDetails.slice(0, criticalFailedStepIndex).map(renderStep)
+      lines.push(...result.stepDetails.slice(0, criticalFailedStepIndex).map(renderStep))
 
       const skippedStepDisplay = renderSkippedSteps(result.stepDetails.slice(criticalFailedStepIndex))
       if (skippedStepDisplay) {
-        stepsDisplay.push(skippedStepDisplay)
+        lines.push(skippedStepDisplay)
       }
-
-      return stepsDisplay.join('\n')
     }
 
-    if (result.failure) {
-      return chalk.red(`    [${chalk.bold(result.failure.code)}] - ${chalk.dim(result.failure.message)}`)
-    }
-
-    return ''
+    return lines.join('\n')
   }
 }
 


### PR DESCRIPTION
### What and why?

This PR updates the default and junit reporters to report test level failures (`result.failure`).

### How?

#### Default reporter

The default reporter will now always show a test level failure when it's present. It's only a visual difference.

##### Before

![image](https://github.com/DataDog/datadog-ci/assets/9317502/171d036e-0476-49ca-8b9f-7bd22d1a7b21)

##### After

![image](https://github.com/DataDog/datadog-ci/assets/9317502/0dde440f-9530-4e0b-b637-cf8182e896d8)

#### JUnit reporter

The JUnit reporter will now **fall back to a test level failure** when no other failures were reported from the step level (e.g. for a multi-step or browser test).

It's only a fall back (and not nothing that is always added) because it may be redundant with what was already reported from the step level, causing the stats to be wrong: if a step timeout is reported both from the test level and from the step level, the `failures` count would be `2` instead of `1`, which is wrong.

Also, generally on the private location side, the step level failure is replicated at the test level, so this fall back is just a safety, to not leave the user without information.

##### Before

<details><summary>Full JUnit report (click to expand)</summary>
<p>

```xml
<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
<testsuites batch_id="6ed6a1a6-a4ee-4324-8fcc-638d8f4a5033" batch_url="https://app.datadoghq.com/synthetics/explorer/ci?batchResultId=6ed6a1a6-a4ee-4324-8fcc-638d8f4a5033" name="Undefined run" tests_critical_error="0" tests_failed="2" tests_failed_non_blocking="0" tests_not_found="0" tests_passed="0" tests_skipped="0" tests_timed_out="0">
  <testsuite errors="0" failures="0" name="../../../../../../Documents/datadog-ci-test-timeout.synthetics.json" skipped="0" tests="2">
    <testcase classname="../../../../../../Documents/datadog-ci-test-timeout.synthetics.json" file="../../../../../../Documents/datadog-ci-test-timeout.synthetics.json" name="[cg] Test with long subtest - id: k2a-n8n-s7m - location: Test Corentin Preprod - device: chrome.laptop_large" time="2" timestamp="2023-12-13T17:27:48.303Z" steps_allowfailures="0" steps_count="3" steps_errors="0" steps_failures="0" steps_skipped="3" steps_warnings="0">
      <properties>
        <property name="check_id" value="k2a-n8n-s7m"/>
        <property name="device" value="chrome.laptop_large"/>
        <property name="width" value="1440"/>
        <property name="height" value="1100"/>
        <property name="location" value="Test Corentin Preprod"/>
        <property name="monitor_id" value="134926419"/>
        <property name="passed" value="false"/>
        <property name="public_id" value="k2a-n8n-s7m"/>
        <property name="result_id" value="7527112776419255121"/>
        <property name="result_url" value="https://app.datadoghq.com/synthetics/details/k2a-n8n-s7m/result/7527112776419255121?from_ci=true"/>
        <property name="start_url" value="https://example.com"/>
        <property name="status" value="paused"/>
        <property name="tags" value="team:synthetics-ct,team:synthetics"/>
        <property name="timeout" value="false"/>
        <property name="type" value="browser"/>
      </properties>
    </testcase>
    <testcase classname="../../../../../../Documents/datadog-ci-test-timeout.synthetics.json" file="../../../../../../Documents/datadog-ci-test-timeout.synthetics.json" name="[cg] Test that is long by itself - id: bh6-3qh-8uw - location: Test Corentin Preprod - device: chrome.laptop_large" time="7" timestamp="2023-12-13T17:27:48.303Z" steps_allowfailures="0" steps_count="4" steps_errors="0" steps_failures="0" steps_skipped="3" steps_warnings="0">
      <properties>
        <property name="check_id" value="bh6-3qh-8uw"/>
        <property name="device" value="chrome.laptop_large"/>
        <property name="width" value="1440"/>
        <property name="height" value="1100"/>
        <property name="location" value="Test Corentin Preprod"/>
        <property name="monitor_id" value="134927290"/>
        <property name="passed" value="false"/>
        <property name="public_id" value="bh6-3qh-8uw"/>
        <property name="result_id" value="8725237869785058615"/>
        <property name="result_url" value="https://app.datadoghq.com/synthetics/details/bh6-3qh-8uw/result/8725237869785058615?from_ci=true"/>
        <property name="start_url" value="https://example.com"/>
        <property name="status" value="paused"/>
        <property name="tags" value="team:synthetics-ct,team:synthetics"/>
        <property name="timeout" value="false"/>
        <property name="type" value="browser"/>
      </properties>
    </testcase>
  </testsuite>
</testsuites>
```

</p>
</details> 

##### After

<details><summary>Full JUnit report (click to expand)</summary>
<p>

```xml
<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
<testsuites batch_id="c937631e-a647-40cb-825e-a0ad922399bd" batch_url="https://app.datadoghq.com/synthetics/explorer/ci?batchResultId=c937631e-a647-40cb-825e-a0ad922399bd" name="Undefined run" tests_critical_error="0" tests_failed="2" tests_failed_non_blocking="0" tests_not_found="0" tests_passed="0" tests_skipped="0" tests_timed_out="0">
  <testsuite errors="0" failures="2" name="../../../../../../Documents/datadog-ci-test-timeout.synthetics.json" skipped="0" tests="2">
    <testcase classname="../../../../../../Documents/datadog-ci-test-timeout.synthetics.json" file="../../../../../../Documents/datadog-ci-test-timeout.synthetics.json" name="[cg] Test with long subtest - id: k2a-n8n-s7m - location: Test Corentin Preprod - device: chrome.laptop_large" time="2" timestamp="2023-12-13T17:29:32.981Z" steps_allowfailures="0" steps_count="3" steps_errors="0" steps_failures="0" steps_skipped="3" steps_warnings="0">
      <failure type="test_failure">[TEST_TIMEOUT] - Error: Maximum test execution time reached: 2 seconds.</failure>
      <properties>
        <property name="check_id" value="k2a-n8n-s7m"/>
        <property name="device" value="chrome.laptop_large"/>
        <property name="width" value="1440"/>
        <property name="height" value="1100"/>
        <property name="location" value="Test Corentin Preprod"/>
        <property name="monitor_id" value="134926419"/>
        <property name="passed" value="false"/>
        <property name="public_id" value="k2a-n8n-s7m"/>
        <property name="result_id" value="3980147241617189798"/>
        <property name="result_url" value="https://app.datadoghq.com/synthetics/details/k2a-n8n-s7m/result/3980147241617189798?from_ci=true"/>
        <property name="start_url" value="https://example.com"/>
        <property name="status" value="paused"/>
        <property name="tags" value="team:synthetics-ct,team:synthetics"/>
        <property name="timeout" value="false"/>
        <property name="type" value="browser"/>
      </properties>
    </testcase>
    <testcase classname="../../../../../../Documents/datadog-ci-test-timeout.synthetics.json" file="../../../../../../Documents/datadog-ci-test-timeout.synthetics.json" name="[cg] Test that is long by itself - id: bh6-3qh-8uw - location: Test Corentin Preprod - device: chrome.laptop_large" time="7" timestamp="2023-12-13T17:29:32.980Z" steps_allowfailures="0" steps_count="4" steps_errors="0" steps_failures="0" steps_skipped="3" steps_warnings="0">
      <failure type="test_failure">[TEST_TIMEOUT] - Error: Maximum test execution time reached: 7 seconds.</failure>
      <properties>
        <property name="check_id" value="bh6-3qh-8uw"/>
        <property name="device" value="chrome.laptop_large"/>
        <property name="width" value="1440"/>
        <property name="height" value="1100"/>
        <property name="location" value="Test Corentin Preprod"/>
        <property name="monitor_id" value="134927290"/>
        <property name="passed" value="false"/>
        <property name="public_id" value="bh6-3qh-8uw"/>
        <property name="result_id" value="1400036863206717448"/>
        <property name="result_url" value="https://app.datadoghq.com/synthetics/details/bh6-3qh-8uw/result/1400036863206717448?from_ci=true"/>
        <property name="start_url" value="https://example.com"/>
        <property name="status" value="paused"/>
        <property name="tags" value="team:synthetics-ct,team:synthetics"/>
        <property name="timeout" value="false"/>
        <property name="type" value="browser"/>
      </properties>
    </testcase>
  </testsuite>
</testsuites>
```

</p>
</details> 

Main difference:

```diff
<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
<testsuites batch_id="c937631e-a647-40cb-825e-a0ad922399bd" tests_critical_error="0" tests_failed="2" tests_failed_non_blocking="0" tests_not_found="0" tests_passed="0" tests_skipped="0" tests_timed_out="0">
  <testsuite errors="0" failures="2" skipped="0" tests="2">
    <testcase name="[cg] Test with long subtest - id: k2a-n8n-s7m - location: Test Corentin Preprod - device: chrome.laptop_large" time="2" steps_allowfailures="0" steps_count="3" steps_errors="0" steps_failures="0" steps_skipped="3" steps_warnings="0">
+     <failure type="test_failure">[TEST_TIMEOUT] - Error: Maximum test execution time reached: 2 seconds.</failure>
      <properties>
        <property name="public_id" value="k2a-n8n-s7m"/>
        <property name="result_id" value="3980147241617189798"/>
        <property name="start_url" value="https://example.com"/>
      </properties>
    </testcase>
    <testcase name="[cg] Test that is long by itself - id: bh6-3qh-8uw - location: Test Corentin Preprod - device: chrome.laptop_large" time="7" steps_allowfailures="0" steps_count="4" steps_errors="0" steps_failures="0" steps_skipped="3" steps_warnings="0">
+     <failure type="test_failure">[TEST_TIMEOUT] - Error: Maximum test execution time reached: 7 seconds.</failure>
      <properties>
        <property name="public_id" value="bh6-3qh-8uw"/>
        <property name="result_id" value="1400036863206717448"/>
        <property name="start_url" value="https://example.com"/>
      </properties>
    </testcase>
  </testsuite>
</testsuites>
```



### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
