### PR TITLE
[STAL-1268] Handle group in payload

### DIFF
--- a/src/commands/sbom/__tests__/fixtures/trivy-4.9.json
+++ b/src/commands/sbom/__tests__/fixtures/trivy-4.9.json
@@ -1,0 +1,13015 @@
+{
+  "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.5",
+  "serialNumber": "urn:uuid:95d36cac-62b0-4947-a73f-2f3740b0b50f",
+  "version": 1,
+  "metadata": {
+    "timestamp": "2024-02-06T21:21:35+00:00",
+    "tools": {
+      "components": [
+        {
+          "type": "application",
+          "group": "aquasecurity",
+          "name": "trivy",
+          "version": "0.49.0"
+        }
+      ]
+    },
+    "component": {
+      "bom-ref": "873837ef-b2ff-4bdd-b2e6-03c4799c23be",
+      "type": "application",
+      "name": ".",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:SchemaVersion",
+          "value": "2"
+        }
+      ]
+    }
+  },
+  "components": [
+    {
+      "bom-ref": "45b4a1a3-f555-4dfe-92d3-7167bf6b9739",
+      "type": "application",
+      "name": "src/commands/react-native/__tests__/fixtures/podfile-lock/with-hermes/Podfile.lock",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:Class",
+          "value": "lang-pkgs"
+        },
+        {
+          "name": "aquasecurity:trivy:Type",
+          "value": "cocoapods"
+        }
+      ]
+    },
+    {
+      "bom-ref": "b9bf924a-12f3-4ca1-98d0-30ae699fe77a",
+      "type": "application",
+      "name": "src/commands/react-native/__tests__/fixtures/podfile-lock/without-hermes/Podfile.lock",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:Class",
+          "value": "lang-pkgs"
+        },
+        {
+          "name": "aquasecurity:trivy:Type",
+          "value": "cocoapods"
+        }
+      ]
+    },
+    {
+      "bom-ref": "e907a761-71ba-4065-9654-87bb2d0dbff0",
+      "type": "application",
+      "name": "yarn.lock",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:Class",
+          "value": "lang-pkgs"
+        },
+        {
+          "name": "aquasecurity:trivy:Type",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:cocoapods/CocoaAsyncSocket@7.6.5",
+      "type": "library",
+      "name": "CocoaAsyncSocket",
+      "version": "7.6.5",
+      "purl": "pkg:cocoapods/CocoaAsyncSocket@7.6.5",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "CocoaAsyncSocket@7.6.5"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "cocoapods"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:cocoapods/DatadogSDK@1.12.1",
+      "type": "library",
+      "name": "DatadogSDK",
+      "version": "1.12.1",
+      "purl": "pkg:cocoapods/DatadogSDK@1.12.1",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "DatadogSDK@1.12.1"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "cocoapods"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:cocoapods/DatadogSDKCrashReporting@1.12.1",
+      "type": "library",
+      "name": "DatadogSDKCrashReporting",
+      "version": "1.12.1",
+      "purl": "pkg:cocoapods/DatadogSDKCrashReporting@1.12.1",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "DatadogSDKCrashReporting@1.12.1"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "cocoapods"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:cocoapods/DatadogSDKReactNative@1.1.4",
+      "type": "library",
+      "name": "DatadogSDKReactNative",
+      "version": "1.1.4",
+      "purl": "pkg:cocoapods/DatadogSDKReactNative@1.1.4",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "DatadogSDKReactNative@1.1.4"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "cocoapods"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:cocoapods/DoubleConversion@1.1.6",
+      "type": "library",
+      "name": "DoubleConversion",
+      "version": "1.1.6",
+      "purl": "pkg:cocoapods/DoubleConversion@1.1.6",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "DoubleConversion@1.1.6"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "cocoapods"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:cocoapods/FBLazyVector@0.70.4",
+      "type": "library",
+      "name": "FBLazyVector",
+      "version": "0.70.4",
+      "purl": "pkg:cocoapods/FBLazyVector@0.70.4",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "FBLazyVector@0.70.4"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "cocoapods"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:cocoapods/FBReactNativeSpec@0.70.4",
+      "type": "library",
+      "name": "FBReactNativeSpec",
+      "version": "0.70.4",
+      "purl": "pkg:cocoapods/FBReactNativeSpec@0.70.4",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "FBReactNativeSpec@0.70.4"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "cocoapods"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:cocoapods/Flipper-Boost-iOSX@1.76.0.1.11",
+      "type": "library",
+      "name": "Flipper-Boost-iOSX",
+      "version": "1.76.0.1.11",
+      "purl": "pkg:cocoapods/Flipper-Boost-iOSX@1.76.0.1.11",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "Flipper-Boost-iOSX@1.76.0.1.11"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "cocoapods"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:cocoapods/Flipper-DoubleConversion@3.2.0.1",
+      "type": "library",
+      "name": "Flipper-DoubleConversion",
+      "version": "3.2.0.1",
+      "purl": "pkg:cocoapods/Flipper-DoubleConversion@3.2.0.1",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "Flipper-DoubleConversion@3.2.0.1"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "cocoapods"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:cocoapods/Flipper-Fmt@7.1.7",
+      "type": "library",
+      "name": "Flipper-Fmt",
+      "version": "7.1.7",
+      "purl": "pkg:cocoapods/Flipper-Fmt@7.1.7",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "Flipper-Fmt@7.1.7"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "cocoapods"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:cocoapods/Flipper-Folly@2.6.10",
+      "type": "library",
+      "name": "Flipper-Folly",
+      "version": "2.6.10",
+      "purl": "pkg:cocoapods/Flipper-Folly@2.6.10",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "Flipper-Folly@2.6.10"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "cocoapods"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:cocoapods/Flipper-Glog@0.5.0.5",
+      "type": "library",
+      "name": "Flipper-Glog",
+      "version": "0.5.0.5",
+      "purl": "pkg:cocoapods/Flipper-Glog@0.5.0.5",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "Flipper-Glog@0.5.0.5"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "cocoapods"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:cocoapods/Flipper-PeerTalk@0.0.4",
+      "type": "library",
+      "name": "Flipper-PeerTalk",
+      "version": "0.0.4",
+      "purl": "pkg:cocoapods/Flipper-PeerTalk@0.0.4",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "Flipper-PeerTalk@0.0.4"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "cocoapods"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:cocoapods/Flipper-RSocket@1.4.3",
+      "type": "library",
+      "name": "Flipper-RSocket",
+      "version": "1.4.3",
+      "purl": "pkg:cocoapods/Flipper-RSocket@1.4.3",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "Flipper-RSocket@1.4.3"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "cocoapods"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:cocoapods/Flipper@0.125.0",
+      "type": "library",
+      "name": "Flipper",
+      "version": "0.125.0",
+      "purl": "pkg:cocoapods/Flipper@0.125.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "Flipper@0.125.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "cocoapods"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:cocoapods/FlipperKit@0.125.0",
+      "type": "library",
+      "name": "FlipperKit",
+      "version": "0.125.0",
+      "purl": "pkg:cocoapods/FlipperKit@0.125.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "FlipperKit@0.125.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "cocoapods"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:cocoapods/FlipperKit@0.125.0#Core",
+      "type": "library",
+      "name": "FlipperKit/Core",
+      "version": "0.125.0",
+      "purl": "pkg:cocoapods/FlipperKit@0.125.0#Core",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "FlipperKit/Core@0.125.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "cocoapods"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:cocoapods/FlipperKit@0.125.0#CppBridge",
+      "type": "library",
+      "name": "FlipperKit/CppBridge",
+      "version": "0.125.0",
+      "purl": "pkg:cocoapods/FlipperKit@0.125.0#CppBridge",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "FlipperKit/CppBridge@0.125.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "cocoapods"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:cocoapods/FlipperKit@0.125.0#FBCxxFollyDynamicConvert",
+      "type": "library",
+      "name": "FlipperKit/FBCxxFollyDynamicConvert",
+      "version": "0.125.0",
+      "purl": "pkg:cocoapods/FlipperKit@0.125.0#FBCxxFollyDynamicConvert",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "FlipperKit/FBCxxFollyDynamicConvert@0.125.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "cocoapods"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:cocoapods/FlipperKit@0.125.0#FBDefines",
+      "type": "library",
+      "name": "FlipperKit/FBDefines",
+      "version": "0.125.0",
+      "purl": "pkg:cocoapods/FlipperKit@0.125.0#FBDefines",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "FlipperKit/FBDefines@0.125.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "cocoapods"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:cocoapods/FlipperKit@0.125.0#FKPortForwarding",
+      "type": "library",
+      "name": "FlipperKit/FKPortForwarding",
+      "version": "0.125.0",
+      "purl": "pkg:cocoapods/FlipperKit@0.125.0#FKPortForwarding",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "FlipperKit/FKPortForwarding@0.125.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "cocoapods"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:cocoapods/FlipperKit@0.125.0#FlipperKitHighlightOverlay",
+      "type": "library",
+      "name": "FlipperKit/FlipperKitHighlightOverlay",
+      "version": "0.125.0",
+      "purl": "pkg:cocoapods/FlipperKit@0.125.0#FlipperKitHighlightOverlay",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "FlipperKit/FlipperKitHighlightOverlay@0.125.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "cocoapods"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:cocoapods/FlipperKit@0.125.0#FlipperKitLayoutHelpers",
+      "type": "library",
+      "name": "FlipperKit/FlipperKitLayoutHelpers",
+      "version": "0.125.0",
+      "purl": "pkg:cocoapods/FlipperKit@0.125.0#FlipperKitLayoutHelpers",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "FlipperKit/FlipperKitLayoutHelpers@0.125.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "cocoapods"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:cocoapods/FlipperKit@0.125.0#FlipperKitLayoutIOSDescriptors",
+      "type": "library",
+      "name": "FlipperKit/FlipperKitLayoutIOSDescriptors",
+      "version": "0.125.0",
+      "purl": "pkg:cocoapods/FlipperKit@0.125.0#FlipperKitLayoutIOSDescriptors",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "FlipperKit/FlipperKitLayoutIOSDescriptors@0.125.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "cocoapods"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:cocoapods/FlipperKit@0.125.0#FlipperKitLayoutPlugin",
+      "type": "library",
+      "name": "FlipperKit/FlipperKitLayoutPlugin",
+      "version": "0.125.0",
+      "purl": "pkg:cocoapods/FlipperKit@0.125.0#FlipperKitLayoutPlugin",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "FlipperKit/FlipperKitLayoutPlugin@0.125.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "cocoapods"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:cocoapods/FlipperKit@0.125.0#FlipperKitLayoutTextSearchable",
+      "type": "library",
+      "name": "FlipperKit/FlipperKitLayoutTextSearchable",
+      "version": "0.125.0",
+      "purl": "pkg:cocoapods/FlipperKit@0.125.0#FlipperKitLayoutTextSearchable",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "FlipperKit/FlipperKitLayoutTextSearchable@0.125.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "cocoapods"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:cocoapods/FlipperKit@0.125.0#FlipperKitNetworkPlugin",
+      "type": "library",
+      "name": "FlipperKit/FlipperKitNetworkPlugin",
+      "version": "0.125.0",
+      "purl": "pkg:cocoapods/FlipperKit@0.125.0#FlipperKitNetworkPlugin",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "FlipperKit/FlipperKitNetworkPlugin@0.125.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "cocoapods"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:cocoapods/FlipperKit@0.125.0#FlipperKitReactPlugin",
+      "type": "library",
+      "name": "FlipperKit/FlipperKitReactPlugin",
+      "version": "0.125.0",
+      "purl": "pkg:cocoapods/FlipperKit@0.125.0#FlipperKitReactPlugin",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "FlipperKit/FlipperKitReactPlugin@0.125.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "cocoapods"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:cocoapods/FlipperKit@0.125.0#FlipperKitUserDefaultsPlugin",
+      "type": "library",
+      "name": "FlipperKit/FlipperKitUserDefaultsPlugin",
+      "version": "0.125.0",
+      "purl": "pkg:cocoapods/FlipperKit@0.125.0#FlipperKitUserDefaultsPlugin",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "FlipperKit/FlipperKitUserDefaultsPlugin@0.125.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "cocoapods"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:cocoapods/FlipperKit@0.125.0#SKIOSNetworkPlugin",
+      "type": "library",
+      "name": "FlipperKit/SKIOSNetworkPlugin",
+      "version": "0.125.0",
+      "purl": "pkg:cocoapods/FlipperKit@0.125.0#SKIOSNetworkPlugin",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "FlipperKit/SKIOSNetworkPlugin@0.125.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "cocoapods"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:cocoapods/OpenSSL-Universal@1.1.1100",
+      "type": "library",
+      "name": "OpenSSL-Universal",
+      "version": "1.1.1100",
+      "purl": "pkg:cocoapods/OpenSSL-Universal@1.1.1100",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "OpenSSL-Universal@1.1.1100"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "cocoapods"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:cocoapods/PLCrashReporter@1.11.0",
+      "type": "library",
+      "name": "PLCrashReporter",
+      "version": "1.11.0",
+      "purl": "pkg:cocoapods/PLCrashReporter@1.11.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "PLCrashReporter@1.11.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "cocoapods"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:cocoapods/RCT-Folly@2021.07.22.00",
+      "type": "library",
+      "name": "RCT-Folly",
+      "version": "2021.07.22.00",
+      "purl": "pkg:cocoapods/RCT-Folly@2021.07.22.00",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "RCT-Folly@2021.07.22.00"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "cocoapods"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:cocoapods/RCT-Folly@2021.07.22.00#Default",
+      "type": "library",
+      "name": "RCT-Folly/Default",
+      "version": "2021.07.22.00",
+      "purl": "pkg:cocoapods/RCT-Folly@2021.07.22.00#Default",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "RCT-Folly/Default@2021.07.22.00"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "cocoapods"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:cocoapods/RCT-Folly@2021.07.22.00#Futures",
+      "type": "library",
+      "name": "RCT-Folly/Futures",
+      "version": "2021.07.22.00",
+      "purl": "pkg:cocoapods/RCT-Folly@2021.07.22.00#Futures",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "RCT-Folly/Futures@2021.07.22.00"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "cocoapods"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:cocoapods/RCTRequired@0.70.4",
+      "type": "library",
+      "name": "RCTRequired",
+      "version": "0.70.4",
+      "purl": "pkg:cocoapods/RCTRequired@0.70.4",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "RCTRequired@0.70.4"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "cocoapods"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:cocoapods/RCTTypeSafety@0.70.4",
+      "type": "library",
+      "name": "RCTTypeSafety",
+      "version": "0.70.4",
+      "purl": "pkg:cocoapods/RCTTypeSafety@0.70.4",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "RCTTypeSafety@0.70.4"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "cocoapods"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:cocoapods/React-Codegen@0.70.4",
+      "type": "library",
+      "name": "React-Codegen",
+      "version": "0.70.4",
+      "purl": "pkg:cocoapods/React-Codegen@0.70.4",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "React-Codegen@0.70.4"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "cocoapods"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:cocoapods/React-Core@0.70.4",
+      "type": "library",
+      "name": "React-Core",
+      "version": "0.70.4",
+      "purl": "pkg:cocoapods/React-Core@0.70.4",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "React-Core@0.70.4"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "cocoapods"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:cocoapods/React-Core@0.70.4#CoreModulesHeaders",
+      "type": "library",
+      "name": "React-Core/CoreModulesHeaders",
+      "version": "0.70.4",
+      "purl": "pkg:cocoapods/React-Core@0.70.4#CoreModulesHeaders",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "React-Core/CoreModulesHeaders@0.70.4"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "cocoapods"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:cocoapods/React-Core@0.70.4#Default",
+      "type": "library",
+      "name": "React-Core/Default",
+      "version": "0.70.4",
+      "purl": "pkg:cocoapods/React-Core@0.70.4#Default",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "React-Core/Default@0.70.4"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "cocoapods"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:cocoapods/React-Core@0.70.4#DevSupport",
+      "type": "library",
+      "name": "React-Core/DevSupport",
+      "version": "0.70.4",
+      "purl": "pkg:cocoapods/React-Core@0.70.4#DevSupport",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "React-Core/DevSupport@0.70.4"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "cocoapods"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:cocoapods/React-Core@0.70.4#RCTActionSheetHeaders",
+      "type": "library",
+      "name": "React-Core/RCTActionSheetHeaders",
+      "version": "0.70.4",
+      "purl": "pkg:cocoapods/React-Core@0.70.4#RCTActionSheetHeaders",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "React-Core/RCTActionSheetHeaders@0.70.4"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "cocoapods"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:cocoapods/React-Core@0.70.4#RCTAnimationHeaders",
+      "type": "library",
+      "name": "React-Core/RCTAnimationHeaders",
+      "version": "0.70.4",
+      "purl": "pkg:cocoapods/React-Core@0.70.4#RCTAnimationHeaders",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "React-Core/RCTAnimationHeaders@0.70.4"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "cocoapods"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:cocoapods/React-Core@0.70.4#RCTBlobHeaders",
+      "type": "library",
+      "name": "React-Core/RCTBlobHeaders",
+      "version": "0.70.4",
+      "purl": "pkg:cocoapods/React-Core@0.70.4#RCTBlobHeaders",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "React-Core/RCTBlobHeaders@0.70.4"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "cocoapods"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:cocoapods/React-Core@0.70.4#RCTImageHeaders",
+      "type": "library",
+      "name": "React-Core/RCTImageHeaders",
+      "version": "0.70.4",
+      "purl": "pkg:cocoapods/React-Core@0.70.4#RCTImageHeaders",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "React-Core/RCTImageHeaders@0.70.4"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "cocoapods"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:cocoapods/React-Core@0.70.4#RCTLinkingHeaders",
+      "type": "library",
+      "name": "React-Core/RCTLinkingHeaders",
+      "version": "0.70.4",
+      "purl": "pkg:cocoapods/React-Core@0.70.4#RCTLinkingHeaders",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "React-Core/RCTLinkingHeaders@0.70.4"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "cocoapods"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:cocoapods/React-Core@0.70.4#RCTNetworkHeaders",
+      "type": "library",
+      "name": "React-Core/RCTNetworkHeaders",
+      "version": "0.70.4",
+      "purl": "pkg:cocoapods/React-Core@0.70.4#RCTNetworkHeaders",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "React-Core/RCTNetworkHeaders@0.70.4"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "cocoapods"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:cocoapods/React-Core@0.70.4#RCTSettingsHeaders",
+      "type": "library",
+      "name": "React-Core/RCTSettingsHeaders",
+      "version": "0.70.4",
+      "purl": "pkg:cocoapods/React-Core@0.70.4#RCTSettingsHeaders",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "React-Core/RCTSettingsHeaders@0.70.4"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "cocoapods"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:cocoapods/React-Core@0.70.4#RCTTextHeaders",
+      "type": "library",
+      "name": "React-Core/RCTTextHeaders",
+      "version": "0.70.4",
+      "purl": "pkg:cocoapods/React-Core@0.70.4#RCTTextHeaders",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "React-Core/RCTTextHeaders@0.70.4"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "cocoapods"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:cocoapods/React-Core@0.70.4#RCTVibrationHeaders",
+      "type": "library",
+      "name": "React-Core/RCTVibrationHeaders",
+      "version": "0.70.4",
+      "purl": "pkg:cocoapods/React-Core@0.70.4#RCTVibrationHeaders",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "React-Core/RCTVibrationHeaders@0.70.4"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "cocoapods"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:cocoapods/React-Core@0.70.4#RCTWebSocket",
+      "type": "library",
+      "name": "React-Core/RCTWebSocket",
+      "version": "0.70.4",
+      "purl": "pkg:cocoapods/React-Core@0.70.4#RCTWebSocket",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "React-Core/RCTWebSocket@0.70.4"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "cocoapods"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:cocoapods/React-CoreModules@0.70.4",
+      "type": "library",
+      "name": "React-CoreModules",
+      "version": "0.70.4",
+      "purl": "pkg:cocoapods/React-CoreModules@0.70.4",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "React-CoreModules@0.70.4"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "cocoapods"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:cocoapods/React-RCTActionSheet@0.70.4",
+      "type": "library",
+      "name": "React-RCTActionSheet",
+      "version": "0.70.4",
+      "purl": "pkg:cocoapods/React-RCTActionSheet@0.70.4",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "React-RCTActionSheet@0.70.4"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "cocoapods"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:cocoapods/React-RCTAnimation@0.70.4",
+      "type": "library",
+      "name": "React-RCTAnimation",
+      "version": "0.70.4",
+      "purl": "pkg:cocoapods/React-RCTAnimation@0.70.4",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "React-RCTAnimation@0.70.4"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "cocoapods"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:cocoapods/React-RCTBlob@0.70.4",
+      "type": "library",
+      "name": "React-RCTBlob",
+      "version": "0.70.4",
+      "purl": "pkg:cocoapods/React-RCTBlob@0.70.4",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "React-RCTBlob@0.70.4"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "cocoapods"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:cocoapods/React-RCTImage@0.70.4",
+      "type": "library",
+      "name": "React-RCTImage",
+      "version": "0.70.4",
+      "purl": "pkg:cocoapods/React-RCTImage@0.70.4",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "React-RCTImage@0.70.4"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "cocoapods"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:cocoapods/React-RCTLinking@0.70.4",
+      "type": "library",
+      "name": "React-RCTLinking",
+      "version": "0.70.4",
+      "purl": "pkg:cocoapods/React-RCTLinking@0.70.4",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "React-RCTLinking@0.70.4"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "cocoapods"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:cocoapods/React-RCTNetwork@0.70.4",
+      "type": "library",
+      "name": "React-RCTNetwork",
+      "version": "0.70.4",
+      "purl": "pkg:cocoapods/React-RCTNetwork@0.70.4",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "React-RCTNetwork@0.70.4"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "cocoapods"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:cocoapods/React-RCTSettings@0.70.4",
+      "type": "library",
+      "name": "React-RCTSettings",
+      "version": "0.70.4",
+      "purl": "pkg:cocoapods/React-RCTSettings@0.70.4",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "React-RCTSettings@0.70.4"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "cocoapods"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:cocoapods/React-RCTText@0.70.4",
+      "type": "library",
+      "name": "React-RCTText",
+      "version": "0.70.4",
+      "purl": "pkg:cocoapods/React-RCTText@0.70.4",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "React-RCTText@0.70.4"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "cocoapods"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:cocoapods/React-RCTVibration@0.70.4",
+      "type": "library",
+      "name": "React-RCTVibration",
+      "version": "0.70.4",
+      "purl": "pkg:cocoapods/React-RCTVibration@0.70.4",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "React-RCTVibration@0.70.4"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "cocoapods"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:cocoapods/React-bridging@0.70.4",
+      "type": "library",
+      "name": "React-bridging",
+      "version": "0.70.4",
+      "purl": "pkg:cocoapods/React-bridging@0.70.4",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "React-bridging@0.70.4"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "cocoapods"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:cocoapods/React-callinvoker@0.70.4",
+      "type": "library",
+      "name": "React-callinvoker",
+      "version": "0.70.4",
+      "purl": "pkg:cocoapods/React-callinvoker@0.70.4",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "React-callinvoker@0.70.4"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "cocoapods"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:cocoapods/React-cxxreact@0.70.4",
+      "type": "library",
+      "name": "React-cxxreact",
+      "version": "0.70.4",
+      "purl": "pkg:cocoapods/React-cxxreact@0.70.4",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "React-cxxreact@0.70.4"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "cocoapods"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:cocoapods/React-hermes@0.70.4",
+      "type": "library",
+      "name": "React-hermes",
+      "version": "0.70.4",
+      "purl": "pkg:cocoapods/React-hermes@0.70.4",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "React-hermes@0.70.4"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "cocoapods"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:cocoapods/React-jsi@0.70.4",
+      "type": "library",
+      "name": "React-jsi",
+      "version": "0.70.4",
+      "purl": "pkg:cocoapods/React-jsi@0.70.4",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "React-jsi@0.70.4"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "cocoapods"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:cocoapods/React-jsi@0.70.4#Default",
+      "type": "library",
+      "name": "React-jsi/Default",
+      "version": "0.70.4",
+      "purl": "pkg:cocoapods/React-jsi@0.70.4#Default",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "React-jsi/Default@0.70.4"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "cocoapods"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:cocoapods/React-jsiexecutor@0.70.4",
+      "type": "library",
+      "name": "React-jsiexecutor",
+      "version": "0.70.4",
+      "purl": "pkg:cocoapods/React-jsiexecutor@0.70.4",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "React-jsiexecutor@0.70.4"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "cocoapods"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:cocoapods/React-jsinspector@0.70.4",
+      "type": "library",
+      "name": "React-jsinspector",
+      "version": "0.70.4",
+      "purl": "pkg:cocoapods/React-jsinspector@0.70.4",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "React-jsinspector@0.70.4"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "cocoapods"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:cocoapods/React-logger@0.70.4",
+      "type": "library",
+      "name": "React-logger",
+      "version": "0.70.4",
+      "purl": "pkg:cocoapods/React-logger@0.70.4",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "React-logger@0.70.4"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "cocoapods"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:cocoapods/React-perflogger@0.70.4",
+      "type": "library",
+      "name": "React-perflogger",
+      "version": "0.70.4",
+      "purl": "pkg:cocoapods/React-perflogger@0.70.4",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "React-perflogger@0.70.4"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "cocoapods"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:cocoapods/React-runtimeexecutor@0.70.4",
+      "type": "library",
+      "name": "React-runtimeexecutor",
+      "version": "0.70.4",
+      "purl": "pkg:cocoapods/React-runtimeexecutor@0.70.4",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "React-runtimeexecutor@0.70.4"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "cocoapods"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:cocoapods/React@0.70.4",
+      "type": "library",
+      "name": "React",
+      "version": "0.70.4",
+      "purl": "pkg:cocoapods/React@0.70.4",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "React@0.70.4"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "cocoapods"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:cocoapods/ReactCommon@0.70.4#turbomodule/core",
+      "type": "library",
+      "name": "ReactCommon/turbomodule/core",
+      "version": "0.70.4",
+      "purl": "pkg:cocoapods/ReactCommon@0.70.4#turbomodule/core",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "ReactCommon/turbomodule/core@0.70.4"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "cocoapods"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:cocoapods/SocketRocket@0.6.0",
+      "type": "library",
+      "name": "SocketRocket",
+      "version": "0.6.0",
+      "purl": "pkg:cocoapods/SocketRocket@0.6.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "SocketRocket@0.6.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "cocoapods"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:cocoapods/Yoga@1.14.0",
+      "type": "library",
+      "name": "Yoga",
+      "version": "1.14.0",
+      "purl": "pkg:cocoapods/Yoga@1.14.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "Yoga@1.14.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "cocoapods"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:cocoapods/YogaKit@1.18.1",
+      "type": "library",
+      "name": "YogaKit",
+      "version": "1.18.1",
+      "purl": "pkg:cocoapods/YogaKit@1.18.1",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "YogaKit@1.18.1"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "cocoapods"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:cocoapods/boost@1.76.0",
+      "type": "library",
+      "name": "boost",
+      "version": "1.76.0",
+      "purl": "pkg:cocoapods/boost@1.76.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "boost@1.76.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "cocoapods"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:cocoapods/fmt@6.2.1",
+      "type": "library",
+      "name": "fmt",
+      "version": "6.2.1",
+      "purl": "pkg:cocoapods/fmt@6.2.1",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "fmt@6.2.1"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "cocoapods"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:cocoapods/glog@0.3.5",
+      "type": "library",
+      "name": "glog",
+      "version": "0.3.5",
+      "purl": "pkg:cocoapods/glog@0.3.5",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "glog@0.3.5"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "cocoapods"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:cocoapods/hermes-engine@0.70.4",
+      "type": "library",
+      "name": "hermes-engine",
+      "version": "0.70.4",
+      "purl": "pkg:cocoapods/hermes-engine@0.70.4",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "hermes-engine@0.70.4"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "cocoapods"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:cocoapods/libevent@2.1.12",
+      "type": "library",
+      "name": "libevent",
+      "version": "2.1.12",
+      "purl": "pkg:cocoapods/libevent@2.1.12",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "libevent@2.1.12"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "cocoapods"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/%40aws-crypto/crc32@3.0.0",
+      "type": "library",
+      "group": "@aws-crypto",
+      "name": "crc32",
+      "version": "3.0.0",
+      "purl": "pkg:npm/%40aws-crypto/crc32@3.0.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "@aws-crypto/crc32@3.0.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/%40aws-crypto/ie11-detection@3.0.0",
+      "type": "library",
+      "group": "@aws-crypto",
+      "name": "ie11-detection",
+      "version": "3.0.0",
+      "purl": "pkg:npm/%40aws-crypto/ie11-detection@3.0.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "@aws-crypto/ie11-detection@3.0.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/%40aws-crypto/sha256-browser@3.0.0",
+      "type": "library",
+      "group": "@aws-crypto",
+      "name": "sha256-browser",
+      "version": "3.0.0",
+      "purl": "pkg:npm/%40aws-crypto/sha256-browser@3.0.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "@aws-crypto/sha256-browser@3.0.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/%40aws-crypto/sha256-js@3.0.0",
+      "type": "library",
+      "group": "@aws-crypto",
+      "name": "sha256-js",
+      "version": "3.0.0",
+      "purl": "pkg:npm/%40aws-crypto/sha256-js@3.0.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "@aws-crypto/sha256-js@3.0.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/%40aws-crypto/supports-web-crypto@3.0.0",
+      "type": "library",
+      "group": "@aws-crypto",
+      "name": "supports-web-crypto",
+      "version": "3.0.0",
+      "purl": "pkg:npm/%40aws-crypto/supports-web-crypto@3.0.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "@aws-crypto/supports-web-crypto@3.0.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/%40aws-crypto/util@3.0.0",
+      "type": "library",
+      "group": "@aws-crypto",
+      "name": "util",
+      "version": "3.0.0",
+      "purl": "pkg:npm/%40aws-crypto/util@3.0.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "@aws-crypto/util@3.0.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/%40aws-sdk/client-cloudwatch-logs@3.454.0",
+      "type": "library",
+      "group": "@aws-sdk",
+      "name": "client-cloudwatch-logs",
+      "version": "3.454.0",
+      "purl": "pkg:npm/%40aws-sdk/client-cloudwatch-logs@3.454.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "@aws-sdk/client-cloudwatch-logs@3.454.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/%40aws-sdk/client-cognito-identity@3.454.0",
+      "type": "library",
+      "group": "@aws-sdk",
+      "name": "client-cognito-identity",
+      "version": "3.454.0",
+      "purl": "pkg:npm/%40aws-sdk/client-cognito-identity@3.454.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "@aws-sdk/client-cognito-identity@3.454.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/%40aws-sdk/client-iam@3.454.0",
+      "type": "library",
+      "group": "@aws-sdk",
+      "name": "client-iam",
+      "version": "3.454.0",
+      "purl": "pkg:npm/%40aws-sdk/client-iam@3.454.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "@aws-sdk/client-iam@3.454.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/%40aws-sdk/client-lambda@3.454.0",
+      "type": "library",
+      "group": "@aws-sdk",
+      "name": "client-lambda",
+      "version": "3.454.0",
+      "purl": "pkg:npm/%40aws-sdk/client-lambda@3.454.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "@aws-sdk/client-lambda@3.454.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/%40aws-sdk/client-sfn@3.454.0",
+      "type": "library",
+      "group": "@aws-sdk",
+      "name": "client-sfn",
+      "version": "3.454.0",
+      "purl": "pkg:npm/%40aws-sdk/client-sfn@3.454.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "@aws-sdk/client-sfn@3.454.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/%40aws-sdk/client-sso@3.451.0",
+      "type": "library",
+      "group": "@aws-sdk",
+      "name": "client-sso",
+      "version": "3.451.0",
+      "purl": "pkg:npm/%40aws-sdk/client-sso@3.451.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "@aws-sdk/client-sso@3.451.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/%40aws-sdk/client-sts@3.454.0",
+      "type": "library",
+      "group": "@aws-sdk",
+      "name": "client-sts",
+      "version": "3.454.0",
+      "purl": "pkg:npm/%40aws-sdk/client-sts@3.454.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "@aws-sdk/client-sts@3.454.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/%40aws-sdk/core@3.451.0",
+      "type": "library",
+      "group": "@aws-sdk",
+      "name": "core",
+      "version": "3.451.0",
+      "purl": "pkg:npm/%40aws-sdk/core@3.451.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "@aws-sdk/core@3.451.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/%40aws-sdk/credential-provider-cognito-identity@3.454.0",
+      "type": "library",
+      "group": "@aws-sdk",
+      "name": "credential-provider-cognito-identity",
+      "version": "3.454.0",
+      "purl": "pkg:npm/%40aws-sdk/credential-provider-cognito-identity@3.454.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "@aws-sdk/credential-provider-cognito-identity@3.454.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/%40aws-sdk/credential-provider-env@3.451.0",
+      "type": "library",
+      "group": "@aws-sdk",
+      "name": "credential-provider-env",
+      "version": "3.451.0",
+      "purl": "pkg:npm/%40aws-sdk/credential-provider-env@3.451.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "@aws-sdk/credential-provider-env@3.451.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/%40aws-sdk/credential-provider-http@3.451.0",
+      "type": "library",
+      "group": "@aws-sdk",
+      "name": "credential-provider-http",
+      "version": "3.451.0",
+      "purl": "pkg:npm/%40aws-sdk/credential-provider-http@3.451.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "@aws-sdk/credential-provider-http@3.451.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/%40aws-sdk/credential-provider-ini@3.451.0",
+      "type": "library",
+      "group": "@aws-sdk",
+      "name": "credential-provider-ini",
+      "version": "3.451.0",
+      "purl": "pkg:npm/%40aws-sdk/credential-provider-ini@3.451.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "@aws-sdk/credential-provider-ini@3.451.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/%40aws-sdk/credential-provider-node@3.451.0",
+      "type": "library",
+      "group": "@aws-sdk",
+      "name": "credential-provider-node",
+      "version": "3.451.0",
+      "purl": "pkg:npm/%40aws-sdk/credential-provider-node@3.451.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "@aws-sdk/credential-provider-node@3.451.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/%40aws-sdk/credential-provider-process@3.451.0",
+      "type": "library",
+      "group": "@aws-sdk",
+      "name": "credential-provider-process",
+      "version": "3.451.0",
+      "purl": "pkg:npm/%40aws-sdk/credential-provider-process@3.451.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "@aws-sdk/credential-provider-process@3.451.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/%40aws-sdk/credential-provider-sso@3.451.0",
+      "type": "library",
+      "group": "@aws-sdk",
+      "name": "credential-provider-sso",
+      "version": "3.451.0",
+      "purl": "pkg:npm/%40aws-sdk/credential-provider-sso@3.451.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "@aws-sdk/credential-provider-sso@3.451.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/%40aws-sdk/credential-provider-web-identity@3.451.0",
+      "type": "library",
+      "group": "@aws-sdk",
+      "name": "credential-provider-web-identity",
+      "version": "3.451.0",
+      "purl": "pkg:npm/%40aws-sdk/credential-provider-web-identity@3.451.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "@aws-sdk/credential-provider-web-identity@3.451.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/%40aws-sdk/credential-providers@3.454.0",
+      "type": "library",
+      "group": "@aws-sdk",
+      "name": "credential-providers",
+      "version": "3.454.0",
+      "purl": "pkg:npm/%40aws-sdk/credential-providers@3.454.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "@aws-sdk/credential-providers@3.454.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/%40aws-sdk/middleware-host-header@3.451.0",
+      "type": "library",
+      "group": "@aws-sdk",
+      "name": "middleware-host-header",
+      "version": "3.451.0",
+      "purl": "pkg:npm/%40aws-sdk/middleware-host-header@3.451.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "@aws-sdk/middleware-host-header@3.451.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/%40aws-sdk/middleware-logger@3.451.0",
+      "type": "library",
+      "group": "@aws-sdk",
+      "name": "middleware-logger",
+      "version": "3.451.0",
+      "purl": "pkg:npm/%40aws-sdk/middleware-logger@3.451.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "@aws-sdk/middleware-logger@3.451.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/%40aws-sdk/middleware-recursion-detection@3.451.0",
+      "type": "library",
+      "group": "@aws-sdk",
+      "name": "middleware-recursion-detection",
+      "version": "3.451.0",
+      "purl": "pkg:npm/%40aws-sdk/middleware-recursion-detection@3.451.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "@aws-sdk/middleware-recursion-detection@3.451.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/%40aws-sdk/middleware-sdk-sts@3.451.0",
+      "type": "library",
+      "group": "@aws-sdk",
+      "name": "middleware-sdk-sts",
+      "version": "3.451.0",
+      "purl": "pkg:npm/%40aws-sdk/middleware-sdk-sts@3.451.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "@aws-sdk/middleware-sdk-sts@3.451.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/%40aws-sdk/middleware-signing@3.451.0",
+      "type": "library",
+      "group": "@aws-sdk",
+      "name": "middleware-signing",
+      "version": "3.451.0",
+      "purl": "pkg:npm/%40aws-sdk/middleware-signing@3.451.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "@aws-sdk/middleware-signing@3.451.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/%40aws-sdk/middleware-user-agent@3.451.0",
+      "type": "library",
+      "group": "@aws-sdk",
+      "name": "middleware-user-agent",
+      "version": "3.451.0",
+      "purl": "pkg:npm/%40aws-sdk/middleware-user-agent@3.451.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "@aws-sdk/middleware-user-agent@3.451.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/%40aws-sdk/region-config-resolver@3.451.0",
+      "type": "library",
+      "group": "@aws-sdk",
+      "name": "region-config-resolver",
+      "version": "3.451.0",
+      "purl": "pkg:npm/%40aws-sdk/region-config-resolver@3.451.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "@aws-sdk/region-config-resolver@3.451.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/%40aws-sdk/token-providers@3.451.0",
+      "type": "library",
+      "group": "@aws-sdk",
+      "name": "token-providers",
+      "version": "3.451.0",
+      "purl": "pkg:npm/%40aws-sdk/token-providers@3.451.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "@aws-sdk/token-providers@3.451.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/%40aws-sdk/types@3.391.0",
+      "type": "library",
+      "group": "@aws-sdk",
+      "name": "types",
+      "version": "3.391.0",
+      "purl": "pkg:npm/%40aws-sdk/types@3.391.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "@aws-sdk/types@3.391.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/%40aws-sdk/types@3.451.0",
+      "type": "library",
+      "group": "@aws-sdk",
+      "name": "types",
+      "version": "3.451.0",
+      "purl": "pkg:npm/%40aws-sdk/types@3.451.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "@aws-sdk/types@3.451.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/%40aws-sdk/util-endpoints@3.451.0",
+      "type": "library",
+      "group": "@aws-sdk",
+      "name": "util-endpoints",
+      "version": "3.451.0",
+      "purl": "pkg:npm/%40aws-sdk/util-endpoints@3.451.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "@aws-sdk/util-endpoints@3.451.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/%40aws-sdk/util-locate-window@3.310.0",
+      "type": "library",
+      "group": "@aws-sdk",
+      "name": "util-locate-window",
+      "version": "3.310.0",
+      "purl": "pkg:npm/%40aws-sdk/util-locate-window@3.310.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "@aws-sdk/util-locate-window@3.310.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/%40aws-sdk/util-user-agent-browser@3.451.0",
+      "type": "library",
+      "group": "@aws-sdk",
+      "name": "util-user-agent-browser",
+      "version": "3.451.0",
+      "purl": "pkg:npm/%40aws-sdk/util-user-agent-browser@3.451.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "@aws-sdk/util-user-agent-browser@3.451.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/%40aws-sdk/util-user-agent-node@3.451.0",
+      "type": "library",
+      "group": "@aws-sdk",
+      "name": "util-user-agent-node",
+      "version": "3.451.0",
+      "purl": "pkg:npm/%40aws-sdk/util-user-agent-node@3.451.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "@aws-sdk/util-user-agent-node@3.451.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/%40aws-sdk/util-utf8-browser@3.259.0",
+      "type": "library",
+      "group": "@aws-sdk",
+      "name": "util-utf8-browser",
+      "version": "3.259.0",
+      "purl": "pkg:npm/%40aws-sdk/util-utf8-browser@3.259.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "@aws-sdk/util-utf8-browser@3.259.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/%40google-cloud/common@5.0.1",
+      "type": "library",
+      "group": "@google-cloud",
+      "name": "common",
+      "version": "5.0.1",
+      "purl": "pkg:npm/%40google-cloud/common@5.0.1",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "@google-cloud/common@5.0.1"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/%40google-cloud/logging@11.0.0",
+      "type": "library",
+      "group": "@google-cloud",
+      "name": "logging",
+      "version": "11.0.0",
+      "purl": "pkg:npm/%40google-cloud/logging@11.0.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "@google-cloud/logging@11.0.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/%40google-cloud/paginator@5.0.0",
+      "type": "library",
+      "group": "@google-cloud",
+      "name": "paginator",
+      "version": "5.0.0",
+      "purl": "pkg:npm/%40google-cloud/paginator@5.0.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "@google-cloud/paginator@5.0.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/%40google-cloud/projectify@4.0.0",
+      "type": "library",
+      "group": "@google-cloud",
+      "name": "projectify",
+      "version": "4.0.0",
+      "purl": "pkg:npm/%40google-cloud/projectify@4.0.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "@google-cloud/projectify@4.0.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/%40google-cloud/promisify@4.0.0",
+      "type": "library",
+      "group": "@google-cloud",
+      "name": "promisify",
+      "version": "4.0.0",
+      "purl": "pkg:npm/%40google-cloud/promisify@4.0.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "@google-cloud/promisify@4.0.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/%40google-cloud/run@1.0.2",
+      "type": "library",
+      "group": "@google-cloud",
+      "name": "run",
+      "version": "1.0.2",
+      "purl": "pkg:npm/%40google-cloud/run@1.0.2",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "@google-cloud/run@1.0.2"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/%40grpc/grpc-js@1.9.11",
+      "type": "library",
+      "group": "@grpc",
+      "name": "grpc-js",
+      "version": "1.9.11",
+      "purl": "pkg:npm/%40grpc/grpc-js@1.9.11",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "@grpc/grpc-js@1.9.11"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/%40grpc/proto-loader@0.7.10",
+      "type": "library",
+      "group": "@grpc",
+      "name": "proto-loader",
+      "version": "0.7.10",
+      "purl": "pkg:npm/%40grpc/proto-loader@0.7.10",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "@grpc/proto-loader@0.7.10"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/%40grpc/proto-loader@0.7.8",
+      "type": "library",
+      "group": "@grpc",
+      "name": "proto-loader",
+      "version": "0.7.8",
+      "purl": "pkg:npm/%40grpc/proto-loader@0.7.8",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "@grpc/proto-loader@0.7.8"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/%40isaacs/cliui@8.0.2",
+      "type": "library",
+      "group": "@isaacs",
+      "name": "cliui",
+      "version": "8.0.2",
+      "purl": "pkg:npm/%40isaacs/cliui@8.0.2",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "@isaacs/cliui@8.0.2"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/%40kwsites/file-exists@1.1.1",
+      "type": "library",
+      "group": "@kwsites",
+      "name": "file-exists",
+      "version": "1.1.1",
+      "purl": "pkg:npm/%40kwsites/file-exists@1.1.1",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "@kwsites/file-exists@1.1.1"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/%40kwsites/promise-deferred@1.1.1",
+      "type": "library",
+      "group": "@kwsites",
+      "name": "promise-deferred",
+      "version": "1.1.1",
+      "purl": "pkg:npm/%40kwsites/promise-deferred@1.1.1",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "@kwsites/promise-deferred@1.1.1"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/%40npmcli/fs@3.1.0",
+      "type": "library",
+      "group": "@npmcli",
+      "name": "fs",
+      "version": "3.1.0",
+      "purl": "pkg:npm/%40npmcli/fs@3.1.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "@npmcli/fs@3.1.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/%40pkgjs/parseargs@0.11.0",
+      "type": "library",
+      "group": "@pkgjs",
+      "name": "parseargs",
+      "version": "0.11.0",
+      "purl": "pkg:npm/%40pkgjs/parseargs@0.11.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "@pkgjs/parseargs@0.11.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/%40protobufjs/aspromise@1.1.2",
+      "type": "library",
+      "group": "@protobufjs",
+      "name": "aspromise",
+      "version": "1.1.2",
+      "purl": "pkg:npm/%40protobufjs/aspromise@1.1.2",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "@protobufjs/aspromise@1.1.2"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/%40protobufjs/base64@1.1.2",
+      "type": "library",
+      "group": "@protobufjs",
+      "name": "base64",
+      "version": "1.1.2",
+      "purl": "pkg:npm/%40protobufjs/base64@1.1.2",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "@protobufjs/base64@1.1.2"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/%40protobufjs/codegen@2.0.4",
+      "type": "library",
+      "group": "@protobufjs",
+      "name": "codegen",
+      "version": "2.0.4",
+      "purl": "pkg:npm/%40protobufjs/codegen@2.0.4",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "@protobufjs/codegen@2.0.4"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/%40protobufjs/eventemitter@1.1.0",
+      "type": "library",
+      "group": "@protobufjs",
+      "name": "eventemitter",
+      "version": "1.1.0",
+      "purl": "pkg:npm/%40protobufjs/eventemitter@1.1.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "@protobufjs/eventemitter@1.1.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/%40protobufjs/fetch@1.1.0",
+      "type": "library",
+      "group": "@protobufjs",
+      "name": "fetch",
+      "version": "1.1.0",
+      "purl": "pkg:npm/%40protobufjs/fetch@1.1.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "@protobufjs/fetch@1.1.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/%40protobufjs/float@1.0.2",
+      "type": "library",
+      "group": "@protobufjs",
+      "name": "float",
+      "version": "1.0.2",
+      "purl": "pkg:npm/%40protobufjs/float@1.0.2",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "@protobufjs/float@1.0.2"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/%40protobufjs/inquire@1.1.0",
+      "type": "library",
+      "group": "@protobufjs",
+      "name": "inquire",
+      "version": "1.1.0",
+      "purl": "pkg:npm/%40protobufjs/inquire@1.1.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "@protobufjs/inquire@1.1.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/%40protobufjs/path@1.1.2",
+      "type": "library",
+      "group": "@protobufjs",
+      "name": "path",
+      "version": "1.1.2",
+      "purl": "pkg:npm/%40protobufjs/path@1.1.2",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "@protobufjs/path@1.1.2"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/%40protobufjs/pool@1.1.0",
+      "type": "library",
+      "group": "@protobufjs",
+      "name": "pool",
+      "version": "1.1.0",
+      "purl": "pkg:npm/%40protobufjs/pool@1.1.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "@protobufjs/pool@1.1.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/%40protobufjs/utf8@1.1.0",
+      "type": "library",
+      "group": "@protobufjs",
+      "name": "utf8",
+      "version": "1.1.0",
+      "purl": "pkg:npm/%40protobufjs/utf8@1.1.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "@protobufjs/utf8@1.1.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/%40smithy/abort-controller@2.0.13",
+      "type": "library",
+      "group": "@smithy",
+      "name": "abort-controller",
+      "version": "2.0.13",
+      "purl": "pkg:npm/%40smithy/abort-controller@2.0.13",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "@smithy/abort-controller@2.0.13"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/%40smithy/config-resolver@2.0.18",
+      "type": "library",
+      "group": "@smithy",
+      "name": "config-resolver",
+      "version": "2.0.18",
+      "purl": "pkg:npm/%40smithy/config-resolver@2.0.18",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "@smithy/config-resolver@2.0.18"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/%40smithy/credential-provider-imds@2.0.3",
+      "type": "library",
+      "group": "@smithy",
+      "name": "credential-provider-imds",
+      "version": "2.0.3",
+      "purl": "pkg:npm/%40smithy/credential-provider-imds@2.0.3",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "@smithy/credential-provider-imds@2.0.3"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/%40smithy/credential-provider-imds@2.1.1",
+      "type": "library",
+      "group": "@smithy",
+      "name": "credential-provider-imds",
+      "version": "2.1.1",
+      "purl": "pkg:npm/%40smithy/credential-provider-imds@2.1.1",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "@smithy/credential-provider-imds@2.1.1"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/%40smithy/eventstream-codec@2.0.13",
+      "type": "library",
+      "group": "@smithy",
+      "name": "eventstream-codec",
+      "version": "2.0.13",
+      "purl": "pkg:npm/%40smithy/eventstream-codec@2.0.13",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "@smithy/eventstream-codec@2.0.13"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/%40smithy/eventstream-codec@2.0.3",
+      "type": "library",
+      "group": "@smithy",
+      "name": "eventstream-codec",
+      "version": "2.0.3",
+      "purl": "pkg:npm/%40smithy/eventstream-codec@2.0.3",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "@smithy/eventstream-codec@2.0.3"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/%40smithy/eventstream-serde-browser@2.0.13",
+      "type": "library",
+      "group": "@smithy",
+      "name": "eventstream-serde-browser",
+      "version": "2.0.13",
+      "purl": "pkg:npm/%40smithy/eventstream-serde-browser@2.0.13",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "@smithy/eventstream-serde-browser@2.0.13"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/%40smithy/eventstream-serde-config-resolver@2.0.13",
+      "type": "library",
+      "group": "@smithy",
+      "name": "eventstream-serde-config-resolver",
+      "version": "2.0.13",
+      "purl": "pkg:npm/%40smithy/eventstream-serde-config-resolver@2.0.13",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "@smithy/eventstream-serde-config-resolver@2.0.13"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/%40smithy/eventstream-serde-node@2.0.13",
+      "type": "library",
+      "group": "@smithy",
+      "name": "eventstream-serde-node",
+      "version": "2.0.13",
+      "purl": "pkg:npm/%40smithy/eventstream-serde-node@2.0.13",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "@smithy/eventstream-serde-node@2.0.13"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/%40smithy/eventstream-serde-universal@2.0.13",
+      "type": "library",
+      "group": "@smithy",
+      "name": "eventstream-serde-universal",
+      "version": "2.0.13",
+      "purl": "pkg:npm/%40smithy/eventstream-serde-universal@2.0.13",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "@smithy/eventstream-serde-universal@2.0.13"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/%40smithy/fetch-http-handler@2.2.6",
+      "type": "library",
+      "group": "@smithy",
+      "name": "fetch-http-handler",
+      "version": "2.2.6",
+      "purl": "pkg:npm/%40smithy/fetch-http-handler@2.2.6",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "@smithy/fetch-http-handler@2.2.6"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/%40smithy/hash-node@2.0.15",
+      "type": "library",
+      "group": "@smithy",
+      "name": "hash-node",
+      "version": "2.0.15",
+      "purl": "pkg:npm/%40smithy/hash-node@2.0.15",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "@smithy/hash-node@2.0.15"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/%40smithy/invalid-dependency@2.0.13",
+      "type": "library",
+      "group": "@smithy",
+      "name": "invalid-dependency",
+      "version": "2.0.13",
+      "purl": "pkg:npm/%40smithy/invalid-dependency@2.0.13",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "@smithy/invalid-dependency@2.0.13"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/%40smithy/is-array-buffer@2.0.0",
+      "type": "library",
+      "group": "@smithy",
+      "name": "is-array-buffer",
+      "version": "2.0.0",
+      "purl": "pkg:npm/%40smithy/is-array-buffer@2.0.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "@smithy/is-array-buffer@2.0.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/%40smithy/middleware-content-length@2.0.15",
+      "type": "library",
+      "group": "@smithy",
+      "name": "middleware-content-length",
+      "version": "2.0.15",
+      "purl": "pkg:npm/%40smithy/middleware-content-length@2.0.15",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "@smithy/middleware-content-length@2.0.15"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/%40smithy/middleware-endpoint@2.2.0",
+      "type": "library",
+      "group": "@smithy",
+      "name": "middleware-endpoint",
+      "version": "2.2.0",
+      "purl": "pkg:npm/%40smithy/middleware-endpoint@2.2.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "@smithy/middleware-endpoint@2.2.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/%40smithy/middleware-retry@2.0.20",
+      "type": "library",
+      "group": "@smithy",
+      "name": "middleware-retry",
+      "version": "2.0.20",
+      "purl": "pkg:npm/%40smithy/middleware-retry@2.0.20",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "@smithy/middleware-retry@2.0.20"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/%40smithy/middleware-serde@2.0.13",
+      "type": "library",
+      "group": "@smithy",
+      "name": "middleware-serde",
+      "version": "2.0.13",
+      "purl": "pkg:npm/%40smithy/middleware-serde@2.0.13",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "@smithy/middleware-serde@2.0.13"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/%40smithy/middleware-stack@2.0.7",
+      "type": "library",
+      "group": "@smithy",
+      "name": "middleware-stack",
+      "version": "2.0.7",
+      "purl": "pkg:npm/%40smithy/middleware-stack@2.0.7",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "@smithy/middleware-stack@2.0.7"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/%40smithy/node-config-provider@2.0.3",
+      "type": "library",
+      "group": "@smithy",
+      "name": "node-config-provider",
+      "version": "2.0.3",
+      "purl": "pkg:npm/%40smithy/node-config-provider@2.0.3",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "@smithy/node-config-provider@2.0.3"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/%40smithy/node-config-provider@2.1.5",
+      "type": "library",
+      "group": "@smithy",
+      "name": "node-config-provider",
+      "version": "2.1.5",
+      "purl": "pkg:npm/%40smithy/node-config-provider@2.1.5",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "@smithy/node-config-provider@2.1.5"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/%40smithy/node-http-handler@2.1.9",
+      "type": "library",
+      "group": "@smithy",
+      "name": "node-http-handler",
+      "version": "2.1.9",
+      "purl": "pkg:npm/%40smithy/node-http-handler@2.1.9",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "@smithy/node-http-handler@2.1.9"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/%40smithy/property-provider@2.0.12",
+      "type": "library",
+      "group": "@smithy",
+      "name": "property-provider",
+      "version": "2.0.12",
+      "purl": "pkg:npm/%40smithy/property-provider@2.0.12",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "@smithy/property-provider@2.0.12"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/%40smithy/property-provider@2.0.14",
+      "type": "library",
+      "group": "@smithy",
+      "name": "property-provider",
+      "version": "2.0.14",
+      "purl": "pkg:npm/%40smithy/property-provider@2.0.14",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "@smithy/property-provider@2.0.14"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/%40smithy/property-provider@2.0.3",
+      "type": "library",
+      "group": "@smithy",
+      "name": "property-provider",
+      "version": "2.0.3",
+      "purl": "pkg:npm/%40smithy/property-provider@2.0.3",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "@smithy/property-provider@2.0.3"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/%40smithy/protocol-http@3.0.9",
+      "type": "library",
+      "group": "@smithy",
+      "name": "protocol-http",
+      "version": "3.0.9",
+      "purl": "pkg:npm/%40smithy/protocol-http@3.0.9",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "@smithy/protocol-http@3.0.9"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/%40smithy/querystring-builder@2.0.13",
+      "type": "library",
+      "group": "@smithy",
+      "name": "querystring-builder",
+      "version": "2.0.13",
+      "purl": "pkg:npm/%40smithy/querystring-builder@2.0.13",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "@smithy/querystring-builder@2.0.13"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/%40smithy/querystring-parser@2.0.13",
+      "type": "library",
+      "group": "@smithy",
+      "name": "querystring-parser",
+      "version": "2.0.13",
+      "purl": "pkg:npm/%40smithy/querystring-parser@2.0.13",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "@smithy/querystring-parser@2.0.13"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/%40smithy/querystring-parser@2.0.3",
+      "type": "library",
+      "group": "@smithy",
+      "name": "querystring-parser",
+      "version": "2.0.3",
+      "purl": "pkg:npm/%40smithy/querystring-parser@2.0.3",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "@smithy/querystring-parser@2.0.3"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/%40smithy/service-error-classification@2.0.6",
+      "type": "library",
+      "group": "@smithy",
+      "name": "service-error-classification",
+      "version": "2.0.6",
+      "purl": "pkg:npm/%40smithy/service-error-classification@2.0.6",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "@smithy/service-error-classification@2.0.6"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/%40smithy/shared-ini-file-loader@2.0.3",
+      "type": "library",
+      "group": "@smithy",
+      "name": "shared-ini-file-loader",
+      "version": "2.0.3",
+      "purl": "pkg:npm/%40smithy/shared-ini-file-loader@2.0.3",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "@smithy/shared-ini-file-loader@2.0.3"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/%40smithy/shared-ini-file-loader@2.2.0",
+      "type": "library",
+      "group": "@smithy",
+      "name": "shared-ini-file-loader",
+      "version": "2.2.0",
+      "purl": "pkg:npm/%40smithy/shared-ini-file-loader@2.2.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "@smithy/shared-ini-file-loader@2.2.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/%40smithy/shared-ini-file-loader@2.2.4",
+      "type": "library",
+      "group": "@smithy",
+      "name": "shared-ini-file-loader",
+      "version": "2.2.4",
+      "purl": "pkg:npm/%40smithy/shared-ini-file-loader@2.2.4",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "@smithy/shared-ini-file-loader@2.2.4"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/%40smithy/signature-v4@2.0.3",
+      "type": "library",
+      "group": "@smithy",
+      "name": "signature-v4",
+      "version": "2.0.3",
+      "purl": "pkg:npm/%40smithy/signature-v4@2.0.3",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "@smithy/signature-v4@2.0.3"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/%40smithy/smithy-client@2.1.15",
+      "type": "library",
+      "group": "@smithy",
+      "name": "smithy-client",
+      "version": "2.1.15",
+      "purl": "pkg:npm/%40smithy/smithy-client@2.1.15",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "@smithy/smithy-client@2.1.15"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/%40smithy/types@2.2.0",
+      "type": "library",
+      "group": "@smithy",
+      "name": "types",
+      "version": "2.2.0",
+      "purl": "pkg:npm/%40smithy/types@2.2.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "@smithy/types@2.2.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/%40smithy/types@2.3.5",
+      "type": "library",
+      "group": "@smithy",
+      "name": "types",
+      "version": "2.3.5",
+      "purl": "pkg:npm/%40smithy/types@2.3.5",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "@smithy/types@2.3.5"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/%40smithy/types@2.5.0",
+      "type": "library",
+      "group": "@smithy",
+      "name": "types",
+      "version": "2.5.0",
+      "purl": "pkg:npm/%40smithy/types@2.5.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "@smithy/types@2.5.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/%40smithy/url-parser@2.0.13",
+      "type": "library",
+      "group": "@smithy",
+      "name": "url-parser",
+      "version": "2.0.13",
+      "purl": "pkg:npm/%40smithy/url-parser@2.0.13",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "@smithy/url-parser@2.0.13"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/%40smithy/url-parser@2.0.3",
+      "type": "library",
+      "group": "@smithy",
+      "name": "url-parser",
+      "version": "2.0.3",
+      "purl": "pkg:npm/%40smithy/url-parser@2.0.3",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "@smithy/url-parser@2.0.3"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/%40smithy/util-base64@2.0.1",
+      "type": "library",
+      "group": "@smithy",
+      "name": "util-base64",
+      "version": "2.0.1",
+      "purl": "pkg:npm/%40smithy/util-base64@2.0.1",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "@smithy/util-base64@2.0.1"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/%40smithy/util-body-length-browser@2.0.0",
+      "type": "library",
+      "group": "@smithy",
+      "name": "util-body-length-browser",
+      "version": "2.0.0",
+      "purl": "pkg:npm/%40smithy/util-body-length-browser@2.0.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "@smithy/util-body-length-browser@2.0.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/%40smithy/util-body-length-node@2.1.0",
+      "type": "library",
+      "group": "@smithy",
+      "name": "util-body-length-node",
+      "version": "2.1.0",
+      "purl": "pkg:npm/%40smithy/util-body-length-node@2.1.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "@smithy/util-body-length-node@2.1.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/%40smithy/util-buffer-from@2.0.0",
+      "type": "library",
+      "group": "@smithy",
+      "name": "util-buffer-from",
+      "version": "2.0.0",
+      "purl": "pkg:npm/%40smithy/util-buffer-from@2.0.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "@smithy/util-buffer-from@2.0.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/%40smithy/util-config-provider@2.0.0",
+      "type": "library",
+      "group": "@smithy",
+      "name": "util-config-provider",
+      "version": "2.0.0",
+      "purl": "pkg:npm/%40smithy/util-config-provider@2.0.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "@smithy/util-config-provider@2.0.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/%40smithy/util-defaults-mode-browser@2.0.19",
+      "type": "library",
+      "group": "@smithy",
+      "name": "util-defaults-mode-browser",
+      "version": "2.0.19",
+      "purl": "pkg:npm/%40smithy/util-defaults-mode-browser@2.0.19",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "@smithy/util-defaults-mode-browser@2.0.19"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/%40smithy/util-defaults-mode-node@2.0.25",
+      "type": "library",
+      "group": "@smithy",
+      "name": "util-defaults-mode-node",
+      "version": "2.0.25",
+      "purl": "pkg:npm/%40smithy/util-defaults-mode-node@2.0.25",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "@smithy/util-defaults-mode-node@2.0.25"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/%40smithy/util-endpoints@1.0.4",
+      "type": "library",
+      "group": "@smithy",
+      "name": "util-endpoints",
+      "version": "1.0.4",
+      "purl": "pkg:npm/%40smithy/util-endpoints@1.0.4",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "@smithy/util-endpoints@1.0.4"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/%40smithy/util-hex-encoding@2.0.0",
+      "type": "library",
+      "group": "@smithy",
+      "name": "util-hex-encoding",
+      "version": "2.0.0",
+      "purl": "pkg:npm/%40smithy/util-hex-encoding@2.0.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "@smithy/util-hex-encoding@2.0.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/%40smithy/util-middleware@2.0.0",
+      "type": "library",
+      "group": "@smithy",
+      "name": "util-middleware",
+      "version": "2.0.0",
+      "purl": "pkg:npm/%40smithy/util-middleware@2.0.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "@smithy/util-middleware@2.0.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/%40smithy/util-middleware@2.0.6",
+      "type": "library",
+      "group": "@smithy",
+      "name": "util-middleware",
+      "version": "2.0.6",
+      "purl": "pkg:npm/%40smithy/util-middleware@2.0.6",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "@smithy/util-middleware@2.0.6"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/%40smithy/util-retry@2.0.6",
+      "type": "library",
+      "group": "@smithy",
+      "name": "util-retry",
+      "version": "2.0.6",
+      "purl": "pkg:npm/%40smithy/util-retry@2.0.6",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "@smithy/util-retry@2.0.6"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/%40smithy/util-stream@2.0.20",
+      "type": "library",
+      "group": "@smithy",
+      "name": "util-stream",
+      "version": "2.0.20",
+      "purl": "pkg:npm/%40smithy/util-stream@2.0.20",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "@smithy/util-stream@2.0.20"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/%40smithy/util-uri-escape@2.0.0",
+      "type": "library",
+      "group": "@smithy",
+      "name": "util-uri-escape",
+      "version": "2.0.0",
+      "purl": "pkg:npm/%40smithy/util-uri-escape@2.0.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "@smithy/util-uri-escape@2.0.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/%40smithy/util-utf8@2.0.0",
+      "type": "library",
+      "group": "@smithy",
+      "name": "util-utf8",
+      "version": "2.0.0",
+      "purl": "pkg:npm/%40smithy/util-utf8@2.0.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "@smithy/util-utf8@2.0.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/%40smithy/util-utf8@2.0.2",
+      "type": "library",
+      "group": "@smithy",
+      "name": "util-utf8",
+      "version": "2.0.2",
+      "purl": "pkg:npm/%40smithy/util-utf8@2.0.2",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "@smithy/util-utf8@2.0.2"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/%40smithy/util-waiter@2.0.13",
+      "type": "library",
+      "group": "@smithy",
+      "name": "util-waiter",
+      "version": "2.0.13",
+      "purl": "pkg:npm/%40smithy/util-waiter@2.0.13",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "@smithy/util-waiter@2.0.13"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/%40tootallnate/once@2.0.0",
+      "type": "library",
+      "group": "@tootallnate",
+      "name": "once",
+      "version": "2.0.0",
+      "purl": "pkg:npm/%40tootallnate/once@2.0.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "@tootallnate/once@2.0.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/%40tootallnate/quickjs-emscripten@0.23.0",
+      "type": "library",
+      "group": "@tootallnate",
+      "name": "quickjs-emscripten",
+      "version": "0.23.0",
+      "purl": "pkg:npm/%40tootallnate/quickjs-emscripten@0.23.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "@tootallnate/quickjs-emscripten@0.23.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/%40types/caseless@0.12.5",
+      "type": "library",
+      "group": "@types",
+      "name": "caseless",
+      "version": "0.12.5",
+      "purl": "pkg:npm/%40types/caseless@0.12.5",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "@types/caseless@0.12.5"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/%40types/datadog-metrics@0.6.1",
+      "type": "library",
+      "group": "@types",
+      "name": "datadog-metrics",
+      "version": "0.6.1",
+      "purl": "pkg:npm/%40types/datadog-metrics@0.6.1",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "@types/datadog-metrics@0.6.1"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/%40types/long@4.0.2",
+      "type": "library",
+      "group": "@types",
+      "name": "long",
+      "version": "4.0.2",
+      "purl": "pkg:npm/%40types/long@4.0.2",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "@types/long@4.0.2"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/%40types/node@20.5.0",
+      "type": "library",
+      "group": "@types",
+      "name": "node",
+      "version": "20.5.0",
+      "purl": "pkg:npm/%40types/node@20.5.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "@types/node@20.5.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/%40types/request@2.48.12",
+      "type": "library",
+      "group": "@types",
+      "name": "request",
+      "version": "2.48.12",
+      "purl": "pkg:npm/%40types/request@2.48.12",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "@types/request@2.48.12"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/%40types/retry@0.12.0",
+      "type": "library",
+      "group": "@types",
+      "name": "retry",
+      "version": "0.12.0",
+      "purl": "pkg:npm/%40types/retry@0.12.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "@types/retry@0.12.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/%40types/tough-cookie@4.0.5",
+      "type": "library",
+      "group": "@types",
+      "name": "tough-cookie",
+      "version": "4.0.5",
+      "purl": "pkg:npm/%40types/tough-cookie@4.0.5",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "@types/tough-cookie@4.0.5"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/abbrev@1.1.1",
+      "type": "library",
+      "name": "abbrev",
+      "version": "1.1.1",
+      "purl": "pkg:npm/abbrev@1.1.1",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "abbrev@1.1.1"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/abort-controller@3.0.0",
+      "type": "library",
+      "name": "abort-controller",
+      "version": "3.0.0",
+      "purl": "pkg:npm/abort-controller@3.0.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "abort-controller@3.0.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/agent-base@6.0.2",
+      "type": "library",
+      "name": "agent-base",
+      "version": "6.0.2",
+      "purl": "pkg:npm/agent-base@6.0.2",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "agent-base@6.0.2"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/agent-base@7.1.0",
+      "type": "library",
+      "name": "agent-base",
+      "version": "7.1.0",
+      "purl": "pkg:npm/agent-base@7.1.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "agent-base@7.1.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/agentkeepalive@4.5.0",
+      "type": "library",
+      "name": "agentkeepalive",
+      "version": "4.5.0",
+      "purl": "pkg:npm/agentkeepalive@4.5.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "agentkeepalive@4.5.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/aggregate-error@3.1.0",
+      "type": "library",
+      "name": "aggregate-error",
+      "version": "3.1.0",
+      "purl": "pkg:npm/aggregate-error@3.1.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "aggregate-error@3.1.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/ajv-formats@2.1.1",
+      "type": "library",
+      "name": "ajv-formats",
+      "version": "2.1.1",
+      "purl": "pkg:npm/ajv-formats@2.1.1",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "ajv-formats@2.1.1"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/ajv@8.12.0",
+      "type": "library",
+      "name": "ajv",
+      "version": "8.12.0",
+      "purl": "pkg:npm/ajv@8.12.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "ajv@8.12.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/ansi-escapes@4.3.2",
+      "type": "library",
+      "name": "ansi-escapes",
+      "version": "4.3.2",
+      "purl": "pkg:npm/ansi-escapes@4.3.2",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "ansi-escapes@4.3.2"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/ansi-regex@5.0.1",
+      "type": "library",
+      "name": "ansi-regex",
+      "version": "5.0.1",
+      "purl": "pkg:npm/ansi-regex@5.0.1",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "ansi-regex@5.0.1"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/ansi-regex@6.0.1",
+      "type": "library",
+      "name": "ansi-regex",
+      "version": "6.0.1",
+      "purl": "pkg:npm/ansi-regex@6.0.1",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "ansi-regex@6.0.1"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/ansi-styles@4.3.0",
+      "type": "library",
+      "name": "ansi-styles",
+      "version": "4.3.0",
+      "purl": "pkg:npm/ansi-styles@4.3.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "ansi-styles@4.3.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/ansi-styles@6.2.1",
+      "type": "library",
+      "name": "ansi-styles",
+      "version": "6.2.1",
+      "purl": "pkg:npm/ansi-styles@6.2.1",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "ansi-styles@6.2.1"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/aproba@2.0.0",
+      "type": "library",
+      "name": "aproba",
+      "version": "2.0.0",
+      "purl": "pkg:npm/aproba@2.0.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "aproba@2.0.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/are-we-there-yet@3.0.1",
+      "type": "library",
+      "name": "are-we-there-yet",
+      "version": "3.0.1",
+      "purl": "pkg:npm/are-we-there-yet@3.0.1",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "are-we-there-yet@3.0.1"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/argparse@1.0.10",
+      "type": "library",
+      "name": "argparse",
+      "version": "1.0.10",
+      "purl": "pkg:npm/argparse@1.0.10",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "argparse@1.0.10"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/arrify@2.0.1",
+      "type": "library",
+      "name": "arrify",
+      "version": "2.0.1",
+      "purl": "pkg:npm/arrify@2.0.1",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "arrify@2.0.1"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/asn1@0.2.6",
+      "type": "library",
+      "name": "asn1",
+      "version": "0.2.6",
+      "purl": "pkg:npm/asn1@0.2.6",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "asn1@0.2.6"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/assert-plus@1.0.0",
+      "type": "library",
+      "name": "assert-plus",
+      "version": "1.0.0",
+      "purl": "pkg:npm/assert-plus@1.0.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "assert-plus@1.0.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/ast-types@0.13.4",
+      "type": "library",
+      "name": "ast-types",
+      "version": "0.13.4",
+      "purl": "pkg:npm/ast-types@0.13.4",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "ast-types@0.13.4"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/async-retry@1.3.1",
+      "type": "library",
+      "name": "async-retry",
+      "version": "1.3.1",
+      "purl": "pkg:npm/async-retry@1.3.1",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "async-retry@1.3.1"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/asynckit@0.4.0",
+      "type": "library",
+      "name": "asynckit",
+      "version": "0.4.0",
+      "purl": "pkg:npm/asynckit@0.4.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "asynckit@0.4.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/axios@1.6.5",
+      "type": "library",
+      "name": "axios",
+      "version": "1.6.5",
+      "purl": "pkg:npm/axios@1.6.5",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "axios@1.6.5"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/balanced-match@1.0.2",
+      "type": "library",
+      "name": "balanced-match",
+      "version": "1.0.2",
+      "purl": "pkg:npm/balanced-match@1.0.2",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "balanced-match@1.0.2"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/base64-js@1.5.1",
+      "type": "library",
+      "name": "base64-js",
+      "version": "1.5.1",
+      "purl": "pkg:npm/base64-js@1.5.1",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "base64-js@1.5.1"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/basic-ftp@5.0.3",
+      "type": "library",
+      "name": "basic-ftp",
+      "version": "5.0.3",
+      "purl": "pkg:npm/basic-ftp@5.0.3",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "basic-ftp@5.0.3"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/bcrypt-pbkdf@1.0.2",
+      "type": "library",
+      "name": "bcrypt-pbkdf",
+      "version": "1.0.2",
+      "purl": "pkg:npm/bcrypt-pbkdf@1.0.2",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "bcrypt-pbkdf@1.0.2"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/bignumber.js@9.1.1",
+      "type": "library",
+      "name": "bignumber.js",
+      "version": "9.1.1",
+      "purl": "pkg:npm/bignumber.js@9.1.1",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "bignumber.js@9.1.1"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/bl@4.1.0",
+      "type": "library",
+      "name": "bl",
+      "version": "4.1.0",
+      "purl": "pkg:npm/bl@4.1.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "bl@4.1.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/bowser@2.11.0",
+      "type": "library",
+      "name": "bowser",
+      "version": "2.11.0",
+      "purl": "pkg:npm/bowser@2.11.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "bowser@2.11.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/brace-expansion@1.1.11",
+      "type": "library",
+      "name": "brace-expansion",
+      "version": "1.1.11",
+      "purl": "pkg:npm/brace-expansion@1.1.11",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "brace-expansion@1.1.11"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/brace-expansion@2.0.1",
+      "type": "library",
+      "name": "brace-expansion",
+      "version": "2.0.1",
+      "purl": "pkg:npm/brace-expansion@2.0.1",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "brace-expansion@2.0.1"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/buffer-equal-constant-time@1.0.1",
+      "type": "library",
+      "name": "buffer-equal-constant-time",
+      "version": "1.0.1",
+      "purl": "pkg:npm/buffer-equal-constant-time@1.0.1",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "buffer-equal-constant-time@1.0.1"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/buffer@5.7.1",
+      "type": "library",
+      "name": "buffer",
+      "version": "5.7.1",
+      "purl": "pkg:npm/buffer@5.7.1",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "buffer@5.7.1"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/buildcheck@0.0.6",
+      "type": "library",
+      "name": "buildcheck",
+      "version": "0.0.6",
+      "purl": "pkg:npm/buildcheck@0.0.6",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "buildcheck@0.0.6"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/cacache@17.1.4",
+      "type": "library",
+      "name": "cacache",
+      "version": "17.1.4",
+      "purl": "pkg:npm/cacache@17.1.4",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "cacache@17.1.4"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/chalk@3.0.0",
+      "type": "library",
+      "name": "chalk",
+      "version": "3.0.0",
+      "purl": "pkg:npm/chalk@3.0.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "chalk@3.0.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/chalk@4.1.2",
+      "type": "library",
+      "name": "chalk",
+      "version": "4.1.2",
+      "purl": "pkg:npm/chalk@4.1.2",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "chalk@4.1.2"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/chardet@0.7.0",
+      "type": "library",
+      "name": "chardet",
+      "version": "0.7.0",
+      "purl": "pkg:npm/chardet@0.7.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "chardet@0.7.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/chownr@2.0.0",
+      "type": "library",
+      "name": "chownr",
+      "version": "2.0.0",
+      "purl": "pkg:npm/chownr@2.0.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "chownr@2.0.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/clean-stack@2.2.0",
+      "type": "library",
+      "name": "clean-stack",
+      "version": "2.2.0",
+      "purl": "pkg:npm/clean-stack@2.2.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "clean-stack@2.2.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/cli-cursor@3.1.0",
+      "type": "library",
+      "name": "cli-cursor",
+      "version": "3.1.0",
+      "purl": "pkg:npm/cli-cursor@3.1.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "cli-cursor@3.1.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/cli-spinners@2.9.0",
+      "type": "library",
+      "name": "cli-spinners",
+      "version": "2.9.0",
+      "purl": "pkg:npm/cli-spinners@2.9.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "cli-spinners@2.9.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/cli-width@3.0.0",
+      "type": "library",
+      "name": "cli-width",
+      "version": "3.0.0",
+      "purl": "pkg:npm/cli-width@3.0.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "cli-width@3.0.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/clipanion@3.2.1",
+      "type": "library",
+      "name": "clipanion",
+      "version": "3.2.1",
+      "purl": "pkg:npm/clipanion@3.2.1",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "clipanion@3.2.1"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/cliui@8.0.1",
+      "type": "library",
+      "name": "cliui",
+      "version": "8.0.1",
+      "purl": "pkg:npm/cliui@8.0.1",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "cliui@8.0.1"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/clone@1.0.4",
+      "type": "library",
+      "name": "clone",
+      "version": "1.0.4",
+      "purl": "pkg:npm/clone@1.0.4",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "clone@1.0.4"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/color-convert@2.0.1",
+      "type": "library",
+      "name": "color-convert",
+      "version": "2.0.1",
+      "purl": "pkg:npm/color-convert@2.0.1",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "color-convert@2.0.1"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/color-name@1.1.4",
+      "type": "library",
+      "name": "color-name",
+      "version": "1.1.4",
+      "purl": "pkg:npm/color-name@1.1.4",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "color-name@1.1.4"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/color-support@1.1.3",
+      "type": "library",
+      "name": "color-support",
+      "version": "1.1.3",
+      "purl": "pkg:npm/color-support@1.1.3",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "color-support@1.1.3"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/combined-stream@1.0.8",
+      "type": "library",
+      "name": "combined-stream",
+      "version": "1.0.8",
+      "purl": "pkg:npm/combined-stream@1.0.8",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "combined-stream@1.0.8"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/concat-map@0.0.1",
+      "type": "library",
+      "name": "concat-map",
+      "version": "0.0.1",
+      "purl": "pkg:npm/concat-map@0.0.1",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "concat-map@0.0.1"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/console-control-strings@1.1.0",
+      "type": "library",
+      "name": "console-control-strings",
+      "version": "1.1.0",
+      "purl": "pkg:npm/console-control-strings@1.1.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "console-control-strings@1.1.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/core-util-is@1.0.3",
+      "type": "library",
+      "name": "core-util-is",
+      "version": "1.0.3",
+      "purl": "pkg:npm/core-util-is@1.0.3",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "core-util-is@1.0.3"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/cpu-features@0.0.9",
+      "type": "library",
+      "name": "cpu-features",
+      "version": "0.0.9",
+      "purl": "pkg:npm/cpu-features@0.0.9",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "cpu-features@0.0.9"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/cross-spawn@7.0.3",
+      "type": "library",
+      "name": "cross-spawn",
+      "version": "7.0.3",
+      "purl": "pkg:npm/cross-spawn@7.0.3",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "cross-spawn@7.0.3"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/dashdash@1.14.1",
+      "type": "library",
+      "name": "dashdash",
+      "version": "1.14.1",
+      "purl": "pkg:npm/dashdash@1.14.1",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "dashdash@1.14.1"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/data-uri-to-buffer@5.0.1",
+      "type": "library",
+      "name": "data-uri-to-buffer",
+      "version": "5.0.1",
+      "purl": "pkg:npm/data-uri-to-buffer@5.0.1",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "data-uri-to-buffer@5.0.1"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/datadog-metrics@0.9.3",
+      "type": "library",
+      "name": "datadog-metrics",
+      "version": "0.9.3",
+      "purl": "pkg:npm/datadog-metrics@0.9.3",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "datadog-metrics@0.9.3"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/debug@3.1.0",
+      "type": "library",
+      "name": "debug",
+      "version": "3.1.0",
+      "purl": "pkg:npm/debug@3.1.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "debug@3.1.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/debug@4.3.4",
+      "type": "library",
+      "name": "debug",
+      "version": "4.3.4",
+      "purl": "pkg:npm/debug@4.3.4",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "debug@4.3.4"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/deep-extend@0.6.0",
+      "type": "library",
+      "name": "deep-extend",
+      "version": "0.6.0",
+      "purl": "pkg:npm/deep-extend@0.6.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "deep-extend@0.6.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/deep-object-diff@1.1.9",
+      "type": "library",
+      "name": "deep-object-diff",
+      "version": "1.1.9",
+      "purl": "pkg:npm/deep-object-diff@1.1.9",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "deep-object-diff@1.1.9"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/defaults@1.0.4",
+      "type": "library",
+      "name": "defaults",
+      "version": "1.0.4",
+      "purl": "pkg:npm/defaults@1.0.4",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "defaults@1.0.4"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/degenerator@5.0.1",
+      "type": "library",
+      "name": "degenerator",
+      "version": "5.0.1",
+      "purl": "pkg:npm/degenerator@5.0.1",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "degenerator@5.0.1"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/delayed-stream@1.0.0",
+      "type": "library",
+      "name": "delayed-stream",
+      "version": "1.0.0",
+      "purl": "pkg:npm/delayed-stream@1.0.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "delayed-stream@1.0.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/delegates@1.0.0",
+      "type": "library",
+      "name": "delegates",
+      "version": "1.0.0",
+      "purl": "pkg:npm/delegates@1.0.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "delegates@1.0.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/dogapi@2.8.4",
+      "type": "library",
+      "name": "dogapi",
+      "version": "2.8.4",
+      "purl": "pkg:npm/dogapi@2.8.4",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "dogapi@2.8.4"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/dot-prop@6.0.1",
+      "type": "library",
+      "name": "dot-prop",
+      "version": "6.0.1",
+      "purl": "pkg:npm/dot-prop@6.0.1",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "dot-prop@6.0.1"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/duplexify@4.1.2",
+      "type": "library",
+      "name": "duplexify",
+      "version": "4.1.2",
+      "purl": "pkg:npm/duplexify@4.1.2",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "duplexify@4.1.2"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/eastasianwidth@0.2.0",
+      "type": "library",
+      "name": "eastasianwidth",
+      "version": "0.2.0",
+      "purl": "pkg:npm/eastasianwidth@0.2.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "eastasianwidth@0.2.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/ecc-jsbn@0.1.2",
+      "type": "library",
+      "name": "ecc-jsbn",
+      "version": "0.1.2",
+      "purl": "pkg:npm/ecc-jsbn@0.1.2",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "ecc-jsbn@0.1.2"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/ecdsa-sig-formatter@1.0.11",
+      "type": "library",
+      "name": "ecdsa-sig-formatter",
+      "version": "1.0.11",
+      "purl": "pkg:npm/ecdsa-sig-formatter@1.0.11",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "ecdsa-sig-formatter@1.0.11"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/ee-first@1.1.1",
+      "type": "library",
+      "name": "ee-first",
+      "version": "1.1.1",
+      "purl": "pkg:npm/ee-first@1.1.1",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "ee-first@1.1.1"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/emoji-regex@8.0.0",
+      "type": "library",
+      "name": "emoji-regex",
+      "version": "8.0.0",
+      "purl": "pkg:npm/emoji-regex@8.0.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "emoji-regex@8.0.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/emoji-regex@9.2.2",
+      "type": "library",
+      "name": "emoji-regex",
+      "version": "9.2.2",
+      "purl": "pkg:npm/emoji-regex@9.2.2",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "emoji-regex@9.2.2"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/encoding@0.1.13",
+      "type": "library",
+      "name": "encoding",
+      "version": "0.1.13",
+      "purl": "pkg:npm/encoding@0.1.13",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "encoding@0.1.13"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/end-of-stream@1.4.4",
+      "type": "library",
+      "name": "end-of-stream",
+      "version": "1.4.4",
+      "purl": "pkg:npm/end-of-stream@1.4.4",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "end-of-stream@1.4.4"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/ent@2.2.0",
+      "type": "library",
+      "name": "ent",
+      "version": "2.2.0",
+      "purl": "pkg:npm/ent@2.2.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "ent@2.2.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/env-paths@2.2.1",
+      "type": "library",
+      "name": "env-paths",
+      "version": "2.2.1",
+      "purl": "pkg:npm/env-paths@2.2.1",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "env-paths@2.2.1"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/err-code@2.0.3",
+      "type": "library",
+      "name": "err-code",
+      "version": "2.0.3",
+      "purl": "pkg:npm/err-code@2.0.3",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "err-code@2.0.3"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/escalade@3.1.1",
+      "type": "library",
+      "name": "escalade",
+      "version": "3.1.1",
+      "purl": "pkg:npm/escalade@3.1.1",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "escalade@3.1.1"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/escape-string-regexp@1.0.5",
+      "type": "library",
+      "name": "escape-string-regexp",
+      "version": "1.0.5",
+      "purl": "pkg:npm/escape-string-regexp@1.0.5",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "escape-string-regexp@1.0.5"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/escodegen@2.1.0",
+      "type": "library",
+      "name": "escodegen",
+      "version": "2.1.0",
+      "purl": "pkg:npm/escodegen@2.1.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "escodegen@2.1.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/esprima@4.0.1",
+      "type": "library",
+      "name": "esprima",
+      "version": "4.0.1",
+      "purl": "pkg:npm/esprima@4.0.1",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "esprima@4.0.1"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/estraverse@5.3.0",
+      "type": "library",
+      "name": "estraverse",
+      "version": "5.3.0",
+      "purl": "pkg:npm/estraverse@5.3.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "estraverse@5.3.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/esutils@2.0.3",
+      "type": "library",
+      "name": "esutils",
+      "version": "2.0.3",
+      "purl": "pkg:npm/esutils@2.0.3",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "esutils@2.0.3"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/event-target-shim@5.0.1",
+      "type": "library",
+      "name": "event-target-shim",
+      "version": "5.0.1",
+      "purl": "pkg:npm/event-target-shim@5.0.1",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "event-target-shim@5.0.1"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/eventid@2.0.1",
+      "type": "library",
+      "name": "eventid",
+      "version": "2.0.1",
+      "purl": "pkg:npm/eventid@2.0.1",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "eventid@2.0.1"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/exponential-backoff@3.1.1",
+      "type": "library",
+      "name": "exponential-backoff",
+      "version": "3.1.1",
+      "purl": "pkg:npm/exponential-backoff@3.1.1",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "exponential-backoff@3.1.1"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/extend@3.0.2",
+      "type": "library",
+      "name": "extend",
+      "version": "3.0.2",
+      "purl": "pkg:npm/extend@3.0.2",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "extend@3.0.2"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/external-editor@3.1.0",
+      "type": "library",
+      "name": "external-editor",
+      "version": "3.1.0",
+      "purl": "pkg:npm/external-editor@3.1.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "external-editor@3.1.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/fast-deep-equal@3.1.3",
+      "type": "library",
+      "name": "fast-deep-equal",
+      "version": "3.1.3",
+      "purl": "pkg:npm/fast-deep-equal@3.1.3",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "fast-deep-equal@3.1.3"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/fast-text-encoding@1.0.6",
+      "type": "library",
+      "name": "fast-text-encoding",
+      "version": "1.0.6",
+      "purl": "pkg:npm/fast-text-encoding@1.0.6",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "fast-text-encoding@1.0.6"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/fast-xml-parser@4.2.5",
+      "type": "library",
+      "name": "fast-xml-parser",
+      "version": "4.2.5",
+      "purl": "pkg:npm/fast-xml-parser@4.2.5",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "fast-xml-parser@4.2.5"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/fast-xml-parser@4.2.7",
+      "type": "library",
+      "name": "fast-xml-parser",
+      "version": "4.2.7",
+      "purl": "pkg:npm/fast-xml-parser@4.2.7",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "fast-xml-parser@4.2.7"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/figures@3.2.0",
+      "type": "library",
+      "name": "figures",
+      "version": "3.2.0",
+      "purl": "pkg:npm/figures@3.2.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "figures@3.2.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/follow-redirects@1.15.4",
+      "type": "library",
+      "name": "follow-redirects",
+      "version": "1.15.4",
+      "purl": "pkg:npm/follow-redirects@1.15.4",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "follow-redirects@1.15.4"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/foreground-child@3.1.1",
+      "type": "library",
+      "name": "foreground-child",
+      "version": "3.1.1",
+      "purl": "pkg:npm/foreground-child@3.1.1",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "foreground-child@3.1.1"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/form-data@2.5.1",
+      "type": "library",
+      "name": "form-data",
+      "version": "2.5.1",
+      "purl": "pkg:npm/form-data@2.5.1",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "form-data@2.5.1"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/form-data@4.0.0",
+      "type": "library",
+      "name": "form-data",
+      "version": "4.0.0",
+      "purl": "pkg:npm/form-data@4.0.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "form-data@4.0.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/fs-extra@8.1.0",
+      "type": "library",
+      "name": "fs-extra",
+      "version": "8.1.0",
+      "purl": "pkg:npm/fs-extra@8.1.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "fs-extra@8.1.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/fs-minipass@2.1.0",
+      "type": "library",
+      "name": "fs-minipass",
+      "version": "2.1.0",
+      "purl": "pkg:npm/fs-minipass@2.1.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "fs-minipass@2.1.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/fs-minipass@3.0.3",
+      "type": "library",
+      "name": "fs-minipass",
+      "version": "3.0.3",
+      "purl": "pkg:npm/fs-minipass@3.0.3",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "fs-minipass@3.0.3"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/fs.realpath@1.0.0",
+      "type": "library",
+      "name": "fs.realpath",
+      "version": "1.0.0",
+      "purl": "pkg:npm/fs.realpath@1.0.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "fs.realpath@1.0.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/fuzzy@0.1.3",
+      "type": "library",
+      "name": "fuzzy",
+      "version": "0.1.3",
+      "purl": "pkg:npm/fuzzy@0.1.3",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "fuzzy@0.1.3"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/gauge@4.0.4",
+      "type": "library",
+      "name": "gauge",
+      "version": "4.0.4",
+      "purl": "pkg:npm/gauge@4.0.4",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "gauge@4.0.4"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/gaxios@5.1.3",
+      "type": "library",
+      "name": "gaxios",
+      "version": "5.1.3",
+      "purl": "pkg:npm/gaxios@5.1.3",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "gaxios@5.1.3"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/gaxios@6.1.1",
+      "type": "library",
+      "name": "gaxios",
+      "version": "6.1.1",
+      "purl": "pkg:npm/gaxios@6.1.1",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "gaxios@6.1.1"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/gcp-metadata@5.3.0",
+      "type": "library",
+      "name": "gcp-metadata",
+      "version": "5.3.0",
+      "purl": "pkg:npm/gcp-metadata@5.3.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "gcp-metadata@5.3.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/gcp-metadata@6.1.0",
+      "type": "library",
+      "name": "gcp-metadata",
+      "version": "6.1.0",
+      "purl": "pkg:npm/gcp-metadata@6.1.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "gcp-metadata@6.1.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/get-caller-file@2.0.5",
+      "type": "library",
+      "name": "get-caller-file",
+      "version": "2.0.5",
+      "purl": "pkg:npm/get-caller-file@2.0.5",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "get-caller-file@2.0.5"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/get-uri@6.0.1",
+      "type": "library",
+      "name": "get-uri",
+      "version": "6.0.1",
+      "purl": "pkg:npm/get-uri@6.0.1",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "get-uri@6.0.1"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/getpass@0.1.7",
+      "type": "library",
+      "name": "getpass",
+      "version": "0.1.7",
+      "purl": "pkg:npm/getpass@0.1.7",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "getpass@0.1.7"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/glob@10.3.3",
+      "type": "library",
+      "name": "glob",
+      "version": "10.3.3",
+      "purl": "pkg:npm/glob@10.3.3",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "glob@10.3.3"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/glob@7.1.4",
+      "type": "library",
+      "name": "glob",
+      "version": "7.1.4",
+      "purl": "pkg:npm/glob@7.1.4",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "glob@7.1.4"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/glob@7.2.3",
+      "type": "library",
+      "name": "glob",
+      "version": "7.2.3",
+      "purl": "pkg:npm/glob@7.2.3",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "glob@7.2.3"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/google-auth-library@8.9.0",
+      "type": "library",
+      "name": "google-auth-library",
+      "version": "8.9.0",
+      "purl": "pkg:npm/google-auth-library@8.9.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "google-auth-library@8.9.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/google-auth-library@9.2.0",
+      "type": "library",
+      "name": "google-auth-library",
+      "version": "9.2.0",
+      "purl": "pkg:npm/google-auth-library@9.2.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "google-auth-library@9.2.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/google-gax@4.0.5",
+      "type": "library",
+      "name": "google-gax",
+      "version": "4.0.5",
+      "purl": "pkg:npm/google-gax@4.0.5",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "google-gax@4.0.5"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/google-p12-pem@4.0.1",
+      "type": "library",
+      "name": "google-p12-pem",
+      "version": "4.0.1",
+      "purl": "pkg:npm/google-p12-pem@4.0.1",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "google-p12-pem@4.0.1"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/graceful-fs@4.2.11",
+      "type": "library",
+      "name": "graceful-fs",
+      "version": "4.2.11",
+      "purl": "pkg:npm/graceful-fs@4.2.11",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "graceful-fs@4.2.11"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/gtoken@6.1.2",
+      "type": "library",
+      "name": "gtoken",
+      "version": "6.1.2",
+      "purl": "pkg:npm/gtoken@6.1.2",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "gtoken@6.1.2"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/gtoken@7.0.1",
+      "type": "library",
+      "name": "gtoken",
+      "version": "7.0.1",
+      "purl": "pkg:npm/gtoken@7.0.1",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "gtoken@7.0.1"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/has-flag@4.0.0",
+      "type": "library",
+      "name": "has-flag",
+      "version": "4.0.0",
+      "purl": "pkg:npm/has-flag@4.0.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "has-flag@4.0.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/has-unicode@2.0.1",
+      "type": "library",
+      "name": "has-unicode",
+      "version": "2.0.1",
+      "purl": "pkg:npm/has-unicode@2.0.1",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "has-unicode@2.0.1"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/http-cache-semantics@4.1.1",
+      "type": "library",
+      "name": "http-cache-semantics",
+      "version": "4.1.1",
+      "purl": "pkg:npm/http-cache-semantics@4.1.1",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "http-cache-semantics@4.1.1"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/http-proxy-agent@5.0.0",
+      "type": "library",
+      "name": "http-proxy-agent",
+      "version": "5.0.0",
+      "purl": "pkg:npm/http-proxy-agent@5.0.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "http-proxy-agent@5.0.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/http-proxy-agent@7.0.0",
+      "type": "library",
+      "name": "http-proxy-agent",
+      "version": "7.0.0",
+      "purl": "pkg:npm/http-proxy-agent@7.0.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "http-proxy-agent@7.0.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/humanize-ms@1.2.1",
+      "type": "library",
+      "name": "humanize-ms",
+      "version": "1.2.1",
+      "purl": "pkg:npm/humanize-ms@1.2.1",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "humanize-ms@1.2.1"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/iconv-lite@0.4.24",
+      "type": "library",
+      "name": "iconv-lite",
+      "version": "0.4.24",
+      "purl": "pkg:npm/iconv-lite@0.4.24",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "iconv-lite@0.4.24"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/iconv-lite@0.6.3",
+      "type": "library",
+      "name": "iconv-lite",
+      "version": "0.6.3",
+      "purl": "pkg:npm/iconv-lite@0.6.3",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "iconv-lite@0.6.3"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/ieee754@1.2.1",
+      "type": "library",
+      "name": "ieee754",
+      "version": "1.2.1",
+      "purl": "pkg:npm/ieee754@1.2.1",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "ieee754@1.2.1"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/immediate@3.0.6",
+      "type": "library",
+      "name": "immediate",
+      "version": "3.0.6",
+      "purl": "pkg:npm/immediate@3.0.6",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "immediate@3.0.6"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/imurmurhash@0.1.4",
+      "type": "library",
+      "name": "imurmurhash",
+      "version": "0.1.4",
+      "purl": "pkg:npm/imurmurhash@0.1.4",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "imurmurhash@0.1.4"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/indent-string@4.0.0",
+      "type": "library",
+      "name": "indent-string",
+      "version": "4.0.0",
+      "purl": "pkg:npm/indent-string@4.0.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "indent-string@4.0.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/inflight@1.0.6",
+      "type": "library",
+      "name": "inflight",
+      "version": "1.0.6",
+      "purl": "pkg:npm/inflight@1.0.6",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "inflight@1.0.6"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/inherits@2.0.4",
+      "type": "library",
+      "name": "inherits",
+      "version": "2.0.4",
+      "purl": "pkg:npm/inherits@2.0.4",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "inherits@2.0.4"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/inquirer-checkbox-plus-prompt@1.4.2",
+      "type": "library",
+      "name": "inquirer-checkbox-plus-prompt",
+      "version": "1.4.2",
+      "purl": "pkg:npm/inquirer-checkbox-plus-prompt@1.4.2",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "inquirer-checkbox-plus-prompt@1.4.2"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/inquirer@8.2.6",
+      "type": "library",
+      "name": "inquirer",
+      "version": "8.2.6",
+      "purl": "pkg:npm/inquirer@8.2.6",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "inquirer@8.2.6"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/ip@1.1.8",
+      "type": "library",
+      "name": "ip",
+      "version": "1.1.8",
+      "purl": "pkg:npm/ip@1.1.8",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "ip@1.1.8"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/ip@2.0.0",
+      "type": "library",
+      "name": "ip",
+      "version": "2.0.0",
+      "purl": "pkg:npm/ip@2.0.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "ip@2.0.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/is-fullwidth-code-point@3.0.0",
+      "type": "library",
+      "name": "is-fullwidth-code-point",
+      "version": "3.0.0",
+      "purl": "pkg:npm/is-fullwidth-code-point@3.0.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "is-fullwidth-code-point@3.0.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/is-interactive@1.0.0",
+      "type": "library",
+      "name": "is-interactive",
+      "version": "1.0.0",
+      "purl": "pkg:npm/is-interactive@1.0.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "is-interactive@1.0.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/is-lambda@1.0.1",
+      "type": "library",
+      "name": "is-lambda",
+      "version": "1.0.1",
+      "purl": "pkg:npm/is-lambda@1.0.1",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "is-lambda@1.0.1"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/is-obj@2.0.0",
+      "type": "library",
+      "name": "is-obj",
+      "version": "2.0.0",
+      "purl": "pkg:npm/is-obj@2.0.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "is-obj@2.0.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/is-stream@2.0.1",
+      "type": "library",
+      "name": "is-stream",
+      "version": "2.0.1",
+      "purl": "pkg:npm/is-stream@2.0.1",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "is-stream@2.0.1"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/is-unicode-supported@0.1.0",
+      "type": "library",
+      "name": "is-unicode-supported",
+      "version": "0.1.0",
+      "purl": "pkg:npm/is-unicode-supported@0.1.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "is-unicode-supported@0.1.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/isarray@1.0.0",
+      "type": "library",
+      "name": "isarray",
+      "version": "1.0.0",
+      "purl": "pkg:npm/isarray@1.0.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "isarray@1.0.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/isexe@2.0.0",
+      "type": "library",
+      "name": "isexe",
+      "version": "2.0.0",
+      "purl": "pkg:npm/isexe@2.0.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "isexe@2.0.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/jackspeak@2.2.3",
+      "type": "library",
+      "name": "jackspeak",
+      "version": "2.2.3",
+      "purl": "pkg:npm/jackspeak@2.2.3",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "jackspeak@2.2.3"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/js-yaml@3.13.1",
+      "type": "library",
+      "name": "js-yaml",
+      "version": "3.13.1",
+      "purl": "pkg:npm/js-yaml@3.13.1",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "js-yaml@3.13.1"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/jsbn@0.1.1",
+      "type": "library",
+      "name": "jsbn",
+      "version": "0.1.1",
+      "purl": "pkg:npm/jsbn@0.1.1",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "jsbn@0.1.1"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/json-bigint@1.0.0",
+      "type": "library",
+      "name": "json-bigint",
+      "version": "1.0.0",
+      "purl": "pkg:npm/json-bigint@1.0.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "json-bigint@1.0.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/json-schema-traverse@1.0.0",
+      "type": "library",
+      "name": "json-schema-traverse",
+      "version": "1.0.0",
+      "purl": "pkg:npm/json-schema-traverse@1.0.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "json-schema-traverse@1.0.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/jsonfile@4.0.0",
+      "type": "library",
+      "name": "jsonfile",
+      "version": "4.0.0",
+      "purl": "pkg:npm/jsonfile@4.0.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "jsonfile@4.0.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/jszip@3.10.1",
+      "type": "library",
+      "name": "jszip",
+      "version": "3.10.1",
+      "purl": "pkg:npm/jszip@3.10.1",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "jszip@3.10.1"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/jwa@2.0.0",
+      "type": "library",
+      "name": "jwa",
+      "version": "2.0.0",
+      "purl": "pkg:npm/jwa@2.0.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "jwa@2.0.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/jws@4.0.0",
+      "type": "library",
+      "name": "jws",
+      "version": "4.0.0",
+      "purl": "pkg:npm/jws@4.0.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "jws@4.0.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/lie@3.3.0",
+      "type": "library",
+      "name": "lie",
+      "version": "3.3.0",
+      "purl": "pkg:npm/lie@3.3.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "lie@3.3.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/lodash.camelcase@4.3.0",
+      "type": "library",
+      "name": "lodash.camelcase",
+      "version": "4.3.0",
+      "purl": "pkg:npm/lodash.camelcase@4.3.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "lodash.camelcase@4.3.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/lodash@4.17.21",
+      "type": "library",
+      "name": "lodash",
+      "version": "4.17.21",
+      "purl": "pkg:npm/lodash@4.17.21",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "lodash@4.17.21"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/log-symbols@4.1.0",
+      "type": "library",
+      "name": "log-symbols",
+      "version": "4.1.0",
+      "purl": "pkg:npm/log-symbols@4.1.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "log-symbols@4.1.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/long@4.0.0",
+      "type": "library",
+      "name": "long",
+      "version": "4.0.0",
+      "purl": "pkg:npm/long@4.0.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "long@4.0.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/long@5.2.3",
+      "type": "library",
+      "name": "long",
+      "version": "5.2.3",
+      "purl": "pkg:npm/long@5.2.3",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "long@5.2.3"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/lru-cache@10.0.1",
+      "type": "library",
+      "name": "lru-cache",
+      "version": "10.0.1",
+      "purl": "pkg:npm/lru-cache@10.0.1",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "lru-cache@10.0.1"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/lru-cache@6.0.0",
+      "type": "library",
+      "name": "lru-cache",
+      "version": "6.0.0",
+      "purl": "pkg:npm/lru-cache@6.0.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "lru-cache@6.0.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/lru-cache@7.18.3",
+      "type": "library",
+      "name": "lru-cache",
+      "version": "7.18.3",
+      "purl": "pkg:npm/lru-cache@7.18.3",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "lru-cache@7.18.3"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/make-fetch-happen@11.1.1",
+      "type": "library",
+      "name": "make-fetch-happen",
+      "version": "11.1.1",
+      "purl": "pkg:npm/make-fetch-happen@11.1.1",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "make-fetch-happen@11.1.1"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/mime-db@1.52.0",
+      "type": "library",
+      "name": "mime-db",
+      "version": "1.52.0",
+      "purl": "pkg:npm/mime-db@1.52.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "mime-db@1.52.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/mime-types@2.1.35",
+      "type": "library",
+      "name": "mime-types",
+      "version": "2.1.35",
+      "purl": "pkg:npm/mime-types@2.1.35",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "mime-types@2.1.35"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/mimic-fn@2.1.0",
+      "type": "library",
+      "name": "mimic-fn",
+      "version": "2.1.0",
+      "purl": "pkg:npm/mimic-fn@2.1.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "mimic-fn@2.1.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/minimatch@3.1.2",
+      "type": "library",
+      "name": "minimatch",
+      "version": "3.1.2",
+      "purl": "pkg:npm/minimatch@3.1.2",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "minimatch@3.1.2"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/minimatch@9.0.3",
+      "type": "library",
+      "name": "minimatch",
+      "version": "9.0.3",
+      "purl": "pkg:npm/minimatch@9.0.3",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "minimatch@9.0.3"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/minimist@1.2.8",
+      "type": "library",
+      "name": "minimist",
+      "version": "1.2.8",
+      "purl": "pkg:npm/minimist@1.2.8",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "minimist@1.2.8"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/minipass-collect@1.0.2",
+      "type": "library",
+      "name": "minipass-collect",
+      "version": "1.0.2",
+      "purl": "pkg:npm/minipass-collect@1.0.2",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "minipass-collect@1.0.2"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/minipass-fetch@3.0.4",
+      "type": "library",
+      "name": "minipass-fetch",
+      "version": "3.0.4",
+      "purl": "pkg:npm/minipass-fetch@3.0.4",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "minipass-fetch@3.0.4"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/minipass-flush@1.0.5",
+      "type": "library",
+      "name": "minipass-flush",
+      "version": "1.0.5",
+      "purl": "pkg:npm/minipass-flush@1.0.5",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "minipass-flush@1.0.5"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/minipass-pipeline@1.2.4",
+      "type": "library",
+      "name": "minipass-pipeline",
+      "version": "1.2.4",
+      "purl": "pkg:npm/minipass-pipeline@1.2.4",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "minipass-pipeline@1.2.4"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/minipass-sized@1.0.3",
+      "type": "library",
+      "name": "minipass-sized",
+      "version": "1.0.3",
+      "purl": "pkg:npm/minipass-sized@1.0.3",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "minipass-sized@1.0.3"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/minipass@3.3.6",
+      "type": "library",
+      "name": "minipass",
+      "version": "3.3.6",
+      "purl": "pkg:npm/minipass@3.3.6",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "minipass@3.3.6"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/minipass@5.0.0",
+      "type": "library",
+      "name": "minipass",
+      "version": "5.0.0",
+      "purl": "pkg:npm/minipass@5.0.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "minipass@5.0.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/minipass@7.0.3",
+      "type": "library",
+      "name": "minipass",
+      "version": "7.0.3",
+      "purl": "pkg:npm/minipass@7.0.3",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "minipass@7.0.3"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/minizlib@2.1.2",
+      "type": "library",
+      "name": "minizlib",
+      "version": "2.1.2",
+      "purl": "pkg:npm/minizlib@2.1.2",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "minizlib@2.1.2"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/mkdirp@1.0.4",
+      "type": "library",
+      "name": "mkdirp",
+      "version": "1.0.4",
+      "purl": "pkg:npm/mkdirp@1.0.4",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "mkdirp@1.0.4"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/ms@2.0.0",
+      "type": "library",
+      "name": "ms",
+      "version": "2.0.0",
+      "purl": "pkg:npm/ms@2.0.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "ms@2.0.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/ms@2.1.2",
+      "type": "library",
+      "name": "ms",
+      "version": "2.1.2",
+      "purl": "pkg:npm/ms@2.1.2",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "ms@2.1.2"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/ms@2.1.3",
+      "type": "library",
+      "name": "ms",
+      "version": "2.1.3",
+      "purl": "pkg:npm/ms@2.1.3",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "ms@2.1.3"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/mute-stream@0.0.8",
+      "type": "library",
+      "name": "mute-stream",
+      "version": "0.0.8",
+      "purl": "pkg:npm/mute-stream@0.0.8",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "mute-stream@0.0.8"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/nan@2.17.0",
+      "type": "library",
+      "name": "nan",
+      "version": "2.17.0",
+      "purl": "pkg:npm/nan@2.17.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "nan@2.17.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/nan@2.18.0",
+      "type": "library",
+      "name": "nan",
+      "version": "2.18.0",
+      "purl": "pkg:npm/nan@2.18.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "nan@2.18.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/negotiator@0.6.3",
+      "type": "library",
+      "name": "negotiator",
+      "version": "0.6.3",
+      "purl": "pkg:npm/negotiator@0.6.3",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "negotiator@0.6.3"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/netmask@2.0.2",
+      "type": "library",
+      "name": "netmask",
+      "version": "2.0.2",
+      "purl": "pkg:npm/netmask@2.0.2",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "netmask@2.0.2"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/node-fetch@2.6.12",
+      "type": "library",
+      "name": "node-fetch",
+      "version": "2.6.12",
+      "purl": "pkg:npm/node-fetch@2.6.12",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "node-fetch@2.6.12"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/node-forge@1.3.1",
+      "type": "library",
+      "name": "node-forge",
+      "version": "1.3.1",
+      "purl": "pkg:npm/node-forge@1.3.1",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "node-forge@1.3.1"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/node-gyp@9.4.0",
+      "type": "library",
+      "name": "node-gyp",
+      "version": "9.4.0",
+      "purl": "pkg:npm/node-gyp@9.4.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "node-gyp@9.4.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/nopt@6.0.0",
+      "type": "library",
+      "name": "nopt",
+      "version": "6.0.0",
+      "purl": "pkg:npm/nopt@6.0.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "nopt@6.0.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/npmlog@6.0.2",
+      "type": "library",
+      "name": "npmlog",
+      "version": "6.0.2",
+      "purl": "pkg:npm/npmlog@6.0.2",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "npmlog@6.0.2"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/object-hash@3.0.0",
+      "type": "library",
+      "name": "object-hash",
+      "version": "3.0.0",
+      "purl": "pkg:npm/object-hash@3.0.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "object-hash@3.0.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/on-finished@2.4.1",
+      "type": "library",
+      "name": "on-finished",
+      "version": "2.4.1",
+      "purl": "pkg:npm/on-finished@2.4.1",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "on-finished@2.4.1"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/once@1.4.0",
+      "type": "library",
+      "name": "once",
+      "version": "1.4.0",
+      "purl": "pkg:npm/once@1.4.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "once@1.4.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/onetime@5.1.2",
+      "type": "library",
+      "name": "onetime",
+      "version": "5.1.2",
+      "purl": "pkg:npm/onetime@5.1.2",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "onetime@5.1.2"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/ora@5.4.1",
+      "type": "library",
+      "name": "ora",
+      "version": "5.4.1",
+      "purl": "pkg:npm/ora@5.4.1",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "ora@5.4.1"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/os-tmpdir@1.0.2",
+      "type": "library",
+      "name": "os-tmpdir",
+      "version": "1.0.2",
+      "purl": "pkg:npm/os-tmpdir@1.0.2",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "os-tmpdir@1.0.2"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/p-map@4.0.0",
+      "type": "library",
+      "name": "p-map",
+      "version": "4.0.0",
+      "purl": "pkg:npm/p-map@4.0.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "p-map@4.0.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/pac-proxy-agent@7.0.0",
+      "type": "library",
+      "name": "pac-proxy-agent",
+      "version": "7.0.0",
+      "purl": "pkg:npm/pac-proxy-agent@7.0.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "pac-proxy-agent@7.0.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/pac-resolver@7.0.0",
+      "type": "library",
+      "name": "pac-resolver",
+      "version": "7.0.0",
+      "purl": "pkg:npm/pac-resolver@7.0.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "pac-resolver@7.0.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/pako@1.0.11",
+      "type": "library",
+      "name": "pako",
+      "version": "1.0.11",
+      "purl": "pkg:npm/pako@1.0.11",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "pako@1.0.11"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/path-is-absolute@1.0.1",
+      "type": "library",
+      "name": "path-is-absolute",
+      "version": "1.0.1",
+      "purl": "pkg:npm/path-is-absolute@1.0.1",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "path-is-absolute@1.0.1"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/path-key@3.1.1",
+      "type": "library",
+      "name": "path-key",
+      "version": "3.1.1",
+      "purl": "pkg:npm/path-key@3.1.1",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "path-key@3.1.1"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/path-scurry@1.10.1",
+      "type": "library",
+      "name": "path-scurry",
+      "version": "1.10.1",
+      "purl": "pkg:npm/path-scurry@1.10.1",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "path-scurry@1.10.1"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/process-nextick-args@2.0.1",
+      "type": "library",
+      "name": "process-nextick-args",
+      "version": "2.0.1",
+      "purl": "pkg:npm/process-nextick-args@2.0.1",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "process-nextick-args@2.0.1"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/promise-retry@2.0.1",
+      "type": "library",
+      "name": "promise-retry",
+      "version": "2.0.1",
+      "purl": "pkg:npm/promise-retry@2.0.1",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "promise-retry@2.0.1"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/proto3-json-serializer@2.0.0",
+      "type": "library",
+      "name": "proto3-json-serializer",
+      "version": "2.0.0",
+      "purl": "pkg:npm/proto3-json-serializer@2.0.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "proto3-json-serializer@2.0.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/protobufjs@7.2.4",
+      "type": "library",
+      "name": "protobufjs",
+      "version": "7.2.4",
+      "purl": "pkg:npm/protobufjs@7.2.4",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "protobufjs@7.2.4"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/protobufjs@7.2.5",
+      "type": "library",
+      "name": "protobufjs",
+      "version": "7.2.5",
+      "purl": "pkg:npm/protobufjs@7.2.5",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "protobufjs@7.2.5"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/proxy-agent@6.3.0",
+      "type": "library",
+      "name": "proxy-agent",
+      "version": "6.3.0",
+      "purl": "pkg:npm/proxy-agent@6.3.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "proxy-agent@6.3.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/proxy-from-env@1.1.0",
+      "type": "library",
+      "name": "proxy-from-env",
+      "version": "1.1.0",
+      "purl": "pkg:npm/proxy-from-env@1.1.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "proxy-from-env@1.1.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/pump@3.0.0",
+      "type": "library",
+      "name": "pump",
+      "version": "3.0.0",
+      "purl": "pkg:npm/pump@3.0.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "pump@3.0.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/pumpify@2.0.1",
+      "type": "library",
+      "name": "pumpify",
+      "version": "2.0.1",
+      "purl": "pkg:npm/pumpify@2.0.1",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "pumpify@2.0.1"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/punycode@2.3.0",
+      "type": "library",
+      "name": "punycode",
+      "version": "2.3.0",
+      "purl": "pkg:npm/punycode@2.3.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "punycode@2.3.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/rc@1.2.8",
+      "type": "library",
+      "name": "rc",
+      "version": "1.2.8",
+      "purl": "pkg:npm/rc@1.2.8",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "rc@1.2.8"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/readable-stream@2.3.8",
+      "type": "library",
+      "name": "readable-stream",
+      "version": "2.3.8",
+      "purl": "pkg:npm/readable-stream@2.3.8",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "readable-stream@2.3.8"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/readable-stream@3.6.2",
+      "type": "library",
+      "name": "readable-stream",
+      "version": "3.6.2",
+      "purl": "pkg:npm/readable-stream@3.6.2",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "readable-stream@3.6.2"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/require-directory@2.1.1",
+      "type": "library",
+      "name": "require-directory",
+      "version": "2.1.1",
+      "purl": "pkg:npm/require-directory@2.1.1",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "require-directory@2.1.1"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/require-from-string@2.0.2",
+      "type": "library",
+      "name": "require-from-string",
+      "version": "2.0.2",
+      "purl": "pkg:npm/require-from-string@2.0.2",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "require-from-string@2.0.2"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/restore-cursor@3.1.0",
+      "type": "library",
+      "name": "restore-cursor",
+      "version": "3.1.0",
+      "purl": "pkg:npm/restore-cursor@3.1.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "restore-cursor@3.1.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/retry-request@7.0.1",
+      "type": "library",
+      "name": "retry-request",
+      "version": "7.0.1",
+      "purl": "pkg:npm/retry-request@7.0.1",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "retry-request@7.0.1"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/retry@0.12.0",
+      "type": "library",
+      "name": "retry",
+      "version": "0.12.0",
+      "purl": "pkg:npm/retry@0.12.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "retry@0.12.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/rimraf@3.0.2",
+      "type": "library",
+      "name": "rimraf",
+      "version": "3.0.2",
+      "purl": "pkg:npm/rimraf@3.0.2",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "rimraf@3.0.2"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/run-async@2.4.1",
+      "type": "library",
+      "name": "run-async",
+      "version": "2.4.1",
+      "purl": "pkg:npm/run-async@2.4.1",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "run-async@2.4.1"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/rxjs@6.6.7",
+      "type": "library",
+      "name": "rxjs",
+      "version": "6.6.7",
+      "purl": "pkg:npm/rxjs@6.6.7",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "rxjs@6.6.7"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/rxjs@7.8.1",
+      "type": "library",
+      "name": "rxjs",
+      "version": "7.8.1",
+      "purl": "pkg:npm/rxjs@7.8.1",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "rxjs@7.8.1"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/safe-buffer@5.1.2",
+      "type": "library",
+      "name": "safe-buffer",
+      "version": "5.1.2",
+      "purl": "pkg:npm/safe-buffer@5.1.2",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "safe-buffer@5.1.2"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/safe-buffer@5.2.1",
+      "type": "library",
+      "name": "safe-buffer",
+      "version": "5.2.1",
+      "purl": "pkg:npm/safe-buffer@5.2.1",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "safe-buffer@5.2.1"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/safer-buffer@2.1.2",
+      "type": "library",
+      "name": "safer-buffer",
+      "version": "2.1.2",
+      "purl": "pkg:npm/safer-buffer@2.1.2",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "safer-buffer@2.1.2"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/sax@1.2.4",
+      "type": "library",
+      "name": "sax",
+      "version": "1.2.4",
+      "purl": "pkg:npm/sax@1.2.4",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "sax@1.2.4"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/semver@7.5.4",
+      "type": "library",
+      "name": "semver",
+      "version": "7.5.4",
+      "purl": "pkg:npm/semver@7.5.4",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "semver@7.5.4"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/set-blocking@2.0.0",
+      "type": "library",
+      "name": "set-blocking",
+      "version": "2.0.0",
+      "purl": "pkg:npm/set-blocking@2.0.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "set-blocking@2.0.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/setimmediate@1.0.5",
+      "type": "library",
+      "name": "setimmediate",
+      "version": "1.0.5",
+      "purl": "pkg:npm/setimmediate@1.0.5",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "setimmediate@1.0.5"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/shebang-command@2.0.0",
+      "type": "library",
+      "name": "shebang-command",
+      "version": "2.0.0",
+      "purl": "pkg:npm/shebang-command@2.0.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "shebang-command@2.0.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/shebang-regex@3.0.0",
+      "type": "library",
+      "name": "shebang-regex",
+      "version": "3.0.0",
+      "purl": "pkg:npm/shebang-regex@3.0.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "shebang-regex@3.0.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/signal-exit@3.0.7",
+      "type": "library",
+      "name": "signal-exit",
+      "version": "3.0.7",
+      "purl": "pkg:npm/signal-exit@3.0.7",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "signal-exit@3.0.7"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/signal-exit@4.1.0",
+      "type": "library",
+      "name": "signal-exit",
+      "version": "4.1.0",
+      "purl": "pkg:npm/signal-exit@4.1.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "signal-exit@4.1.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/simple-git@3.16.0",
+      "type": "library",
+      "name": "simple-git",
+      "version": "3.16.0",
+      "purl": "pkg:npm/simple-git@3.16.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "simple-git@3.16.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/smart-buffer@4.2.0",
+      "type": "library",
+      "name": "smart-buffer",
+      "version": "4.2.0",
+      "purl": "pkg:npm/smart-buffer@4.2.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "smart-buffer@4.2.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/socks-proxy-agent@7.0.0",
+      "type": "library",
+      "name": "socks-proxy-agent",
+      "version": "7.0.0",
+      "purl": "pkg:npm/socks-proxy-agent@7.0.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "socks-proxy-agent@7.0.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/socks-proxy-agent@8.0.1",
+      "type": "library",
+      "name": "socks-proxy-agent",
+      "version": "8.0.1",
+      "purl": "pkg:npm/socks-proxy-agent@8.0.1",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "socks-proxy-agent@8.0.1"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/socks@2.7.1",
+      "type": "library",
+      "name": "socks",
+      "version": "2.7.1",
+      "purl": "pkg:npm/socks@2.7.1",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "socks@2.7.1"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/source-map@0.6.1",
+      "type": "library",
+      "name": "source-map",
+      "version": "0.6.1",
+      "purl": "pkg:npm/source-map@0.6.1",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "source-map@0.6.1"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/sprintf-js@1.0.3",
+      "type": "library",
+      "name": "sprintf-js",
+      "version": "1.0.3",
+      "purl": "pkg:npm/sprintf-js@1.0.3",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "sprintf-js@1.0.3"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/ssh2-streams@0.4.10",
+      "type": "library",
+      "name": "ssh2-streams",
+      "version": "0.4.10",
+      "purl": "pkg:npm/ssh2-streams@0.4.10",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "ssh2-streams@0.4.10"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/ssh2@1.15.0",
+      "type": "library",
+      "name": "ssh2",
+      "version": "1.15.0",
+      "purl": "pkg:npm/ssh2@1.15.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "ssh2@1.15.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/sshpk@1.16.1",
+      "type": "library",
+      "name": "sshpk",
+      "version": "1.16.1",
+      "purl": "pkg:npm/sshpk@1.16.1",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "sshpk@1.16.1"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/ssri@10.0.5",
+      "type": "library",
+      "name": "ssri",
+      "version": "10.0.5",
+      "purl": "pkg:npm/ssri@10.0.5",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "ssri@10.0.5"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/stream-events@1.0.5",
+      "type": "library",
+      "name": "stream-events",
+      "version": "1.0.5",
+      "purl": "pkg:npm/stream-events@1.0.5",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "stream-events@1.0.5"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/stream-shift@1.0.1",
+      "type": "library",
+      "name": "stream-shift",
+      "version": "1.0.1",
+      "purl": "pkg:npm/stream-shift@1.0.1",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "stream-shift@1.0.1"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/streamsearch@0.1.2",
+      "type": "library",
+      "name": "streamsearch",
+      "version": "0.1.2",
+      "purl": "pkg:npm/streamsearch@0.1.2",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "streamsearch@0.1.2"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/string-width-cjs@4.2.3",
+      "type": "library",
+      "name": "string-width-cjs",
+      "version": "4.2.3",
+      "purl": "pkg:npm/string-width-cjs@4.2.3",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "string-width-cjs@4.2.3"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/string-width@5.1.2",
+      "type": "library",
+      "name": "string-width",
+      "version": "5.1.2",
+      "purl": "pkg:npm/string-width@5.1.2",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "string-width@5.1.2"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/string_decoder@1.1.1",
+      "type": "library",
+      "name": "string_decoder",
+      "version": "1.1.1",
+      "purl": "pkg:npm/string_decoder@1.1.1",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "string_decoder@1.1.1"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/string_decoder@1.3.0",
+      "type": "library",
+      "name": "string_decoder",
+      "version": "1.3.0",
+      "purl": "pkg:npm/string_decoder@1.3.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "string_decoder@1.3.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/strip-ansi-cjs@6.0.1",
+      "type": "library",
+      "name": "strip-ansi-cjs",
+      "version": "6.0.1",
+      "purl": "pkg:npm/strip-ansi-cjs@6.0.1",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "strip-ansi-cjs@6.0.1"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/strip-ansi@7.1.0",
+      "type": "library",
+      "name": "strip-ansi",
+      "version": "7.1.0",
+      "purl": "pkg:npm/strip-ansi@7.1.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "strip-ansi@7.1.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/strip-json-comments@2.0.1",
+      "type": "library",
+      "name": "strip-json-comments",
+      "version": "2.0.1",
+      "purl": "pkg:npm/strip-json-comments@2.0.1",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "strip-json-comments@2.0.1"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/strnum@1.0.5",
+      "type": "library",
+      "name": "strnum",
+      "version": "1.0.5",
+      "purl": "pkg:npm/strnum@1.0.5",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "strnum@1.0.5"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/stubs@3.0.0",
+      "type": "library",
+      "name": "stubs",
+      "version": "3.0.0",
+      "purl": "pkg:npm/stubs@3.0.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "stubs@3.0.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/supports-color@7.2.0",
+      "type": "library",
+      "name": "supports-color",
+      "version": "7.2.0",
+      "purl": "pkg:npm/supports-color@7.2.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "supports-color@7.2.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/supports-hyperlinks@2.3.0",
+      "type": "library",
+      "name": "supports-hyperlinks",
+      "version": "2.3.0",
+      "purl": "pkg:npm/supports-hyperlinks@2.3.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "supports-hyperlinks@2.3.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/tar@6.1.15",
+      "type": "library",
+      "name": "tar",
+      "version": "6.1.15",
+      "purl": "pkg:npm/tar@6.1.15",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "tar@6.1.15"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/teeny-request@9.0.0",
+      "type": "library",
+      "name": "teeny-request",
+      "version": "9.0.0",
+      "purl": "pkg:npm/teeny-request@9.0.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "teeny-request@9.0.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/terminal-link@2.1.1",
+      "type": "library",
+      "name": "terminal-link",
+      "version": "2.1.1",
+      "purl": "pkg:npm/terminal-link@2.1.1",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "terminal-link@2.1.1"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/through@2.3.8",
+      "type": "library",
+      "name": "through",
+      "version": "2.3.8",
+      "purl": "pkg:npm/through@2.3.8",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "through@2.3.8"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/tiny-async-pool@2.1.0",
+      "type": "library",
+      "name": "tiny-async-pool",
+      "version": "2.1.0",
+      "purl": "pkg:npm/tiny-async-pool@2.1.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "tiny-async-pool@2.1.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/tmp@0.0.33",
+      "type": "library",
+      "name": "tmp",
+      "version": "0.0.33",
+      "purl": "pkg:npm/tmp@0.0.33",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "tmp@0.0.33"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/tr46@0.0.3",
+      "type": "library",
+      "name": "tr46",
+      "version": "0.0.3",
+      "purl": "pkg:npm/tr46@0.0.3",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "tr46@0.0.3"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/tslib@1.14.1",
+      "type": "library",
+      "name": "tslib",
+      "version": "1.14.1",
+      "purl": "pkg:npm/tslib@1.14.1",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "tslib@1.14.1"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/tslib@2.6.1",
+      "type": "library",
+      "name": "tslib",
+      "version": "2.6.1",
+      "purl": "pkg:npm/tslib@2.6.1",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "tslib@2.6.1"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/tweetnacl@0.14.5",
+      "type": "library",
+      "name": "tweetnacl",
+      "version": "0.14.5",
+      "purl": "pkg:npm/tweetnacl@0.14.5",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "tweetnacl@0.14.5"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/typanion@3.14.0",
+      "type": "library",
+      "name": "typanion",
+      "version": "3.14.0",
+      "purl": "pkg:npm/typanion@3.14.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "typanion@3.14.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/type-fest@0.21.3",
+      "type": "library",
+      "name": "type-fest",
+      "version": "0.21.3",
+      "purl": "pkg:npm/type-fest@0.21.3",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "type-fest@0.21.3"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/unique-filename@3.0.0",
+      "type": "library",
+      "name": "unique-filename",
+      "version": "3.0.0",
+      "purl": "pkg:npm/unique-filename@3.0.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "unique-filename@3.0.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/unique-slug@4.0.0",
+      "type": "library",
+      "name": "unique-slug",
+      "version": "4.0.0",
+      "purl": "pkg:npm/unique-slug@4.0.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "unique-slug@4.0.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/universalify@0.1.2",
+      "type": "library",
+      "name": "universalify",
+      "version": "0.1.2",
+      "purl": "pkg:npm/universalify@0.1.2",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "universalify@0.1.2"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/uri-js@4.4.1",
+      "type": "library",
+      "name": "uri-js",
+      "version": "4.4.1",
+      "purl": "pkg:npm/uri-js@4.4.1",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "uri-js@4.4.1"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/util-deprecate@1.0.2",
+      "type": "library",
+      "name": "util-deprecate",
+      "version": "1.0.2",
+      "purl": "pkg:npm/util-deprecate@1.0.2",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "util-deprecate@1.0.2"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/uuid@8.3.2",
+      "type": "library",
+      "name": "uuid",
+      "version": "8.3.2",
+      "purl": "pkg:npm/uuid@8.3.2",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "uuid@8.3.2"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/uuid@9.0.0",
+      "type": "library",
+      "name": "uuid",
+      "version": "9.0.0",
+      "purl": "pkg:npm/uuid@9.0.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "uuid@9.0.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/wcwidth@1.0.1",
+      "type": "library",
+      "name": "wcwidth",
+      "version": "1.0.1",
+      "purl": "pkg:npm/wcwidth@1.0.1",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "wcwidth@1.0.1"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/webidl-conversions@3.0.1",
+      "type": "library",
+      "name": "webidl-conversions",
+      "version": "3.0.1",
+      "purl": "pkg:npm/webidl-conversions@3.0.1",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "webidl-conversions@3.0.1"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/whatwg-url@5.0.0",
+      "type": "library",
+      "name": "whatwg-url",
+      "version": "5.0.0",
+      "purl": "pkg:npm/whatwg-url@5.0.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "whatwg-url@5.0.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/which@2.0.2",
+      "type": "library",
+      "name": "which",
+      "version": "2.0.2",
+      "purl": "pkg:npm/which@2.0.2",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "which@2.0.2"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/wide-align@1.1.5",
+      "type": "library",
+      "name": "wide-align",
+      "version": "1.1.5",
+      "purl": "pkg:npm/wide-align@1.1.5",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "wide-align@1.1.5"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/wrap-ansi-cjs@7.0.0",
+      "type": "library",
+      "name": "wrap-ansi-cjs",
+      "version": "7.0.0",
+      "purl": "pkg:npm/wrap-ansi-cjs@7.0.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "wrap-ansi-cjs@7.0.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/wrap-ansi@6.2.0",
+      "type": "library",
+      "name": "wrap-ansi",
+      "version": "6.2.0",
+      "purl": "pkg:npm/wrap-ansi@6.2.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "wrap-ansi@6.2.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/wrap-ansi@8.1.0",
+      "type": "library",
+      "name": "wrap-ansi",
+      "version": "8.1.0",
+      "purl": "pkg:npm/wrap-ansi@8.1.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "wrap-ansi@8.1.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/wrappy@1.0.2",
+      "type": "library",
+      "name": "wrappy",
+      "version": "1.0.2",
+      "purl": "pkg:npm/wrappy@1.0.2",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "wrappy@1.0.2"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/ws@7.4.6",
+      "type": "library",
+      "name": "ws",
+      "version": "7.4.6",
+      "purl": "pkg:npm/ws@7.4.6",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "ws@7.4.6"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/xml2js@0.5.0",
+      "type": "library",
+      "name": "xml2js",
+      "version": "0.5.0",
+      "purl": "pkg:npm/xml2js@0.5.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "xml2js@0.5.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/xmlbuilder@11.0.1",
+      "type": "library",
+      "name": "xmlbuilder",
+      "version": "11.0.1",
+      "purl": "pkg:npm/xmlbuilder@11.0.1",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "xmlbuilder@11.0.1"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/y18n@5.0.8",
+      "type": "library",
+      "name": "y18n",
+      "version": "5.0.8",
+      "purl": "pkg:npm/y18n@5.0.8",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "y18n@5.0.8"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/yallist@4.0.0",
+      "type": "library",
+      "name": "yallist",
+      "version": "4.0.0",
+      "purl": "pkg:npm/yallist@4.0.0",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "yallist@4.0.0"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/yamux-js@0.1.2",
+      "type": "library",
+      "name": "yamux-js",
+      "version": "0.1.2",
+      "purl": "pkg:npm/yamux-js@0.1.2",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "yamux-js@0.1.2"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/yargs-parser@21.1.1",
+      "type": "library",
+      "name": "yargs-parser",
+      "version": "21.1.1",
+      "purl": "pkg:npm/yargs-parser@21.1.1",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "yargs-parser@21.1.1"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/yargs@17.7.2",
+      "type": "library",
+      "name": "yargs",
+      "version": "17.7.2",
+      "purl": "pkg:npm/yargs@17.7.2",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "yargs@17.7.2"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "yarn"
+        }
+      ]
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "45b4a1a3-f555-4dfe-92d3-7167bf6b9739",
+      "dependsOn": [
+        "pkg:cocoapods/CocoaAsyncSocket@7.6.5",
+        "pkg:cocoapods/DatadogSDK@1.12.1",
+        "pkg:cocoapods/DatadogSDKCrashReporting@1.12.1",
+        "pkg:cocoapods/DatadogSDKReactNative@1.1.4",
+        "pkg:cocoapods/DoubleConversion@1.1.6",
+        "pkg:cocoapods/FBLazyVector@0.70.4",
+        "pkg:cocoapods/FBReactNativeSpec@0.70.4",
+        "pkg:cocoapods/Flipper-Boost-iOSX@1.76.0.1.11",
+        "pkg:cocoapods/Flipper-DoubleConversion@3.2.0.1",
+        "pkg:cocoapods/Flipper-Fmt@7.1.7",
+        "pkg:cocoapods/Flipper-Folly@2.6.10",
+        "pkg:cocoapods/Flipper-Glog@0.5.0.5",
+        "pkg:cocoapods/Flipper-PeerTalk@0.0.4",
+        "pkg:cocoapods/Flipper-RSocket@1.4.3",
+        "pkg:cocoapods/Flipper@0.125.0",
+        "pkg:cocoapods/FlipperKit@0.125.0",
+        "pkg:cocoapods/FlipperKit@0.125.0#Core",
+        "pkg:cocoapods/FlipperKit@0.125.0#CppBridge",
+        "pkg:cocoapods/FlipperKit@0.125.0#FBCxxFollyDynamicConvert",
+        "pkg:cocoapods/FlipperKit@0.125.0#FBDefines",
+        "pkg:cocoapods/FlipperKit@0.125.0#FKPortForwarding",
+        "pkg:cocoapods/FlipperKit@0.125.0#FlipperKitHighlightOverlay",
+        "pkg:cocoapods/FlipperKit@0.125.0#FlipperKitLayoutHelpers",
+        "pkg:cocoapods/FlipperKit@0.125.0#FlipperKitLayoutIOSDescriptors",
+        "pkg:cocoapods/FlipperKit@0.125.0#FlipperKitLayoutPlugin",
+        "pkg:cocoapods/FlipperKit@0.125.0#FlipperKitLayoutTextSearchable",
+        "pkg:cocoapods/FlipperKit@0.125.0#FlipperKitNetworkPlugin",
+        "pkg:cocoapods/FlipperKit@0.125.0#FlipperKitReactPlugin",
+        "pkg:cocoapods/FlipperKit@0.125.0#FlipperKitUserDefaultsPlugin",
+        "pkg:cocoapods/FlipperKit@0.125.0#SKIOSNetworkPlugin",
+        "pkg:cocoapods/OpenSSL-Universal@1.1.1100",
+        "pkg:cocoapods/PLCrashReporter@1.11.0",
+        "pkg:cocoapods/RCT-Folly@2021.07.22.00",
+        "pkg:cocoapods/RCT-Folly@2021.07.22.00#Default",
+        "pkg:cocoapods/RCT-Folly@2021.07.22.00#Futures",
+        "pkg:cocoapods/RCTRequired@0.70.4",
+        "pkg:cocoapods/RCTTypeSafety@0.70.4",
+        "pkg:cocoapods/React-Codegen@0.70.4",
+        "pkg:cocoapods/React-Core@0.70.4",
+        "pkg:cocoapods/React-Core@0.70.4#CoreModulesHeaders",
+        "pkg:cocoapods/React-Core@0.70.4#Default",
+        "pkg:cocoapods/React-Core@0.70.4#DevSupport",
+        "pkg:cocoapods/React-Core@0.70.4#RCTActionSheetHeaders",
+        "pkg:cocoapods/React-Core@0.70.4#RCTAnimationHeaders",
+        "pkg:cocoapods/React-Core@0.70.4#RCTBlobHeaders",
+        "pkg:cocoapods/React-Core@0.70.4#RCTImageHeaders",
+        "pkg:cocoapods/React-Core@0.70.4#RCTLinkingHeaders",
+        "pkg:cocoapods/React-Core@0.70.4#RCTNetworkHeaders",
+        "pkg:cocoapods/React-Core@0.70.4#RCTSettingsHeaders",
+        "pkg:cocoapods/React-Core@0.70.4#RCTTextHeaders",
+        "pkg:cocoapods/React-Core@0.70.4#RCTVibrationHeaders",
+        "pkg:cocoapods/React-Core@0.70.4#RCTWebSocket",
+        "pkg:cocoapods/React-CoreModules@0.70.4",
+        "pkg:cocoapods/React-RCTActionSheet@0.70.4",
+        "pkg:cocoapods/React-RCTAnimation@0.70.4",
+        "pkg:cocoapods/React-RCTBlob@0.70.4",
+        "pkg:cocoapods/React-RCTImage@0.70.4",
+        "pkg:cocoapods/React-RCTLinking@0.70.4",
+        "pkg:cocoapods/React-RCTNetwork@0.70.4",
+        "pkg:cocoapods/React-RCTSettings@0.70.4",
+        "pkg:cocoapods/React-RCTText@0.70.4",
+        "pkg:cocoapods/React-RCTVibration@0.70.4",
+        "pkg:cocoapods/React-bridging@0.70.4",
+        "pkg:cocoapods/React-callinvoker@0.70.4",
+        "pkg:cocoapods/React-cxxreact@0.70.4",
+        "pkg:cocoapods/React-hermes@0.70.4",
+        "pkg:cocoapods/React-jsi@0.70.4",
+        "pkg:cocoapods/React-jsi@0.70.4#Default",
+        "pkg:cocoapods/React-jsiexecutor@0.70.4",
+        "pkg:cocoapods/React-jsinspector@0.70.4",
+        "pkg:cocoapods/React-logger@0.70.4",
+        "pkg:cocoapods/React-perflogger@0.70.4",
+        "pkg:cocoapods/React-runtimeexecutor@0.70.4",
+        "pkg:cocoapods/React@0.70.4",
+        "pkg:cocoapods/ReactCommon@0.70.4#turbomodule/core",
+        "pkg:cocoapods/SocketRocket@0.6.0",
+        "pkg:cocoapods/Yoga@1.14.0",
+        "pkg:cocoapods/YogaKit@1.18.1",
+        "pkg:cocoapods/boost@1.76.0",
+        "pkg:cocoapods/fmt@6.2.1",
+        "pkg:cocoapods/glog@0.3.5",
+        "pkg:cocoapods/hermes-engine@0.70.4",
+        "pkg:cocoapods/libevent@2.1.12"
+      ]
+    },
+    {
+      "ref": "873837ef-b2ff-4bdd-b2e6-03c4799c23be",
+      "dependsOn": [
+        "45b4a1a3-f555-4dfe-92d3-7167bf6b9739",
+        "b9bf924a-12f3-4ca1-98d0-30ae699fe77a",
+        "e907a761-71ba-4065-9654-87bb2d0dbff0"
+      ]
+    },
+    {
+      "ref": "b9bf924a-12f3-4ca1-98d0-30ae699fe77a",
+      "dependsOn": [
+        "pkg:cocoapods/CocoaAsyncSocket@7.6.5",
+        "pkg:cocoapods/DatadogSDK@1.12.1",
+        "pkg:cocoapods/DatadogSDKCrashReporting@1.12.1",
+        "pkg:cocoapods/DatadogSDKReactNative@1.1.4",
+        "pkg:cocoapods/DoubleConversion@1.1.6",
+        "pkg:cocoapods/FBLazyVector@0.70.4",
+        "pkg:cocoapods/FBReactNativeSpec@0.70.4",
+        "pkg:cocoapods/Flipper-Boost-iOSX@1.76.0.1.11",
+        "pkg:cocoapods/Flipper-DoubleConversion@3.2.0.1",
+        "pkg:cocoapods/Flipper-Fmt@7.1.7",
+        "pkg:cocoapods/Flipper-Folly@2.6.10",
+        "pkg:cocoapods/Flipper-Glog@0.5.0.5",
+        "pkg:cocoapods/Flipper-PeerTalk@0.0.4",
+        "pkg:cocoapods/Flipper-RSocket@1.4.3",
+        "pkg:cocoapods/Flipper@0.125.0",
+        "pkg:cocoapods/FlipperKit@0.125.0",
+        "pkg:cocoapods/FlipperKit@0.125.0#Core",
+        "pkg:cocoapods/FlipperKit@0.125.0#CppBridge",
+        "pkg:cocoapods/FlipperKit@0.125.0#FBCxxFollyDynamicConvert",
+        "pkg:cocoapods/FlipperKit@0.125.0#FBDefines",
+        "pkg:cocoapods/FlipperKit@0.125.0#FKPortForwarding",
+        "pkg:cocoapods/FlipperKit@0.125.0#FlipperKitHighlightOverlay",
+        "pkg:cocoapods/FlipperKit@0.125.0#FlipperKitLayoutHelpers",
+        "pkg:cocoapods/FlipperKit@0.125.0#FlipperKitLayoutIOSDescriptors",
+        "pkg:cocoapods/FlipperKit@0.125.0#FlipperKitLayoutPlugin",
+        "pkg:cocoapods/FlipperKit@0.125.0#FlipperKitLayoutTextSearchable",
+        "pkg:cocoapods/FlipperKit@0.125.0#FlipperKitNetworkPlugin",
+        "pkg:cocoapods/FlipperKit@0.125.0#FlipperKitReactPlugin",
+        "pkg:cocoapods/FlipperKit@0.125.0#FlipperKitUserDefaultsPlugin",
+        "pkg:cocoapods/FlipperKit@0.125.0#SKIOSNetworkPlugin",
+        "pkg:cocoapods/OpenSSL-Universal@1.1.1100",
+        "pkg:cocoapods/PLCrashReporter@1.11.0",
+        "pkg:cocoapods/RCT-Folly@2021.07.22.00",
+        "pkg:cocoapods/RCT-Folly@2021.07.22.00#Default",
+        "pkg:cocoapods/RCTRequired@0.70.4",
+        "pkg:cocoapods/RCTTypeSafety@0.70.4",
+        "pkg:cocoapods/React-Codegen@0.70.4",
+        "pkg:cocoapods/React-Core@0.70.4",
+        "pkg:cocoapods/React-Core@0.70.4#CoreModulesHeaders",
+        "pkg:cocoapods/React-Core@0.70.4#Default",
+        "pkg:cocoapods/React-Core@0.70.4#DevSupport",
+        "pkg:cocoapods/React-Core@0.70.4#RCTActionSheetHeaders",
+        "pkg:cocoapods/React-Core@0.70.4#RCTAnimationHeaders",
+        "pkg:cocoapods/React-Core@0.70.4#RCTBlobHeaders",
+        "pkg:cocoapods/React-Core@0.70.4#RCTImageHeaders",
+        "pkg:cocoapods/React-Core@0.70.4#RCTLinkingHeaders",
+        "pkg:cocoapods/React-Core@0.70.4#RCTNetworkHeaders",
+        "pkg:cocoapods/React-Core@0.70.4#RCTSettingsHeaders",
+        "pkg:cocoapods/React-Core@0.70.4#RCTTextHeaders",
+        "pkg:cocoapods/React-Core@0.70.4#RCTVibrationHeaders",
+        "pkg:cocoapods/React-Core@0.70.4#RCTWebSocket",
+        "pkg:cocoapods/React-CoreModules@0.70.4",
+        "pkg:cocoapods/React-RCTActionSheet@0.70.4",
+        "pkg:cocoapods/React-RCTAnimation@0.70.4",
+        "pkg:cocoapods/React-RCTBlob@0.70.4",
+        "pkg:cocoapods/React-RCTImage@0.70.4",
+        "pkg:cocoapods/React-RCTLinking@0.70.4",
+        "pkg:cocoapods/React-RCTNetwork@0.70.4",
+        "pkg:cocoapods/React-RCTSettings@0.70.4",
+        "pkg:cocoapods/React-RCTText@0.70.4",
+        "pkg:cocoapods/React-RCTVibration@0.70.4",
+        "pkg:cocoapods/React-bridging@0.70.4",
+        "pkg:cocoapods/React-callinvoker@0.70.4",
+        "pkg:cocoapods/React-cxxreact@0.70.4",
+        "pkg:cocoapods/React-jsi@0.70.4",
+        "pkg:cocoapods/React-jsi@0.70.4#Default",
+        "pkg:cocoapods/React-jsiexecutor@0.70.4",
+        "pkg:cocoapods/React-jsinspector@0.70.4",
+        "pkg:cocoapods/React-logger@0.70.4",
+        "pkg:cocoapods/React-perflogger@0.70.4",
+        "pkg:cocoapods/React-runtimeexecutor@0.70.4",
+        "pkg:cocoapods/React@0.70.4",
+        "pkg:cocoapods/ReactCommon@0.70.4#turbomodule/core",
+        "pkg:cocoapods/SocketRocket@0.6.0",
+        "pkg:cocoapods/Yoga@1.14.0",
+        "pkg:cocoapods/YogaKit@1.18.1",
+        "pkg:cocoapods/boost@1.76.0",
+        "pkg:cocoapods/fmt@6.2.1",
+        "pkg:cocoapods/glog@0.3.5",
+        "pkg:cocoapods/libevent@2.1.12"
+      ]
+    },
+    {
+      "ref": "e907a761-71ba-4065-9654-87bb2d0dbff0",
+      "dependsOn": [
+        "pkg:npm/%40aws-sdk/client-cloudwatch-logs@3.454.0",
+        "pkg:npm/%40aws-sdk/client-iam@3.454.0",
+        "pkg:npm/%40aws-sdk/client-lambda@3.454.0",
+        "pkg:npm/%40aws-sdk/client-sfn@3.454.0",
+        "pkg:npm/%40aws-sdk/credential-providers@3.454.0",
+        "pkg:npm/%40google-cloud/logging@11.0.0",
+        "pkg:npm/%40google-cloud/run@1.0.2",
+        "pkg:npm/%40smithy/property-provider@2.0.12",
+        "pkg:npm/%40smithy/property-provider@2.0.14",
+        "pkg:npm/%40smithy/util-retry@2.0.6",
+        "pkg:npm/%40types/datadog-metrics@0.6.1",
+        "pkg:npm/%40types/retry@0.12.0",
+        "pkg:npm/ajv-formats@2.1.1",
+        "pkg:npm/ajv@8.12.0",
+        "pkg:npm/async-retry@1.3.1",
+        "pkg:npm/axios@1.6.5",
+        "pkg:npm/chalk@3.0.0",
+        "pkg:npm/clipanion@3.2.1",
+        "pkg:npm/datadog-metrics@0.9.3",
+        "pkg:npm/deep-extend@0.6.0",
+        "pkg:npm/deep-object-diff@1.1.9",
+        "pkg:npm/fast-xml-parser@4.2.5",
+        "pkg:npm/fast-xml-parser@4.2.7",
+        "pkg:npm/form-data@4.0.0",
+        "pkg:npm/fuzzy@0.1.3",
+        "pkg:npm/glob@7.1.4",
+        "pkg:npm/google-auth-library@8.9.0",
+        "pkg:npm/http-proxy-agent@7.0.0",
+        "pkg:npm/inquirer-checkbox-plus-prompt@1.4.2",
+        "pkg:npm/inquirer@8.2.6",
+        "pkg:npm/js-yaml@3.13.1",
+        "pkg:npm/jszip@3.10.1",
+        "pkg:npm/ora@5.4.1",
+        "pkg:npm/proxy-agent@6.3.0",
+        "pkg:npm/rimraf@3.0.2",
+        "pkg:npm/semver@7.5.4",
+        "pkg:npm/simple-git@3.16.0",
+        "pkg:npm/ssh2-streams@0.4.10",
+        "pkg:npm/ssh2@1.15.0",
+        "pkg:npm/sshpk@1.16.1",
+        "pkg:npm/terminal-link@2.1.1",
+        "pkg:npm/tiny-async-pool@2.1.0",
+        "pkg:npm/typanion@3.14.0",
+        "pkg:npm/uuid@9.0.0",
+        "pkg:npm/ws@7.4.6",
+        "pkg:npm/xml2js@0.5.0",
+        "pkg:npm/yamux-js@0.1.2"
+      ]
+    },
+    {
+      "ref": "pkg:cocoapods/CocoaAsyncSocket@7.6.5",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:cocoapods/DatadogSDK@1.12.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:cocoapods/DatadogSDKCrashReporting@1.12.1",
+      "dependsOn": [
+        "pkg:cocoapods/DatadogSDK@1.12.1",
+        "pkg:cocoapods/PLCrashReporter@1.11.0"
+      ]
+    },
+    {
+      "ref": "pkg:cocoapods/DatadogSDKReactNative@1.1.4",
+      "dependsOn": [
+        "pkg:cocoapods/DatadogSDK@1.12.1",
+        "pkg:cocoapods/DatadogSDKCrashReporting@1.12.1",
+        "pkg:cocoapods/React-Core@0.70.4"
+      ]
+    },
+    {
+      "ref": "pkg:cocoapods/DoubleConversion@1.1.6",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:cocoapods/FBLazyVector@0.70.4",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:cocoapods/FBReactNativeSpec@0.70.4",
+      "dependsOn": [
+        "pkg:cocoapods/RCT-Folly@2021.07.22.00",
+        "pkg:cocoapods/RCTRequired@0.70.4",
+        "pkg:cocoapods/RCTTypeSafety@0.70.4",
+        "pkg:cocoapods/React-Core@0.70.4",
+        "pkg:cocoapods/React-jsi@0.70.4",
+        "pkg:cocoapods/ReactCommon@0.70.4#turbomodule/core"
+      ]
+    },
+    {
+      "ref": "pkg:cocoapods/Flipper-Boost-iOSX@1.76.0.1.11",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:cocoapods/Flipper-DoubleConversion@3.2.0.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:cocoapods/Flipper-Fmt@7.1.7",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:cocoapods/Flipper-Folly@2.6.10",
+      "dependsOn": [
+        "pkg:cocoapods/Flipper-Boost-iOSX@1.76.0.1.11",
+        "pkg:cocoapods/Flipper-DoubleConversion@3.2.0.1",
+        "pkg:cocoapods/Flipper-Fmt@7.1.7",
+        "pkg:cocoapods/Flipper-Glog@0.5.0.5",
+        "pkg:cocoapods/OpenSSL-Universal@1.1.1100",
+        "pkg:cocoapods/libevent@2.1.12"
+      ]
+    },
+    {
+      "ref": "pkg:cocoapods/Flipper-Glog@0.5.0.5",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:cocoapods/Flipper-PeerTalk@0.0.4",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:cocoapods/Flipper-RSocket@1.4.3",
+      "dependsOn": [
+        "pkg:cocoapods/Flipper-Folly@2.6.10"
+      ]
+    },
+    {
+      "ref": "pkg:cocoapods/Flipper@0.125.0",
+      "dependsOn": [
+        "pkg:cocoapods/Flipper-Folly@2.6.10",
+        "pkg:cocoapods/Flipper-RSocket@1.4.3"
+      ]
+    },
+    {
+      "ref": "pkg:cocoapods/FlipperKit@0.125.0",
+      "dependsOn": [
+        "pkg:cocoapods/FlipperKit@0.125.0#Core"
+      ]
+    },
+    {
+      "ref": "pkg:cocoapods/FlipperKit@0.125.0#Core",
+      "dependsOn": [
+        "pkg:cocoapods/Flipper@0.125.0",
+        "pkg:cocoapods/FlipperKit@0.125.0#CppBridge",
+        "pkg:cocoapods/FlipperKit@0.125.0#FBCxxFollyDynamicConvert",
+        "pkg:cocoapods/FlipperKit@0.125.0#FBDefines",
+        "pkg:cocoapods/FlipperKit@0.125.0#FKPortForwarding",
+        "pkg:cocoapods/SocketRocket@0.6.0"
+      ]
+    },
+    {
+      "ref": "pkg:cocoapods/FlipperKit@0.125.0#CppBridge",
+      "dependsOn": [
+        "pkg:cocoapods/Flipper@0.125.0"
+      ]
+    },
+    {
+      "ref": "pkg:cocoapods/FlipperKit@0.125.0#FBCxxFollyDynamicConvert",
+      "dependsOn": [
+        "pkg:cocoapods/Flipper-Folly@2.6.10"
+      ]
+    },
+    {
+      "ref": "pkg:cocoapods/FlipperKit@0.125.0#FBDefines",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:cocoapods/FlipperKit@0.125.0#FKPortForwarding",
+      "dependsOn": [
+        "pkg:cocoapods/CocoaAsyncSocket@7.6.5",
+        "pkg:cocoapods/Flipper-PeerTalk@0.0.4"
+      ]
+    },
+    {
+      "ref": "pkg:cocoapods/FlipperKit@0.125.0#FlipperKitHighlightOverlay",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:cocoapods/FlipperKit@0.125.0#FlipperKitLayoutHelpers",
+      "dependsOn": [
+        "pkg:cocoapods/FlipperKit@0.125.0#Core",
+        "pkg:cocoapods/FlipperKit@0.125.0#FlipperKitHighlightOverlay",
+        "pkg:cocoapods/FlipperKit@0.125.0#FlipperKitLayoutTextSearchable"
+      ]
+    },
+    {
+      "ref": "pkg:cocoapods/FlipperKit@0.125.0#FlipperKitLayoutIOSDescriptors",
+      "dependsOn": [
+        "pkg:cocoapods/FlipperKit@0.125.0#Core",
+        "pkg:cocoapods/FlipperKit@0.125.0#FlipperKitHighlightOverlay",
+        "pkg:cocoapods/FlipperKit@0.125.0#FlipperKitLayoutHelpers",
+        "pkg:cocoapods/YogaKit@1.18.1"
+      ]
+    },
+    {
+      "ref": "pkg:cocoapods/FlipperKit@0.125.0#FlipperKitLayoutPlugin",
+      "dependsOn": [
+        "pkg:cocoapods/FlipperKit@0.125.0#Core",
+        "pkg:cocoapods/FlipperKit@0.125.0#FlipperKitHighlightOverlay",
+        "pkg:cocoapods/FlipperKit@0.125.0#FlipperKitLayoutHelpers",
+        "pkg:cocoapods/FlipperKit@0.125.0#FlipperKitLayoutIOSDescriptors",
+        "pkg:cocoapods/FlipperKit@0.125.0#FlipperKitLayoutTextSearchable",
+        "pkg:cocoapods/YogaKit@1.18.1"
+      ]
+    },
+    {
+      "ref": "pkg:cocoapods/FlipperKit@0.125.0#FlipperKitLayoutTextSearchable",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:cocoapods/FlipperKit@0.125.0#FlipperKitNetworkPlugin",
+      "dependsOn": [
+        "pkg:cocoapods/FlipperKit@0.125.0#Core"
+      ]
+    },
+    {
+      "ref": "pkg:cocoapods/FlipperKit@0.125.0#FlipperKitReactPlugin",
+      "dependsOn": [
+        "pkg:cocoapods/FlipperKit@0.125.0#Core"
+      ]
+    },
+    {
+      "ref": "pkg:cocoapods/FlipperKit@0.125.0#FlipperKitUserDefaultsPlugin",
+      "dependsOn": [
+        "pkg:cocoapods/FlipperKit@0.125.0#Core"
+      ]
+    },
+    {
+      "ref": "pkg:cocoapods/FlipperKit@0.125.0#SKIOSNetworkPlugin",
+      "dependsOn": [
+        "pkg:cocoapods/FlipperKit@0.125.0#Core",
+        "pkg:cocoapods/FlipperKit@0.125.0#FlipperKitNetworkPlugin"
+      ]
+    },
+    {
+      "ref": "pkg:cocoapods/OpenSSL-Universal@1.1.1100",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:cocoapods/PLCrashReporter@1.11.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:cocoapods/RCT-Folly@2021.07.22.00",
+      "dependsOn": [
+        "pkg:cocoapods/DoubleConversion@1.1.6",
+        "pkg:cocoapods/RCT-Folly@2021.07.22.00#Default",
+        "pkg:cocoapods/boost@1.76.0",
+        "pkg:cocoapods/fmt@6.2.1",
+        "pkg:cocoapods/glog@0.3.5"
+      ]
+    },
+    {
+      "ref": "pkg:cocoapods/RCT-Folly@2021.07.22.00#Default",
+      "dependsOn": [
+        "pkg:cocoapods/DoubleConversion@1.1.6",
+        "pkg:cocoapods/boost@1.76.0",
+        "pkg:cocoapods/fmt@6.2.1",
+        "pkg:cocoapods/glog@0.3.5"
+      ]
+    },
+    {
+      "ref": "pkg:cocoapods/RCT-Folly@2021.07.22.00#Futures",
+      "dependsOn": [
+        "pkg:cocoapods/DoubleConversion@1.1.6",
+        "pkg:cocoapods/boost@1.76.0",
+        "pkg:cocoapods/fmt@6.2.1",
+        "pkg:cocoapods/glog@0.3.5",
+        "pkg:cocoapods/libevent@2.1.12"
+      ]
+    },
+    {
+      "ref": "pkg:cocoapods/RCTRequired@0.70.4",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:cocoapods/RCTTypeSafety@0.70.4",
+      "dependsOn": [
+        "pkg:cocoapods/FBLazyVector@0.70.4",
+        "pkg:cocoapods/RCTRequired@0.70.4",
+        "pkg:cocoapods/React-Core@0.70.4"
+      ]
+    },
+    {
+      "ref": "pkg:cocoapods/React-Codegen@0.70.4",
+      "dependsOn": [
+        "pkg:cocoapods/FBReactNativeSpec@0.70.4",
+        "pkg:cocoapods/RCT-Folly@2021.07.22.00",
+        "pkg:cocoapods/RCTRequired@0.70.4",
+        "pkg:cocoapods/RCTTypeSafety@0.70.4",
+        "pkg:cocoapods/React-Core@0.70.4",
+        "pkg:cocoapods/React-jsi@0.70.4",
+        "pkg:cocoapods/React-jsiexecutor@0.70.4",
+        "pkg:cocoapods/ReactCommon@0.70.4#turbomodule/core"
+      ]
+    },
+    {
+      "ref": "pkg:cocoapods/React-Core@0.70.4",
+      "dependsOn": [
+        "pkg:cocoapods/RCT-Folly@2021.07.22.00",
+        "pkg:cocoapods/React-Core@0.70.4#Default",
+        "pkg:cocoapods/React-cxxreact@0.70.4",
+        "pkg:cocoapods/React-jsi@0.70.4",
+        "pkg:cocoapods/React-jsiexecutor@0.70.4",
+        "pkg:cocoapods/React-perflogger@0.70.4",
+        "pkg:cocoapods/Yoga@1.14.0",
+        "pkg:cocoapods/glog@0.3.5"
+      ]
+    },
+    {
+      "ref": "pkg:cocoapods/React-Core@0.70.4#CoreModulesHeaders",
+      "dependsOn": [
+        "pkg:cocoapods/RCT-Folly@2021.07.22.00",
+        "pkg:cocoapods/React-Core@0.70.4#Default",
+        "pkg:cocoapods/React-cxxreact@0.70.4",
+        "pkg:cocoapods/React-jsi@0.70.4",
+        "pkg:cocoapods/React-jsiexecutor@0.70.4",
+        "pkg:cocoapods/React-perflogger@0.70.4",
+        "pkg:cocoapods/Yoga@1.14.0",
+        "pkg:cocoapods/glog@0.3.5"
+      ]
+    },
+    {
+      "ref": "pkg:cocoapods/React-Core@0.70.4#Default",
+      "dependsOn": [
+        "pkg:cocoapods/RCT-Folly@2021.07.22.00",
+        "pkg:cocoapods/React-cxxreact@0.70.4",
+        "pkg:cocoapods/React-jsi@0.70.4",
+        "pkg:cocoapods/React-jsiexecutor@0.70.4",
+        "pkg:cocoapods/React-perflogger@0.70.4",
+        "pkg:cocoapods/Yoga@1.14.0",
+        "pkg:cocoapods/glog@0.3.5"
+      ]
+    },
+    {
+      "ref": "pkg:cocoapods/React-Core@0.70.4#DevSupport",
+      "dependsOn": [
+        "pkg:cocoapods/RCT-Folly@2021.07.22.00",
+        "pkg:cocoapods/React-Core@0.70.4#Default",
+        "pkg:cocoapods/React-Core@0.70.4#RCTWebSocket",
+        "pkg:cocoapods/React-cxxreact@0.70.4",
+        "pkg:cocoapods/React-jsi@0.70.4",
+        "pkg:cocoapods/React-jsiexecutor@0.70.4",
+        "pkg:cocoapods/React-jsinspector@0.70.4",
+        "pkg:cocoapods/React-perflogger@0.70.4",
+        "pkg:cocoapods/Yoga@1.14.0",
+        "pkg:cocoapods/glog@0.3.5"
+      ]
+    },
+    {
+      "ref": "pkg:cocoapods/React-Core@0.70.4#RCTActionSheetHeaders",
+      "dependsOn": [
+        "pkg:cocoapods/RCT-Folly@2021.07.22.00",
+        "pkg:cocoapods/React-Core@0.70.4#Default",
+        "pkg:cocoapods/React-cxxreact@0.70.4",
+        "pkg:cocoapods/React-jsi@0.70.4",
+        "pkg:cocoapods/React-jsiexecutor@0.70.4",
+        "pkg:cocoapods/React-perflogger@0.70.4",
+        "pkg:cocoapods/Yoga@1.14.0",
+        "pkg:cocoapods/glog@0.3.5"
+      ]
+    },
+    {
+      "ref": "pkg:cocoapods/React-Core@0.70.4#RCTAnimationHeaders",
+      "dependsOn": [
+        "pkg:cocoapods/RCT-Folly@2021.07.22.00",
+        "pkg:cocoapods/React-Core@0.70.4#Default",
+        "pkg:cocoapods/React-cxxreact@0.70.4",
+        "pkg:cocoapods/React-jsi@0.70.4",
+        "pkg:cocoapods/React-jsiexecutor@0.70.4",
+        "pkg:cocoapods/React-perflogger@0.70.4",
+        "pkg:cocoapods/Yoga@1.14.0",
+        "pkg:cocoapods/glog@0.3.5"
+      ]
+    },
+    {
+      "ref": "pkg:cocoapods/React-Core@0.70.4#RCTBlobHeaders",
+      "dependsOn": [
+        "pkg:cocoapods/RCT-Folly@2021.07.22.00",
+        "pkg:cocoapods/React-Core@0.70.4#Default",
+        "pkg:cocoapods/React-cxxreact@0.70.4",
+        "pkg:cocoapods/React-jsi@0.70.4",
+        "pkg:cocoapods/React-jsiexecutor@0.70.4",
+        "pkg:cocoapods/React-perflogger@0.70.4",
+        "pkg:cocoapods/Yoga@1.14.0",
+        "pkg:cocoapods/glog@0.3.5"
+      ]
+    },
+    {
+      "ref": "pkg:cocoapods/React-Core@0.70.4#RCTImageHeaders",
+      "dependsOn": [
+        "pkg:cocoapods/RCT-Folly@2021.07.22.00",
+        "pkg:cocoapods/React-Core@0.70.4#Default",
+        "pkg:cocoapods/React-cxxreact@0.70.4",
+        "pkg:cocoapods/React-jsi@0.70.4",
+        "pkg:cocoapods/React-jsiexecutor@0.70.4",
+        "pkg:cocoapods/React-perflogger@0.70.4",
+        "pkg:cocoapods/Yoga@1.14.0",
+        "pkg:cocoapods/glog@0.3.5"
+      ]
+    },
+    {
+      "ref": "pkg:cocoapods/React-Core@0.70.4#RCTLinkingHeaders",
+      "dependsOn": [
+        "pkg:cocoapods/RCT-Folly@2021.07.22.00",
+        "pkg:cocoapods/React-Core@0.70.4#Default",
+        "pkg:cocoapods/React-cxxreact@0.70.4",
+        "pkg:cocoapods/React-jsi@0.70.4",
+        "pkg:cocoapods/React-jsiexecutor@0.70.4",
+        "pkg:cocoapods/React-perflogger@0.70.4",
+        "pkg:cocoapods/Yoga@1.14.0",
+        "pkg:cocoapods/glog@0.3.5"
+      ]
+    },
+    {
+      "ref": "pkg:cocoapods/React-Core@0.70.4#RCTNetworkHeaders",
+      "dependsOn": [
+        "pkg:cocoapods/RCT-Folly@2021.07.22.00",
+        "pkg:cocoapods/React-Core@0.70.4#Default",
+        "pkg:cocoapods/React-cxxreact@0.70.4",
+        "pkg:cocoapods/React-jsi@0.70.4",
+        "pkg:cocoapods/React-jsiexecutor@0.70.4",
+        "pkg:cocoapods/React-perflogger@0.70.4",
+        "pkg:cocoapods/Yoga@1.14.0",
+        "pkg:cocoapods/glog@0.3.5"
+      ]
+    },
+    {
+      "ref": "pkg:cocoapods/React-Core@0.70.4#RCTSettingsHeaders",
+      "dependsOn": [
+        "pkg:cocoapods/RCT-Folly@2021.07.22.00",
+        "pkg:cocoapods/React-Core@0.70.4#Default",
+        "pkg:cocoapods/React-cxxreact@0.70.4",
+        "pkg:cocoapods/React-jsi@0.70.4",
+        "pkg:cocoapods/React-jsiexecutor@0.70.4",
+        "pkg:cocoapods/React-perflogger@0.70.4",
+        "pkg:cocoapods/Yoga@1.14.0",
+        "pkg:cocoapods/glog@0.3.5"
+      ]
+    },
+    {
+      "ref": "pkg:cocoapods/React-Core@0.70.4#RCTTextHeaders",
+      "dependsOn": [
+        "pkg:cocoapods/RCT-Folly@2021.07.22.00",
+        "pkg:cocoapods/React-Core@0.70.4#Default",
+        "pkg:cocoapods/React-cxxreact@0.70.4",
+        "pkg:cocoapods/React-jsi@0.70.4",
+        "pkg:cocoapods/React-jsiexecutor@0.70.4",
+        "pkg:cocoapods/React-perflogger@0.70.4",
+        "pkg:cocoapods/Yoga@1.14.0",
+        "pkg:cocoapods/glog@0.3.5"
+      ]
+    },
+    {
+      "ref": "pkg:cocoapods/React-Core@0.70.4#RCTVibrationHeaders",
+      "dependsOn": [
+        "pkg:cocoapods/RCT-Folly@2021.07.22.00",
+        "pkg:cocoapods/React-Core@0.70.4#Default",
+        "pkg:cocoapods/React-cxxreact@0.70.4",
+        "pkg:cocoapods/React-jsi@0.70.4",
+        "pkg:cocoapods/React-jsiexecutor@0.70.4",
+        "pkg:cocoapods/React-perflogger@0.70.4",
+        "pkg:cocoapods/Yoga@1.14.0",
+        "pkg:cocoapods/glog@0.3.5"
+      ]
+    },
+    {
+      "ref": "pkg:cocoapods/React-Core@0.70.4#RCTWebSocket",
+      "dependsOn": [
+        "pkg:cocoapods/RCT-Folly@2021.07.22.00",
+        "pkg:cocoapods/React-Core@0.70.4#Default",
+        "pkg:cocoapods/React-cxxreact@0.70.4",
+        "pkg:cocoapods/React-jsi@0.70.4",
+        "pkg:cocoapods/React-jsiexecutor@0.70.4",
+        "pkg:cocoapods/React-perflogger@0.70.4",
+        "pkg:cocoapods/Yoga@1.14.0",
+        "pkg:cocoapods/glog@0.3.5"
+      ]
+    },
+    {
+      "ref": "pkg:cocoapods/React-CoreModules@0.70.4",
+      "dependsOn": [
+        "pkg:cocoapods/RCT-Folly@2021.07.22.00",
+        "pkg:cocoapods/RCTTypeSafety@0.70.4",
+        "pkg:cocoapods/React-Codegen@0.70.4",
+        "pkg:cocoapods/React-Core@0.70.4#CoreModulesHeaders",
+        "pkg:cocoapods/React-RCTImage@0.70.4",
+        "pkg:cocoapods/React-jsi@0.70.4",
+        "pkg:cocoapods/ReactCommon@0.70.4#turbomodule/core"
+      ]
+    },
+    {
+      "ref": "pkg:cocoapods/React-RCTActionSheet@0.70.4",
+      "dependsOn": [
+        "pkg:cocoapods/React-Core@0.70.4#RCTActionSheetHeaders"
+      ]
+    },
+    {
+      "ref": "pkg:cocoapods/React-RCTAnimation@0.70.4",
+      "dependsOn": [
+        "pkg:cocoapods/RCT-Folly@2021.07.22.00",
+        "pkg:cocoapods/RCTTypeSafety@0.70.4",
+        "pkg:cocoapods/React-Codegen@0.70.4",
+        "pkg:cocoapods/React-Core@0.70.4#RCTAnimationHeaders",
+        "pkg:cocoapods/React-jsi@0.70.4",
+        "pkg:cocoapods/ReactCommon@0.70.4#turbomodule/core"
+      ]
+    },
+    {
+      "ref": "pkg:cocoapods/React-RCTBlob@0.70.4",
+      "dependsOn": [
+        "pkg:cocoapods/RCT-Folly@2021.07.22.00",
+        "pkg:cocoapods/React-Codegen@0.70.4",
+        "pkg:cocoapods/React-Core@0.70.4#RCTBlobHeaders",
+        "pkg:cocoapods/React-Core@0.70.4#RCTWebSocket",
+        "pkg:cocoapods/React-RCTNetwork@0.70.4",
+        "pkg:cocoapods/React-jsi@0.70.4",
+        "pkg:cocoapods/ReactCommon@0.70.4#turbomodule/core"
+      ]
+    },
+    {
+      "ref": "pkg:cocoapods/React-RCTImage@0.70.4",
+      "dependsOn": [
+        "pkg:cocoapods/RCT-Folly@2021.07.22.00",
+        "pkg:cocoapods/RCTTypeSafety@0.70.4",
+        "pkg:cocoapods/React-Codegen@0.70.4",
+        "pkg:cocoapods/React-Core@0.70.4#RCTImageHeaders",
+        "pkg:cocoapods/React-RCTNetwork@0.70.4",
+        "pkg:cocoapods/React-jsi@0.70.4",
+        "pkg:cocoapods/ReactCommon@0.70.4#turbomodule/core"
+      ]
+    },
+    {
+      "ref": "pkg:cocoapods/React-RCTLinking@0.70.4",
+      "dependsOn": [
+        "pkg:cocoapods/React-Codegen@0.70.4",
+        "pkg:cocoapods/React-Core@0.70.4#RCTLinkingHeaders",
+        "pkg:cocoapods/React-jsi@0.70.4",
+        "pkg:cocoapods/ReactCommon@0.70.4#turbomodule/core"
+      ]
+    },
+    {
+      "ref": "pkg:cocoapods/React-RCTNetwork@0.70.4",
+      "dependsOn": [
+        "pkg:cocoapods/RCT-Folly@2021.07.22.00",
+        "pkg:cocoapods/RCTTypeSafety@0.70.4",
+        "pkg:cocoapods/React-Codegen@0.70.4",
+        "pkg:cocoapods/React-Core@0.70.4#RCTNetworkHeaders",
+        "pkg:cocoapods/React-jsi@0.70.4",
+        "pkg:cocoapods/ReactCommon@0.70.4#turbomodule/core"
+      ]
+    },
+    {
+      "ref": "pkg:cocoapods/React-RCTSettings@0.70.4",
+      "dependsOn": [
+        "pkg:cocoapods/RCT-Folly@2021.07.22.00",
+        "pkg:cocoapods/RCTTypeSafety@0.70.4",
+        "pkg:cocoapods/React-Codegen@0.70.4",
+        "pkg:cocoapods/React-Core@0.70.4#RCTSettingsHeaders",
+        "pkg:cocoapods/React-jsi@0.70.4",
+        "pkg:cocoapods/ReactCommon@0.70.4#turbomodule/core"
+      ]
+    },
+    {
+      "ref": "pkg:cocoapods/React-RCTText@0.70.4",
+      "dependsOn": [
+        "pkg:cocoapods/React-Core@0.70.4#RCTTextHeaders"
+      ]
+    },
+    {
+      "ref": "pkg:cocoapods/React-RCTVibration@0.70.4",
+      "dependsOn": [
+        "pkg:cocoapods/RCT-Folly@2021.07.22.00",
+        "pkg:cocoapods/React-Codegen@0.70.4",
+        "pkg:cocoapods/React-Core@0.70.4#RCTVibrationHeaders",
+        "pkg:cocoapods/React-jsi@0.70.4",
+        "pkg:cocoapods/ReactCommon@0.70.4#turbomodule/core"
+      ]
+    },
+    {
+      "ref": "pkg:cocoapods/React-bridging@0.70.4",
+      "dependsOn": [
+        "pkg:cocoapods/RCT-Folly@2021.07.22.00",
+        "pkg:cocoapods/React-jsi@0.70.4"
+      ]
+    },
+    {
+      "ref": "pkg:cocoapods/React-callinvoker@0.70.4",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:cocoapods/React-cxxreact@0.70.4",
+      "dependsOn": [
+        "pkg:cocoapods/DoubleConversion@1.1.6",
+        "pkg:cocoapods/RCT-Folly@2021.07.22.00",
+        "pkg:cocoapods/React-callinvoker@0.70.4",
+        "pkg:cocoapods/React-jsi@0.70.4",
+        "pkg:cocoapods/React-jsinspector@0.70.4",
+        "pkg:cocoapods/React-logger@0.70.4",
+        "pkg:cocoapods/React-perflogger@0.70.4",
+        "pkg:cocoapods/React-runtimeexecutor@0.70.4",
+        "pkg:cocoapods/boost@1.76.0",
+        "pkg:cocoapods/glog@0.3.5"
+      ]
+    },
+    {
+      "ref": "pkg:cocoapods/React-hermes@0.70.4",
+      "dependsOn": [
+        "pkg:cocoapods/DoubleConversion@1.1.6",
+        "pkg:cocoapods/RCT-Folly@2021.07.22.00",
+        "pkg:cocoapods/RCT-Folly@2021.07.22.00#Futures",
+        "pkg:cocoapods/React-cxxreact@0.70.4",
+        "pkg:cocoapods/React-jsi@0.70.4",
+        "pkg:cocoapods/React-jsiexecutor@0.70.4",
+        "pkg:cocoapods/React-jsinspector@0.70.4",
+        "pkg:cocoapods/React-perflogger@0.70.4",
+        "pkg:cocoapods/glog@0.3.5",
+        "pkg:cocoapods/hermes-engine@0.70.4"
+      ]
+    },
+    {
+      "ref": "pkg:cocoapods/React-jsi@0.70.4",
+      "dependsOn": [
+        "pkg:cocoapods/DoubleConversion@1.1.6",
+        "pkg:cocoapods/RCT-Folly@2021.07.22.00",
+        "pkg:cocoapods/React-jsi@0.70.4#Default",
+        "pkg:cocoapods/boost@1.76.0",
+        "pkg:cocoapods/glog@0.3.5"
+      ]
+    },
+    {
+      "ref": "pkg:cocoapods/React-jsi@0.70.4#Default",
+      "dependsOn": [
+        "pkg:cocoapods/DoubleConversion@1.1.6",
+        "pkg:cocoapods/RCT-Folly@2021.07.22.00",
+        "pkg:cocoapods/boost@1.76.0",
+        "pkg:cocoapods/glog@0.3.5"
+      ]
+    },
+    {
+      "ref": "pkg:cocoapods/React-jsiexecutor@0.70.4",
+      "dependsOn": [
+        "pkg:cocoapods/DoubleConversion@1.1.6",
+        "pkg:cocoapods/RCT-Folly@2021.07.22.00",
+        "pkg:cocoapods/React-cxxreact@0.70.4",
+        "pkg:cocoapods/React-jsi@0.70.4",
+        "pkg:cocoapods/React-perflogger@0.70.4",
+        "pkg:cocoapods/glog@0.3.5"
+      ]
+    },
+    {
+      "ref": "pkg:cocoapods/React-jsinspector@0.70.4",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:cocoapods/React-logger@0.70.4",
+      "dependsOn": [
+        "pkg:cocoapods/glog@0.3.5"
+      ]
+    },
+    {
+      "ref": "pkg:cocoapods/React-perflogger@0.70.4",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:cocoapods/React-runtimeexecutor@0.70.4",
+      "dependsOn": [
+        "pkg:cocoapods/React-jsi@0.70.4"
+      ]
+    },
+    {
+      "ref": "pkg:cocoapods/React@0.70.4",
+      "dependsOn": [
+        "pkg:cocoapods/React-Core@0.70.4",
+        "pkg:cocoapods/React-Core@0.70.4#DevSupport",
+        "pkg:cocoapods/React-Core@0.70.4#RCTWebSocket",
+        "pkg:cocoapods/React-RCTActionSheet@0.70.4",
+        "pkg:cocoapods/React-RCTAnimation@0.70.4",
+        "pkg:cocoapods/React-RCTBlob@0.70.4",
+        "pkg:cocoapods/React-RCTImage@0.70.4",
+        "pkg:cocoapods/React-RCTLinking@0.70.4",
+        "pkg:cocoapods/React-RCTNetwork@0.70.4",
+        "pkg:cocoapods/React-RCTSettings@0.70.4",
+        "pkg:cocoapods/React-RCTText@0.70.4",
+        "pkg:cocoapods/React-RCTVibration@0.70.4"
+      ]
+    },
+    {
+      "ref": "pkg:cocoapods/ReactCommon@0.70.4#turbomodule/core",
+      "dependsOn": [
+        "pkg:cocoapods/DoubleConversion@1.1.6",
+        "pkg:cocoapods/RCT-Folly@2021.07.22.00",
+        "pkg:cocoapods/React-Core@0.70.4",
+        "pkg:cocoapods/React-bridging@0.70.4",
+        "pkg:cocoapods/React-callinvoker@0.70.4",
+        "pkg:cocoapods/React-cxxreact@0.70.4",
+        "pkg:cocoapods/React-jsi@0.70.4",
+        "pkg:cocoapods/React-logger@0.70.4",
+        "pkg:cocoapods/React-perflogger@0.70.4",
+        "pkg:cocoapods/glog@0.3.5"
+      ]
+    },
+    {
+      "ref": "pkg:cocoapods/SocketRocket@0.6.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:cocoapods/Yoga@1.14.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:cocoapods/YogaKit@1.18.1",
+      "dependsOn": [
+        "pkg:cocoapods/Yoga@1.14.0"
+      ]
+    },
+    {
+      "ref": "pkg:cocoapods/boost@1.76.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:cocoapods/fmt@6.2.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:cocoapods/glog@0.3.5",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:cocoapods/hermes-engine@0.70.4",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:cocoapods/libevent@2.1.12",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/%40aws-crypto/crc32@3.0.0",
+      "dependsOn": [
+        "pkg:npm/%40aws-crypto/util@3.0.0",
+        "pkg:npm/%40aws-sdk/types@3.391.0",
+        "pkg:npm/tslib@1.14.1"
+      ]
+    },
+    {
+      "ref": "pkg:npm/%40aws-crypto/ie11-detection@3.0.0",
+      "dependsOn": [
+        "pkg:npm/tslib@1.14.1"
+      ]
+    },
+    {
+      "ref": "pkg:npm/%40aws-crypto/sha256-browser@3.0.0",
+      "dependsOn": [
+        "pkg:npm/%40aws-crypto/ie11-detection@3.0.0",
+        "pkg:npm/%40aws-crypto/sha256-js@3.0.0",
+        "pkg:npm/%40aws-crypto/supports-web-crypto@3.0.0",
+        "pkg:npm/%40aws-crypto/util@3.0.0",
+        "pkg:npm/%40aws-sdk/types@3.391.0",
+        "pkg:npm/%40aws-sdk/util-locate-window@3.310.0",
+        "pkg:npm/%40aws-sdk/util-utf8-browser@3.259.0",
+        "pkg:npm/tslib@1.14.1"
+      ]
+    },
+    {
+      "ref": "pkg:npm/%40aws-crypto/sha256-js@3.0.0",
+      "dependsOn": [
+        "pkg:npm/%40aws-crypto/util@3.0.0",
+        "pkg:npm/%40aws-sdk/types@3.391.0",
+        "pkg:npm/tslib@1.14.1"
+      ]
+    },
+    {
+      "ref": "pkg:npm/%40aws-crypto/supports-web-crypto@3.0.0",
+      "dependsOn": [
+        "pkg:npm/tslib@1.14.1"
+      ]
+    },
+    {
+      "ref": "pkg:npm/%40aws-crypto/util@3.0.0",
+      "dependsOn": [
+        "pkg:npm/%40aws-sdk/types@3.391.0",
+        "pkg:npm/%40aws-sdk/util-utf8-browser@3.259.0",
+        "pkg:npm/tslib@1.14.1"
+      ]
+    },
+    {
+      "ref": "pkg:npm/%40aws-sdk/client-cloudwatch-logs@3.454.0",
+      "dependsOn": [
+        "pkg:npm/%40aws-crypto/sha256-browser@3.0.0",
+        "pkg:npm/%40aws-crypto/sha256-js@3.0.0",
+        "pkg:npm/%40aws-sdk/client-sts@3.454.0",
+        "pkg:npm/%40aws-sdk/core@3.451.0",
+        "pkg:npm/%40aws-sdk/credential-provider-node@3.451.0",
+        "pkg:npm/%40aws-sdk/middleware-host-header@3.451.0",
+        "pkg:npm/%40aws-sdk/middleware-logger@3.451.0",
+        "pkg:npm/%40aws-sdk/middleware-recursion-detection@3.451.0",
+        "pkg:npm/%40aws-sdk/middleware-signing@3.451.0",
+        "pkg:npm/%40aws-sdk/middleware-user-agent@3.451.0",
+        "pkg:npm/%40aws-sdk/region-config-resolver@3.451.0",
+        "pkg:npm/%40aws-sdk/types@3.451.0",
+        "pkg:npm/%40aws-sdk/util-endpoints@3.451.0",
+        "pkg:npm/%40aws-sdk/util-user-agent-browser@3.451.0",
+        "pkg:npm/%40aws-sdk/util-user-agent-node@3.451.0",
+        "pkg:npm/%40smithy/config-resolver@2.0.18",
+        "pkg:npm/%40smithy/fetch-http-handler@2.2.6",
+        "pkg:npm/%40smithy/hash-node@2.0.15",
+        "pkg:npm/%40smithy/invalid-dependency@2.0.13",
+        "pkg:npm/%40smithy/middleware-content-length@2.0.15",
+        "pkg:npm/%40smithy/middleware-endpoint@2.2.0",
+        "pkg:npm/%40smithy/middleware-retry@2.0.20",
+        "pkg:npm/%40smithy/middleware-serde@2.0.13",
+        "pkg:npm/%40smithy/middleware-stack@2.0.7",
+        "pkg:npm/%40smithy/node-config-provider@2.1.5",
+        "pkg:npm/%40smithy/node-http-handler@2.1.9",
+        "pkg:npm/%40smithy/protocol-http@3.0.9",
+        "pkg:npm/%40smithy/smithy-client@2.1.15",
+        "pkg:npm/%40smithy/types@2.5.0",
+        "pkg:npm/%40smithy/url-parser@2.0.13",
+        "pkg:npm/%40smithy/util-base64@2.0.1",
+        "pkg:npm/%40smithy/util-body-length-browser@2.0.0",
+        "pkg:npm/%40smithy/util-body-length-node@2.1.0",
+        "pkg:npm/%40smithy/util-defaults-mode-browser@2.0.19",
+        "pkg:npm/%40smithy/util-defaults-mode-node@2.0.25",
+        "pkg:npm/%40smithy/util-endpoints@1.0.4",
+        "pkg:npm/%40smithy/util-retry@2.0.6",
+        "pkg:npm/%40smithy/util-utf8@2.0.2",
+        "pkg:npm/tslib@2.6.1",
+        "pkg:npm/uuid@8.3.2"
+      ]
+    },
+    {
+      "ref": "pkg:npm/%40aws-sdk/client-cognito-identity@3.454.0",
+      "dependsOn": [
+        "pkg:npm/%40aws-crypto/sha256-browser@3.0.0",
+        "pkg:npm/%40aws-crypto/sha256-js@3.0.0",
+        "pkg:npm/%40aws-sdk/client-sts@3.454.0",
+        "pkg:npm/%40aws-sdk/core@3.451.0",
+        "pkg:npm/%40aws-sdk/credential-provider-node@3.451.0",
+        "pkg:npm/%40aws-sdk/middleware-host-header@3.451.0",
+        "pkg:npm/%40aws-sdk/middleware-logger@3.451.0",
+        "pkg:npm/%40aws-sdk/middleware-recursion-detection@3.451.0",
+        "pkg:npm/%40aws-sdk/middleware-signing@3.451.0",
+        "pkg:npm/%40aws-sdk/middleware-user-agent@3.451.0",
+        "pkg:npm/%40aws-sdk/region-config-resolver@3.451.0",
+        "pkg:npm/%40aws-sdk/types@3.451.0",
+        "pkg:npm/%40aws-sdk/util-endpoints@3.451.0",
+        "pkg:npm/%40aws-sdk/util-user-agent-browser@3.451.0",
+        "pkg:npm/%40aws-sdk/util-user-agent-node@3.451.0",
+        "pkg:npm/%40smithy/config-resolver@2.0.18",
+        "pkg:npm/%40smithy/fetch-http-handler@2.2.6",
+        "pkg:npm/%40smithy/hash-node@2.0.15",
+        "pkg:npm/%40smithy/invalid-dependency@2.0.13",
+        "pkg:npm/%40smithy/middleware-content-length@2.0.15",
+        "pkg:npm/%40smithy/middleware-endpoint@2.2.0",
+        "pkg:npm/%40smithy/middleware-retry@2.0.20",
+        "pkg:npm/%40smithy/middleware-serde@2.0.13",
+        "pkg:npm/%40smithy/middleware-stack@2.0.7",
+        "pkg:npm/%40smithy/node-config-provider@2.1.5",
+        "pkg:npm/%40smithy/node-http-handler@2.1.9",
+        "pkg:npm/%40smithy/protocol-http@3.0.9",
+        "pkg:npm/%40smithy/smithy-client@2.1.15",
+        "pkg:npm/%40smithy/types@2.5.0",
+        "pkg:npm/%40smithy/url-parser@2.0.13",
+        "pkg:npm/%40smithy/util-base64@2.0.1",
+        "pkg:npm/%40smithy/util-body-length-browser@2.0.0",
+        "pkg:npm/%40smithy/util-body-length-node@2.1.0",
+        "pkg:npm/%40smithy/util-defaults-mode-browser@2.0.19",
+        "pkg:npm/%40smithy/util-defaults-mode-node@2.0.25",
+        "pkg:npm/%40smithy/util-endpoints@1.0.4",
+        "pkg:npm/%40smithy/util-retry@2.0.6",
+        "pkg:npm/%40smithy/util-utf8@2.0.2",
+        "pkg:npm/tslib@2.6.1"
+      ]
+    },
+    {
+      "ref": "pkg:npm/%40aws-sdk/client-iam@3.454.0",
+      "dependsOn": [
+        "pkg:npm/%40aws-crypto/sha256-browser@3.0.0",
+        "pkg:npm/%40aws-crypto/sha256-js@3.0.0",
+        "pkg:npm/%40aws-sdk/client-sts@3.454.0",
+        "pkg:npm/%40aws-sdk/core@3.451.0",
+        "pkg:npm/%40aws-sdk/credential-provider-node@3.451.0",
+        "pkg:npm/%40aws-sdk/middleware-host-header@3.451.0",
+        "pkg:npm/%40aws-sdk/middleware-logger@3.451.0",
+        "pkg:npm/%40aws-sdk/middleware-recursion-detection@3.451.0",
+        "pkg:npm/%40aws-sdk/middleware-signing@3.451.0",
+        "pkg:npm/%40aws-sdk/middleware-user-agent@3.451.0",
+        "pkg:npm/%40aws-sdk/region-config-resolver@3.451.0",
+        "pkg:npm/%40aws-sdk/types@3.451.0",
+        "pkg:npm/%40aws-sdk/util-endpoints@3.451.0",
+        "pkg:npm/%40aws-sdk/util-user-agent-browser@3.451.0",
+        "pkg:npm/%40aws-sdk/util-user-agent-node@3.451.0",
+        "pkg:npm/%40smithy/config-resolver@2.0.18",
+        "pkg:npm/%40smithy/fetch-http-handler@2.2.6",
+        "pkg:npm/%40smithy/hash-node@2.0.15",
+        "pkg:npm/%40smithy/invalid-dependency@2.0.13",
+        "pkg:npm/%40smithy/middleware-content-length@2.0.15",
+        "pkg:npm/%40smithy/middleware-endpoint@2.2.0",
+        "pkg:npm/%40smithy/middleware-retry@2.0.20",
+        "pkg:npm/%40smithy/middleware-serde@2.0.13",
+        "pkg:npm/%40smithy/middleware-stack@2.0.7",
+        "pkg:npm/%40smithy/node-config-provider@2.1.5",
+        "pkg:npm/%40smithy/node-http-handler@2.1.9",
+        "pkg:npm/%40smithy/protocol-http@3.0.9",
+        "pkg:npm/%40smithy/smithy-client@2.1.15",
+        "pkg:npm/%40smithy/types@2.5.0",
+        "pkg:npm/%40smithy/url-parser@2.0.13",
+        "pkg:npm/%40smithy/util-base64@2.0.1",
+        "pkg:npm/%40smithy/util-body-length-browser@2.0.0",
+        "pkg:npm/%40smithy/util-body-length-node@2.1.0",
+        "pkg:npm/%40smithy/util-defaults-mode-browser@2.0.19",
+        "pkg:npm/%40smithy/util-defaults-mode-node@2.0.25",
+        "pkg:npm/%40smithy/util-endpoints@1.0.4",
+        "pkg:npm/%40smithy/util-retry@2.0.6",
+        "pkg:npm/%40smithy/util-utf8@2.0.2",
+        "pkg:npm/%40smithy/util-waiter@2.0.13",
+        "pkg:npm/fast-xml-parser@4.2.5",
+        "pkg:npm/tslib@2.6.1"
+      ]
+    },
+    {
+      "ref": "pkg:npm/%40aws-sdk/client-lambda@3.454.0",
+      "dependsOn": [
+        "pkg:npm/%40aws-crypto/sha256-browser@3.0.0",
+        "pkg:npm/%40aws-crypto/sha256-js@3.0.0",
+        "pkg:npm/%40aws-sdk/client-sts@3.454.0",
+        "pkg:npm/%40aws-sdk/core@3.451.0",
+        "pkg:npm/%40aws-sdk/credential-provider-node@3.451.0",
+        "pkg:npm/%40aws-sdk/middleware-host-header@3.451.0",
+        "pkg:npm/%40aws-sdk/middleware-logger@3.451.0",
+        "pkg:npm/%40aws-sdk/middleware-recursion-detection@3.451.0",
+        "pkg:npm/%40aws-sdk/middleware-signing@3.451.0",
+        "pkg:npm/%40aws-sdk/middleware-user-agent@3.451.0",
+        "pkg:npm/%40aws-sdk/region-config-resolver@3.451.0",
+        "pkg:npm/%40aws-sdk/types@3.451.0",
+        "pkg:npm/%40aws-sdk/util-endpoints@3.451.0",
+        "pkg:npm/%40aws-sdk/util-user-agent-browser@3.451.0",
+        "pkg:npm/%40aws-sdk/util-user-agent-node@3.451.0",
+        "pkg:npm/%40smithy/config-resolver@2.0.18",
+        "pkg:npm/%40smithy/eventstream-serde-browser@2.0.13",
+        "pkg:npm/%40smithy/eventstream-serde-config-resolver@2.0.13",
+        "pkg:npm/%40smithy/eventstream-serde-node@2.0.13",
+        "pkg:npm/%40smithy/fetch-http-handler@2.2.6",
+        "pkg:npm/%40smithy/hash-node@2.0.15",
+        "pkg:npm/%40smithy/invalid-dependency@2.0.13",
+        "pkg:npm/%40smithy/middleware-content-length@2.0.15",
+        "pkg:npm/%40smithy/middleware-endpoint@2.2.0",
+        "pkg:npm/%40smithy/middleware-retry@2.0.20",
+        "pkg:npm/%40smithy/middleware-serde@2.0.13",
+        "pkg:npm/%40smithy/middleware-stack@2.0.7",
+        "pkg:npm/%40smithy/node-config-provider@2.1.5",
+        "pkg:npm/%40smithy/node-http-handler@2.1.9",
+        "pkg:npm/%40smithy/protocol-http@3.0.9",
+        "pkg:npm/%40smithy/smithy-client@2.1.15",
+        "pkg:npm/%40smithy/types@2.5.0",
+        "pkg:npm/%40smithy/url-parser@2.0.13",
+        "pkg:npm/%40smithy/util-base64@2.0.1",
+        "pkg:npm/%40smithy/util-body-length-browser@2.0.0",
+        "pkg:npm/%40smithy/util-body-length-node@2.1.0",
+        "pkg:npm/%40smithy/util-defaults-mode-browser@2.0.19",
+        "pkg:npm/%40smithy/util-defaults-mode-node@2.0.25",
+        "pkg:npm/%40smithy/util-endpoints@1.0.4",
+        "pkg:npm/%40smithy/util-retry@2.0.6",
+        "pkg:npm/%40smithy/util-stream@2.0.20",
+        "pkg:npm/%40smithy/util-utf8@2.0.2",
+        "pkg:npm/%40smithy/util-waiter@2.0.13",
+        "pkg:npm/tslib@2.6.1"
+      ]
+    },
+    {
+      "ref": "pkg:npm/%40aws-sdk/client-sfn@3.454.0",
+      "dependsOn": [
+        "pkg:npm/%40aws-crypto/sha256-browser@3.0.0",
+        "pkg:npm/%40aws-crypto/sha256-js@3.0.0",
+        "pkg:npm/%40aws-sdk/client-sts@3.454.0",
+        "pkg:npm/%40aws-sdk/core@3.451.0",
+        "pkg:npm/%40aws-sdk/credential-provider-node@3.451.0",
+        "pkg:npm/%40aws-sdk/middleware-host-header@3.451.0",
+        "pkg:npm/%40aws-sdk/middleware-logger@3.451.0",
+        "pkg:npm/%40aws-sdk/middleware-recursion-detection@3.451.0",
+        "pkg:npm/%40aws-sdk/middleware-signing@3.451.0",
+        "pkg:npm/%40aws-sdk/middleware-user-agent@3.451.0",
+        "pkg:npm/%40aws-sdk/region-config-resolver@3.451.0",
+        "pkg:npm/%40aws-sdk/types@3.451.0",
+        "pkg:npm/%40aws-sdk/util-endpoints@3.451.0",
+        "pkg:npm/%40aws-sdk/util-user-agent-browser@3.451.0",
+        "pkg:npm/%40aws-sdk/util-user-agent-node@3.451.0",
+        "pkg:npm/%40smithy/config-resolver@2.0.18",
+        "pkg:npm/%40smithy/fetch-http-handler@2.2.6",
+        "pkg:npm/%40smithy/hash-node@2.0.15",
+        "pkg:npm/%40smithy/invalid-dependency@2.0.13",
+        "pkg:npm/%40smithy/middleware-content-length@2.0.15",
+        "pkg:npm/%40smithy/middleware-endpoint@2.2.0",
+        "pkg:npm/%40smithy/middleware-retry@2.0.20",
+        "pkg:npm/%40smithy/middleware-serde@2.0.13",
+        "pkg:npm/%40smithy/middleware-stack@2.0.7",
+        "pkg:npm/%40smithy/node-config-provider@2.1.5",
+        "pkg:npm/%40smithy/node-http-handler@2.1.9",
+        "pkg:npm/%40smithy/protocol-http@3.0.9",
+        "pkg:npm/%40smithy/smithy-client@2.1.15",
+        "pkg:npm/%40smithy/types@2.5.0",
+        "pkg:npm/%40smithy/url-parser@2.0.13",
+        "pkg:npm/%40smithy/util-base64@2.0.1",
+        "pkg:npm/%40smithy/util-body-length-browser@2.0.0",
+        "pkg:npm/%40smithy/util-body-length-node@2.1.0",
+        "pkg:npm/%40smithy/util-defaults-mode-browser@2.0.19",
+        "pkg:npm/%40smithy/util-defaults-mode-node@2.0.25",
+        "pkg:npm/%40smithy/util-endpoints@1.0.4",
+        "pkg:npm/%40smithy/util-retry@2.0.6",
+        "pkg:npm/%40smithy/util-utf8@2.0.2",
+        "pkg:npm/tslib@2.6.1",
+        "pkg:npm/uuid@8.3.2"
+      ]
+    },
+    {
+      "ref": "pkg:npm/%40aws-sdk/client-sso@3.451.0",
+      "dependsOn": [
+        "pkg:npm/%40aws-crypto/sha256-browser@3.0.0",
+        "pkg:npm/%40aws-crypto/sha256-js@3.0.0",
+        "pkg:npm/%40aws-sdk/core@3.451.0",
+        "pkg:npm/%40aws-sdk/middleware-host-header@3.451.0",
+        "pkg:npm/%40aws-sdk/middleware-logger@3.451.0",
+        "pkg:npm/%40aws-sdk/middleware-recursion-detection@3.451.0",
+        "pkg:npm/%40aws-sdk/middleware-user-agent@3.451.0",
+        "pkg:npm/%40aws-sdk/region-config-resolver@3.451.0",
+        "pkg:npm/%40aws-sdk/types@3.451.0",
+        "pkg:npm/%40aws-sdk/util-endpoints@3.451.0",
+        "pkg:npm/%40aws-sdk/util-user-agent-browser@3.451.0",
+        "pkg:npm/%40aws-sdk/util-user-agent-node@3.451.0",
+        "pkg:npm/%40smithy/config-resolver@2.0.18",
+        "pkg:npm/%40smithy/fetch-http-handler@2.2.6",
+        "pkg:npm/%40smithy/hash-node@2.0.15",
+        "pkg:npm/%40smithy/invalid-dependency@2.0.13",
+        "pkg:npm/%40smithy/middleware-content-length@2.0.15",
+        "pkg:npm/%40smithy/middleware-endpoint@2.2.0",
+        "pkg:npm/%40smithy/middleware-retry@2.0.20",
+        "pkg:npm/%40smithy/middleware-serde@2.0.13",
+        "pkg:npm/%40smithy/middleware-stack@2.0.7",
+        "pkg:npm/%40smithy/node-config-provider@2.1.5",
+        "pkg:npm/%40smithy/node-http-handler@2.1.9",
+        "pkg:npm/%40smithy/protocol-http@3.0.9",
+        "pkg:npm/%40smithy/smithy-client@2.1.15",
+        "pkg:npm/%40smithy/types@2.5.0",
+        "pkg:npm/%40smithy/url-parser@2.0.13",
+        "pkg:npm/%40smithy/util-base64@2.0.1",
+        "pkg:npm/%40smithy/util-body-length-browser@2.0.0",
+        "pkg:npm/%40smithy/util-body-length-node@2.1.0",
+        "pkg:npm/%40smithy/util-defaults-mode-browser@2.0.19",
+        "pkg:npm/%40smithy/util-defaults-mode-node@2.0.25",
+        "pkg:npm/%40smithy/util-endpoints@1.0.4",
+        "pkg:npm/%40smithy/util-retry@2.0.6",
+        "pkg:npm/%40smithy/util-utf8@2.0.2",
+        "pkg:npm/tslib@2.6.1"
+      ]
+    },
+    {
+      "ref": "pkg:npm/%40aws-sdk/client-sts@3.454.0",
+      "dependsOn": [
+        "pkg:npm/%40aws-crypto/sha256-browser@3.0.0",
+        "pkg:npm/%40aws-crypto/sha256-js@3.0.0",
+        "pkg:npm/%40aws-sdk/core@3.451.0",
+        "pkg:npm/%40aws-sdk/credential-provider-node@3.451.0",
+        "pkg:npm/%40aws-sdk/middleware-host-header@3.451.0",
+        "pkg:npm/%40aws-sdk/middleware-logger@3.451.0",
+        "pkg:npm/%40aws-sdk/middleware-recursion-detection@3.451.0",
+        "pkg:npm/%40aws-sdk/middleware-sdk-sts@3.451.0",
+        "pkg:npm/%40aws-sdk/middleware-signing@3.451.0",
+        "pkg:npm/%40aws-sdk/middleware-user-agent@3.451.0",
+        "pkg:npm/%40aws-sdk/region-config-resolver@3.451.0",
+        "pkg:npm/%40aws-sdk/types@3.451.0",
+        "pkg:npm/%40aws-sdk/util-endpoints@3.451.0",
+        "pkg:npm/%40aws-sdk/util-user-agent-browser@3.451.0",
+        "pkg:npm/%40aws-sdk/util-user-agent-node@3.451.0",
+        "pkg:npm/%40smithy/config-resolver@2.0.18",
+        "pkg:npm/%40smithy/fetch-http-handler@2.2.6",
+        "pkg:npm/%40smithy/hash-node@2.0.15",
+        "pkg:npm/%40smithy/invalid-dependency@2.0.13",
+        "pkg:npm/%40smithy/middleware-content-length@2.0.15",
+        "pkg:npm/%40smithy/middleware-endpoint@2.2.0",
+        "pkg:npm/%40smithy/middleware-retry@2.0.20",
+        "pkg:npm/%40smithy/middleware-serde@2.0.13",
+        "pkg:npm/%40smithy/middleware-stack@2.0.7",
+        "pkg:npm/%40smithy/node-config-provider@2.1.5",
+        "pkg:npm/%40smithy/node-http-handler@2.1.9",
+        "pkg:npm/%40smithy/protocol-http@3.0.9",
+        "pkg:npm/%40smithy/smithy-client@2.1.15",
+        "pkg:npm/%40smithy/types@2.5.0",
+        "pkg:npm/%40smithy/url-parser@2.0.13",
+        "pkg:npm/%40smithy/util-base64@2.0.1",
+        "pkg:npm/%40smithy/util-body-length-browser@2.0.0",
+        "pkg:npm/%40smithy/util-body-length-node@2.1.0",
+        "pkg:npm/%40smithy/util-defaults-mode-browser@2.0.19",
+        "pkg:npm/%40smithy/util-defaults-mode-node@2.0.25",
+        "pkg:npm/%40smithy/util-endpoints@1.0.4",
+        "pkg:npm/%40smithy/util-retry@2.0.6",
+        "pkg:npm/%40smithy/util-utf8@2.0.2",
+        "pkg:npm/fast-xml-parser@4.2.5",
+        "pkg:npm/tslib@2.6.1"
+      ]
+    },
+    {
+      "ref": "pkg:npm/%40aws-sdk/core@3.451.0",
+      "dependsOn": [
+        "pkg:npm/%40smithy/smithy-client@2.1.15",
+        "pkg:npm/tslib@2.6.1"
+      ]
+    },
+    {
+      "ref": "pkg:npm/%40aws-sdk/credential-provider-cognito-identity@3.454.0",
+      "dependsOn": [
+        "pkg:npm/%40aws-sdk/client-cognito-identity@3.454.0",
+        "pkg:npm/%40aws-sdk/types@3.451.0",
+        "pkg:npm/%40smithy/property-provider@2.0.3",
+        "pkg:npm/%40smithy/types@2.5.0",
+        "pkg:npm/tslib@2.6.1"
+      ]
+    },
+    {
+      "ref": "pkg:npm/%40aws-sdk/credential-provider-env@3.451.0",
+      "dependsOn": [
+        "pkg:npm/%40aws-sdk/types@3.451.0",
+        "pkg:npm/%40smithy/property-provider@2.0.3",
+        "pkg:npm/%40smithy/types@2.5.0",
+        "pkg:npm/tslib@2.6.1"
+      ]
+    },
+    {
+      "ref": "pkg:npm/%40aws-sdk/credential-provider-http@3.451.0",
+      "dependsOn": [
+        "pkg:npm/%40aws-sdk/types@3.451.0",
+        "pkg:npm/%40smithy/fetch-http-handler@2.2.6",
+        "pkg:npm/%40smithy/node-http-handler@2.1.9",
+        "pkg:npm/%40smithy/property-provider@2.0.3",
+        "pkg:npm/%40smithy/protocol-http@3.0.9",
+        "pkg:npm/%40smithy/smithy-client@2.1.15",
+        "pkg:npm/%40smithy/types@2.5.0",
+        "pkg:npm/%40smithy/util-stream@2.0.20",
+        "pkg:npm/tslib@2.6.1"
+      ]
+    },
+    {
+      "ref": "pkg:npm/%40aws-sdk/credential-provider-ini@3.451.0",
+      "dependsOn": [
+        "pkg:npm/%40aws-sdk/credential-provider-env@3.451.0",
+        "pkg:npm/%40aws-sdk/credential-provider-process@3.451.0",
+        "pkg:npm/%40aws-sdk/credential-provider-sso@3.451.0",
+        "pkg:npm/%40aws-sdk/credential-provider-web-identity@3.451.0",
+        "pkg:npm/%40aws-sdk/types@3.451.0",
+        "pkg:npm/%40smithy/credential-provider-imds@2.0.3",
+        "pkg:npm/%40smithy/property-provider@2.0.3",
+        "pkg:npm/%40smithy/shared-ini-file-loader@2.2.0",
+        "pkg:npm/%40smithy/types@2.5.0",
+        "pkg:npm/tslib@2.6.1"
+      ]
+    },
+    {
+      "ref": "pkg:npm/%40aws-sdk/credential-provider-node@3.451.0",
+      "dependsOn": [
+        "pkg:npm/%40aws-sdk/credential-provider-env@3.451.0",
+        "pkg:npm/%40aws-sdk/credential-provider-ini@3.451.0",
+        "pkg:npm/%40aws-sdk/credential-provider-process@3.451.0",
+        "pkg:npm/%40aws-sdk/credential-provider-sso@3.451.0",
+        "pkg:npm/%40aws-sdk/credential-provider-web-identity@3.451.0",
+        "pkg:npm/%40aws-sdk/types@3.451.0",
+        "pkg:npm/%40smithy/credential-provider-imds@2.0.3",
+        "pkg:npm/%40smithy/property-provider@2.0.3",
+        "pkg:npm/%40smithy/shared-ini-file-loader@2.2.0",
+        "pkg:npm/%40smithy/types@2.5.0",
+        "pkg:npm/tslib@2.6.1"
+      ]
+    },
+    {
+      "ref": "pkg:npm/%40aws-sdk/credential-provider-process@3.451.0",
+      "dependsOn": [
+        "pkg:npm/%40aws-sdk/types@3.451.0",
+        "pkg:npm/%40smithy/property-provider@2.0.3",
+        "pkg:npm/%40smithy/shared-ini-file-loader@2.2.0",
+        "pkg:npm/%40smithy/types@2.5.0",
+        "pkg:npm/tslib@2.6.1"
+      ]
+    },
+    {
+      "ref": "pkg:npm/%40aws-sdk/credential-provider-sso@3.451.0",
+      "dependsOn": [
+        "pkg:npm/%40aws-sdk/client-sso@3.451.0",
+        "pkg:npm/%40aws-sdk/token-providers@3.451.0",
+        "pkg:npm/%40aws-sdk/types@3.451.0",
+        "pkg:npm/%40smithy/property-provider@2.0.3",
+        "pkg:npm/%40smithy/shared-ini-file-loader@2.2.0",
+        "pkg:npm/%40smithy/types@2.5.0",
+        "pkg:npm/tslib@2.6.1"
+      ]
+    },
+    {
+      "ref": "pkg:npm/%40aws-sdk/credential-provider-web-identity@3.451.0",
+      "dependsOn": [
+        "pkg:npm/%40aws-sdk/types@3.451.0",
+        "pkg:npm/%40smithy/property-provider@2.0.3",
+        "pkg:npm/%40smithy/types@2.5.0",
+        "pkg:npm/tslib@2.6.1"
+      ]
+    },
+    {
+      "ref": "pkg:npm/%40aws-sdk/credential-providers@3.454.0",
+      "dependsOn": [
+        "pkg:npm/%40aws-sdk/client-cognito-identity@3.454.0",
+        "pkg:npm/%40aws-sdk/client-sso@3.451.0",
+        "pkg:npm/%40aws-sdk/client-sts@3.454.0",
+        "pkg:npm/%40aws-sdk/credential-provider-cognito-identity@3.454.0",
+        "pkg:npm/%40aws-sdk/credential-provider-env@3.451.0",
+        "pkg:npm/%40aws-sdk/credential-provider-http@3.451.0",
+        "pkg:npm/%40aws-sdk/credential-provider-ini@3.451.0",
+        "pkg:npm/%40aws-sdk/credential-provider-node@3.451.0",
+        "pkg:npm/%40aws-sdk/credential-provider-process@3.451.0",
+        "pkg:npm/%40aws-sdk/credential-provider-sso@3.451.0",
+        "pkg:npm/%40aws-sdk/credential-provider-web-identity@3.451.0",
+        "pkg:npm/%40aws-sdk/types@3.451.0",
+        "pkg:npm/%40smithy/credential-provider-imds@2.0.3",
+        "pkg:npm/%40smithy/property-provider@2.0.3",
+        "pkg:npm/%40smithy/types@2.5.0",
+        "pkg:npm/tslib@2.6.1"
+      ]
+    },
+    {
+      "ref": "pkg:npm/%40aws-sdk/middleware-host-header@3.451.0",
+      "dependsOn": [
+        "pkg:npm/%40aws-sdk/types@3.451.0",
+        "pkg:npm/%40smithy/protocol-http@3.0.9",
+        "pkg:npm/%40smithy/types@2.5.0",
+        "pkg:npm/tslib@2.6.1"
+      ]
+    },
+    {
+      "ref": "pkg:npm/%40aws-sdk/middleware-logger@3.451.0",
+      "dependsOn": [
+        "pkg:npm/%40aws-sdk/types@3.451.0",
+        "pkg:npm/%40smithy/types@2.5.0",
+        "pkg:npm/tslib@2.6.1"
+      ]
+    },
+    {
+      "ref": "pkg:npm/%40aws-sdk/middleware-recursion-detection@3.451.0",
+      "dependsOn": [
+        "pkg:npm/%40aws-sdk/types@3.451.0",
+        "pkg:npm/%40smithy/protocol-http@3.0.9",
+        "pkg:npm/%40smithy/types@2.5.0",
+        "pkg:npm/tslib@2.6.1"
+      ]
+    },
+    {
+      "ref": "pkg:npm/%40aws-sdk/middleware-sdk-sts@3.451.0",
+      "dependsOn": [
+        "pkg:npm/%40aws-sdk/middleware-signing@3.451.0",
+        "pkg:npm/%40aws-sdk/types@3.451.0",
+        "pkg:npm/%40smithy/types@2.5.0",
+        "pkg:npm/tslib@2.6.1"
+      ]
+    },
+    {
+      "ref": "pkg:npm/%40aws-sdk/middleware-signing@3.451.0",
+      "dependsOn": [
+        "pkg:npm/%40aws-sdk/types@3.451.0",
+        "pkg:npm/%40smithy/property-provider@2.0.3",
+        "pkg:npm/%40smithy/protocol-http@3.0.9",
+        "pkg:npm/%40smithy/signature-v4@2.0.3",
+        "pkg:npm/%40smithy/types@2.5.0",
+        "pkg:npm/%40smithy/util-middleware@2.0.6",
+        "pkg:npm/tslib@2.6.1"
+      ]
+    },
+    {
+      "ref": "pkg:npm/%40aws-sdk/middleware-user-agent@3.451.0",
+      "dependsOn": [
+        "pkg:npm/%40aws-sdk/types@3.451.0",
+        "pkg:npm/%40aws-sdk/util-endpoints@3.451.0",
+        "pkg:npm/%40smithy/protocol-http@3.0.9",
+        "pkg:npm/%40smithy/types@2.5.0",
+        "pkg:npm/tslib@2.6.1"
+      ]
+    },
+    {
+      "ref": "pkg:npm/%40aws-sdk/region-config-resolver@3.451.0",
+      "dependsOn": [
+        "pkg:npm/%40smithy/node-config-provider@2.1.5",
+        "pkg:npm/%40smithy/types@2.5.0",
+        "pkg:npm/%40smithy/util-config-provider@2.0.0",
+        "pkg:npm/%40smithy/util-middleware@2.0.6",
+        "pkg:npm/tslib@2.6.1"
+      ]
+    },
+    {
+      "ref": "pkg:npm/%40aws-sdk/token-providers@3.451.0",
+      "dependsOn": [
+        "pkg:npm/%40aws-crypto/sha256-browser@3.0.0",
+        "pkg:npm/%40aws-crypto/sha256-js@3.0.0",
+        "pkg:npm/%40aws-sdk/middleware-host-header@3.451.0",
+        "pkg:npm/%40aws-sdk/middleware-logger@3.451.0",
+        "pkg:npm/%40aws-sdk/middleware-recursion-detection@3.451.0",
+        "pkg:npm/%40aws-sdk/middleware-user-agent@3.451.0",
+        "pkg:npm/%40aws-sdk/region-config-resolver@3.451.0",
+        "pkg:npm/%40aws-sdk/types@3.451.0",
+        "pkg:npm/%40aws-sdk/util-endpoints@3.451.0",
+        "pkg:npm/%40aws-sdk/util-user-agent-browser@3.451.0",
+        "pkg:npm/%40aws-sdk/util-user-agent-node@3.451.0",
+        "pkg:npm/%40smithy/config-resolver@2.0.18",
+        "pkg:npm/%40smithy/fetch-http-handler@2.2.6",
+        "pkg:npm/%40smithy/hash-node@2.0.15",
+        "pkg:npm/%40smithy/invalid-dependency@2.0.13",
+        "pkg:npm/%40smithy/middleware-content-length@2.0.15",
+        "pkg:npm/%40smithy/middleware-endpoint@2.2.0",
+        "pkg:npm/%40smithy/middleware-retry@2.0.20",
+        "pkg:npm/%40smithy/middleware-serde@2.0.13",
+        "pkg:npm/%40smithy/middleware-stack@2.0.7",
+        "pkg:npm/%40smithy/node-config-provider@2.1.5",
+        "pkg:npm/%40smithy/node-http-handler@2.1.9",
+        "pkg:npm/%40smithy/property-provider@2.0.3",
+        "pkg:npm/%40smithy/protocol-http@3.0.9",
+        "pkg:npm/%40smithy/shared-ini-file-loader@2.2.0",
+        "pkg:npm/%40smithy/smithy-client@2.1.15",
+        "pkg:npm/%40smithy/types@2.5.0",
+        "pkg:npm/%40smithy/url-parser@2.0.13",
+        "pkg:npm/%40smithy/util-base64@2.0.1",
+        "pkg:npm/%40smithy/util-body-length-browser@2.0.0",
+        "pkg:npm/%40smithy/util-body-length-node@2.1.0",
+        "pkg:npm/%40smithy/util-defaults-mode-browser@2.0.19",
+        "pkg:npm/%40smithy/util-defaults-mode-node@2.0.25",
+        "pkg:npm/%40smithy/util-endpoints@1.0.4",
+        "pkg:npm/%40smithy/util-retry@2.0.6",
+        "pkg:npm/%40smithy/util-utf8@2.0.2",
+        "pkg:npm/tslib@2.6.1"
+      ]
+    },
+    {
+      "ref": "pkg:npm/%40aws-sdk/types@3.391.0",
+      "dependsOn": [
+        "pkg:npm/%40smithy/types@2.2.0",
+        "pkg:npm/tslib@2.6.1"
+      ]
+    },
+    {
+      "ref": "pkg:npm/%40aws-sdk/types@3.451.0",
+      "dependsOn": [
+        "pkg:npm/%40smithy/types@2.5.0",
+        "pkg:npm/tslib@2.6.1"
+      ]
+    },
+    {
+      "ref": "pkg:npm/%40aws-sdk/util-endpoints@3.451.0",
+      "dependsOn": [
+        "pkg:npm/%40aws-sdk/types@3.451.0",
+        "pkg:npm/%40smithy/util-endpoints@1.0.4",
+        "pkg:npm/tslib@2.6.1"
+      ]
+    },
+    {
+      "ref": "pkg:npm/%40aws-sdk/util-locate-window@3.310.0",
+      "dependsOn": [
+        "pkg:npm/tslib@2.6.1"
+      ]
+    },
+    {
+      "ref": "pkg:npm/%40aws-sdk/util-user-agent-browser@3.451.0",
+      "dependsOn": [
+        "pkg:npm/%40aws-sdk/types@3.451.0",
+        "pkg:npm/%40smithy/types@2.5.0",
+        "pkg:npm/bowser@2.11.0",
+        "pkg:npm/tslib@2.6.1"
+      ]
+    },
+    {
+      "ref": "pkg:npm/%40aws-sdk/util-user-agent-node@3.451.0",
+      "dependsOn": [
+        "pkg:npm/%40aws-sdk/types@3.451.0",
+        "pkg:npm/%40smithy/node-config-provider@2.1.5",
+        "pkg:npm/%40smithy/types@2.5.0",
+        "pkg:npm/tslib@2.6.1"
+      ]
+    },
+    {
+      "ref": "pkg:npm/%40aws-sdk/util-utf8-browser@3.259.0",
+      "dependsOn": [
+        "pkg:npm/tslib@2.6.1"
+      ]
+    },
+    {
+      "ref": "pkg:npm/%40google-cloud/common@5.0.1",
+      "dependsOn": [
+        "pkg:npm/%40google-cloud/projectify@4.0.0",
+        "pkg:npm/%40google-cloud/promisify@4.0.0",
+        "pkg:npm/arrify@2.0.1",
+        "pkg:npm/duplexify@4.1.2",
+        "pkg:npm/ent@2.2.0",
+        "pkg:npm/extend@3.0.2",
+        "pkg:npm/google-auth-library@9.2.0",
+        "pkg:npm/retry-request@7.0.1",
+        "pkg:npm/teeny-request@9.0.0"
+      ]
+    },
+    {
+      "ref": "pkg:npm/%40google-cloud/logging@11.0.0",
+      "dependsOn": [
+        "pkg:npm/%40google-cloud/common@5.0.1",
+        "pkg:npm/%40google-cloud/paginator@5.0.0",
+        "pkg:npm/%40google-cloud/projectify@4.0.0",
+        "pkg:npm/%40google-cloud/promisify@4.0.0",
+        "pkg:npm/arrify@2.0.1",
+        "pkg:npm/dot-prop@6.0.1",
+        "pkg:npm/eventid@2.0.1",
+        "pkg:npm/extend@3.0.2",
+        "pkg:npm/gcp-metadata@6.1.0",
+        "pkg:npm/google-auth-library@9.2.0",
+        "pkg:npm/google-gax@4.0.5",
+        "pkg:npm/on-finished@2.4.1",
+        "pkg:npm/pumpify@2.0.1",
+        "pkg:npm/stream-events@1.0.5",
+        "pkg:npm/uuid@9.0.0"
+      ]
+    },
+    {
+      "ref": "pkg:npm/%40google-cloud/paginator@5.0.0",
+      "dependsOn": [
+        "pkg:npm/arrify@2.0.1",
+        "pkg:npm/extend@3.0.2"
+      ]
+    },
+    {
+      "ref": "pkg:npm/%40google-cloud/projectify@4.0.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/%40google-cloud/promisify@4.0.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/%40google-cloud/run@1.0.2",
+      "dependsOn": [
+        "pkg:npm/google-gax@4.0.5"
+      ]
+    },
+    {
+      "ref": "pkg:npm/%40grpc/grpc-js@1.9.11",
+      "dependsOn": [
+        "pkg:npm/%40grpc/proto-loader@0.7.10",
+        "pkg:npm/%40types/node@20.5.0"
+      ]
+    },
+    {
+      "ref": "pkg:npm/%40grpc/proto-loader@0.7.10",
+      "dependsOn": [
+        "pkg:npm/lodash.camelcase@4.3.0",
+        "pkg:npm/long@5.2.3",
+        "pkg:npm/protobufjs@7.2.4",
+        "pkg:npm/yargs@17.7.2"
+      ]
+    },
+    {
+      "ref": "pkg:npm/%40grpc/proto-loader@0.7.8",
+      "dependsOn": [
+        "pkg:npm/%40types/long@4.0.2",
+        "pkg:npm/lodash.camelcase@4.3.0",
+        "pkg:npm/long@4.0.0",
+        "pkg:npm/protobufjs@7.2.4",
+        "pkg:npm/yargs@17.7.2"
+      ]
+    },
+    {
+      "ref": "pkg:npm/%40isaacs/cliui@8.0.2",
+      "dependsOn": [
+        "pkg:npm/string-width-cjs@4.2.3",
+        "pkg:npm/string-width@5.1.2",
+        "pkg:npm/strip-ansi-cjs@6.0.1",
+        "pkg:npm/strip-ansi@7.1.0",
+        "pkg:npm/wrap-ansi-cjs@7.0.0",
+        "pkg:npm/wrap-ansi@8.1.0"
+      ]
+    },
+    {
+      "ref": "pkg:npm/%40kwsites/file-exists@1.1.1",
+      "dependsOn": [
+        "pkg:npm/debug@4.3.4"
+      ]
+    },
+    {
+      "ref": "pkg:npm/%40kwsites/promise-deferred@1.1.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/%40npmcli/fs@3.1.0",
+      "dependsOn": [
+        "pkg:npm/semver@7.5.4"
+      ]
+    },
+    {
+      "ref": "pkg:npm/%40pkgjs/parseargs@0.11.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/%40protobufjs/aspromise@1.1.2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/%40protobufjs/base64@1.1.2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/%40protobufjs/codegen@2.0.4",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/%40protobufjs/eventemitter@1.1.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/%40protobufjs/fetch@1.1.0",
+      "dependsOn": [
+        "pkg:npm/%40protobufjs/aspromise@1.1.2",
+        "pkg:npm/%40protobufjs/inquire@1.1.0"
+      ]
+    },
+    {
+      "ref": "pkg:npm/%40protobufjs/float@1.0.2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/%40protobufjs/inquire@1.1.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/%40protobufjs/path@1.1.2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/%40protobufjs/pool@1.1.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/%40protobufjs/utf8@1.1.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/%40smithy/abort-controller@2.0.13",
+      "dependsOn": [
+        "pkg:npm/%40smithy/types@2.5.0",
+        "pkg:npm/tslib@2.6.1"
+      ]
+    },
+    {
+      "ref": "pkg:npm/%40smithy/config-resolver@2.0.18",
+      "dependsOn": [
+        "pkg:npm/%40smithy/node-config-provider@2.1.5",
+        "pkg:npm/%40smithy/types@2.5.0",
+        "pkg:npm/%40smithy/util-config-provider@2.0.0",
+        "pkg:npm/%40smithy/util-middleware@2.0.6",
+        "pkg:npm/tslib@2.6.1"
+      ]
+    },
+    {
+      "ref": "pkg:npm/%40smithy/credential-provider-imds@2.0.3",
+      "dependsOn": [
+        "pkg:npm/%40smithy/node-config-provider@2.0.3",
+        "pkg:npm/%40smithy/property-provider@2.0.3",
+        "pkg:npm/%40smithy/types@2.2.0",
+        "pkg:npm/%40smithy/url-parser@2.0.3",
+        "pkg:npm/tslib@2.6.1"
+      ]
+    },
+    {
+      "ref": "pkg:npm/%40smithy/credential-provider-imds@2.1.1",
+      "dependsOn": [
+        "pkg:npm/%40smithy/node-config-provider@2.1.5",
+        "pkg:npm/%40smithy/property-provider@2.0.14",
+        "pkg:npm/%40smithy/types@2.5.0",
+        "pkg:npm/%40smithy/url-parser@2.0.13",
+        "pkg:npm/tslib@2.6.1"
+      ]
+    },
+    {
+      "ref": "pkg:npm/%40smithy/eventstream-codec@2.0.13",
+      "dependsOn": [
+        "pkg:npm/%40aws-crypto/crc32@3.0.0",
+        "pkg:npm/%40smithy/types@2.5.0",
+        "pkg:npm/%40smithy/util-hex-encoding@2.0.0",
+        "pkg:npm/tslib@2.6.1"
+      ]
+    },
+    {
+      "ref": "pkg:npm/%40smithy/eventstream-codec@2.0.3",
+      "dependsOn": [
+        "pkg:npm/%40aws-crypto/crc32@3.0.0",
+        "pkg:npm/%40smithy/types@2.2.0",
+        "pkg:npm/%40smithy/util-hex-encoding@2.0.0",
+        "pkg:npm/tslib@2.6.1"
+      ]
+    },
+    {
+      "ref": "pkg:npm/%40smithy/eventstream-serde-browser@2.0.13",
+      "dependsOn": [
+        "pkg:npm/%40smithy/eventstream-serde-universal@2.0.13",
+        "pkg:npm/%40smithy/types@2.5.0",
+        "pkg:npm/tslib@2.6.1"
+      ]
+    },
+    {
+      "ref": "pkg:npm/%40smithy/eventstream-serde-config-resolver@2.0.13",
+      "dependsOn": [
+        "pkg:npm/%40smithy/types@2.5.0",
+        "pkg:npm/tslib@2.6.1"
+      ]
+    },
+    {
+      "ref": "pkg:npm/%40smithy/eventstream-serde-node@2.0.13",
+      "dependsOn": [
+        "pkg:npm/%40smithy/eventstream-serde-universal@2.0.13",
+        "pkg:npm/%40smithy/types@2.5.0",
+        "pkg:npm/tslib@2.6.1"
+      ]
+    },
+    {
+      "ref": "pkg:npm/%40smithy/eventstream-serde-universal@2.0.13",
+      "dependsOn": [
+        "pkg:npm/%40smithy/eventstream-codec@2.0.13",
+        "pkg:npm/%40smithy/types@2.5.0",
+        "pkg:npm/tslib@2.6.1"
+      ]
+    },
+    {
+      "ref": "pkg:npm/%40smithy/fetch-http-handler@2.2.6",
+      "dependsOn": [
+        "pkg:npm/%40smithy/protocol-http@3.0.9",
+        "pkg:npm/%40smithy/querystring-builder@2.0.13",
+        "pkg:npm/%40smithy/types@2.5.0",
+        "pkg:npm/%40smithy/util-base64@2.0.1",
+        "pkg:npm/tslib@2.6.1"
+      ]
+    },
+    {
+      "ref": "pkg:npm/%40smithy/hash-node@2.0.15",
+      "dependsOn": [
+        "pkg:npm/%40smithy/types@2.5.0",
+        "pkg:npm/%40smithy/util-buffer-from@2.0.0",
+        "pkg:npm/%40smithy/util-utf8@2.0.2",
+        "pkg:npm/tslib@2.6.1"
+      ]
+    },
+    {
+      "ref": "pkg:npm/%40smithy/invalid-dependency@2.0.13",
+      "dependsOn": [
+        "pkg:npm/%40smithy/types@2.5.0",
+        "pkg:npm/tslib@2.6.1"
+      ]
+    },
+    {
+      "ref": "pkg:npm/%40smithy/is-array-buffer@2.0.0",
+      "dependsOn": [
+        "pkg:npm/tslib@2.6.1"
+      ]
+    },
+    {
+      "ref": "pkg:npm/%40smithy/middleware-content-length@2.0.15",
+      "dependsOn": [
+        "pkg:npm/%40smithy/protocol-http@3.0.9",
+        "pkg:npm/%40smithy/types@2.5.0",
+        "pkg:npm/tslib@2.6.1"
+      ]
+    },
+    {
+      "ref": "pkg:npm/%40smithy/middleware-endpoint@2.2.0",
+      "dependsOn": [
+        "pkg:npm/%40smithy/middleware-serde@2.0.13",
+        "pkg:npm/%40smithy/node-config-provider@2.1.5",
+        "pkg:npm/%40smithy/shared-ini-file-loader@2.2.4",
+        "pkg:npm/%40smithy/types@2.5.0",
+        "pkg:npm/%40smithy/url-parser@2.0.13",
+        "pkg:npm/%40smithy/util-middleware@2.0.6",
+        "pkg:npm/tslib@2.6.1"
+      ]
+    },
+    {
+      "ref": "pkg:npm/%40smithy/middleware-retry@2.0.20",
+      "dependsOn": [
+        "pkg:npm/%40smithy/node-config-provider@2.1.5",
+        "pkg:npm/%40smithy/protocol-http@3.0.9",
+        "pkg:npm/%40smithy/service-error-classification@2.0.6",
+        "pkg:npm/%40smithy/types@2.5.0",
+        "pkg:npm/%40smithy/util-middleware@2.0.6",
+        "pkg:npm/%40smithy/util-retry@2.0.6",
+        "pkg:npm/tslib@2.6.1",
+        "pkg:npm/uuid@8.3.2"
+      ]
+    },
+    {
+      "ref": "pkg:npm/%40smithy/middleware-serde@2.0.13",
+      "dependsOn": [
+        "pkg:npm/%40smithy/types@2.5.0",
+        "pkg:npm/tslib@2.6.1"
+      ]
+    },
+    {
+      "ref": "pkg:npm/%40smithy/middleware-stack@2.0.7",
+      "dependsOn": [
+        "pkg:npm/%40smithy/types@2.5.0",
+        "pkg:npm/tslib@2.6.1"
+      ]
+    },
+    {
+      "ref": "pkg:npm/%40smithy/node-config-provider@2.0.3",
+      "dependsOn": [
+        "pkg:npm/%40smithy/property-provider@2.0.3",
+        "pkg:npm/%40smithy/shared-ini-file-loader@2.0.3",
+        "pkg:npm/%40smithy/types@2.2.0",
+        "pkg:npm/tslib@2.6.1"
+      ]
+    },
+    {
+      "ref": "pkg:npm/%40smithy/node-config-provider@2.1.5",
+      "dependsOn": [
+        "pkg:npm/%40smithy/property-provider@2.0.14",
+        "pkg:npm/%40smithy/shared-ini-file-loader@2.2.4",
+        "pkg:npm/%40smithy/types@2.5.0",
+        "pkg:npm/tslib@2.6.1"
+      ]
+    },
+    {
+      "ref": "pkg:npm/%40smithy/node-http-handler@2.1.9",
+      "dependsOn": [
+        "pkg:npm/%40smithy/abort-controller@2.0.13",
+        "pkg:npm/%40smithy/protocol-http@3.0.9",
+        "pkg:npm/%40smithy/querystring-builder@2.0.13",
+        "pkg:npm/%40smithy/types@2.5.0",
+        "pkg:npm/tslib@2.6.1"
+      ]
+    },
+    {
+      "ref": "pkg:npm/%40smithy/property-provider@2.0.12",
+      "dependsOn": [
+        "pkg:npm/%40smithy/types@2.3.5",
+        "pkg:npm/tslib@2.6.1"
+      ]
+    },
+    {
+      "ref": "pkg:npm/%40smithy/property-provider@2.0.14",
+      "dependsOn": [
+        "pkg:npm/%40smithy/types@2.5.0",
+        "pkg:npm/tslib@2.6.1"
+      ]
+    },
+    {
+      "ref": "pkg:npm/%40smithy/property-provider@2.0.3",
+      "dependsOn": [
+        "pkg:npm/%40smithy/types@2.2.0",
+        "pkg:npm/tslib@2.6.1"
+      ]
+    },
+    {
+      "ref": "pkg:npm/%40smithy/protocol-http@3.0.9",
+      "dependsOn": [
+        "pkg:npm/%40smithy/types@2.5.0",
+        "pkg:npm/tslib@2.6.1"
+      ]
+    },
+    {
+      "ref": "pkg:npm/%40smithy/querystring-builder@2.0.13",
+      "dependsOn": [
+        "pkg:npm/%40smithy/types@2.5.0",
+        "pkg:npm/%40smithy/util-uri-escape@2.0.0",
+        "pkg:npm/tslib@2.6.1"
+      ]
+    },
+    {
+      "ref": "pkg:npm/%40smithy/querystring-parser@2.0.13",
+      "dependsOn": [
+        "pkg:npm/%40smithy/types@2.5.0",
+        "pkg:npm/tslib@2.6.1"
+      ]
+    },
+    {
+      "ref": "pkg:npm/%40smithy/querystring-parser@2.0.3",
+      "dependsOn": [
+        "pkg:npm/%40smithy/types@2.2.0",
+        "pkg:npm/tslib@2.6.1"
+      ]
+    },
+    {
+      "ref": "pkg:npm/%40smithy/service-error-classification@2.0.6",
+      "dependsOn": [
+        "pkg:npm/%40smithy/types@2.5.0"
+      ]
+    },
+    {
+      "ref": "pkg:npm/%40smithy/shared-ini-file-loader@2.0.3",
+      "dependsOn": [
+        "pkg:npm/%40smithy/types@2.2.0",
+        "pkg:npm/tslib@2.6.1"
+      ]
+    },
+    {
+      "ref": "pkg:npm/%40smithy/shared-ini-file-loader@2.2.0",
+      "dependsOn": [
+        "pkg:npm/%40smithy/types@2.3.5",
+        "pkg:npm/tslib@2.6.1"
+      ]
+    },
+    {
+      "ref": "pkg:npm/%40smithy/shared-ini-file-loader@2.2.4",
+      "dependsOn": [
+        "pkg:npm/%40smithy/types@2.5.0",
+        "pkg:npm/tslib@2.6.1"
+      ]
+    },
+    {
+      "ref": "pkg:npm/%40smithy/signature-v4@2.0.3",
+      "dependsOn": [
+        "pkg:npm/%40smithy/eventstream-codec@2.0.3",
+        "pkg:npm/%40smithy/is-array-buffer@2.0.0",
+        "pkg:npm/%40smithy/types@2.2.0",
+        "pkg:npm/%40smithy/util-hex-encoding@2.0.0",
+        "pkg:npm/%40smithy/util-middleware@2.0.0",
+        "pkg:npm/%40smithy/util-uri-escape@2.0.0",
+        "pkg:npm/%40smithy/util-utf8@2.0.0",
+        "pkg:npm/tslib@2.6.1"
+      ]
+    },
+    {
+      "ref": "pkg:npm/%40smithy/smithy-client@2.1.15",
+      "dependsOn": [
+        "pkg:npm/%40smithy/middleware-stack@2.0.7",
+        "pkg:npm/%40smithy/types@2.5.0",
+        "pkg:npm/%40smithy/util-stream@2.0.20",
+        "pkg:npm/tslib@2.6.1"
+      ]
+    },
+    {
+      "ref": "pkg:npm/%40smithy/types@2.2.0",
+      "dependsOn": [
+        "pkg:npm/tslib@2.6.1"
+      ]
+    },
+    {
+      "ref": "pkg:npm/%40smithy/types@2.3.5",
+      "dependsOn": [
+        "pkg:npm/tslib@2.6.1"
+      ]
+    },
+    {
+      "ref": "pkg:npm/%40smithy/types@2.5.0",
+      "dependsOn": [
+        "pkg:npm/tslib@2.6.1"
+      ]
+    },
+    {
+      "ref": "pkg:npm/%40smithy/url-parser@2.0.13",
+      "dependsOn": [
+        "pkg:npm/%40smithy/querystring-parser@2.0.13",
+        "pkg:npm/%40smithy/types@2.5.0",
+        "pkg:npm/tslib@2.6.1"
+      ]
+    },
+    {
+      "ref": "pkg:npm/%40smithy/url-parser@2.0.3",
+      "dependsOn": [
+        "pkg:npm/%40smithy/querystring-parser@2.0.3",
+        "pkg:npm/%40smithy/types@2.2.0",
+        "pkg:npm/tslib@2.6.1"
+      ]
+    },
+    {
+      "ref": "pkg:npm/%40smithy/util-base64@2.0.1",
+      "dependsOn": [
+        "pkg:npm/%40smithy/util-buffer-from@2.0.0",
+        "pkg:npm/tslib@2.6.1"
+      ]
+    },
+    {
+      "ref": "pkg:npm/%40smithy/util-body-length-browser@2.0.0",
+      "dependsOn": [
+        "pkg:npm/tslib@2.6.1"
+      ]
+    },
+    {
+      "ref": "pkg:npm/%40smithy/util-body-length-node@2.1.0",
+      "dependsOn": [
+        "pkg:npm/tslib@2.6.1"
+      ]
+    },
+    {
+      "ref": "pkg:npm/%40smithy/util-buffer-from@2.0.0",
+      "dependsOn": [
+        "pkg:npm/%40smithy/is-array-buffer@2.0.0",
+        "pkg:npm/tslib@2.6.1"
+      ]
+    },
+    {
+      "ref": "pkg:npm/%40smithy/util-config-provider@2.0.0",
+      "dependsOn": [
+        "pkg:npm/tslib@2.6.1"
+      ]
+    },
+    {
+      "ref": "pkg:npm/%40smithy/util-defaults-mode-browser@2.0.19",
+      "dependsOn": [
+        "pkg:npm/%40smithy/property-provider@2.0.14",
+        "pkg:npm/%40smithy/smithy-client@2.1.15",
+        "pkg:npm/%40smithy/types@2.5.0",
+        "pkg:npm/bowser@2.11.0",
+        "pkg:npm/tslib@2.6.1"
+      ]
+    },
+    {
+      "ref": "pkg:npm/%40smithy/util-defaults-mode-node@2.0.25",
+      "dependsOn": [
+        "pkg:npm/%40smithy/config-resolver@2.0.18",
+        "pkg:npm/%40smithy/credential-provider-imds@2.1.1",
+        "pkg:npm/%40smithy/node-config-provider@2.1.5",
+        "pkg:npm/%40smithy/property-provider@2.0.14",
+        "pkg:npm/%40smithy/smithy-client@2.1.15",
+        "pkg:npm/%40smithy/types@2.5.0",
+        "pkg:npm/tslib@2.6.1"
+      ]
+    },
+    {
+      "ref": "pkg:npm/%40smithy/util-endpoints@1.0.4",
+      "dependsOn": [
+        "pkg:npm/%40smithy/node-config-provider@2.1.5",
+        "pkg:npm/%40smithy/types@2.5.0",
+        "pkg:npm/tslib@2.6.1"
+      ]
+    },
+    {
+      "ref": "pkg:npm/%40smithy/util-hex-encoding@2.0.0",
+      "dependsOn": [
+        "pkg:npm/tslib@2.6.1"
+      ]
+    },
+    {
+      "ref": "pkg:npm/%40smithy/util-middleware@2.0.0",
+      "dependsOn": [
+        "pkg:npm/tslib@2.6.1"
+      ]
+    },
+    {
+      "ref": "pkg:npm/%40smithy/util-middleware@2.0.6",
+      "dependsOn": [
+        "pkg:npm/%40smithy/types@2.5.0",
+        "pkg:npm/tslib@2.6.1"
+      ]
+    },
+    {
+      "ref": "pkg:npm/%40smithy/util-retry@2.0.6",
+      "dependsOn": [
+        "pkg:npm/%40smithy/service-error-classification@2.0.6",
+        "pkg:npm/%40smithy/types@2.5.0",
+        "pkg:npm/tslib@2.6.1"
+      ]
+    },
+    {
+      "ref": "pkg:npm/%40smithy/util-stream@2.0.20",
+      "dependsOn": [
+        "pkg:npm/%40smithy/fetch-http-handler@2.2.6",
+        "pkg:npm/%40smithy/node-http-handler@2.1.9",
+        "pkg:npm/%40smithy/types@2.5.0",
+        "pkg:npm/%40smithy/util-base64@2.0.1",
+        "pkg:npm/%40smithy/util-buffer-from@2.0.0",
+        "pkg:npm/%40smithy/util-hex-encoding@2.0.0",
+        "pkg:npm/%40smithy/util-utf8@2.0.2",
+        "pkg:npm/tslib@2.6.1"
+      ]
+    },
+    {
+      "ref": "pkg:npm/%40smithy/util-uri-escape@2.0.0",
+      "dependsOn": [
+        "pkg:npm/tslib@2.6.1"
+      ]
+    },
+    {
+      "ref": "pkg:npm/%40smithy/util-utf8@2.0.0",
+      "dependsOn": [
+        "pkg:npm/%40smithy/util-buffer-from@2.0.0",
+        "pkg:npm/tslib@2.6.1"
+      ]
+    },
+    {
+      "ref": "pkg:npm/%40smithy/util-utf8@2.0.2",
+      "dependsOn": [
+        "pkg:npm/%40smithy/util-buffer-from@2.0.0",
+        "pkg:npm/tslib@2.6.1"
+      ]
+    },
+    {
+      "ref": "pkg:npm/%40smithy/util-waiter@2.0.13",
+      "dependsOn": [
+        "pkg:npm/%40smithy/abort-controller@2.0.13",
+        "pkg:npm/%40smithy/types@2.5.0",
+        "pkg:npm/tslib@2.6.1"
+      ]
+    },
+    {
+      "ref": "pkg:npm/%40tootallnate/once@2.0.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/%40tootallnate/quickjs-emscripten@0.23.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/%40types/caseless@0.12.5",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/%40types/datadog-metrics@0.6.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/%40types/long@4.0.2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/%40types/node@20.5.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/%40types/request@2.48.12",
+      "dependsOn": [
+        "pkg:npm/%40types/caseless@0.12.5",
+        "pkg:npm/%40types/node@20.5.0",
+        "pkg:npm/%40types/tough-cookie@4.0.5",
+        "pkg:npm/form-data@2.5.1"
+      ]
+    },
+    {
+      "ref": "pkg:npm/%40types/retry@0.12.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/%40types/tough-cookie@4.0.5",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/abbrev@1.1.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/abort-controller@3.0.0",
+      "dependsOn": [
+        "pkg:npm/event-target-shim@5.0.1"
+      ]
+    },
+    {
+      "ref": "pkg:npm/agent-base@6.0.2",
+      "dependsOn": [
+        "pkg:npm/debug@4.3.4"
+      ]
+    },
+    {
+      "ref": "pkg:npm/agent-base@7.1.0",
+      "dependsOn": [
+        "pkg:npm/debug@4.3.4"
+      ]
+    },
+    {
+      "ref": "pkg:npm/agentkeepalive@4.5.0",
+      "dependsOn": [
+        "pkg:npm/humanize-ms@1.2.1"
+      ]
+    },
+    {
+      "ref": "pkg:npm/aggregate-error@3.1.0",
+      "dependsOn": [
+        "pkg:npm/clean-stack@2.2.0",
+        "pkg:npm/indent-string@4.0.0"
+      ]
+    },
+    {
+      "ref": "pkg:npm/ajv-formats@2.1.1",
+      "dependsOn": [
+        "pkg:npm/ajv@8.12.0"
+      ]
+    },
+    {
+      "ref": "pkg:npm/ajv@8.12.0",
+      "dependsOn": [
+        "pkg:npm/fast-deep-equal@3.1.3",
+        "pkg:npm/json-schema-traverse@1.0.0",
+        "pkg:npm/require-from-string@2.0.2",
+        "pkg:npm/uri-js@4.4.1"
+      ]
+    },
+    {
+      "ref": "pkg:npm/ansi-escapes@4.3.2",
+      "dependsOn": [
+        "pkg:npm/type-fest@0.21.3"
+      ]
+    },
+    {
+      "ref": "pkg:npm/ansi-regex@5.0.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/ansi-regex@6.0.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/ansi-styles@4.3.0",
+      "dependsOn": [
+        "pkg:npm/color-convert@2.0.1"
+      ]
+    },
+    {
+      "ref": "pkg:npm/ansi-styles@6.2.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/aproba@2.0.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/are-we-there-yet@3.0.1",
+      "dependsOn": [
+        "pkg:npm/delegates@1.0.0",
+        "pkg:npm/readable-stream@3.6.2"
+      ]
+    },
+    {
+      "ref": "pkg:npm/argparse@1.0.10",
+      "dependsOn": [
+        "pkg:npm/sprintf-js@1.0.3"
+      ]
+    },
+    {
+      "ref": "pkg:npm/arrify@2.0.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/asn1@0.2.6",
+      "dependsOn": [
+        "pkg:npm/safer-buffer@2.1.2"
+      ]
+    },
+    {
+      "ref": "pkg:npm/assert-plus@1.0.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/ast-types@0.13.4",
+      "dependsOn": [
+        "pkg:npm/tslib@2.6.1"
+      ]
+    },
+    {
+      "ref": "pkg:npm/async-retry@1.3.1",
+      "dependsOn": [
+        "pkg:npm/retry@0.12.0"
+      ]
+    },
+    {
+      "ref": "pkg:npm/asynckit@0.4.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/axios@1.6.5",
+      "dependsOn": [
+        "pkg:npm/follow-redirects@1.15.4",
+        "pkg:npm/form-data@4.0.0",
+        "pkg:npm/proxy-from-env@1.1.0"
+      ]
+    },
+    {
+      "ref": "pkg:npm/balanced-match@1.0.2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/base64-js@1.5.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/basic-ftp@5.0.3",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/bcrypt-pbkdf@1.0.2",
+      "dependsOn": [
+        "pkg:npm/tweetnacl@0.14.5"
+      ]
+    },
+    {
+      "ref": "pkg:npm/bignumber.js@9.1.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/bl@4.1.0",
+      "dependsOn": [
+        "pkg:npm/buffer@5.7.1",
+        "pkg:npm/inherits@2.0.4",
+        "pkg:npm/readable-stream@3.6.2"
+      ]
+    },
+    {
+      "ref": "pkg:npm/bowser@2.11.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/brace-expansion@1.1.11",
+      "dependsOn": [
+        "pkg:npm/balanced-match@1.0.2",
+        "pkg:npm/concat-map@0.0.1"
+      ]
+    },
+    {
+      "ref": "pkg:npm/brace-expansion@2.0.1",
+      "dependsOn": [
+        "pkg:npm/balanced-match@1.0.2"
+      ]
+    },
+    {
+      "ref": "pkg:npm/buffer-equal-constant-time@1.0.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/buffer@5.7.1",
+      "dependsOn": [
+        "pkg:npm/base64-js@1.5.1",
+        "pkg:npm/ieee754@1.2.1"
+      ]
+    },
+    {
+      "ref": "pkg:npm/buildcheck@0.0.6",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/cacache@17.1.4",
+      "dependsOn": [
+        "pkg:npm/%40npmcli/fs@3.1.0",
+        "pkg:npm/fs-minipass@3.0.3",
+        "pkg:npm/glob@10.3.3",
+        "pkg:npm/lru-cache@7.18.3",
+        "pkg:npm/minipass-collect@1.0.2",
+        "pkg:npm/minipass-flush@1.0.5",
+        "pkg:npm/minipass-pipeline@1.2.4",
+        "pkg:npm/minipass@7.0.3",
+        "pkg:npm/p-map@4.0.0",
+        "pkg:npm/ssri@10.0.5",
+        "pkg:npm/tar@6.1.15",
+        "pkg:npm/unique-filename@3.0.0"
+      ]
+    },
+    {
+      "ref": "pkg:npm/chalk@3.0.0",
+      "dependsOn": [
+        "pkg:npm/ansi-styles@4.3.0",
+        "pkg:npm/supports-color@7.2.0"
+      ]
+    },
+    {
+      "ref": "pkg:npm/chalk@4.1.2",
+      "dependsOn": [
+        "pkg:npm/ansi-styles@4.3.0",
+        "pkg:npm/supports-color@7.2.0"
+      ]
+    },
+    {
+      "ref": "pkg:npm/chardet@0.7.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/chownr@2.0.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/clean-stack@2.2.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/cli-cursor@3.1.0",
+      "dependsOn": [
+        "pkg:npm/restore-cursor@3.1.0"
+      ]
+    },
+    {
+      "ref": "pkg:npm/cli-spinners@2.9.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/cli-width@3.0.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/clipanion@3.2.1",
+      "dependsOn": [
+        "pkg:npm/typanion@3.14.0"
+      ]
+    },
+    {
+      "ref": "pkg:npm/cliui@8.0.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/clone@1.0.4",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/color-convert@2.0.1",
+      "dependsOn": [
+        "pkg:npm/color-name@1.1.4"
+      ]
+    },
+    {
+      "ref": "pkg:npm/color-name@1.1.4",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/color-support@1.1.3",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/combined-stream@1.0.8",
+      "dependsOn": [
+        "pkg:npm/delayed-stream@1.0.0"
+      ]
+    },
+    {
+      "ref": "pkg:npm/concat-map@0.0.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/console-control-strings@1.1.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/core-util-is@1.0.3",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/cpu-features@0.0.9",
+      "dependsOn": [
+        "pkg:npm/buildcheck@0.0.6",
+        "pkg:npm/nan@2.17.0",
+        "pkg:npm/node-gyp@9.4.0"
+      ]
+    },
+    {
+      "ref": "pkg:npm/cross-spawn@7.0.3",
+      "dependsOn": [
+        "pkg:npm/path-key@3.1.1",
+        "pkg:npm/shebang-command@2.0.0",
+        "pkg:npm/which@2.0.2"
+      ]
+    },
+    {
+      "ref": "pkg:npm/dashdash@1.14.1",
+      "dependsOn": [
+        "pkg:npm/assert-plus@1.0.0"
+      ]
+    },
+    {
+      "ref": "pkg:npm/data-uri-to-buffer@5.0.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/datadog-metrics@0.9.3",
+      "dependsOn": [
+        "pkg:npm/debug@3.1.0",
+        "pkg:npm/dogapi@2.8.4"
+      ]
+    },
+    {
+      "ref": "pkg:npm/debug@3.1.0",
+      "dependsOn": [
+        "pkg:npm/ms@2.0.0"
+      ]
+    },
+    {
+      "ref": "pkg:npm/debug@4.3.4",
+      "dependsOn": [
+        "pkg:npm/ms@2.1.2"
+      ]
+    },
+    {
+      "ref": "pkg:npm/deep-extend@0.6.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/deep-object-diff@1.1.9",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/defaults@1.0.4",
+      "dependsOn": [
+        "pkg:npm/clone@1.0.4"
+      ]
+    },
+    {
+      "ref": "pkg:npm/degenerator@5.0.1",
+      "dependsOn": [
+        "pkg:npm/ast-types@0.13.4",
+        "pkg:npm/escodegen@2.1.0",
+        "pkg:npm/esprima@4.0.1"
+      ]
+    },
+    {
+      "ref": "pkg:npm/delayed-stream@1.0.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/delegates@1.0.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/dogapi@2.8.4",
+      "dependsOn": [
+        "pkg:npm/extend@3.0.2",
+        "pkg:npm/json-bigint@1.0.0",
+        "pkg:npm/lodash@4.17.21",
+        "pkg:npm/minimist@1.2.8",
+        "pkg:npm/rc@1.2.8"
+      ]
+    },
+    {
+      "ref": "pkg:npm/dot-prop@6.0.1",
+      "dependsOn": [
+        "pkg:npm/is-obj@2.0.0"
+      ]
+    },
+    {
+      "ref": "pkg:npm/duplexify@4.1.2",
+      "dependsOn": [
+        "pkg:npm/end-of-stream@1.4.4",
+        "pkg:npm/inherits@2.0.4",
+        "pkg:npm/readable-stream@3.6.2",
+        "pkg:npm/stream-shift@1.0.1"
+      ]
+    },
+    {
+      "ref": "pkg:npm/eastasianwidth@0.2.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/ecc-jsbn@0.1.2",
+      "dependsOn": [
+        "pkg:npm/jsbn@0.1.1",
+        "pkg:npm/safer-buffer@2.1.2"
+      ]
+    },
+    {
+      "ref": "pkg:npm/ecdsa-sig-formatter@1.0.11",
+      "dependsOn": [
+        "pkg:npm/safe-buffer@5.2.1"
+      ]
+    },
+    {
+      "ref": "pkg:npm/ee-first@1.1.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/emoji-regex@8.0.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/emoji-regex@9.2.2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/encoding@0.1.13",
+      "dependsOn": [
+        "pkg:npm/iconv-lite@0.6.3"
+      ]
+    },
+    {
+      "ref": "pkg:npm/end-of-stream@1.4.4",
+      "dependsOn": [
+        "pkg:npm/once@1.4.0"
+      ]
+    },
+    {
+      "ref": "pkg:npm/ent@2.2.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/env-paths@2.2.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/err-code@2.0.3",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/escalade@3.1.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/escape-string-regexp@1.0.5",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/escodegen@2.1.0",
+      "dependsOn": [
+        "pkg:npm/esprima@4.0.1",
+        "pkg:npm/estraverse@5.3.0",
+        "pkg:npm/esutils@2.0.3",
+        "pkg:npm/source-map@0.6.1"
+      ]
+    },
+    {
+      "ref": "pkg:npm/esprima@4.0.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/estraverse@5.3.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/esutils@2.0.3",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/event-target-shim@5.0.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/eventid@2.0.1",
+      "dependsOn": [
+        "pkg:npm/uuid@8.3.2"
+      ]
+    },
+    {
+      "ref": "pkg:npm/exponential-backoff@3.1.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/extend@3.0.2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/external-editor@3.1.0",
+      "dependsOn": [
+        "pkg:npm/chardet@0.7.0",
+        "pkg:npm/iconv-lite@0.4.24",
+        "pkg:npm/tmp@0.0.33"
+      ]
+    },
+    {
+      "ref": "pkg:npm/fast-deep-equal@3.1.3",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/fast-text-encoding@1.0.6",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/fast-xml-parser@4.2.5",
+      "dependsOn": [
+        "pkg:npm/strnum@1.0.5"
+      ]
+    },
+    {
+      "ref": "pkg:npm/fast-xml-parser@4.2.7",
+      "dependsOn": [
+        "pkg:npm/strnum@1.0.5"
+      ]
+    },
+    {
+      "ref": "pkg:npm/figures@3.2.0",
+      "dependsOn": [
+        "pkg:npm/escape-string-regexp@1.0.5"
+      ]
+    },
+    {
+      "ref": "pkg:npm/follow-redirects@1.15.4",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/foreground-child@3.1.1",
+      "dependsOn": [
+        "pkg:npm/cross-spawn@7.0.3",
+        "pkg:npm/signal-exit@4.1.0"
+      ]
+    },
+    {
+      "ref": "pkg:npm/form-data@2.5.1",
+      "dependsOn": [
+        "pkg:npm/asynckit@0.4.0",
+        "pkg:npm/combined-stream@1.0.8",
+        "pkg:npm/mime-types@2.1.35"
+      ]
+    },
+    {
+      "ref": "pkg:npm/form-data@4.0.0",
+      "dependsOn": [
+        "pkg:npm/asynckit@0.4.0",
+        "pkg:npm/combined-stream@1.0.8",
+        "pkg:npm/mime-types@2.1.35"
+      ]
+    },
+    {
+      "ref": "pkg:npm/fs-extra@8.1.0",
+      "dependsOn": [
+        "pkg:npm/graceful-fs@4.2.11",
+        "pkg:npm/jsonfile@4.0.0",
+        "pkg:npm/universalify@0.1.2"
+      ]
+    },
+    {
+      "ref": "pkg:npm/fs-minipass@2.1.0",
+      "dependsOn": [
+        "pkg:npm/minipass@3.3.6"
+      ]
+    },
+    {
+      "ref": "pkg:npm/fs-minipass@3.0.3",
+      "dependsOn": [
+        "pkg:npm/minipass@7.0.3"
+      ]
+    },
+    {
+      "ref": "pkg:npm/fs.realpath@1.0.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/fuzzy@0.1.3",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/gauge@4.0.4",
+      "dependsOn": [
+        "pkg:npm/aproba@2.0.0",
+        "pkg:npm/color-support@1.1.3",
+        "pkg:npm/console-control-strings@1.1.0",
+        "pkg:npm/has-unicode@2.0.1",
+        "pkg:npm/signal-exit@3.0.7",
+        "pkg:npm/wide-align@1.1.5"
+      ]
+    },
+    {
+      "ref": "pkg:npm/gaxios@5.1.3",
+      "dependsOn": [
+        "pkg:npm/extend@3.0.2",
+        "pkg:npm/is-stream@2.0.1",
+        "pkg:npm/node-fetch@2.6.12"
+      ]
+    },
+    {
+      "ref": "pkg:npm/gaxios@6.1.1",
+      "dependsOn": [
+        "pkg:npm/extend@3.0.2",
+        "pkg:npm/is-stream@2.0.1",
+        "pkg:npm/node-fetch@2.6.12"
+      ]
+    },
+    {
+      "ref": "pkg:npm/gcp-metadata@5.3.0",
+      "dependsOn": [
+        "pkg:npm/gaxios@5.1.3",
+        "pkg:npm/json-bigint@1.0.0"
+      ]
+    },
+    {
+      "ref": "pkg:npm/gcp-metadata@6.1.0",
+      "dependsOn": [
+        "pkg:npm/gaxios@6.1.1",
+        "pkg:npm/json-bigint@1.0.0"
+      ]
+    },
+    {
+      "ref": "pkg:npm/get-caller-file@2.0.5",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/get-uri@6.0.1",
+      "dependsOn": [
+        "pkg:npm/basic-ftp@5.0.3",
+        "pkg:npm/data-uri-to-buffer@5.0.1",
+        "pkg:npm/debug@4.3.4",
+        "pkg:npm/fs-extra@8.1.0"
+      ]
+    },
+    {
+      "ref": "pkg:npm/getpass@0.1.7",
+      "dependsOn": [
+        "pkg:npm/assert-plus@1.0.0"
+      ]
+    },
+    {
+      "ref": "pkg:npm/glob@10.3.3",
+      "dependsOn": [
+        "pkg:npm/foreground-child@3.1.1",
+        "pkg:npm/jackspeak@2.2.3",
+        "pkg:npm/minimatch@9.0.3",
+        "pkg:npm/minipass@7.0.3",
+        "pkg:npm/path-scurry@1.10.1"
+      ]
+    },
+    {
+      "ref": "pkg:npm/glob@7.1.4",
+      "dependsOn": [
+        "pkg:npm/fs.realpath@1.0.0",
+        "pkg:npm/inflight@1.0.6",
+        "pkg:npm/inherits@2.0.4",
+        "pkg:npm/minimatch@3.1.2",
+        "pkg:npm/once@1.4.0",
+        "pkg:npm/path-is-absolute@1.0.1"
+      ]
+    },
+    {
+      "ref": "pkg:npm/glob@7.2.3",
+      "dependsOn": [
+        "pkg:npm/fs.realpath@1.0.0",
+        "pkg:npm/inflight@1.0.6",
+        "pkg:npm/inherits@2.0.4",
+        "pkg:npm/minimatch@3.1.2",
+        "pkg:npm/once@1.4.0",
+        "pkg:npm/path-is-absolute@1.0.1"
+      ]
+    },
+    {
+      "ref": "pkg:npm/google-auth-library@8.9.0",
+      "dependsOn": [
+        "pkg:npm/arrify@2.0.1",
+        "pkg:npm/base64-js@1.5.1",
+        "pkg:npm/ecdsa-sig-formatter@1.0.11",
+        "pkg:npm/fast-text-encoding@1.0.6",
+        "pkg:npm/gaxios@5.1.3",
+        "pkg:npm/gcp-metadata@5.3.0",
+        "pkg:npm/gtoken@6.1.2",
+        "pkg:npm/jws@4.0.0",
+        "pkg:npm/lru-cache@6.0.0"
+      ]
+    },
+    {
+      "ref": "pkg:npm/google-auth-library@9.2.0",
+      "dependsOn": [
+        "pkg:npm/base64-js@1.5.1",
+        "pkg:npm/ecdsa-sig-formatter@1.0.11",
+        "pkg:npm/gaxios@6.1.1",
+        "pkg:npm/gcp-metadata@6.1.0",
+        "pkg:npm/gtoken@7.0.1",
+        "pkg:npm/jws@4.0.0"
+      ]
+    },
+    {
+      "ref": "pkg:npm/google-gax@4.0.5",
+      "dependsOn": [
+        "pkg:npm/%40grpc/grpc-js@1.9.11",
+        "pkg:npm/%40grpc/proto-loader@0.7.8",
+        "pkg:npm/%40types/long@4.0.2",
+        "pkg:npm/abort-controller@3.0.0",
+        "pkg:npm/duplexify@4.1.2",
+        "pkg:npm/google-auth-library@9.2.0",
+        "pkg:npm/node-fetch@2.6.12",
+        "pkg:npm/object-hash@3.0.0",
+        "pkg:npm/proto3-json-serializer@2.0.0",
+        "pkg:npm/protobufjs@7.2.5",
+        "pkg:npm/retry-request@7.0.1"
+      ]
+    },
+    {
+      "ref": "pkg:npm/google-p12-pem@4.0.1",
+      "dependsOn": [
+        "pkg:npm/node-forge@1.3.1"
+      ]
+    },
+    {
+      "ref": "pkg:npm/graceful-fs@4.2.11",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/gtoken@6.1.2",
+      "dependsOn": [
+        "pkg:npm/gaxios@5.1.3",
+        "pkg:npm/google-p12-pem@4.0.1",
+        "pkg:npm/jws@4.0.0"
+      ]
+    },
+    {
+      "ref": "pkg:npm/gtoken@7.0.1",
+      "dependsOn": [
+        "pkg:npm/gaxios@6.1.1",
+        "pkg:npm/jws@4.0.0"
+      ]
+    },
+    {
+      "ref": "pkg:npm/has-flag@4.0.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/has-unicode@2.0.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/http-cache-semantics@4.1.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/http-proxy-agent@5.0.0",
+      "dependsOn": [
+        "pkg:npm/%40tootallnate/once@2.0.0",
+        "pkg:npm/agent-base@6.0.2",
+        "pkg:npm/debug@4.3.4"
+      ]
+    },
+    {
+      "ref": "pkg:npm/http-proxy-agent@7.0.0",
+      "dependsOn": [
+        "pkg:npm/agent-base@7.1.0",
+        "pkg:npm/debug@4.3.4"
+      ]
+    },
+    {
+      "ref": "pkg:npm/humanize-ms@1.2.1",
+      "dependsOn": [
+        "pkg:npm/ms@2.1.3"
+      ]
+    },
+    {
+      "ref": "pkg:npm/iconv-lite@0.4.24",
+      "dependsOn": [
+        "pkg:npm/safer-buffer@2.1.2"
+      ]
+    },
+    {
+      "ref": "pkg:npm/iconv-lite@0.6.3",
+      "dependsOn": [
+        "pkg:npm/safer-buffer@2.1.2"
+      ]
+    },
+    {
+      "ref": "pkg:npm/ieee754@1.2.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/immediate@3.0.6",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/imurmurhash@0.1.4",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/indent-string@4.0.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/inflight@1.0.6",
+      "dependsOn": [
+        "pkg:npm/once@1.4.0",
+        "pkg:npm/wrappy@1.0.2"
+      ]
+    },
+    {
+      "ref": "pkg:npm/inherits@2.0.4",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/inquirer-checkbox-plus-prompt@1.4.2",
+      "dependsOn": [
+        "pkg:npm/chalk@4.1.2",
+        "pkg:npm/cli-cursor@3.1.0",
+        "pkg:npm/figures@3.2.0",
+        "pkg:npm/lodash@4.17.21",
+        "pkg:npm/rxjs@6.6.7"
+      ]
+    },
+    {
+      "ref": "pkg:npm/inquirer@8.2.6",
+      "dependsOn": [
+        "pkg:npm/ansi-escapes@4.3.2",
+        "pkg:npm/chalk@4.1.2",
+        "pkg:npm/cli-cursor@3.1.0",
+        "pkg:npm/cli-width@3.0.0",
+        "pkg:npm/external-editor@3.1.0",
+        "pkg:npm/figures@3.2.0",
+        "pkg:npm/lodash@4.17.21",
+        "pkg:npm/mute-stream@0.0.8",
+        "pkg:npm/ora@5.4.1",
+        "pkg:npm/run-async@2.4.1",
+        "pkg:npm/rxjs@7.8.1",
+        "pkg:npm/through@2.3.8",
+        "pkg:npm/wrap-ansi@6.2.0"
+      ]
+    },
+    {
+      "ref": "pkg:npm/ip@1.1.8",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/ip@2.0.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/is-fullwidth-code-point@3.0.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/is-interactive@1.0.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/is-lambda@1.0.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/is-obj@2.0.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/is-stream@2.0.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/is-unicode-supported@0.1.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/isarray@1.0.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/isexe@2.0.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/jackspeak@2.2.3",
+      "dependsOn": [
+        "pkg:npm/%40isaacs/cliui@8.0.2",
+        "pkg:npm/%40pkgjs/parseargs@0.11.0"
+      ]
+    },
+    {
+      "ref": "pkg:npm/js-yaml@3.13.1",
+      "dependsOn": [
+        "pkg:npm/argparse@1.0.10",
+        "pkg:npm/esprima@4.0.1"
+      ]
+    },
+    {
+      "ref": "pkg:npm/jsbn@0.1.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/json-bigint@1.0.0",
+      "dependsOn": [
+        "pkg:npm/bignumber.js@9.1.1"
+      ]
+    },
+    {
+      "ref": "pkg:npm/json-schema-traverse@1.0.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/jsonfile@4.0.0",
+      "dependsOn": [
+        "pkg:npm/graceful-fs@4.2.11"
+      ]
+    },
+    {
+      "ref": "pkg:npm/jszip@3.10.1",
+      "dependsOn": [
+        "pkg:npm/lie@3.3.0",
+        "pkg:npm/pako@1.0.11",
+        "pkg:npm/readable-stream@2.3.8",
+        "pkg:npm/setimmediate@1.0.5"
+      ]
+    },
+    {
+      "ref": "pkg:npm/jwa@2.0.0",
+      "dependsOn": [
+        "pkg:npm/buffer-equal-constant-time@1.0.1",
+        "pkg:npm/ecdsa-sig-formatter@1.0.11",
+        "pkg:npm/safe-buffer@5.2.1"
+      ]
+    },
+    {
+      "ref": "pkg:npm/jws@4.0.0",
+      "dependsOn": [
+        "pkg:npm/jwa@2.0.0",
+        "pkg:npm/safe-buffer@5.2.1"
+      ]
+    },
+    {
+      "ref": "pkg:npm/lie@3.3.0",
+      "dependsOn": [
+        "pkg:npm/immediate@3.0.6"
+      ]
+    },
+    {
+      "ref": "pkg:npm/lodash.camelcase@4.3.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/lodash@4.17.21",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/log-symbols@4.1.0",
+      "dependsOn": [
+        "pkg:npm/chalk@4.1.2",
+        "pkg:npm/is-unicode-supported@0.1.0"
+      ]
+    },
+    {
+      "ref": "pkg:npm/long@4.0.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/long@5.2.3",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/lru-cache@10.0.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/lru-cache@6.0.0",
+      "dependsOn": [
+        "pkg:npm/yallist@4.0.0"
+      ]
+    },
+    {
+      "ref": "pkg:npm/lru-cache@7.18.3",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/make-fetch-happen@11.1.1",
+      "dependsOn": [
+        "pkg:npm/agentkeepalive@4.5.0",
+        "pkg:npm/cacache@17.1.4",
+        "pkg:npm/http-cache-semantics@4.1.1",
+        "pkg:npm/http-proxy-agent@5.0.0",
+        "pkg:npm/is-lambda@1.0.1",
+        "pkg:npm/lru-cache@7.18.3",
+        "pkg:npm/minipass-fetch@3.0.4",
+        "pkg:npm/minipass-flush@1.0.5",
+        "pkg:npm/minipass-pipeline@1.2.4",
+        "pkg:npm/minipass@5.0.0",
+        "pkg:npm/negotiator@0.6.3",
+        "pkg:npm/promise-retry@2.0.1",
+        "pkg:npm/socks-proxy-agent@7.0.0",
+        "pkg:npm/ssri@10.0.5"
+      ]
+    },
+    {
+      "ref": "pkg:npm/mime-db@1.52.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/mime-types@2.1.35",
+      "dependsOn": [
+        "pkg:npm/mime-db@1.52.0"
+      ]
+    },
+    {
+      "ref": "pkg:npm/mimic-fn@2.1.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/minimatch@3.1.2",
+      "dependsOn": [
+        "pkg:npm/brace-expansion@1.1.11"
+      ]
+    },
+    {
+      "ref": "pkg:npm/minimatch@9.0.3",
+      "dependsOn": [
+        "pkg:npm/brace-expansion@2.0.1"
+      ]
+    },
+    {
+      "ref": "pkg:npm/minimist@1.2.8",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/minipass-collect@1.0.2",
+      "dependsOn": [
+        "pkg:npm/minipass@3.3.6"
+      ]
+    },
+    {
+      "ref": "pkg:npm/minipass-fetch@3.0.4",
+      "dependsOn": [
+        "pkg:npm/encoding@0.1.13",
+        "pkg:npm/minipass-sized@1.0.3",
+        "pkg:npm/minipass@7.0.3",
+        "pkg:npm/minizlib@2.1.2"
+      ]
+    },
+    {
+      "ref": "pkg:npm/minipass-flush@1.0.5",
+      "dependsOn": [
+        "pkg:npm/minipass@3.3.6"
+      ]
+    },
+    {
+      "ref": "pkg:npm/minipass-pipeline@1.2.4",
+      "dependsOn": [
+        "pkg:npm/minipass@3.3.6"
+      ]
+    },
+    {
+      "ref": "pkg:npm/minipass-sized@1.0.3",
+      "dependsOn": [
+        "pkg:npm/minipass@3.3.6"
+      ]
+    },
+    {
+      "ref": "pkg:npm/minipass@3.3.6",
+      "dependsOn": [
+        "pkg:npm/yallist@4.0.0"
+      ]
+    },
+    {
+      "ref": "pkg:npm/minipass@5.0.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/minipass@7.0.3",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/minizlib@2.1.2",
+      "dependsOn": [
+        "pkg:npm/minipass@3.3.6",
+        "pkg:npm/yallist@4.0.0"
+      ]
+    },
+    {
+      "ref": "pkg:npm/mkdirp@1.0.4",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/ms@2.0.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/ms@2.1.2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/ms@2.1.3",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/mute-stream@0.0.8",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/nan@2.17.0",
+      "dependsOn": [
+        "pkg:npm/node-gyp@9.4.0"
+      ]
+    },
+    {
+      "ref": "pkg:npm/nan@2.18.0",
+      "dependsOn": [
+        "pkg:npm/node-gyp@9.4.0"
+      ]
+    },
+    {
+      "ref": "pkg:npm/negotiator@0.6.3",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/netmask@2.0.2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/node-fetch@2.6.12",
+      "dependsOn": [
+        "pkg:npm/whatwg-url@5.0.0"
+      ]
+    },
+    {
+      "ref": "pkg:npm/node-forge@1.3.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/node-gyp@9.4.0",
+      "dependsOn": [
+        "pkg:npm/env-paths@2.2.1",
+        "pkg:npm/exponential-backoff@3.1.1",
+        "pkg:npm/glob@7.2.3",
+        "pkg:npm/graceful-fs@4.2.11",
+        "pkg:npm/make-fetch-happen@11.1.1",
+        "pkg:npm/nopt@6.0.0",
+        "pkg:npm/npmlog@6.0.2",
+        "pkg:npm/rimraf@3.0.2",
+        "pkg:npm/semver@7.5.4",
+        "pkg:npm/tar@6.1.15",
+        "pkg:npm/which@2.0.2"
+      ]
+    },
+    {
+      "ref": "pkg:npm/nopt@6.0.0",
+      "dependsOn": [
+        "pkg:npm/abbrev@1.1.1"
+      ]
+    },
+    {
+      "ref": "pkg:npm/npmlog@6.0.2",
+      "dependsOn": [
+        "pkg:npm/are-we-there-yet@3.0.1",
+        "pkg:npm/console-control-strings@1.1.0",
+        "pkg:npm/gauge@4.0.4",
+        "pkg:npm/set-blocking@2.0.0"
+      ]
+    },
+    {
+      "ref": "pkg:npm/object-hash@3.0.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/on-finished@2.4.1",
+      "dependsOn": [
+        "pkg:npm/ee-first@1.1.1"
+      ]
+    },
+    {
+      "ref": "pkg:npm/once@1.4.0",
+      "dependsOn": [
+        "pkg:npm/wrappy@1.0.2"
+      ]
+    },
+    {
+      "ref": "pkg:npm/onetime@5.1.2",
+      "dependsOn": [
+        "pkg:npm/mimic-fn@2.1.0"
+      ]
+    },
+    {
+      "ref": "pkg:npm/ora@5.4.1",
+      "dependsOn": [
+        "pkg:npm/bl@4.1.0",
+        "pkg:npm/chalk@4.1.2",
+        "pkg:npm/cli-cursor@3.1.0",
+        "pkg:npm/cli-spinners@2.9.0",
+        "pkg:npm/is-interactive@1.0.0",
+        "pkg:npm/is-unicode-supported@0.1.0",
+        "pkg:npm/log-symbols@4.1.0",
+        "pkg:npm/wcwidth@1.0.1"
+      ]
+    },
+    {
+      "ref": "pkg:npm/os-tmpdir@1.0.2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/p-map@4.0.0",
+      "dependsOn": [
+        "pkg:npm/aggregate-error@3.1.0"
+      ]
+    },
+    {
+      "ref": "pkg:npm/pac-proxy-agent@7.0.0",
+      "dependsOn": [
+        "pkg:npm/%40tootallnate/quickjs-emscripten@0.23.0",
+        "pkg:npm/agent-base@7.1.0",
+        "pkg:npm/debug@4.3.4",
+        "pkg:npm/get-uri@6.0.1",
+        "pkg:npm/http-proxy-agent@7.0.0",
+        "pkg:npm/pac-resolver@7.0.0",
+        "pkg:npm/socks-proxy-agent@8.0.1"
+      ]
+    },
+    {
+      "ref": "pkg:npm/pac-resolver@7.0.0",
+      "dependsOn": [
+        "pkg:npm/degenerator@5.0.1",
+        "pkg:npm/ip@1.1.8",
+        "pkg:npm/netmask@2.0.2"
+      ]
+    },
+    {
+      "ref": "pkg:npm/pako@1.0.11",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/path-is-absolute@1.0.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/path-key@3.1.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/path-scurry@1.10.1",
+      "dependsOn": [
+        "pkg:npm/lru-cache@10.0.1",
+        "pkg:npm/minipass@7.0.3"
+      ]
+    },
+    {
+      "ref": "pkg:npm/process-nextick-args@2.0.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/promise-retry@2.0.1",
+      "dependsOn": [
+        "pkg:npm/err-code@2.0.3",
+        "pkg:npm/retry@0.12.0"
+      ]
+    },
+    {
+      "ref": "pkg:npm/proto3-json-serializer@2.0.0",
+      "dependsOn": [
+        "pkg:npm/protobufjs@7.2.4"
+      ]
+    },
+    {
+      "ref": "pkg:npm/protobufjs@7.2.4",
+      "dependsOn": [
+        "pkg:npm/%40protobufjs/aspromise@1.1.2",
+        "pkg:npm/%40protobufjs/base64@1.1.2",
+        "pkg:npm/%40protobufjs/codegen@2.0.4",
+        "pkg:npm/%40protobufjs/eventemitter@1.1.0",
+        "pkg:npm/%40protobufjs/fetch@1.1.0",
+        "pkg:npm/%40protobufjs/float@1.0.2",
+        "pkg:npm/%40protobufjs/inquire@1.1.0",
+        "pkg:npm/%40protobufjs/path@1.1.2",
+        "pkg:npm/%40protobufjs/pool@1.1.0",
+        "pkg:npm/%40protobufjs/utf8@1.1.0",
+        "pkg:npm/%40types/node@20.5.0",
+        "pkg:npm/long@5.2.3"
+      ]
+    },
+    {
+      "ref": "pkg:npm/protobufjs@7.2.5",
+      "dependsOn": [
+        "pkg:npm/%40protobufjs/aspromise@1.1.2",
+        "pkg:npm/%40protobufjs/base64@1.1.2",
+        "pkg:npm/%40protobufjs/codegen@2.0.4",
+        "pkg:npm/%40protobufjs/eventemitter@1.1.0",
+        "pkg:npm/%40protobufjs/fetch@1.1.0",
+        "pkg:npm/%40protobufjs/float@1.0.2",
+        "pkg:npm/%40protobufjs/inquire@1.1.0",
+        "pkg:npm/%40protobufjs/path@1.1.2",
+        "pkg:npm/%40protobufjs/pool@1.1.0",
+        "pkg:npm/%40protobufjs/utf8@1.1.0",
+        "pkg:npm/%40types/node@20.5.0",
+        "pkg:npm/long@5.2.3"
+      ]
+    },
+    {
+      "ref": "pkg:npm/proxy-agent@6.3.0",
+      "dependsOn": [
+        "pkg:npm/agent-base@7.1.0",
+        "pkg:npm/debug@4.3.4",
+        "pkg:npm/http-proxy-agent@7.0.0",
+        "pkg:npm/lru-cache@7.18.3",
+        "pkg:npm/pac-proxy-agent@7.0.0",
+        "pkg:npm/proxy-from-env@1.1.0",
+        "pkg:npm/socks-proxy-agent@8.0.1"
+      ]
+    },
+    {
+      "ref": "pkg:npm/proxy-from-env@1.1.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/pump@3.0.0",
+      "dependsOn": [
+        "pkg:npm/end-of-stream@1.4.4",
+        "pkg:npm/once@1.4.0"
+      ]
+    },
+    {
+      "ref": "pkg:npm/pumpify@2.0.1",
+      "dependsOn": [
+        "pkg:npm/duplexify@4.1.2",
+        "pkg:npm/inherits@2.0.4",
+        "pkg:npm/pump@3.0.0"
+      ]
+    },
+    {
+      "ref": "pkg:npm/punycode@2.3.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/rc@1.2.8",
+      "dependsOn": [
+        "pkg:npm/deep-extend@0.6.0",
+        "pkg:npm/minimist@1.2.8",
+        "pkg:npm/strip-json-comments@2.0.1"
+      ]
+    },
+    {
+      "ref": "pkg:npm/readable-stream@2.3.8",
+      "dependsOn": [
+        "pkg:npm/core-util-is@1.0.3",
+        "pkg:npm/inherits@2.0.4",
+        "pkg:npm/isarray@1.0.0",
+        "pkg:npm/process-nextick-args@2.0.1",
+        "pkg:npm/safe-buffer@5.1.2",
+        "pkg:npm/string_decoder@1.1.1",
+        "pkg:npm/util-deprecate@1.0.2"
+      ]
+    },
+    {
+      "ref": "pkg:npm/readable-stream@3.6.2",
+      "dependsOn": [
+        "pkg:npm/inherits@2.0.4",
+        "pkg:npm/string_decoder@1.3.0",
+        "pkg:npm/util-deprecate@1.0.2"
+      ]
+    },
+    {
+      "ref": "pkg:npm/require-directory@2.1.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/require-from-string@2.0.2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/restore-cursor@3.1.0",
+      "dependsOn": [
+        "pkg:npm/onetime@5.1.2",
+        "pkg:npm/signal-exit@3.0.7"
+      ]
+    },
+    {
+      "ref": "pkg:npm/retry-request@7.0.1",
+      "dependsOn": [
+        "pkg:npm/%40types/request@2.48.12",
+        "pkg:npm/debug@4.3.4",
+        "pkg:npm/extend@3.0.2",
+        "pkg:npm/teeny-request@9.0.0"
+      ]
+    },
+    {
+      "ref": "pkg:npm/retry@0.12.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/rimraf@3.0.2",
+      "dependsOn": [
+        "pkg:npm/glob@7.2.3"
+      ]
+    },
+    {
+      "ref": "pkg:npm/run-async@2.4.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/rxjs@6.6.7",
+      "dependsOn": [
+        "pkg:npm/tslib@1.14.1"
+      ]
+    },
+    {
+      "ref": "pkg:npm/rxjs@7.8.1",
+      "dependsOn": [
+        "pkg:npm/tslib@2.6.1"
+      ]
+    },
+    {
+      "ref": "pkg:npm/safe-buffer@5.1.2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/safe-buffer@5.2.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/safer-buffer@2.1.2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/sax@1.2.4",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/semver@7.5.4",
+      "dependsOn": [
+        "pkg:npm/lru-cache@6.0.0"
+      ]
+    },
+    {
+      "ref": "pkg:npm/set-blocking@2.0.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/setimmediate@1.0.5",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/shebang-command@2.0.0",
+      "dependsOn": [
+        "pkg:npm/shebang-regex@3.0.0"
+      ]
+    },
+    {
+      "ref": "pkg:npm/shebang-regex@3.0.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/signal-exit@3.0.7",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/signal-exit@4.1.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/simple-git@3.16.0",
+      "dependsOn": [
+        "pkg:npm/%40kwsites/file-exists@1.1.1",
+        "pkg:npm/%40kwsites/promise-deferred@1.1.1",
+        "pkg:npm/debug@4.3.4"
+      ]
+    },
+    {
+      "ref": "pkg:npm/smart-buffer@4.2.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/socks-proxy-agent@7.0.0",
+      "dependsOn": [
+        "pkg:npm/agent-base@6.0.2",
+        "pkg:npm/debug@4.3.4",
+        "pkg:npm/socks@2.7.1"
+      ]
+    },
+    {
+      "ref": "pkg:npm/socks-proxy-agent@8.0.1",
+      "dependsOn": [
+        "pkg:npm/agent-base@7.1.0",
+        "pkg:npm/debug@4.3.4",
+        "pkg:npm/socks@2.7.1"
+      ]
+    },
+    {
+      "ref": "pkg:npm/socks@2.7.1",
+      "dependsOn": [
+        "pkg:npm/ip@2.0.0",
+        "pkg:npm/smart-buffer@4.2.0"
+      ]
+    },
+    {
+      "ref": "pkg:npm/source-map@0.6.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/sprintf-js@1.0.3",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/ssh2-streams@0.4.10",
+      "dependsOn": [
+        "pkg:npm/asn1@0.2.6",
+        "pkg:npm/bcrypt-pbkdf@1.0.2",
+        "pkg:npm/streamsearch@0.1.2"
+      ]
+    },
+    {
+      "ref": "pkg:npm/ssh2@1.15.0",
+      "dependsOn": [
+        "pkg:npm/asn1@0.2.6",
+        "pkg:npm/bcrypt-pbkdf@1.0.2",
+        "pkg:npm/cpu-features@0.0.9",
+        "pkg:npm/nan@2.18.0"
+      ]
+    },
+    {
+      "ref": "pkg:npm/sshpk@1.16.1",
+      "dependsOn": [
+        "pkg:npm/asn1@0.2.6",
+        "pkg:npm/assert-plus@1.0.0",
+        "pkg:npm/bcrypt-pbkdf@1.0.2",
+        "pkg:npm/dashdash@1.14.1",
+        "pkg:npm/ecc-jsbn@0.1.2",
+        "pkg:npm/getpass@0.1.7",
+        "pkg:npm/jsbn@0.1.1",
+        "pkg:npm/safer-buffer@2.1.2",
+        "pkg:npm/tweetnacl@0.14.5"
+      ]
+    },
+    {
+      "ref": "pkg:npm/ssri@10.0.5",
+      "dependsOn": [
+        "pkg:npm/minipass@7.0.3"
+      ]
+    },
+    {
+      "ref": "pkg:npm/stream-events@1.0.5",
+      "dependsOn": [
+        "pkg:npm/stubs@3.0.0"
+      ]
+    },
+    {
+      "ref": "pkg:npm/stream-shift@1.0.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/streamsearch@0.1.2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/string-width-cjs@4.2.3",
+      "dependsOn": [
+        "pkg:npm/emoji-regex@8.0.0",
+        "pkg:npm/is-fullwidth-code-point@3.0.0"
+      ]
+    },
+    {
+      "ref": "pkg:npm/string-width@5.1.2",
+      "dependsOn": [
+        "pkg:npm/eastasianwidth@0.2.0",
+        "pkg:npm/emoji-regex@9.2.2",
+        "pkg:npm/strip-ansi@7.1.0"
+      ]
+    },
+    {
+      "ref": "pkg:npm/string_decoder@1.1.1",
+      "dependsOn": [
+        "pkg:npm/safe-buffer@5.1.2"
+      ]
+    },
+    {
+      "ref": "pkg:npm/string_decoder@1.3.0",
+      "dependsOn": [
+        "pkg:npm/safe-buffer@5.2.1"
+      ]
+    },
+    {
+      "ref": "pkg:npm/strip-ansi-cjs@6.0.1",
+      "dependsOn": [
+        "pkg:npm/ansi-regex@5.0.1"
+      ]
+    },
+    {
+      "ref": "pkg:npm/strip-ansi@7.1.0",
+      "dependsOn": [
+        "pkg:npm/ansi-regex@6.0.1"
+      ]
+    },
+    {
+      "ref": "pkg:npm/strip-json-comments@2.0.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/strnum@1.0.5",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/stubs@3.0.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/supports-color@7.2.0",
+      "dependsOn": [
+        "pkg:npm/has-flag@4.0.0"
+      ]
+    },
+    {
+      "ref": "pkg:npm/supports-hyperlinks@2.3.0",
+      "dependsOn": [
+        "pkg:npm/has-flag@4.0.0",
+        "pkg:npm/supports-color@7.2.0"
+      ]
+    },
+    {
+      "ref": "pkg:npm/tar@6.1.15",
+      "dependsOn": [
+        "pkg:npm/chownr@2.0.0",
+        "pkg:npm/fs-minipass@2.1.0",
+        "pkg:npm/minipass@5.0.0",
+        "pkg:npm/minizlib@2.1.2",
+        "pkg:npm/mkdirp@1.0.4",
+        "pkg:npm/yallist@4.0.0"
+      ]
+    },
+    {
+      "ref": "pkg:npm/teeny-request@9.0.0",
+      "dependsOn": [
+        "pkg:npm/http-proxy-agent@5.0.0",
+        "pkg:npm/node-fetch@2.6.12",
+        "pkg:npm/stream-events@1.0.5",
+        "pkg:npm/uuid@9.0.0"
+      ]
+    },
+    {
+      "ref": "pkg:npm/terminal-link@2.1.1",
+      "dependsOn": [
+        "pkg:npm/ansi-escapes@4.3.2",
+        "pkg:npm/supports-hyperlinks@2.3.0"
+      ]
+    },
+    {
+      "ref": "pkg:npm/through@2.3.8",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/tiny-async-pool@2.1.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/tmp@0.0.33",
+      "dependsOn": [
+        "pkg:npm/os-tmpdir@1.0.2"
+      ]
+    },
+    {
+      "ref": "pkg:npm/tr46@0.0.3",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/tslib@1.14.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/tslib@2.6.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/tweetnacl@0.14.5",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/typanion@3.14.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/type-fest@0.21.3",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/unique-filename@3.0.0",
+      "dependsOn": [
+        "pkg:npm/unique-slug@4.0.0"
+      ]
+    },
+    {
+      "ref": "pkg:npm/unique-slug@4.0.0",
+      "dependsOn": [
+        "pkg:npm/imurmurhash@0.1.4"
+      ]
+    },
+    {
+      "ref": "pkg:npm/universalify@0.1.2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/uri-js@4.4.1",
+      "dependsOn": [
+        "pkg:npm/punycode@2.3.0"
+      ]
+    },
+    {
+      "ref": "pkg:npm/util-deprecate@1.0.2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/uuid@8.3.2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/uuid@9.0.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/wcwidth@1.0.1",
+      "dependsOn": [
+        "pkg:npm/defaults@1.0.4"
+      ]
+    },
+    {
+      "ref": "pkg:npm/webidl-conversions@3.0.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/whatwg-url@5.0.0",
+      "dependsOn": [
+        "pkg:npm/tr46@0.0.3",
+        "pkg:npm/webidl-conversions@3.0.1"
+      ]
+    },
+    {
+      "ref": "pkg:npm/which@2.0.2",
+      "dependsOn": [
+        "pkg:npm/isexe@2.0.0"
+      ]
+    },
+    {
+      "ref": "pkg:npm/wide-align@1.1.5",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/wrap-ansi-cjs@7.0.0",
+      "dependsOn": [
+        "pkg:npm/ansi-styles@4.3.0"
+      ]
+    },
+    {
+      "ref": "pkg:npm/wrap-ansi@6.2.0",
+      "dependsOn": [
+        "pkg:npm/ansi-styles@4.3.0"
+      ]
+    },
+    {
+      "ref": "pkg:npm/wrap-ansi@8.1.0",
+      "dependsOn": [
+        "pkg:npm/ansi-styles@6.2.1",
+        "pkg:npm/string-width@5.1.2",
+        "pkg:npm/strip-ansi@7.1.0"
+      ]
+    },
+    {
+      "ref": "pkg:npm/wrappy@1.0.2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/ws@7.4.6",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/xml2js@0.5.0",
+      "dependsOn": [
+        "pkg:npm/sax@1.2.4",
+        "pkg:npm/xmlbuilder@11.0.1"
+      ]
+    },
+    {
+      "ref": "pkg:npm/xmlbuilder@11.0.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/y18n@5.0.8",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/yallist@4.0.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/yamux-js@0.1.2",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/yargs-parser@21.1.1",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:npm/yargs@17.7.2",
+      "dependsOn": [
+        "pkg:npm/cliui@8.0.1",
+        "pkg:npm/escalade@3.1.1",
+        "pkg:npm/get-caller-file@2.0.5",
+        "pkg:npm/require-directory@2.1.1",
+        "pkg:npm/y18n@5.0.8",
+        "pkg:npm/yargs-parser@21.1.1"
+      ]
+    }
+  ],
+  "vulnerabilities": []
+}

