### PR TITLE
[STAL-1561] add .net support

### DIFF
--- a/src/commands/sbom/language.ts
+++ b/src/commands/sbom/language.ts
@@ -27,6 +27,9 @@ export const getLanguageFromComponent = (component: any): DependencyLanguage | u
     if (component['purl'].includes('pkg:pypi')) {
       return DependencyLanguage.PYTHON
     }
+    if (component['purl'].includes('pkg:nuget')) {
+      return DependencyLanguage.DOTNET
+    }
   }
 
   console.debug(`language for component ${componentName} not found`)

--- a/src/commands/sbom/types.ts
+++ b/src/commands/sbom/types.ts
@@ -1,4 +1,5 @@
 export enum DependencyLanguage {
+  DOTNET = 'dotnet',
   NPM = 'node',
   PYTHON = 'python',
   PHP = 'php',


### PR DESCRIPTION
### What and why?

Add .net support

### How?

Correctly map the language when the package purl contains `pkg:nuget`.

### Testing

```
yarn launch sbom upload --service vscode --env local ~/tmp/debug.json
[...]
✅ Uploaded 1 files in 0.443 seconds.
ℹ️  Results available on https://app.datad0g.com/ci/code-analysis
=================================================================================================
```

### Others

Removed the message about license not found which is noisy and this logic will move into the backend.