### PR TITLE
`react-native xcode`: Respect `USE_HERMES` env var being set to false

### DIFF
--- a/src/commands/react-native/__tests__/xcode.test.ts
+++ b/src/commands/react-native/__tests__/xcode.test.ts
@@ -260,6 +260,7 @@ describe('xcode', () => {
         CONFIGURATION_BUILD_DIR: './src/commands/react-native/__tests__/fixtures/compose-sourcemaps',
         UNLOCALIZED_RESOURCES_FOLDER_PATH: 'MyApp.app',
         PODS_PODFILE_DIR_PATH: './src/commands/react-native/__tests__/fixtures/podfile-lock/without-hermes',
+        USE_HERMES: 'false',
       }
       reactNativeVersionSpy.mockReturnValue('0.70.0')
 

--- a/src/commands/react-native/xcode.ts
+++ b/src/commands/react-native/xcode.ts
@@ -409,7 +409,7 @@ export class XCodeCommand extends Command {
      * Since RN 0.70, Hermes is enabled even if it is empty.
      */
     if (process.env.USE_HERMES) {
-      return true
+      return process.env.USE_HERMES.toLowerCase() !== 'false'
     }
 
     /**


### PR DESCRIPTION
### What and why?
https://github.com/DataDog/datadog-ci/issues/1189#issuecomment-1941745706 is related.

It is possible for the `USE_HERMES` environment variable to be set to false. In which case, `process.env.USE_HERMES` would then be `"false"`, causing the check in `shouldComposeHermesSourcemaps` to incorrectly interpret that process env to be true.

### How?

Evaluate the actual value of `process.env.USE_HERMES` instead of just checking for its existence.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration) - TODO by @louiszawadzki 
