### PR TITLE
[STAL-1340] Add link to results

### DIFF
--- a/src/commands/sarif/renderer.ts
+++ b/src/commands/sarif/renderer.ts
@@ -4,6 +4,8 @@ import chalk from 'chalk'
 
 import {SpanTags} from '../../helpers/interfaces'
 
+import {getBaseUrl} from '../junit/utils'
+
 import {Payload} from './interfaces'
 
 const ICONS = {
@@ -45,6 +47,7 @@ export const renderSuccessfulCommand = (
 ) => {
   let fullStr = ''
   fullStr += chalk.green(`${ICONS.SUCCESS} Uploaded ${fileCount} files in ${duration} seconds.\n`)
+  fullStr += chalk.green(`${ICONS.INFO}  Results available on ${getBaseUrl()}ci/code-analysis\n`)
   fullStr += chalk.green(
     '=================================================================================================\n'
   )

--- a/src/commands/sbom/upload.ts
+++ b/src/commands/sbom/upload.ts
@@ -9,6 +9,8 @@ import {Command, Option} from 'clipanion'
 
 import {getSpanTags} from '../../helpers/tags'
 
+import {getBaseUrl} from '../junit/utils'
+
 import {getApiHelper} from './api'
 import {generatePayload} from './payload'
 import {ScaRequest} from './types'
@@ -123,7 +125,7 @@ export class UploadSbomCommand extends Command {
       }
     }
 
-    this.context.stdout.write('Upload finished\n')
+    this.context.stdout.write(`Upload finished, results available on ${getBaseUrl()}ci/code-analysis\n`)
 
     return 0
   }


### PR DESCRIPTION
### What and why?

Add a link to the results page to direct the user to our product page on datadog.

### How?

We are adding a link to the code-analysis dashboard to check the results.

## Testing

### SARIF

```
...
✅ Uploaded 1 files in 0.336 seconds.
ℹ️ Results available on https://app.datad0g.com/ci/code-analysis
=================================================================================================
```

### SBOM

**Prod**
```
File /Users/julien.delange/datadog-ci-sbom.json successfully uploaded in 381 ms
Upload finished, please check results on https://app.datadoghq.com/ci/code-analysis
```

**Staging**

```
File /Users/julien.delange/datadog-ci-sbom.json successfully uploaded in 366 ms
Upload finished, results available on https://app.datad0g.com/ci/code-analysis
```