### PR TITLE
v2.30.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci",
-  "version": "2.30.0",
+  "version": "2.30.1",
   "description": "Run datadog actions from the CI.",
   "repository": "https://github.com/DataDog/datadog-ci",
   "license": "Apache-2.0",


### PR DESCRIPTION
## What's Changed
### RUM
* `react-native xcode`: Respect `USE_HERMES` env var being set to false by @FrikkieSnyman in https://github.com/DataDog/datadog-ci/pull/1190

### Chores
* [dep] Upgrade packages to remove `ip` dependency by @Drarig29 in https://github.com/DataDog/datadog-ci/pull/1192
* [docker] Fix `amd64` double building by @Drarig29 in https://github.com/DataDog/datadog-ci/pull/1193

## New Contributors
* @FrikkieSnyman made their first contribution in https://github.com/DataDog/datadog-ci/pull/1190

**Full Changelog**: https://github.com/DataDog/datadog-ci/compare/v2.30.0...v2.30.1