### PR TITLE
[SYNTH-12914] Include `?batch_id` in result links

### DIFF
--- a/src/commands/synthetics/README.md
+++ b/src/commands/synthetics/README.md
@@ -406,12 +406,12 @@ Reporters can hook themselves into the `MainReporter` of the command.
 | `log`            | `(log: string)`                                                                          | Called for logging.                                             |
 | `error`          | `(error: string)`                                                                        | Called whenever an error occurs.                                |
 | `initErrors`     | `(errors: string[])`                                                                     | Called whenever an error occurs during the tests parsing phase. |
-| `reportStart`    | `(timings: {startTime: number})`                                                         | Called at the start of the report.                              |
-| `resultEnd`      | `(result: Result, baseUrl: string)`                                                      | Called for each result at the end of all results.               |
-| `resultReceived` | `(result: Result)`                                                                       | Called when a result is received.                               |
 | `testTrigger`    | `(test: Test, testId: string, executionRule: ExecutionRule, config: UserConfigOverride)` | Called when a test is triggered.                                |
 | `testWait`       | `(test: Test)`                                                                           | Called when a test is waiting to receive its results.           |
 | `testsWait`      | `(tests: Test[], baseUrl: string, batchId: string, skippedCount?: number)`               | Called when all tests are waiting to receive their results.     |
+| `resultReceived` | `(result: ResultInBatch)`                                                                | Called when a result is received.                               |
+| `resultEnd`      | `(result: Result, baseUrl: string)`                                                      | Called for each result at the end of all results.               |
+| `reportStart`    | `(timings: {startTime: number})`                                                         | Called at the start of the report.                              |
 | `runEnd`         | `(summary: Summary, baseUrl: string, orgSettings?: SyntheticsOrgSettings)`               | Called at the end of the run.                                   |
 
 ## View test results

--- a/src/commands/synthetics/README.md
+++ b/src/commands/synthetics/README.md
@@ -410,7 +410,7 @@ Reporters can hook themselves into the `MainReporter` of the command.
 | `testWait`       | `(test: Test)`                                                                           | Called when a test is waiting to receive its results.           |
 | `testsWait`      | `(tests: Test[], baseUrl: string, batchId: string, skippedCount?: number)`               | Called when all tests are waiting to receive their results.     |
 | `resultReceived` | `(result: ResultInBatch)`                                                                | Called when a result is received.                               |
-| `resultEnd`      | `(result: Result, baseUrl: string)`                                                      | Called for each result at the end of all results.               |
+| `resultEnd`      | `(result: Result, baseUrl: string, batchId: string)`                                     | Called for each result at the end of all results.               |
 | `reportStart`    | `(timings: {startTime: number})`                                                         | Called at the start of the report.                              |
 | `runEnd`         | `(summary: Summary, baseUrl: string, orgSettings?: SyntheticsOrgSettings)`               | Called at the end of the run.                                   |
 

--- a/src/commands/synthetics/__tests__/reporters/__snapshots__/default.test.ts.snap
+++ b/src/commands/synthetics/__tests__/reporters/__snapshots__/default.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`Default reporter resultEnd 1 API test, 1 location, 1 result: success 1`] = `
 "[1m[32m✓[39m[22m [[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m - [1m[32mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m
   • Total duration: 123 ms - View test run details:
-    ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=1&batch_id=123[39m[22m 
+    ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=1&from_ci=true&batch_id=123[39m[22m 
   [1m[32m✓[39m[22m [1m[32m[1mGET[22m[1m - http://fake.url[39m[22m
 
 "
@@ -12,19 +12,19 @@ exports[`Default reporter resultEnd 1 API test, 1 location, 1 result: success 1`
 exports[`Default reporter resultEnd 1 API test, 1 location, 3 results: success, failed non-blocking, failed blocking 1`] = `
 "[1m[32m✓[39m[22m [[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m - [1m[32mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m
   • Total duration: 123 ms - View test run details:
