### PR TITLE
[dep] Bump ssh2 to `1.15.0`

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "rimraf": "^3.0.2",
     "semver": "^7.5.3",
     "simple-git": "3.16.0",
-    "ssh2": "1.14.0",
+    "ssh2": "^1.15.0",
     "ssh2-streams": "0.4.10",
     "sshpk": "1.16.1",
     "terminal-link": "2.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2045,7 +2045,7 @@ __metadata:
     rimraf: ^3.0.2
     semver: ^7.5.3
     simple-git: 3.16.0
-    ssh2: 1.14.0
+    ssh2: ^1.15.0
     ssh2-streams: 0.4.10
     sshpk: 1.16.1
     terminal-link: 2.1.1
@@ -5110,14 +5110,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cpu-features@npm:~0.0.8":
-  version: 0.0.8
-  resolution: "cpu-features@npm:0.0.8"
+"cpu-features@npm:~0.0.9":
+  version: 0.0.9
+  resolution: "cpu-features@npm:0.0.9"
   dependencies:
     buildcheck: ~0.0.6
     nan: ^2.17.0
     node-gyp: latest
-  checksum: 7b52da1e538beb31185c63a874c8b88c40048ee7ebb5dfd37bb15d9c9044fffa2da048c2bc46d9f2e0916ec86d38c6812c7c6baafdddd504d56594eeff614444
+  checksum: 1ff6045a16d32d9667d5dd69c7d485944494d3378ac9381c52bca772bd0c948812eaeda55a76ef09212b0c0e0c575e5d53221899ce51692b1196089452c5aef1
   languageName: node
   linkType: hard
 
@@ -8912,6 +8912,15 @@ jschardet@latest:
   languageName: node
   linkType: hard
 
+"nan@npm:^2.18.0":
+  version: 2.18.0
+  resolution: "nan@npm:2.18.0"
+  dependencies:
+    node-gyp: latest
+  checksum: 4fe42f58456504eab3105c04a5cffb72066b5f22bd45decf33523cb17e7d6abc33cca2a19829407b9000539c5cb25f410312d4dc5b30220167a3594896ea6a0a
+  languageName: node
+  linkType: hard
+
 "napi-build-utils@npm:^1.0.1":
   version: 1.0.2
   resolution: "napi-build-utils@npm:1.0.2"
@@ -10410,20 +10419,20 @@ jschardet@latest:
   languageName: node
   linkType: hard
 
-"ssh2@npm:1.14.0":
-  version: 1.14.0
-  resolution: "ssh2@npm:1.14.0"
+"ssh2@npm:^1.15.0":
+  version: 1.15.0
+  resolution: "ssh2@npm:1.15.0"
   dependencies:
     asn1: ^0.2.6
     bcrypt-pbkdf: ^1.0.2
-    cpu-features: ~0.0.8
-    nan: ^2.17.0
+    cpu-features: ~0.0.9
+    nan: ^2.18.0
   dependenciesMeta:
     cpu-features:
       optional: true
     nan:
       optional: true
-  checksum: c583527950312716f1b620d5120e3c3e241f8cc221f19fc88fd3d561c6020c1009532438f2177a2e706223d91842deff137d93e00832b7b9016593da9a00fb89
+  checksum: 56baa07dc0dd8d97aefa05033b8a95d220a34b2f203aa9116173d7adc5e9fd46be22d7cfed99cdd9f5548862ae44abd1ec136e20ea856d5c470a0df0e5aea9d1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### What and why?

Closes https://github.com/DataDog/datadog-ci/issues/1164

### How?

Bump `ssh2` to `1.15.0`

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
