### PR TITLE
[SYNTH-13771] Fix "No tests to run" not being shown anymore

### DIFF
--- a/src/commands/synthetics/__tests__/test.test.ts
+++ b/src/commands/synthetics/__tests__/test.test.ts
@@ -1,0 +1,32 @@
+import {RunTestsCommandConfig} from '../interfaces'
+import {getTestsFromSearchQuery} from '../test'
+
+import {mockReporter} from './fixtures'
+
+describe('getTestsFromSearchQuery', () => {
+  it('should return an empty array if no tests are found', async () => {
+    const api = {
+      searchTests: jest.fn().mockResolvedValue({tests: []}),
+    }
+    const config = {global: {}, testSearchQuery: 'my search query'} as RunTestsCommandConfig
+
+    const result = await getTestsFromSearchQuery(api as any, config, mockReporter)
+
+    expect(result).toEqual([])
+    expect(mockReporter.error).not.toHaveBeenCalled()
+  })
+
+  it('should log an error message if too many tests are returned by the search query', async () => {
+    const api = {
+      searchTests: jest.fn().mockResolvedValue({tests: Array(101)}),
+    }
+    const config = {global: {}, testSearchQuery: 'my search query'} as RunTestsCommandConfig
+
+    const result = await getTestsFromSearchQuery(api as any, config, mockReporter)
+
+    expect(result).toEqual([])
+    expect(mockReporter.error).toHaveBeenCalledWith(
+      'More than 100 tests returned by search query, only the first 100 will be fetched.\n'
+    )
+  })
+})

--- a/src/commands/synthetics/test.ts
+++ b/src/commands/synthetics/test.ts
@@ -1,7 +1,6 @@
 import chalk from 'chalk'
 
 import {APIHelper, EndpointError, formatBackendErrors, isNotFoundError} from './api'
-import {CiError} from './errors'
 import {MainReporter, RunTestsCommandConfig, Suite, Test, TriggerConfig, UserConfigOverride} from './interfaces'
 import {MAX_TESTS_TO_TRIGGER} from './run-tests-command'
 import {getSuites, normalizePublicId} from './utils/public'
@@ -41,10 +40,6 @@ export const getTestsFromSearchQuery = async (
     reporter.error(
       `More than ${MAX_TESTS_TO_TRIGGER} tests returned by search query, only the first ${MAX_TESTS_TO_TRIGGER} will be fetched.\n`
     )
-  }
-
-  if (testsToTriggerBySearchQuery.length === 0) {
-    throw new CiError('NO_TESTS_TO_RUN')
   }
 
   return testsToTriggerBySearchQuery

