### PR TITLE
Support custom tags and metrics for GH jobs

### DIFF
--- a/src/commands/metric/README.md
+++ b/src/commands/metric/README.md
@@ -28,7 +28,7 @@ datadog-ci metric --level job --metrics binary.size:1024
 
 ### Supported providers
 
-The metric command only works for the following CI providers: [Buildkite, CircleCI, GitHub, GitLab, AzurePipelines, Jenkins]. If used in
+The metric command only works for the following CI providers: Buildkite, CircleCI, GitHub, GitLab, Azure Pipelines and Jenkins. If used in
 any other provider it will fail.
 
 ### End-to-end testing process

--- a/src/commands/metric/README.md
+++ b/src/commands/metric/README.md
@@ -28,10 +28,8 @@ datadog-ci metric --level job --metrics binary.size:1024
 
 ### Supported providers
 
-The metric command only works for the following CI providers: [Buildkite, CircleCI, GitHub, GitLab]. If used in
-any other provider it will fail. Note that for GitHub actions only the level `pipeline` is supported. If the
-command is invoked in GitHub actions with level `job` it will exit with status code 1 and return an
-error.
+The metric command only works for the following CI providers: [Buildkite, CircleCI, GitHub, GitLab, AzurePipelines, Jenkins]. If used in
+any other provider it will fail.
 
 ### End-to-end testing process
 

--- a/src/commands/metric/__tests__/metric.test.ts
+++ b/src/commands/metric/__tests__/metric.test.ts
@@ -92,15 +92,14 @@ describe('execute', () => {
     )
   })
 
-  test('should fail if provider is GitHub and level is job', async () => {
+  test('should fail if provider is BuddyWorks and level is job', async () => {
     const {context, code} = await runCLI('job', ['key:1'], {
-      GITHUB_ACTIONS: 'true',
-      GITHUB_REPOSITORY: 'example/example',
-      GITHUB_RUN_ATTEMPT: '10',
-      GITHUB_RUN_ID: '40',
-      GITHUB_SERVER_URL: 'github.com',
+      BUDDY: 'true',
+      BUDDY_PIPELINE_ID: 'example/example',
+      BUDDY_EXECUTION_ID: '10',
+      BUDDY_EXECUTION_START_DATE: '2023-03-08T00:00:00Z',
     })
     expect(code).toBe(1)
-    expect(context.stderr.toString()).toContain('Cannot use level "job" for GitHub Actions.')
+    expect(context.stderr.toString()).toContain('Cannot use level "job" for Buddy.')
   })
 })

