### PR TITLE
[source-code-integration] Set `apiKey` in logger

### DIFF
--- a/src/commands/git-metadata/upload.ts
+++ b/src/commands/git-metadata/upload.ts
@@ -88,6 +88,7 @@ export class UploadCommand extends Command {
     }
 
     const metricsLogger = getMetricsLogger({
+      apiKey: this.config.apiKey,
       datadogSite: process.env.DATADOG_SITE || process.env.DD_SITE,
       defaultTags: [`cli_version:${this.cliVersion}`],
       prefix: 'datadog.ci.report_commits.',


### PR DESCRIPTION
### What and why?

If another command uses `git-metadata upload` and accept a `DD_API_KEY` environment variable, the command will fail.

### How?

We set the `apiKey` field in the `getMetricsLogger` utils, so it will use the which ever API key is set on [this line](https://github.com/DataDog/datadog-ci/blob/13beb67eadf79cb92abc2b509c6e56b992afe9a3/src/commands/git-metadata/upload.ts#L53) instead of just falling back to solely a `DATADOG_API_KEY` env var.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
