### PR TITLE
[SYNTH-11928] Reference Bitrise integrations in datadog-ci

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,8 @@ jobs:
           - synthetics-ci-github-action
           - datadog-ci-azure-devops
           - synthetics-test-automation-circleci-orb
+          - synthetics-test-automation-bitrise-step-run-tests
+          - synthetics-test-automation-bitrise-step-upload-application
     steps:
       - name: Create bump datadog-ci PR
         uses: actions/github-script@v6


### PR DESCRIPTION
### What and why?

We want datadog-ci releases to trigger the creating of PRs in the integrations to update the version of datadog-ci

### How?

We added the 2 new integrations in the list of integrations that need to be triggered

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
