### PR TITLE
[ci-visibility] Add silent option to tag command

### DIFF
--- a/src/commands/deployment/mark.ts
+++ b/src/commands/deployment/mark.ts
@@ -61,6 +61,7 @@ export class DeploymentMarkCommand extends Command {
     tagPipelineCommand.setLevel('pipeline')
     tagPipelineCommand.setTags(this.createPipelineDeploymentTags())
     tagPipelineCommand.context = this.context
+    tagPipelineCommand.setSilent(true)
 
     if (this.noFail) {
       tagJobCommand.setNoFail(true)

--- a/src/commands/deployment/mark.ts
+++ b/src/commands/deployment/mark.ts
@@ -56,6 +56,7 @@ export class DeploymentMarkCommand extends Command {
     tagJobCommand.setLevel('job')
     tagJobCommand.setTags(this.createJobDeploymentTags())
     tagJobCommand.context = this.context
+    tagJobCommand.setSilent(false)
 
     const tagPipelineCommand = new TagCommand()
     tagPipelineCommand.setLevel('pipeline')

--- a/src/commands/tag/README.md
+++ b/src/commands/tag/README.md
@@ -20,6 +20,7 @@ datadog-ci tag --level job --tags "go.version:`go version`"
 - `--no-fail` (default: `false`) will prevent the tag command from failing if there are issues submitting the data.
 - `--tags` is an array of key value pairs of the shape `key:value`. This will be the tags added to the pipeline or job span.
   The resulting dictionary will be merged with whatever is in the `DD_TAGS` environment variable. If a `key` appears both in `--tags` and `DD_TAGS`, whatever value is in `DD_TAGS` will take precedence.
+- `--silent` (default: `false`) will prevent the tag command from writing to stdout and stderr.
 
 ### Environment variables
 

--- a/src/commands/tag/__tests__/tag.test.ts
+++ b/src/commands/tag/__tests__/tag.test.ts
@@ -30,7 +30,7 @@ const createMockContext = () => {
 }
 
 describe('execute', () => {
-  const runCLI = async (level: string, tags: string[], env: Record<string, string>) => {
+  const runCLI = async (level: string, tags: string[], env: Record<string, string>, extraArgs: string[]) => {
     const cli = makeCLI()
     const context = createMockContext() as any
     process.env = {
@@ -44,19 +44,19 @@ describe('execute', () => {
       tagsList.push(t)
     })
 
-    const code = await cli.run(['tag', '--level', level, ...tagsList], context)
+    const code = await cli.run(['tag', '--level', level, ...extraArgs, ...tagsList], context)
 
     return {context, code}
   }
 
   test('should fail if an invalid level given', async () => {
-    const {context, code} = await runCLI('stage', ['key:value'], {BUILDKITE: 'true', BUILDKITE_BUILD_ID: 'id'})
+    const {context, code} = await runCLI('stage', ['key:value'], {BUILDKITE: 'true', BUILDKITE_BUILD_ID: 'id'}, [])
     expect(code).toBe(1)
     expect(context.stderr.toString()).toContain('Level must be one of [pipeline, job]')
   })
 
   test('should fail if no tags provided', async () => {
-    const {context, code} = await runCLI('pipeline', [], {})
+    const {context, code} = await runCLI('pipeline', [], {}, [])
     expect(code).toBe(1)
     expect(context.stderr.toString()).toContain(
       'DD_TAGS environment variable or --tags command line argument is required'
@@ -64,7 +64,7 @@ describe('execute', () => {
   })
 
   test('should fail if not running in a supported provider', async () => {
-    const {context, code} = await runCLI('pipeline', ['key:value'], {})
+    const {context, code} = await runCLI('pipeline', ['key:value'], {}, [])
     expect(code).toBe(1)
     expect(context.stderr.toString()).toContain(
       'Only providers [GitHub, GitLab, CircleCI, Buildkite, Buddy, Jenkins, TeamCity, AzurePipelines] are supported'
@@ -77,8 +77,18 @@ describe('execute', () => {
       BUDDY_PIPELINE_ID: 'example/example',
       BUDDY_EXECUTION_ID: '10',
       BUDDY_EXECUTION_START_DATE: '2023-03-08T00:00:00Z',
-    })
+    }, [])
     expect(code).toBe(1)
     expect(context.stderr.toString()).toContain('Cannot use level "job" for Buddy.')
+  })
+
+  test('should not output anything if silent mode is enabled', async () => {
+    const result = await runCLI('pipeline', ['key:value'], {
+      BUILDKITE: 'true',
+      BUILDKITE_BUILD_ID: 'id',
+      BUILDKITE_JOB_ID: 'id',
+    }, ['--silent'])
+    expect(result.context.stderr.toString()).toBe('')
+    expect(result.context.stdout.toString()).toBe('')
   })
 })

--- a/src/commands/tag/__tests__/tag.test.ts
+++ b/src/commands/tag/__tests__/tag.test.ts
@@ -72,22 +72,32 @@ describe('execute', () => {
   })
 
   test('should fail if provider is BuddyWorks and level is job', async () => {
-    const {context, code} = await runCLI('job', ['key:value'], {
-      BUDDY: 'true',
-      BUDDY_PIPELINE_ID: 'example/example',
-      BUDDY_EXECUTION_ID: '10',
-      BUDDY_EXECUTION_START_DATE: '2023-03-08T00:00:00Z',
-    }, [])
+    const {context, code} = await runCLI(
+      'job',
+      ['key:value'],
+      {
+        BUDDY: 'true',
+        BUDDY_PIPELINE_ID: 'example/example',
+        BUDDY_EXECUTION_ID: '10',
+        BUDDY_EXECUTION_START_DATE: '2023-03-08T00:00:00Z',
+      },
+      []
+    )
     expect(code).toBe(1)
     expect(context.stderr.toString()).toContain('Cannot use level "job" for Buddy.')
   })
 
   test('should not output anything if silent mode is enabled', async () => {
-    const result = await runCLI('pipeline', ['key:value'], {
-      BUILDKITE: 'true',
-      BUILDKITE_BUILD_ID: 'id',
-      BUILDKITE_JOB_ID: 'id',
-    }, ['--silent'])
+    const result = await runCLI(
+      'pipeline',
+      ['key:value'],
+      {
+        BUILDKITE: 'true',
+        BUILDKITE_BUILD_ID: 'id',
+        BUILDKITE_JOB_ID: 'id',
+      },
+      ['--silent']
+    )
     expect(result.context.stderr.toString()).toBe('')
     expect(result.context.stdout.toString()).toBe('')
   })

--- a/src/commands/tag/__tests__/tag.test.ts
+++ b/src/commands/tag/__tests__/tag.test.ts
@@ -30,7 +30,7 @@ const createMockContext = () => {
 }
 
 describe('execute', () => {
-  const runCLI = async (level: string, tags: string[], env: Record<string, string>, extraArgs: string[]) => {
+  const runCLI = async (level: string, tags: string[], env: Record<string, string>, extraArgs: string[] = []) => {
     const cli = makeCLI()
     const context = createMockContext() as any
     process.env = {
@@ -50,13 +50,13 @@ describe('execute', () => {
   }
 
   test('should fail if an invalid level given', async () => {
-    const {context, code} = await runCLI('stage', ['key:value'], {BUILDKITE: 'true', BUILDKITE_BUILD_ID: 'id'}, [])
+    const {context, code} = await runCLI('stage', ['key:value'], {BUILDKITE: 'true', BUILDKITE_BUILD_ID: 'id'})
     expect(code).toBe(1)
     expect(context.stderr.toString()).toContain('Level must be one of [pipeline, job]')
   })
 
   test('should fail if no tags provided', async () => {
-    const {context, code} = await runCLI('pipeline', [], {}, [])
+    const {context, code} = await runCLI('pipeline', [], {})
     expect(code).toBe(1)
     expect(context.stderr.toString()).toContain(
       'DD_TAGS environment variable or --tags command line argument is required'
@@ -64,7 +64,7 @@ describe('execute', () => {
   })
 
   test('should fail if not running in a supported provider', async () => {
-    const {context, code} = await runCLI('pipeline', ['key:value'], {}, [])
+    const {context, code} = await runCLI('pipeline', ['key:value'], {})
     expect(code).toBe(1)
     expect(context.stderr.toString()).toContain(
       'Only providers [GitHub, GitLab, CircleCI, Buildkite, Buddy, Jenkins, TeamCity, AzurePipelines] are supported'
@@ -72,17 +72,12 @@ describe('execute', () => {
   })
 
   test('should fail if provider is BuddyWorks and level is job', async () => {
-    const {context, code} = await runCLI(
-      'job',
-      ['key:value'],
-      {
-        BUDDY: 'true',
-        BUDDY_PIPELINE_ID: 'example/example',
-        BUDDY_EXECUTION_ID: '10',
-        BUDDY_EXECUTION_START_DATE: '2023-03-08T00:00:00Z',
-      },
-      []
-    )
+    const {context, code} = await runCLI('job', ['key:value'], {
+      BUDDY: 'true',
+      BUDDY_PIPELINE_ID: 'example/example',
+      BUDDY_EXECUTION_ID: '10',
+      BUDDY_EXECUTION_START_DATE: '2023-03-08T00:00:00Z',
+    })
     expect(code).toBe(1)
     expect(context.stderr.toString()).toContain('Cannot use level "job" for Buddy.')
   })

--- a/src/commands/tag/tag.ts
+++ b/src/commands/tag/tag.ts
@@ -44,6 +44,10 @@ export class TagCommand extends Command {
     this.noFail = noFail
   }
 
+  public setSilent(silent: boolean) {
+    this.silent = silent
+  }
+
   public async execute() {
     if (this.level !== 'pipeline' && this.level !== 'job') {
       this.context.stderr.write(`${chalk.red.bold('[ERROR]')} Level must be one of [pipeline, job]\n`)

--- a/src/commands/tag/tag.ts
+++ b/src/commands/tag/tag.ts
@@ -24,6 +24,7 @@ export class TagCommand extends Command {
 
   private level = Option.String('--level')
   private noFail = Option.Boolean('--no-fail')
+  private silent = Option.Boolean('--silent')
   private tags = Option.Array('--tags')
 
   private config = {
@@ -48,6 +49,15 @@ export class TagCommand extends Command {
       this.context.stderr.write(`${chalk.red.bold('[ERROR]')} Level must be one of [pipeline, job]\n`)
 
       return 1
+    }
+
+    if (this.silent) {
+      this.context.stdout.write = () => {
+        return true
+      }
+      this.context.stderr.write = () => {
+        return true
+      }
     }
 
     const tags = {


### PR DESCRIPTION
### What and why?

This PR introduces the `--silent` option to the `tag` command. This option, as the README will state, it prevents the tag command from writing to stdout and stderr. One of its uses will be to hide implementation details for the `datadog-ci deployment mark` beta command. That command runs the tag command twice and we do not want the second time to output anything as it would be redundant.

### How?

A brief description of implementation details of this PR.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
