### PR TITLE
[STAL-998] Add metadata validation in SBOM/SARIF upload commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,10 +76,10 @@ See each command's linked README for more details, or click on [📚](https://do
 - `xcode`: Upload [React Native sourcemaps](src/commands/react-native) for Error Tracking from the XCode bundle build phase. [📚](https://docs.datadoghq.com/real_user_monitoring/error_tracking/reactnative/)
 
 #### `sarif`
-- `upload`: Upload [Static Analysis Results Interchange Format (SARIF)](src/commands/sarif) reports to Datadog. [📚](https://docs.datadoghq.com/static_analysis/)
+- `upload`: Upload [Static Analysis Results Interchange Format (SARIF)](src/commands/sarif) reports to Datadog. [📚](https://docs.datadoghq.com/code_analysis/static_analysis/)
 
 #### `sbom`
-- `upload`: Upload [Software Bill of Materials (SBOM)](src/commands/sbom) files to Datadog. [📚](https://docs.datadoghq.com/static_analysis/)
+- `upload`: Upload [Software Bill of Materials (SBOM)](src/commands/sbom) files to Datadog. [📚](https://docs.datadoghq.com/code_analysis/software_composition_analysis/)
 
 #### `sourcemaps`
 - `upload`: Upload [JavaScript sourcemaps](src/commands/sourcemaps) for Error Tracking. [📚](https://docs.datadoghq.com/real_user_monitoring/guide/upload-javascript-source-maps)

--- a/src/commands/sarif/renderer.ts
+++ b/src/commands/sarif/renderer.ts
@@ -2,8 +2,6 @@ import path from 'path'
 
 import chalk from 'chalk'
 
-import {SpanTags} from '../../helpers/interfaces'
-
 import {getBaseUrl} from '../junit/utils'
 
 import {Payload} from './interfaces'
@@ -26,10 +24,29 @@ export const renderInvalidFile = (sarifReport: string, errorMessage: string) => 
   return fullStr
 }
 
-export const renderFailedUpload = (sarifReport: Payload, errorMessage: string) => {
+export const renderMissingSpan = (errorMessage: string) => {
+  const currentPath = `[${chalk.bold.dim(process.cwd())}]`
+
+  let fullStr = ''
+  fullStr += chalk.yellow(`${ICONS.WARNING}  Validation failed: ${errorMessage}.\n`)
+  fullStr += chalk.yellow(
+    `Upload attempted from ${currentPath}. Is this the directory for which this analysis is for?\n`
+  )
+  fullStr += chalk.yellow(`The upload must come from a directory with a ".git" directory.\n`)
+
+  return fullStr
+}
+
+export const renderFailedUpload = (sarifReport: Payload, error: any) => {
   const reportPath = `[${chalk.bold.dim(sarifReport.reportPath)}]`
 
-  return chalk.red(`${ICONS.FAILED} Failed upload SARIF report file ${reportPath}: ${errorMessage}\n`)
+  let fullStr = ''
+  fullStr += chalk.red(`${ICONS.FAILED} Failed upload SARIF report file ${reportPath}: ${error.message}\n`)
+  if (error?.response?.status) {
+    fullStr += chalk.red(`API status code: ${error.response.status}\n`)
+  }
+
+  return fullStr
 }
 
 export const renderRetriedUpload = (sarifReport: Payload, errorMessage: string, attempt: number) => {
@@ -38,13 +55,7 @@ export const renderRetriedUpload = (sarifReport: Payload, errorMessage: string, 
   return chalk.yellow(`[attempt ${attempt}] Retrying SARIF report upload ${sarifReportPath}: ${errorMessage}\n`)
 }
 
-export const renderSuccessfulCommand = (
-  fileCount: number,
-  duration: number,
-  spanTags: SpanTags,
-  service: string,
-  env?: string
-) => {
+export const renderSuccessfulCommand = (fileCount: number, duration: number) => {
   let fullStr = ''
   fullStr += chalk.green(`${ICONS.SUCCESS} Uploaded ${fileCount} files in ${duration} seconds.\n`)
   fullStr += chalk.green(`${ICONS.INFO}  Results available on ${getBaseUrl()}ci/code-analysis\n`)

--- a/src/commands/sarif/renderer.ts
+++ b/src/commands/sarif/renderer.ts
@@ -30,7 +30,7 @@ export const renderMissingSpan = (errorMessage: string) => {
   let fullStr = ''
   fullStr += chalk.yellow(`${ICONS.WARNING}  Validation failed: ${errorMessage}.\n`)
   fullStr += chalk.yellow(
-    `Upload attempted from ${currentPath}. Is this the directory for which this analysis is for?\n`
+    `Upload attempted from ${currentPath}. Is this the directory for which this analysis was run?\n`
   )
   fullStr += chalk.yellow(`The upload must come from a directory with a ".git" directory.\n`)
 

--- a/src/commands/sbom/api.ts
+++ b/src/commands/sbom/api.ts
@@ -1,6 +1,6 @@
 import type {AxiosPromise, AxiosRequestConfig, AxiosResponse} from 'axios'
 
-import {CONTENT_TYPE_HEADER, CONTENT_TYPE_VALUE_JSON, CONTENT_TYPE_VALUE_PROTOBUF, METHOD_POST} from '../../constants'
+import {CONTENT_TYPE_HEADER, CONTENT_TYPE_VALUE_JSON, METHOD_POST} from '../../constants'
 import {getRequestBuilder} from '../../helpers/utils'
 
 import {getBaseUrl} from '../junit/utils'

--- a/src/commands/sbom/renderer.ts
+++ b/src/commands/sbom/renderer.ts
@@ -31,7 +31,7 @@ export const renderMissingSpan = (errorMessage: string) => {
   let fullStr = ''
   fullStr += chalk.yellow(`${ICONS.WARNING}  Validation failed: ${errorMessage}.\n`)
   fullStr += chalk.yellow(
-    `Upload attempted from ${currentPath}. Is this the directory for which this analysis is for?\n`
+    `Upload attempted from ${currentPath}. Is this the directory for which this analysis was run?\n`
   )
   fullStr += chalk.yellow(`The upload must come from a directory with a ".git" directory.\n`)
 

--- a/src/commands/sbom/renderer.ts
+++ b/src/commands/sbom/renderer.ts
@@ -1,0 +1,64 @@
+import chalk from 'chalk'
+
+import {getBaseUrl} from '../junit/utils'
+
+const ICONS = {
+  FAILED: '❌',
+  SUCCESS: '✅',
+  WARNING: '⚠️',
+  INFO: 'ℹ️',
+}
+
+export const renderInvalidFile = (sbomReport: string) => {
+  const reportPath = `[${chalk.bold.dim(sbomReport)}]`
+
+  let fullStr = ''
+  fullStr += chalk.red(`${ICONS.FAILED} Invalid SARIF report file ${reportPath}.\n`)
+  fullStr += chalk.red(`The report is not a valid SBOM or is not compliant with our json schema.\n`)
+
+  return fullStr
+}
+
+export const renderInvalidPayload = (sbomReport: string) => {
+  const reportPath = `[${chalk.bold.dim(sbomReport)}]`
+
+  return chalk.red(`Cannot generate payload for file ${reportPath}.\n`)
+}
+
+export const renderMissingSpan = (errorMessage: string) => {
+  const currentPath = `[${chalk.bold.dim(process.cwd())}]`
+
+  let fullStr = ''
+  fullStr += chalk.yellow(`${ICONS.WARNING}  Validation failed: ${errorMessage}.\n`)
+  fullStr += chalk.yellow(
+    `Upload attempted from ${currentPath}. Is this the directory for which this analysis is for?\n`
+  )
+  fullStr += chalk.yellow(`The upload must come from a directory with a ".git" directory.\n`)
+
+  return fullStr
+}
+
+export const renderFailedUpload = (sbomReport: string, error: any) => {
+  const reportPath = `[${chalk.bold.dim(sbomReport)}]`
+
+  let fullStr = ''
+  fullStr += chalk.red(`${ICONS.FAILED} Failed upload SBOM file ${reportPath}: ${error.message}\n`)
+  if (error?.response?.status) {
+    fullStr += chalk.red(`API status code: ${error.response.status}\n`)
+  }
+
+  return fullStr
+}
+
+export const renderUploading = (sbomReport: string): string => `Uploading SBOM report in ${sbomReport}\n`
+
+export const renderSuccessfulCommand = (fileCount: number, duration: number) => {
+  let fullStr = ''
+  fullStr += chalk.green(`${ICONS.SUCCESS} Uploaded ${fileCount} files in ${duration} seconds.\n`)
+  fullStr += chalk.green(`${ICONS.INFO}  Results available on ${getBaseUrl()}ci/code-analysis\n`)
+  fullStr += chalk.green(
+    '=================================================================================================\n'
+  )
+
+  return fullStr
+}

--- a/src/commands/sbom/upload.ts
+++ b/src/commands/sbom/upload.ts
@@ -4,15 +4,20 @@ import process from 'process'
 import type {AxiosPromise, AxiosResponse} from 'axios'
 
 import Ajv from 'ajv'
-import chalk from 'chalk'
 import {Command, Option} from 'clipanion'
 
-import {getSpanTags} from '../../helpers/tags'
-
-import {getBaseUrl} from '../junit/utils'
+import {getSpanTags, mandatoryGitFields} from '../../helpers/tags'
 
 import {getApiHelper} from './api'
 import {generatePayload} from './payload'
+import {
+  renderFailedUpload,
+  renderInvalidFile,
+  renderInvalidPayload,
+  renderMissingSpan,
+  renderSuccessfulCommand,
+  renderUploading,
+} from './renderer'
 import {ScaRequest} from './types'
 import {getValidator, validateSbomFile} from './validation'
 
@@ -83,49 +88,55 @@ export class UploadSbomCommand extends Command {
 
     const tags = await getSpanTags(this.config, this.tags)
 
+    // Check if we have all the mandatory git fields
+    const spanTagsKeys = Object.keys(tags)
+    const filteredSpanTags = spanTagsKeys.filter((key) => mandatoryGitFields[key])
+    if (filteredSpanTags.length !== Object.keys(mandatoryGitFields).length) {
+      this.context.stdout.write(renderMissingSpan('missing span tags (CI, git, or user-provided tags)'))
+
+      return 1
+    }
+
+
     const validator: Ajv = getValidator()
+
+    const startTimeMs = Date.now()
     for (const basePath of this.basePaths) {
       if (this.debug) {
         this.context.stdout.write(`Processing file ${basePath}\n`)
       }
 
       if (!validateSbomFile(basePath, validator, !!this.debug)) {
-        this.context.stdout.write(`File ${chalk.red.bold(basePath)} is not a valid SBOM file.\n`)
+        this.context.stdout.write(renderInvalidFile(basePath))
 
         return 1
       }
 
-      const filePath = basePath
       const jsonContent = JSON.parse(fs.readFileSync(basePath).toString('utf8'))
 
       // Upload content
       try {
         const scaPayload = generatePayload(jsonContent, tags, service, environment)
         if (!scaPayload) {
-          console.log(`Cannot generate payload for file ${filePath}`)
+          this.context.stdout.write(renderInvalidPayload(basePath))
+
           continue
         }
 
-        const startTimeMs = Date.now()
-        const response = await api(scaPayload)
-        const endTimeMs = Date.now()
+        this.context.stdout.write(renderUploading(basePath))
+        await api(scaPayload)
         if (this.debug) {
-          this.context.stdout.write(`Upload done, status: ${response.status}\n`)
+          this.context.stdout.write(`Upload done for ${basePath}.\n`)
         }
-
-        const apiTimeMs = endTimeMs - startTimeMs
-        this.context.stdout.write(`File ${basePath} successfully uploaded in ${apiTimeMs} ms\n`)
       } catch (error) {
-        process.stderr.write(`Error while writing the payload: ${error.message}\n`)
-        if (error.response) {
-          process.stderr.write(`API status: ${error.response.status}\n`)
-        }
+        this.context.stderr.write(renderFailedUpload(basePath, error))
 
         return 1
       }
     }
 
-    this.context.stdout.write(`Upload finished, results available on ${getBaseUrl()}ci/code-analysis\n`)
+    const uploadTimeMs = (Date.now() - startTimeMs)  / 1000
+    this.context.stdout.write(renderSuccessfulCommand(this.basePaths.length, uploadTimeMs))
 
     return 0
   }

--- a/src/commands/sbom/upload.ts
+++ b/src/commands/sbom/upload.ts
@@ -97,7 +97,6 @@ export class UploadSbomCommand extends Command {
       return 1
     }
 
-
     const validator: Ajv = getValidator()
 
     const startTimeMs = Date.now()
@@ -135,7 +134,7 @@ export class UploadSbomCommand extends Command {
       }
     }
 
-    const uploadTimeMs = (Date.now() - startTimeMs)  / 1000
+    const uploadTimeMs = (Date.now() - startTimeMs) / 1000
     this.context.stdout.write(renderSuccessfulCommand(this.basePaths.length, uploadTimeMs))
 
     return 0

--- a/src/helpers/tags.ts
+++ b/src/helpers/tags.ts
@@ -105,6 +105,14 @@ export const parseMetrics = (tags: string[]) => {
 }
 
 /**
+ * The repository URL is mandatory in processing for the following commands: sarif and sbom.
+ * Note: for sarif uploads, this will fail silent on the backend.
+ */
+export const mandatoryGitFields: Record<string, boolean> = {
+  [GIT_REPOSITORY_URL]: true,
+}
+
+/**
  * Get the tags to upload results in CI for the following commands: sarif and sbom.
  * @param config - the configuration of the CLI
  * @param additionalTags - additional tags passed, generally from the command line.
@@ -120,7 +128,7 @@ export const getSpanTags = async (config: DatadogCiConfig, additionalTags: strin
   return {
     ...gitSpanTags,
     ...ciSpanTags,
-    ...userGitSpanTags,
+    ...userGitSpanTags, // User-provided git tags have precedence over the ones we get from the git command
     ...cliTags,
     ...envVarTags,
     ...(config.env ? {env: config.env} : {}),


### PR DESCRIPTION
### What and why?

Adds validation and a pretty message when the commands are not run in `.git` directory. 

Updates the root readme as we've updated the documentation and each product has it's own page now.

### How?

We check for a `git.repository_url` as this field is required in the backend for further processing and in the case of the SARIF upload, this failure will not be surfaced to the user. 

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)

### Verification

Ran both commands locally in and outside of a `.git` directory.

**SARIF:**
<img width="848" alt="Screenshot 2024-03-11 at 1 16 12 PM" src="https://github.com/DataDog/datadog-ci/assets/33348592/3117424d-28c3-44d0-a4e1-b6b8d84c9268">

**SBOM:**
<img width="1096" alt="Screenshot 2024-03-11 at 1 16 53 PM" src="https://github.com/DataDog/datadog-ci/assets/33348592/698507ee-c033-4b83-9b03-8434968e6025">
