### PR TITLE
[lambda] Deprecate dotnetcore 3.1 instrumentation

### DIFF
--- a/src/commands/lambda/__tests__/functions/uninstrument.test.ts
+++ b/src/commands/lambda/__tests__/functions/uninstrument.test.ts
@@ -197,7 +197,7 @@ describe('uninstrument', () => {
             },
           },
           FunctionArn: 'arn:aws:lambda:us-east-1:000000000000:function:dotnet',
-          Runtime: Runtime.dotnetcore31,
+          Runtime: Runtime.dotnet6,
         }
 
         const updateRequest = calculateUpdateRequest(config, config.Runtime as any)
@@ -389,7 +389,7 @@ describe('uninstrument', () => {
               },
             },
             FunctionArn: 'arn:aws:lambda:us-east-1:000000000000:function:uninstrument',
-            Runtime: 'dotnetcore3.1',
+            Runtime: 'dotnet6',
           },
         },
       })

--- a/src/commands/lambda/__tests__/instrument.test.ts
+++ b/src/commands/lambda/__tests__/instrument.test.ts
@@ -212,7 +212,7 @@ describe('lambda', () => {
           'arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world': {
             config: {
               FunctionArn: 'arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world',
-              Runtime: 'dotnetcore3.1',
+              Runtime: 'dotnet6',
             },
           },
         })
@@ -1221,7 +1221,7 @@ describe('lambda', () => {
             config: {
               Architectures: ['arm64'],
               FunctionArn: 'arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world',
-              Runtime: 'dotnetcore3.1',
+              Runtime: 'dotnet6',
             },
           },
         })

--- a/src/commands/lambda/constants.ts
+++ b/src/commands/lambda/constants.ts
@@ -9,7 +9,6 @@ export const EXTENSION_LAYER_KEY = 'extension'
 export const LAYER_LOOKUP = {
   [EXTENSION_LAYER_KEY]: DD_LAMBDA_EXTENSION_LAYER_NAME,
   dotnet6: 'dd-trace-dotnet',
-  'dotnetcore3.1': 'dd-trace-dotnet',
   java11: 'dd-trace-java',
   java17: 'dd-trace-java',
   'java8.al2': 'dd-trace-java',
@@ -40,7 +39,6 @@ export enum RuntimeType {
 // Lookup table for runtimes that are currently supported by the CLI
 export const RUNTIME_LOOKUP: Partial<Record<Runtime, RuntimeType>> = {
   dotnet6: RuntimeType.DOTNET,
-  'dotnetcore3.1': RuntimeType.DOTNET,
   java11: RuntimeType.JAVA,
   java17: RuntimeType.JAVA,
   'java8.al2': RuntimeType.JAVA,


### PR DESCRIPTION
### What and why?

Dotnetcore 3.1 went in deprecation phase 2 (a long time ago) as per [AWS Lambda Runtime Deprecation Policy](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html#runtime-support-policy).

### How?

Removing all mentions of it.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
