### PR TITLE
[chores] Improve release process

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -1,4 +1,4 @@
-name: Publish package on NPM
+name: Publish package on NPM (pre-release)
 on:
   release:
     types: [prereleased]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,49 +47,6 @@ jobs:
 
             return release.id
 
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '14'
-      - run: yarn
-      - run: yarn npm publish
-        env:
-          YARN_NPM_AUTH_TOKEN: ${{ secrets.YARN_NPM_AUTH_TOKEN }}
-
-  bump-ci-integrations:
-    name: Bump datadog-ci in integration
-    runs-on: ubuntu-latest
-    needs: build
-    strategy:
-      fail-fast: false
-      matrix:
-        integration:
-          - synthetics-ci-github-action
-          - datadog-ci-azure-devops
-          - synthetics-test-automation-circleci-orb
-          - synthetics-test-automation-bitrise-step-run-tests
-          - synthetics-test-automation-bitrise-step-upload-application
-    steps:
-      - name: Create bump datadog-ci PR
-        uses: actions/github-script@v7
-        with:
-          github-token: ${{ secrets.CROSS_REPOSITORY_GITHUB_TOKEN }}
-          script: |
-            const tagName = '${{ github.event.release.tag_name }}'.replace('v', '')
-
-            github.rest.actions.createWorkflowDispatch({
-              owner: context.repo.owner,
-              repo: '${{ matrix.integration }}',
-              workflow_id: 'bump-datadog-ci.yml',
-              ref: 'main',
-              inputs: {
-                datadog_ci_version: tagName,
-              },
-            });
-
   build-binary-ubuntu:
     runs-on: ubuntu-latest
     needs: create-draft-release
@@ -193,4 +150,48 @@ jobs:
               release_id: "${{ needs.create-draft-release.outputs.release-id }}",
               name: 'datadog-ci_darwin-x64',
               data: await fs.readFile('./datadog-ci_darwin-x64'),
+            })
+
+  npm-publish:
+    runs-on: ubuntu-latest
+    needs: [build-binary-ubuntu, build-binary-windows, build-binary-macos]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '14'
+      - run: yarn
+      - run: yarn npm publish
+        env:
+          YARN_NPM_AUTH_TOKEN: ${{ secrets.YARN_NPM_AUTH_TOKEN }}
+
+  bump-ci-integrations:
+    name: Bump datadog-ci in integration
+    runs-on: ubuntu-latest
+    needs: npm-publish
+    strategy:
+      fail-fast: false
+      matrix:
+        integration:
+          - synthetics-ci-github-action
+          - datadog-ci-azure-devops
+          - synthetics-test-automation-circleci-orb
+          - synthetics-test-automation-bitrise-step-run-tests
+          - synthetics-test-automation-bitrise-step-upload-application
+    steps:
+      - name: Create bump datadog-ci PR
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.CROSS_REPOSITORY_GITHUB_TOKEN }}
+          script: |
+            const tagName = '${{ github.event.release.tag_name }}'.replace('v', '')
+
+            github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: '${{ matrix.integration }}',
+              workflow_id: 'bump-datadog-ci.yml',
+              ref: 'main',
+              inputs: {
+                datadog_ci_version: tagName,
+              },
             })

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,10 @@
 name: Publish package on NPM
+
 on:
-  release:
-    types: [released]
+  push:
+    tags:
+      - v* # Any version tag
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,6 +92,7 @@ jobs:
 
   build-binary-ubuntu:
     runs-on: ubuntu-latest
+    needs: create-draft-release
     steps:
       - uses: actions/checkout@v4
       - name: Install node
@@ -110,14 +111,23 @@ jobs:
           rm -rf src
       - name: Test generated standalone binary
         run: yarn dist-standalone:test
-      - name: Upload binaries to GitHub release
-        uses: shogo82148/actions-upload-release-asset@v1
+      - name: Upload release asset
+        uses: actions/github-script@v7
         with:
-          upload_url: ${{ github.event.release.upload_url }}
-          asset_path: ./datadog-ci_linux-x64
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require("fs").promises
+            github.rest.repos.uploadReleaseAsset({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              release_id: "${{ needs.create-draft-release.outputs.release-id }}",
+              name: 'datadog-ci_linux-x64',
+              data: await fs.readFile('./datadog-ci_linux-x64'),
+            })
 
   build-binary-windows:
     runs-on: windows-latest
