### PR TITLE
Remove sbom from beta

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,7 +107,6 @@ jobs:
       - name: Run sbom upload test
         run: yarn datadog-ci sbom upload --service=datadog-ci-e2e-tests-sbom --env test artifacts/e2e/sbom-reports/sbom.json
         env:
-          DD_BETA_COMMANDS_ENABLED: 1
           DD_API_KEY: ${{ secrets.DD_API_KEY_CI_VISIBILITY }}
           DD_APP_KEY: ${{ secrets.DD_APP_KEY_CI_VISIBILITY }}
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,9 @@ See each command's linked README for more details, or click on [📚](https://do
 #### `sarif`
 - `upload`: Upload [Static Analysis Results Interchange Format (SARIF)](src/commands/sarif) reports to Datadog. [📚](https://docs.datadoghq.com/static_analysis/)
 
+#### `sbom`
+- `upload`: Upload [Software Bill of Materials (SBOM)](src/commands/sbom) files to Datadog. [📚](https://docs.datadoghq.com/static_analysis/)
+
 #### `sourcemaps`
 - `upload`: Upload [JavaScript sourcemaps](src/commands/sourcemaps) for Error Tracking. [📚](https://docs.datadoghq.com/real_user_monitoring/guide/upload-javascript-source-maps)
 
@@ -107,9 +110,6 @@ The following are **beta** commands, you can enable them with with `DD_BETA_COMM
 
 #### `gate`
 - `evaluate`: Evaluate [Quality Gates](src/commands/gate) rules in Datadog. [📚](https://docs.datadoghq.com/quality_gates/)
-
-#### `sbom`
-- `upload`: Upload [Software Bill of Materials (SBOM)](src/commands/sbom) files to Datadog. [📚](https://docs.datadoghq.com/static_analysis/)
 
 ## More ways to install the CLI
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,7 +5,7 @@ import {CommandClass} from 'clipanion/lib/advanced/Command'
 
 import {version} from './helpers/version'
 
-export const BETA_COMMANDS = ['sbom', 'dora', 'deployment']
+export const BETA_COMMANDS = ['dora', 'deployment']
 
 const onError = (err: any) => {
   console.log(err)


### PR DESCRIPTION
### What and why?

The SCA product is out now and available to customers. We are removing the beta flag.
