### PR TITLE
v2.31.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci",
-  "version": "2.31.1",
+  "version": "2.31.2",
   "description": "Run datadog actions from the CI.",
   "repository": "https://github.com/DataDog/datadog-ci",
   "license": "Apache-2.0",


### PR DESCRIPTION
## What's Changed

### datadog-ci

* [CIVIS-9031] Deprecate 'metrics' naming in favour of 'measures' in junit cmd by @ManuelPalenzuelaDD in https://github.com/DataDog/datadog-ci/pull/1211

[CIVIS-9031]: https://datadoghq.atlassian.net/browse/CIVIS-9031?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