### PR TITLE
[dep] Bump `upload-artifact` github action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
       - run: cp -r .github/workflows/e2e artifacts/
       - uses: actions/upload-artifact@v4
         with:
-          name: artifacts
+          name: artifacts-${{ matrix.version }}
           path: artifacts/
       - uses: actions/upload-artifact@v4
         if: always()
@@ -58,6 +58,7 @@ jobs:
           name: sarif-datadog-ci.sarif
           path: sarif-datadog-ci.sarif
           if-no-files-found: error
+          overwrite: true
 
   e2e-test:
     strategy:
@@ -74,9 +75,11 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.version }}
-      - uses: actions/download-artifact@v1
+      - uses: actions/download-artifact@v4
         with:
-          name: artifacts
+          path: artifacts/
+          pattern: artifacts-*
+          merge-multiple: true
       - run: yarn add ./artifacts/datadog-ci-${{ matrix.version }}.tgz
       - name: Run synthetics test
         run: yarn datadog-ci synthetics run-tests --config artifacts/e2e/global.config.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,11 +48,11 @@ jobs:
       - run: mkdir artifacts
       - run: yarn pack --filename artifacts/datadog-ci-${{ matrix.version }}.tgz
       - run: cp -r .github/workflows/e2e artifacts/
-      - uses: actions/upload-artifact@v1
+      - uses: actions/upload-artifact@v4
         with:
           name: artifacts
           path: artifacts/
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: sarif-datadog-ci.sarif

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,9 +77,8 @@ jobs:
           node-version: ${{ matrix.version }}
       - uses: actions/download-artifact@v4
         with:
+          name: artifacts-${{ matrix.version }}
           path: artifacts/
-          pattern: artifacts-*
-          merge-multiple: true
       - run: yarn add ./artifacts/datadog-ci-${{ matrix.version }}.tgz
       - name: Run synthetics test
         run: yarn datadog-ci synthetics run-tests --config artifacts/e2e/global.config.json


### PR DESCRIPTION
### What and why?

Fixes these warnings:

<img width="1123" alt="image" src="https://github.com/DataDog/datadog-ci/assets/9317502/d4bb98b9-3058-4379-8e29-7bc47dceb8ec">

### How?

Bumping github actions.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
