### PR TITLE
[git-metadata] Consistent usage of datadog site

### DIFF
--- a/src/commands/git-metadata/upload.ts
+++ b/src/commands/git-metadata/upload.ts
@@ -89,7 +89,7 @@ export class UploadCommand extends Command {
 
     const metricsLogger = getMetricsLogger({
       apiKey: this.config.apiKey,
-      datadogSite: process.env.DATADOG_SITE || process.env.DD_SITE,
+      datadogSite,
       defaultTags: [`cli_version:${this.cliVersion}`],
       prefix: 'datadog.ci.report_commits.',
     })
@@ -222,6 +222,6 @@ export class UploadCommand extends Command {
   }
 
   private isTargetingGov(): boolean {
-    return process.env.DATADOG_SITE === DATADOG_SITE_GOV
+    return datadogSite === DATADOG_SITE_GOV
   }
 }


### PR DESCRIPTION
Use `datadogSite` defined here as a source of truth, instead of reading env vars in several places:
https://github.com/DataDog/datadog-ci/blob/2af42a806e5f5b4f6f6927895c901d4b96d713a4/src/commands/git-metadata/api.ts#L1

Currently, anyone using `DD_SITE` or defaulting to `datadoghq.com` would have broken metrics & GovCloud detection