### PR TITLE
[lambda] support Python 3.12

### DIFF
--- a/src/commands/lambda/__tests__/functions/instrument.part2.test.ts
+++ b/src/commands/lambda/__tests__/functions/instrument.part2.test.ts
@@ -61,8 +61,11 @@ describe('instrument', () => {
       `)
     })
 
-    test('calculates an update request with python 3.10', async () => {
-      const runtime = Runtime.python310
+    test.each([
+      [Runtime.python310, 'Datadog-Python310'],
+      [Runtime.python311, 'Datadog-Python311'],
+      [Runtime.python312, 'Datadog-Python312'],
+    ])('calculates an update request for %s', async (runtime: Runtime, layer: string) => {
       const config = {
         FunctionArn: 'arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world',
         Handler: 'index.handler',
@@ -93,45 +96,7 @@ describe('instrument', () => {
           "FunctionName": "arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world",
           "Handler": "datadog_lambda.handler.handler",
           "Layers": [
-            "arn:aws:lambda:sa-east-1:123456789012:layer:Datadog-Python310:71",
-          ],
-        }
-      `)
-    })
-
-    test('calculates an update request with python 3.11', async () => {
-      const runtime = Runtime.python311
-      const config = {
-        FunctionArn: 'arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world',
-        Handler: 'index.handler',
-        Layers: [],
-        Runtime: runtime,
-      }
-      const settings = {
-        flushMetricsToLogs: false,
-        layerAWSAccount: mockAwsAccount,
-        layerVersion: 77,
-        mergeXrayTraces: false,
-        tracingEnabled: false,
-      }
-      const region = 'sa-east-1'
-
-      const updateRequest = await calculateUpdateRequest(config, settings, region, runtime)
-      expect(updateRequest).toMatchInlineSnapshot(`
-        {
-          "Environment": {
-            "Variables": {
-              "DD_FLUSH_TO_LOG": "false",
-              "DD_LAMBDA_HANDLER": "index.handler",
-              "DD_MERGE_XRAY_TRACES": "false",
-              "DD_SITE": "datadoghq.com",
-              "DD_TRACE_ENABLED": "false",
-            },
-          },
-          "FunctionName": "arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world",
-          "Handler": "datadog_lambda.handler.handler",
-          "Layers": [
-            "arn:aws:lambda:sa-east-1:123456789012:layer:Datadog-Python311:77",
+            "arn:aws:lambda:sa-east-1:123456789012:layer:${layer}:71",
           ],
         }
       `)

--- a/src/commands/lambda/constants.ts
+++ b/src/commands/lambda/constants.ts
@@ -23,6 +23,7 @@ export const LAYER_LOOKUP = {
   'python3.9': 'Datadog-Python39',
   'python3.10': 'Datadog-Python310',
   'python3.11': 'Datadog-Python311',
+  'python3.12': 'Datadog-Python312',
   'ruby2.7': 'Datadog-Ruby2-7',
   'ruby3.2': 'Datadog-Ruby3-2',
 } as const
@@ -54,6 +55,7 @@ export const RUNTIME_LOOKUP: Partial<Record<Runtime, RuntimeType>> = {
   'python3.9': RuntimeType.PYTHON,
   'python3.10': RuntimeType.PYTHON,
   'python3.11': RuntimeType.PYTHON,
+  'python3.12': RuntimeType.PYTHON,
   'ruby2.7': RuntimeType.RUBY,
   'ruby3.2': RuntimeType.RUBY,
 }
@@ -66,6 +68,7 @@ export const ARM_LAYERS = [
   'python3.9',
   'python3.10',
   'python3.11',
+  'python3.12',
   'ruby2.7',
   'ruby3.2',
 ]


### PR DESCRIPTION
### What and why?

It's now supported in GA for AWS Lambdas.

### How?

Added constant and unit tests.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