--- a/src/commands/metric/metric.ts
+++ b/src/commands/metric/metric.ts
@@ -63,8 +63,8 @@ export class MetricCommand extends Command {
     try {
       const metrics = parseMetrics(this.metrics)
       const {provider, ciEnv} = getCIEnv()
-      // For GitHub and Buddy only the pipeline level is supported as there is no way to identify the job from the runner.
-      if ((provider === 'github' || provider === 'buddy') && this.level === 'job') {
+      // For Buddy only the pipeline level is supported as there is no way to identify the job from the runner.
+      if (provider === 'buddy' && this.level === 'job') {
         this.context.stderr.write(
           `${chalk.red.bold('[ERROR]')} Cannot use level "job" for ${PROVIDER_TO_DISPLAY_NAME[provider]}.`
         )

--- a/src/commands/tag/README.md
+++ b/src/commands/tag/README.md
@@ -29,10 +29,8 @@ datadog-ci tag --level job --tags "go.version:`go version`"
 
 ### Supported providers
 
-The tag command only works for the following CI providers: [Buildkite, CircleCI, GitHub, GitLab]. If used in
-any other provider it will fail. Note that for GitHub actions only the level `pipeline` is supported. If the
-command is invoked in GitHub actions with level `job` it will exit with status code 1 and return an
-error.
+The tag command only works for the following CI providers: [Buildkite, CircleCI, GitHub, GitLab, AzurePipelines, Jenkins]. If used in
+any other provider it will fail.
 
 ### End-to-end testing process
 

--- a/src/commands/tag/README.md
+++ b/src/commands/tag/README.md
@@ -29,7 +29,7 @@ datadog-ci tag --level job --tags "go.version:`go version`"
 
 ### Supported providers
 
-The tag command only works for the following CI providers: [Buildkite, CircleCI, GitHub, GitLab, AzurePipelines, Jenkins]. If used in
+The tag command only works for the following CI providers: Buildkite, CircleCI, GitHub, GitLab, Azure Pipelines and Jenkins. If used in
 any other provider it will fail.
 
 ### End-to-end testing process

--- a/src/commands/tag/__tests__/tag.test.ts
+++ b/src/commands/tag/__tests__/tag.test.ts
@@ -71,15 +71,14 @@ describe('execute', () => {
     )
   })
 
-  test('should fail if provider is GitHub and level is job', async () => {
+  test('should fail if provider is BuddyWorks and level is job', async () => {
     const {context, code} = await runCLI('job', ['key:value'], {
-      GITHUB_ACTIONS: 'true',
-      GITHUB_REPOSITORY: 'example/example',
-      GITHUB_RUN_ATTEMPT: '10',
-      GITHUB_RUN_ID: '40',
-      GITHUB_SERVER_URL: 'github.com',
+      BUDDY: 'true',
+      BUDDY_PIPELINE_ID: 'example/example',
+      BUDDY_EXECUTION_ID: '10',
+      BUDDY_EXECUTION_START_DATE: '2023-03-08T00:00:00Z',
     })
     expect(code).toBe(1)
-    expect(context.stderr.toString()).toContain('Cannot use level "job" for GitHub Actions.')
+    expect(context.stderr.toString()).toContain('Cannot use level "job" for Buddy.')
   })
 })

--- a/src/commands/tag/tag.ts
+++ b/src/commands/tag/tag.ts
@@ -65,8 +65,8 @@ export class TagCommand extends Command {
 
     try {
       const {provider, ciEnv} = getCIEnv()
-      // For GitHub and Buddy only the pipeline level is supported as there is no way to identify the job from the runner.
-      if ((provider === 'github' || provider === 'buddy') && this.level === 'job') {
+      // For BuddyWorks only the pipeline level is supported as there is no way to identify the job from the runner.
+      if (provider === 'buddy' && this.level === 'job') {
         this.context.stderr.write(
           `${chalk.red.bold('[ERROR]')} Cannot use level "job" for ${PROVIDER_TO_DISPLAY_NAME[provider]}.`
         )

--- a/src/helpers/ci.ts
+++ b/src/helpers/ci.ts
@@ -50,7 +50,7 @@ export const PROVIDER_TO_DISPLAY_NAME = {
 
 // DD_GITHUB_JOB_NAME is an override that is required for adding custom tags and metrics
 // to GHA jobs if the 'name' property is used. It's ok for it to be missing in case the name property is not used.
-const envAllowedToBeMissing  = ['DD_GITHUB_JOB_NAME']
+const envAllowedToBeMissing = ['DD_GITHUB_JOB_NAME']
 
 // Receives a string with the form 'John Doe <john.doe@gmail.com>'
 // and returns { name: 'John Doe', email: 'john.doe@gmail.com' }
@@ -717,7 +717,14 @@ export const getCIEnv = (): {ciEnv: Record<string, string>; provider: string} =>
 
   if (process.env.GITHUB_ACTIONS || process.env.GITHUB_ACTION) {
     return {
-      ciEnv: filterEnv(['GITHUB_SERVER_URL', 'GITHUB_REPOSITORY', 'GITHUB_RUN_ID', 'GITHUB_RUN_ATTEMPT', 'GITHUB_JOB', 'DD_GITHUB_JOB_NAME']),
+      ciEnv: filterEnv([
+        'GITHUB_SERVER_URL',
+        'GITHUB_REPOSITORY',
+        'GITHUB_RUN_ID',
+        'GITHUB_RUN_ATTEMPT',
+        'GITHUB_JOB',
+        'DD_GITHUB_JOB_NAME',
+      ]),
       provider: 'github',
     }
   }

--- a/src/helpers/ci.ts
+++ b/src/helpers/ci.ts
@@ -713,7 +713,7 @@ export const getCIEnv = (): {ciEnv: Record<string, string>; provider: string} =>
 
   if (process.env.GITHUB_ACTIONS || process.env.GITHUB_ACTION) {
     return {
-      ciEnv: filterEnv(['GITHUB_SERVER_URL', 'GITHUB_REPOSITORY', 'GITHUB_RUN_ID', 'GITHUB_RUN_ATTEMPT']),
+      ciEnv: filterEnv(['GITHUB_SERVER_URL', 'GITHUB_REPOSITORY', 'GITHUB_RUN_ID', 'GITHUB_RUN_ATTEMPT', 'GITHUB_JOB']),
       provider: 'github',
     }
   }


### PR DESCRIPTION
### What and why?

Adding support for custom tags at job level for GitHub by relying on the `GITHUB_JOB` environment variables. In case the [name](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#name) property is used when defining jobs, customers will need to additionally expose the `DD_GITHUB_JOB_NAME` pointing to that name.

### How?

A brief description of implementation details of this PR.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
