### PR TITLE
Creating release v2.29.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci",
-  "version": "2.28.0",
+  "version": "2.29.0",
   "description": "Run datadog actions from the CI.",
   "repository": "https://github.com/DataDog/datadog-ci",
   "license": "Apache-2.0",


### PR DESCRIPTION
### What and why?

Releasing version 2.29.0.

### CI Visibility:
* Support custom tags and metrics for GH jobs by @andrea-mosk in https://github.com/DataDog/datadog-ci/pull/1161

**Full Changelog**: https://github.com/DataDog/datadog-ci/compare/v2.28.0...v2.29.0

### How?

A brief description of implementation details of this PR.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
