### PR TITLE
[CIVIS-8421] Remove gate from beta commands

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,7 +5,7 @@ import {CommandClass} from 'clipanion/lib/advanced/Command'
 
 import {version} from './helpers/version'
 
-const BETA_COMMANDS = ['gate', 'sbom', 'dora', 'deployment']
+const BETA_COMMANDS = ['sbom', 'dora', 'deployment']
 
 const onError = (err: any) => {
   console.log(err)


### PR DESCRIPTION
### What and why?
Remove gate from beta commands, because quality gates is in public beta now.

### How?

Remove gate from BETA_COMMANDS.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
