### PR TITLE
v2.31.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci",
-  "version": "2.31.0",
+  "version": "2.31.1",
   "description": "Run datadog actions from the CI.",
   "repository": "https://github.com/DataDog/datadog-ci",
   "license": "Apache-2.0",


### PR DESCRIPTION
## What's Changed

* Revert "[CIVIS-9031] Deprecate 'metrics' naming in favour of 'measures' in junit cmd" by @liashenko in https://github.com/DataDog/datadog-ci/pull/1209

**Full Changelog**: https://github.com/DataDog/datadog-ci/compare/v2.31.0...v2.31.1