-    ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=1&batch_id=123[39m[22m 
+    ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=1&from_ci=true&batch_id=123[39m[22m 
   [1m[32m✓[39m[22m [1m[32m[1mGET[22m[1m - http://fake.url[39m[22m
 
 [1m[33m✖[39m[22m [[1m[33mnon-blocking[39m[22m] [[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m - [1m[33mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m
   • Total duration: 123 ms - View test run details:
-    ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=2&batch_id=123[39m[22m 
+    ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=2&from_ci=true&batch_id=123[39m[22m 
   [1m[33m✖[39m[22m [1m[33m[1mGET[22m[1m - http://fake.url[39m[22m
 [1m[33m  - Assertion failed:[39m[22m
 [1m[33m    ▶ responseTime should be less than [4m1000[24m. Actual: [4m1234[24m[39m[22m
 
 [1m[31m✖[39m[22m [[1m[31mblocking[39m[22m] [[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m - [1m[31mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m
   • Total duration: 123 ms - View test run details:
-    ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=3&batch_id=123[39m[22m 
+    ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=3&from_ci=true&batch_id=123[39m[22m 
   [1m[31m✖[39m[22m [1m[31m[1mGET[22m[1m - http://fake.url[39m[22m
 [1m[31m  - Assertion failed:[39m[22m
 [1m[31m    ▶ responseTime should be less than [4m1000[24m. Actual: [4m1234[24m[39m[22m
@@ -35,16 +35,16 @@ exports[`Default reporter resultEnd 1 API test, 1 location, 3 results: success, 
 exports[`Default reporter resultEnd 3 API tests, 2 passed (1 from previous CI run) 1`] = `
 "[1m[32m✓[39m[22m [[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m - [1m[32mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m
   • Total duration: 123 ms - View test run details:
-    ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=1001&batch_id=123[39m[22m 
+    ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=1001&from_ci=true&batch_id=123[39m[22m 
   [1m[32m✓[39m[22m [1m[32m[1mGET[22m[1m - http://fake.url[39m[22m
 
 [1m[32m✓[39m[22m [[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m
 [2m  [1m[32m◀[39m[22m[2m Successful result from [1m[32mprevious[39m[22m[2m CI run:[22m
-    ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=0002&batch_id=123[39m[22m
+    ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=0002&from_ci=true&batch_id=123[39m[22m
 
 [1m[32m✓[39m[22m [2m(edited) [22m[[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m - [1m[32mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m
   • Total duration: 123 ms - View test run details:
-    ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=1003&batch_id=123[39m[22m 
+    ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=1003&from_ci=true&batch_id=123[39m[22m 
   [1m[32m✓[39m[22m [1m[32m[1mGET[22m[1m - http://fake.url[39m[22m
 
 "
@@ -53,7 +53,7 @@ exports[`Default reporter resultEnd 3 API tests, 2 passed (1 from previous CI ru
 exports[`Default reporter resultEnd 3 Browser test: failed blocking, timed out, global failure 1`] = `
 "[1m[31m✖[39m[22m [[1m[31mblocking[39m[22m] [[1m[2mabc-def-ghi[22m[22m] [1mTest name[22m - [1m[31mlocation: [1mLocation name[22m[1m[39m[22m - [1m[31mdevice: [1mchrome.laptop_large[22m[1m[39m[22m
   • Total duration: 20000 ms - View test run details:
-    ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/abc-def-ghi/result/1?batch_id=123[39m[22m 
+    ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/abc-def-ghi/result/1?from_ci=true&batch_id=123[39m[22m 
 [31m    [[1mSTEP_TIMEOUT[22m] - [2mStep failed because it took more than 20 seconds.[22m[39m
     [1m[32m✓[39m[22m | [1m1000[22mms - Navigate to start URL
     [2mhttps://example.org/[22m
@@ -67,12 +67,12 @@ exports[`Default reporter resultEnd 3 Browser test: failed blocking, timed out, 
 
 [1m[31m✖[39m[22m [[1m[31mblocking[39m[22m] [[1m[2mabc-def-ghi[22m[22m] [1mTest name[22m - [1m[31mlocation: [1mLocation name[22m[1m[39m[22m
   • View test run details:
-    ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/abc-def-ghi/result/1?batch_id=123[39m[22m (not yet received)
+    ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/abc-def-ghi/result/1?from_ci=true&batch_id=123[39m[22m (not yet received)
 [31m    [[1mTIMEOUT[22m] - [2mThe batch timed out before receiving the result.[22m[39m
 
 [1m[31m✖[39m[22m [[1m[31mblocking[39m[22m] [[1m[2mabc-def-ghi[22m[22m] [1mTest name[22m - [1m[31mlocation: [1mLocation name[22m[1m[39m[22m
   • View test run details:
-    ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/abc-def-ghi/result/1?batch_id=123[39m[22m 
+    ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/abc-def-ghi/result/1?from_ci=true&batch_id=123[39m[22m 
 [31m    [[1mFAILURE_CODE[22m] - [2mFailure message[22m[39m
 
 "
@@ -242,7 +242,7 @@ exports[`Default reporter testsWait the spinner text is updated and cleared at t
 "View pending summary in Datadog: [2m[36mhttps://app.datadoghq.com/synthetics/explorer/ci?batchResultId=123[39m[22m
 [1m[32m✓[39m[22m [[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m - [1m[32mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m
   • Total duration: 123 ms - View test run details:
-    ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=rid&batch_id=123[39m[22m 
+    ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=rid&from_ci=true&batch_id=123[39m[22m 
   [1m[32m✓[39m[22m [1m[32m[1mGET[22m[1m - http://fake.url[39m[22m
 
 "
@@ -252,7 +252,7 @@ exports[`Default reporter testsWait the spinner text is updated and cleared at t
 "View pending summary in Datadog: [2m[36mhttps://app.datadoghq.com/synthetics/explorer/ci?batchResultId=123[39m[22m
 [1m[32m✓[39m[22m [[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m - [1m[32mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m
   • Total duration: 123 ms - View test run details:
-    ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=rid&batch_id=123[39m[22m 
+    ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=rid&from_ci=true&batch_id=123[39m[22m 
   [1m[32m✓[39m[22m [1m[32m[1mGET[22m[1m - http://fake.url[39m[22m
 
  [36m⠙[39m Waiting for [1m[36m1[39m[22m test [90m(aaa-aaa-aaa)[39m…
@@ -274,7 +274,7 @@ exports[`Default reporter testsWait the spinner text is updated and cleared at t
 
 [1m[32m✓[39m[22m [[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m - [1m[32mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m
   • Total duration: 123 ms - View test run details:
-    ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=rid&batch_id=123[39m[22m 
+    ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=rid&from_ci=true&batch_id=123[39m[22m 
   [1m[32m✓[39m[22m [1m[32m[1mGET[22m[1m - http://fake.url[39m[22m
 
 "
@@ -287,7 +287,7 @@ exports[`Default reporter testsWait the spinner text is updated and cleared at t
 
 [1m[32m✓[39m[22m [[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m - [1m[32mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m
   • Total duration: 123 ms - View test run details:
-    ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=rid&batch_id=123[39m[22m 
+    ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=rid&from_ci=true&batch_id=123[39m[22m 
   [1m[32m✓[39m[22m [1m[32m[1mGET[22m[1m - http://fake.url[39m[22m
 
 - Waiting for [1m[36m1[39m[22m test [90m(aaa-aaa-aaa)[39m…

--- a/src/commands/synthetics/__tests__/reporters/__snapshots__/default.test.ts.snap
+++ b/src/commands/synthetics/__tests__/reporters/__snapshots__/default.test.ts.snap
@@ -2,7 +2,8 @@
 
 exports[`Default reporter resultEnd 1 API test, 1 location, 1 result: success 1`] = `
 "[1m[32m✓[39m[22m [[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m - [1m[32mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m
-  ⎋ Total duration: 123 ms - View test run details: [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=1&from_ci=true[39m[22m 
+  • Total duration: 123 ms - View test run details:
+    ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=1&batch_id=123[39m[22m 
   [1m[32m✓[39m[22m [1m[32m[1mGET[22m[1m - http://fake.url[39m[22m
 
 "
@@ -10,17 +11,20 @@ exports[`Default reporter resultEnd 1 API test, 1 location, 1 result: success 1`
 
 exports[`Default reporter resultEnd 1 API test, 1 location, 3 results: success, failed non-blocking, failed blocking 1`] = `
 "[1m[32m✓[39m[22m [[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m - [1m[32mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m
-  ⎋ Total duration: 123 ms - View test run details: [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=1&from_ci=true[39m[22m 
+  • Total duration: 123 ms - View test run details:
+    ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=1&batch_id=123[39m[22m 
   [1m[32m✓[39m[22m [1m[32m[1mGET[22m[1m - http://fake.url[39m[22m
 
 [1m[33m✖[39m[22m [[1m[33mnon-blocking[39m[22m] [[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m - [1m[33mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m
-  ⎋ Total duration: 123 ms - View test run details: [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=2&from_ci=true[39m[22m 
+  • Total duration: 123 ms - View test run details:
+    ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=2&batch_id=123[39m[22m 
   [1m[33m✖[39m[22m [1m[33m[1mGET[22m[1m - http://fake.url[39m[22m
 [1m[33m  - Assertion failed:[39m[22m
 [1m[33m    ▶ responseTime should be less than [4m1000[24m. Actual: [4m1234[24m[39m[22m
 
 [1m[31m✖[39m[22m [[1m[31mblocking[39m[22m] [[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m - [1m[31mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m
-  ⎋ Total duration: 123 ms - View test run details: [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=3&from_ci=true[39m[22m 
+  • Total duration: 123 ms - View test run details:
+    ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=3&batch_id=123[39m[22m 
   [1m[31m✖[39m[22m [1m[31m[1mGET[22m[1m - http://fake.url[39m[22m
 [1m[31m  - Assertion failed:[39m[22m
 [1m[31m    ▶ responseTime should be less than [4m1000[24m. Actual: [4m1234[24m[39m[22m
@@ -30,14 +34,17 @@ exports[`Default reporter resultEnd 1 API test, 1 location, 3 results: success, 
 
 exports[`Default reporter resultEnd 3 API tests, 2 passed (1 from previous CI run) 1`] = `
 "[1m[32m✓[39m[22m [[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m - [1m[32mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m
-  ⎋ Total duration: 123 ms - View test run details: [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=1001&from_ci=true[39m[22m 
+  • Total duration: 123 ms - View test run details:
+    ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=1001&batch_id=123[39m[22m 
   [1m[32m✓[39m[22m [1m[32m[1mGET[22m[1m - http://fake.url[39m[22m
 
 [1m[32m✓[39m[22m [[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m
-[2m  [1m[32m◀[39m[22m[2m Successful result from [1m[32mprevious[39m[22m[2m CI run: [36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=0002&from_ci=true[39m[22m
+[2m  [1m[32m◀[39m[22m[2m Successful result from [1m[32mprevious[39m[22m[2m CI run:[22m
+    ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=0002&batch_id=123[39m[22m
 
 [1m[32m✓[39m[22m [2m(edited) [22m[[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m - [1m[32mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m
-  ⎋ Total duration: 123 ms - View test run details: [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=1003&from_ci=true[39m[22m 
+  • Total duration: 123 ms - View test run details:
+    ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=1003&batch_id=123[39m[22m 
   [1m[32m✓[39m[22m [1m[32m[1mGET[22m[1m - http://fake.url[39m[22m
 
 "
@@ -45,7 +52,8 @@ exports[`Default reporter resultEnd 3 API tests, 2 passed (1 from previous CI ru
 
 exports[`Default reporter resultEnd 3 Browser test: failed blocking, timed out, global failure 1`] = `
 "[1m[31m✖[39m[22m [[1m[31mblocking[39m[22m] [[1m[2mabc-def-ghi[22m[22m] [1mTest name[22m - [1m[31mlocation: [1mLocation name[22m[1m[39m[22m - [1m[31mdevice: [1mchrome.laptop_large[22m[1m[39m[22m
-  ⎋ Total duration: 20000 ms - View test run details: [2m[36mhttps://app.datadoghq.com/synthetics/details/abc-def-ghi/result/1?from_ci=true[39m[22m 
+  • Total duration: 20000 ms - View test run details:
+    ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/abc-def-ghi/result/1?batch_id=123[39m[22m 
 [31m    [[1mSTEP_TIMEOUT[22m] - [2mStep failed because it took more than 20 seconds.[22m[39m
     [1m[32m✓[39m[22m | [1m1000[22mms - Navigate to start URL
     [2mhttps://example.org/[22m
@@ -58,11 +66,13 @@ exports[`Default reporter resultEnd 3 Browser test: failed blocking, timed out, 
     [1m[33m⇢[39m[22m | 3 skipped steps
 
 [1m[31m✖[39m[22m [[1m[31mblocking[39m[22m] [[1m[2mabc-def-ghi[22m[22m] [1mTest name[22m - [1m[31mlocation: [1mLocation name[22m[1m[39m[22m
-  ⎋ View test run details: [2m[36mhttps://app.datadoghq.com/synthetics/details/abc-def-ghi/result/1?from_ci=true[39m[22m (not yet received)
+  • View test run details:
+    ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/abc-def-ghi/result/1?batch_id=123[39m[22m (not yet received)
 [31m    [[1mTIMEOUT[22m] - [2mThe batch timed out before receiving the result.[22m[39m
 
 [1m[31m✖[39m[22m [[1m[31mblocking[39m[22m] [[1m[2mabc-def-ghi[22m[22m] [1mTest name[22m - [1m[31mlocation: [1mLocation name[22m[1m[39m[22m
-  ⎋ View test run details: [2m[36mhttps://app.datadoghq.com/synthetics/details/abc-def-ghi/result/1?from_ci=true[39m[22m 
+  • View test run details:
+    ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/abc-def-ghi/result/1?batch_id=123[39m[22m 
 [31m    [[1mFAILURE_CODE[22m] - [2mFailure message[22m[39m
 
 "
@@ -231,7 +241,8 @@ exports[`Default reporter testsWait the spinner text is updated and cleared at t
 exports[`Default reporter testsWait the spinner text is updated and cleared at the end (in CI: false) 2`] = `
 "View pending summary in Datadog: [2m[36mhttps://app.datadoghq.com/synthetics/explorer/ci?batchResultId=123[39m[22m
 [1m[32m✓[39m[22m [[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m - [1m[32mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m
-  ⎋ Total duration: 123 ms - View test run details: [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=rid&from_ci=true[39m[22m 
+  • Total duration: 123 ms - View test run details:
+    ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=rid&batch_id=123[39m[22m 
   [1m[32m✓[39m[22m [1m[32m[1mGET[22m[1m - http://fake.url[39m[22m
 
 "
@@ -240,7 +251,8 @@ exports[`Default reporter testsWait the spinner text is updated and cleared at t
 exports[`Default reporter testsWait the spinner text is updated and cleared at the end (in CI: false) 3`] = `
 "View pending summary in Datadog: [2m[36mhttps://app.datadoghq.com/synthetics/explorer/ci?batchResultId=123[39m[22m
 [1m[32m✓[39m[22m [[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m - [1m[32mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m
-  ⎋ Total duration: 123 ms - View test run details: [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=rid&from_ci=true[39m[22m 
+  • Total duration: 123 ms - View test run details:
+    ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=rid&batch_id=123[39m[22m 
   [1m[32m✓[39m[22m [1m[32m[1mGET[22m[1m - http://fake.url[39m[22m
 
  [36m⠙[39m Waiting for [1m[36m1[39m[22m test [90m(aaa-aaa-aaa)[39m…
@@ -261,7 +273,8 @@ exports[`Default reporter testsWait the spinner text is updated and cleared at t
 - Waiting for [1m[36m2[39m[22m tests [90m(aaa-aaa-aaa, bbb-bbb-bbb)[39m…
 
 [1m[32m✓[39m[22m [[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m - [1m[32mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m
-  ⎋ Total duration: 123 ms - View test run details: [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=rid&from_ci=true[39m[22m 
+  • Total duration: 123 ms - View test run details:
+    ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=rid&batch_id=123[39m[22m 
   [1m[32m✓[39m[22m [1m[32m[1mGET[22m[1m - http://fake.url[39m[22m
 
 "
@@ -273,7 +286,8 @@ exports[`Default reporter testsWait the spinner text is updated and cleared at t
 - Waiting for [1m[36m2[39m[22m tests [90m(aaa-aaa-aaa, bbb-bbb-bbb)[39m…
 
 [1m[32m✓[39m[22m [[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m - [1m[32mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m
-  ⎋ Total duration: 123 ms - View test run details: [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=rid&from_ci=true[39m[22m 
+  • Total duration: 123 ms - View test run details:
+    ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=rid&batch_id=123[39m[22m 
   [1m[32m✓[39m[22m [1m[32m[1mGET[22m[1m - http://fake.url[39m[22m
 
 - Waiting for [1m[36m1[39m[22m test [90m(aaa-aaa-aaa)[39m…

--- a/src/commands/synthetics/__tests__/reporters/__snapshots__/default.test.ts.snap
+++ b/src/commands/synthetics/__tests__/reporters/__snapshots__/default.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`Default reporter resultEnd 1 API test, 1 location, 1 result: success 1`] = `
 "[1m[32m✓[39m[22m [[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m - [1m[32mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m
   • Total duration: 123 ms - View test run details:
-    ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=1&from_ci=true&batch_id=123[39m[22m 
+    ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=1&batch_id=123&from_ci=true[39m[22m 
   [1m[32m✓[39m[22m [1m[32m[1mGET[22m[1m - http://fake.url[39m[22m
 
 "
@@ -12,19 +12,19 @@ exports[`Default reporter resultEnd 1 API test, 1 location, 1 result: success 1`
 exports[`Default reporter resultEnd 1 API test, 1 location, 3 results: success, failed non-blocking, failed blocking 1`] = `
 "[1m[32m✓[39m[22m [[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m - [1m[32mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m
   • Total duration: 123 ms - View test run details:
-    ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=1&from_ci=true&batch_id=123[39m[22m 
+    ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=1&batch_id=123&from_ci=true[39m[22m 
   [1m[32m✓[39m[22m [1m[32m[1mGET[22m[1m - http://fake.url[39m[22m
 
 [1m[33m✖[39m[22m [[1m[33mnon-blocking[39m[22m] [[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m - [1m[33mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m
   • Total duration: 123 ms - View test run details:
-    ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=2&from_ci=true&batch_id=123[39m[22m 
+    ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=2&batch_id=123&from_ci=true[39m[22m 
   [1m[33m✖[39m[22m [1m[33m[1mGET[22m[1m - http://fake.url[39m[22m
 [1m[33m  - Assertion failed:[39m[22m
 [1m[33m    ▶ responseTime should be less than [4m1000[24m. Actual: [4m1234[24m[39m[22m
 
 [1m[31m✖[39m[22m [[1m[31mblocking[39m[22m] [[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m - [1m[31mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m
   • Total duration: 123 ms - View test run details:
-    ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=3&from_ci=true&batch_id=123[39m[22m 
+    ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=3&batch_id=123&from_ci=true[39m[22m 
   [1m[31m✖[39m[22m [1m[31m[1mGET[22m[1m - http://fake.url[39m[22m
 [1m[31m  - Assertion failed:[39m[22m
 [1m[31m    ▶ responseTime should be less than [4m1000[24m. Actual: [4m1234[24m[39m[22m
@@ -35,16 +35,16 @@ exports[`Default reporter resultEnd 1 API test, 1 location, 3 results: success, 
 exports[`Default reporter resultEnd 3 API tests, 2 passed (1 from previous CI run) 1`] = `
 "[1m[32m✓[39m[22m [[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m - [1m[32mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m
   • Total duration: 123 ms - View test run details:
-    ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=1001&from_ci=true&batch_id=123[39m[22m 
+    ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=1001&batch_id=123&from_ci=true[39m[22m 
   [1m[32m✓[39m[22m [1m[32m[1mGET[22m[1m - http://fake.url[39m[22m
 
 [1m[32m✓[39m[22m [[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m
 [2m  [1m[32m◀[39m[22m[2m Successful result from [1m[32mprevious[39m[22m[2m CI run:[22m
-    ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=0002&from_ci=true&batch_id=123[39m[22m
+    ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=0002&batch_id=123&from_ci=true[39m[22m
 
 [1m[32m✓[39m[22m [2m(edited) [22m[[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m - [1m[32mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m
   • Total duration: 123 ms - View test run details:
-    ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=1003&from_ci=true&batch_id=123[39m[22m 
+    ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=1003&batch_id=123&from_ci=true[39m[22m 
   [1m[32m✓[39m[22m [1m[32m[1mGET[22m[1m - http://fake.url[39m[22m
 
 "
@@ -53,7 +53,7 @@ exports[`Default reporter resultEnd 3 API tests, 2 passed (1 from previous CI ru
 exports[`Default reporter resultEnd 3 Browser test: failed blocking, timed out, global failure 1`] = `
 "[1m[31m✖[39m[22m [[1m[31mblocking[39m[22m] [[1m[2mabc-def-ghi[22m[22m] [1mTest name[22m - [1m[31mlocation: [1mLocation name[22m[1m[39m[22m - [1m[31mdevice: [1mchrome.laptop_large[22m[1m[39m[22m
   • Total duration: 20000 ms - View test run details:
-    ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/abc-def-ghi/result/1?from_ci=true&batch_id=123[39m[22m 
+    ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/abc-def-ghi/result/1?batch_id=123&from_ci=true[39m[22m 
 [31m    [[1mSTEP_TIMEOUT[22m] - [2mStep failed because it took more than 20 seconds.[22m[39m
     [1m[32m✓[39m[22m | [1m1000[22mms - Navigate to start URL
     [2mhttps://example.org/[22m
@@ -67,12 +67,12 @@ exports[`Default reporter resultEnd 3 Browser test: failed blocking, timed out, 
 
 [1m[31m✖[39m[22m [[1m[31mblocking[39m[22m] [[1m[2mabc-def-ghi[22m[22m] [1mTest name[22m - [1m[31mlocation: [1mLocation name[22m[1m[39m[22m
   • View test run details:
-    ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/abc-def-ghi/result/1?from_ci=true&batch_id=123[39m[22m (not yet received)
+    ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/abc-def-ghi/result/1?batch_id=123&from_ci=true[39m[22m (not yet received)
 [31m    [[1mTIMEOUT[22m] - [2mThe batch timed out before receiving the result.[22m[39m
 
 [1m[31m✖[39m[22m [[1m[31mblocking[39m[22m] [[1m[2mabc-def-ghi[22m[22m] [1mTest name[22m - [1m[31mlocation: [1mLocation name[22m[1m[39m[22m
   • View test run details:
-    ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/abc-def-ghi/result/1?from_ci=true&batch_id=123[39m[22m 
+    ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/abc-def-ghi/result/1?batch_id=123&from_ci=true[39m[22m 
 [31m    [[1mFAILURE_CODE[22m] - [2mFailure message[22m[39m
 
 "
@@ -242,7 +242,7 @@ exports[`Default reporter testsWait the spinner text is updated and cleared at t
 "View pending summary in Datadog: [2m[36mhttps://app.datadoghq.com/synthetics/explorer/ci?batchResultId=123[39m[22m
 [1m[32m✓[39m[22m [[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m - [1m[32mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m
   • Total duration: 123 ms - View test run details:
-    ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=rid&from_ci=true&batch_id=123[39m[22m 
+    ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=rid&batch_id=123&from_ci=true[39m[22m 
   [1m[32m✓[39m[22m [1m[32m[1mGET[22m[1m - http://fake.url[39m[22m
 
 "
@@ -252,7 +252,7 @@ exports[`Default reporter testsWait the spinner text is updated and cleared at t
 "View pending summary in Datadog: [2m[36mhttps://app.datadoghq.com/synthetics/explorer/ci?batchResultId=123[39m[22m
 [1m[32m✓[39m[22m [[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m - [1m[32mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m
   • Total duration: 123 ms - View test run details:
-    ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=rid&from_ci=true&batch_id=123[39m[22m 
+    ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=rid&batch_id=123&from_ci=true[39m[22m 
   [1m[32m✓[39m[22m [1m[32m[1mGET[22m[1m - http://fake.url[39m[22m
 
  [36m⠙[39m Waiting for [1m[36m1[39m[22m test [90m(aaa-aaa-aaa)[39m…
@@ -274,7 +274,7 @@ exports[`Default reporter testsWait the spinner text is updated and cleared at t
 
 [1m[32m✓[39m[22m [[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m - [1m[32mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m
   • Total duration: 123 ms - View test run details:
-    ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=rid&from_ci=true&batch_id=123[39m[22m 
+    ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=rid&batch_id=123&from_ci=true[39m[22m 
   [1m[32m✓[39m[22m [1m[32m[1mGET[22m[1m - http://fake.url[39m[22m
 
 "
@@ -287,7 +287,7 @@ exports[`Default reporter testsWait the spinner text is updated and cleared at t
 
 [1m[32m✓[39m[22m [[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m - [1m[32mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m
   • Total duration: 123 ms - View test run details:
-    ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=rid&from_ci=true&batch_id=123[39m[22m 
+    ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=rid&batch_id=123&from_ci=true[39m[22m 
   [1m[32m✓[39m[22m [1m[32m[1mGET[22m[1m - http://fake.url[39m[22m
 
 - Waiting for [1m[36m1[39m[22m test [90m(aaa-aaa-aaa)[39m…

--- a/src/commands/synthetics/__tests__/reporters/default.test.ts
+++ b/src/commands/synthetics/__tests__/reporters/default.test.ts
@@ -50,7 +50,7 @@ describe('Default reporter', () => {
       ['initErrors', [['error']], 1],
       ['log', ['log'], 1],
       ['reportStart', [{startTime: 0}], 1],
-      ['resultEnd', [getApiResult('1', getApiTest()), ''], 1],
+      ['resultEnd', [getApiResult('1', getApiTest()), '', ''], 1],
       ['runEnd', [getSummary(), ''], 1],
       ['testTrigger', [getApiTest(), '', ExecutionRule.BLOCKING, {}], 1],
       ['testsWait', [[getApiTest()], '', ''], 2],
@@ -186,7 +186,7 @@ describe('Default reporter', () => {
       expect(simulatedTerminalOutput).toMatchSnapshot()
 
       clearLine.mockClear()
-      ttyReporter.resultEnd(getApiResult('rid', getApiTest('aaa-aaa-aaa')), MOCK_BASE_URL)
+      ttyReporter.resultEnd(getApiResult('rid', getApiTest('aaa-aaa-aaa')), MOCK_BASE_URL, '123')
       if (inCI) {
         // In CI the spinner does not spin, so `resultEnd()` has no spinner text to clear.
         expect(clearLine).not.toHaveBeenCalled()
@@ -319,7 +319,7 @@ describe('Default reporter', () => {
     test.each(cases)('$description', (testCase) => {
       const {results, baseUrl} = testCase.fixtures
       for (const result of results) {
-        reporter.resultEnd(result, baseUrl)
+        reporter.resultEnd(result, baseUrl, '123')
       }
       const output = writeMock.mock.calls.map((c) => c[0]).join('')
       expect(output).toMatchSnapshot()

--- a/src/commands/synthetics/__tests__/reporters/junit.test.ts
+++ b/src/commands/synthetics/__tests__/reporters/junit.test.ts
@@ -141,7 +141,7 @@ describe('Junit reporter', () => {
     })
 
     it('should give a default suite name', () => {
-      reporter.resultEnd(globalResultMock, '')
+      reporter.resultEnd(globalResultMock, '', '')
       const testsuite = reporter['json'].testsuites.testsuite[0]
       expect(testsuite.$.name).toBe('Undefined suite')
     })
@@ -152,7 +152,7 @@ describe('Junit reporter', () => {
         {...globalResultMock, test: {...globalTestMock, suite: 'same suite'}},
       ]
 
-      results.forEach((result) => reporter.resultEnd(result, ''))
+      results.forEach((result) => reporter.resultEnd(result, '', ''))
 
       // We should have 1 unique report. Not 2 different ones.
       expect(reporter['json'].testsuites.testsuite.length).toBe(1)
@@ -165,7 +165,7 @@ describe('Junit reporter', () => {
     })
 
     it('should add stats to the run', () => {
-      reporter.resultEnd({...globalResultMock, test: {...globalTestMock, suite: 'suite 1'}}, '')
+      reporter.resultEnd({...globalResultMock, test: {...globalTestMock, suite: 'suite 1'}}, '', '')
 
       reporter.testTrigger({...globalTestMock, suite: 'suite 2'}, '', ExecutionRule.SKIPPED, {})
       reporter.resultEnd(
@@ -178,6 +178,7 @@ describe('Junit reporter', () => {
             suite: 'suite 2',
           },
         },
+        '',
         ''
       )
       reporter.resultEnd(
@@ -192,6 +193,7 @@ describe('Junit reporter', () => {
           },
           timedOut: false,
         },
+        '',
         ''
       )
 
@@ -221,6 +223,7 @@ describe('Junit reporter', () => {
             suite: 'suite 1',
           },
         },
+        '',
         ''
       )
 
@@ -294,10 +297,10 @@ describe('Junit reporter', () => {
           ],
         },
       }
-      reporter.resultEnd(browserResult1, '')
-      reporter.resultEnd(browserResult2, '')
-      reporter.resultEnd(browserResult3, '')
-      reporter.resultEnd(apiResult, '')
+      reporter.resultEnd(browserResult1, '', '')
+      reporter.resultEnd(browserResult2, '', '')
+      reporter.resultEnd(browserResult3, '', '')
+      reporter.resultEnd(apiResult, '', '')
       const testsuite = reporter['json'].testsuites.testsuite[0]
       const results = [
         [1, 2, 0, 1],
@@ -326,7 +329,7 @@ describe('Junit reporter', () => {
         ...globalResultMock,
         result: getApiServerResult({passed: false}),
       }
-      const testCase = reporter['getTestCase'](resultMock, '')
+      const testCase = reporter['getTestCase'](resultMock, '', '')
       expect(testCase.$).toMatchObject({
         ...getDefaultTestCaseStats(),
         steps_count: 1,
@@ -340,7 +343,7 @@ describe('Junit reporter', () => {
         ...globalResultMock,
         result: getFailedMultiStepsServerResult(),
       }
-      const testCase = reporter['getTestCase'](resultMock, '')
+      const testCase = reporter['getTestCase'](resultMock, '', '')
       expect(testCase.$).toMatchObject({
         ...getDefaultTestCaseStats(),
         steps_allowfailures: 1,
@@ -372,7 +375,7 @@ describe('Junit reporter', () => {
           },
         },
       }
-      const testCase = reporter['getTestCase'](resultMock, '')
+      const testCase = reporter['getTestCase'](resultMock, '', '')
       expect(testCase.$).toMatchObject({
         ...getDefaultTestCaseStats(),
         steps_count: 3,
@@ -427,6 +430,7 @@ describe('GitLab test report compatibility', () => {
           ...(location && {location}),
           ...(timedOut && {timedOut}),
         },
+        '',
         ''
       )
 
@@ -489,7 +493,7 @@ describe('GitLab test report compatibility', () => {
       test: {...baseResult.test, suite: 'tests.json'},
     }
 
-    reporter['resultEnd'](result, '')
+    reporter['resultEnd'](result, '', '')
 
     const testCase = reporter['json'].testsuites.testsuite[0].testcase[0]
 
@@ -528,9 +532,9 @@ describe('GitLab test report compatibility', () => {
 
     reporter['testTrigger'](globalTestMock, '', ExecutionRule.SKIPPED, {})
 
-    reporter['resultEnd']({...getFailedBrowserResult(), executionRule: ExecutionRule.BLOCKING} as Result, '')
-    reporter['resultEnd']({...getFailedBrowserResult(), executionRule: ExecutionRule.NON_BLOCKING} as Result, '')
-    reporter['resultEnd']({...getBrowserResult('', globalTestMock), executionRule: ExecutionRule.BLOCKING}, '')
+    reporter['resultEnd']({...getFailedBrowserResult(), executionRule: ExecutionRule.BLOCKING} as Result, '', '')
+    reporter['resultEnd']({...getFailedBrowserResult(), executionRule: ExecutionRule.NON_BLOCKING} as Result, '', '')
+    reporter['resultEnd']({...getBrowserResult('', globalTestMock), executionRule: ExecutionRule.BLOCKING}, '', '')
 
     const [testCaseSkipped, testCaseBlocking, testCaseNonBlocking, testCasePassed] = reporter[
       'json'
@@ -560,7 +564,7 @@ describe('GitLab test report compatibility', () => {
       result: {...baseResult.result, failure},
     }
 
-    reporter['resultEnd'](result, '')
+    reporter['resultEnd'](result, '', '')
 
     const testCase = reporter['json'].testsuites.testsuite[0].testcase[0]
     expect(testCase.failure).toStrictEqual([

--- a/src/commands/synthetics/__tests__/utils/public.test.ts
+++ b/src/commands/synthetics/__tests__/utils/public.test.ts
@@ -918,7 +918,7 @@ describe('utils', () => {
         status: 'passed',
         result_id: 'rid-2',
       })
-      expect(mockReporter.resultEnd).toHaveBeenNthCalledWith(1, {...result, resultId: 'rid-2'}, MOCK_BASE_URL)
+      expect(mockReporter.resultEnd).toHaveBeenNthCalledWith(1, {...result, resultId: 'rid-2'}, MOCK_BASE_URL, 'bid')
       // Still waiting for 2 tests
       expect(mockReporter.testsWait).toHaveBeenNthCalledWith(
         3,
@@ -955,7 +955,7 @@ describe('utils', () => {
         ...batch.results[0],
         status: 'passed',
       })
-      expect(mockReporter.resultEnd).toHaveBeenNthCalledWith(2, result, MOCK_BASE_URL)
+      expect(mockReporter.resultEnd).toHaveBeenNthCalledWith(2, result, MOCK_BASE_URL, 'bid')
       // Now waiting for 1 test
       expect(mockReporter.testsWait).toHaveBeenNthCalledWith(4, [tests[1]], MOCK_BASE_URL, trigger.batch_id, 0)
 
@@ -987,7 +987,7 @@ describe('utils', () => {
         test_public_id: 'other-public-id',
         result_id: 'rid-3',
       })
-      expect(mockReporter.resultEnd).toHaveBeenNthCalledWith(3, {...result, resultId: 'rid-3'}, MOCK_BASE_URL)
+      expect(mockReporter.resultEnd).toHaveBeenNthCalledWith(3, {...result, resultId: 'rid-3'}, MOCK_BASE_URL, 'bid')
       // Do not report when there are no tests to wait anymore
       expect(mockReporter.testsWait).toHaveBeenCalledTimes(4)
     })
@@ -1067,8 +1067,8 @@ describe('utils', () => {
       expect(mockReporter.resultReceived).toHaveBeenCalledTimes(1)
 
       // `resultEnd` should return the same data as `waitForResults`
-      expect(mockReporter.resultEnd).toHaveBeenNthCalledWith(1, result, MOCK_BASE_URL)
-      expect(mockReporter.resultEnd).toHaveBeenNthCalledWith(2, expectedTimeoutResult, MOCK_BASE_URL)
+      expect(mockReporter.resultEnd).toHaveBeenNthCalledWith(1, result, MOCK_BASE_URL, 'bid')
+      expect(mockReporter.resultEnd).toHaveBeenNthCalledWith(2, expectedTimeoutResult, MOCK_BASE_URL, 'bid')
     })
 
     test('results failure should ignore if timed-out', async () => {

--- a/src/commands/synthetics/batch.ts
+++ b/src/commands/synthetics/batch.ts
@@ -140,14 +140,14 @@ const reportResults = (
   results: ResultInBatch[],
   pollResultMap: PollResultMap,
   resultDisplayInfo: ResultDisplayInfo,
-  hasBatchExceededMaxPollingDate: boolean,
+  safeDeadlineReached: boolean,
   reporter: MainReporter
 ) => {
   const baseUrl = getAppBaseURL(resultDisplayInfo.options)
 
   for (const result of results) {
     reporter.resultEnd(
-      getResultFromBatch(result, pollResultMap, resultDisplayInfo, hasBatchExceededMaxPollingDate),
+      getResultFromBatch(result, pollResultMap, resultDisplayInfo, safeDeadlineReached),
       baseUrl,
       batchId
     )

--- a/src/commands/synthetics/interfaces.ts
+++ b/src/commands/synthetics/interfaces.ts
@@ -13,7 +13,7 @@ export interface MainReporter {
   testWait(test: Test): void
   testsWait(tests: Test[], baseUrl: string, batchId: string, skippedCount?: number): void
   resultReceived(result: ResultInBatch): void
-  resultEnd(result: Result, baseUrl: string): void
+  resultEnd(result: Result, baseUrl: string, batchId: string): void
   reportStart(timings: {startTime: number}): void
   runEnd(summary: Summary, baseUrl: string, orgSettings?: SyntheticsOrgSettings): void
 }

--- a/src/commands/synthetics/interfaces.ts
+++ b/src/commands/synthetics/interfaces.ts
@@ -6,16 +6,16 @@ import {TunnelInfo} from './tunnel'
 export type SupportedReporter = 'junit' | 'default'
 
 export interface MainReporter {
+  log(log: string): void
   error(error: string): void
   initErrors(errors: string[]): void
-  log(log: string): void
-  reportStart(timings: {startTime: number}): void
-  resultEnd(result: Result, baseUrl: string): void
-  resultReceived(result: Batch['results'][0]): void
-  runEnd(summary: Summary, baseUrl: string, orgSettings?: SyntheticsOrgSettings): void
-  testsWait(tests: Test[], baseUrl: string, batchId: string, skippedCount?: number): void
   testTrigger(test: Test, testId: string, executionRule: ExecutionRule, config: UserConfigOverride): void
   testWait(test: Test): void
+  testsWait(tests: Test[], baseUrl: string, batchId: string, skippedCount?: number): void
+  resultReceived(result: ResultInBatch): void
+  resultEnd(result: Result, baseUrl: string): void
+  reportStart(timings: {startTime: number}): void
+  runEnd(summary: Summary, baseUrl: string, orgSettings?: SyntheticsOrgSettings): void
 }
 
 export type Reporter = Partial<MainReporter>

--- a/src/commands/synthetics/reporters/default.ts
+++ b/src/commands/synthetics/reporters/default.ts
@@ -203,7 +203,7 @@ const renderApiRequestDescription = (subType: string, config: Test['config']): s
   return `${chalk.bold(subType)} test`
 }
 
-const renderExecutionResult = (test: Test, execution: Result, baseUrl: string) => {
+const renderExecutionResult = (test: Test, execution: Result, baseUrl: string, batchId: string) => {
   const {executionRule, test: overriddenTest, resultId, timedOut} = execution
   const resultOutcome = getResultOutcome(execution)
   const [icon, setColor] = getResultIconAndColor(resultOutcome)
@@ -229,20 +229,18 @@ const renderExecutionResult = (test: Test, execution: Result, baseUrl: string) =
     const duration = getResultDuration(execution.result)
     const durationText = duration ? ` Total duration: ${duration} ms -` : ''
 
-    const resultUrl = getResultUrl(baseUrl, test, resultId)
+    const resultUrl = getResultUrl(baseUrl, test, resultId, batchId)
     const resultUrlStatus = timedOut ? '(not yet received)' : ''
 
-    const resultInfo = `  ⎋${durationText} View test run details: ${chalk.dim.cyan(resultUrl)} ${resultUrlStatus}`
-    outputLines.push(resultInfo)
+    outputLines.push(`  •${durationText} View test run details:`)
+    outputLines.push(`    ⎋ ${chalk.dim.cyan(resultUrl)} ${resultUrlStatus}`)
   }
 
   if (isResultSkippedBySelectiveRerun(execution)) {
-    const resultUrl = getResultUrl(baseUrl, test, resultId)
+    const resultUrl = getResultUrl(baseUrl, test, resultId, batchId)
 
-    const resultInfo = chalk.dim(
-      `  ${setColor('◀')} Successful result from ${setColor('previous')} CI run: ${chalk.cyan(resultUrl)}`
-    )
-    outputLines.push(resultInfo)
+    outputLines.push(chalk.dim(`  ${setColor('◀')} Successful result from ${setColor('previous')} CI run:`))
+    outputLines.push(`    ⎋ ${chalk.dim.cyan(resultUrl)}`)
   } else {
     const resultOutcomeText = renderResultOutcome(execution.result, overriddenTest || test, icon, setColor)
 
@@ -313,10 +311,10 @@ export class DefaultReporter implements MainReporter {
     )
   }
 
-  public resultEnd(result: Result, baseUrl: string) {
+  public resultEnd(result: Result, baseUrl: string, batchId: string) {
     // Stop the spinner so it doesn't show multiple times in a burst of received results.
     this.testWaitSpinner?.stop()
-    this.write(renderExecutionResult(result.test, result, baseUrl) + '\n\n')
+    this.write(renderExecutionResult(result.test, result, baseUrl, batchId) + '\n\n')
   }
 
   public resultReceived(result: ResultInBatch): void {

--- a/src/commands/synthetics/reporters/default.ts
+++ b/src/commands/synthetics/reporters/default.ts
@@ -17,7 +17,7 @@ import {
   Summary,
   Test,
   UserConfigOverride,
-  Batch,
+  ResultInBatch,
 } from '../interfaces'
 import {hasResult} from '../utils/internal'
 import {
@@ -319,7 +319,7 @@ export class DefaultReporter implements MainReporter {
     this.write(renderExecutionResult(result.test, result, baseUrl) + '\n\n')
   }
 
-  public resultReceived(result: Batch['results'][0]): void {
+  public resultReceived(result: ResultInBatch): void {
     return
   }
 

--- a/src/commands/synthetics/reporters/junit.ts
+++ b/src/commands/synthetics/reporters/junit.ts
@@ -216,9 +216,9 @@ export class JUnitReporter implements Reporter {
     }
   }
 
-  public resultEnd(result: Result, baseUrl: string) {
+  public resultEnd(result: Result, baseUrl: string, batchId: string) {
     const suite = this.getSuiteByName(result.test.suite)
-    const testCase = this.getTestCase(result, baseUrl)
+    const testCase = this.getTestCase(result, baseUrl, batchId)
 
     if (isResultSkippedBySelectiveRerun(result)) {
       return this.addTestCaseToSuite(suite, testCase)
@@ -488,10 +488,10 @@ export class JUnitReporter implements Reporter {
     return existingSuite
   }
 
-  private getTestCase(result: Result, baseUrl: string): XMLTestCase {
+  private getTestCase(result: Result, baseUrl: string, batchId: string): XMLTestCase {
     const test = result.test
     const resultOutcome = getResultOutcome(result)
-    const resultUrl = getResultUrl(baseUrl, test, result.resultId)
+    const resultUrl = getResultUrl(baseUrl, test, result.resultId, batchId)
 
     const passed = PASSED_RESULT_OUTCOMES.includes(resultOutcome)
 

--- a/src/commands/synthetics/utils/public.ts
+++ b/src/commands/synthetics/utils/public.ts
@@ -893,7 +893,7 @@ export const getBatchUrl = (baseUrl: string, batchId: string) =>
   `${baseUrl}synthetics/explorer/ci?batchResultId=${batchId}`
 
 export const getResultUrl = (baseUrl: string, test: Test, resultId: string, batchId: string) => {
-  const ciQueryParam = `batch_id=${batchId}`
+  const ciQueryParam = `from_ci=true&batch_id=${batchId}`
   const testDetailUrl = `${baseUrl}synthetics/details/${test.public_id}`
   if (test.type === 'browser') {
     return `${testDetailUrl}/result/${resultId}?${ciQueryParam}`

--- a/src/commands/synthetics/utils/public.ts
+++ b/src/commands/synthetics/utils/public.ts
@@ -893,7 +893,7 @@ export const getBatchUrl = (baseUrl: string, batchId: string) =>
   `${baseUrl}synthetics/explorer/ci?batchResultId=${batchId}`
 
 export const getResultUrl = (baseUrl: string, test: Test, resultId: string, batchId: string) => {
-  const ciQueryParam = `from_ci=true&batch_id=${batchId}`
+  const ciQueryParam = `batch_id=${batchId}&from_ci=true`
   const testDetailUrl = `${baseUrl}synthetics/details/${test.public_id}`
   if (test.type === 'browser') {
     return `${testDetailUrl}/result/${resultId}?${ciQueryParam}`


### PR DESCRIPTION
### What and why?

- https://github.com/DataDog/datadog-ci/pull/1254
- https://github.com/DataDog/datadog-ci/pull/1255  (← **you are here**)

The frontend will now provide more information when the result isn't found yet, but known to be in-progress in the batch. For this, we change `?from_ci=true` to `?batch_id=<batchId>` in the results link.

#### Before
<img width="1097" alt="image" src="https://github.com/DataDog/datadog-ci/assets/9317502/d51966f4-149b-4328-b07d-df7782b1885c">

#### After
![image](https://github.com/DataDog/datadog-ci/assets/9317502/c8778787-ec68-41ea-8ff3-ebe1fa756185)


### How?

Since the lines were becoming really long, I added a line break. The `⎋` icon represents an external link, so I kept it next to the result link.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
