### PR TITLE
[STAL] Add `DD_SITE` fallback

### DIFF
--- a/src/commands/git-metadata/upload.ts
+++ b/src/commands/git-metadata/upload.ts
@@ -88,7 +88,7 @@ export class UploadCommand extends Command {
     }
 
     const metricsLogger = getMetricsLogger({
-      datadogSite: process.env.DATADOG_SITE,
+      datadogSite: process.env.DATADOG_SITE || process.env.DD_SITE,
       defaultTags: [`cli_version:${this.cliVersion}`],
       prefix: 'datadog.ci.report_commits.',
     })


### PR DESCRIPTION
### What and why?

Adds a `DD_SITE` fallback when `DATADOG_SITE` is not defined. 

### How?

Many other commands use this fallback, so this increases the consistency when using multiple commands together.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
