### PR TITLE
[chores] Exclude `release` label from release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -3,6 +3,9 @@
 #
 # See .github/workflows/pr-required-labels.yml
 changelog:
+  exclude:
+    labels:
+      - release # Exclude release PRs from changelog
   categories:
     - title: Dependencies
       labels:

--- a/.github/workflows/pr-required-labels.yml
+++ b/.github/workflows/pr-required-labels.yml
@@ -24,6 +24,7 @@ jobs:
             dependencies
             documentation
             chores
+            release
             ci-visibility
             static-analysis
             rum

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,7 +92,8 @@ To release a new version of `datadog-ci`:
 4. Push the branch **along with the tag** with `git push --tags origin name-of-the-branch`, create a PR, and get at least one approval.
    - **Find and open** the workflow run corresponding to your tag [in this list](https://github.com/DataDog/datadog-ci/actions/workflows/release.yml).
    - Copy the release notes from the summary, and paste them in the description of your PR. This ensures the feature PRs have a link to your release PR.
-   - See this [example PR](https://github.com/DataDog/datadog-ci/pull/1047).
+   - Add the `release` label to your PR.
+   - See this [example PR](https://github.com/DataDog/datadog-ci/pull/1215).
 5. Once you've received at least one approval, merge the PR **with the "Create a merge commit" strategy**.
    - You may notice that a **GitHub** job is waiting for an approval, and some **_GitLab_** jobs are pending: this is expected (see **step 6 and 8**). You can merge the PR when *only those jobs* are left.
    - The "Create a merge commit" strategy is required for **step 7**, and for the GitHub Release to point to an existing commit once the PR is merged.


### PR DESCRIPTION
### What and why?

Since we use the "Create a merge commit" strategy when merging release PRs, the merge commit always shows _after_ the corresponding `vX.X.X` commit in the history:

![image](https://github.com/DataDog/datadog-ci/assets/9317502/220ca00f-d8f2-4e20-9a90-488eb1f46b2f)

Because of that, the release PR ends up in the release notes for `v2.32.0...v2.32.1`:

![image](https://github.com/DataDog/datadog-ci/assets/9317502/9e4bcc60-477d-4ed6-88d1-cba31703c902)

### How?

- Require all release PRs to have a `release` label
- Exclude PRs with the `release` label in the release notes
- Update the release process instructions

### Review checklist

- ~~[ ] Feature or bugfix MUST have appropriate tests (unit, integration)~~
