### PR TITLE
[synthetics] Change wording around selective re-run

### DIFF
--- a/src/commands/synthetics/__tests__/reporters/__snapshots__/default.test.ts.snap
+++ b/src/commands/synthetics/__tests__/reporters/__snapshots__/default.test.ts.snap
@@ -34,7 +34,7 @@ exports[`Default reporter resultEnd 3 API tests, 2 passed (1 from previous CI ru
   [1m[32m✓[39m[22m [1m[32m[1mGET[22m[1m - http://fake.url[39m[22m
 
 [1m[32m✓[39m[22m [[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m
-[2m  [1m[32m◀[39m[22m[2m Successful result from [1m[32mprevious[39m[22m[2m CI run: [36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=0002&from_ci=true[39m[22m
+[2m  [1m[32m◀[39m[22m[2m Successful result from a [1m[32mprevious[39m[22m[2m CI batch: [36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=0002&from_ci=true[39m[22m
 
 [1m[32m✓[39m[22m [2m(edited) [22m[[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m - [1m[32mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m
   ⎋ Total duration: 123 ms - View test run details: [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=1003&from_ci=true[39m[22m 

--- a/src/commands/synthetics/reporters/default.ts
+++ b/src/commands/synthetics/reporters/default.ts
@@ -240,7 +240,7 @@ const renderExecutionResult = (test: Test, execution: Result, baseUrl: string) =
     const resultUrl = getResultUrl(baseUrl, test, resultId)
 
     const resultInfo = chalk.dim(
-      `  ${setColor('◀')} Successful result from ${setColor('previous')} CI run: ${chalk.cyan(resultUrl)}`
+      `  ${setColor('◀')} Successful result from a ${setColor('previous')} CI batch: ${chalk.cyan(resultUrl)}`
     )
     outputLines.push(resultInfo)
   } else {


### PR DESCRIPTION
### What and why?

This PR changes the wording for selective re-run to align with the UI, which talks about batches (and not CI runs).

#### Before

![image](https://github.com/DataDog/datadog-ci/assets/9317502/6595a612-f361-4f6a-bf53-bbf2b8fb4b9c)

#### After

![image](https://github.com/DataDog/datadog-ci/assets/9317502/606133b2-bd0a-437f-bd77-2d2cdfdfa609)



### How?

Update wording.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
