### PR TITLE
[junit] Tolerate `--skip-git-metadata-upload` as boolean flag

### DIFF
--- a/src/commands/junit/__tests__/upload.test.ts
+++ b/src/commands/junit/__tests__/upload.test.ts
@@ -506,9 +506,21 @@ describe('execute', () => {
     expect(output[3]).toContain('service: test-service')
   })
 
-  test('without git metadata', async () => {
+  test('without git metadata (default value)', async () => {
     const {context, code} = await runCLI([
       '--verbose',
+      process.cwd() + '/src/commands/junit/__tests__/fixtures/single_file.xml',
+    ])
+    const output = context.stdout.toString().split(os.EOL)
+    expect(id).not.toHaveBeenCalled()
+    expect(code).toBe(0)
+    expect(output[5]).toContain('Not syncing git metadata (skip git upload flag detected)')
+  })
+
+  test('without git metadata (with argument)', async () => {
+    const {context, code} = await runCLI([
+      '--verbose',
+      '--skip-git-metadata-upload', // should tolerate the option as a boolean flag
       process.cwd() + '/src/commands/junit/__tests__/fixtures/single_file.xml',
     ])
     const output = context.stdout.toString().split(os.EOL)

--- a/src/commands/junit/upload.ts
+++ b/src/commands/junit/upload.ts
@@ -128,7 +128,10 @@ export class UploadJUnitXMLCommand extends Command {
   private reportMeasures = Option.Array('--report-measures')
   private rawXPathTags = Option.Array('--xpath-tag')
   private gitRepositoryURL = Option.String('--git-repository-url')
-  private skipGitMetadataUpload = Option.String('--skip-git-metadata-upload', 'true', {validator: t.isBoolean()})
+  private skipGitMetadataUpload = Option.String('--skip-git-metadata-upload', 'true', {
+    validator: t.isBoolean(),
+    tolerateBoolean: true,
+  })
 
   private config = {
     apiKey: process.env.DATADOG_API_KEY || process.env.DD_API_KEY,


### PR DESCRIPTION
### What and why?

Closes #1222 

The default behavior of the `junit upload` command was changed to skip the upload of git metadata **by default** in https://github.com/DataDog/datadog-ci/pull/928 for performance reasons (released in [v2.15.0](https://github.com/DataDog/datadog-ci/releases/tag/v2.15.0)).

But in case users want to be explicit about skipping the git metadata upload, passing `--skip-git-metadata-upload` should work without an extra `=true` at the end. This behavior broke because of #1021.

### How?

Use `tolerateBoolean: true`

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