--- a/src/commands/sbom/__tests__/payload.test.ts
+++ b/src/commands/sbom/__tests__/payload.test.ts
@@ -162,4 +162,30 @@ describe('generation of payload', () => {
     const dependenciesWithPython = payload?.dependencies.filter((d) => d.language === DependencyLanguage.PYTHON)
     expect(dependenciesWithPython?.length).toStrictEqual(19)
   })
+
+  test('SBOM generated from Trivy 4.9 with group', async () => {
+    const sbomFile = './src/commands/sbom/__tests__/fixtures/trivy-4.9.json'
+    const sbomContent = JSON.parse(fs.readFileSync(sbomFile).toString('utf8'))
+    const config: DatadogCiConfig = {
+      apiKey: undefined,
+      env: undefined,
+      envVarTags: undefined,
+    }
+    const tags = await getSpanTags(config, [])
+
+    const payload = generatePayload(sbomContent, tags, 'service', 'env')
+
+    expect(payload?.dependencies.length).toStrictEqual(433)
+    const dependencies = payload?.dependencies
+    const dependenciesWithoutLicense = payload?.dependencies.filter((d) => d.licenses.length === 0)
+    expect(dependenciesWithoutLicense?.length).toStrictEqual(433)
+
+    // all languages are detected
+    const dependenciesWithoutLanguage = payload?.dependencies.filter((d) => !d.language)
+    expect(dependenciesWithoutLanguage?.length).toStrictEqual(0)
+    const dependenciesWithNode = payload?.dependencies.filter((d) => d.language === DependencyLanguage.NPM)
+    expect(dependenciesWithNode?.length).toStrictEqual(433)
+    expect(dependencies?.filter((d) => d.group !== undefined).length).toBeGreaterThan(0)
+    expect(dependencies && dependencies[10].group).toStrictEqual('@aws-sdk')
+  })
 })

