### PR TITLE
[synthetics] Fix enabling selective re-run with config file

### DIFF
--- a/src/commands/synthetics/__tests__/cli.test.ts
+++ b/src/commands/synthetics/__tests__/cli.test.ts
@@ -4,7 +4,7 @@ import {createCommand} from '../../../helpers/__tests__/fixtures'
 import * as ciUtils from '../../../helpers/utils'
 
 import * as api from '../api'
-import {UserConfigOverride} from '../interfaces'
+import {RunTestsCommandConfig, UploadApplicationCommandConfig, UserConfigOverride} from '../interfaces'
 import {DEFAULT_COMMAND_CONFIG, DEFAULT_POLLING_TIMEOUT, RunTestsCommand} from '../run-tests-command'
 import {DEFAULT_UPLOAD_COMMAND_CONFIG, UploadApplicationCommand} from '../upload-application-command'
 import * as utils from '../utils/public'
@@ -71,7 +71,7 @@ describe('run-test', () => {
     })
 
     test('override from config file', async () => {
-      const overrideConfigFile = {
+      const overrideConfigFile: RunTestsCommandConfig = {
         apiKey: 'fake_api_key',
         appKey: 'fake_app_key',
         configPath: 'src/commands/synthetics/__tests__/config-fixtures/config-with-all-keys.json',
@@ -81,15 +81,17 @@ describe('run-test', () => {
         failOnTimeout: false,
         files: ['my-new-file'],
         global: {
-          locations: [],
+          locations: ['us-east-1'],
           pollingTimeout: 2,
           mobileApplicationVersionFilePath: './path/to/application.apk',
         },
         locations: [],
         pollingTimeout: 1,
-        proxy: {protocol: 'https'},
+        proxy: {
+          protocol: 'https',
+        },
         publicIds: ['ran-dom-id'],
-        selectiveRerun: false,
+        selectiveRerun: true,
         subdomain: 'ppa',
         tunnel: true,
         variableStrings: [],
@@ -103,7 +105,7 @@ describe('run-test', () => {
     })
 
     test('override from CLI', async () => {
-      const overrideCLI = {
+      const overrideCLI: Omit<RunTestsCommandConfig, 'global' | 'proxy'> = {
         apiKey: 'fake_api_key',
         appKey: 'fake_app_key',
         configPath: 'src/commands/synthetics/__tests__/config-fixtures/empty-config-file.json',
@@ -112,11 +114,15 @@ describe('run-test', () => {
         failOnMissingTests: true,
         failOnTimeout: false,
         files: ['new-file'],
+        locations: ['us-east-1'],
         mobileApplicationVersionFilePath: './path/to/application.apk',
+        pollingTimeout: 1,
         publicIds: ['ran-dom-id'],
+        selectiveRerun: true,
         subdomain: 'new-sub-domain',
         testSearchQuery: 'a-search-query',
         tunnel: true,
+        variableStrings: ['key=value'],
       }
 
       const command = createCommand(RunTestsCommand)
@@ -513,7 +519,7 @@ describe('upload-application', () => {
     })
 
     test('override from config file', async () => {
-      const overrideConfigFile = {
+      const overrideConfigFile: UploadApplicationCommandConfig = {
         apiKey: 'fake_api_key',
         appKey: 'fake_app_key',
         configPath: 'src/commands/synthetics/__tests__/config-fixtures/upload-app-config-with-all-keys.json',
@@ -533,7 +539,7 @@ describe('upload-application', () => {
     })
 
     test('override from CLI', async () => {
-      const overrideCLI = {
+      const overrideCLI: Omit<UploadApplicationCommandConfig, 'proxy'> = {
         apiKey: 'fake_api_key_cli',
         appKey: 'fake_app_key_cli',
         configPath: 'src/commands/synthetics/__tests__/config-fixtures/empty-config-file.json',

--- a/src/commands/synthetics/__tests__/config-fixtures/config-with-all-keys.json
+++ b/src/commands/synthetics/__tests__/config-fixtures/config-with-all-keys.json
@@ -8,7 +8,7 @@
   "failOnTimeout": false,
   "files": ["my-new-file"],
   "global": {
-    "locations": [],
+    "locations": ["us-east-1"],
     "pollingTimeout": 2,
     "mobileApplicationVersionFilePath": "./path/to/application.apk"
   },
@@ -18,6 +18,7 @@
     "protocol": "https"
   },
   "publicIds": ["ran-dom-id"],
+  "selectiveRerun": true,
   "subdomain": "ppa",
   "tunnel": true,
   "variableStrings": []

--- a/src/commands/synthetics/interfaces.ts
+++ b/src/commands/synthetics/interfaces.ts
@@ -444,6 +444,7 @@ export interface RunTestsCommandConfig extends SyntheticsCIConfig {
   files: string[]
   global: UserConfigOverride
   locations: string[]
+  mobileApplicationVersionFilePath?: string
   pollingTimeout: number
   publicIds: string[]
   selectiveRerun: boolean

--- a/src/commands/synthetics/run-tests-command.ts
+++ b/src/commands/synthetics/run-tests-command.ts
@@ -112,7 +112,7 @@ export class RunTestsCommand extends Command {
     validator: validation.isInteger(),
   })
   private publicIds = Option.Array('-p,--public-id', {description: 'Specify a test to run.'})
-  private selectiveRerun = Option.Boolean('--selectiveRerun', false, {
+  private selectiveRerun = Option.Boolean('--selectiveRerun', {
     description:
       'A boolean flag to only run the tests which failed in the previous test batches. Use `--no-selectiveRerun` to force a full run if your configuration enables it by default.',
   })


### PR DESCRIPTION
### What and why?

This PR fixes a bug which makes it impossible to turn on `selectiveRerun` via config files. This is because the default value of the CLI parameter is `false` and not `undefined`, thus the `selectiveRerun` value set in a config file is overridden.

### How?

Remove the default value for the CLI parameter, and only rely on `DEFAULT_COMMAND_CONFIG`, which is the source of truth for default config parameters.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
