### PR TITLE
Revert "[CIVIS-9031] Deprecate 'metrics' naming in favour of 'measures' in junit cmd"

### DIFF
--- a/src/commands/junit/README.md
+++ b/src/commands/junit/README.md
@@ -24,12 +24,12 @@ datadog-ci junit upload --service my-service --tags key1:value1 --tags key2:valu
 - `--service` (default: `DD_SERVICE` env var) should be set as the name of the service you're uploading jUnit XML reports for.
 - `--tags` is an array of key value pairs of the shape `key:value`. This will set global tags applied to all spans.
   - The resulting dictionary will be merged with whatever is in the `DD_TAGS` environment variable. If a `key` appears both in `--tags` and `DD_TAGS`, whatever value is in `DD_TAGS` will take precedence.
-- `--measures` is an array of key numerical value pairs of the shape `key:123`. This will set global measures applied to all spans.
-  - The resulting dictionary will be merged with whatever is in the `DD_MEASURES` environment variable. If a `key` appears both in `--measures` and `DD_MEASURES`, whatever value is in `DD_MEASURES` will take precedence.
+- `--metrics` is an array of key numerical value pairs of the shape `key:123`. This will set global metrics applied to all spans.
+  - The resulting dictionary will be merged with whatever is in the `DD_METRICS` environment variable. If a `key` appears both in `--metrics` and `DD_METRICS`, whatever value is in `DD_METRICS` will take precedence.
 - `--report-tags` is an array of key value pairs like the `--tags` argument, but the tags are only applied to the session instead of to every test.
   - The resulting dictionary will NOT be merged with `DD_TAGS`.
-- `--report-measures` is an array of key numerical value pairs like the `--measures` argument, but the measures are only applied to the session instead of to every test.
-  - The resulting dictionary will NOT be merged with `DD_MEASURES`.
+- `--report-metrics` is an array of key numerical value pairs like the `--metrics` argument, but the metrics are only applied to the session instead of to every test.
+  - The resulting dictionary will NOT be merged with `DD_METRICS`.
 - `--env` (default: `DD_ENV` env var) is a string that represents the environment where you want your tests to appear in.
 - `--max-concurrency` (default: `20`): number of concurrent uploads to the API.
 - `--dry-run` (default: `false`): it will run the command without the final upload step. All other checks are performed.
@@ -47,8 +47,8 @@ Additionally you might configure the `junit` command with environment variables:
 - `DD_SERVICE`: if you haven't specified a service through `--service` you might do it with this env var.
 - `DD_TAGS`: set global tags applied to all test spans. The format must be `key1:value1,key2:value2`.
   - The resulting dictionary will be merged with whatever is in the `--tags` parameter. If a `key` appears both in `--tags` and `DD_TAGS`, whatever value is in `DD_TAGS` will take precedence.
