### PR TITLE
[chores] Add `needs:` to `npm-publish`

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -159,6 +159,7 @@ jobs:
   npm-publish:
     runs-on: ubuntu-latest
     environment: npm
+    needs: [build-binary-ubuntu, build-binary-windows, build-binary-macos]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4


### PR DESCRIPTION
### What and why?

I used to have this `needs:` property [during my testing](https://github.com/DataDog/datadog-ci/actions/runs/8249102051/workflow#L152), but forgot to add it in #1219... 🤦 

**During my testing:**
<img width="1135" alt="image" src="https://github.com/DataDog/datadog-ci/assets/9317502/e884aa6b-4cd2-4f54-8ed0-6b0e94852ef9">


**Right now:**
<img width="678" alt="image" src="https://github.com/DataDog/datadog-ci/assets/9317502/674fe1ff-757d-42fe-ac04-a3411cc972ff">

### How?

- Add `needs:` to `npm-publish`

### Review checklist

- ~~[ ] Feature or bugfix MUST have appropriate tests (unit, integration)~~
