### PR TITLE
[synthetics] Improve warning for too many tests to trigger 

### DIFF
--- a/src/commands/synthetics/__tests__/run-tests-lib.test.ts
+++ b/src/commands/synthetics/__tests__/run-tests-lib.test.ts
@@ -638,21 +638,6 @@ describe('run-test', () => {
       ])
     })
 
-    test('display warning if too many tests from search', async () => {
-      const apiHelper = {
-        searchTests: () => ({
-          tests: Array(MAX_TESTS_TO_TRIGGER + 1).fill({public_id: 'stu-vwx-yza'}),
-        }),
-      } as any
-
-      const searchQuery = 'fake search'
-
-      await runTests.getTriggerConfigs(apiHelper, {...ciConfig, testSearchQuery: searchQuery}, mockReporter)
-      expect(mockReporter.error).toHaveBeenCalledWith(
-        `More than ${MAX_TESTS_TO_TRIGGER} tests returned by search query, only the first ${MAX_TESTS_TO_TRIGGER} will be fetched.\n`
-      )
-    })
-
     test('should use given globs to get tests list', async () => {
       const getSuitesMock = jest.spyOn(utils, 'getSuites').mockImplementation((() => fakeSuites) as any)
       const configOverride = {startUrl}

--- a/src/commands/synthetics/__tests__/test.test.ts
+++ b/src/commands/synthetics/__tests__/test.test.ts
@@ -1,20 +1,20 @@
 import {getTestsFromSearchQuery} from '../test'
 
 describe('getTestsFromSearchQuery', () => {
-  it('should return an empty array if no tests are found', async () => {
+  it('should return an empty array if an empty string is given', async () => {
     const api = {
       searchTests: jest.fn().mockResolvedValue({tests: []}),
     }
-    const config = {global: {}, testSearchQuery: 'my search query'}
+    const config = {global: {}, testSearchQuery: ''}
 
     const result = await getTestsFromSearchQuery(api as any, config)
 
     expect(result).toEqual([])
   })
 
-  it('should log an error message if too many tests are returned by the search query', async () => {
+  it('should return an empty array if no tests are found', async () => {
     const api = {
-      searchTests: jest.fn().mockResolvedValue({tests: Array(101)}),
+      searchTests: jest.fn().mockResolvedValue({tests: []}),
     }
     const config = {global: {}, testSearchQuery: 'my search query'}
 

--- a/src/commands/synthetics/__tests__/test.test.ts
+++ b/src/commands/synthetics/__tests__/test.test.ts
@@ -1,0 +1,32 @@
+import {RunTestsCommandConfig} from '../interfaces'
+import {getTestsFromSearchQuery} from '../test'
+
+import {mockReporter} from './fixtures'
+
+describe('getTestsFromSearchQuery', () => {
+  it('should return an empty array if no tests are found', async () => {
+    const api = {
+      searchTests: jest.fn().mockResolvedValue({tests: []}),
+    }
+    const config = {global: {}, testSearchQuery: 'my search query'} as RunTestsCommandConfig
+
+    const result = await getTestsFromSearchQuery(api as any, config, mockReporter)
+
+    expect(result).toEqual([])
+    expect(mockReporter.error).not.toHaveBeenCalled()
+  })
+
+  it('should log an error message if too many tests are returned by the search query', async () => {
+    const api = {
+      searchTests: jest.fn().mockResolvedValue({tests: Array(101)}),
+    }
+    const config = {global: {}, testSearchQuery: 'my search query'} as RunTestsCommandConfig
+
+    const result = await getTestsFromSearchQuery(api as any, config, mockReporter)
+
+    expect(result).toEqual([])
+    expect(mockReporter.error).toHaveBeenCalledWith(
+      'More than 100 tests returned by search query, only the first 100 will be fetched.\n'
+    )
+  })
+})

--- a/src/commands/synthetics/__tests__/test.test.ts
+++ b/src/commands/synthetics/__tests__/test.test.ts
@@ -1,32 +1,25 @@
-import {RunTestsCommandConfig} from '../interfaces'
 import {getTestsFromSearchQuery} from '../test'
-
-import {mockReporter} from './fixtures'
 
 describe('getTestsFromSearchQuery', () => {
   it('should return an empty array if no tests are found', async () => {
     const api = {
       searchTests: jest.fn().mockResolvedValue({tests: []}),
     }
-    const config = {global: {}, testSearchQuery: 'my search query'} as RunTestsCommandConfig
+    const config = {global: {}, testSearchQuery: 'my search query'}
 
-    const result = await getTestsFromSearchQuery(api as any, config, mockReporter)
+    const result = await getTestsFromSearchQuery(api as any, config)
 
     expect(result).toEqual([])
-    expect(mockReporter.error).not.toHaveBeenCalled()
   })
 
   it('should log an error message if too many tests are returned by the search query', async () => {
     const api = {
       searchTests: jest.fn().mockResolvedValue({tests: Array(101)}),
     }
-    const config = {global: {}, testSearchQuery: 'my search query'} as RunTestsCommandConfig
+    const config = {global: {}, testSearchQuery: 'my search query'}
 
-    const result = await getTestsFromSearchQuery(api as any, config, mockReporter)
+    const result = await getTestsFromSearchQuery(api as any, config)
 
     expect(result).toEqual([])
-    expect(mockReporter.error).toHaveBeenCalledWith(
-      'More than 100 tests returned by search query, only the first 100 will be fetched.\n'
-    )
   })
 })

--- a/src/commands/synthetics/__tests__/utils/__snapshots__/public.test.ts.snap
+++ b/src/commands/synthetics/__tests__/utils/__snapshots__/public.test.ts.snap
@@ -5,7 +5,7 @@ exports[`utils getTestsToTrigger too many tests to trigger trim and warn if from
   "calls": [
     [
       [
-        "[33mMore than [1m100[22m tests returned by search query, only the first [1m100[22m were fetched.[39m
+        "[33mThe search query returned 110 tests, only the first [1m100[22m will be triggered.[39m
 [33m[39m",
       ],
     ],

--- a/src/commands/synthetics/run-tests-lib.ts
+++ b/src/commands/synthetics/run-tests-lib.ts
@@ -21,7 +21,6 @@ import {JUnitReporter} from './reporters/junit'
 import {DEFAULT_COMMAND_CONFIG} from './run-tests-command'
 import {getTestConfigs, getTestsFromSearchQuery} from './test'
 import {Tunnel} from './tunnel'
-import {hasTestSearchQuery} from './utils/internal'
 import {
   getReporter,
   getOrgSettings,
@@ -172,14 +171,14 @@ export const getTriggerConfigs = async (
   reporter: MainReporter,
   suites?: Suite[]
 ): Promise<TriggerConfig[]> => {
-  // Grab the test config overrides from all the sources: default test config overrides, test files containing specific test config override, env variable, and cli params
+  // Grab the test config overrides from all the sources: default test config overrides, test files containing specific test config override, env variable, and CLI params
   const defaultTestConfigOverrides = config.global
   // TODO: Clean up locations as part of SYNTH-12989
   const testConfigOverridesFromEnv = config.locations?.length ? {locations: config.locations} : {}
   const testsFromTestConfigs = await getTestConfigs(config, reporter, suites)
 
-  // Grab the test defined from the search query. Their config will contain the suite name, and the search query itself.
-  const testsFromSearchQuery = hasTestSearchQuery(config) ? await getTestsFromSearchQuery(api, config) : []
+  // Grab the tests returned by the search query (or `[]` if not given).
+  const testsFromSearchQuery = await getTestsFromSearchQuery(api, config)
 
   // Grab the list of publicIds of tests to trigger from config file/env variable/CLI params, search query or test config files
   const testIdsFromCli = config.publicIds

--- a/src/commands/synthetics/run-tests-lib.ts
+++ b/src/commands/synthetics/run-tests-lib.ts
@@ -21,6 +21,7 @@ import {JUnitReporter} from './reporters/junit'
 import {DEFAULT_COMMAND_CONFIG} from './run-tests-command'
 import {getTestConfigs, getTestsFromSearchQuery} from './test'
 import {Tunnel} from './tunnel'
+import {hasTestSearchQuery} from './utils/internal'
 import {
   getReporter,
   getOrgSettings,
@@ -178,7 +179,7 @@ export const getTriggerConfigs = async (
   const testsFromTestConfigs = await getTestConfigs(config, reporter, suites)
 
   // Grab the test defined from the search query. Their config will contain the suite name, and the search query itself.
-  const testsFromSearchQuery = config.testSearchQuery ? await getTestsFromSearchQuery(api, config, reporter) : []
+  const testsFromSearchQuery = hasTestSearchQuery(config) ? await getTestsFromSearchQuery(api, config) : []
 
   // Grab the list of publicIds of tests to trigger from config file/env variable/CLI params, search query or test config files
   const testIdsFromCli = config.publicIds

--- a/src/commands/synthetics/test.ts
+++ b/src/commands/synthetics/test.ts
@@ -1,7 +1,6 @@
 import chalk from 'chalk'
 
 import {APIHelper, EndpointError, formatBackendErrors, isNotFoundError} from './api'
-import {CiError} from './errors'
 import {MainReporter, RunTestsCommandConfig, Suite, Test, TriggerConfig, UserConfigOverride} from './interfaces'
 import {MAX_TESTS_TO_TRIGGER} from './run-tests-command'
 import {getSuites, normalizePublicId} from './utils/public'
@@ -41,10 +40,6 @@ export const getTestsFromSearchQuery = async (
     reporter.error(
       `More than ${MAX_TESTS_TO_TRIGGER} tests returned by search query, only the first ${MAX_TESTS_TO_TRIGGER} will be fetched.\n`
     )
-  }
-
-  if (testsToTriggerBySearchQuery.length === 0) {
-    throw new CiError('NO_TESTS_TO_RUN')
   }
 
   return testsToTriggerBySearchQuery

--- a/src/commands/synthetics/test.ts
+++ b/src/commands/synthetics/test.ts
@@ -30,9 +30,14 @@ export const getTestConfigs = async (
 
 export const getTestsFromSearchQuery = async (
   api: APIHelper,
-  config: Required<Pick<RunTestsCommandConfig, 'global' | 'testSearchQuery'>>
+  config: Pick<RunTestsCommandConfig, 'global' | 'testSearchQuery'>
 ) => {
   const {global: globalConfigOverride, testSearchQuery} = config
+
+  // Empty search queries are not allowed.
+  if (!testSearchQuery) {
+    return []
+  }
 
   const testSearchResults = await api.searchTests(testSearchQuery)
 

--- a/src/commands/synthetics/test.ts
+++ b/src/commands/synthetics/test.ts
@@ -1,0 +1,87 @@
+import chalk from 'chalk'
+
+import {APIHelper, EndpointError, formatBackendErrors, isNotFoundError} from './api'
+import {CiError} from './errors'
+import {MainReporter, RunTestsCommandConfig, Suite, Test, TriggerConfig, UserConfigOverride} from './interfaces'
+import {MAX_TESTS_TO_TRIGGER} from './run-tests-command'
+import {getSuites, normalizePublicId} from './utils/public'
+
+export const getTestConfigs = async (
+  config: RunTestsCommandConfig,
+  reporter: MainReporter,
+  suites: Suite[] = []
+): Promise<TriggerConfig[]> => {
+  const suitesFromFiles = (await Promise.all(config.files.map((glob: string) => getSuites(glob, reporter))))
+    .reduce((acc, val) => acc.concat(val), [])
+    .filter((suite) => !!suite.content.tests)
+
+  suites.push(...suitesFromFiles)
+
+  const testConfigs = suites
+    .map((suite) =>
+      suite.content.tests.map((test) => ({
+        config: test.config,
+        id: normalizePublicId(test.id) ?? '',
+        suite: suite.name,
+      }))
+    )
+    .reduce((acc, suiteTests) => acc.concat(suiteTests), [])
+
+  return testConfigs
+}
+
+export const getTestsFromSearchQuery = async (
+  api: APIHelper,
+  config: RunTestsCommandConfig,
+  reporter: MainReporter
+) => {
+  const testsToTriggerBySearchQuery = await getTestListBySearchQuery(api, config.global, config.testSearchQuery || '')
+
+  if (testsToTriggerBySearchQuery.length > MAX_TESTS_TO_TRIGGER) {
+    reporter.error(
+      `More than ${MAX_TESTS_TO_TRIGGER} tests returned by search query, only the first ${MAX_TESTS_TO_TRIGGER} will be fetched.\n`
+    )
+  }
+
+  if (testsToTriggerBySearchQuery.length === 0) {
+    throw new CiError('NO_TESTS_TO_RUN')
+  }
+
+  return testsToTriggerBySearchQuery
+}
+
+export const getTest = async (
+  api: APIHelper,
+  {id, suite}: TriggerConfig
+): Promise<{test: Test} | {errorMessage: string}> => {
+  try {
+    const test = {
+      ...(await api.getTest(id)),
+      suite,
+    }
+
+    return {test}
+  } catch (error) {
+    if (isNotFoundError(error)) {
+      const errorMessage = formatBackendErrors(error)
+
+      return {errorMessage: `[${chalk.bold.dim(id)}] ${chalk.yellow.bold('Test not found')}: ${errorMessage}`}
+    }
+
+    throw new EndpointError(`Failed to get test: ${formatBackendErrors(error)}\n`, error.response?.status)
+  }
+}
+
+const getTestListBySearchQuery = async (
+  api: APIHelper,
+  globalConfigOverride: UserConfigOverride,
+  testSearchQuery: string
+) => {
+  const testSearchResults = await api.searchTests(testSearchQuery)
+
+  return testSearchResults.tests.map((test) => ({
+    config: globalConfigOverride,
+    id: test.public_id,
+    suite: `Query: ${testSearchQuery}`,
+  }))
+}

--- a/src/commands/synthetics/test.ts
+++ b/src/commands/synthetics/test.ts
@@ -1,8 +1,7 @@
 import chalk from 'chalk'
 
 import {APIHelper, EndpointError, formatBackendErrors, isNotFoundError} from './api'
-import {MainReporter, RunTestsCommandConfig, Suite, Test, TriggerConfig, UserConfigOverride} from './interfaces'
-import {MAX_TESTS_TO_TRIGGER} from './run-tests-command'
+import {MainReporter, RunTestsCommandConfig, Suite, Test, TriggerConfig} from './interfaces'
 import {getSuites, normalizePublicId} from './utils/public'
 
 export const getTestConfigs = async (
@@ -31,18 +30,17 @@ export const getTestConfigs = async (
 
 export const getTestsFromSearchQuery = async (
   api: APIHelper,
-  config: RunTestsCommandConfig,
-  reporter: MainReporter
+  config: Required<Pick<RunTestsCommandConfig, 'global' | 'testSearchQuery'>>
 ) => {
-  const testsToTriggerBySearchQuery = await getTestListBySearchQuery(api, config.global, config.testSearchQuery || '')
+  const {global: globalConfigOverride, testSearchQuery} = config
 
-  if (testsToTriggerBySearchQuery.length > MAX_TESTS_TO_TRIGGER) {
-    reporter.error(
-      `More than ${MAX_TESTS_TO_TRIGGER} tests returned by search query, only the first ${MAX_TESTS_TO_TRIGGER} will be fetched.\n`
-    )
-  }
+  const testSearchResults = await api.searchTests(testSearchQuery)
 
-  return testsToTriggerBySearchQuery
+  return testSearchResults.tests.map((test) => ({
+    config: globalConfigOverride,
+    id: test.public_id,
+    suite: `Query: ${testSearchQuery}`,
+  }))
 }
 
 export const getTest = async (
@@ -65,18 +63,4 @@ export const getTest = async (
 
     throw new EndpointError(`Failed to get test: ${formatBackendErrors(error)}\n`, error.response?.status)
   }
-}
-
-const getTestListBySearchQuery = async (
-  api: APIHelper,
-  globalConfigOverride: UserConfigOverride,
-  testSearchQuery: string
-) => {
-  const testSearchResults = await api.searchTests(testSearchQuery)
-
-  return testSearchResults.tests.map((test) => ({
-    config: globalConfigOverride,
-    id: test.public_id,
-    suite: `Query: ${testSearchQuery}`,
-  }))
 }

--- a/src/commands/synthetics/utils/internal.ts
+++ b/src/commands/synthetics/utils/internal.ts
@@ -23,10 +23,6 @@ export const hasResult = (result: Result): result is BaseResult => {
   return !isResultSkippedBySelectiveRerun(result)
 }
 
-export const hasTestSearchQuery = (config: {testSearchQuery?: string}): config is {testSearchQuery: string} => {
-  return config.testSearchQuery !== undefined && config.testSearchQuery !== '' // For backwards compatibility, empty search queries are not allowed
-}
-
 export const isResultInBatchSkippedBySelectiveRerun = (
   result: ResultInBatch
 ): result is ResultInBatchSkippedBySelectiveRerun => {

--- a/src/commands/synthetics/utils/internal.ts
+++ b/src/commands/synthetics/utils/internal.ts
@@ -23,6 +23,10 @@ export const hasResult = (result: Result): result is BaseResult => {
   return !isResultSkippedBySelectiveRerun(result)
 }
 
+export const hasTestSearchQuery = (config: {testSearchQuery?: string}): config is {testSearchQuery: string} => {
+  return config.testSearchQuery !== undefined && config.testSearchQuery !== '' // For backwards compatibility, empty search queries are not allowed
+}
+
 export const isResultInBatchSkippedBySelectiveRerun = (
   result: ResultInBatch
 ): result is ResultInBatchSkippedBySelectiveRerun => {

--- a/src/commands/synthetics/utils/public.ts
+++ b/src/commands/synthetics/utils/public.ts
@@ -507,11 +507,12 @@ export const getTestsToTrigger = async (
   const errorMessages: string[] = []
   // When too many tests are triggered, if fetched from a search query: simply trim them and show a warning,
   // otherwise: retrieve them and fail later if still exceeding without skipped/missing tests.
-  if (triggerConfigs.length > MAX_TESTS_TO_TRIGGER && triggerFromSearch) {
+  if (triggerFromSearch && triggerConfigs.length > MAX_TESTS_TO_TRIGGER) {
+    const testsCount = triggerConfigs.length
     triggerConfigs.splice(MAX_TESTS_TO_TRIGGER)
     const maxTests = chalk.bold(MAX_TESTS_TO_TRIGGER)
     errorMessages.push(
-      chalk.yellow(`More than ${maxTests} tests returned by search query, only the first ${maxTests} were fetched.\n`)
+      chalk.yellow(`The search query returned ${testsCount} tests, only the first ${maxTests} will be triggered.\n`)
     )
   }
 

--- a/src/commands/synthetics/utils/public.ts
+++ b/src/commands/synthetics/utils/public.ts
@@ -12,7 +12,7 @@ import {getCIMetadata} from '../../../helpers/ci'
 import {GIT_COMMIT_MESSAGE} from '../../../helpers/tags'
 import {pick} from '../../../helpers/utils'
 
-import {APIHelper, EndpointError, formatBackendErrors, getApiHelper, isNotFoundError} from '../api'
+import {APIHelper, EndpointError, formatBackendErrors, getApiHelper} from '../api'
 import {waitForBatchToFinish} from '../batch'
 import {CiError, CriticalError} from '../errors'
 import {
@@ -41,6 +41,7 @@ import {
 } from '../interfaces'
 import {uploadApplicationAndOverrideConfig} from '../mobile'
 import {MAX_TESTS_TO_TRIGGER} from '../run-tests-command'
+import {getTest} from '../test'
 import {Tunnel} from '../tunnel'
 
 import {getOverriddenExecutionRule, hasResult} from './internal'
@@ -428,25 +429,6 @@ export const getReporter = (reporters: Reporter[]): MainReporter => ({
     }
   },
 })
-
-const getTest = async (api: APIHelper, {id, suite}: TriggerConfig): Promise<{test: Test} | {errorMessage: string}> => {
-  try {
-    const test = {
-      ...(await api.getTest(id)),
-      suite,
-    }
-
-    return {test}
-  } catch (error) {
-    if (isNotFoundError(error)) {
-      const errorMessage = formatBackendErrors(error)
-
-      return {errorMessage: `[${chalk.bold.dim(id)}] ${chalk.yellow.bold('Test not found')}: ${errorMessage}`}
-    }
-
-    throw new EndpointError(`Failed to get test: ${formatBackendErrors(error)}\n`, error.response?.status)
-  }
-}
 
 type NotFound = {errorMessage: string}
 type Skipped = {overriddenConfig: TestPayload}


### PR DESCRIPTION
### What and why?

- https://github.com/DataDog/datadog-ci/pull/1271
- https://github.com/DataDog/datadog-ci/pull/1272 (← **you are here**)

This PR merges 2 not-so-useful warnings into a single more-useful warning.

#### Before

The 2 warnings were almost duplicates, and the most important fact is that _only 100 tests_ will be **TRIGGERED**. The fact that datadog-ci will FETCH only 100 tests isn't important.

Also, we never say how many were returned _exactly_, just "more than 100".

![image](https://github.com/DataDog/datadog-ci/assets/9317502/7c094c0c-dc3e-4d7b-9d26-f2c5ef679a28)

#### After

![image](https://github.com/DataDog/datadog-ci/assets/9317502/fdd69042-6112-4610-8163-5095cb05f4af)

### How?

The `getTestsList()` function used to be the one reporting the "will be fetched" warning, and https://github.com/DataDog/datadog-ci/pull/1214 changed it to be reported by `getTriggerConfigs()` instead.

The "were fetched" one didn't change: it's still reported by `getTestsToTrigger()`.

My proposition is to only keep the "were fetched" one, and rephrase it into "will be triggered".

See https://github.com/DataDog/datadog-ci/pull/1214/files#r1508534127.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
