### PR TITLE
[lambda] Deprecate Python 3.7 instrumentation

### DIFF
--- a/src/commands/lambda/__tests__/functions/commons.test.ts
+++ b/src/commands/lambda/__tests__/functions/commons.test.ts
@@ -292,7 +292,7 @@ describe('commons', () => {
     })
 
     test('returns 0 when no layer can be found', async () => {
-      const runtime: Runtime = 'python3.7'
+      const runtime: Runtime = 'python3.12'
       const region = 'us-east-1'
       const expectedLatestVersion = 0
       const latestVersionFound = await findLatestLayerVersion(runtime, region)
@@ -533,8 +533,8 @@ describe('commons', () => {
       const layerArn = getLayerArn(config, config.Runtime as LayerKey, region, settings)
       expect(layerArn).toEqual(`arn:aws:lambda:${region}:${mockAwsAccount}:layer:Datadog-Python39-ARM`)
     })
-    test('gets us-gov-1 Python37 gov cloud Lambda Library layer ARN', async () => {
-      const runtime = Runtime.python37
+    test('gets us-gov-1 Python312 gov cloud Lambda Library layer ARN', async () => {
+      const runtime = Runtime.python312
       const config = {
         Runtime: runtime,
       }
@@ -546,7 +546,7 @@ describe('commons', () => {
       }
       const region = 'us-gov-1'
       const layerArn = getLayerArn(config, config.Runtime as LayerKey, region, settings)
-      expect(layerArn).toEqual(`arn:aws-us-gov:lambda:${region}:${GOVCLOUD_LAYER_AWS_ACCOUNT}:layer:Datadog-Python37`)
+      expect(layerArn).toEqual(`arn:aws-us-gov:lambda:${region}:${GOVCLOUD_LAYER_AWS_ACCOUNT}:layer:Datadog-Python312`)
     })
     test('gets us-gov-1 Python39 gov cloud arm64 Lambda Library layer ARN', async () => {
       const runtime = Runtime.python39

--- a/src/commands/lambda/constants.ts
+++ b/src/commands/lambda/constants.ts
@@ -18,7 +18,6 @@ export const LAYER_LOOKUP = {
   'nodejs16.x': 'Datadog-Node16-x',
   'nodejs18.x': 'Datadog-Node18-x',
   'nodejs20.x': 'Datadog-Node20-x',
-  'python3.7': 'Datadog-Python37',
   'python3.8': 'Datadog-Python38',
   'python3.9': 'Datadog-Python39',
   'python3.10': 'Datadog-Python310',

--- a/src/commands/lambda/constants.ts
+++ b/src/commands/lambda/constants.ts
@@ -49,7 +49,6 @@ export const RUNTIME_LOOKUP: Partial<Record<Runtime, RuntimeType>> = {
   'nodejs18.x': RuntimeType.NODE,
   'nodejs20.x': RuntimeType.NODE,
   'provided.al2': RuntimeType.CUSTOM,
-  'python3.7': RuntimeType.PYTHON,
   'python3.8': RuntimeType.PYTHON,
   'python3.9': RuntimeType.PYTHON,
   'python3.10': RuntimeType.PYTHON,


### PR DESCRIPTION
### What and why?

Python 3.7 went in deprecation phase 2 as per [AWS Lambda Runtime Deprecation Policy](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html#runtime-support-policy).

### How?

Removing all mentions of it.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
