### PR TITLE
[synthetics] Make results from previous CI runs dimmer

### DIFF
--- a/src/commands/synthetics/__tests__/reporters/__snapshots__/default.test.ts.snap
+++ b/src/commands/synthetics/__tests__/reporters/__snapshots__/default.test.ts.snap
@@ -34,7 +34,7 @@ exports[`Default reporter resultEnd 3 API tests, 2 passed (1 from previous CI ru
   [1m[32m✓[39m[22m [1m[32m[1mGET[22m[1m - http://fake.url[39m[22m
 
 [1m[32m✓[39m[22m [[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m
-  [1m[32m◂[39m[22m Successful result from previous CI run: [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=0002&from_ci=true[39m[22m
+  [1m[32m◀[39m[22m Successful result from previous CI run: [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=0002&from_ci=true[39m[22m
 
 [1m[32m✓[39m[22m [2m(edited) [22m[[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m - [1m[32mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m
   ⎋ Total duration: 123 ms - View test run details: [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=1003&from_ci=true[39m[22m 

--- a/src/commands/synthetics/__tests__/reporters/__snapshots__/default.test.ts.snap
+++ b/src/commands/synthetics/__tests__/reporters/__snapshots__/default.test.ts.snap
@@ -34,7 +34,7 @@ exports[`Default reporter resultEnd 3 API tests, 2 passed (1 from previous CI ru
   [1m[32m✓[39m[22m [1m[32m[1mGET[22m[1m - http://fake.url[39m[22m
 
 [1m[32m✓[39m[22m [[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m
-  [1m[32m◀[39m[22m Successful result from previous CI run: [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=0002&from_ci=true[39m[22m
+[2m  [1m[32m◀[39m[22m[2m Successful result from [1m[32mprevious[39m[22m[2m CI run: [36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=0002&from_ci=true[39m[22m
 
 [1m[32m✓[39m[22m [2m(edited) [22m[[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m - [1m[32mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m
   ⎋ Total duration: 123 ms - View test run details: [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=1003&from_ci=true[39m[22m 

--- a/src/commands/synthetics/reporters/default.ts
+++ b/src/commands/synthetics/reporters/default.ts
@@ -239,7 +239,9 @@ const renderExecutionResult = (test: Test, execution: Result, baseUrl: string) =
   if (isResultSkippedBySelectiveRerun(execution)) {
     const resultUrl = getResultUrl(baseUrl, test, resultId)
 
-    const resultInfo = `  ${setColor('◀')} Successful result from previous CI run: ${chalk.dim.cyan(resultUrl)}`
+    const resultInfo = chalk.dim(
+      `  ${setColor('◀')} Successful result from ${setColor('previous')} CI run: ${chalk.cyan(resultUrl)}`
+    )
     outputLines.push(resultInfo)
   } else {
     const resultOutcomeText = renderResultOutcome(execution.result, overriddenTest || test, icon, setColor)

--- a/src/commands/synthetics/reporters/default.ts
+++ b/src/commands/synthetics/reporters/default.ts
@@ -239,7 +239,7 @@ const renderExecutionResult = (test: Test, execution: Result, baseUrl: string) =
   if (isResultSkippedBySelectiveRerun(execution)) {
     const resultUrl = getResultUrl(baseUrl, test, resultId)
 
-    const resultInfo = `  ${setColor('◂')} Successful result from previous CI run: ${chalk.dim.cyan(resultUrl)}`
+    const resultInfo = `  ${setColor('◀')} Successful result from previous CI run: ${chalk.dim.cyan(resultUrl)}`
     outputLines.push(resultInfo)
   } else {
     const resultOutcomeText = renderResultOutcome(execution.result, overriddenTest || test, icon, setColor)


### PR DESCRIPTION
### What and why?

**Before:**
![image](https://github.com/DataDog/datadog-ci/assets/9317502/42bea944-6385-434f-93fb-be9ab81c9adc)

**After:**
![image](https://github.com/DataDog/datadog-ci/assets/9317502/6a96aaab-db33-4936-ac0a-56a196b63721)

### How?

- Change the icon from `◂` to `◀`
- Highlight `previous` in green
- Make the rest dimmer

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
