### PR TITLE
[dep] Bump axios to `1.6.5`

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "ajv": "^8.12.0",
     "ajv-formats": "^2.1.1",
     "async-retry": "1.3.1",
-    "axios": "1.6.0",
+    "axios": "1.6.5",
     "chalk": "3.0.0",
     "clipanion": "^3.2.1",
     "datadog-metrics": "0.9.3",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "ajv": "^8.12.0",
     "ajv-formats": "^2.1.1",
     "async-retry": "1.3.1",
-    "axios": "1.6.5",
+    "axios": "^1.6.5",
     "chalk": "3.0.0",
     "clipanion": "^3.2.1",
     "datadog-metrics": "0.9.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2011,7 +2011,7 @@ __metadata:
     async-retry: 1.3.1
     aws-sdk-client-mock: ^2.1.1
     aws-sdk-client-mock-jest: ^2.1.1
-    axios: 1.6.0
+    axios: 1.6.5
     chalk: 3.0.0
     clipanion: ^3.2.1
     datadog-metrics: 0.9.3
@@ -4531,14 +4531,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios@npm:1.6.0":
-  version: 1.6.0
-  resolution: "axios@npm:1.6.0"
+"axios@npm:1.6.5":
+  version: 1.6.5
+  resolution: "axios@npm:1.6.5"
   dependencies:
-    follow-redirects: ^1.15.0
+    follow-redirects: ^1.15.4
     form-data: ^4.0.0
     proxy-from-env: ^1.1.0
-  checksum: c7c9f2ae9e0b9bad7d6f9a4dff030930b12ee667dedf54c3c776714f91681feb743c509ac0796ae5c01e12c4ab4a2bee74905068dd200fbc1ab86f9814578fb0
+  checksum: e28d67b2d9134cb4608c44d8068b0678cfdccc652742e619006f27264a30c7aba13b2cd19c6f1f52ae195b5232734925928fb192d5c85feea7edd2f273df206d
   languageName: node
   linkType: hard
 
@@ -6324,13 +6324,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"follow-redirects@npm:^1.15.0":
-  version: 1.15.3
-  resolution: "follow-redirects@npm:1.15.3"
+"follow-redirects@npm:^1.15.4":
+  version: 1.15.4
+  resolution: "follow-redirects@npm:1.15.4"
   peerDependenciesMeta:
     debug:
       optional: true
-  checksum: 584da22ec5420c837bd096559ebfb8fe69d82512d5585004e36a3b4a6ef6d5905780e0c74508c7b72f907d1fa2b7bd339e613859e9c304d0dc96af2027fd0231
+  checksum: e178d1deff8b23d5d24ec3f7a94cde6e47d74d0dc649c35fc9857041267c12ec5d44650a0c5597ef83056ada9ea6ca0c30e7c4f97dbf07d035086be9e6a5b7b6
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2011,7 +2011,7 @@ __metadata:
     async-retry: 1.3.1
     aws-sdk-client-mock: ^2.1.1
     aws-sdk-client-mock-jest: ^2.1.1
-    axios: 1.6.5
+    axios: ^1.6.5
     chalk: 3.0.0
     clipanion: ^3.2.1
     datadog-metrics: 0.9.3
@@ -4531,7 +4531,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios@npm:1.6.5":
+"axios@npm:^1.6.5":
   version: 1.6.5
   resolution: "axios@npm:1.6.5"
   dependencies:


### PR DESCRIPTION
### What and why?

Fixes:
* Prototype pollution vulnerability https://security.snyk.io/vuln/SNYK-JS-AXIOS-6144788
* ReDoS vulnerability https://security.snyk.io/vuln/SNYK-JS-AXIOS-6124857

This upgrade [jumps over multiple patch releases](https://github.com/axios/axios/releases), which all are low risk.

Related: https://github.com/DataDog/datadog-ci/pull/1154
