### PR TITLE
[synthetics] Align README and reporter interface

### DIFF
--- a/src/commands/synthetics/README.md
+++ b/src/commands/synthetics/README.md
@@ -406,12 +406,12 @@ Reporters can hook themselves into the `MainReporter` of the command.
 | `log`            | `(log: string)`                                                                          | Called for logging.                                             |
 | `error`          | `(error: string)`                                                                        | Called whenever an error occurs.                                |
 | `initErrors`     | `(errors: string[])`                                                                     | Called whenever an error occurs during the tests parsing phase. |
-| `reportStart`    | `(timings: {startTime: number})`                                                         | Called at the start of the report.                              |
-| `resultEnd`      | `(result: Result, baseUrl: string)`                                                      | Called for each result at the end of all results.               |
-| `resultReceived` | `(result: Result)`                                                                       | Called when a result is received.                               |
 | `testTrigger`    | `(test: Test, testId: string, executionRule: ExecutionRule, config: UserConfigOverride)` | Called when a test is triggered.                                |
 | `testWait`       | `(test: Test)`                                                                           | Called when a test is waiting to receive its results.           |
 | `testsWait`      | `(tests: Test[], baseUrl: string, batchId: string, skippedCount?: number)`               | Called when all tests are waiting to receive their results.     |
+| `resultReceived` | `(result: ResultInBatch)`                                                                | Called when a result is received.                               |
+| `resultEnd`      | `(result: Result, baseUrl: string)`                                                      | Called for each result at the end of all results.               |
+| `reportStart`    | `(timings: {startTime: number})`                                                         | Called at the start of the report.                              |
 | `runEnd`         | `(summary: Summary, baseUrl: string, orgSettings?: SyntheticsOrgSettings)`               | Called at the end of the run.                                   |
 
 ## View test results

--- a/src/commands/synthetics/interfaces.ts
+++ b/src/commands/synthetics/interfaces.ts
@@ -6,16 +6,16 @@ import {TunnelInfo} from './tunnel'
 export type SupportedReporter = 'junit' | 'default'
 
 export interface MainReporter {
+  log(log: string): void
   error(error: string): void
   initErrors(errors: string[]): void
-  log(log: string): void
-  reportStart(timings: {startTime: number}): void
-  resultEnd(result: Result, baseUrl: string): void
-  resultReceived(result: Batch['results'][0]): void
-  runEnd(summary: Summary, baseUrl: string, orgSettings?: SyntheticsOrgSettings): void
-  testsWait(tests: Test[], baseUrl: string, batchId: string, skippedCount?: number): void
   testTrigger(test: Test, testId: string, executionRule: ExecutionRule, config: UserConfigOverride): void
   testWait(test: Test): void
+  testsWait(tests: Test[], baseUrl: string, batchId: string, skippedCount?: number): void
+  resultReceived(result: ResultInBatch): void
+  resultEnd(result: Result, baseUrl: string): void
+  reportStart(timings: {startTime: number}): void
+  runEnd(summary: Summary, baseUrl: string, orgSettings?: SyntheticsOrgSettings): void
 }
 
 export type Reporter = Partial<MainReporter>

--- a/src/commands/synthetics/reporters/default.ts
+++ b/src/commands/synthetics/reporters/default.ts
@@ -17,7 +17,7 @@ import {
   Summary,
   Test,
   UserConfigOverride,
-  Batch,
+  ResultInBatch,
 } from '../interfaces'
 import {hasResult} from '../utils/internal'
 import {
@@ -319,7 +319,7 @@ export class DefaultReporter implements MainReporter {
     this.write(renderExecutionResult(result.test, result, baseUrl) + '\n\n')
   }
 
-  public resultReceived(result: Batch['results'][0]): void {
+  public resultReceived(result: ResultInBatch): void {
     return
   }
 


### PR DESCRIPTION
### What and why?

- https://github.com/DataDog/datadog-ci/pull/1254 (← **you are here**)
- https://github.com/DataDog/datadog-ci/pull/1255

This PR aligns what we say in the README and the actual reporter interface.

### How?

- Use `ResultInBatch` instead of `Batch['results'][0]` since it's exported
- Order in the order of events, instead of alphabetically because it makes zero sense.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
