### PR TITLE
[rum] Add command for upload of certain Unity symbol files

### DIFF
--- a/src/commands/unity-symbols/README.md
+++ b/src/commands/unity-symbols/README.md
@@ -1,0 +1,47 @@
+## Overview
+
+To deobfuscate and symbolicate errors and crashes, upload IL2CPP mappings and iOS dSYMs to Datadog.
+
+## Setup
+
+You need to have `DATADOG_API_KEY` in your environment.
+
+```bash
+# Environment setup
+export DATADOG_API_KEY="<API KEY>"
+```
+
+You can configure the tool to use Datadog EU by defining the `DATADOG_SITE` environment variable as `datadoghq.eu`. By default, the requests are sent to Datadog US.
+
+To make these variables available, Datadog recommends setting them in an encrypted `datadog-ci.json` file at the root of your project:
+
+```json
+{
+  "apiKey": "<DATADOG_API_KEY>",
+  "datadogSite": "<DATADOG_SITE>"
+}
+```
+
+To override the full URL for the intake endpoint, define the `DATADOG_SOURCEMAP_INTAKE_URL` environment variable.
+
+## Commands
+
+### `upload`
+
+This command uploads your IL2CPP mapping file and iOS dSYMs to Datadog in order to deobfuscate and symbolicate your application's stack traces on iOS. Note that
+Android symbol files, Proguard mapping files, and IL2CPP mapping are handled by the [Datadog Android Gradle Plugin](https://github.com/DataDog/dd-sdk-android-gradle-plugin)
+
+After performing an iOS build, the Datadog Unity SDK will copy all required files to you build output directory under `datadogSymbols`. You should then be able to
+run the following command to upload all the necessary files:
+
+```bash
+datadog-ci unity-symbols upload --service-name com.companyname.application --symbols-locaion datadogSymbols
+```
+
+| Parameter | Condition | Description |
+|-----------|-----------|-------------|
+| `--symbols-location`  | Optional  | The location of of your dSYMs, `build_id` and `LineNumberMappings.json` file.  Defaults to `datadogSymbols`. |
+| `--dry-run` | Optional | It runs the command without the final step of uploading. All other checks are performed. |
+| `--max-concurrency` | Optional | The number of concurrent upload to the API. Defaults to 20. |
+| `--disable-git`    | Optional | Prevents the command from invoking git in the current working directory and sending repository-related data to Datadog (such as the hash, remote URL, and paths within the repository of sources referenced in the source map). |
+| `--repository-url` | Optional | Overrides the remote repository with a custom URL. For example, `https://github.com/my-company/my-project`. |

--- a/src/commands/unity-symbols/__tests__/fixtures/buildIdOnly/build_id
+++ b/src/commands/unity-symbols/__tests__/fixtures/buildIdOnly/build_id
@@ -1,0 +1,1 @@
+fake-build-id

--- a/src/commands/unity-symbols/__tests__/fixtures/config/datadog-ci.json
+++ b/src/commands/unity-symbols/__tests__/fixtures/config/datadog-ci.json
@@ -1,0 +1,3 @@
+{
+  "apiKey": "PLACEHOLDER"
+}

--- a/src/commands/unity-symbols/__tests__/fixtures/mappingFile/LineNumberMappings.json
+++ b/src/commands/unity-symbols/__tests__/fixtures/mappingFile/LineNumberMappings.json
@@ -1,0 +1,3 @@
+{
+  "doc": "This is a mock file that does not contain actual IL2CPP mapping information"
+}

--- a/src/commands/unity-symbols/__tests__/fixtures/mappingFile/build_id
+++ b/src/commands/unity-symbols/__tests__/fixtures/mappingFile/build_id
@@ -1,0 +1,1 @@
+fake-build-id

--- a/src/commands/unity-symbols/__tests__/upload.test.ts
+++ b/src/commands/unity-symbols/__tests__/upload.test.ts
@@ -1,0 +1,256 @@
+import {ReadStream} from 'fs'
+import os from 'os'
+
+import FormData from 'form-data'
+
+import {createCommand} from '../../../helpers/__tests__/fixtures'
+import {TrackedFilesMatcher, getRepositoryData} from '../../../helpers/git/format-git-sourcemaps-data'
+import {MultipartPayload} from '../../../helpers/upload'
+import {performSubCommand} from '../../../helpers/utils'
+import {version} from '../../../helpers/version'
+
+import * as dsyms from '../../dsyms/upload'
+
+import {uploadMultipartHelper} from '../helpers'
+import {renderArgumentMissingError, renderMissingBuildId, renderMissingIL2CPPMappingFile} from '../renderer'
+import {UploadCommand} from '../upload'
+
+jest.mock('../../../helpers/utils', () => ({
+  ...jest.requireActual('../../../helpers/utils'),
+  performSubCommand: jest.fn(),
+}))
+
+jest.mock('../helpers', () => ({
+  ...jest.requireActual('../helpers'),
+  uploadMultipartHelper: jest.fn(),
+}))
+
+jest.mock('../../../helpers/git/format-git-sourcemaps-data', () => ({
+  ...jest.requireActual('../../../helpers/git/format-git-sourcemaps-data'),
+  getRepositoryData: jest.fn(),
+}))
+
+const cliVersion = version
+
+describe('unity-symbols upload', () => {
+  const runCommand = async (prepFunction: (command: UploadCommand) => void) => {
+    const command = createCommand(UploadCommand)
+    prepFunction(command)
+
+    const exitCode = await command.execute()
+
+    return {exitCode, context: command.context}
+  }
+
+  describe('parameter validation', () => {
+    test('fails if symbols-location is blank', async () => {
+      const {exitCode, context} = await runCommand((cmd) => {
+        cmd['symbolsLocation'] = ''
+      })
+      const errorOutput = context.stderr.toString()
+
+      expect(exitCode).not.toBe(0)
+      expect(errorOutput).toContain(renderArgumentMissingError('symbols-location'))
+    })
+
+    test('requires build_id file', async () => {
+      const {exitCode, context} = await runCommand((_) => {})
+      const errorOutput = context.stderr.toString()
+
+      expect(exitCode).not.toBe(0)
+      expect(errorOutput).toContain(renderMissingBuildId('datadogSymbols/build_id'))
+    })
+
+    test('uses API Key from env over config from JSON file', async () => {
+      const {exitCode, context} = await runCommand((cmd) => {
+        cmd['symbolsLocation'] = 'src/commands/unity-symbols/__tests__/fixtures/buildIdOnly'
+        cmd['configPath'] = 'src/commands/unity-symbols/__tests__/fixtures/config/datadog-ci.json'
+
+        process.env.DATADOG_API_KEY = 'fake_api_key'
+      })
+      const output = context.stdout.toString().split(os.EOL)
+
+      expect(exitCode).toBe(0)
+
+      expect(output).toContain('API keys were specified both in a configuration file and in the environment.')
+      expect(output).toContain('The environment API key ending in _key will be used.')
+    })
+  })
+
+  describe('dsyms upload', () => {
+    // Use a path with only a build_id file to pass parameter validation, but prevent
+    // other steps from executing
+    const symbolsLocation = 'src/commands/unity-symbols/__tests__/fixtures/buildIdOnly'
+
+    test('calls dsyms sub-command with proper default parameters', async () => {
+      const {exitCode} = await runCommand((cmd) => {
+        cmd['symbolsLocation'] = symbolsLocation
+      })
+
+      expect(exitCode).toBe(0)
+
+      expect(performSubCommand).toHaveBeenCalledWith(
+        dsyms.UploadCommand,
+        ['dsyms', 'upload', symbolsLocation, '--max-concurrency 20'],
+        expect.anything()
+      )
+    })
+
+    test('calls dsyms sub-command with dry-run on dry-run', async () => {
+      const {exitCode} = await runCommand((cmd) => {
+        cmd['symbolsLocation'] = symbolsLocation
+        cmd['dryRun'] = true
+      })
+
+      expect(exitCode).toBe(0)
+      expect(performSubCommand).toHaveBeenCalledWith(
+        dsyms.UploadCommand,
+        ['dsyms', 'upload', symbolsLocation, '--max-concurrency 20', '--dry-run'],
+        expect.anything()
+      )
+    })
+
+    test('calls dsyms sub-command passing through max concurrency', async () => {
+      const {exitCode, context: _} = await runCommand((cmd) => {
+        cmd['symbolsLocation'] = symbolsLocation
+        cmd['maxConcurrency'] = 12
+      })
+
+      expect(exitCode).toBe(0)
+      expect(performSubCommand).toHaveBeenCalledWith(
+        dsyms.UploadCommand,
+        ['dsyms', 'upload', symbolsLocation, '--max-concurrency 12'],
+        expect.anything()
+      )
+    })
+  })
+
+  describe('il2cpp mapping upload', () => {
+    const mockGitRepoParameters = (command: UploadCommand) => {
+      command['gitData'] = {
+        hash: 'fake-git-hash',
+        remote: 'fake-git-remote',
+        trackedFilesMatcher: new TrackedFilesMatcher([
+          './Assets/Scripts/Behavior.cs',
+          './Assets/Scripts/UIBehavior.cs',
+        ]),
+      }
+    }
+
+    test('warns if mapping file does not exist', async () => {
+      const fixtureDir = 'src/commands/unity-symbols/__tests__/fixtures/buildIdOnly'
+      const {exitCode, context} = await runCommand((cmd) => {
+        cmd['symbolsLocation'] = fixtureDir
+      })
+
+      const errorOutput = context.stderr.toString().split(os.EOL)
+
+      // Doesn't fail, only warning
+      expect(exitCode).toBe(0)
+      expect(errorOutput).toContain(renderMissingIL2CPPMappingFile(`${fixtureDir}/LineNumberMappings.json`))
+    })
+
+    test('creates correct metadata payload', async () => {
+      const fixtureDir = 'src/commands/unity-symbols/__tests__/fixtures/mappingFile'
+      const command = createCommand(UploadCommand)
+      command['symbolsLocation'] = fixtureDir
+      await command['verifyParameters']()
+
+      mockGitRepoParameters(command)
+
+      const metadata = command['getMappingMetadata']()
+
+      expect(metadata).toEqual({
+        cli_version: cliVersion,
+        git_commit_sha: 'fake-git-hash',
+        git_repository_url: 'fake-git-remote',
+        build_id: 'fake-build-id',
+        type: 'il2cpp_mapping_file',
+      })
+    })
+
+    test('uploads correct multipart payload with repository', async () => {
+      const fixtureDir = 'src/commands/unity-symbols/__tests__/fixtures/mappingFile'
+
+      ;(uploadMultipartHelper as jest.Mock).mockResolvedValueOnce('')
+      ;(getRepositoryData as jest.Mock).mockResolvedValueOnce({
+        hash: 'fake-git-hash',
+        remote: 'fake-git-remote',
+        trackedFilesMatcher: new TrackedFilesMatcher([
+          './Assets/Scripts/Behavior.cs',
+          './Assets/Scripts/UIBehavior.cs',
+        ]),
+      })
+
+      const {exitCode} = await runCommand((cmd) => {
+        cmd['symbolsLocation'] = fixtureDir
+      })
+
+      const expectedMetadata = {
+        cli_version: cliVersion,
+        git_commit_sha: 'fake-git-hash',
+        git_repository_url: 'fake-git-remote',
+        type: 'il2cpp_mapping_file',
+        build_id: 'fake-build-id',
+      }
+
+      const expectedRepository = {
+        data: [
+          {
+            files: ['./Assets/Scripts/Behavior.cs', './Assets/Scripts/UIBehavior.cs'],
+            hash: 'fake-git-hash',
+            repository_url: 'fake-git-remote',
+          },
+        ],
+        version: 1,
+      }
+
+      expect(uploadMultipartHelper).toHaveBeenCalled()
+      const payload = (uploadMultipartHelper as jest.Mock).mock.calls[0][1] as MultipartPayload
+      expect(JSON.parse(payload.content.get('event')?.value as string)).toStrictEqual(expectedMetadata)
+      const repoValue = payload.content.get('repository')
+      expect(JSON.parse(repoValue?.value as string)).toStrictEqual(expectedRepository)
+      expect((repoValue?.options as FormData.AppendOptions).filename).toBe('repository')
+      expect((repoValue?.options as FormData.AppendOptions).contentType).toBe('application/json')
+      expect(exitCode).toBe(0)
+    })
+
+    test('uploads correct multipart payload without repository', async () => {
+      ;(uploadMultipartHelper as jest.Mock).mockResolvedValueOnce('')
+
+      const fixtureDir = 'src/commands/unity-symbols/__tests__/fixtures/mappingFile'
+      const {exitCode} = await runCommand((cmd) => {
+        cmd['symbolsLocation'] = fixtureDir
+      })
+
+      const expectedMetadata = {
+        cli_version: cliVersion,
+        build_id: 'fake-build-id',
+        type: 'il2cpp_mapping_file',
+      }
+
+      expect(uploadMultipartHelper).toHaveBeenCalled()
+      const payload = (uploadMultipartHelper as jest.Mock).mock.calls[0][1] as MultipartPayload
+      expect(JSON.parse(payload.content.get('event')?.value as string)).toStrictEqual(expectedMetadata)
+      const mappingFileItem = payload.content.get('il2cpp_mapping_file')
+      expect(mappingFileItem).toBeTruthy()
+      expect((mappingFileItem?.options as FormData.AppendOptions).filename).toBe('LineNumberMappings.json')
+      expect(mappingFileItem?.value).toBeInstanceOf(ReadStream)
+      expect((mappingFileItem?.value as ReadStream).path).toBe(`${fixtureDir}/LineNumberMappings.json`)
+      expect(exitCode).toBe(0)
+    })
+
+    test('skips upload on dry run', async () => {
+      ;(uploadMultipartHelper as jest.Mock).mockResolvedValueOnce('')
+
+      const fixtureDir = 'src/commands/unity-symbols/__tests__/fixtures/mappingFile'
+      const {exitCode} = await runCommand((cmd) => {
+        cmd['symbolsLocation'] = fixtureDir
+        cmd['dryRun'] = true
+      })
+
+      expect(uploadMultipartHelper).not.toHaveBeenCalled()
+      expect(exitCode).toBe(0)
+    })
+  })
+})

--- a/src/commands/unity-symbols/cli.ts
+++ b/src/commands/unity-symbols/cli.ts
@@ -1,0 +1,3 @@
+import {UploadCommand} from './upload'
+
+module.exports = [UploadCommand]

--- a/src/commands/unity-symbols/helpers.ts
+++ b/src/commands/unity-symbols/helpers.ts
@@ -1,0 +1,22 @@
+import {getBaseSourcemapIntakeUrl} from '../../helpers/base-intake-url'
+import {RequestBuilder} from '../../helpers/interfaces'
+import {MultipartPayload, upload, UploadOptions} from '../../helpers/upload'
+import {getRequestBuilder} from '../../helpers/utils'
+
+export const getUnityRequestBuilder = (apiKey: string, cliVersion: string, site: string) =>
+  getRequestBuilder({
+    apiKey,
+    baseUrl: getBaseSourcemapIntakeUrl(site),
+    headers: new Map([
+      ['DD-EVP-ORIGIN', 'datadog-ci unity-symbols'],
+      ['DD-EVP-ORIGIN-VERSION', cliVersion],
+    ]),
+    overrideUrl: 'api/v2/srcmap',
+  })
+
+// This function exists partially just to make mocking networkc calls easier.
+export const uploadMultipartHelper = async (
+  requestBuilder: RequestBuilder,
+  payload: MultipartPayload,
+  opts: UploadOptions
+) => upload(requestBuilder)(payload, opts)

--- a/src/commands/unity-symbols/interfaces.ts
+++ b/src/commands/unity-symbols/interfaces.ts
@@ -1,0 +1,12 @@
+export const TYPE_IL2CPP_MAPPING = 'il2cpp_mapping_file'
+export const VALUE_NAME_IL2CPP_MAPPING = 'il2cpp_mapping_file'
+export const IL2CPP_MAPPING_FILE_NAME = 'LineNumberMappings.json'
+
+export interface MappingMetadata {
+  cli_version: string
+  git_commit_sha?: string
+  git_repository_url?: string
+  platform?: string
+  build_id: string
+  type: string
+}

--- a/src/commands/unity-symbols/renderer.ts
+++ b/src/commands/unity-symbols/renderer.ts
@@ -1,0 +1,122 @@
+import chalk from 'chalk'
+
+import {ICONS} from '../../helpers/formatting'
+import {UploadStatus} from '../../helpers/upload'
+import {pluralize} from '../../helpers/utils'
+
+export interface UploadInfo {
+  fileType: string
+  location: string
+  platform: string
+}
+
+export const renderCommandInfo = (
+  dryRun: boolean,
+  version: string,
+  service: string,
+  flavor: string,
+  uploadInfo: UploadInfo[]
+) => {
+  let fullString = ''
+  if (dryRun) {
+    fullString += chalk.yellow(`${ICONS.WARNING} DRY-RUN MODE ENABLED. WILL NOT UPLOAD SOURCEMAPS\n`)
+  }
+  const startStr = chalk.green('Starting upload. \n')
+
+  fullString += startStr
+  uploadInfo.forEach((ui) => {
+    fullString += chalk.green(`Uploading ${ui.platform} ${ui.fileType} at location ${ui.location}\n`)
+  })
+  const serviceVersionProjectPathStr = chalk.green(`  version: ${version} service: ${service} flavor: ${flavor}\n`)
+  fullString += serviceVersionProjectPathStr
+
+  fullString += chalk.green(
+    `Please ensure you use the same values during SDK initialization to guarantee the success of the symbolication process.\n`
+  )
+
+  fullString += chalk.green(
+    `After upload is successful symbol files will be processed and ready to use within the next 5 minutes.\n`
+  )
+
+  return fullString
+}
+
+export const renderCommandSummary = (statuses: UploadStatus[], duration: number, dryRun: boolean) => {
+  const results = new Map<UploadStatus, number>()
+  statuses.forEach((status) => {
+    if (!results.has(status)) {
+      results.set(status, 0)
+    }
+    results.set(status, results.get(status)! + 1)
+  })
+
+  const output = ['', chalk.bold('Command summary:')]
+  if (results.get(UploadStatus.Failure)) {
+    output.push(chalk.red(`${ICONS.FAILED} Some symbol files may not been uploaded correctly.`))
+  } else if (results.get(UploadStatus.Skipped)) {
+    output.push(chalk.yellow(`${ICONS.WARNING}  Some symbol files have been skipped.`))
+  } else if (results.get(UploadStatus.Success)) {
+    if (dryRun) {
+      output.push(
+        chalk.green(
+          `${ICONS.SUCCESS} [DRYRUN] Handled symbol ${pluralize(
+            results.get(UploadStatus.Success)!,
+            'file',
+            'files'
+          )} with success in ${duration} seconds.`
+        )
+      )
+    } else {
+      output.push(
+        chalk.green(
+          `${ICONS.SUCCESS} Uploaded symbol ${pluralize(
+            results.get(UploadStatus.Success)!,
+            'file',
+            'files'
+          )} in ${duration} seconds.`
+        )
+      )
+    }
+  } else {
+    output.push(chalk.yellow(`${ICONS.WARNING} No actions were taken. Did you specify the correct path?`))
+  }
+
+  return output.join('\n') + '\n'
+}
+
+export const renderMissingBuildId = (path: string) =>
+  chalk.red(`${ICONS.FAILED} Error: Invalid or missing 'build_id' file. Expected at path ${path}`)
+
+export const renderGitWarning = (errorMessage: string) =>
+  chalk.yellow(`${ICONS.WARNING} An error occured while invoking git: ${errorMessage}
+Make sure the command is running within your git repository to fully leverage Datadog's git integration.
+To ignore this warning use the --disable-git flag.\n`)
+
+export const renderArgumentMissingError = (argumentName: string) =>
+  chalk.red(`${ICONS.FAILED} Error: parameter "${argumentName}" is required.\n`)
+
+export const renderGeneralizedError = (error: any) => {
+  let str = chalk.red(`${ICONS.FAILED} Error: ${error}\n`)
+  str += error.stack
+
+  return str
+}
+
+export const renderMissingIL2CPPMappingFile = (path: string) =>
+  chalk.yellow(
+    `${ICONS.WARNING} No IL2CPP mapping file was found at ${path}. This file is needed for C# line level symbolication.`
+  )
+
+export const renderFailedUpload = (filePath: string, errorMessage: string) => {
+  const filePathBold = `[${chalk.bold.dim(filePath)}]`
+
+  return chalk.red(`${ICONS.FAILED} Failed upload for ${filePathBold}: ${errorMessage}\n`)
+}
+
+export const renderRetriedUpload = (filePath: string, errorMessage: string, attempt: number) => {
+  const sourcemapPathBold = `[${chalk.bold.dim(filePath)}]`
+
+  return chalk.yellow(`[attempt ${attempt}] Retrying upload ${sourcemapPathBold}: ${errorMessage}\n`)
+}
+
+export const renderUpload = (type: string, filePath: string): string => `Uploading ${type} ${filePath}\n`

--- a/src/commands/unity-symbols/upload.ts
+++ b/src/commands/unity-symbols/upload.ts
@@ -1,0 +1,255 @@
+import fs from 'fs'
+import path from 'path'
+
+import {Command, Option} from 'clipanion'
+
+import {newApiKeyValidator} from '../../helpers/apikey'
+import {RepositoryData, getRepositoryData, newSimpleGit} from '../../helpers/git/format-git-sourcemaps-data'
+import {MetricsLogger, getMetricsLogger} from '../../helpers/metrics'
+import {MultipartValue, UploadStatus} from '../../helpers/upload'
+import {DEFAULT_CONFIG_PATHS, performSubCommand, resolveConfigFromFileAndEnvironment} from '../../helpers/utils'
+import * as validation from '../../helpers/validation'
+import {checkAPIKeyOverride} from '../../helpers/validation'
+import {version} from '../../helpers/version'
+
+import * as dsyms from '../dsyms/upload'
+
+import {getUnityRequestBuilder, uploadMultipartHelper} from './helpers'
+import {IL2CPP_MAPPING_FILE_NAME, MappingMetadata, TYPE_IL2CPP_MAPPING, VALUE_NAME_IL2CPP_MAPPING} from './interfaces'
+import {
+  renderArgumentMissingError,
+  renderFailedUpload,
+  renderGitWarning,
+  renderMissingBuildId,
+  renderMissingIL2CPPMappingFile as renderMissingIl2CppMappingFile,
+  renderRetriedUpload,
+  renderUpload,
+} from './renderer'
+
+export class UploadCommand extends Command {
+  public static paths = [['unity-symbols', 'upload']]
+
+  public static usage = Command.Usage({
+    category: 'RUM',
+    description: 'Upload Unity symbol files to Datadog.',
+    details: `
+            This command will upload all iOS symbol files for Unity applications in order to symbolicate errors and
+            crash reports received by Datadog. This includes uploading dSYMs and IL2CPP mapping files.
+        `,
+    examples: [
+      [
+        'Upload all symbol files from the default location',
+        'datadog-ci unity-symbols upload --service-name com.datadog.example',
+      ],
+    ],
+  })
+
+  private disableGit = Option.Boolean('--disable-git', false)
+  private dryRun = Option.Boolean('--dry-run', false)
+  private configPath = Option.String('--config')
+  private maxConcurrency = Option.String('--max-concurrency', '20', {validator: validation.isInteger()})
+  private repositoryUrl = Option.String('--repository-url')
+  private symbolsLocation = Option.String('--symbols-location', './datadogSymbols')
+
+  private buildId?: string
+  private cliVersion = version
+  private config: Record<string, string> = {
+    datadogSite: 'datadoghq.com',
+  }
+  private gitData?: RepositoryData
+
+  public async execute() {
+    if (!(await this.verifyParameters())) {
+      return 1
+    }
+
+    this.config = await resolveConfigFromFileAndEnvironment(
+      this.config,
+      {
+        apiKey: process.env.DATADOG_API_KEY,
+        datadogSite: process.env.DATADOG_SITE,
+      },
+      {
+        configPath: this.configPath,
+        defaultConfigPaths: DEFAULT_CONFIG_PATHS,
+        configFromFileCallback: (configFromFile: any) => {
+          checkAPIKeyOverride(process.env.DATADOG_API_KEY, configFromFile.apiKey, this.context.stdout)
+        },
+      }
+    )
+
+    if (!this.disableGit) {
+      this.gitData = await this.getGitMetadata()
+    }
+
+    await this.performDsymUpload()
+    await this.performIl2CppMappingUpload()
+
+    return 0
+  }
+
+  private getApiKeyValidator(metricsLogger: MetricsLogger) {
+    return newApiKeyValidator({
+      apiKey: this.config.apiKey,
+      datadogSite: this.config.datadogSite,
+      metricsLogger: metricsLogger.logger,
+    })
+  }
+
+  private getGitDataPayload(gitData: RepositoryData): MultipartValue {
+    const files = gitData.trackedFilesMatcher.rawTrackedFilesList()
+    const repoPayload = {
+      data: [
+        {
+          files,
+          hash: gitData.hash,
+          repository_url: gitData.remote,
+        },
+      ],
+      version: 1,
+    }
+
+    return {
+      options: {filename: 'repository', contentType: 'application/json'},
+      value: JSON.stringify(repoPayload),
+    }
+  }
+
+  private async getGitMetadata(): Promise<RepositoryData | undefined> {
+    try {
+      return await getRepositoryData(await newSimpleGit(), this.repositoryUrl)
+    } catch (e) {
+      this.context.stdout.write(renderGitWarning(e))
+    }
+
+    return undefined
+  }
+
+  private getMappingMetadata(): MappingMetadata {
+    return {
+      cli_version: this.cliVersion,
+      git_commit_sha: this.gitData?.hash,
+      git_repository_url: this.gitData?.remote,
+      build_id: this.buildId!,
+      type: TYPE_IL2CPP_MAPPING,
+    }
+  }
+
+  private getMetricsLogger(tags: string[]) {
+    const metricsLogger = getMetricsLogger({
+      apiKey: this.config.apiKey,
+      datadogSite: this.config.datadogSite,
+      defaultTags: [`cli_version:${this.cliVersion}`, 'platform:unity', ...tags],
+      prefix: 'datadog.ci.symbols.upload.',
+    })
+
+    return metricsLogger
+  }
+
+  private async performDsymUpload() {
+    const dsymUploadCommand = ['dsyms', 'upload', this.symbolsLocation]
+    dsymUploadCommand.push(`--max-concurrency ${this.maxConcurrency}`)
+    if (this.dryRun) {
+      dsymUploadCommand.push('--dry-run')
+    }
+
+    const exitCode = await performSubCommand(dsyms.UploadCommand, dsymUploadCommand, this.context)
+    if (exitCode && exitCode !== 0) {
+      return UploadStatus.Failure
+    }
+
+    return UploadStatus.Success
+  }
+
+  private async getBuildId(): Promise<number> {
+    const buildIdPath = path.join(this.symbolsLocation, 'build_id')
+    if (!fs.existsSync(buildIdPath)) {
+      this.context.stderr.write(renderMissingBuildId(buildIdPath))
+
+      return 1
+    }
+
+    this.buildId = fs.readFileSync(buildIdPath)?.toString()
+    if (!this.buildId) {
+      this.context.stderr.write(renderMissingBuildId(buildIdPath))
+
+      return 1
+    }
+
+    return 0
+  }
+
+  private async performIl2CppMappingUpload(): Promise<number> {
+    const il2cppMappingPath = path.join(this.symbolsLocation, 'LineNumberMappings.json')
+    if (!fs.existsSync(il2cppMappingPath)) {
+      this.context.stderr.write(renderMissingIl2CppMappingFile(il2cppMappingPath))
+
+      return 1
+    }
+
+    const metricsLogger = this.getMetricsLogger(['platform:unity'])
+    const apiKeyValidator = this.getApiKeyValidator(metricsLogger)
+
+    const requestBuilder = getUnityRequestBuilder(this.config.apiKey!, this.cliVersion, this.config.datadogSite)
+    if (this.dryRun) {
+      this.context.stdout.write(`[DRYRUN] ${renderUpload('IL2CPP Mapping File', il2cppMappingPath)}`)
+
+      return 0
+    }
+
+    const metadata = this.getMappingMetadata()
+
+    const payload = {
+      content: new Map<string, MultipartValue>([
+        ['event', {value: JSON.stringify(metadata), options: {filename: 'event', contentType: 'application/json'}}],
+        [
+          VALUE_NAME_IL2CPP_MAPPING,
+          {value: fs.createReadStream(il2cppMappingPath), options: {filename: IL2CPP_MAPPING_FILE_NAME}},
+        ],
+      ]),
+    }
+    if (this.gitData !== undefined) {
+      payload.content.set('repository', this.getGitDataPayload(this.gitData))
+    }
+
+    const status = await uploadMultipartHelper(requestBuilder, payload, {
+      apiKeyValidator,
+      onError: (e) => {
+        this.context.stdout.write(renderFailedUpload(il2cppMappingPath, e.message))
+        metricsLogger.logger.increment('failed', 1)
+      },
+      onRetry: (e, attempts) => {
+        this.context.stdout.write(renderRetriedUpload(il2cppMappingPath, e.message, attempts))
+        metricsLogger.logger.increment('retries', 1)
+      },
+      onUpload: () => {
+        this.context.stdout.write(renderUpload('IL2CPP Mapping File', il2cppMappingPath))
+      },
+      retries: 5,
+      useGzip: true,
+    })
+
+    if (status === UploadStatus.Success) {
+      this.context.stdout.write('IL2CPP Mapping upload finished\n')
+    } else {
+      this.context.stdout.write(`IL2CPP Mapping upload failed\n`)
+    }
+
+    return status
+  }
+
+  private async verifyParameters(): Promise<boolean> {
+    let parametersOkay = true
+
+    if (!this.symbolsLocation) {
+      this.context.stderr.write(renderArgumentMissingError('symbols-location'))
+      parametersOkay = false
+    }
+
+    if (await this.getBuildId()) {
+      parametersOkay = false
+    }
+
+    return parametersOkay
+  }
+}


### PR DESCRIPTION
### What and why?

datadog-ci will be used for upload of iOS dSYMs and for the IL2CPP mapping file for iOS (and potentially other supported platforms in the future).  This adds support uploading those files from a single command: `unity-symbols upload`

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
