### PR TITLE
enable diff-aware and non-diff-aware

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,7 +219,7 @@ jobs:
           dd_app_key: ${{ secrets.DATADOG_APP_KEY_MAIN_ACCOUNT }}
           dd_api_key: ${{ secrets.DATADOG_API_KEY_MAIN_ACCOUNT }}
           dd_service: 'datadog-ci'
-          dd_env: 'ci-no-dq'
+          dd_env: 'ci-no-da'
           cpu_count: 2
           sca_enabled: true
           diff_aware: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,7 +203,6 @@ jobs:
           dd_service: 'datadog-ci'
           dd_env: 'ci'
           cpu_count: 2
-          enable_performance_statistics: true
           sca_enabled: true
           diff_aware: true
 
@@ -222,7 +221,6 @@ jobs:
           dd_service: 'datadog-ci'
           dd_env: 'ci-no-dq'
           cpu_count: 2
-          enable_performance_statistics: true
           sca_enabled: true
           diff_aware: false
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,7 +190,7 @@ jobs:
 
   datadog-static-analyzer:
     runs-on: ubuntu-latest
-    name: Datadog Static Analyzer
+    name: Static Analyzer - Diff Aware
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -208,7 +208,7 @@ jobs:
 
   datadog-static-analyzer-non-diff-aware:
     runs-on: ubuntu-latest
-    name: Datadog Static Analyzer
+    name: Static Analyzer - Non Diff Aware
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,6 +205,27 @@ jobs:
           cpu_count: 2
           enable_performance_statistics: true
           sca_enabled: true
+          diff_aware: true
+
+  datadog-static-analyzer-non-diff-aware:
+    runs-on: ubuntu-latest
+    name: Datadog Static Analyzer
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Run Datadog static analyzer
+        id: datadog-static-analysis
+        uses: DataDog/datadog-static-analyzer-github-action@main
+        with:
+          dd_app_key: ${{ secrets.DATADOG_APP_KEY_MAIN_ACCOUNT }}
+          dd_api_key: ${{ secrets.DATADOG_API_KEY_MAIN_ACCOUNT }}
+          dd_service: 'datadog-ci'
+          dd_env: 'ci-no-dq'
+          cpu_count: 2
+          enable_performance_statistics: true
+          sca_enabled: true
+          diff_aware: false
+
 
   check-licenses:
     name: Check licenses


### PR DESCRIPTION
### What and why?

We want to enable the static analyzer with diff-aware and not diff-aware to test the results on a live, public repo

### How?

Have two jobs to upload results for this repository:
1. One with diff-aware
2. One without diff-aware

This way we can compare the output in the datadog UI.