+    needs: create-draft-release
     steps:
       - uses: actions/checkout@v4
       - name: Install node
@@ -136,14 +146,23 @@ jobs:
           rm src -r
       - name: Test generated standalone binary
         run: yarn dist-standalone:test
-      - name: Upload binaries to GitHub release
-        uses: shogo82148/actions-upload-release-asset@v1
+      - name: Upload release asset
+        uses: actions/github-script@v7
         with:
-          upload_url: ${{ github.event.release.upload_url }}
-          asset_path: ./datadog-ci_win-x64.exe
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require("fs").promises
+            github.rest.repos.uploadReleaseAsset({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              release_id: "${{ needs.create-draft-release.outputs.release-id }}",
+              name: 'datadog-ci_win-x64',
+              data: await fs.readFile('./datadog-ci_win-x64'),
+            })
 
   build-binary-macos:
     runs-on: macos-latest
+    needs: create-draft-release
     steps:
       - uses: actions/checkout@v4
       - name: Install node
@@ -162,8 +181,16 @@ jobs:
           rm -rf src
       - name: Test generated standalone binary
         run: yarn dist-standalone:test
-      - name: Upload binaries to GitHub release
-        uses: shogo82148/actions-upload-release-asset@v1
+      - name: Upload release asset
+        uses: actions/github-script@v7
         with:
-          upload_url: ${{ github.event.release.upload_url }}
-          asset_path: ./datadog-ci_darwin-x64
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require("fs").promises
+            github.rest.repos.uploadReleaseAsset({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              release_id: "${{ needs.create-draft-release.outputs.release-id }}",
+              name: 'datadog-ci_darwin-x64',
+              data: await fs.readFile('./datadog-ci_darwin-x64'),
+            })

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,47 @@ on:
       - v* # Any version tag
 
 jobs:
+  create-draft-release:
+    runs-on: ubuntu-latest
+    outputs:
+      release-id: ${{ steps.draft-release.outputs.result }}
+    steps:
+      - name: Create a draft release
+        uses: actions/github-script@v7
+        id: draft-release
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { data: releaseNotes } = await github.rest.repos.generateReleaseNotes({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              tag_name: '${{ github.ref_name }}',
+            })
+
+            const { data: release } = await github.rest.repos.createRelease({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              tag_name: '${{ github.ref_name }}',
+              name: '${{ github.ref_name }}',
+              draft: true,
+              prerelease: false,
+              body: releaseNotes.body,
+            })
+
+            await core.summary
+              .addHeading('Draft release created')
+              .addRaw('Find it here: ')
+              .addLink('${{ github.ref_name }} (draft)', release.html_url)
+              .addBreak()
+              .addBreak()
+              .addRaw('Copy the release notes below, and paste them inside your release PR.')
+              .addBreak()
+              .addBreak()
+              .addCodeBlock(releaseNotes.body, 'markdown')
+              .write()
+
+            return release.id
+
   build:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -152,9 +152,10 @@ jobs:
               data: await fs.readFile('./datadog-ci_darwin-x64'),
             })
 
+  # Requires an approval
   npm-publish:
     runs-on: ubuntu-latest
