### PR TITLE
[chores] Add missing `.exe` and fix release notes bug

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -116,7 +116,7 @@ jobs:
               repo: context.repo.repo,
               release_id: "${{ needs.create-draft-release.outputs.release-id }}",
               name: 'datadog-ci_win-x64',
-              data: await fs.readFile('./datadog-ci_win-x64'),
+              data: await fs.readFile('./datadog-ci_win-x64.exe'),
             })
 
   build-binary-macos:

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -33,6 +33,11 @@ jobs:
               body: releaseNotes.body,
             })
 
+            console.debug('Release notes:', JSON.stringify(releaseNotes.body))
+
+            // https://github.com/actions/toolkit/issues/1689
+            const releaseNotesToCopy = releaseNotes.body.replace('-->\n\n', '-->\n')
+
             await core.summary
               .addHeading('Draft release created')
               .addRaw('Find it here: ')
@@ -42,7 +47,7 @@ jobs:
               .addRaw('Copy the release notes below, and paste them inside your release PR.')
               .addBreak()
               .addBreak()
-              .addCodeBlock(releaseNotes.body, 'markdown')
+              .addCodeBlock(releaseNotesToCopy, 'markdown')
               .write()
 
             return release.id


### PR DESCRIPTION
### What and why?

I worked on #1217 (introduces `.github/release.yml` to configure the release notes) and #1219 separately, so I hadn't tested the job summary with release notes **configured with `.github/release.yml`**.

Turns out that in that case, the release notes start with a HTML comment like so:
```html
<!-- Release notes generated using configuration in .github/release.yml at v0.0.1 -->
```

And this results in the markdown codeblock being rendered incorrectly. All the `#` and `*` are missing:

<img width="1163" alt="image" src="https://github.com/DataDog/datadog-ci/assets/9317502/8d471969-9d61-45fc-97f7-2c80544b14c2">

### How?

I reported the bug here: https://github.com/actions/toolkit/issues/1689

For now, we can replace `\n\n` with `\n` after the HTML comment.

### Review checklist

- ~~[ ] Feature or bugfix MUST have appropriate tests (unit, integration)~~
