### PR TITLE
[chores] Fix last nits about the release process

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -7,21 +7,18 @@ changelog:
     labels:
       - release # Exclude release PRs from changelog
   categories:
+    - title: datadog-ci
+      labels:
+        - '*'
     - title: Dependencies
       labels:
-        - dependencies
+        - dependencies # Generally about vulnerability fixes
     - title: Documentation
       labels:
         - documentation
-    - title: Chores
-      labels:
-        - chores
     - title: CI Visibility
       labels:
         - ci-visibility
-    - title: Static Analysis
-      labels:
-        - static-analysis
     - title: RUM
       labels:
         - rum
@@ -31,9 +28,12 @@ changelog:
     - title: Source Code Integration
       labels:
         - source-code-integration
+    - title: Static Analysis
+      labels:
+        - static-analysis
     - title: Synthetics
       labels:
         - synthetics
-    - title: datadog-ci
+    - title: Chores
       labels:
-        - '*'
+        - chores

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -17,12 +17,6 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const { data: releaseNotes } = await github.rest.repos.generateReleaseNotes({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              tag_name: '${{ github.ref_name }}',
-            })
-
             const { data: release } = await github.rest.repos.createRelease({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -30,24 +24,17 @@ jobs:
               name: '${{ github.ref_name }}',
               draft: true,
               prerelease: false,
-              body: releaseNotes.body,
+              generate_release_notes: true,
             })
 
-            console.debug('Release notes:', JSON.stringify(releaseNotes.body))
-
-            // https://github.com/actions/toolkit/issues/1689
-            const releaseNotesToCopy = releaseNotes.body.replace('-->\n\n', '-->\n')
+            const editReleaseLink = release.html_url.replace('datadog-ci/releases/tag/', 'datadog-ci/releases/edit/')
 
             await core.summary
               .addHeading('Draft release created')
-              .addRaw('Find it here: ')
-              .addLink('${{ github.ref_name }} (draft)', release.html_url)
+              .addRaw('Please go to the link below, copy the release notes and paste them in your release PR.', true)
               .addBreak()
               .addBreak()
-              .addRaw('Copy the release notes below, and paste them inside your release PR.')
-              .addBreak()
-              .addBreak()
-              .addCodeBlock(releaseNotesToCopy, 'markdown')
+              .addLink('Edit v0.0.1 (draft)', editReleaseLink)
               .write()
 
             return release.id

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -34,7 +34,7 @@ jobs:
               .addRaw('Please go to the link below, copy the release notes and paste them in your release PR.', true)
               .addBreak()
               .addBreak()
-              .addLink('Edit v0.0.1 (draft)', editReleaseLink)
+              .addLink('Edit ${{ github.ref_name }} (draft)', editReleaseLink)
               .write()
 
             return release.id


### PR DESCRIPTION
### What and why?

The products in the changelog should be alphabetized, while the other sections should appear in their order of priority: chores are far less important than vulnerability fixes.

Even after https://github.com/DataDog/datadog-ci/pull/1228, the release notes [were still not rendering properly](https://github.com/actions/toolkit/issues/1689#issuecomment-1997415469). So I decided to just get rid of this problematic codeblock, and just give a link to the draft release.

### How?

Update some YAML 😁 

### Review checklist

- ~~[ ] Feature or bugfix MUST have appropriate tests (unit, integration)~~