-- `DD_MEASURES`: set global numerical tags applied to all test spans. The format must be `key1:123,key2:321`.
-  - The resulting dictionary will be merged with whatever is in the `--measures` parameter. If a `key` appears both in `--measures` and `DD_MEASURES`, whatever value is in `DD_MEASURES` will take precedence.
+- `DD_METRICS`: set global numerical tags applied to all test spans. The format must be `key1:123,key2:321`.
+  - The resulting dictionary will be merged with whatever is in the `--metrics` parameter. If a `key` appears both in `--metrics` and `DD_METRICS`, whatever value is in `DD_METRICS` will take precedence.
 - `DD_SITE`: choose your Datadog site, e.g. datadoghq.com or datadoghq.eu.
 - `DD_CIVISIBILITY_LOGS_ENABLED`: it will enable collecting logs from the content in the XML reports.
 - `DD_SUBDOMAIN`: if you have a [custom sub-domain enabled](https://docs.datadoghq.com/account_management/multi_organization/#custom-sub-domains) for your organization, this value should be set with the subdomain so that the link to the Datadog Application that the library logs once the upload finishes is accurate.

--- a/src/commands/junit/__tests__/upload.test.ts
+++ b/src/commands/junit/__tests__/upload.test.ts
@@ -298,29 +298,11 @@ describe('upload', () => {
     })
     test('should parse metrics argument', async () => {
       const context = createMockContext()
-      const stdoutWriteSpy = jest.spyOn(context.stdout, 'write')
       const command = new UploadJUnitXMLCommand()
-      const spanTags: SpanTags = command['getCustomMeasures'].call({
+      const spanTags: SpanTags = command['getCustomMetrics'].call({
         config: {},
         context,
         metrics: ['key1:10', 'key2:20'],
-      })
-
-      expect(stdoutWriteSpy).toHaveBeenCalledWith(
-        '⚠️ The "--metrics" option is deprecated. Please use the "--measures" option instead.\n'
-      )
-      expect(spanTags).toMatchObject({
-        key1: 10,
-        key2: 20,
-      })
-    })
-    test('should parse measures argument', async () => {
-      const context = createMockContext()
-      const command = new UploadJUnitXMLCommand()
-      const spanTags: SpanTags = command['getCustomMeasures'].call({
-        config: {},
-        context,
-        measures: ['key1:10', 'key2:20'],
       })
 
       expect(spanTags).toMatchObject({
@@ -331,36 +313,13 @@ describe('upload', () => {
     test('should parse DD_METRICS environment variable', async () => {
       process.env.DD_METRICS = 'key1:321,key2:123,key3:321.1,key4:abc,key5:-12.1'
       const context = createMockContext()
-      const stdoutWriteSpy = jest.spyOn(context.stdout, 'write')
       const command = new UploadJUnitXMLCommand()
-      const spanTags: SpanTags = command['getCustomMeasures'].call({
+      const spanTags: SpanTags = command['getCustomMetrics'].call({
         config: {
           envVarMetrics: process.env.DD_METRICS,
         },
         context,
       })
-
-      expect(stdoutWriteSpy).toHaveBeenCalledWith(
-        '⚠️ The "DD_METRICS" environment variable is deprecated. Please use the "DD_MEASURES" environment variable instead.\n'
-      )
-      expect(spanTags).toMatchObject({
-        key1: 321,
-        key2: 123,
-        key3: 321.1,
-        key5: -12.1,
-      })
-    })
-    test('should parse DD_MEASURES environment variable', async () => {
-      process.env.DD_MEASURES = 'key1:321,key2:123,key3:321.1,key4:abc,key5:-12.1'
-      const context = createMockContext()
-      const command = new UploadJUnitXMLCommand()
-      const spanTags: SpanTags = command['getCustomMeasures'].call({
-        config: {
-          envVarMeasures: process.env.DD_MEASURES,
-        },
-        context,
-      })
-
       expect(spanTags).toMatchObject({
         key1: 321,
         key2: 123,
@@ -384,29 +343,11 @@ describe('upload', () => {
     })
     test('should parse report metrics argument', async () => {
       const context = createMockContext()
-      const stdoutWriteSpy = jest.spyOn(context.stdout, 'write')
       const command = new UploadJUnitXMLCommand()
-      const spanTags: SpanTags = command['getReportMeasures'].call({
+      const spanTags: SpanTags = command['getReportMetrics'].call({
         config: {},
         context,
         reportMetrics: ['key1:20', 'key2:30'],
-      })
-
-      expect(stdoutWriteSpy).toHaveBeenCalledWith(
-        '⚠️ The "--report-metrics" option is deprecated. Please use the "--report-measures" option instead.\n'
-      )
-      expect(spanTags).toMatchObject({
-        key1: 20,
-        key2: 30,
-      })
-    })
-    test('should parse report measures argument', async () => {
-      const context = createMockContext()
-      const command = new UploadJUnitXMLCommand()
-      const spanTags: SpanTags = command['getReportMeasures'].call({
-        config: {},
-        context,
-        reportMeasures: ['key1:20', 'key2:30'],
       })
 
       expect(spanTags).toMatchObject({

--- a/src/commands/junit/api.ts
+++ b/src/commands/junit/api.ts
@@ -31,16 +31,16 @@ export const uploadJUnitXML = (request: (args: AxiosRequestConfig) => AxiosPromi
     fileName = 'default_file_name'
   }
 
-  const reportTagsAndMeasures: Record<string, any> = {
+  const reportTagsAndMetrics: Record<string, any> = {
     tags: jUnitXML.reportTags,
-    measures: jUnitXML.reportMeasures,
+    metrics: jUnitXML.reportMetrics,
   }
 
   const custom: Record<string, any> = {
     metadata: jUnitXML.spanTags,
     tags: jUnitXML.customTags,
-    metrics: jUnitXML.customMeasures,
-    session: reportTagsAndMeasures,
+    metrics: jUnitXML.customMetrics,
+    session: reportTagsAndMetrics,
     '_dd.cireport_version': '3',
     '_dd.hostname': jUnitXML.hostname,
     '_dd.report_name': fileName,

--- a/src/commands/junit/interfaces.ts
+++ b/src/commands/junit/interfaces.ts
@@ -7,9 +7,9 @@ export interface Payload {
   logsEnabled: boolean
   spanTags: SpanTags
   customTags: Record<string, string>
-  customMeasures: Record<string, number>
+  customMetrics: Record<string, number>
   reportTags: Record<string, string>
-  reportMeasures: Record<string, number>
+  reportMetrics: Record<string, number>
   xmlPath: string
   xpathTags?: Record<string, string>
 }

--- a/src/commands/junit/renderer.ts
+++ b/src/commands/junit/renderer.ts
@@ -35,12 +35,6 @@ export const renderRetriedUpload = (payload: Payload, errorMessage: string, atte
   return chalk.yellow(`[attempt ${attempt}] Retrying jUnitXML upload ${jUnitXMLPath}: ${errorMessage}\n`)
 }
 
-export const renderDeprecatedMention = (deprecatedMention: string, newMention: string, deprecatedType: string) => {
-  return chalk.yellow(
-    `${ICONS.WARNING} The "${deprecatedMention}" ${deprecatedType} is deprecated. Please use the "${newMention}" ${deprecatedType} instead.\n`
-  )
-}
-
 export const renderSuccessfulUpload = (dryRun: boolean, fileCount: number, duration: number) => {
   return chalk.green(`${dryRun ? '[DRYRUN] ' : ''}${ICONS.SUCCESS} Uploaded ${fileCount} files in ${duration} seconds.`)
 }

--- a/src/commands/tag/README.md
+++ b/src/commands/tag/README.md
@@ -54,6 +54,6 @@ Tags sent
 
 Additional helpful documentation, links, and articles:
 
-- [Learn about Adding Custom Tags and Measures to Pipeline Traces][1]
+- [Learn about Adding Custom Tags and Metrics to Pipeline Traces][1]
 
-[1]: https://docs.datadoghq.com/continuous_integration/pipelines/custom_tags_and_measures/
+[1]: https://docs.datadoghq.com/continuous_integration/pipelines/custom_tags_and_metrics/


### PR DESCRIPTION
Reverts DataDog/datadog-ci#1203