### PR TITLE
[docs] Update READMEs with more links to the official docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,13 +58,10 @@ The tests can then be launched through the `yarn test` command, it will find all
 
 ### Continuous Integration tests
 
-The CI performs tests to avoid regressions by building the project, running unit tests and running one end-to-end test.
+The CI performs tests to avoid regressions by building the project, running unit tests and running end-to-end tests.
 
-The end-to-end test installs the package in a new project, configures it by using files in the `.github/workflows/e2e` folder, and runs a `synthetics run-tests` command in a Datadog org (such as `Synthetics E2E Testing Org`) to verify the command is able to perform a test.
-
-The Synthetic tests that are run include a browser test (with a test ID of `neg-qw9-eut`) and an API test (with a test ID of `v5u-56k-hgk`). Both tests load a page which outputs the headers of the request and verifies the `X-Fake-Header` header is present. This header is configured as an override in the `.github/workflows/e2e/test.synthetics.json` file. The API and application keys used by the command are stored in GitHub Secrets named `datadog_api_key` and `datadog_app_key`.
-
-The goal of this test is to verify the command is able to run tests and wait for their results as expected as well as handling configuration overrides.
+For the end-to-end tests (defined in `.github/workflows/ci.yml` inside the `e2e-test` job), the `datadog-ci` package is installed in a new project with a `.tgz` artifact and configured with files in the `.github/workflows/e2e` folder.
+Then a suite of commands are tested to ensure they work as expected. Each command generally uses a dedicated Datadog org (e.g. `Synthetics E2E Testing Org` for Synthetics tests).
 
 ### Workflow
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,132 @@
+## Contributing
+
+Pull requests for bug fixes are welcome, but before submitting new features or changes to current functionality, [open an issue](https://github.com/DataDog/datadog-ci/issues/new)
+and discuss your ideas or propose the changes you wish to make. After a resolution is reached, a PR can be submitted for review.
+
+### Running command in development environment
+
+When developing the tool, it is possible to run commands using `yarn launch`. It relies on `ts-node`, so does not require building the project for every new change.
+
+```bash
+yarn launch synthetics run-tests --config dev/global.config.json
+```
+
+### Framework and libraries used
+
+- [clipanion](https://github.com/arcanis/clipanion): CLI library to handle the different commands.
+- [eslint](https://github.com/eslint/eslint): Linting ([.eslintrc.js](/.eslintrc.js)).
+- [jest](https://github.com/facebook/jest): Tests are written in Jest.
+- [volta](https://github.com/volta-cli/volta): NodeJS and yarn versioning.
+
+### Repository structure
+
+Commands are stored in the [src/commands](src/commands) folder.
+
+The skeleton of a command is composed of a README, an `index.ts` and a folder for the tests.
+
+```bash
+src/
+└── commands/
+    └── fakeCommand/
+         ├── __tests__/
+         │   └── index.test.ts
+         ├── README.md
+         └── index.ts
+```
+
+Documentation of the command must be placed in the README.md file, the [current README](/README.md) must be updated to link to the new command README.
+
+The `index.ts` file must export classes extending the `Command` class of `clipanion`. The commands of all `src/commands/*/index.ts` files will then be imported and made available in the `datadog-ci` tool.
+
+A sample `index.ts` file for a new command would be:
+
+```typescript
+import {Command} from 'clipanion'
+
+export class HelloWorldCommand extends Command {
+  public async execute() {
+    this.context.stdout.write('Hello world!')
+  }
+}
+
+module.exports = [HelloWorldCommand]
+```
+
+Lastly, test files must be created in the `__tests__/` folder. `jest` is used to run the tests and a CI has been set using GitHub Actions to ensure all tests are passing when merging a Pull Request.
+
+The tests can then be launched through the `yarn test` command, it will find all files with a filename ending in `.test.ts` in the repo and execute them.
+
+### Continuous Integration tests
+
+The CI performs tests to avoid regressions by building the project, running unit tests and running one end-to-end test.
+
+The end-to-end test installs the package in a new project, configures it by using files in the `.github/workflows/e2e` folder, and runs a `synthetics run-tests` command in a Datadog org (such as `Synthetics E2E Testing Org`) to verify the command is able to perform a test.
+
+The Synthetic tests that are run include a browser test (with a test ID of `neg-qw9-eut`) and an API test (with a test ID of `v5u-56k-hgk`). Both tests load a page which outputs the headers of the request and verifies the `X-Fake-Header` header is present. This header is configured as an override in the `.github/workflows/e2e/test.synthetics.json` file. The API and application keys used by the command are stored in GitHub Secrets named `datadog_api_key` and `datadog_app_key`.
+
+The goal of this test is to verify the command is able to run tests and wait for their results as expected as well as handling configuration overrides.
+
+### Workflow
+
+```bash
+# Compile and watch
+yarn watch
+
+# Run the tests
+yarn test
+
+# Build code
+yarn build
+
+# Make bin executable
+yarn prepack
+```
+
+#### Release Process
+
+<details>
+  <summary>Instructions</summary>
+
+To release a new version of `datadog-ci`:
+
+1. Create a new branch for the version upgrade.
+2. Update the `package.json` version to `X.X.X`, commit the change `vX.X.X` and tag it with `git tag vX.X.X`.
+   - You may refer to [Semantic Versioning](https://semver.org/#summary) to determine what level to increment.
+4. Push the branch **along with the tag** with `git push --tags origin name-of-the-branch`, create a PR, and get at least one approval.
+   - [Create a draft GitHub Release (prefilled link)](https://github.com/DataDog/datadog-ci/releases/new?title=%3Csame-as-tag%3E&body=%3C!--%20Use%20the%20%22Generate%20release%20notes%22%20button%20at%20the%20top%20right,%20then%20categorize%20the%20changes%20--%3E) and **save it as a draft**.
+   - Please categorize the changes by product or "Documentation" / "Dependencies" / "Chores". You can find commands grouped by product in the [`.github/CODEOWNERS`](https://github.com/DataDog/datadog-ci/blob/master/.github/CODEOWNERS) file.
+   - Copy the categorized release notes, and paste them in the description of your PR. This ensures the feature PRs have a link to your release PR.
+   - See this [example PR](https://github.com/DataDog/datadog-ci/pull/1047).
+5. Once you've received at least one approval, merge the PR **with the "Create a merge commit" strategy**.
+   - You may notice that some **_GitLab_** jobs are pending, this is expected (see **step 7**). You can merge the PR when *only those jobs* are left.
+   - The "Create a merge commit" strategy is required for **step 7**, and for the GitHub Release to point to an existing commit once the PR is merged.
+6. Go back to your draft GitHub Release, and publish it.
+7. Once the release is published, [this GitHub Workflow](https://github.com/DataDog/datadog-ci/actions/workflows/release.yml) publishes the NPM package and adds binaries to the release's assets. Wait for it to succeed.
+8. When the NPM package is published, go to the [_GitLab_ pipelines](https://gitlab.ddbuild.io/DataDog/datadog-ci/-/pipelines?scope=tags&status=manual), find the pipeline for your tag, and start the `build` stage to run the Docker image build jobs.
+   - Make sure all the jobs and downstream jobs succeed.
+
+Thanks for creating a release! 🎉
+
+</details>
+
+#### Pre-Release Process
+
+<details>
+  <summary>Instructions</summary>
+
+To create a pre-release or releasing in a different channel:
+
+1. Create a new branch for the channel you want to release to (`alpha`, `beta`, and more).
+2. Create a PR for your feature branch with the channel branch as a base.
+3. Pick a version following this format: `<version>-<channel>`. For example, `0.10.9-alpha`, `1-beta`, and more.
+4. Update the `version` field in `package.json`.
+5. Once you've received at least one approval, merge the Pull Request **with the "Create a merge commit" strategy**.
+6. Create a [GitHub Release](https://github.com/DataDog/datadog-ci/releases/new?target=alpha&tag=0.10.9-alpha&prerelease=1&title=Alpha+prerelease):
+   - Target the channel branch.
+   - Pick a tag based on your version `<version>-<channel>`.
+   - Check the `This is a pre-release` checkbox.
+7. Publish the release and an action publishes it on npm.
+
+<img src="./assets/pre-release.png" width="500"/>
+
+</details>

--- a/README.md
+++ b/README.md
@@ -67,8 +67,8 @@ See each command's corresponding README for more details, or click on 🔗 to se
 - `sourcemaps`:
   - `upload`: Upload [JavaScript sourcemaps](src/commands/sourcemaps) for Error Tracking. [🔗](https://docs.datadoghq.com/real_user_monitoring/browser/)
 - `stepfunctions`:
-  - `instrument`: Subscribe [AWS Step Function](src/commands/stepfunctions) log groups to a Datadog Forwarder. [🔗](https://docs.datadoghq.com/serverless/step_functions/installation/tab=datadogcli)
-  - `uninstrument`: Unsubscribe a [AWS Step Function](src/commands/stepfunctions) log group from the specified Datadog Forwarder. [🔗](https://docs.datadoghq.com/serverless/step_functions/installation/tab=datadogcli)
+  - `instrument`: Instrument [AWS Step Function](src/commands/stepfunctions) with Datadog to get logs and traces. [🔗](https://docs.datadoghq.com/serverless/step_functions/installation/tab=datadogcli)
+  - `uninstrument`: Uninstrument [AWS Step Function](src/commands/stepfunctions). [🔗](https://docs.datadoghq.com/serverless/step_functions/installation/tab=datadogcli)
 - `synthetics`:
   - `run-tests`: Run [Continuous Testing tests](src/commands/synthetics) from the CI. [🔗](https://docs.datadoghq.com/continuous_testing/)
   - `upload-application`: Upload a new version to an [existing mobile application](src/commands/synthetics) in Datadog. [🔗](https://docs.datadoghq.com/mobile_app_testing/)

--- a/README.md
+++ b/README.md
@@ -71,6 +71,16 @@ The following values are available for each `<command>` and `<subcommand>`. See 
 - `tag`: Add [custom tags](src/commands/tag) to a CI Visibility Pipeline trace or Job span in Datadog. See [documentation](https://docs.datadoghq.com/continuous_integration/pipelines/custom_tags_and_metrics/).
 - `trace`: Add [custom commands](src/commands/trace) to a CI Visibility Pipeline in Datadog. See [documentation](https://docs.datadoghq.com/continuous_integration/pipelines/custom_commands/).
 
+The following are **beta** commands, you can enable them with with `DD_BETA_COMMANDS_ENABLED=1`:
+- `deployment`:
+  - `mark`: Mark a CI job as a [deployment](src/commands/deployment). See [documentation](https://docs.datadoghq.com/continuous_delivery/).
+- `dora`:
+  - `deployment`: Send a new Deployment event for [DORA Metrics](src/commands/dora) to Datadog. See [documentation](https://docs.datadoghq.com/dora_metrics/).
+- `gate`:
+  - `evaluate`: Evaluate [Quality Gates](src/commands/gate) rules in Datadog. See [documentation](https://docs.datadoghq.com/quality_gates/).
+- `sbom`:
+  - `upload`: Upload [Software Bill of Materials (SBOM)](src/commands/sbom) files to Datadog. See [documentation](https://docs.datadoghq.com/static_analysis/).
+
 ## More ways to install the CLI
 
 ### Standalone binary (**beta**)

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ See each command's linked README for more details, or click on [📚](https://do
 - `sarif`:
   - `upload`: Upload [Static Analysis Results Interchange Format (SARIF)](src/commands/sarif) reports to Datadog. [📚](https://docs.datadoghq.com/static_analysis/)
 - `sourcemaps`:
-  - `upload`: Upload [JavaScript sourcemaps](src/commands/sourcemaps) for Error Tracking. [📚](https://docs.datadoghq.com/real_user_monitoring/browser/)
+  - `upload`: Upload [JavaScript sourcemaps](src/commands/sourcemaps) for Error Tracking. [📚](https://docs.datadoghq.com/real_user_monitoring/guide/upload-javascript-source-maps)
 - `stepfunctions`:
   - `instrument`: Instrument [AWS Step Function](src/commands/stepfunctions) with Datadog to get logs and traces. [📚](https://docs.datadoghq.com/serverless/step_functions/installation/tab=datadogcli)
   - `uninstrument`: Uninstrument [AWS Step Function](src/commands/stepfunctions). [📚](https://docs.datadoghq.com/serverless/step_functions/installation/tab=datadogcli)

--- a/README.md
+++ b/README.md
@@ -57,7 +57,9 @@ The following values are available for each `<command>` and `<subcommand>`. See 
   - `uninstrument`: Uninstrument [AWS Lambda functions](src/commands/lambda).
 - `metric`: Add [metrics](src/commands/metric) to a CI Visibility Pipeline trace or Job span in Datadog. See [documentation](https://docs.datadoghq.com/continuous_integration/pipelines/custom_tags_and_metrics/).
 - `react-native`:
-  - `xcode`: Upload [React Native sourcemaps](src/commands/react-native) for Error Tracking. See [documentation](https://docs.datadoghq.com/real_user_monitoring/error_tracking/reactnative/).
+  - `codepush`: Upload [React Native CodePush sourcemaps](src/commands/react-native) for Error Tracking. See [documentation](https://docs.datadoghq.com/real_user_monitoring/mobile_and_tv_monitoring/setup/codepush/).
+  - `upload`: Upload [React Native sourcemaps](src/commands/react-native) for Error Tracking. See [documentation](https://docs.datadoghq.com/real_user_monitoring/error_tracking/reactnative/).
+  - `xcode`: Upload [React Native sourcemaps](src/commands/react-native) for Error Tracking from the XCode bundle build phase. See [documentation](https://docs.datadoghq.com/real_user_monitoring/error_tracking/reactnative/).
 - `sarif`:
   - `upload`: Upload [Static Analysis Results Interchange Format (SARIF)](src/commands/sarif) reports to Datadog. See [documentation](https://docs.datadoghq.com/static_analysis/).
 - `sourcemaps`:

--- a/README.md
+++ b/README.md
@@ -54,9 +54,9 @@ See each command's corresponding README for more details, or click on 🔗 to se
 - `junit`:
   - `upload`: Upload [JUnit test reports](src/commands/junit). [🔗](https://docs.datadoghq.com/tests/setup/junit_xml/)
 - `lambda`:
-  - `flare`: Troubleshoot your issues with Datadog monitoring on your [AWS Lambda functions](src/commands/lambda).
-  - `instrument`: Instrument [AWS Lambda functions](src/commands/lambda).
-  - `uninstrument`: Uninstrument [AWS Lambda functions](src/commands/lambda).
+  - `flare`: Troubleshoot your issues with Datadog instrumentation on your [AWS Lambda functions](src/commands/lambda).
+  - `instrument`: Apply Datadog instrumentation to the given [AWS Lambda functions](src/commands/lambda).
+  - `uninstrument`: Revert Datadog instrumentation to the given [AWS Lambda functions](src/commands/lambda).
 - `metric`: Add [metrics](src/commands/metric) to a CI Visibility Pipeline trace or Job span in Datadog. [🔗](https://docs.datadoghq.com/continuous_integration/pipelines/custom_tags_and_metrics/)
 - `react-native`:
   - `codepush`: Upload [React Native CodePush sourcemaps](src/commands/react-native) for Error Tracking. [🔗](https://docs.datadoghq.com/real_user_monitoring/mobile_and_tv_monitoring/setupcodepush/)

--- a/README.md
+++ b/README.md
@@ -39,49 +39,51 @@ For more ways to install the CLI, see [this section](#more-ways-to-install-the-c
 Usage: datadog-ci <command> <subcommand> [options]
 ```
 
-The following values are available for each `<command>` and `<subcommand>`. See the corresponding documentation for more details:
+The following values are available for each `<command>` and `<subcommand>`.
+
+See each command's corresponding README for more details, or click on 🔗 to see the related documentation page.
 
 - `cloud-run`:
-  - `flare`: Troubleshoot your issues with [Cloud Run service](src/commands/cloud-run) configuration. See [documentation](https://docs.datadoghq.com/serverless/google_cloud_run).
+  - `flare`: Troubleshoot your issues with [Cloud Run service](src/commands/cloud-run) configuration. [🔗](https://docs.datadoghq.com/serverless/google_cloud_run)
 - `dsyms`:
-  - `upload`: Upload [iOS dSYM files](src/commands/dsyms) for Error Tracking (macOS only). See [documentation](https://docs.datadoghq.com/real_user_monitoring/error_tracking/ios/).
+  - `upload`: Upload [iOS dSYM files](src/commands/dsyms) for Error Tracking (macOS only). [🔗](https://docs.datadoghq.com/real_user_monitoring/error_tracking/ios/)
 - `flutter-symbols`:
-  - `upload`: Upload [Flutter symbols](src/commands/flutter-symbols) for Error Tracking. See [documentation](https://docs.datadoghq.com/real_user_monitoring/error_tracking/flutter/).
+  - `upload`: Upload [Flutter symbols](src/commands/flutter-symbols) for Error Tracking. [🔗](https://docs.datadoghq.com/real_user_monitoring/error_tracking/flutter/)
 - `git-metadata`:
-  - `upload`: Upload [Git metadata](src/commands/git-metadata). See [documentation](https://docs.datadoghq.com/integrations/guide/source-code-integration/).
+  - `upload`: Upload [Git metadata](src/commands/git-metadata). [🔗](https://docs.datadoghq.com/integrations/guide/source-code-integration/)
 - `junit`:
-  - `upload`: Upload [JUnit test reports](src/commands/junit). See [documentation](https://docs.datadoghq.com/tests/setup/junit_xml/).
+  - `upload`: Upload [JUnit test reports](src/commands/junit). [🔗](https://docs.datadoghq.com/tests/setup/junit_xml/)
 - `lambda`:
   - `flare`: Troubleshoot your issues with Datadog monitoring on your [AWS Lambda functions](src/commands/lambda).
   - `instrument`: Instrument [AWS Lambda functions](src/commands/lambda).
   - `uninstrument`: Uninstrument [AWS Lambda functions](src/commands/lambda).
-- `metric`: Add [metrics](src/commands/metric) to a CI Visibility Pipeline trace or Job span in Datadog. See [documentation](https://docs.datadoghq.com/continuous_integration/pipelines/custom_tags_and_metrics/).
+- `metric`: Add [metrics](src/commands/metric) to a CI Visibility Pipeline trace or Job span in Datadog. [🔗](https://docs.datadoghq.com/continuous_integration/pipelines/custom_tags_and_metrics/)
 - `react-native`:
-  - `codepush`: Upload [React Native CodePush sourcemaps](src/commands/react-native) for Error Tracking. See [documentation](https://docs.datadoghq.com/real_user_monitoring/mobile_and_tv_monitoring/setup/codepush/).
-  - `upload`: Upload [React Native sourcemaps](src/commands/react-native) for Error Tracking. See [documentation](https://docs.datadoghq.com/real_user_monitoring/error_tracking/reactnative/).
-  - `xcode`: Upload [React Native sourcemaps](src/commands/react-native) for Error Tracking from the XCode bundle build phase. See [documentation](https://docs.datadoghq.com/real_user_monitoring/error_tracking/reactnative/).
+  - `codepush`: Upload [React Native CodePush sourcemaps](src/commands/react-native) for Error Tracking. [🔗](https://docs.datadoghq.com/real_user_monitoring/mobile_and_tv_monitoring/setupcodepush/).
+  - `upload`: Upload [React Native sourcemaps](src/commands/react-native) for Error Tracking. [🔗](https://docs.datadoghq.com/real_user_monitoring/error_tracking/reactnative/)
+  - `xcode`: Upload [React Native sourcemaps](src/commands/react-native) for Error Tracking from the XCode bundle build phase. [🔗](https://docs.datadoghq.com/real_user_monitoring/error_trackingreactnative/).
 - `sarif`:
-  - `upload`: Upload [Static Analysis Results Interchange Format (SARIF)](src/commands/sarif) reports to Datadog. See [documentation](https://docs.datadoghq.com/static_analysis/).
+  - `upload`: Upload [Static Analysis Results Interchange Format (SARIF)](src/commands/sarif) reports to Datadog. [🔗](https://docs.datadoghq.com/static_analysis/)
 - `sourcemaps`:
-  - `upload`: Upload [JavaScript sourcemaps](src/commands/sourcemaps) for Error Tracking. See [documentation](https://docs.datadoghq.com/real_user_monitoring/browser/).
+  - `upload`: Upload [JavaScript sourcemaps](src/commands/sourcemaps) for Error Tracking. [🔗](https://docs.datadoghq.com/real_user_monitoring/browser/)
 - `stepfunctions`:
-  - `instrument`: Subscribe [AWS Step Function](src/commands/stepfunctions) log groups to a Datadog Forwarder. See [documentation](https://docs.datadoghq.com/serverless/step_functions/installation/?tab=datadogcli).
+  - `instrument`: Subscribe [AWS Step Function](src/commands/stepfunctions) log groups to a Datadog Forwarder. [🔗](https://docs.datadoghq.com/serverless/step_functions/installation/tab=datadogcli).
   - `uninstrument`: Unsubscribe a [AWS Step Function](src/commands/stepfunctions) log group from the specified Datadog Forwarder.
 - `synthetics`:
-  - `run-tests`: Run [Continuous Testing tests](src/commands/synthetics) from the CI. See [documentation](https://docs.datadoghq.com/continuous_testing/).
-  - `upload-application`: Upload a new version to an [existing mobile application](src/commands/synthetics) in Datadog. See [documentation](https://docs.datadoghq.com/mobile_app_testing/).
-- `tag`: Add [custom tags](src/commands/tag) to a CI Visibility Pipeline trace or Job span in Datadog. See [documentation](https://docs.datadoghq.com/continuous_integration/pipelines/custom_tags_and_metrics/).
-- `trace`: Add [custom commands](src/commands/trace) to a CI Visibility Pipeline in Datadog. See [documentation](https://docs.datadoghq.com/continuous_integration/pipelines/custom_commands/).
+  - `run-tests`: Run [Continuous Testing tests](src/commands/synthetics) from the CI. [🔗](https://docs.datadoghq.com/continuous_testing/)
+  - `upload-application`: Upload a new version to an [existing mobile application](src/commands/synthetics) in Datadog. [🔗](https://docs.datadoghq.com/mobile_app_testing/)
+- `tag`: Add [custom tags](src/commands/tag) to a CI Visibility Pipeline trace or Job span in Datadog. [🔗](https://docs.datadoghq.com/continuous_integration/pipelines/custom_tags_and_metrics/)
+- `trace`: Add [custom commands](src/commands/trace) to a CI Visibility Pipeline in Datadog. [🔗](https://docs.datadoghq.com/continuous_integration/pipelines/custom_commands/)
 
 The following are **beta** commands, you can enable them with with `DD_BETA_COMMANDS_ENABLED=1`:
 - `deployment`:
-  - `mark`: Mark a CI job as a [deployment](src/commands/deployment). See [documentation](https://docs.datadoghq.com/continuous_delivery/).
+  - `mark`: Mark a CI job as a [deployment](src/commands/deployment). [🔗](https://docs.datadoghq.com/continuous_delivery/)
 - `dora`:
-  - `deployment`: Send a new Deployment event for [DORA Metrics](src/commands/dora) to Datadog. See [documentation](https://docs.datadoghq.com/dora_metrics/).
+  - `deployment`: Send a new Deployment event for [DORA Metrics](src/commands/dora) to Datadog. [🔗](https://docs.datadoghq.com/dora_metrics/)
 - `gate`:
-  - `evaluate`: Evaluate [Quality Gates](src/commands/gate) rules in Datadog. See [documentation](https://docs.datadoghq.com/quality_gates/).
+  - `evaluate`: Evaluate [Quality Gates](src/commands/gate) rules in Datadog. [🔗](https://docs.datadoghq.com/quality_gates/)
 - `sbom`:
-  - `upload`: Upload [Software Bill of Materials (SBOM)](src/commands/sbom) files to Datadog. See [documentation](https://docs.datadoghq.com/static_analysis/).
+  - `upload`: Upload [Software Bill of Materials (SBOM)](src/commands/sbom) files to Datadog. [🔗](https://docs.datadoghq.com/static_analysis/)
 
 ## More ways to install the CLI
 

--- a/README.md
+++ b/README.md
@@ -52,139 +52,6 @@ The following values are available for each `<command>`. See the corresponding d
 - `tag`: [Tag](src/commands/tag)
 - `trace`: [Trace](src/commands/trace)
 
-## Contributing
-
-Pull requests for bug fixes are welcome, but before submitting new features or changes to current functionality, [open an issue](https://github.com/DataDog/datadog-ci/issues/new)
-and discuss your ideas or propose the changes you wish to make. After a resolution is reached, a PR can be submitted for review.
-
-### Running command in development environment
-
-When developing the tool, it is possible to run commands using `yarn launch`. It relies on `ts-node`, so does not require building the project for every new change.
-
-```bash
-yarn launch synthetics run-tests --config dev/global.config.json
-```
-
-### Framework and libraries used
-
-- [clipanion](https://github.com/arcanis/clipanion): CLI library to handle the different commands.
-- [eslint](https://github.com/eslint/eslint): Linting ([.eslintrc.js](/.eslintrc.js)).
-- [jest](https://github.com/facebook/jest): Tests are written in Jest.
-- [volta](https://github.com/volta-cli/volta): NodeJS and yarn versioning.
-
-### Repository structure
-
-Commands are stored in the [src/commands](src/commands) folder.
-
-The skeleton of a command is composed of a README, an `index.ts` and a folder for the tests.
-
-```bash
-src/
-└── commands/
-    └── fakeCommand/
-         ├── __tests__/
-         │   └── index.test.ts
-         ├── README.md
-         └── index.ts
-```
-
-Documentation of the command must be placed in the README.md file, the [current README](/README.md) must be updated to link to the new command README.
-
-The `index.ts` file must export classes extending the `Command` class of `clipanion`. The commands of all `src/commands/*/index.ts` files will then be imported and made available in the `datadog-ci` tool.
-
-A sample `index.ts` file for a new command would be:
-
-```typescript
-import {Command} from 'clipanion'
-
-export class HelloWorldCommand extends Command {
-  public async execute() {
-    this.context.stdout.write('Hello world!')
-  }
-}
-
-module.exports = [HelloWorldCommand]
-```
-
-Lastly, test files must be created in the `__tests__/` folder. `jest` is used to run the tests and a CI has been set using GitHub Actions to ensure all tests are passing when merging a Pull Request.
-
-The tests can then be launched through the `yarn test` command, it will find all files with a filename ending in `.test.ts` in the repo and execute them.
-
-### Continuous Integration tests
-
-The CI performs tests to avoid regressions by building the project, running unit tests and running one end-to-end test.
-
-The end-to-end test installs the package in a new project, configures it by using files in the `.github/workflows/e2e` folder, and runs a `synthetics run-tests` command in a Datadog org (such as `Synthetics E2E Testing Org`) to verify the command is able to perform a test.
-
-The Synthetic tests that are run include a browser test (with a test ID of `neg-qw9-eut`) and an API test (with a test ID of `v5u-56k-hgk`). Both tests load a page which outputs the headers of the request and verifies the `X-Fake-Header` header is present. This header is configured as an override in the `.github/workflows/e2e/test.synthetics.json` file. The API and application keys used by the command are stored in GitHub Secrets named `datadog_api_key` and `datadog_app_key`.
-
-The goal of this test is to verify the command is able to run tests and wait for their results as expected as well as handling configuration overrides.
-
-### Workflow
-
-```bash
-# Compile and watch
-yarn watch
-
-# Run the tests
-yarn test
-
-# Build code
-yarn build
-
-# Make bin executable
-yarn prepack
-```
-
-#### Release Process
-
-<details>
-  <summary>Instructions</summary>
-
-To release a new version of `datadog-ci`:
-
-1. Create a new branch for the version upgrade.
-2. Update the `package.json` version to `X.X.X`, commit the change `vX.X.X` and tag it with `git tag vX.X.X`.
-   - You may refer to [Semantic Versioning](https://semver.org/#summary) to determine what level to increment.
-4. Push the branch **along with the tag** with `git push --tags origin name-of-the-branch`, create a PR, and get at least one approval.
-   - [Create a draft GitHub Release (prefilled link)](https://github.com/DataDog/datadog-ci/releases/new?title=%3Csame-as-tag%3E&body=%3C!--%20Use%20the%20%22Generate%20release%20notes%22%20button%20at%20the%20top%20right,%20then%20categorize%20the%20changes%20--%3E) and **save it as a draft**.
-   - Please categorize the changes by product or "Documentation" / "Dependencies" / "Chores". You can find commands grouped by product in the [`.github/CODEOWNERS`](https://github.com/DataDog/datadog-ci/blob/master/.github/CODEOWNERS) file.
-   - Copy the categorized release notes, and paste them in the description of your PR. This ensures the feature PRs have a link to your release PR.
-   - See this [example PR](https://github.com/DataDog/datadog-ci/pull/1047).
-5. Once you've received at least one approval, merge the PR **with the "Create a merge commit" strategy**.
-   - You may notice that some **_GitLab_** jobs are pending, this is expected (see **step 7**). You can merge the PR when *only those jobs* are left.
-   - The "Create a merge commit" strategy is required for **step 7**, and for the GitHub Release to point to an existing commit once the PR is merged.
-6. Go back to your draft GitHub Release, and publish it.
-7. Once the release is published, [this GitHub Workflow](https://github.com/DataDog/datadog-ci/actions/workflows/release.yml) publishes the NPM package and adds binaries to the release's assets. Wait for it to succeed.
-8. When the NPM package is published, go to the [_GitLab_ pipelines](https://gitlab.ddbuild.io/DataDog/datadog-ci/-/pipelines?scope=tags&status=manual), find the pipeline for your tag, and start the `build` stage to run the Docker image build jobs.
-   - Make sure all the jobs and downstream jobs succeed.
-
-Thanks for creating a release! 🎉
-
-</details>
-
-#### Pre-Release Process
-
-<details>
-  <summary>Instructions</summary>
-
-To create a pre-release or releasing in a different channel:
-
-1. Create a new branch for the channel you want to release to (`alpha`, `beta`, and more).
-2. Create a PR for your feature branch with the channel branch as a base.
-3. Pick a version following this format: `<version>-<channel>`. For example, `0.10.9-alpha`, `1-beta`, and more.
-4. Update the `version` field in `package.json`.
-5. Once you've received at least one approval, merge the Pull Request **with the "Create a merge commit" strategy**.
-6. Create a [GitHub Release](https://github.com/DataDog/datadog-ci/releases/new?target=alpha&tag=0.10.9-alpha&prerelease=1&title=Alpha+prerelease):
-   - Target the channel branch.
-   - Pick a tag based on your version `<version>-<channel>`.
-   - Check the `This is a pre-release` checkbox.
-7. Publish the release and an action publishes it on npm.
-
-<img src="./assets/pre-release.png" width="500"/>
-
-</details>
-
 ## More ways to install the CLI
 
 ### Standalone binary (**beta**)
@@ -247,6 +114,10 @@ Optionally, you can use the `VERSION` build argument to build an image for a spe
 ```sh
 docker build --build-arg "VERSION=v1.14" --t datadog-ci .
 ```
+
+## Development
+
+Before contributing to this open source project, read our [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -59,16 +59,16 @@ See each command's corresponding README for more details, or click on 🔗 to se
   - `uninstrument`: Uninstrument [AWS Lambda functions](src/commands/lambda).
 - `metric`: Add [metrics](src/commands/metric) to a CI Visibility Pipeline trace or Job span in Datadog. [🔗](https://docs.datadoghq.com/continuous_integration/pipelines/custom_tags_and_metrics/)
 - `react-native`:
-  - `codepush`: Upload [React Native CodePush sourcemaps](src/commands/react-native) for Error Tracking. [🔗](https://docs.datadoghq.com/real_user_monitoring/mobile_and_tv_monitoring/setupcodepush/).
+  - `codepush`: Upload [React Native CodePush sourcemaps](src/commands/react-native) for Error Tracking. [🔗](https://docs.datadoghq.com/real_user_monitoring/mobile_and_tv_monitoring/setupcodepush/)
   - `upload`: Upload [React Native sourcemaps](src/commands/react-native) for Error Tracking. [🔗](https://docs.datadoghq.com/real_user_monitoring/error_tracking/reactnative/)
-  - `xcode`: Upload [React Native sourcemaps](src/commands/react-native) for Error Tracking from the XCode bundle build phase. [🔗](https://docs.datadoghq.com/real_user_monitoring/error_trackingreactnative/).
+  - `xcode`: Upload [React Native sourcemaps](src/commands/react-native) for Error Tracking from the XCode bundle build phase. [🔗](https://docs.datadoghq.com/real_user_monitoring/error_trackingreactnative/)
 - `sarif`:
   - `upload`: Upload [Static Analysis Results Interchange Format (SARIF)](src/commands/sarif) reports to Datadog. [🔗](https://docs.datadoghq.com/static_analysis/)
 - `sourcemaps`:
   - `upload`: Upload [JavaScript sourcemaps](src/commands/sourcemaps) for Error Tracking. [🔗](https://docs.datadoghq.com/real_user_monitoring/browser/)
 - `stepfunctions`:
-  - `instrument`: Subscribe [AWS Step Function](src/commands/stepfunctions) log groups to a Datadog Forwarder. [🔗](https://docs.datadoghq.com/serverless/step_functions/installation/tab=datadogcli).
-  - `uninstrument`: Unsubscribe a [AWS Step Function](src/commands/stepfunctions) log group from the specified Datadog Forwarder.
+  - `instrument`: Subscribe [AWS Step Function](src/commands/stepfunctions) log groups to a Datadog Forwarder. [🔗](https://docs.datadoghq.com/serverless/step_functions/installation/tab=datadogcli)
+  - `uninstrument`: Unsubscribe a [AWS Step Function](src/commands/stepfunctions) log group from the specified Datadog Forwarder. [🔗](https://docs.datadoghq.com/serverless/step_functions/installation/tab=datadogcli)
 - `synthetics`:
   - `run-tests`: Run [Continuous Testing tests](src/commands/synthetics) from the CI. [🔗](https://docs.datadoghq.com/continuous_testing/)
   - `upload-application`: Upload a new version to an [existing mobile application](src/commands/synthetics) in Datadog. [🔗](https://docs.datadoghq.com/mobile_app_testing/)

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ See each command's corresponding README for more details, or click on 🔗 to se
 - `lambda`:
   - `flare`: Troubleshoot your issues with Datadog instrumentation on your [AWS Lambda functions](src/commands/lambda).
   - `instrument`: Apply Datadog instrumentation to the given [AWS Lambda functions](src/commands/lambda).
-  - `uninstrument`: Revert Datadog instrumentation to the given [AWS Lambda functions](src/commands/lambda).
+  - `uninstrument`: Revert Datadog instrumentation from the given [AWS Lambda functions](src/commands/lambda).
 - `metric`: Add [metrics](src/commands/metric) to a CI Visibility Pipeline trace or Job span in Datadog. [🔗](https://docs.datadoghq.com/continuous_integration/pipelines/custom_tags_and_metrics/)
 - `react-native`:
   - `codepush`: Upload [React Native CodePush sourcemaps](src/commands/react-native) for Error Tracking. [🔗](https://docs.datadoghq.com/real_user_monitoring/mobile_and_tv_monitoring/setupcodepush/)

--- a/README.md
+++ b/README.md
@@ -41,49 +41,49 @@ Usage: datadog-ci <command> <subcommand> [options]
 
 The following values are available for each `<command>` and `<subcommand>`.
 
-See each command's corresponding README for more details, or click on 🔗 to see the related documentation page.
+See each command's linked README for more details, or click on [📚](https://docs.datadoghq.com/) to see the related documentation page.
 
 - `cloud-run`:
-  - `flare`: Troubleshoot your issues with [Cloud Run service](src/commands/cloud-run) configuration. [🔗](https://docs.datadoghq.com/serverless/google_cloud_run)
+  - `flare`: Troubleshoot your issues with [Cloud Run service](src/commands/cloud-run) configuration. [📚](https://docs.datadoghq.com/serverless/google_cloud_run)
 - `dsyms`:
-  - `upload`: Upload [iOS dSYM files](src/commands/dsyms) for Error Tracking (macOS only). [🔗](https://docs.datadoghq.com/real_user_monitoring/error_tracking/ios/)
+  - `upload`: Upload [iOS dSYM files](src/commands/dsyms) for Error Tracking (macOS only). [📚](https://docs.datadoghq.com/real_user_monitoring/error_tracking/ios/)
 - `flutter-symbols`:
-  - `upload`: Upload [Flutter symbols](src/commands/flutter-symbols) for Error Tracking. [🔗](https://docs.datadoghq.com/real_user_monitoring/error_tracking/flutter/)
+  - `upload`: Upload [Flutter symbols](src/commands/flutter-symbols) for Error Tracking. [📚](https://docs.datadoghq.com/real_user_monitoring/error_tracking/flutter/)
 - `git-metadata`:
-  - `upload`: Upload [Git metadata](src/commands/git-metadata) for Source Code Integration. [🔗](https://docs.datadoghq.com/integrations/guide/source-code-integration/)
+  - `upload`: Upload [Git metadata](src/commands/git-metadata) for Source Code Integration. [📚](https://docs.datadoghq.com/integrations/guide/source-code-integration/)
 - `junit`:
-  - `upload`: Upload [JUnit test reports](src/commands/junit) for Test Visibility. [🔗](https://docs.datadoghq.com/tests/setup/junit_xml/)
+  - `upload`: Upload [JUnit test reports](src/commands/junit) for Test Visibility. [📚](https://docs.datadoghq.com/tests/setup/junit_xml/)
 - `lambda`:
   - `flare`: Troubleshoot your issues with Datadog instrumentation on your [AWS Lambda functions](src/commands/lambda).
   - `instrument`: Apply Datadog instrumentation to the given [AWS Lambda functions](src/commands/lambda).
   - `uninstrument`: Revert Datadog instrumentation from the given [AWS Lambda functions](src/commands/lambda).
-- `metric`: Add [metrics](src/commands/metric) to a CI Visibility Pipeline trace or Job span in Datadog. [🔗](https://docs.datadoghq.com/continuous_integration/pipelines/custom_tags_and_metrics/)
+- `metric`: Add [metrics](src/commands/metric) to a CI Visibility Pipeline trace or Job span in Datadog. [📚](https://docs.datadoghq.com/continuous_integration/pipelines/custom_tags_and_metrics/)
 - `react-native`:
-  - `codepush`: Upload [React Native CodePush sourcemaps](src/commands/react-native) for Error Tracking. [🔗](https://docs.datadoghq.com/real_user_monitoring/mobile_and_tv_monitoring/setupcodepush/)
-  - `upload`: Upload [React Native sourcemaps](src/commands/react-native) for Error Tracking. [🔗](https://docs.datadoghq.com/real_user_monitoring/error_tracking/reactnative/)
-  - `xcode`: Upload [React Native sourcemaps](src/commands/react-native) for Error Tracking from the XCode bundle build phase. [🔗](https://docs.datadoghq.com/real_user_monitoring/error_trackingreactnative/)
+  - `codepush`: Upload [React Native CodePush sourcemaps](src/commands/react-native) for Error Tracking. [📚](https://docs.datadoghq.com/real_user_monitoring/mobile_and_tv_monitoring/setupcodepush/)
+  - `upload`: Upload [React Native sourcemaps](src/commands/react-native) for Error Tracking. [📚](https://docs.datadoghq.com/real_user_monitoring/error_tracking/reactnative/)
+  - `xcode`: Upload [React Native sourcemaps](src/commands/react-native) for Error Tracking from the XCode bundle build phase. [📚](https://docs.datadoghq.com/real_user_monitoring/error_trackingreactnative/)
 - `sarif`:
-  - `upload`: Upload [Static Analysis Results Interchange Format (SARIF)](src/commands/sarif) reports to Datadog. [🔗](https://docs.datadoghq.com/static_analysis/)
+  - `upload`: Upload [Static Analysis Results Interchange Format (SARIF)](src/commands/sarif) reports to Datadog. [📚](https://docs.datadoghq.com/static_analysis/)
 - `sourcemaps`:
-  - `upload`: Upload [JavaScript sourcemaps](src/commands/sourcemaps) for Error Tracking. [🔗](https://docs.datadoghq.com/real_user_monitoring/browser/)
+  - `upload`: Upload [JavaScript sourcemaps](src/commands/sourcemaps) for Error Tracking. [📚](https://docs.datadoghq.com/real_user_monitoring/browser/)
 - `stepfunctions`:
-  - `instrument`: Instrument [AWS Step Function](src/commands/stepfunctions) with Datadog to get logs and traces. [🔗](https://docs.datadoghq.com/serverless/step_functions/installation/tab=datadogcli)
-  - `uninstrument`: Uninstrument [AWS Step Function](src/commands/stepfunctions). [🔗](https://docs.datadoghq.com/serverless/step_functions/installation/tab=datadogcli)
+  - `instrument`: Instrument [AWS Step Function](src/commands/stepfunctions) with Datadog to get logs and traces. [📚](https://docs.datadoghq.com/serverless/step_functions/installation/tab=datadogcli)
+  - `uninstrument`: Uninstrument [AWS Step Function](src/commands/stepfunctions). [📚](https://docs.datadoghq.com/serverless/step_functions/installation/tab=datadogcli)
 - `synthetics`:
-  - `run-tests`: Run [Continuous Testing tests](src/commands/synthetics) from the CI. [🔗](https://docs.datadoghq.com/continuous_testing/)
-  - `upload-application`: Upload a new version to an [existing mobile application](src/commands/synthetics) in Datadog. [🔗](https://docs.datadoghq.com/mobile_app_testing/)
-- `tag`: Add [custom tags](src/commands/tag) to a CI Visibility Pipeline trace or Job span in Datadog. [🔗](https://docs.datadoghq.com/continuous_integration/pipelines/custom_tags_and_metrics/)
-- `trace`: Add [custom commands](src/commands/trace) to a CI Visibility Pipeline in Datadog. [🔗](https://docs.datadoghq.com/continuous_integration/pipelines/custom_commands/)
+  - `run-tests`: Run [Continuous Testing tests](src/commands/synthetics) from the CI. [📚](https://docs.datadoghq.com/continuous_testing/)
+  - `upload-application`: Upload a new version to an [existing mobile application](src/commands/synthetics) in Datadog. [📚](https://docs.datadoghq.com/mobile_app_testing/)
+- `tag`: Add [custom tags](src/commands/tag) to a CI Visibility Pipeline trace or Job span in Datadog. [📚](https://docs.datadoghq.com/continuous_integration/pipelines/custom_tags_and_metrics/)
+- `trace`: Add [custom commands](src/commands/trace) to a CI Visibility Pipeline in Datadog. [📚](https://docs.datadoghq.com/continuous_integration/pipelines/custom_commands/)
 
 The following are **beta** commands, you can enable them with with `DD_BETA_COMMANDS_ENABLED=1`:
 - `deployment`:
-  - `mark`: Mark a CI job as a [deployment](src/commands/deployment). [🔗](https://docs.datadoghq.com/continuous_delivery/)
+  - `mark`: Mark a CI job as a [deployment](src/commands/deployment). [📚](https://docs.datadoghq.com/continuous_delivery/)
 - `dora`:
-  - `deployment`: Send a new Deployment event for [DORA Metrics](src/commands/dora) to Datadog. [🔗](https://docs.datadoghq.com/dora_metrics/)
+  - `deployment`: Send a new Deployment event for [DORA Metrics](src/commands/dora) to Datadog. [📚](https://docs.datadoghq.com/dora_metrics/)
 - `gate`:
-  - `evaluate`: Evaluate [Quality Gates](src/commands/gate) rules in Datadog. [🔗](https://docs.datadoghq.com/quality_gates/)
+  - `evaluate`: Evaluate [Quality Gates](src/commands/gate) rules in Datadog. [📚](https://docs.datadoghq.com/quality_gates/)
 - `sbom`:
-  - `upload`: Upload [Software Bill of Materials (SBOM)](src/commands/sbom) files to Datadog. [🔗](https://docs.datadoghq.com/static_analysis/)
+  - `upload`: Upload [Software Bill of Materials (SBOM)](src/commands/sbom) files to Datadog. [📚](https://docs.datadoghq.com/static_analysis/)
 
 ## More ways to install the CLI
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ See each command's corresponding README for more details, or click on 🔗 to se
 - `flutter-symbols`:
   - `upload`: Upload [Flutter symbols](src/commands/flutter-symbols) for Error Tracking. [🔗](https://docs.datadoghq.com/real_user_monitoring/error_tracking/flutter/)
 - `git-metadata`:
-  - `upload`: Upload [Git metadata](src/commands/git-metadata). [🔗](https://docs.datadoghq.com/integrations/guide/source-code-integration/)
+  - `upload`: Upload [Git metadata](src/commands/git-metadata) for Source Code Integration. [🔗](https://docs.datadoghq.com/integrations/guide/source-code-integration/)
 - `junit`:
   - `upload`: Upload [JUnit test reports](src/commands/junit). [🔗](https://docs.datadoghq.com/tests/setup/junit_xml/)
 - `lambda`:

--- a/README.md
+++ b/README.md
@@ -39,20 +39,37 @@ For more ways to install the CLI, see [this section](#more-ways-to-install-the-c
 Usage: datadog-ci <command> <subcommand> [options]
 ```
 
-The following values are available for each `<command>`. See the corresponding documentation for more details:
+The following values are available for each `<command>` and `<subcommand>`. See the corresponding documentation for more details:
 
-- `dsyms`: [iOS dSYM Files](src/commands/dsyms/)
-- `flutter-symbols`: [Flutter Symbols](src/commands/flutter-symbols/)
-- `git-metadata`: [Git metadata](src/commands/git-metadata)
-- `junit`: [JUnit XML](src/commands/junit)
-- `lambda`: [Lambda](src/commands/lambda)
-- `metric`: [Metric](src/commands/metric)
-- `react-native`: [React Native sourcemaps](src/commands/react-native/)
-- `sourcemaps`: [Browser sourcemaps](src/commands/sourcemaps/)
-- `stepfunctions`: [Step Functions](src/commands/stepfunctions)
-- `synthetics`: [Continuous Testing](src/commands/synthetics/)
-- `tag`: [Tag](src/commands/tag)
-- `trace`: [Trace](src/commands/trace)
+- `cloud-run`:
+  - `flare`: Troubleshoot your issues with [Cloud Run service](src/commands/cloud-run) configuration. See [documentation](https://docs.datadoghq.com/serverless/google_cloud_run).
+- `dsyms`:
+  - `upload`: Upload [iOS dSYM files](src/commands/dsyms) for Error Tracking (macOS only). See [documentation](https://docs.datadoghq.com/real_user_monitoring/error_tracking/ios/).
+- `flutter-symbols`:
+  - `upload`: Upload [Flutter symbols](src/commands/flutter-symbols) for Error Tracking. See [documentation](https://docs.datadoghq.com/real_user_monitoring/error_tracking/flutter/).
+- `git-metadata`:
+  - `upload`: Upload [Git metadata](src/commands/git-metadata). See [documentation](https://docs.datadoghq.com/integrations/guide/source-code-integration/).
+- `junit`:
+  - `upload`: Upload [JUnit test reports](src/commands/junit). See [documentation](https://docs.datadoghq.com/tests/setup/junit_xml/).
+- `lambda`:
+  - `flare`: Troubleshoot your issues with Datadog monitoring on your [AWS Lambda functions](src/commands/lambda).
+  - `instrument`: Instrument [AWS Lambda functions](src/commands/lambda).
+  - `uninstrument`: Uninstrument [AWS Lambda functions](src/commands/lambda).
+- `metric`: Add [metrics](src/commands/metric) to a CI Visibility Pipeline trace or Job span in Datadog. See [documentation](https://docs.datadoghq.com/continuous_integration/pipelines/custom_tags_and_metrics/).
+- `react-native`:
+  - `xcode`: Upload [React Native sourcemaps](src/commands/react-native) for Error Tracking. See [documentation](https://docs.datadoghq.com/real_user_monitoring/error_tracking/reactnative/).
+- `sarif`:
+  - `upload`: Upload [Static Analysis Results Interchange Format (SARIF)](src/commands/sarif) reports to Datadog. See [documentation](https://docs.datadoghq.com/static_analysis/).
+- `sourcemaps`:
+  - `upload`: Upload [JavaScript sourcemaps](src/commands/sourcemaps) for Error Tracking. See [documentation](https://docs.datadoghq.com/real_user_monitoring/browser/).
+- `stepfunctions`:
+  - `instrument`: Subscribe [AWS Step Function](src/commands/stepfunctions) log groups to a Datadog Forwarder. See [documentation](https://docs.datadoghq.com/serverless/step_functions/installation/?tab=datadogcli).
+  - `uninstrument`: Unsubscribe a [AWS Step Function](src/commands/stepfunctions) log group from the specified Datadog Forwarder.
+- `synthetics`:
+  - `run-tests`: Run [Continuous Testing tests](src/commands/synthetics) from the CI. See [documentation](https://docs.datadoghq.com/continuous_testing/).
+  - `upload-application`: Upload a new version to an [existing mobile application](src/commands/synthetics) in Datadog. See [documentation](https://docs.datadoghq.com/mobile_app_testing/).
+- `tag`: Add [custom tags](src/commands/tag) to a CI Visibility Pipeline trace or Job span in Datadog. See [documentation](https://docs.datadoghq.com/continuous_integration/pipelines/custom_tags_and_metrics/).
+- `trace`: Add [custom commands](src/commands/trace) to a CI Visibility Pipeline in Datadog. See [documentation](https://docs.datadoghq.com/continuous_integration/pipelines/custom_commands/).
 
 ## More ways to install the CLI
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 [![NPM Version](https://img.shields.io/npm/v/@datadog/datadog-ci)](https://www.npmjs.com/package/@datadog/datadog-ci) ![Continuous Integration](https://github.com/DataDog/datadog-ci/workflows/Continuous%20Integration/badge.svg) [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) ![NodeJS Version](https://img.shields.io/badge/Node.js-14+-green)
 
-Execute commands with Datadog from within your Continuous Integration/Continuous Deployment scripts to perform end-to-end tests of your application before applying your changes or deploying. `datadog-ci` allows you to run Continuous Testing tests and wait for the results.
+Execute commands from your Continuous Integration (CI) and Continuous Delivery (CD) pipelines to integrate with existing Datadog products.
+
+See the [Usage section](#usage) for a list of available commands.
 
 ## How to install the CLI
 

--- a/README.md
+++ b/README.md
@@ -36,54 +36,77 @@ For more ways to install the CLI, see [this section](#more-ways-to-install-the-c
 ## Usage
 
 ```bash
-Usage: datadog-ci <command> <subcommand> [options]
+Usage: datadog-ci <command> [<subcommand>] [options]
 ```
 
-The following values are available for each `<command>` and `<subcommand>`.
+The following values are available for each `<command>` and (optionally) `<subcommand>`.
 
 See each command's linked README for more details, or click on [📚](https://docs.datadoghq.com/) to see the related documentation page.
 
-- `cloud-run`:
-  - `flare`: Troubleshoot your issues with [Cloud Run service](src/commands/cloud-run) configuration. [📚](https://docs.datadoghq.com/serverless/google_cloud_run)
-- `dsyms`:
-  - `upload`: Upload [iOS dSYM files](src/commands/dsyms) for Error Tracking (macOS only). [📚](https://docs.datadoghq.com/real_user_monitoring/error_tracking/ios/)
-- `flutter-symbols`:
-  - `upload`: Upload [Flutter symbols](src/commands/flutter-symbols) for Error Tracking. [📚](https://docs.datadoghq.com/real_user_monitoring/error_tracking/flutter/)
-- `git-metadata`:
-  - `upload`: Upload [Git metadata](src/commands/git-metadata) for Source Code Integration. [📚](https://docs.datadoghq.com/integrations/guide/source-code-integration/)
-- `junit`:
-  - `upload`: Upload [JUnit test reports](src/commands/junit) for Test Visibility. [📚](https://docs.datadoghq.com/tests/setup/junit_xml/)
-- `lambda`:
-  - `flare`: Troubleshoot your issues with Datadog instrumentation on your [AWS Lambda functions](src/commands/lambda).
-  - `instrument`: Apply Datadog instrumentation to the given [AWS Lambda functions](src/commands/lambda).
-  - `uninstrument`: Revert Datadog instrumentation from the given [AWS Lambda functions](src/commands/lambda).
-- `metric`: Add [metrics](src/commands/metric) to a CI Visibility Pipeline trace or Job span in Datadog. [📚](https://docs.datadoghq.com/continuous_integration/pipelines/custom_tags_and_metrics/)
-- `react-native`:
-  - `codepush`: Upload [React Native CodePush sourcemaps](src/commands/react-native) for Error Tracking. [📚](https://docs.datadoghq.com/real_user_monitoring/mobile_and_tv_monitoring/setupcodepush/)
-  - `upload`: Upload [React Native sourcemaps](src/commands/react-native) for Error Tracking. [📚](https://docs.datadoghq.com/real_user_monitoring/error_tracking/reactnative/)
-  - `xcode`: Upload [React Native sourcemaps](src/commands/react-native) for Error Tracking from the XCode bundle build phase. [📚](https://docs.datadoghq.com/real_user_monitoring/error_trackingreactnative/)
-- `sarif`:
-  - `upload`: Upload [Static Analysis Results Interchange Format (SARIF)](src/commands/sarif) reports to Datadog. [📚](https://docs.datadoghq.com/static_analysis/)
-- `sourcemaps`:
-  - `upload`: Upload [JavaScript sourcemaps](src/commands/sourcemaps) for Error Tracking. [📚](https://docs.datadoghq.com/real_user_monitoring/guide/upload-javascript-source-maps)
-- `stepfunctions`:
-  - `instrument`: Instrument [AWS Step Function](src/commands/stepfunctions) with Datadog to get logs and traces. [📚](https://docs.datadoghq.com/serverless/step_functions/installation/tab=datadogcli)
-  - `uninstrument`: Uninstrument [AWS Step Function](src/commands/stepfunctions). [📚](https://docs.datadoghq.com/serverless/step_functions/installation/tab=datadogcli)
-- `synthetics`:
-  - `run-tests`: Run [Continuous Testing tests](src/commands/synthetics) from the CI. [📚](https://docs.datadoghq.com/continuous_testing/)
-  - `upload-application`: Upload a new version to an [existing mobile application](src/commands/synthetics) in Datadog. [📚](https://docs.datadoghq.com/mobile_app_testing/)
-- `tag`: Add [custom tags](src/commands/tag) to a CI Visibility Pipeline trace or Job span in Datadog. [📚](https://docs.datadoghq.com/continuous_integration/pipelines/custom_tags_and_metrics/)
-- `trace`: Add [custom commands](src/commands/trace) to a CI Visibility Pipeline in Datadog. [📚](https://docs.datadoghq.com/continuous_integration/pipelines/custom_commands/)
+#### `cloud-run`
+- `flare`: Troubleshoot your issues with [Cloud Run service](src/commands/cloud-run) configuration. [📚](https://docs.datadoghq.com/serverless/google_cloud_run)
+
+#### `dsyms`
+- `upload`: Upload [iOS dSYM files](src/commands/dsyms) for Error Tracking (macOS only). [📚](https://docs.datadoghq.com/real_user_monitoring/error_tracking/ios/)
+
+#### `flutter-symbols`
+- `upload`: Upload [Flutter symbols](src/commands/flutter-symbols) for Error Tracking. [📚](https://docs.datadoghq.com/real_user_monitoring/error_tracking/flutter/)
+
+#### `git-metadata`
+- `upload`: Upload [Git metadata](src/commands/git-metadata) for Source Code Integration. [📚](https://docs.datadoghq.com/integrations/guide/source-code-integration/)
+
+#### `junit`
+- `upload`: Upload [JUnit test reports](src/commands/junit) for Test Visibility. [📚](https://docs.datadoghq.com/tests/setup/junit_xml/)
+
+#### `lambda`
+- `flare`: Troubleshoot your issues with Datadog instrumentation on your [AWS Lambda functions](src/commands/lambda).
+- `instrument`: Apply Datadog instrumentation to the given [AWS Lambda functions](src/commands/lambda).
+- `uninstrument`: Revert Datadog instrumentation from the given [AWS Lambda functions](src/commands/lambda).
+
+#### `metric`
+
+- Add [metrics](src/commands/metric) to a CI Visibility Pipeline trace or Job span in Datadog. [📚](https://docs.datadoghq.com/continuous_integration/pipelines/custom_tags_and_metrics/)
+
+#### `react-native`
+- `codepush`: Upload [React Native CodePush sourcemaps](src/commands/react-native) for Error Tracking. [📚](https://docs.datadoghq.com/real_user_monitoring/mobile_and_tv_monitoring/setupcodepush/)
+- `upload`: Upload [React Native sourcemaps](src/commands/react-native) for Error Tracking. [📚](https://docs.datadoghq.com/real_user_monitoring/error_tracking/reactnative/)
+- `xcode`: Upload [React Native sourcemaps](src/commands/react-native) for Error Tracking from the XCode bundle build phase. [📚](https://docs.datadoghq.com/real_user_monitoring/error_trackingreactnative/)
+
+#### `sarif`
+- `upload`: Upload [Static Analysis Results Interchange Format (SARIF)](src/commands/sarif) reports to Datadog. [📚](https://docs.datadoghq.com/static_analysis/)
+
+#### `sourcemaps`
+- `upload`: Upload [JavaScript sourcemaps](src/commands/sourcemaps) for Error Tracking. [📚](https://docs.datadoghq.com/real_user_monitoring/guide/upload-javascript-source-maps)
+
+#### `stepfunctions`
+- `instrument`: Instrument [AWS Step Function](src/commands/stepfunctions) with Datadog to get logs and traces. [📚](https://docs.datadoghq.com/serverless/step_functions/installation/tab=datadogcli)
+- `uninstrument`: Uninstrument [AWS Step Function](src/commands/stepfunctions). [📚](https://docs.datadoghq.com/serverless/step_functions/installation/tab=datadogcli)
+
+#### `synthetics`
+- `run-tests`: Run [Continuous Testing tests](src/commands/synthetics) from the CI. [📚](https://docs.datadoghq.com/continuous_testing/)
+- `upload-application`: Upload a new version to an [existing mobile application](src/commands/synthetics) in Datadog. [📚](https://docs.datadoghq.com/mobile_app_testing/)
+
+#### `tag`
+- Add [custom tags](src/commands/tag) to a CI Visibility Pipeline trace or Job span in Datadog. [📚](https://docs.datadoghq.com/continuous_integration/pipelines/custom_tags_and_metrics/)
+
+#### `trace`
+- Add [custom commands](src/commands/trace) to a CI Visibility Pipeline in Datadog. [📚](https://docs.datadoghq.com/continuous_integration/pipelines/custom_commands/)
+
+### Beta commands
 
 The following are **beta** commands, you can enable them with with `DD_BETA_COMMANDS_ENABLED=1`:
-- `deployment`:
-  - `mark`: Mark a CI job as a [deployment](src/commands/deployment). [📚](https://docs.datadoghq.com/continuous_delivery/)
-- `dora`:
-  - `deployment`: Send a new Deployment event for [DORA Metrics](src/commands/dora) to Datadog. [📚](https://docs.datadoghq.com/dora_metrics/)
-- `gate`:
-  - `evaluate`: Evaluate [Quality Gates](src/commands/gate) rules in Datadog. [📚](https://docs.datadoghq.com/quality_gates/)
-- `sbom`:
-  - `upload`: Upload [Software Bill of Materials (SBOM)](src/commands/sbom) files to Datadog. [📚](https://docs.datadoghq.com/static_analysis/)
+
+#### `deployment`
+- `mark`: Mark a CI job as a [deployment](src/commands/deployment). [📚](https://docs.datadoghq.com/continuous_delivery/)
+
+#### `dora`
+- `deployment`: Send a new Deployment event for [DORA Metrics](src/commands/dora) to Datadog. [📚](https://docs.datadoghq.com/dora_metrics/)
+
+#### `gate`
+- `evaluate`: Evaluate [Quality Gates](src/commands/gate) rules in Datadog. [📚](https://docs.datadoghq.com/quality_gates/)
+
+#### `sbom`
+- `upload`: Upload [Software Bill of Materials (SBOM)](src/commands/sbom) files to Datadog. [📚](https://docs.datadoghq.com/static_analysis/)
 
 ## More ways to install the CLI
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ See each command's corresponding README for more details, or click on 🔗 to se
 - `git-metadata`:
   - `upload`: Upload [Git metadata](src/commands/git-metadata) for Source Code Integration. [🔗](https://docs.datadoghq.com/integrations/guide/source-code-integration/)
 - `junit`:
-  - `upload`: Upload [JUnit test reports](src/commands/junit). [🔗](https://docs.datadoghq.com/tests/setup/junit_xml/)
+  - `upload`: Upload [JUnit test reports](src/commands/junit) for Test Visibility. [🔗](https://docs.datadoghq.com/tests/setup/junit_xml/)
 - `lambda`:
   - `flare`: Troubleshoot your issues with Datadog instrumentation on your [AWS Lambda functions](src/commands/lambda).
   - `instrument`: Apply Datadog instrumentation to the given [AWS Lambda functions](src/commands/lambda).

--- a/src/__tests__/cli.test.ts
+++ b/src/__tests__/cli.test.ts
@@ -1,6 +1,9 @@
 import {Builtins, CommandClass} from 'clipanion'
 
-import {cli} from '../cli'
+// Test all commands, including beta ones.
+process.env.DD_BETA_COMMANDS_ENABLED = '1'
+
+import {cli, BETA_COMMANDS} from '../cli'
 
 const builtins: CommandClass[] = [Builtins.HelpCommand, Builtins.VersionCommand]
 
@@ -11,7 +14,8 @@ describe('cli', () => {
 
     const cases: [string, [string, CommandClass][]][] = Object.entries(
       userDefinedCommands.reduce((acc, command) => {
-        const commandName = command.paths?.[0][0] || 'unknown' // e.g. synthetics
+        const commandRootPath = command.paths?.[0][0] || 'unknown' // e.g. synthetics
+        const commandName = BETA_COMMANDS.includes(commandRootPath) ? `${commandRootPath} (beta)` : commandRootPath
         const subcommandName = command.paths?.[0].slice(1).join(' ') || '<root>' // e.g. run-tests
         const newCase: [string, CommandClass] = [subcommandName, command]
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,7 +5,7 @@ import {CommandClass} from 'clipanion/lib/advanced/Command'
 
 import {version} from './helpers/version'
 
-const BETA_COMMANDS = ['gate', 'sbom', 'dora', 'deployment']
+export const BETA_COMMANDS = ['gate', 'sbom', 'dora', 'deployment']
 
 const onError = (err: any) => {
   console.log(err)

--- a/src/commands/cloud-run/README.md
+++ b/src/commands/cloud-run/README.md
@@ -13,7 +13,7 @@ You must have valid [GCP credentials][1] configured with access to the Lambda an
 Expose these environment variables in the environment where you are running `datadog-ci cloud-run flare`:
 
 | Environment Variable | Description                                                                                                                                                                                                                                      | Example                          |
-|----------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------|
+| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------- |
 | `DD_API_KEY`         | Datadog API Key. Used to attach the flare files to your Zendesk ticket. For more information about getting a Datadog API key, see the [API key documentation][2].                                                                                | `export DD_API_KEY=<API_KEY>`    |
 | `DD_SITE`            | Optional. Set which Datadog site to send the flare for lower latency. Possible values are  `datadoghq.com` , `datadoghq.eu` , `us3.datadoghq.com`, `us5.datadoghq.com`, `ap1.datadoghq.com`, and `ddog-gov.com`. The default is `datadoghq.com`. | `export DD_SITE="datadoghq.com"` |
 
@@ -33,17 +33,16 @@ datadog-ci cloud-run -s <service> -p <project> -r <region/location> -c <case-id>
 
 **Arguments**
 
-| Argument              | Shorthand | Description                                                                                                               | Default |
-|-----------------------|-----------|---------------------------------------------------------------------------------------------------------------------------|---------|
-| `--service`           | `-s`      | The name of the Cloud Run service.                                                                                        |         |
-| `--project`           | `-p`      | The name of the Google Cloud project where the Cloud Run service is hosted.                                               |         |
-| `--region`            | `-r`      | The region where the Cloud Run service is hosted.                                                                         |         |
-| `--case-id`           | `-c`      | The Datadog case ID to send the files to.                                                                                 |         |
-| `--email`             | `-e`      | The email associated with the specified case ID.                                                                          |         |
-| `--with-logs`         |           | Collect recent logs for the specified service.                                                                            | `false` |
+| Argument              | Shorthand | Description                                                                                                                           | Default |
+| --------------------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| `--service`           | `-s`      | The name of the Cloud Run service.                                                                                                    |         |
+| `--project`           | `-p`      | The name of the Google Cloud project where the Cloud Run service is hosted.                                                           |         |
+| `--region`            | `-r`      | The region where the Cloud Run service is hosted.                                                                                     |         |
+| `--case-id`           | `-c`      | The Datadog case ID to send the files to.                                                                                             |         |
+| `--email`             | `-e`      | The email associated with the specified case ID.                                                                                      |         |
+| `--with-logs`         |           | Collect recent logs for the specified service.                                                                                        | `false` |
 | `--start` and `--end` |           | Only gather logs within the time range (`--with-logs` must be included.) Both arguments are numbers in milliseconds since Unix Epoch. |         |
-| `--dry-run`           | `-d`      | Preview data that will be sent to Datadog support.                                                                        | `false` |
-
+| `--dry-run`           | `-d`      | Preview data that will be sent to Datadog support.                                                                                    | `false` |
 
 ## Community
 
@@ -51,3 +50,11 @@ For product feedback and questions, join the `#serverless` channel in the [Datad
 
 [1]: https://cloud.google.com/sdk/gcloud/reference/auth/login
 [2]: https://docs.datadoghq.com/account_management/api-app-keys/#api-keys
+
+## Further reading
+
+Additional helpful documentation, links, and articles:
+
+- [Learn about instrumenting Google Cloud Run][1]
+
+[1]: https://docs.datadoghq.com/serverless/google_cloud_run

--- a/src/commands/deployment/README.md
+++ b/src/commands/deployment/README.md
@@ -31,3 +31,10 @@ datadog-ci deployment mark --env prod --revision v1.1.0 --tags team:backend --no
 - `DD_API_KEY` (**required**): API key used to authenticate the requests.
 - `DD_SITE`: choose your Datadog site. For example, datadoghq.com or datadoghq.eu.
 
+## Further reading
+
+Additional helpful documentation, links, and articles:
+
+- [Learn about Continuous Delivery][1]
+
+[1]: https://docs.datadoghq.com/continuous_delivery/

--- a/src/commands/deployment/mark.ts
+++ b/src/commands/deployment/mark.ts
@@ -13,7 +13,7 @@ export class DeploymentMarkCommand extends Command {
 
   public static usage = Command.Usage({
     category: 'CI Visibility',
-    description: 'Mark a job as a deployment',
+    description: 'Mark a job as a deployment.',
     details: `
       This command will mark a job as a deployment.\n
       See README for details.

--- a/src/commands/deployment/mark.ts
+++ b/src/commands/deployment/mark.ts
@@ -13,16 +13,16 @@ export class DeploymentMarkCommand extends Command {
 
   public static usage = Command.Usage({
     category: 'CI Visibility',
-    description: 'Mark a job as a deployment.',
+    description: 'Mark a CI job as a deployment.',
     details: `
-      This command will mark a job as a deployment.\n
+      This command will mark a CI job as a deployment.\n
       See README for details.
     `,
     examples: [
-      ['Mark a job as a deployment', 'datadog-ci deployment mark'],
-      ['Mark a job as a deployment to the staging environment', 'datadog-ci deployment mark --env:staging'],
-      ['Mark a job as a rollback deployment', 'datadog-ci deployment mark --is-rollback'],
-      ['Mark a job as a deployment of the v123-456 version', 'datadog-ci deployment mark --revision:v123-456'],
+      ['Mark a CI job as a deployment', 'datadog-ci deployment mark'],
+      ['Mark a CI job as a deployment to the staging environment', 'datadog-ci deployment mark --env:staging'],
+      ['Mark a CI job as a rollback deployment', 'datadog-ci deployment mark --is-rollback'],
+      ['Mark a CI job as a deployment of the v123-456 version', 'datadog-ci deployment mark --revision:v123-456'],
     ],
   })
 

--- a/src/commands/dora/README.md
+++ b/src/commands/dora/README.md
@@ -89,3 +89,11 @@ This warning can be disabled with --skip-git but git data is required for Change
   }
 }
 ```
+
+## Further reading
+
+Additional helpful documentation, links, and articles:
+
+- [Learn about DORA Metrics][1]
+
+[1]: https://docs.datadoghq.com/dora_metrics/

--- a/src/commands/dsyms/README.md
+++ b/src/commands/dsyms/README.md
@@ -19,8 +19,6 @@ It is possible to configure the tool to use Datadog EU by defining the `DATADOG_
 
 It is also possible to override the full URL for the intake endpoint by defining the `DATADOG_DSYM_INTAKE_URL` environment variable.
 
-
-
 ### Commands
 
 #### `upload`
@@ -75,3 +73,11 @@ Command summary:
 ✅ Uploaded 5 dSYMs in 8.281 seconds.
 ✨  Done in 10.71s.
 ```
+
+## Further reading
+
+Additional helpful documentation, links, and articles:
+
+- [Learn about iOS Crash Reporting and Error Tracking][1]
+
+[1]: https://docs.datadoghq.com/real_user_monitoring/error_tracking/ios/

--- a/src/commands/flutter-symbols/README.md
+++ b/src/commands/flutter-symbols/README.md
@@ -36,21 +36,29 @@ After running `flutter build --split-debug-info=./debug-info --obfuscate`, you c
 datadog-ci flutter-symbols upload --dart-symbols-location ./debug-info --service-name com.companyname.application --ios-dsyms --android-mapping
 ```
 
-| Parameter | Condition | Description |
-|-----------|-----------|-------------|
-| `--service-name` | Required | Set as the service name you are uploading files for. Datadog uses this service name to find corresponding files based on the `service` options set when you configured the Datadog Flutter SDK for RUM.<br>By default, the Datadog Flutter SDK for RUM uses your application's bundle identifier as the service. |
-| `--flavor` | Optional | The build flavor that was built. Only one upload is needed for a specific `version`, `service`, and `flavor` combination. Subsequent uploads are ignored until one parameter changes. Defaults to `release`. |
-| `--dart-symbols-location`  | Optional  | The location of your Dart symbol files. This should be the same path specified to `--split-debug-info`. |
-| `--ios-dsyms` | Optional | Upload iOS dSYM files to Datadog. |
-| `--ios-dsyms-location` | Optional | Specify the location of iOS dSYM files. By default, these are located at `./build/ios/archive/Runner.xcarchive/dSYMs`. Adding this parameter automatically sets `--ios-dsyms`. |
-| `--android-mapping` | Optional | Upload Android Proguard mapping file. This is usually only necessary if you specify `--obfuscate` as a parameter to `flutter build`. |
-| `--android-mapping-location` | Optional | Specify the location of your Android Proguard mapping file. By default, this is located at `./build/app/outputs/mapping/[flavor]/mapping.txt`. Adding this parameter automatically sets `--android-mapping`. |
-| `--web-sourcemaps` | Optional | Upload a JavaScript mapping file to Datadog. |
-| `--web-sourcemaps-location` | Optional | Specify the directory of your Flutter Web source maps. Defaults to `./build/web` |
-| `--minified-path-prefix` | Optional | For Flutter Web, a prefix common to all your source files, depending on the URL they are served from. Required if `--web-sourcemaps` is specified |
-| `--pubspec` | Optional | The location of the pubspec for this application. The pubspec is used to automatically determine the version number of the application. Defaults to the current directory. |
-| `--version` | Optional | The version of your application. This defaults to the version specified in your pubspec. Only one upload is needed for a specific `version`, `service`, and `flavor` combination. Subsequent uploads are ignored until one parameter changes. |
-| `--dry-run` | Optional | It runs the command without the final step of uploading. All other checks are performed. |
-| `--disable-git`    | Optional   | Prevents the command from invoking git in the current working directory and sending repository-related data to Datadog (such as the hash, remote URL, and paths within the repository of sources referenced in the source map). |
-| `--repository-url` | Optional | Overrides the remote repository with a custom URL. For example, `https://github.com/my-company/my-project`. |
+| Parameter                    | Condition | Description                                                                                                                                                                                                                                                                                                      |
+| ---------------------------- | --------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--service-name`             | Required  | Set as the service name you are uploading files for. Datadog uses this service name to find corresponding files based on the `service` options set when you configured the Datadog Flutter SDK for RUM.<br>By default, the Datadog Flutter SDK for RUM uses your application's bundle identifier as the service. |
+| `--flavor`                   | Optional  | The build flavor that was built. Only one upload is needed for a specific `version`, `service`, and `flavor` combination. Subsequent uploads are ignored until one parameter changes. Defaults to `release`.                                                                                                     |
+| `--dart-symbols-location`    | Optional  | The location of your Dart symbol files. This should be the same path specified to `--split-debug-info`.                                                                                                                                                                                                          |
+| `--ios-dsyms`                | Optional  | Upload iOS dSYM files to Datadog.                                                                                                                                                                                                                                                                                |
+| `--ios-dsyms-location`       | Optional  | Specify the location of iOS dSYM files. By default, these are located at `./build/ios/archive/Runner.xcarchive/dSYMs`. Adding this parameter automatically sets `--ios-dsyms`.                                                                                                                                   |
+| `--android-mapping`          | Optional  | Upload Android Proguard mapping file. This is usually only necessary if you specify `--obfuscate` as a parameter to `flutter build`.                                                                                                                                                                             |
+| `--android-mapping-location` | Optional  | Specify the location of your Android Proguard mapping file. By default, this is located at `./build/app/outputs/mapping/[flavor]/mapping.txt`. Adding this parameter automatically sets `--android-mapping`.                                                                                                     |
+| `--web-sourcemaps`           | Optional  | Upload a JavaScript mapping file to Datadog.                                                                                                                                                                                                                                                                     |
+| `--web-sourcemaps-location`  | Optional  | Specify the directory of your Flutter Web source maps. Defaults to `./build/web`                                                                                                                                                                                                                                 |
+| `--minified-path-prefix`     | Optional  | For Flutter Web, a prefix common to all your source files, depending on the URL they are served from. Required if `--web-sourcemaps` is specified                                                                                                                                                                |
+| `--pubspec`                  | Optional  | The location of the pubspec for this application. The pubspec is used to automatically determine the version number of the application. Defaults to the current directory.                                                                                                                                       |
+| `--version`                  | Optional  | The version of your application. This defaults to the version specified in your pubspec. Only one upload is needed for a specific `version`, `service`, and `flavor` combination. Subsequent uploads are ignored until one parameter changes.                                                                    |
+| `--dry-run`                  | Optional  | It runs the command without the final step of uploading. All other checks are performed.                                                                                                                                                                                                                         |
+| `--disable-git`              | Optional  | Prevents the command from invoking git in the current working directory and sending repository-related data to Datadog (such as the hash, remote URL, and paths within the repository of sources referenced in the source map).                                                                                  |
+| `--repository-url`           | Optional  | Overrides the remote repository with a custom URL. For example, `https://github.com/my-company/my-project`.                                                                                                                                                                                                      |
 
+
+## Further reading
+
+Additional helpful documentation, links, and articles:
+
+- [Learn about Flutter Crash Reporting and Error Tracking][1]
+
+[1]: https://docs.datadoghq.com/real_user_monitoring/error_tracking/flutter/

--- a/src/commands/gate/README.md
+++ b/src/commands/gate/README.md
@@ -63,3 +63,11 @@ team: backend
 
 Dry run mode is enabled. Not evaluating the rules.
 ```
+
+## Further reading
+
+Additional helpful documentation, links, and articles:
+
+- [Learn about Quality Gates][1]
+
+[1]: https://docs.datadoghq.com/quality_gates/

--- a/src/commands/git-metadata/README.md
+++ b/src/commands/git-metadata/README.md
@@ -34,9 +34,9 @@ datadog-ci git-metadata upload
 #### Limitations
 
 The repository URL is inferred from the remote named `origin` (or the first remote if none are named `origin`). The value can be overridden by using the `--repository-url` flag.
-For example: The remote `git@github.com:DataDog/example.git` will create links that point to `https://github.com/DataDog/example`.
+For example: The remote `git@github.com:Datadog/example.git` will create links that point to `https://github.com/Datadog/example`.
 
-The only repository URLs supported are the ones whose host contains: `github`, `gitlab`, `bitbucket`, or `dev.azure`. This allows DataDog to create proper URLs such as:
+The only repository URLs supported are the ones whose host contains: `github`, `gitlab`, `bitbucket`, or `dev.azure`. This allows Datadog to create proper URLs such as:
 
 | Provider        | URL                                                                                                                                                 |
 | --------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/src/commands/git-metadata/README.md
+++ b/src/commands/git-metadata/README.md
@@ -38,11 +38,11 @@ For example: The remote `git@github.com:DataDog/example.git` will create links t
 
 The only repository URLs supported are the ones whose host contains: `github`, `gitlab`, `bitbucket`, or `dev.azure`. This allows DataDog to create proper URLs such as:
 
-| Provider  | URL |
-| --- | --- |
-| GitHub / GitLab  | https://\<repository-url\>/blob/\<commit-hash\>/\<tracked-file-path\>#L\<line\> |
-| Bitbucket | https://\<repository-url\>/src/\<commit-hash\>/\<tracked-file-path\>#lines-\<line\>  |
-| Azure DevOps | https://\<repository-url\>?version=GC\<commit-hash\>&path=\<tracked-file-path\>&line=\<line\>&lineEnd=\<line + 1>&lineStartColumn=1&lineEndColumn=1 |
+| Provider        | URL                                                                                                                                                 |
+| --------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| GitHub / GitLab | https://\<repository-url\>/blob/\<commit-hash\>/\<tracked-file-path\>#L\<line\>                                                                     |
+| Bitbucket       | https://\<repository-url\>/src/\<commit-hash\>/\<tracked-file-path\>#lines-\<line\>                                                                 |
+| Azure DevOps    | https://\<repository-url\>?version=GC\<commit-hash\>&path=\<tracked-file-path\>&line=\<line\>&lineEnd=\<line + 1>&lineStartColumn=1&lineEndColumn=1 |
 
 ### End-to-end testing process
 
@@ -61,3 +61,12 @@ Reporting commit fceed94376fc50dea8ba6d6310002dcf1efcc06e from repository git@gi
 ✅ Uploaded in 0.736 seconds.
 ✨  Done in 4.27s
 ```
+
+
+## Further reading
+
+Additional helpful documentation, links, and articles:
+
+- [Learn about Source Code Integration][1]
+
+[1]: https://docs.datadoghq.com/integrations/guide/source-code-integration/

--- a/src/commands/junit/README.md
+++ b/src/commands/junit/README.md
@@ -77,3 +77,12 @@ service: example-upload
 [DRYRUN] Uploading jUnit XML test report file in src/commands/junit/__tests__/fixtures/java-report.xml
 ✅ Uploaded 1 files in 0 seconds.
 ```
+
+
+## Further reading
+
+Additional helpful documentation, links, and articles:
+
+- [Learn about Uploading JUnit test report files to Datadog][1]
+
+[1]: https://docs.datadoghq.com/tests/setup/junit_xml/

--- a/src/commands/lambda/README.md
+++ b/src/commands/lambda/README.md
@@ -66,12 +66,12 @@ You must have valid [AWS credentials][1] configured with access to the Lambda an
 
 You must expose these environment variables in the environment where you are running `datadog-ci lambda instrument`:
 
-| Environment Variable | Description | Example |
-| --- | --- | --- |
-| `DATADOG_API_KEY` | Datadog API Key. Sets the `DD_API_KEY` environment variable on your Lambda function configuration. For more information about getting a Datadog API key, see the [API key documentation][5].  | `export DATADOG_API_KEY=<API_KEY>` |
-| `DATADOG_API_KEY_SECRET_ARN` | The ARN of the secret storing the Datadog API key in AWS Secrets Manager. Sets the `DD_API_KEY_SECRET_ARN` on your Lambda function configuration. Notes: `DD_API_KEY_SECRET_ARN` is ignored when `DD_KMS_API_KEY` is set. Add the `secretsmanager:GetSecretValue` permission to the Lambda execution role. | `export DATADOG_API_KEY_SECRET_ARN=<SECRETS_MANAGER_RESOURCE_ARN>` |
-| `DATADOG_KMS_API_KEY` | Datadog API Key encrypted using KMS. Sets the `DD_KMS_API_KEY` environment variable on your Lambda function configuration. Note: `DD_API_KEY` is ignored when `DD_KMS_API_KEY` is set. | `export DATADOG_KMS_API_KEY=<KMS_ENCRYPTED_API_KEY>` |
-| `DATADOG_SITE` | Set which Datadog site to send data. Only needed when using the Datadog Lambda Extension. Possible values are  `datadoghq.com` , `datadoghq.eu` , `us3.datadoghq.com`, `us5.datadoghq.com`, `ap1.datadoghq.com`, and `ddog-gov.com`. The default is `datadoghq.com`. Sets the `DD_SITE` environment variable on your Lambda function configurations. | `export DATADOG_SITE="datadoghq.com"` |
+| Environment Variable         | Description                                                                                                                                                                                                                                                                                                                                          | Example                                                            |
+| ---------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
+| `DATADOG_API_KEY`            | Datadog API Key. Sets the `DD_API_KEY` environment variable on your Lambda function configuration. For more information about getting a Datadog API key, see the [API key documentation][5].                                                                                                                                                         | `export DATADOG_API_KEY=<API_KEY>`                                 |
+| `DATADOG_API_KEY_SECRET_ARN` | The ARN of the secret storing the Datadog API key in AWS Secrets Manager. Sets the `DD_API_KEY_SECRET_ARN` on your Lambda function configuration. Notes: `DD_API_KEY_SECRET_ARN` is ignored when `DD_KMS_API_KEY` is set. Add the `secretsmanager:GetSecretValue` permission to the Lambda execution role.                                           | `export DATADOG_API_KEY_SECRET_ARN=<SECRETS_MANAGER_RESOURCE_ARN>` |
+| `DATADOG_KMS_API_KEY`        | Datadog API Key encrypted using KMS. Sets the `DD_KMS_API_KEY` environment variable on your Lambda function configuration. Note: `DD_API_KEY` is ignored when `DD_KMS_API_KEY` is set.                                                                                                                                                               | `export DATADOG_KMS_API_KEY=<KMS_ENCRYPTED_API_KEY>`               |
+| `DATADOG_SITE`               | Set which Datadog site to send data. Only needed when using the Datadog Lambda Extension. Possible values are  `datadoghq.com` , `datadoghq.eu` , `us3.datadoghq.com`, `us5.datadoghq.com`, `ap1.datadoghq.com`, and `ddog-gov.com`. The default is `datadoghq.com`. Sets the `DD_SITE` environment variable on your Lambda function configurations. | `export DATADOG_SITE="datadoghq.com"`                              |
 
 
 ### Arguments
@@ -81,31 +81,31 @@ Configuration can be done using command-line arguments or a JSON configuration f
 #### `instrument`
 You can pass the following arguments to `instrument` to specify its behavior. These arguments will override the values set in the configuration file, if any.
 
-| Argument | Shorthand | Description | Default |
-| --- | --- | --- | --- |
-| `--function` | `-f` | The ARN of the Lambda function to be **instrumented**, or the name of the Lambda function (`--region` must be defined). | |
-| `--functions-regex` | | A regex pattern to match with the Lambda function name. | |
-| `--interactive` | `-i` | Allows the user to interactively choose how their function gets instrumented. There is no need to provide any other flags if you choose to use interactive mode since you will be prompted for the information instead. | |
-| `--region` | `-r` | Default region to use, when `--function` is specified by the function name instead of the ARN. | |
-| `--service` | | Use `--service` to group related functions belonging to similar workloads. Learn more about the `service` tag [here][8]. | |
-| `--version` | | Add the `--version` tag to correlate spikes in latency, load or errors to new versions. Learn more about the `version` tag [here][7]. | |
-| `--env` | | Use `--env` to separate out your staging, development, and production environments. Learn more about the `env` tag [here][6]. | |
-| `--extra-tags` | | Add custom tags to your Lambda function in Datadog. Must be a list of `<key>:<value>` separated by commas such as: `layer:api,team:intake`. | |
-| `--profile` | | Specify the AWS named profile credentials to use to instrument. Learn more about AWS named profiles [here][11]. |  | 
-| `--layer-version` | `-v` | Version of the Datadog Lambda Library layer to apply. This varies between runtimes. To see the latest layer version check the [JS][2] or [python][3] datadog-lambda-layer repo release notes. | |
-| `--extension-version` | `-e` | Version of the Datadog Lambda Extension layer to apply. When `extension-version` is set, make sure to export `DATADOG_API_KEY` (or if encrypted, `DATADOG_KMS_API_KEY` or `DATADOG_API_KEY_SECRET_ARN`) in your environment as well. While using `extension-version`, leave out `forwarder`. Learn more about the Lambda Extension [here][4]. | |
-| `--tracing` |  | Whether to enable dd-trace tracing on your Lambda. | `true` |
-| `--merge-xray-traces` | | Whether to join dd-trace traces to AWS X-Ray traces. Useful for tracing API Gateway spans. | `false` |
-| `--flush-metrics-to-logs` | | Whether to send metrics via the Datadog Forwarder [asynchronously][10]. If you disable this parameter, it's required to export `DATADOG_API_KEY` (or if encrypted, `DATADOG_KMS_API_KEY` or `DATADOG_API_KEY_SECRET_ARN`). | `true` |
-| `--capture-lambda-payload` | | Whether to capture and store the payload and response of a lambda invocation. | `false` |
-| `--forwarder` | | The ARN of the [datadog forwarder][9] to attach this function's LogGroup to. | |
-| `--dry-run` | `-d` | Preview changes running command would apply. | `false` |
-| `--log-level` | | Set to `debug` to see additional output from the Datadog Lambda Library and/or Lambda Extension for troubleshooting purposes. | |
-| `--source-code-integration` | `-s` | Whether to enable [Datadog Source Code Integration][12]. This will tag your lambda(s) with the Git repository URL and the latest commit hash of the current local directory. **Note**: Git repository must not be ahead of remote, and must not be dirty. | `true` |
-| `--no-source-code-integration` | | Disables Datadog Source Code Integration. | |
-| `--upload-git-metadata` | `-u` | Whether to enable Git metadata uploading, as a part of source code integration. Git metadata uploading is only required if you don't have the Datadog Github Integration installed. | `true` | 
-| `--no-upload-git-metadata` | | Disables Git metadata uploading, as a part of source code integration. Use this flag if you have the Datadog Github Integration installed, as it renders Git metadata uploading unnecessary. ||
-| `--apm-flush-deadline` | | Used to determine when to submit spans before a timeout occurs, in milliseconds. When the remaining time in an AWS Lambda invocation is less than the value set, the tracer attempts to submit the current active spans and all finished spans. Supported for NodeJS and Python. Defaults to `100` milliseconds. ||
+| Argument                       | Shorthand | Description                                                                                                                                                                                                                                                                                                                                   | Default |
+| ------------------------------ | --------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| `--function`                   | `-f`      | The ARN of the Lambda function to be **instrumented**, or the name of the Lambda function (`--region` must be defined).                                                                                                                                                                                                                       |         |
+| `--functions-regex`            |           | A regex pattern to match with the Lambda function name.                                                                                                                                                                                                                                                                                       |         |
+| `--interactive`                | `-i`      | Allows the user to interactively choose how their function gets instrumented. There is no need to provide any other flags if you choose to use interactive mode since you will be prompted for the information instead.                                                                                                                       |         |
+| `--region`                     | `-r`      | Default region to use, when `--function` is specified by the function name instead of the ARN.                                                                                                                                                                                                                                                |         |
+| `--service`                    |           | Use `--service` to group related functions belonging to similar workloads. Learn more about the `service` tag [here][8].                                                                                                                                                                                                                      |         |
+| `--version`                    |           | Add the `--version` tag to correlate spikes in latency, load or errors to new versions. Learn more about the `version` tag [here][7].                                                                                                                                                                                                         |         |
+| `--env`                        |           | Use `--env` to separate out your staging, development, and production environments. Learn more about the `env` tag [here][6].                                                                                                                                                                                                                 |         |
+| `--extra-tags`                 |           | Add custom tags to your Lambda function in Datadog. Must be a list of `<key>:<value>` separated by commas such as: `layer:api,team:intake`.                                                                                                                                                                                                   |         |
+| `--profile`                    |           | Specify the AWS named profile credentials to use to instrument. Learn more about AWS named profiles [here][11].                                                                                                                                                                                                                               |         |
+| `--layer-version`              | `-v`      | Version of the Datadog Lambda Library layer to apply. This varies between runtimes. To see the latest layer version check the [JS][2] or [python][3] datadog-lambda-layer repo release notes.                                                                                                                                                 |         |
+| `--extension-version`          | `-e`      | Version of the Datadog Lambda Extension layer to apply. When `extension-version` is set, make sure to export `DATADOG_API_KEY` (or if encrypted, `DATADOG_KMS_API_KEY` or `DATADOG_API_KEY_SECRET_ARN`) in your environment as well. While using `extension-version`, leave out `forwarder`. Learn more about the Lambda Extension [here][4]. |         |
+| `--tracing`                    |           | Whether to enable dd-trace tracing on your Lambda.                                                                                                                                                                                                                                                                                            | `true`  |
+| `--merge-xray-traces`          |           | Whether to join dd-trace traces to AWS X-Ray traces. Useful for tracing API Gateway spans.                                                                                                                                                                                                                                                    | `false` |
+| `--flush-metrics-to-logs`      |           | Whether to send metrics via the Datadog Forwarder [asynchronously][10]. If you disable this parameter, it's required to export `DATADOG_API_KEY` (or if encrypted, `DATADOG_KMS_API_KEY` or `DATADOG_API_KEY_SECRET_ARN`).                                                                                                                    | `true`  |
+| `--capture-lambda-payload`     |           | Whether to capture and store the payload and response of a lambda invocation.                                                                                                                                                                                                                                                                 | `false` |
+| `--forwarder`                  |           | The ARN of the [datadog forwarder][9] to attach this function's LogGroup to.                                                                                                                                                                                                                                                                  |         |
+| `--dry-run`                    | `-d`      | Preview changes running command would apply.                                                                                                                                                                                                                                                                                                  | `false` |
+| `--log-level`                  |           | Set to `debug` to see additional output from the Datadog Lambda Library and/or Lambda Extension for troubleshooting purposes.                                                                                                                                                                                                                 |         |
+| `--source-code-integration`    | `-s`      | Whether to enable [Datadog Source Code Integration][12]. This will tag your lambda(s) with the Git repository URL and the latest commit hash of the current local directory. **Note**: Git repository must not be ahead of remote, and must not be dirty.                                                                                     | `true`  |
+| `--no-source-code-integration` |           | Disables Datadog Source Code Integration.                                                                                                                                                                                                                                                                                                     |         |
+| `--upload-git-metadata`        | `-u`      | Whether to enable Git metadata uploading, as a part of source code integration. Git metadata uploading is only required if you don't have the Datadog Github Integration installed.                                                                                                                                                           | `true`  |
+| `--no-upload-git-metadata`     |           | Disables Git metadata uploading, as a part of source code integration. Use this flag if you have the Datadog Github Integration installed, as it renders Git metadata uploading unnecessary.                                                                                                                                                  |         |
+| `--apm-flush-deadline`         |           | Used to determine when to submit spans before a timeout occurs, in milliseconds. When the remaining time in an AWS Lambda invocation is less than the value set, the tracer attempts to submit the current active spans and all finished spans. Supported for NodeJS and Python. Defaults to `100` milliseconds.                              |         |
 <br />
 
 #### `uninstrument`
@@ -113,14 +113,14 @@ The following arguments are passed to `uninstrument` to specify its behavior. Th
 
 Any other argument stated on the `instrument` table, but not below, will be ignored, this to allow you to uninstrument quicker, if needed.
 
-| Argument | Shorthand | Description | Default |
-| --- | --- | --- | --- |
-| `--function` | `-f` | The ARN of the Lambda function to be **uninstrumented**, or the name of the Lambda function (`--region` must be defined). | |
-| `--functions-regex` | | A regex pattern to match with the Lambda function name to be **uninstrumented**. | |
-| `--region` | `-r` | Default region to use, when `--function` is specified by the function name instead of the ARN. | |
-| `--profile` | | Specify the AWS named profile credentials to use to uninstrument. Learn more about AWS named profiles [here][11]. |  | 
-| `--forwarder` | | The ARN of the [datadog forwarder][9] to remove from this function. | |
-| `--dry-run` | `-d` | Preview changes running command would apply. | `false` |
+| Argument            | Shorthand | Description                                                                                                               | Default |
+| ------------------- | --------- | ------------------------------------------------------------------------------------------------------------------------- | ------- |
+| `--function`        | `-f`      | The ARN of the Lambda function to be **uninstrumented**, or the name of the Lambda function (`--region` must be defined). |         |
+| `--functions-regex` |           | A regex pattern to match with the Lambda function name to be **uninstrumented**.                                          |         |
+| `--region`          | `-r`      | Default region to use, when `--function` is specified by the function name instead of the ARN.                            |         |
+| `--profile`         |           | Specify the AWS named profile credentials to use to uninstrument. Learn more about AWS named profiles [here][11].         |         |
+| `--forwarder`       |           | The ARN of the [datadog forwarder][9] to remove from this function.                                                       |         |
+| `--dry-run`         | `-d`      | Preview changes running command would apply.                                                                              | `false` |
 
 <br/>
 
@@ -170,7 +170,7 @@ datadog-ci lambda flare -f <function-arn> -c <case-id> -e <email-on-case-id> --w
 **Arguments**
 
 | Argument              | Shorthand | Description                                                                                                                           | Default |
-|-----------------------|-----------|---------------------------------------------------------------------------------------------------------------------------------------|---------|
+| --------------------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------- | ------- |
 | `--function`          | `-f`      | The ARN of the Lambda function to gather data for, or the name of the Lambda function (`--region` must be defined).                   |         |
 | `--region`            | `-r`      | Default region to use, when `--function` is specified by the function name instead of the ARN.                                        |         |
 | `--case-id`           | `-c`      | The Datadog case ID to send the files to.                                                                                             |         |
@@ -196,3 +196,8 @@ For product feedback and questions, join the `#serverless` channel in the [Datad
 [10]: https://docs.datadoghq.com/serverless/custom_metrics?tab=python#enabling-asynchronous-custom-metrics
 [11]: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html#using-profiles
 [12]: https://docs.datadoghq.com/integrations/guide/source-code-integration
+
+<!--
+  This page is single-sourced:
+  https://github.com/DataDog/documentation/blob/7007931530baf7da59310e7224a26dc9a71c53c5/local/bin/py/build/configurations/pull_config_preview.yaml#L301
+->

--- a/src/commands/metric/README.md
+++ b/src/commands/metric/README.md
@@ -51,3 +51,10 @@ Successful output should look like this:
 Metrics sent
 ```
 
+## Further reading
+
+Additional helpful documentation, links, and articles:
+
+- [Learn about Adding Custom Tags and Metrics to Pipeline Traces][1]
+
+[1]: https://docs.datadoghq.com/continuous_integration/pipelines/custom_tags_and_metrics/

--- a/src/commands/react-native/README.md
+++ b/src/commands/react-native/README.md
@@ -96,11 +96,11 @@ The supported repository URLs are ones whose host contains `github`, `gitlab`, `
 
 This allows Datadog to create proper URLs such as:
 
-| Provider         | URL                                                                                 |
-| ---------------- | ----------------------------------------------------------------------------------- |
-| GitHub or GitLab | https://\<repository-url\>/blob/\<commit-hash\>/\<tracked-file-path\>#L\<line\>     |
-| Bitbucket        | https://\<repository-url\>/src/\<commit-hash\>/\<tracked-file-path\>#lines-\<line\> |
-| Azure DevOps | https://\<repository-url\>?version=GC\<commit-hash\>&path=\<tracked-file-path\>&line=\<line\>&lineEnd=\<line + 1>&lineStartColumn=1&lineEndColumn=1 |
+| Provider         | URL                                                                                                                                                 |
+| ---------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| GitHub or GitLab | https://\<repository-url\>/blob/\<commit-hash\>/\<tracked-file-path\>#L\<line\>                                                                     |
+| Bitbucket        | https://\<repository-url\>/src/\<commit-hash\>/\<tracked-file-path\>#lines-\<line\>                                                                 |
+| Azure DevOps     | https://\<repository-url\>?version=GC\<commit-hash\>&path=\<tracked-file-path\>&line=\<line\>&lineEnd=\<line + 1>&lineStartColumn=1&lineEndColumn=1 |
 
 ### `codepush`
 
@@ -255,3 +255,12 @@ cp /path/to/datadog-ci/dist/cli.js /path/to/project/node_modules/.bin/datadog-ci
 ```
 
 Then, follow the usual installation steps.
+
+
+## Further reading
+
+Additional helpful documentation, links, and articles:
+
+- [Learn about React Native Crash Reporting and Error Tracking][1]
+
+[1]: https://docs.datadoghq.com/real_user_monitoring/error_tracking/reactnative/

--- a/src/commands/react-native/codepush.ts
+++ b/src/commands/react-native/codepush.ts
@@ -13,7 +13,7 @@ export class CodepushCommand extends Command {
     category: 'RUM',
     description: 'Upload your React Native Codepush bundle and sourcemaps to Datadog.',
     details: `
-      This command will upload React Native Codepush sourcemaps and their corresponding javascript bundle to Datadog in order to un-minify front-end stack traces received by Datadog.\n
+      This command will upload React Native Codepush sourcemaps and their corresponding JavaScript bundle to Datadog in order to un-minify front-end stack traces received by Datadog.\n
       See README for details.
     `,
     examples: [

--- a/src/commands/react-native/upload.ts
+++ b/src/commands/react-native/upload.ts
@@ -38,7 +38,7 @@ export class UploadCommand extends Command {
     category: 'RUM',
     description: 'Upload React Native sourcemaps to Datadog.',
     details: `
-      This command will upload React Native sourcemaps and their corresponding javascript bundle to Datadog in order to un-minify front-end stack traces received by Datadog.\n
+      This command will upload React Native sourcemaps and their corresponding JavaScript bundle to Datadog in order to un-minify front-end stack traces received by Datadog.\n
       See README for details.
     `,
     examples: [

--- a/src/commands/react-native/xcode.ts
+++ b/src/commands/react-native/xcode.ts
@@ -48,7 +48,7 @@ export class XCodeCommand extends Command {
     category: 'RUM',
     description: 'Bundle React Native code and images in XCode and send sourcemaps to Datadog.',
     details: `
-      This command will bundle the react native code and images and then upload React Native sourcemaps and their corresponding javascript bundle to Datadog in order to un-minify front-end stack traces received by Datadog.\n
+      This command will bundle the react native code and images and then upload React Native sourcemaps and their corresponding JavaScript bundle to Datadog in order to un-minify front-end stack traces received by Datadog.\n
       See README for details.
     `,
     examples: [

--- a/src/commands/sarif/README.md
+++ b/src/commands/sarif/README.md
@@ -62,3 +62,11 @@ service: example-upload
 [DRYRUN] Uploading SARIF report in src/commands/sarif/__tests__/fixtures/valid-results.sarif
 ✅ Uploaded 1 files in 0 seconds.
 ```
+
+## Further reading
+
+Additional helpful documentation, links, and articles:
+
+- [Learn about Static Analysis][1]
+
+[1]: https://docs.datadoghq.com/static_analysis/

--- a/src/commands/sbom/README.md
+++ b/src/commands/sbom/README.md
@@ -1,4 +1,4 @@
-# SBOM uploader
+# SBOM command
 
 <div class="alert alert-warning"><strong>Warning:</strong> The <code>SBOM upload</code> command is in beta. It requires you to set <code>DD_BETA_COMMANDS_ENABLED=1</code>, and should not be used in production.</div>
 
@@ -32,3 +32,11 @@ When developing software, you can try with the following command:
 ```bash
 DD_BETA_COMMANDS_ENABLED=1 yarn launch sbom upload --service <your-service> --env <your-environment> /path/to/sbom.json
 ```
+
+## Further reading
+
+Additional helpful documentation, links, and articles:
+
+- [Learn about Static Analysis][1]
+
+[1]: https://docs.datadoghq.com/static_analysis

--- a/src/commands/sbom/upload.ts
+++ b/src/commands/sbom/upload.ts
@@ -18,6 +18,7 @@ export class UploadSbomCommand extends Command {
   public static paths = [['sbom', 'upload']]
 
   public static usage = Command.Usage({
+    category: 'Static Analysis',
     description: 'Upload SBOM files to Datadog.',
     details: `
       This command uploads SBOM files to Datadog for dependency tracking.

--- a/src/commands/sourcemaps/README.md
+++ b/src/commands/sourcemaps/README.md
@@ -19,7 +19,7 @@ It is also possible to override the full URL for the intake endpoint by defining
 
 ### `upload`
 
-This command will upload all JavaScript sourcemaps and their corresponding JavaScript file to Datadog in order to un-minify front-end stack traces received by Datadog.
+This command will upload all JavaScript sourcemaps and their corresponding JavaScript bundles to Datadog in order to un-minify front-end stack traces received by Datadog.
 
 To upload the sourcemaps in the build folder, this command should be run:
 

--- a/src/commands/sourcemaps/README.md
+++ b/src/commands/sourcemaps/README.md
@@ -81,11 +81,11 @@ For example, if your repository contains a file at `src/foo/example.js`, then:
 
 The only repository URLs supported are the ones whose host contains: `github`, `gitlab`, `bitbucket`, or `dev.azure`. This allows Datadog to create proper URLs such as:
 
-| Provider  | URL |
-| --- | --- |
-| GitHub / GitLab  | https://\<repository-url\>/blob/\<commit-hash\>/\<tracked-file-path\>#L\<line\> |
-| Bitbucket | https://\<repository-url\>/src/\<commit-hash\>/\<tracked-file-path\>#lines-\<line\>  |
-| Azure DevOps | https://\<repository-url\>?version=GC\<commit-hash\>&path=\<tracked-file-path\>&line=\<line\>&lineEnd=\<line + 1>&lineStartColumn=1&lineEndColumn=1 |
+| Provider        | URL                                                                                                                                                 |
+| --------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| GitHub / GitLab | https://\<repository-url\>/blob/\<commit-hash\>/\<tracked-file-path\>#L\<line\>                                                                     |
+| Bitbucket       | https://\<repository-url\>/src/\<commit-hash\>/\<tracked-file-path\>#lines-\<line\>                                                                 |
+| Azure DevOps    | https://\<repository-url\>?version=GC\<commit-hash\>&path=\<tracked-file-path\>&line=\<line\>&lineEnd=\<line + 1>&lineStartColumn=1&lineEndColumn=1 |
 
 ## End-to-end testing process
 
@@ -112,3 +112,11 @@ version: 0.0.1 service: test_datadog-ci project path:
 Uploading sourcemap /var/folders/s_/ds1hc9g54k7ct8x7p3kwsq1h0000gn/T/tmp.fqWhNgGdn6/fake.js.map for JS file available at https//fake.website/fake.js
 ✅ Uploaded 1 files in 0.68 seconds.
 ```
+
+## Further reading
+
+Additional helpful documentation, links, and articles:
+
+- [Learn about Uploading JavaScript Source Maps][1]
+
+[1]: https://docs.datadoghq.com/real_user_monitoring/guide/upload-javascript-source-maps/

--- a/src/commands/sourcemaps/README.md
+++ b/src/commands/sourcemaps/README.md
@@ -1,6 +1,6 @@
 # Sourcemaps command
 
-Upload JS sourcemaps to Datadog to un-minify your errors.
+Upload JavaScript sourcemaps to Datadog to un-minify your errors.
 
 ## Setup
 
@@ -19,7 +19,7 @@ It is also possible to override the full URL for the intake endpoint by defining
 
 ### `upload`
 
-This command will upload all javascript sourcemaps and their corresponding javascript file to Datadog in order to un-minify front-end stack traces received by Datadog.
+This command will upload all JavaScript sourcemaps and their corresponding JavaScript file to Datadog in order to un-minify front-end stack traces received by Datadog.
 
 To upload the sourcemaps in the build folder, this command should be run:
 

--- a/src/commands/sourcemaps/upload.ts
+++ b/src/commands/sourcemaps/upload.ts
@@ -38,9 +38,9 @@ export class UploadCommand extends Command {
 
   public static usage = Command.Usage({
     category: 'RUM',
-    description: 'Upload javascript sourcemaps to Datadog.',
+    description: 'Upload JavaScript sourcemaps to Datadog.',
     details: `
-      This command will upload all javascript sourcemaps and their corresponding javascript file to Datadog in order to un-minify front-end stack traces received by Datadog.\n
+      This command will upload all JavaScript sourcemaps and their corresponding JavaScript file to Datadog in order to un-minify front-end stack traces received by Datadog.\n
       See README for details.
     `,
     examples: [

--- a/src/commands/stepfunctions/README.md
+++ b/src/commands/stepfunctions/README.md
@@ -27,21 +27,21 @@ datadog-ci stepfunctions uninstrument --step-function <step-function-arn> --forw
 
 ### instrument
 
-| Argument | Shorthand  | Description | Default |
-| --- | --- | --- | --- |
-| `--step-function` | `-s` | The ARN of the Step Function to be instrumented. | |
-| `--forwarder` | | The ARN of the [Datadog Forwarder](https://docs.datadoghq.com/logs/guide/forwarder/) to subscribe Step Function log groups. | |
-| `--env` | `-e` | Separate your staging, development, and production environments by `env`. Learn more about [Serverless Tagging](https://docs.datadoghq.com/serverless/guide/serverless_tagging/#the-env-tag). ** **Optional if env tag is already set on Step Functions** | |
-| `--service` | | Group Step Functions belonging to similar workloads by `service`. Learn more about [Serverless Tagging](https://docs.datadoghq.com/serverless/guide/serverless_tagging/#the-service-tag). | |
-| `--dry-run` | `-d` | Preview changes without applying them. | `false` |
+| Argument          | Shorthand | Description                                                                                                                                                                                                                                               | Default |
+| ----------------- | --------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| `--step-function` | `-s`      | The ARN of the Step Function to be instrumented.                                                                                                                                                                                                          |         |
+| `--forwarder`     |           | The ARN of the [Datadog Forwarder](https://docs.datadoghq.com/logs/guide/forwarder/) to subscribe Step Function log groups.                                                                                                                               |         |
+| `--env`           | `-e`      | Separate your staging, development, and production environments by `env`. Learn more about [Serverless Tagging](https://docs.datadoghq.com/serverless/guide/serverless_tagging/#the-env-tag). ** **Optional if env tag is already set on Step Functions** |         |
+| `--service`       |           | Group Step Functions belonging to similar workloads by `service`. Learn more about [Serverless Tagging](https://docs.datadoghq.com/serverless/guide/serverless_tagging/#the-service-tag).                                                                 |         |
+| `--dry-run`       | `-d`      | Preview changes without applying them.                                                                                                                                                                                                                    | `false` |
 
 ### uninstrument
 
-| Argument | Shorthand | Required | Description | Default |
-| --- | --- | --- | --- | --- |
-| `--step-function` | `-s` |:white_check_mark: | The ARN of the Step Function to be instrumented. | |
-| `--forwarder` | | :white_check_mark: | The ARN of the [Datadog Forwarder](https://docs.datadoghq.com/logs/guide/forwarder/) to subscribe Step Function log groups. | |
-| `--dry-run` | `-d` | | Preview changes without applying them. | `false` |
+| Argument          | Shorthand | Required           | Description                                                                                                                 | Default |
+| ----------------- | --------- | ------------------ | --------------------------------------------------------------------------------------------------------------------------- | ------- |
+| `--step-function` | `-s`      | :white_check_mark: | The ARN of the Step Function to be instrumented.                                                                            |         |
+| `--forwarder`     |           | :white_check_mark: | The ARN of the [Datadog Forwarder](https://docs.datadoghq.com/logs/guide/forwarder/) to subscribe Step Function log groups. |         |
+| `--dry-run`       | `-d`      |                    | Preview changes without applying them.                                                                                      | `false` |
 
 ## Installation
 
@@ -64,3 +64,11 @@ For product feedback and questions, join the `#serverless` channel in the [Datad
 [5]: https://docs.datadoghq.com/serverless/forwarder/
 [6]: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html#using-profiles
 [7]: https://docs.datadoghq.com/serverless/libraries_integrations/cli/
+
+## Further reading
+
+Additional helpful documentation, links, and articles:
+
+- [Learn about Installing Serverless Monitoring for AWS Step Functions][8]
+
+[8]: https://docs.datadoghq.com/serverless/step_functions/installation/?tab=datadogcli

--- a/src/commands/stepfunctions/instrument.ts
+++ b/src/commands/stepfunctions/instrument.ts
@@ -33,7 +33,7 @@ export class InstrumentStepFunctionsCommand extends Command {
 
   public static usage = Command.Usage({
     category: 'Serverless',
-    description: 'Subscribe Step Function Log Groups to a Datadog Forwarder.',
+    description: 'Subscribe Step Function log groups to a Datadog Forwarder.',
     details: '--step-function expects a Step Function ARN\n--forwarder expects a Lambda ARN',
     examples: [
       [

--- a/src/commands/stepfunctions/uninstrument.ts
+++ b/src/commands/stepfunctions/uninstrument.ts
@@ -11,7 +11,7 @@ export class UninstrumentStepFunctionsCommand extends Command {
 
   public static usage = Command.Usage({
     category: 'Serverless',
-    description: 'Remove Step Functions log groups subscription filter created by datadog-ci.',
+    description: 'Remove Step Function log groups subscription filter created by datadog-ci.',
     details: '--stepfunction expects a Step Function ARN',
     examples: [
       [

--- a/src/commands/synthetics/README.md
+++ b/src/commands/synthetics/README.md
@@ -491,6 +491,7 @@ Additional helpful documentation, links, and articles:
 
 - [Use Datadog's GitHub Action to add continuous testing to your workflows][6]
 - [Learn about Continuous Testing and CI/CD][7]
+- [Learn about Mobile Application Testing][10]
 - [Learn about the Continuous Testing Explorer][8]
 - [Learn about the Continuous Testing Tunnel][3]
 
@@ -503,3 +504,9 @@ Additional helpful documentation, links, and articles:
 [7]: https://docs.datadoghq.com/continuous_testing/cicd_integrations/
 [8]: https://docs.datadoghq.com/continuous_testing/explorer/
 [9]: https://github.com/DataDog/datadog-ci/blob/master/.github/workflows/e2e/global.config.json
+[10]: https://docs.datadoghq.com/mobile_app_testing/
+
+<!--
+  This page is single-sourced:
+  https://github.com/DataDog/documentation/blob/7007931530baf7da59310e7224a26dc9a71c53c5/local/bin/py/build/configurations/pull_config_preview.yaml#L315
+->

--- a/src/commands/synthetics/README.md
+++ b/src/commands/synthetics/README.md
@@ -1,4 +1,4 @@
-<div class="alert alert-info">This page is about configuring Continuous Testing tests for your continuous integration (CI) and continuous delivery (CD) pipelines. If you want to bring your CI/CD metrics and data into Datadog dashboards, see the <a href="https://docs.datadoghq.com/continuous_integration/" target="_blank">CI Visibility</a> section.</div>
+<div class="alert alert-info">This page is about configuring Continuous Testing tests for your Continuous Integration (CI) and Continuous Delivery (CD) pipelines. If you want to bring your CI/CD metrics and data into Datadog dashboards, see the <a href="https://docs.datadoghq.com/continuous_integration/" target="_blank">CI Visibility</a> section.</div>
 
 ## Overview
 
@@ -441,7 +441,7 @@ You can also see the outcome of test executions directly in your CI as your test
 
 ## Upload Application Command
 
-This command uploads a new version to an **existing application**.
+This command uploads a new version to an **existing** mobile application.
 
 ### Command line options
 

--- a/src/commands/synthetics/upload-application-command.ts
+++ b/src/commands/synthetics/upload-application-command.ts
@@ -31,7 +31,7 @@ export class UploadApplicationCommand extends Command {
 
   public static usage = Command.Usage({
     category: 'Synthetics',
-    description: 'Upload a new version to an existing application in Datadog.',
+    description: 'Upload a new version to an existing mobile application in Datadog.',
     details: `
       This command will upload a \`.apk\` or \`.ipa\` file as a new version for a given application, which already exists in Datadog.\n
       https://docs.datadoghq.com/mobile_app_testing/mobile_app_tests

--- a/src/commands/tag/README.md
+++ b/src/commands/tag/README.md
@@ -52,3 +52,10 @@ Successful output should look like this:
 Tags sent
 ```
 
+## Further reading
+
+Additional helpful documentation, links, and articles:
+
+- [Learn about Adding Custom Tags and Metrics to Pipeline Traces][1]
+
+[1]: https://docs.datadoghq.com/continuous_integration/pipelines/custom_tags_and_metrics/

--- a/src/commands/trace/README.md
+++ b/src/commands/trace/README.md
@@ -47,3 +47,11 @@ Successful output should look like this:
 ```bash
 Hello World
 ```
+
+## Further reading
+
+Additional helpful documentation, links, and articles:
+
+- [Learn about Adding Custom Commands to Pipeline Traces][1]
+
+[1]: https://docs.datadoghq.com/continuous_integration/pipelines/custom_commands/

--- a/src/commands/trace/trace.ts
+++ b/src/commands/trace/trace.ts
@@ -140,7 +140,7 @@ export class TraceCommand extends Command {
         this.context.stdout.write(
           `${chalk.yellow.bold(
             '[WARNING]'
-          )} Your Jenkins instance does not seem to be instrumented with the DataDog plugin.\n`
+          )} Your Jenkins instance does not seem to be instrumented with the Datadog plugin.\n`
         )
         this.context.stdout.write(
           'Please follow the instructions at https://docs.datadoghq.com/continuous_integration/setup_pipelines/jenkins/\n'


### PR DESCRIPTION
### What and why?

The description was outdated (thank you @andrea-mosk) and the entrypoint README was really big because of the contributing section.

> [!NOTE]
> Can be reviewed commit by commit.

### How?

- Move the contributing section to its own `CONTRIBUTING.md` file.
  - Replaced by a `Development` section, [as in the dd-trace](https://github.com/DataDog/dd-trace-js/tree/master?tab=readme-ov-file#development) repo.
- Update the main description.
- Add all commands in the `Usage` section, including 1 link to the corresponding README and 1 link to the corresponding `docs.datadoghq.com` page.
- Align another READMEs. (e.g. adding `Further reading` sections)

### Validation

Go [here](https://github.com/DataDog/datadog-ci/tree/corentin.girard/update-readme) to see the updated README on this branch.

All command READMEs now have a `Further reading` section with at least one link to the official documentation website, except for 1 command:
```bash
$ grep -L "Further reading" src/commands/**/README.md

src/commands/lambda/README.md
```

because it's single-sourced already, which means that [the corresponding official docs page](https://docs.datadoghq.com/serverless/libraries_integrations/cli/) uses the README as source code.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
