### PR TITLE
[synthetics] Fix incomplete residual results message

### DIFF
--- a/src/commands/synthetics/__tests__/utils/public.test.ts
+++ b/src/commands/synthetics/__tests__/utils/public.test.ts
@@ -1132,8 +1132,8 @@ describe('utils', () => {
         MOCK_BASE_URL,
         'bid'
       )
-      expect(mockReporter.log).toHaveBeenCalledWith(
-        'The full information for result rid was incomplete at the end of the batch.'
+      expect(mockReporter.error).toHaveBeenCalledWith(
+        'The full information for result rid was incomplete at the end of the batch.\n\n'
       )
 
       // Do not report when there are no tests to wait anymore


### PR DESCRIPTION
### What and why?

The message was always showing for timed out results because they are very likely to be incomplete. And for timed out results, we do not show anything, so we don't need such message.

### How?

- Fix the formatting (add new lines)
- Do not show an error message when an incomplete result is timed out
- Use `reporter.error()` instead of `reporter.info()` because it's more correct semantically

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
