### PR TITLE
[docs] Replace `APP` with `App`

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ To run `datadog-ci` from a container, you can use the `datadog/ci` image availab
 docker pull datadog/ci
 ```
 
-This example demonstrates how to run a command using the container and passing in the API and APP keys:
+This example demonstrates how to run a command using the container and passing in the API and App keys:
 
 ```
 export DD_API_KEY=$(cat /secret/dd_api_key)

--- a/src/commands/gate/README.md
+++ b/src/commands/gate/README.md
@@ -48,7 +48,7 @@ To verify the command works as expected, use `--dry-run`:
 
 ```bash
 export DD_API_KEY='<API key>'
-export DD_APP_KEY='<APP key>'
+export DD_APP_KEY='<App key>'
 
 yarn launch gate evaluate --scope team:backend --dry-run
 ```

--- a/src/commands/gate/__tests__/evaluate.test.ts
+++ b/src/commands/gate/__tests__/evaluate.test.ts
@@ -21,7 +21,7 @@ describe('evaluate', () => {
       const write = jest.fn()
       const command = createCommand(GateEvaluateCommand, {stdout: {write}} as any)
 
-      expect(command['getApiHelper'].bind(command)).toThrow('APP key is missing')
+      expect(command['getApiHelper'].bind(command)).toThrow('App key is missing')
       expect(write.mock.calls[0][0]).toContain('DD_APP_KEY')
     })
   })

--- a/src/commands/gate/__tests__/evaluate.test.ts
+++ b/src/commands/gate/__tests__/evaluate.test.ts
@@ -16,7 +16,7 @@ describe('evaluate', () => {
       expect(command['getApiHelper'].bind(command)).toThrow('API key is missing')
       expect(write.mock.calls[0][0]).toContain('DD_API_KEY')
     })
-    test('should throw an error if APP key is undefined', () => {
+    test('should throw an error if App key is undefined', () => {
       process.env = {DD_API_KEY: 'PLACEHOLDER'}
       const write = jest.fn()
       const command = createCommand(GateEvaluateCommand, {stdout: {write}} as any)

--- a/src/commands/gate/evaluate.ts
+++ b/src/commands/gate/evaluate.ts
@@ -111,7 +111,7 @@ export class GateEvaluateCommand extends Command {
 
     if (!this.config.appKey) {
       this.context.stdout.write(`Missing ${chalk.red.bold('DD_APP_KEY')} in your environment.\n`)
-      throw new Error('APP key is missing')
+      throw new Error('App key is missing')
     }
 
     return apiConstructor(getBaseIntakeUrl(), this.config.apiKey, this.config.appKey)

--- a/src/commands/sbom/README.md
+++ b/src/commands/sbom/README.md
@@ -20,7 +20,7 @@ DD_BETA_COMMANDS_ENABLED=1 datadog-ci sbom upload --service <my-service> <path/t
 The following environment variables must be defined:
 
  - `DD_SITE`: the [Datadog site](https://docs.datadoghq.com/getting_started/site/#access-the-datadog-site)
- - `DD_APP_KEY`: the App Key to use
+ - `DD_APP_KEY`: the App key to use
  - `DD_API_KEY`: the API key to use
  - `DD_SERVICE`: the Datadog service you use (if `--service` not specified)
 


### PR DESCRIPTION
### What and why?

`APP` isn't an acronym, but just the abbreviation for "Application" key.

### How?

Global search and replace

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
