### PR TITLE
[synthetics] Change error message for timed out results

### DIFF
--- a/src/commands/synthetics/__tests__/fixtures.ts
+++ b/src/commands/synthetics/__tests__/fixtures.ts
@@ -216,7 +216,7 @@ export const getTimedOutBrowserResult = (): Result => ({
   passed: false,
   result: {
     duration: 0,
-    failure: {code: 'TIMEOUT', message: 'Result timed out'},
+    failure: {code: 'TIMEOUT', message: 'The batch timed out before receiving the result.'},
     passed: false,
     steps: [],
   },
@@ -483,7 +483,7 @@ export const getResults = (resultsFixtures: ResultFixtures[]): Result[] => {
 
     if (timedOut) {
       result.timedOut = true
-      result.result.failure = {code: 'TIMEOUT', message: 'Result timed out'}
+      result.result.failure = {code: 'TIMEOUT', message: 'The batch timed out before receiving the result.'}
     }
 
     if (selectiveRerun) {

--- a/src/commands/synthetics/__tests__/reporters/__snapshots__/default.test.ts.snap
+++ b/src/commands/synthetics/__tests__/reporters/__snapshots__/default.test.ts.snap
@@ -59,7 +59,7 @@ exports[`Default reporter resultEnd 3 Browser test: failed blocking, timed out, 
 
 [1m[31m✖[39m[22m [[1m[31mblocking[39m[22m] [[1m[2mabc-def-ghi[22m[22m] [1mTest name[22m - [1m[31mlocation: [1mLocation name[22m[1m[39m[22m
   ⎋ View test run details: [2m[36mhttps://app.datadoghq.com/synthetics/details/abc-def-ghi/result/1?from_ci=true[39m[22m (not yet received)
-[31m    [[1mTIMEOUT[22m] - [2mResult timed out[22m[39m
+[31m    [[1mTIMEOUT[22m] - [2mThe batch timed out before receiving the result.[22m[39m
 
 [1m[31m✖[39m[22m [[1m[31mblocking[39m[22m] [[1m[2mabc-def-ghi[22m[22m] [1mTest name[22m - [1m[31mlocation: [1mLocation name[22m[1m[39m[22m
   ⎋ View test run details: [2m[36mhttps://app.datadoghq.com/synthetics/details/abc-def-ghi/result/1?from_ci=true[39m[22m 

--- a/src/commands/synthetics/__tests__/reporters/junit.test.ts
+++ b/src/commands/synthetics/__tests__/reporters/junit.test.ts
@@ -273,7 +273,10 @@ describe('Junit reporter', () => {
       }
       const browserResult3: Result = {
         ...globalResultMock,
-        result: {...getBrowserServerResult(), failure: {code: 'TIMEOUT', message: 'Result timed out'}},
+        result: {
+          ...getBrowserServerResult(),
+          failure: {code: 'TIMEOUT', message: 'The batch timed out before receiving the result.'},
+        },
         timedOut: true,
       }
       const apiResult: Result = {

--- a/src/commands/synthetics/__tests__/utils/public.test.ts
+++ b/src/commands/synthetics/__tests__/utils/public.test.ts
@@ -1009,7 +1009,7 @@ describe('utils', () => {
         ...result,
         result: {
           ...result.result,
-          failure: {code: 'TIMEOUT', message: 'Result timed out'},
+          failure: {code: 'TIMEOUT', message: 'The batch timed out before receiving the result.'},
           passed: false,
         },
         resultId: '3',
@@ -1077,7 +1077,11 @@ describe('utils', () => {
       ).toStrictEqual([
         {
           ...result,
-          result: {...result.result, failure: {code: 'TIMEOUT', message: 'Result timed out'}, passed: false},
+          result: {
+            ...result.result,
+            failure: {code: 'TIMEOUT', message: 'The batch timed out before receiving the result.'},
+            passed: false,
+          },
           timedOut: true,
         },
       ])
@@ -1107,7 +1111,11 @@ describe('utils', () => {
       ).toEqual([
         {
           ...result,
-          result: {...result.result, failure: {code: 'TIMEOUT', message: 'Result timed out'}, passed: false},
+          result: {
+            ...result.result,
+            failure: {code: 'TIMEOUT', message: 'The batch timed out before receiving the result.'},
+            passed: false,
+          },
           timedOut: true,
         },
       ])
@@ -1189,7 +1197,7 @@ describe('utils', () => {
             ...result.result,
             failure: {
               code: 'TIMEOUT',
-              message: 'Result timed out',
+              message: 'The batch timed out before receiving the result.',
             },
             passed: false,
           },

--- a/src/commands/synthetics/reporters/junit.ts
+++ b/src/commands/synthetics/reporters/junit.ts
@@ -254,7 +254,7 @@ export class JUnitReporter implements Reporter {
     }
 
     if (result.timedOut) {
-      // Timeout errors are manually reported by the CLI at the test level. ('Result timed out')
+      // Timeout errors are manually reported by the CLI at the test level. ('The batch timed out before receiving the result.')
       errorOrFailure.push({
         $: {type: 'timeout'},
         _: String(result.result.failure?.message),

--- a/src/commands/synthetics/utils/public.ts
+++ b/src/commands/synthetics/utils/public.ts
@@ -447,7 +447,7 @@ const getResultFromBatch = (
   const pollResult = pollResultMap[resultInBatch.result_id]
 
   if (hasTimedOut) {
-    pollResult.result.failure = {code: 'TIMEOUT', message: 'Result timed out'}
+    pollResult.result.failure = {code: 'TIMEOUT', message: 'The batch timed out before receiving the result.'}
     pollResult.result.passed = false
   }
 


### PR DESCRIPTION
### What and why?

The current error message ("Result timed out") doesn't give enough information.

### How?

Change the error message to be more explicit:

> The batch timed out before receiving the result.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
