### PR TITLE
[lambda] Deprecate Ruby 2.7 instrumentation

### DIFF
--- a/src/commands/lambda/__tests__/__snapshots__/instrument.test.ts.snap
+++ b/src/commands/lambda/__tests__/__snapshots__/instrument.test.ts.snap
@@ -309,8 +309,6 @@ exports[`lambda instrument execute instruments Ruby application properly 1`] = `
 [!] Functions to be updated:
 	- arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world
 	- arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world-2
-	- arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world-3
-	- arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world-4
 
 [Dry Run] Will apply the following updates:
 UpdateFunctionConfiguration -> arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world
@@ -332,7 +330,7 @@ UpdateFunctionConfiguration -> arn:aws:lambda:us-east-1:123456789012:function:la
   },
   "Layers": [
     "arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Extension:40",
-    "arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Ruby2-7:19"
+    "arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Ruby3-2:19"
   ]
 }
 TagResource -> arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world
@@ -358,62 +356,10 @@ UpdateFunctionConfiguration -> arn:aws:lambda:us-east-1:123456789012:function:la
   },
   "Layers": [
     "arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Extension-ARM:40",
-    "arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Ruby2-7-ARM:19"
-  ]
-}
-TagResource -> arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world-2
-{
-  "dd_sls_ci": "vXXXX"
-}
-UpdateFunctionConfiguration -> arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world-3
-{
-  "FunctionName": "arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world-3",
-  "Environment": {
-    "Variables": {
-      "DD_API_KEY": "02**********33bd",
-      "DD_SITE": "datadoghq.com",
-      "DD_SERVERLESS_APPSEC_ENABLED": "false",
-      "DD_CAPTURE_LAMBDA_PAYLOAD": "false",
-      "DD_ENV": "staging",
-      "DD_TAGS": "layer:api,team:intake",
-      "DD_MERGE_XRAY_TRACES": "false",
-      "DD_SERVICE": "middletier",
-      "DD_TRACE_ENABLED": "true",
-      "DD_VERSION": "0.2"
-    }
-  },
-  "Layers": [
-    "arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Extension:40",
-    "arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Ruby3-2:19"
-  ]
-}
-TagResource -> arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world-3
-{
-  "dd_sls_ci": "vXXXX"
-}
-UpdateFunctionConfiguration -> arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world-4
-{
-  "FunctionName": "arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world-4",
-  "Environment": {
-    "Variables": {
-      "DD_API_KEY": "02**********33bd",
-      "DD_SITE": "datadoghq.com",
-      "DD_SERVERLESS_APPSEC_ENABLED": "false",
-      "DD_CAPTURE_LAMBDA_PAYLOAD": "false",
-      "DD_ENV": "staging",
-      "DD_TAGS": "layer:api,team:intake",
-      "DD_MERGE_XRAY_TRACES": "false",
-      "DD_SERVICE": "middletier",
-      "DD_TRACE_ENABLED": "true",
-      "DD_VERSION": "0.2"
-    }
-  },
-  "Layers": [
-    "arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Extension-ARM:40",
     "arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Ruby3-2-ARM:19"
   ]
 }
-TagResource -> arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world-4
+TagResource -> arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world-2
 {
   "dd_sls_ci": "vXXXX"
 }

--- a/src/commands/lambda/__tests__/instrument.test.ts
+++ b/src/commands/lambda/__tests__/instrument.test.ts
@@ -1106,25 +1106,12 @@ describe('lambda', () => {
           'arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world': {
             config: {
               FunctionArn: 'arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world',
-              Runtime: 'ruby2.7',
+              Runtime: 'ruby3.2',
             },
           },
           'arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world-2': {
             config: {
               FunctionArn: 'arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world-2',
-              Runtime: 'ruby2.7',
-              Architectures: ['arm64'],
-            },
-          },
-          'arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world-3': {
-            config: {
-              FunctionArn: 'arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world-3',
-              Runtime: 'ruby3.2',
-            },
-          },
-          'arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world-4': {
-            config: {
-              FunctionArn: 'arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world-4',
               Runtime: 'ruby3.2',
               Architectures: ['arm64'],
             },
@@ -1142,10 +1129,6 @@ describe('lambda', () => {
             'arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world',
             '-f',
             'arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world-2',
-            '-f',
-            'arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world-3',
-            '-f',
-            'arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world-4',
             '--dry-run',
             '-e',
             '40',

--- a/src/commands/lambda/constants.ts
+++ b/src/commands/lambda/constants.ts
@@ -24,7 +24,6 @@ export const LAYER_LOOKUP = {
   'python3.10': 'Datadog-Python310',
   'python3.11': 'Datadog-Python311',
   'python3.12': 'Datadog-Python312',
-  'ruby2.7': 'Datadog-Ruby2-7',
   'ruby3.2': 'Datadog-Ruby3-2',
 } as const
 
@@ -56,7 +55,6 @@ export const RUNTIME_LOOKUP: Partial<Record<Runtime, RuntimeType>> = {
   'python3.10': RuntimeType.PYTHON,
   'python3.11': RuntimeType.PYTHON,
   'python3.12': RuntimeType.PYTHON,
-  'ruby2.7': RuntimeType.RUBY,
   'ruby3.2': RuntimeType.RUBY,
 }
 
@@ -69,7 +67,6 @@ export const ARM_LAYERS = [
   'python3.10',
   'python3.11',
   'python3.12',
-  'ruby2.7',
   'ruby3.2',
 ]
 export const ARM64_ARCHITECTURE = 'arm64'


### PR DESCRIPTION
### What and why?

Ruby 2.7 went in deprecation phase 2 as per [AWS Lambda Runtime Deprecation Policy](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html#runtime-support-policy).

### How?

Removing all mentions of it.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
