### PR TITLE
[SYNTH-12059] Trailing slash in test suite id leads to `[] Found test "undefined"`

### DIFF
--- a/src/commands/synthetics/__tests__/run-tests-lib.test.ts
+++ b/src/commands/synthetics/__tests__/run-tests-lib.test.ts
@@ -53,14 +53,14 @@ describe('run-test', () => {
         runTests.executeTests(mockReporter, {
           ...ciConfig,
           global: userConfigOverride,
-          publicIds: ['public-id-1', 'public-id-2'],
+          publicIds: ['aaa-aaa-aaa', 'bbb-bbb-bbb'],
         })
       ).rejects.toThrow()
       expect(getTestsToTriggersMock).toHaveBeenCalledWith(
         apiHelper,
         expect.arrayContaining([
-          expect.objectContaining({id: 'public-id-1', config: userConfigOverride}),
-          expect.objectContaining({id: 'public-id-2', config: userConfigOverride}),
+          expect.objectContaining({id: 'aaa-aaa-aaa', config: userConfigOverride}),
+          expect.objectContaining({id: 'bbb-bbb-bbb', config: userConfigOverride}),
         ]),
         expect.anything(),
         false,
@@ -103,14 +103,14 @@ describe('run-test', () => {
           runTests.executeTests(mockReporter, {
             ...ciConfig,
             ...partialCIConfig,
-            publicIds: ['public-id-1', 'public-id-2'],
+            publicIds: ['aaa-aaa-aaa', 'bbb-bbb-bbb'],
           })
         ).rejects.toThrow(new CiError('NO_TESTS_TO_RUN'))
         expect(getTestsToTriggersMock).toHaveBeenCalledWith(
           apiHelper,
           expect.arrayContaining([
-            expect.objectContaining({id: 'public-id-1', config: expectedOverriddenConfig}),
-            expect.objectContaining({id: 'public-id-2', config: expectedOverriddenConfig}),
+            expect.objectContaining({id: 'aaa-aaa-aaa', config: expectedOverriddenConfig}),
+            expect.objectContaining({id: 'bbb-bbb-bbb', config: expectedOverriddenConfig}),
           ]),
           expect.anything(),
           false,
@@ -137,14 +137,14 @@ describe('run-test', () => {
         runTests.executeTests(mockReporter, {
           ...ciConfig,
           global: configOverride,
-          publicIds: ['public-id-1', 'public-id-2'],
+          publicIds: ['aaa-aaa-aaa', 'bbb-bbb-bbb'],
         })
       ).rejects.toThrow(new CiError('NO_TESTS_TO_RUN'))
       expect(getTestsToTriggersMock).toHaveBeenCalledWith(
         apiHelper,
         expect.arrayContaining([
-          expect.objectContaining({id: 'public-id-1', config: configOverride}),
-          expect.objectContaining({id: 'public-id-2', config: configOverride}),
+          expect.objectContaining({id: 'aaa-aaa-aaa', config: configOverride}),
+          expect.objectContaining({id: 'bbb-bbb-bbb', config: configOverride}),
         ]),
         expect.anything(),
         false,
@@ -172,15 +172,15 @@ describe('run-test', () => {
         runTests.executeTests(mockReporter, {
           ...ciConfig,
           global: configOverride,
-          publicIds: ['public-id-1', 'public-id-2'],
+          publicIds: ['aaa-aaa-aaa', 'bbb-bbb-bbb'],
           tunnel: true,
         })
       ).rejects.toThrow(new CiError('NO_TESTS_TO_RUN'))
       expect(getTestsToTriggersMock).toHaveBeenCalledWith(
         apiHelper,
         expect.arrayContaining([
-          expect.objectContaining({id: 'public-id-1', config: configOverride}),
-          expect.objectContaining({id: 'public-id-2', config: configOverride}),
+          expect.objectContaining({id: 'aaa-aaa-aaa', config: configOverride}),
+          expect.objectContaining({id: 'bbb-bbb-bbb', config: configOverride}),
         ]),
         expect.anything(),
         false,
@@ -251,7 +251,7 @@ describe('run-test', () => {
         }
         jest.spyOn(api, 'getApiHelper').mockImplementation(() => apiHelper as any)
         await expect(
-          runTests.executeTests(mockReporter, {...ciConfig, publicIds: ['public-id-1'], tunnel: true})
+          runTests.executeTests(mockReporter, {...ciConfig, publicIds: ['aaa-aaa-aaa'], tunnel: true})
         ).rejects.toThrow(
           new CriticalError(
             error,
@@ -278,7 +278,7 @@ describe('run-test', () => {
 
       jest.spyOn(api, 'getApiHelper').mockImplementation(() => apiHelper as any)
       await expect(
-        runTests.executeTests(mockReporter, {...ciConfig, publicIds: ['public-id-1', 'public-id-2'], tunnel: true})
+        runTests.executeTests(mockReporter, {...ciConfig, publicIds: ['aaa-aaa-aaa', 'bbb-bbb-bbb'], tunnel: true})
       ).rejects.toThrow(new CriticalError('UNAVAILABLE_TUNNEL_CONFIG', 'Server Error'))
     })
 
@@ -366,7 +366,7 @@ describe('run-test', () => {
 
       jest.spyOn(api, 'getApiHelper').mockImplementation(() => apiHelper as any)
       await expect(
-        runTests.executeTests(mockReporter, {...ciConfig, publicIds: ['public-id-1', 'public-id-2'], tunnel: true})
+        runTests.executeTests(mockReporter, {...ciConfig, publicIds: ['aaa-aaa-aaa', 'bbb-bbb-bbb'], tunnel: true})
       ).rejects.toThrow(
         new CriticalError(
           'TRIGGER_TESTS_FAILED',
@@ -416,7 +416,7 @@ describe('run-test', () => {
         runTests.executeTests(mockReporter, {
           ...ciConfig,
           failOnCriticalErrors: true,
-          publicIds: ['public-id-1', 'public-id-2'],
+          publicIds: ['aaa-aaa-aaa', 'bbb-bbb-bbb'],
           tunnel: true,
         })
       ).rejects.toThrow(

--- a/src/commands/synthetics/utils/public.ts
+++ b/src/commands/synthetics/utils/public.ts
@@ -54,7 +54,7 @@ import {
 } from './internal'
 
 const POLLING_INTERVAL = 5000 // In ms
-const PUBLIC_ID_REGEX = /^[\d\w]{3}-[\d\w]{3}-[\d\w]{3}$/
+const PUBLIC_ID_REGEX = /\b[\d\w]{3}-[\d\w]{3}-[\d\w]{3}\b/
 const TEMPLATE_REGEX = /{{\s*([^{}]*?)\s*}}/g
 
 export const readableOperation: {[key in Operator]: string} = {
@@ -644,7 +644,11 @@ export const getTestAndOverrideConfig = async (
   summary: InitialSummary,
   isTunnelEnabled?: boolean
 ): Promise<NotFound | Skipped | TestWithOverride> => {
-  const normalizedId = PUBLIC_ID_REGEX.test(id) ? id : id.substring(id.lastIndexOf('/') + 1)
+  const normalizedId = id.match(PUBLIC_ID_REGEX)?.[0]
+
+  if (normalizedId === undefined) {
+    throw new CriticalError('INVALID_CONFIG', `No valid public ID found in: \`${id}\``)
+  }
 
   const testResult = await getTest(api, {config, id: normalizedId, suite})
   if ('errorMessage' in testResult) {

--- a/src/commands/synthetics/utils/public.ts
+++ b/src/commands/synthetics/utils/public.ts
@@ -54,7 +54,7 @@ import {
 } from './internal'
 
 const POLLING_INTERVAL = 5000 // In ms
-const PUBLIC_ID_REGEX = /\b[\d\w]{3}-[\d\w]{3}-[\d\w]{3}\b/
+const PUBLIC_ID_REGEX = /\b[a-z0-9]{3}-[a-z0-9]{3}-[a-z0-9]{3}\b/
 const TEMPLATE_REGEX = /{{\s*([^{}]*?)\s*}}/g
 
 export const readableOperation: {[key in Operator]: string} = {

--- a/src/commands/synthetics/utils/public.ts
+++ b/src/commands/synthetics/utils/public.ts
@@ -646,7 +646,7 @@ export const getTestAndOverrideConfig = async (
 ): Promise<NotFound | Skipped | TestWithOverride> => {
   const normalizedId = id.match(PUBLIC_ID_REGEX)?.[0]
 
-  if (normalizedId === undefined) {
+  if (!normalizedId) {
     throw new CriticalError('INVALID_CONFIG', `No valid public ID found in: \`${id}\``)
   }
 


### PR DESCRIPTION
### What and why?

In cases where we would have a "/" at the end of the url in a `Test Config` or a cli command like
`datadog-ci synthetics run-tests --public-id ''`
We would get a `[] Found test "undefined"` message. Neither of these are desired behaviours.

For the first case we want the test to be correctly identified. And for the 2nd we want to raise an error. 

### How?

This PR is addressing both by improving the way we find the public_id in a url and in case we don't find it we raise an error.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
