### PR TITLE
v2.31.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci",
-  "version": "2.30.1",
+  "version": "2.31.0",
   "description": "Run datadog actions from the CI.",
   "repository": "https://github.com/DataDog/datadog-ci",
   "license": "Apache-2.0",


### PR DESCRIPTION
<!-- Use the "Generate release notes" button at the top right, then categorize the changes -->

## What's Changed

### datadog-ci
* [CIVIS-9031] Fix bug in metrics command examples by @ManuelPalenzuelaDD in https://github.com/DataDog/datadog-ci/pull/1204
* [CIVIS-9031] Deprecate `metrics` cmd in favour of `measures` cmd by @ManuelPalenzuelaDD in https://github.com/DataDog/datadog-ci/pull/1205
* [CIVIS-9031] Deprecate 'metrics' naming in favour of 'measures' in junit cmd by @ManuelPalenzuelaDD in https://github.com/DataDog/datadog-ci/pull/1203

### Synthetics
* [SYNTH-12557] Add missing mobileApplicationVersion  configurations for Bitrise integrations by @teodor2312 in https://github.com/DataDog/datadog-ci/pull/1181
* [SYNTH-12557] Add missing deviceIds configurations for Bitrise integrations by @teodor2312 in https://github.com/DataDog/datadog-ci/pull/1196
* [ci] Upgrade github actions to Node 20 by @Drarig29 in https://github.com/DataDog/datadog-ci/pull/1195
* Add service to deployment mark command by @andrea-mosk in https://github.com/DataDog/datadog-ci/pull/1201
* [SYNTH-12906] Include browser in the description for allowInsecureCertificates by @teodor2312 in https://github.com/DataDog/datadog-ci/pull/1200

### Lambda
* [lambda] Deprecate Ruby 2.7 instrumentation by @duncanista in https://github.com/DataDog/datadog-ci/pull/1183
* [lambda] Deprecate Python 3.7 instrumentation by @duncanista in https://github.com/DataDog/datadog-ci/pull/1184
* [lambda] Deprecate dotnetcore 3.1 instrumentation by @duncanista in https://github.com/DataDog/datadog-ci/pull/1185
* [lambda] Deprecate Node.js 12x instrumentation by @duncanista in https://github.com/DataDog/datadog-ci/pull/1186
* [lambda] Deprecate Node.js 14x instrumentation by @duncanista in https://github.com/DataDog/datadog-ci/pull/1187

### Static Analysis
* [STAL-1340] Add link to results by @juli1 in https://github.com/DataDog/datadog-ci/pull/1199


**Full Changelog**: https://github.com/DataDog/datadog-ci/compare/v2.30.1...v2.31.0

[CIVIS-9031]: https://datadoghq.atlassian.net/browse/CIVIS-9031?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CIVIS-9031]: https://datadoghq.atlassian.net/browse/CIVIS-9031?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CIVIS-9031]: https://datadoghq.atlassian.net/browse/CIVIS-9031?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SYNTH-12557]: https://datadoghq.atlassian.net/browse/SYNTH-12557?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SYNTH-12557]: https://datadoghq.atlassian.net/browse/SYNTH-12557?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SYNTH-12906]: https://datadoghq.atlassian.net/browse/SYNTH-12906?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