--- a/src/commands/sbom/__tests__/validation.test.ts
+++ b/src/commands/sbom/__tests__/validation.test.ts
@@ -20,4 +20,8 @@ describe('validation of sbom file', () => {
       validateSbomFile('./src/commands/sbom/__tests__/fixtures/sbom.1.4.invalid.json', validator, false)
     ).toBeFalsy()
   })
+  test('should validate SBOM file from trivy 4.9', () => {
+    // type and name of the "component" have been removed from the valid file.
+    expect(validateSbomFile('./src/commands/sbom/__tests__/fixtures/trivy-4.9.json', validator, true)).toBeTruthy()
+  })
 })

--- a/src/commands/sbom/payload.ts
+++ b/src/commands/sbom/payload.ts
@@ -60,6 +60,7 @@ export const generatePayload = (
 
         const dependency: Dependency = {
           name: component['name'],
+          group: component['group'] || undefined,
           version: component['version'],
           language: lang,
           licenses: getLicensesFromComponent(component),

--- a/src/commands/sbom/types.ts
+++ b/src/commands/sbom/types.ts
@@ -51,6 +51,7 @@ export enum DependencyLicense {
 export interface Dependency {
   name: string
   version: string
+  group: undefined | string
   language: DependencyLanguage
   licenses: DependencyLicense[]
   purl: string


### PR DESCRIPTION
### What and why?

We need to handle the `group` attribute of an SBOM. Previous version only handle `name`, `version` and `language`.

### How?

When the payload has a `group` attribute in a dependency, pass it to the payload. Otherwise, set it to `undefined`.


### Review checklist

- Added unit test to check a SBOM with `group`
- Ran in staging, see output below 


```
yarn launch sbom upload --service rodrigo --env local src/commands/sbom/__tests__/fixtures/trivy-4.9.json
File src/commands/sbom/__tests__/fixtures/trivy-4.9.json successfully uploaded in 1633 ms
Upload finished
```