### PR TITLE
[git-metadata] Make exported function upload to gitdb

### DIFF
--- a/src/commands/git-metadata/__tests__/library.test.ts
+++ b/src/commands/git-metadata/__tests__/library.test.ts
@@ -2,6 +2,7 @@ import * as apikey from '../../../helpers/apikey'
 import * as upload from '../../../helpers/upload'
 
 import * as git from '../git'
+import * as gitdb from '../gitdb'
 import {CommitInfo} from '../interfaces'
 import {isGitRepo, uploadGitCommitHash} from '../library'
 
@@ -53,6 +54,12 @@ describe('library', () => {
 
         return new CommitInfo('hash', 'url', ['file1', 'file2'])
       })
+      jest.spyOn(gitdb, 'uploadToGitDB').mockImplementation((log, req, simplegit, dryRun, repositoryURL) => {
+        expect(repositoryURL).toEqual('url')
+        expect(dryRun).toBe(false)
+
+        return Promise.resolve()
+      })
       jest.spyOn(upload, 'upload').mockReturnValue((a, b) => {
         {
           return new Promise<upload.UploadStatus>((resolve) => {
@@ -74,6 +81,12 @@ describe('library', () => {
         expect(repositoryURL).toEqual('customUrl')
 
         return new CommitInfo('hash', 'customUrl', ['file1', 'file2'])
+      })
+      jest.spyOn(gitdb, 'uploadToGitDB').mockImplementation((log, req, simplegit, dryRun, repositoryURL) => {
+        expect(repositoryURL).toEqual('customUrl')
+        expect(dryRun).toBe(false)
+
+        return Promise.resolve()
       })
       jest.spyOn(upload, 'upload').mockReturnValue((a, b) => {
         {


### PR DESCRIPTION
Currently, the `datadog-ci git-metadata upload` command both:
- synchronises GitDB
- uploads a payload with tracked files to the legacy sourcemap intake

But the `uploadGitCommitSha` function that is exported and used in the serverless plugin (here: https://github.com/DataDog/serverless-plugin-datadog/blob/51b7844efd6224d1a4fb5c1215453aac3038f915/src/index.ts#L302) only upload to the sourcemap intake.

We want all upload tooling to synchronize GitDB, and eventually deprecate the sourcemap store for Git metadata.

This PR updates the exported function to also synchronize GitDB.

