### PR TITLE
[ci] Upgrade github actions to Node 20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.version }}
       - run: yarn install --immutable
@@ -69,9 +69,9 @@ jobs:
     needs: build-and-test
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.version }}
       - uses: actions/download-artifact@v1
@@ -114,9 +114,9 @@ jobs:
     name: Test standalone binary in ubuntu
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: '14.18.3'
       - run: yarn install --immutable
@@ -134,9 +134,9 @@ jobs:
     name: Test standalone binary in windows
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: '14.18.3'
       - run: yarn install --immutable
@@ -154,9 +154,9 @@ jobs:
     name: Test standalone binary in macOS
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: '14.18.3'
       - run: yarn install --immutable
@@ -175,7 +175,7 @@ jobs:
     name: Datadog Static Analyzer
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Run Datadog static analyzer
         id: datadog-static-analysis
         uses: DataDog/datadog-static-analyzer-github-action@main
@@ -193,9 +193,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: '14'
       # The install step has been added here such that the `.yarn/install-state.gz` file is generated. This file is used

--- a/.github/workflows/issue-labeler.yml
+++ b/.github/workflows/issue-labeler.yml
@@ -10,7 +10,7 @@ jobs:
     permissions:
       issues: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Parse issue form
         uses: stefanbuck/github-issue-parser@v3
         id: issue-parser

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -6,8 +6,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: '14'
       - run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,8 +6,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: '14'
       - run: yarn
@@ -30,7 +30,7 @@ jobs:
           - synthetics-test-automation-bitrise-step-upload-application
     steps:
       - name: Create bump datadog-ci PR
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.CROSS_REPOSITORY_GITHUB_TOKEN }}
           script: |
@@ -49,9 +49,9 @@ jobs:
   build-binary-ubuntu:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: '14.18.3'
       - name: Install project dependencies
@@ -75,9 +75,9 @@ jobs:
   build-binary-windows:
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: '14.18.3'
       - name: Install project dependencies
@@ -101,9 +101,9 @@ jobs:
   build-binary-macos:
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: '14.18.3'
       - name: Install project dependencies


### PR DESCRIPTION
### What and why?

Fixes the [following warnings](https://github.com/DataDog/datadog-ci/actions/runs/7914928358):

![image](https://github.com/DataDog/datadog-ci/assets/9317502/b6af7ac7-8950-4abb-9ebd-efd1f13babe7)

### How?

Upgrade:
- `actions/checkout` to v4
- `actions/setup-node` to v4
- `actions/github-script` to v7

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
