### PR TITLE
[synthetics] Fix newline in text output with JUnit reports

### DIFF
--- a/src/commands/synthetics/__tests__/reporters/__snapshots__/default.test.ts.snap
+++ b/src/commands/synthetics/__tests__/reporters/__snapshots__/default.test.ts.snap
@@ -74,7 +74,8 @@ View full summary in Datadog: [2m[36mhttps://app.datadoghq.com/synthetics/expl
 
 [1mContinuous Testing Summary:[22m
 • Test Results: [32m[1m3[22m passed[39m, [31m[1m0[22m failed[39m, [33m[1m1[22m failed (non-blocking)[39m ([31m[1m1[22m critical errors[39m)
-• Total Duration: 9m 28s"
+• Total Duration: 9m 28s
+"
 `;
 
 exports[`Default reporter runEnd Case with 2 passed results, of which 1 comes from previous CI run 1`] = `
@@ -83,7 +84,8 @@ exports[`Default reporter runEnd Case with 2 passed results, of which 1 comes fr
 [1mContinuous Testing Summary:[22m
 • Test Results: [32m[1m2[22m passed ([1m1[22m in previous CI run)[39m, [31m[1m0[22m failed[39m
 • Selective re-run: ran 1 out of 2 tests
-• Total Duration: 9m 28s"
+• Total Duration: 9m 28s
+"
 `;
 
 exports[`Default reporter runEnd Complex case with all the tests and results outcomes possible 1`] = `
@@ -93,7 +95,8 @@ View full summary in Datadog: [2m[36mhttps://app.datadoghq.com/synthetics/expl
 [1mContinuous Testing Summary:[22m
 • Test Results: [32m[1m2[22m passed ([1m1[22m in previous CI run)[39m, [31m[1m1[22m failed[39m, [33m[1m3[22m failed (non-blocking)[39m, [1m1[22m skipped ([33m[1m1[22m timed out[39m, [31m[1m2[22m critical errors[39m)
 • Selective re-run: ran 5 out of 6 tests
-• Total Duration: 9m 28s"
+• Total Duration: 9m 28s
+"
 `;
 
 exports[`Default reporter runEnd Simple case with 1 test with 1 result (passed) 1`] = `
@@ -101,7 +104,8 @@ exports[`Default reporter runEnd Simple case with 1 test with 1 result (passed) 
 
 [1mContinuous Testing Summary:[22m
 • Test Results: [32m[1m1[22m passed[39m, [31m[1m0[22m failed[39m
-• Total Duration: 9m 28s"
+• Total Duration: 9m 28s
+"
 `;
 
 exports[`Default reporter runEnd communicates 2 tests parallelization 1`] = `
@@ -113,6 +117,7 @@ exports[`Default reporter runEnd communicates 2 tests parallelization 1`] = `
 • Total Duration: 9m 28s
 
 Increase your parallelization to reduce the test batch duration: [2m[36mhttps://app.datadoghq.com/synthetics/settings/continuous-testing[39m[22m
+
 "
 `;
 
@@ -125,6 +130,7 @@ exports[`Default reporter runEnd communicates no parallelization (1 test at a ti
 • Total Duration: 9m 28s
 
 Increase your parallelization to reduce the test batch duration: [2m[36mhttps://app.datadoghq.com/synthetics/settings/continuous-testing[39m[22m
+
 "
 `;
 
@@ -133,7 +139,8 @@ exports[`Default reporter runEnd does not communicate for uncapped orgs 1`] = `
 
 [1mContinuous Testing Summary:[22m
 • Test Results: [32m[1m1[22m passed[39m, [31m[1m0[22m failed[39m
-• Total Duration: 9m 28s"
+• Total Duration: 9m 28s
+"
 `;
 
 exports[`Default reporter testTrigger Blocking test, with 1 config override 1`] = `

--- a/src/commands/synthetics/reporters/default.ts
+++ b/src/commands/synthetics/reporters/default.ts
@@ -399,7 +399,7 @@ export class DefaultReporter implements MainReporter {
       )
     }
 
-    this.write(lines.join('\n'))
+    this.write(lines.join('\n') + '\n')
   }
 
   public testsWait(tests: Test[], baseUrl: string, batchId: string, skippedCount?: number) {

--- a/src/commands/synthetics/reporters/junit.ts
+++ b/src/commands/synthetics/reporters/junit.ts
@@ -289,9 +289,9 @@ export class JUnitReporter implements Reporter {
       const xml = this.builder.buildObject(this.json)
       fs.mkdirSync(path.dirname(this.destination), {recursive: true})
       fs.writeFileSync(this.destination, xml, 'utf8')
-      this.write(`✅ Created a jUnit report at ${c.bold.green(this.destination)}\n`)
+      this.write(`\n✅ Created a jUnit report at ${c.bold.green(this.destination)}\n`)
     } catch (e) {
-      this.write(`❌ Couldn't write the report to ${c.bold.green(this.destination)}:\n${e.toString()}\n`)
+      this.write(`\n❌ Couldn't write the report to ${c.bold.green(this.destination)}:\n${e.toString()}\n`)
     }
   }
 


### PR DESCRIPTION
### What and why?

#### Before
Without JUnit report (the `%` with white background is **added by Zsh** to show that a command's `stdout` doesn't end with a newline):
<img width="927" alt="image" src="https://github.com/DataDog/datadog-ci/assets/9317502/7390b1b4-ca1e-47b5-bb45-cc046adb4738">

With JUnit report: (notice the missing newline)
<img width="927" alt="image" src="https://github.com/DataDog/datadog-ci/assets/9317502/d0dba3b7-215c-4f7d-87cc-31ad0757cf8a">

#### After
Without JUnit report:
<img width="935" alt="image" src="https://github.com/DataDog/datadog-ci/assets/9317502/f120d212-c7ba-41ac-90b0-91bb744c4809">

With JUnit report:
<img width="921" alt="image" src="https://github.com/DataDog/datadog-ci/assets/9317502/a5f86faa-08ff-43b8-b5d4-5f4f04d63d9d">

### How?

Add a `\n` at the end of the `Continuous Testing Summary` and at the beginning of the `Created a JUnit report` text.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
