### PR TITLE
[docker] Fix `amd64` double building

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,37 +5,31 @@ stages:
 variables:
   INTERNAL_REGISTRY: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci
 
-build-docker-image-amd64:
+build-docker-image:
   stage: build
   only: ['tags']
   when: manual
   allow_failure: false
   tags: ['arch:amd64']
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/docker:20.10
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/docker:24.0.4-gbi-focal
   script:
     - cd container
-    - docker buildx build --build-arg "VERSION=${CI_COMMIT_TAG}" --tag "${INTERNAL_REGISTRY}/datadog-ci:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-amd64" --push .
-
-build-docker-image-arm64:
-  stage: build
-  only: ['tags']
-  when: manual
-  allow_failure: false
-  tags: ['arch:arm64']
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/docker:20.10
-  script:
-    - cd container
-    - docker buildx build --build-arg "VERSION=${CI_COMMIT_TAG}" --tag "${INTERNAL_REGISTRY}/datadog-ci:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-arm64" --push .
+    - docker buildx build
+      --platform linux/amd64,linux/arm64/v8
+      --build-arg "VERSION=${CI_COMMIT_TAG}"
+      --tag "${INTERNAL_REGISTRY}/datadog-ci:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}"
+      --push
+      .
 
 publish-docker-image:
   stage: release
   only: ['tags']
-  needs: ['build-docker-image-amd64', 'build-docker-image-arm64']
+  needs: ['build-docker-image']
   trigger:
     project: DataDog/public-images
     branch: main
     strategy: depend
   variables:
-    IMG_SOURCES: ${INTERNAL_REGISTRY}/datadog-ci:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-amd64,${INTERNAL_REGISTRY}/datadog-ci:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-arm64
+    IMG_SOURCES: ${INTERNAL_REGISTRY}/datadog-ci:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}
     IMG_DESTINATIONS: ci:${CI_COMMIT_TAG},ci:latest
     IMG_SIGNING: 'false'


### PR DESCRIPTION
### What and why?

In #1175, I thought that since `tags: ['arch:arm64']` asks for a arm64 runner, the build `platform` would automatically be set to `arm64`, but it's not enough: https://hub.docker.com/r/datadog/ci/tags?name=v2.30.0 was built for `amd64` twice.

<img width="567" alt="image" src="https://github.com/DataDog/datadog-ci/assets/9317502/4bb4c072-ed96-446b-baf7-126c3a6cb1e0">

### How?

- Use a single job (`build-docker-image`) to build a **multi-arch image** thanks to `--platform linux/amd64,linux/arm64/v8`.
- Remove the `-amd64` and `-arm64` suffix from our internal tags.

I took inspiration from the [`observability-pipelines-worker`'s image build process](https://github.com/DataDog/observability-pipelines-worker/blob/a1e730d415d59af6367f0ba73ee70def2e614118/.gitlab/release.yml#L31-L32).

This will be fixed in `v2.30.1`.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