--- a/src/commands/synthetics/test.ts
+++ b/src/commands/synthetics/test.ts
@@ -1,0 +1,87 @@
+import chalk from 'chalk'
+
+import {APIHelper, EndpointError, formatBackendErrors, isNotFoundError} from './api'
+import {CiError} from './errors'
+import {MainReporter, RunTestsCommandConfig, Suite, Test, TriggerConfig, UserConfigOverride} from './interfaces'
+import {MAX_TESTS_TO_TRIGGER} from './run-tests-command'
+import {getSuites, normalizePublicId} from './utils/public'
+
+export const getTestConfigs = async (
+  config: RunTestsCommandConfig,
+  reporter: MainReporter,
+  suites: Suite[] = []
+): Promise<TriggerConfig[]> => {
+  const suitesFromFiles = (await Promise.all(config.files.map((glob: string) => getSuites(glob, reporter))))
+    .reduce((acc, val) => acc.concat(val), [])
+    .filter((suite) => !!suite.content.tests)
+
+  suites.push(...suitesFromFiles)
+
+  const testConfigs = suites
+    .map((suite) =>
+      suite.content.tests.map((test) => ({
+        config: test.config,
+        id: normalizePublicId(test.id) ?? '',
+        suite: suite.name,
+      }))
+    )
+    .reduce((acc, suiteTests) => acc.concat(suiteTests), [])
+
+  return testConfigs
+}
+
+export const getTestsFromSearchQuery = async (
+  api: APIHelper,
+  config: RunTestsCommandConfig,
+  reporter: MainReporter
+) => {
+  const testsToTriggerBySearchQuery = await getTestListBySearchQuery(api, config.global, config.testSearchQuery || '')
+
+  if (testsToTriggerBySearchQuery.length > MAX_TESTS_TO_TRIGGER) {
+    reporter.error(
+      `More than ${MAX_TESTS_TO_TRIGGER} tests returned by search query, only the first ${MAX_TESTS_TO_TRIGGER} will be fetched.\n`
+    )
+  }
+
+  if (testsToTriggerBySearchQuery.length === 0) {
+    throw new CiError('NO_TESTS_TO_RUN')
+  }
+
+  return testsToTriggerBySearchQuery
+}
+
+export const getTest = async (
+  api: APIHelper,
+  {id, suite}: TriggerConfig
+): Promise<{test: Test} | {errorMessage: string}> => {
+  try {
+    const test = {
+      ...(await api.getTest(id)),
+      suite,
+    }
+
+    return {test}
+  } catch (error) {
+    if (isNotFoundError(error)) {
+      const errorMessage = formatBackendErrors(error)
+
+      return {errorMessage: `[${chalk.bold.dim(id)}] ${chalk.yellow.bold('Test not found')}: ${errorMessage}`}
+    }
+
+    throw new EndpointError(`Failed to get test: ${formatBackendErrors(error)}\n`, error.response?.status)
+  }
+}
+
+const getTestListBySearchQuery = async (
+  api: APIHelper,
+  globalConfigOverride: UserConfigOverride,
+  testSearchQuery: string
+) => {
+  const testSearchResults = await api.searchTests(testSearchQuery)
+
+  return testSearchResults.tests.map((test) => ({
+    config: globalConfigOverride,
+    id: test.public_id,
+    suite: `Query: ${testSearchQuery}`,
+  }))
+}

--- a/src/commands/synthetics/utils/public.ts
+++ b/src/commands/synthetics/utils/public.ts
@@ -12,7 +12,7 @@ import {getCIMetadata} from '../../../helpers/ci'
 import {GIT_COMMIT_MESSAGE} from '../../../helpers/tags'
 import {pick} from '../../../helpers/utils'
 
-import {APIHelper, EndpointError, formatBackendErrors, getApiHelper, isNotFoundError} from '../api'
+import {APIHelper, EndpointError, formatBackendErrors, getApiHelper} from '../api'
 import {waitForBatchToFinish} from '../batch'
 import {CiError, CriticalError} from '../errors'
 import {
@@ -41,6 +41,7 @@ import {
 } from '../interfaces'
 import {uploadApplicationAndOverrideConfig} from '../mobile'
 import {MAX_TESTS_TO_TRIGGER} from '../run-tests-command'
+import {getTest} from '../test'
 import {Tunnel} from '../tunnel'
 
 import {getOverriddenExecutionRule, hasResult} from './internal'
@@ -428,25 +429,6 @@ export const getReporter = (reporters: Reporter[]): MainReporter => ({
     }
   },
 })
-
-const getTest = async (api: APIHelper, {id, suite}: TriggerConfig): Promise<{test: Test} | {errorMessage: string}> => {
-  try {
-    const test = {
-      ...(await api.getTest(id)),
-      suite,
-    }
-
-    return {test}
-  } catch (error) {
-    if (isNotFoundError(error)) {
-      const errorMessage = formatBackendErrors(error)
-
-      return {errorMessage: `[${chalk.bold.dim(id)}] ${chalk.yellow.bold('Test not found')}: ${errorMessage}`}
-    }
-
-    throw new EndpointError(`Failed to get test: ${formatBackendErrors(error)}\n`, error.response?.status)
-  }
-}
 
 type NotFound = {errorMessage: string}
 type Skipped = {overriddenConfig: TestPayload}


### PR DESCRIPTION
### What and why?

- https://github.com/DataDog/datadog-ci/pull/1271 (← **you are here**)
- https://github.com/DataDog/datadog-ci/pull/1272

Fixes a bug introduced in https://github.com/DataDog/datadog-ci/pull/1214 (released in `2.32.1`)

For better unit testing, this PR first moves some non-exported code to a new file named `test.ts`, which contains all S8S-test-related logic.

> [!NOTE]  
> 💡 Better reviewed commit by commit.

### How?

The main change of this PR is: 50a262c13af8fea8e7c64cdfcfe77f5f92371351

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
