### PR TITLE
v2.30.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci",
-  "version": "2.29.0",
+  "version": "2.30.0",
   "description": "Run datadog actions from the CI.",
   "repository": "https://github.com/DataDog/datadog-ci",
   "license": "Apache-2.0",


### PR DESCRIPTION
## What's Changed

### Reliability
* 🐛 [RUM-2721] fix upload retry by @BenoitZugmeyer in https://github.com/DataDog/datadog-ci/pull/1180

### Static Analysis
* [STAL-1268] Handle group in payload by @juli1 in https://github.com/DataDog/datadog-ci/pull/1177
* Remove sbom from beta by @juli1 in https://github.com/DataDog/datadog-ci/pull/1168

### Synthetics
* [synthetics] Change error message for timed out results by @Drarig29 in https://github.com/DataDog/datadog-ci/pull/1163
* [SYNTH-11928] Reference Bitrise integrations in datadog-ci by @teodor2312 in https://github.com/DataDog/datadog-ci/pull/1179
* [SYNTH-12059] Trailing slash in test suite id leads to `[] Found test "undefined"` by @teodor2312 in https://github.com/DataDog/datadog-ci/pull/1172
* [synthetics] Fix newline in text output with JUnit reports by @Drarig29 in https://github.com/DataDog/datadog-ci/pull/1165

### Dependencies
* [dep] Bump ssh2 to `1.15.0` by @Drarig29 in https://github.com/DataDog/datadog-ci/pull/1173
* [dep] Bump dd-trace to `3.47.0` by @Drarig29 in https://github.com/DataDog/datadog-ci/pull/1174
* [dep] Bump @google-cloud/run to `1.0.2` by @Drarig29 in https://github.com/DataDog/datadog-ci/pull/1176

### Chores
* docs(sourcemaps): fix minified path prefix URL example on E2E tests by @Gummiees in https://github.com/DataDog/datadog-ci/pull/1170
* [ci] Use docker buildx for public images by @Drarig29 in https://github.com/DataDog/datadog-ci/pull/1175
* [ci] Unit test against Node 20 by @Drarig29 in https://github.com/DataDog/datadog-ci/pull/1166
* [dev] Use Node 20 for development by @Drarig29 in https://github.com/DataDog/datadog-ci/pull/1178

## New Contributors
* @Gummiees made their first contribution in https://github.com/DataDog/datadog-ci/pull/1170

**Full Changelog**: https://github.com/DataDog/datadog-ci/compare/v2.29.0...v2.30.0

[RUM-2721]: https://datadoghq.atlassian.net/browse/RUM-2721?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[STAL-1268]: https://datadoghq.atlassian.net/browse/STAL-1268?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SYNTH-11928]: https://datadoghq.atlassian.net/browse/SYNTH-11928?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SYNTH-12059]: https://datadoghq.atlassian.net/browse/SYNTH-12059?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