### PR TITLE
[SYNTH-13000] Fix bug where Test Config was not being used when a public_id was already defined

### DIFF
--- a/src/commands/synthetics/__tests__/run-tests-lib.test.ts
+++ b/src/commands/synthetics/__tests__/run-tests-lib.test.ts
@@ -620,7 +620,7 @@ describe('run-test', () => {
       ])
     })
 
-    test('should not use testSearchQeury if global config has defined public_ids', async () => {
+    test('should not use testSearchQuery if global config has defined public_ids', async () => {
       const configOverride = {startUrl}
       const searchQuery = 'fake search'
 

--- a/src/commands/synthetics/__tests__/run-tests-lib.test.ts
+++ b/src/commands/synthetics/__tests__/run-tests-lib.test.ts
@@ -516,7 +516,7 @@ describe('run-test', () => {
     })
   })
 
-  describe('getFinalVersionOfTestsFromCi', () => {
+  describe('getTriggerConfigs', () => {
     beforeEach(() => {
       jest.restoreAllMocks()
     })
@@ -553,7 +553,7 @@ describe('run-test', () => {
       const configOverride = {startUrl}
 
       await expect(
-        runTests.getFinalVersionOfTestsFromCi(
+        runTests.getTriggerConfigs(
           fakeApi,
           {...ciConfig, global: configOverride, locations: ['aws:ap-northeast-1']},
           mockReporter
@@ -577,7 +577,7 @@ describe('run-test', () => {
       const configOverride = {startUrl}
 
       await expect(
-        runTests.getFinalVersionOfTestsFromCi(
+        runTests.getTriggerConfigs(
           fakeApi,
           {
             ...ciConfig,
@@ -606,7 +606,7 @@ describe('run-test', () => {
       const searchQuery = 'fake search'
 
       await expect(
-        runTests.getFinalVersionOfTestsFromCi(
+        runTests.getTriggerConfigs(
           fakeApi,
           {...ciConfig, global: configOverride, locations: ['aws:ap-northeast-1'], testSearchQuery: searchQuery},
           mockReporter
@@ -625,7 +625,7 @@ describe('run-test', () => {
       const searchQuery = 'fake search'
 
       await expect(
-        runTests.getFinalVersionOfTestsFromCi(
+        runTests.getTriggerConfigs(
           fakeApi,
           {...ciConfig, global: configOverride, publicIds: ['abc-def-ghi'], testSearchQuery: searchQuery},
           mockReporter
@@ -647,7 +647,7 @@ describe('run-test', () => {
 
       const searchQuery = 'fake search'
 
-      await runTests.getFinalVersionOfTestsFromCi(apiHelper, {...ciConfig, testSearchQuery: searchQuery}, mockReporter)
+      await runTests.getTriggerConfigs(apiHelper, {...ciConfig, testSearchQuery: searchQuery}, mockReporter)
       expect(mockReporter.error).toHaveBeenCalledWith(
         `More than ${MAX_TESTS_TO_TRIGGER} tests returned by search query, only the first ${MAX_TESTS_TO_TRIGGER} will be fetched.\n`
       )
@@ -658,7 +658,7 @@ describe('run-test', () => {
       const configOverride = {startUrl}
       const files = ['new glob', 'another one']
 
-      await runTests.getFinalVersionOfTestsFromCi(fakeApi, {...ciConfig, global: configOverride, files}, mockReporter)
+      await runTests.getTriggerConfigs(fakeApi, {...ciConfig, global: configOverride, files}, mockReporter)
       expect(getSuitesMock).toHaveBeenCalledTimes(2)
       expect(getSuitesMock).toHaveBeenCalledWith('new glob', mockReporter)
       expect(getSuitesMock).toHaveBeenCalledWith('another one', mockReporter)
@@ -669,7 +669,7 @@ describe('run-test', () => {
       const configOverride = {startUrl}
       const files: string[] = []
 
-      const tests = await runTests.getFinalVersionOfTestsFromCi(
+      const tests = await runTests.getTriggerConfigs(
         fakeApi,
         {...ciConfig, global: configOverride, files},
         mockReporter,
@@ -690,7 +690,7 @@ describe('run-test', () => {
       const configOverride = {startUrl}
       const files = ['glob']
 
-      const tests = await runTests.getFinalVersionOfTestsFromCi(
+      const tests = await runTests.getTriggerConfigs(
         fakeApi,
         {...ciConfig, global: configOverride, files},
         mockReporter,

--- a/src/commands/synthetics/run-tests-lib.ts
+++ b/src/commands/synthetics/run-tests-lib.ts
@@ -174,7 +174,7 @@ export const getFinalVersionOfTestsFromCi = async (
   reporter: MainReporter,
   suites?: Suite[]
 ) => {
-  let testConfig: TriggerConfig[]
+  let TestConfigs: TriggerConfig[]
   // TODO: Clean up locations as part of SYNTH-12989
   const configFromEnvironment = config.locations?.length ? {locations: config.locations} : {}
 
@@ -205,13 +205,13 @@ export const getFinalVersionOfTestsFromCi = async (
   }
 
   try {
-    testConfig = await getTestConfig(config, reporter, suites)
+    TestConfigs = await getTestConfigs(config, reporter, suites)
   } catch (error) {
     throw new CriticalError(isForbiddenError(error) ? 'AUTHORIZATION_ERROR' : 'UNAVAILABLE_TEST_CONFIG', error.message)
   }
 
   if (!testsToTrigger.length) {
-    testsToTrigger = testConfig.map((test) => ({
+    testsToTrigger = TestConfigs.map((test) => ({
       ...test,
       config: {
         ...config.global,
@@ -220,7 +220,7 @@ export const getFinalVersionOfTestsFromCi = async (
       },
     }))
   } else {
-    testsToTrigger = overrideWithTestConfig(testsToTrigger, testConfig)
+    testsToTrigger = overrideWithTestConfigs(testsToTrigger, TestConfigs)
   }
 
   if (!testsToTrigger.length) {
@@ -242,7 +242,7 @@ const getTestsFromSearchQuery = async (api: APIHelper, config: RunTestsCommandCo
   return testsToTriggerBySearchQuery
 }
 
-const getTestConfig = async (
+const getTestConfigs = async (
   config: RunTestsCommandConfig,
   reporter: MainReporter,
   suites: Suite[] = []
@@ -253,22 +253,22 @@ const getTestConfig = async (
 
   suites.push(...suitesFromFiles)
 
-  const testsFromTestConfig = suites
+  const TestConfigs = suites
     .map((suite) =>
       suite.content.tests.map((test) => ({
-        config: {...test.config},
+        config: test.config,
         id: normalizePublicId(test.id) ?? '',
         suite: suite.name,
       }))
     )
     .reduce((acc, suiteTests) => acc.concat(suiteTests), [])
 
-  return testsFromTestConfig
+  return TestConfigs
 }
 
-const overrideWithTestConfig = (testsToTrigger: TriggerConfig[], testConfig: TriggerConfig[]): TriggerConfig[] => {
+const overrideWithTestConfigs = (testsToTrigger: TriggerConfig[], TestConfigs: TriggerConfig[]): TriggerConfig[] => {
   return testsToTrigger.map((testToTrigger) => {
-    const matchingTest = testConfig.find((test) => test.id === testToTrigger.id)
+    const matchingTest = TestConfigs.find((test) => test.id === testToTrigger.id)
     if (matchingTest) {
       return {
         ...testToTrigger,


### PR DESCRIPTION
### What and why?

Currently the logic that fetches the Test Config and uses to override the previous configurations only gets executed if publicIds were not defined before that point through the Global Level Configuration (Global Config, Env Variables, CLI params). It should happen always instead, so fix that.

### How?

Moved out the code that fetches the Test Config out of that if statement and did some small refactoring. Also added tests to make sure that we account for that edge case

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
