### PR TITLE
[ci] Unit test against Node 20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [14, 16, 18]
+        version: [14, 16, 18, 20]
 
     name: Build and test
     runs-on: ubuntu-latest
@@ -62,7 +62,7 @@ jobs:
   e2e-test:
     strategy:
       matrix:
-        version: [14, 16, 18]
+        version: [14, 16, 18, 20]
 
     name: End-to-end test the package
     runs-on: ubuntu-latest
@@ -183,8 +183,8 @@ jobs:
         with:
           dd_app_key: ${{ secrets.DATADOG_APP_KEY_MAIN_ACCOUNT }}
           dd_api_key: ${{ secrets.DATADOG_API_KEY_MAIN_ACCOUNT }}
-          dd_service: "datadog-ci"
-          dd_env: "ci"
+          dd_service: 'datadog-ci'
+          dd_env: 'ci'
           cpu_count: 2
           enable_performance_statistics: true
           sca_enabled: true

--- a/src/commands/sarif/__tests__/upload.test.ts
+++ b/src/commands/sarif/__tests__/upload.test.ts
@@ -66,6 +66,17 @@ describe('upload', () => {
         reportPath: './src/commands/sarif/__tests__/fixtures/valid-results.sarif',
       })
 
+      const getInvalidJsonUnexpectedTokenErrorMessage = () => {
+        try {
+          JSON.parse('this is an invalid sarif report')
+        } catch (e) {
+          // This error message is different in Node.js >=20
+          return (e as SyntaxError).message
+        }
+
+        throw Error('unreachable')
+      }
+
       const output = context.stdout.toString()
       expect(output).toContain(
         renderInvalidFile('./src/commands/sarif/__tests__/fixtures/empty.sarif', 'Unexpected end of JSON input')
@@ -73,7 +84,7 @@ describe('upload', () => {
       expect(output).toContain(
         renderInvalidFile(
           './src/commands/sarif/__tests__/fixtures/invalid.sarif',
-          'Unexpected token h in JSON at position 1'
+          getInvalidJsonUnexpectedTokenErrorMessage()
         )
       )
       expect(output).toContain(


### PR DESCRIPTION
### What and why?

This PR adds Node.js 20 to the unit test matrix.

### How?

A single unit test was breaking because of a different error message in Node.js 20.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
