### PR TITLE
[CIVIS-2981] Add the rule url when printing a rule evaluation

### DIFF
--- a/src/commands/gate/__tests__/evaluate.test.ts
+++ b/src/commands/gate/__tests__/evaluate.test.ts
@@ -55,7 +55,9 @@ describe('evaluate', () => {
         rule_evaluations: [ruleEvaluation],
       }
       expect(command['handleEvaluationSuccess'].bind(command).call({}, response)).toEqual(0)
-      expect(write.mock.calls[0][0]).toContain('Rule URL: https://app.datadoghq.com/ci/quality-gates/rule/943d0eb8-907e-48cf-8178-3498900fe493')
+      expect(write.mock.calls[0][0]).toContain(
+        'Rule URL: https://app.datadoghq.com/ci/quality-gates/rule/943d0eb8-907e-48cf-8178-3498900fe493'
+      )
       expect(write.mock.calls[0][0]).toContain('Rule Name: No new flaky tests')
     })
     test('should render the rule URL for datad0g', () => {
@@ -68,7 +70,9 @@ describe('evaluate', () => {
         rule_evaluations: [ruleEvaluation],
       }
       expect(command['handleEvaluationSuccess'].bind(command).call({}, response)).toEqual(0)
-      expect(write.mock.calls[0][0]).toContain('Rule URL: https://dd.datad0g.com/ci/quality-gates/rule/943d0eb8-907e-48cf-8178-3498900fe493')
+      expect(write.mock.calls[0][0]).toContain(
+        'Rule URL: https://dd.datad0g.com/ci/quality-gates/rule/943d0eb8-907e-48cf-8178-3498900fe493'
+      )
     })
     test('should render the rule URL for ap1.datadoghq.com', () => {
       process.env = {DD_SITE: 'ap1.datadoghq.com'}
@@ -80,7 +84,9 @@ describe('evaluate', () => {
         rule_evaluations: [ruleEvaluation],
       }
       expect(command['handleEvaluationSuccess'].bind(command).call({}, response)).toEqual(0)
-      expect(write.mock.calls[0][0]).toContain('Rule URL: https://ap1.datadoghq.com/ci/quality-gates/rule/943d0eb8-907e-48cf-8178-3498900fe493')
+      expect(write.mock.calls[0][0]).toContain(
+        'Rule URL: https://ap1.datadoghq.com/ci/quality-gates/rule/943d0eb8-907e-48cf-8178-3498900fe493'
+      )
     })
     test('should pass the command on empty evaluation status by default', () => {
       const write = jest.fn()

--- a/src/commands/gate/__tests__/evaluate.test.ts
+++ b/src/commands/gate/__tests__/evaluate.test.ts
@@ -1,4 +1,4 @@
-import type {AxiosResponse, InternalAxiosRequestConfig} from 'axios'
+import type {AxiosResponse, AxiosRequestConfig} from 'axios'
 
 import {createCommand} from '../../../helpers/__tests__/fixtures'
 
@@ -45,6 +45,42 @@ describe('evaluate', () => {
         rule_evaluations: [],
       }
       expect(command['handleEvaluationSuccess'].bind(command).call({}, response)).toEqual(0)
+    })
+    test('should render the rule URL and rule name', () => {
+      const write = jest.fn()
+      const command = createCommand(GateEvaluateCommand, {stdout: {write}} as any)
+
+      const response: EvaluationResponse = {
+        status: 'passed',
+        rule_evaluations: [ruleEvaluation],
+      }
+      expect(command['handleEvaluationSuccess'].bind(command).call({}, response)).toEqual(0)
+      expect(write.mock.calls[0][0]).toContain('Rule URL: https://app.datadoghq.com/ci/quality-gates/rule/943d0eb8-907e-48cf-8178-3498900fe493')
+      expect(write.mock.calls[0][0]).toContain('Rule Name: No new flaky tests')
+    })
+    test('should render the rule URL for datad0g', () => {
+      process.env = {DD_SITE: 'datad0g.com', DD_SUBDOMAIN: 'dd'}
+      const write = jest.fn()
+      const command = createCommand(GateEvaluateCommand, {stdout: {write}} as any)
+
+      const response: EvaluationResponse = {
+        status: 'passed',
+        rule_evaluations: [ruleEvaluation],
+      }
+      expect(command['handleEvaluationSuccess'].bind(command).call({}, response)).toEqual(0)
+      expect(write.mock.calls[0][0]).toContain('Rule URL: https://dd.datad0g.com/ci/quality-gates/rule/943d0eb8-907e-48cf-8178-3498900fe493')
+    })
+    test('should render the rule URL for ap1.datadoghq.com', () => {
+      process.env = {DD_SITE: 'ap1.datadoghq.com'}
+      const write = jest.fn()
+      const command = createCommand(GateEvaluateCommand, {stdout: {write}} as any)
+
+      const response: EvaluationResponse = {
+        status: 'passed',
+        rule_evaluations: [ruleEvaluation],
+      }
+      expect(command['handleEvaluationSuccess'].bind(command).call({}, response)).toEqual(0)
+      expect(write.mock.calls[0][0]).toContain('Rule URL: https://ap1.datadoghq.com/ci/quality-gates/rule/943d0eb8-907e-48cf-8178-3498900fe493')
     })
     test('should pass the command on empty evaluation status by default', () => {
       const write = jest.fn()
@@ -158,7 +194,7 @@ describe('evaluate', () => {
         status: 200,
         statusText: 'OK',
         headers: {},
-        config: {} as InternalAxiosRequestConfig,
+        config: {} as AxiosRequestConfig,
         data: {
           data: {
             attributes: {
@@ -176,7 +212,7 @@ describe('evaluate', () => {
       status: 200,
       statusText: 'OK',
       headers: {},
-      config: {} as InternalAxiosRequestConfig,
+      config: {} as AxiosRequestConfig,
       data: {
         data: {
           attributes: {
@@ -310,6 +346,15 @@ describe('evaluate', () => {
     })
   })
 })
+
+const ruleEvaluation = {
+  rule_id: '943d0eb8-907e-48cf-8178-3498900fe493',
+  rule_name: 'No new flaky tests',
+  status: 'Passed',
+  is_blocking: true,
+  failure_reason: '',
+  details_url: '',
+}
 
 const createError = (statusCode: number, message: string): any => {
   return {

--- a/src/commands/gate/__tests__/evaluate.test.ts
+++ b/src/commands/gate/__tests__/evaluate.test.ts
@@ -1,4 +1,4 @@
-import type {AxiosResponse, AxiosRequestConfig} from 'axios'
+import type {AxiosResponse, InternalAxiosRequestConfig} from 'axios'
 
 import {createCommand} from '../../../helpers/__tests__/fixtures'
 
@@ -194,7 +194,7 @@ describe('evaluate', () => {
         status: 200,
         statusText: 'OK',
         headers: {},
-        config: {} as AxiosRequestConfig,
+        config: {} as InternalAxiosRequestConfig,
         data: {
           data: {
             attributes: {
@@ -212,7 +212,7 @@ describe('evaluate', () => {
       status: 200,
       statusText: 'OK',
       headers: {},
-      config: {} as AxiosRequestConfig,
+      config: {} as InternalAxiosRequestConfig,
       data: {
         data: {
           attributes: {

--- a/src/commands/gate/renderer.ts
+++ b/src/commands/gate/renderer.ts
@@ -3,7 +3,7 @@ import chalk from 'chalk'
 import {GIT_BRANCH, GIT_REPOSITORY_URL} from '../../helpers/tags'
 
 import {EvaluationResponse, Payload, RuleEvaluation} from './interfaces'
-import {getStatus, is5xxError, isBadRequestError, isTimeout} from './utils'
+import {getStatus, is5xxError, isBadRequestError, isTimeout, getBaseUrl} from './utils'
 
 const ICONS = {
   FAILED: '❌',
@@ -53,11 +53,14 @@ export const renderStatus = (result: string): string => {
   return result.toLowerCase()
 }
 
+export const renderRuleUrl = (ruleId: string): string => {
+  return `${getBaseUrl()}ci/quality-gates/rule/${ruleId}`
+}
+
 export const renderRuleEvaluation = (ruleEvaluation: RuleEvaluation): string => {
-  // TODO add URL here once we have it
   let fullStr = ''
-  fullStr += `Rule ID: ${ruleEvaluation.rule_id}\n`
   fullStr += `Rule Name: ${ruleEvaluation.rule_name}\n`
+  fullStr += `Rule URL: ${renderRuleUrl(ruleEvaluation.rule_id)}\n`
   fullStr += `Status: ${renderStatus(ruleEvaluation.status)}\n`
   if (ruleEvaluation.status.toLowerCase() === 'failed') {
     fullStr += `${chalk.red.bold('Failure reason')}: ${ruleEvaluation.failure_reason}\n`

--- a/src/commands/gate/utils.ts
+++ b/src/commands/gate/utils.ts
@@ -1,3 +1,12 @@
+import {getCommonAppBaseURL} from '../../helpers/app'
+
+export const getBaseUrl = () => {
+  const site = process.env.DD_SITE || 'datadoghq.com'
+  const subdomain = process.env.DD_SUBDOMAIN || ''
+
+  return getCommonAppBaseURL(site, subdomain)
+}
+
 export const getBaseIntakeUrl = () => {
   if (process.env.DD_SITE) {
     return `https://quality-gates.${process.env.DD_SITE}`


### PR DESCRIPTION
### What and why?
Add the rule url when printing a rule evaluation.

### How?
Reusing `getCommonAppBaseURL` method, build a url to the rule in Datadog.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