-    needs: [build-binary-ubuntu, build-binary-windows, build-binary-macos]
+    environment: npm
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,6 +74,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const fs = require("fs").promises
+
             github.rest.repos.uploadReleaseAsset({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -109,6 +110,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const fs = require("fs").promises
+
             github.rest.repos.uploadReleaseAsset({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -144,6 +146,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const fs = require("fs").promises
+
             github.rest.repos.uploadReleaseAsset({
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,16 +90,16 @@ To release a new version of `datadog-ci`:
 2. Update the `package.json` version to `X.X.X`, commit the change `vX.X.X` and tag it with `git tag vX.X.X`.
    - You may refer to [Semantic Versioning](https://semver.org/#summary) to determine what level to increment.
 4. Push the branch **along with the tag** with `git push --tags origin name-of-the-branch`, create a PR, and get at least one approval.
-   - [Create a draft GitHub Release (prefilled link)](https://github.com/DataDog/datadog-ci/releases/new?title=%3Csame-as-tag%3E&body=%3C!--%20Use%20the%20%22Generate%20release%20notes%22%20button%20at%20the%20top%20right,%20then%20categorize%20the%20changes%20--%3E) and **save it as a draft**.
-   - Please categorize the changes by product or "Documentation" / "Dependencies" / "Chores". You can find commands grouped by product in the [`.github/CODEOWNERS`](https://github.com/DataDog/datadog-ci/blob/master/.github/CODEOWNERS) file.
-   - Copy the categorized release notes, and paste them in the description of your PR. This ensures the feature PRs have a link to your release PR.
+   - **Find and open** the workflow run corresponding to your tag [in this list](https://github.com/DataDog/datadog-ci/actions/workflows/release.yml).
+   - Copy the release notes from the summary, and paste them in the description of your PR. This ensures the feature PRs have a link to your release PR.
    - See this [example PR](https://github.com/DataDog/datadog-ci/pull/1047).
 5. Once you've received at least one approval, merge the PR **with the "Create a merge commit" strategy**.
-   - You may notice that some **_GitLab_** jobs are pending, this is expected (see **step 7**). You can merge the PR when *only those jobs* are left.
+   - You may notice that a **GitHub** job is waiting for an approval, and some **_GitLab_** jobs are pending: this is expected (see **step 6 and 8**). You can merge the PR when *only those jobs* are left.
    - The "Create a merge commit" strategy is required for **step 7**, and for the GitHub Release to point to an existing commit once the PR is merged.
-6. Go back to your draft GitHub Release, and publish it.
-7. Once the release is published, [this GitHub Workflow](https://github.com/DataDog/datadog-ci/actions/workflows/release.yml) publishes the NPM package and adds binaries to the release's assets. Wait for it to succeed.
-8. When the NPM package is published, go to the [_GitLab_ pipelines](https://gitlab.ddbuild.io/DataDog/datadog-ci/-/pipelines?scope=tags&status=manual), find the pipeline for your tag, and start the `build` stage to run the Docker image build jobs.
+6. The `npm-publish` job is waiting for an approval: accept it and wait for it and its downstream jobs to succeed.
+7. Go to the draft GitHub Release, and publish it as **latest**.
+   - There should be 3 binaries available in the release's assets.
+8. Finally, go to the [_GitLab_ pipelines](https://gitlab.ddbuild.io/DataDog/datadog-ci/-/pipelines?scope=tags&status=manual), find the pipeline for your tag, and start the `build` stage to run the Docker image build jobs.
    - Make sure all the jobs and downstream jobs succeed.
 
 Thanks for creating a release! 🎉


### PR DESCRIPTION
### What and why?

Related: #1217 

> [!NOTE]  
> 💡 Can be reviewed commit by commit.

The main reason for this PR is that a customer reported their CI was failing for ~4 minutes each time we publish a release.

Their logs:

```bash
Run curl -L --fail "https://github.com/DataDog/datadog-ci/releases/latest/download/datadog-ci_linux-x64" --output "/usr/local/bin/datadog-ci" && chmod +x /usr/local/bin/datadog-ci
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0

  0     9    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
curl: (22) The requested URL returned error: 404
```

This is caused by the fact that in our release process, we [first publish the release **as latest**](https://github.com/DataDog/datadog-ci/blob/271e3e486ffca53f4aebe839b6e62544785786c3/CONTRIBUTING.md?plain=1#L100), and **only after that** [the binaries start being built and uploaded as release assets](https://github.com/DataDog/datadog-ci/blob/271e3e486ffca53f4aebe839b6e62544785786c3/CONTRIBUTING.md?plain=1#L101).

So for ~4 minutes, our latest release is published **without assets**, resulting in `https://github.com/DataDog/datadog-ci/releases/latest/download/datadog-ci_<platform>` to fail with a 404 error.

### How?

To fix the issue, we now:
- Upload binaries to the draft release.
- Publish the release as latest _when all binaries are there_ (still manually).

This PR also simplifies the release process by:
- Automatically generating the release notes (not a manual button click anymore)
- Automatically categorizing the changes per product in the release notes.
  - Thanks to #1217
- Automatically creating the draft release, with those release notes.

This PR also uses GitHub Deployments & Environments:

![image](https://github.com/DataDog/datadog-ci/assets/9317502/8b1e7b73-e2fa-43cc-b372-2c17803cf9ea)

**Note:** Turning the draft release into a public release is still manual for safety.

### Review checklist

- ~~[ ] Feature or bugfix MUST have appropriate tests (unit, integration)~~
