### PR TITLE
[STAL-1577] Improve SBOM/SARIF messaging

### DIFF
--- a/src/commands/sarif/__tests__/upload.test.ts
+++ b/src/commands/sarif/__tests__/upload.test.ts
@@ -183,7 +183,10 @@ describe('execute', () => {
     const cli = makeCli()
     const context = createMockContext() as any
     process.env = {DATADOG_API_KEY: 'PLACEHOLDER'}
-    const code = await cli.run(['sarif', 'upload', '--service', 'test-service', '--dry-run', ...paths], context)
+    const code = await cli.run(
+      ['sarif', 'upload', '--service', 'test-service', '--env', 'ci', '--dry-run', ...paths],
+      context
+    )
 
     return {context, code}
   }
@@ -195,6 +198,7 @@ describe('execute', () => {
       basePaths: ['src/commands/sarif/__tests__/fixtures/subfolder'],
       concurrency: 20,
       service: 'test-service',
+      env: 'ci',
     })
   })
   test('multiple paths', async () => {
@@ -211,6 +215,7 @@ describe('execute', () => {
       ],
       concurrency: 20,
       service: 'test-service',
+      env: 'ci',
     })
   })
 
@@ -222,6 +227,7 @@ describe('execute', () => {
       basePaths: [`${process.cwd()}/src/commands/sarif/__tests__/fixtures/subfolder`],
       concurrency: 20,
       service: 'test-service',
+      env: 'ci',
     })
   })
 
@@ -233,7 +239,9 @@ describe('execute', () => {
     expect(output[0]).toContain('DRY-RUN MODE ENABLED. WILL NOT UPLOAD SARIF REPORT')
     expect(output[1]).toContain('Starting upload with concurrency 20.')
     expect(output[2]).toContain(`Will upload SARIF report file ${path}`)
-    expect(output[3]).toContain('service: test-service')
+    expect(output[3]).toContain('Only one upload per commit, env, service and tool')
+    expect(output[4]).toContain(`Preparing upload for`)
+    expect(output[4]).toContain(`env:ci service:test-service`)
   })
 
   test('not found file', async () => {
@@ -250,11 +258,14 @@ interface ExpectedOutput {
   basePaths: string[]
   concurrency: number
   service: string
+  env: string
 }
 
 const checkConsoleOutput = (output: string[], expected: ExpectedOutput) => {
   expect(output[0]).toContain('DRY-RUN MODE ENABLED. WILL NOT UPLOAD SARIF REPORT')
   expect(output[1]).toContain(`Starting upload with concurrency ${expected.concurrency}.`)
   expect(output[2]).toContain(`Will look for SARIF report files in ${expected.basePaths.join(', ')}`)
-  expect(output[3]).toContain(`service: ${expected.service}`)
+  expect(output[3]).toContain('Only one upload per commit, env, service and tool')
+  expect(output[4]).toContain(`Preparing upload for`)
+  expect(output[4]).toContain(`env:${expected.env} service:${expected.service}`)
 }

--- a/src/commands/sarif/renderer.ts
+++ b/src/commands/sarif/renderer.ts
@@ -73,6 +73,8 @@ export const renderUpload = (payload: Payload): string => `Uploading SARIF repor
 export const renderCommandInfo = (
   basePaths: string[],
   service: string,
+  env: string,
+  sha: string,
   concurrency: number,
   dryRun: boolean,
   noVerify: boolean
@@ -92,7 +94,8 @@ export const renderCommandInfo = (
   } else {
     fullStr += chalk.green(`Will look for SARIF report files in ${basePaths.join(', ')}\n`)
   }
-  fullStr += chalk.green(`service: ${service}\n`)
+  fullStr += `Only one upload per commit, env, service and tool\n`
+  fullStr += `Preparing upload for sha:${sha} env:${env} service:${service}\n`
 
   return fullStr
 }

--- a/src/commands/sarif/upload.ts
+++ b/src/commands/sarif/upload.ts
@@ -13,7 +13,7 @@ import {doWithMaxConcurrency} from '../../helpers/concurrency'
 import {DatadogCiConfig} from '../../helpers/config'
 import {SpanTags} from '../../helpers/interfaces'
 import {retryRequest} from '../../helpers/retry'
-import {getSpanTags, mandatoryGitFields} from '../../helpers/tags'
+import {GIT_SHA, getSpanTags, mandatoryGitFields} from '../../helpers/tags'
 import {buildPath} from '../../helpers/utils'
 import * as validation from '../../helpers/validation'
 
@@ -138,8 +138,10 @@ export class UploadSarifReportCommand extends Command {
       return 1
     }
 
+    const sha = spanTags[GIT_SHA] || 'sha-not-found'
+    const env = this.config.env || 'env-not-set'
     this.context.stdout.write(
-      renderCommandInfo(this.basePaths, this.service, this.maxConcurrency, this.dryRun, this.noVerify)
+      renderCommandInfo(this.basePaths, this.service, env, sha, this.maxConcurrency, this.dryRun, this.noVerify)
     )
     const upload = (p: Payload) => this.uploadSarifReport(api, p)
 

--- a/src/commands/sbom/renderer.ts
+++ b/src/commands/sbom/renderer.ts
@@ -48,7 +48,6 @@ export const renderDuplicateUpload = (sha: string, env: string, service: string)
   return fullStr
 }
 
-
 export const renderFailedUpload = (sbomReport: string, error: any) => {
   const reportPath = `[${chalk.bold.dim(sbomReport)}]`
 

--- a/src/commands/sbom/renderer.ts
+++ b/src/commands/sbom/renderer.ts
@@ -38,13 +38,12 @@ export const renderMissingSpan = (errorMessage: string) => {
   return fullStr
 }
 
-export const renderDuplicateUpload = (sbomReport: string, error: any, sha: string, env: string, service: string) => {
-  const reportPath = `[${chalk.bold.dim(sbomReport)}]`
-
+export const renderDuplicateUpload = (sha: string, env: string, service: string) => {
   let fullStr = ''
-  fullStr += chalk.red(`${ICONS.WARNING} Duplicate SBOM upload detected for ${reportPath}: ${error.message}\n`)
-  fullStr += chalk.red(`An analysis has already been processed for sha:${sha}, env:${env} and service:${service}\n`)
-  fullStr += chalk.red(`Push a new commit or specify a new env or service variable.\n`)
+  fullStr += chalk.red(`${ICONS.WARNING}  Duplicate SBOM upload detected\n`)
+  fullStr += chalk.red(`An analysis has already been processed for sha:${sha} env:${env} service:${service}\n`)
+  fullStr += chalk.red(`Push a new commit or specify a different env or service variable\n`)
+  fullStr += chalk.red(`Exiting with code 0\n`)
 
   return fullStr
 }
@@ -54,7 +53,7 @@ export const renderFailedUpload = (sbomReport: string, error: any) => {
   const reportPath = `[${chalk.bold.dim(sbomReport)}]`
 
   let fullStr = ''
-  fullStr += chalk.red(`${ICONS.FAILED} Failed upload SBOM file ${reportPath}: ${error.message}\n`)
+  fullStr += chalk.red(`${ICONS.FAILED}  Failed upload SBOM file ${reportPath}: ${error.message}\n`)
   if (error?.response?.status) {
     fullStr += chalk.red(`API status code: ${error.response.status}\n`)
   }

--- a/src/commands/sbom/renderer.ts
+++ b/src/commands/sbom/renderer.ts
@@ -38,6 +38,18 @@ export const renderMissingSpan = (errorMessage: string) => {
   return fullStr
 }
 
+export const renderDuplicateUpload = (sbomReport: string, error: any, sha: string, env: string, service: string) => {
+  const reportPath = `[${chalk.bold.dim(sbomReport)}]`
+
+  let fullStr = ''
+  fullStr += chalk.red(`${ICONS.WARNING} Duplicate SBOM upload detected for ${reportPath}: ${error.message}\n`)
+  fullStr += chalk.red(`An analysis has already been processed for sha:${sha}, env:${env} and service:${service}\n`)
+  fullStr += chalk.red(`Push a new commit or specify a new env or service variable.\n`)
+
+  return fullStr
+}
+
+
 export const renderFailedUpload = (sbomReport: string, error: any) => {
   const reportPath = `[${chalk.bold.dim(sbomReport)}]`
 

--- a/src/commands/sbom/upload.ts
+++ b/src/commands/sbom/upload.ts
@@ -1,7 +1,6 @@
 import fs from 'fs'
 import process from 'process'
 
-
 import Ajv from 'ajv'
 import {AxiosPromise, AxiosResponse, isAxiosError} from 'axios'
 import {Command, Option} from 'clipanion'

--- a/src/commands/sbom/upload.ts
+++ b/src/commands/sbom/upload.ts
@@ -134,11 +134,10 @@ export class UploadSbomCommand extends Command {
           this.context.stdout.write(`Upload done for ${basePath}.\n`)
         }
       } catch (error) {
-        console.log(error)
         if (isAxiosError(error)) {
           if (error.response?.status === 409) {
             const sha = tags[GIT_SHA] || 'sha-not-found'
-            this.context.stderr.write(renderDuplicateUpload(basePath, error, sha, environment, service))
+            this.context.stderr.write(renderDuplicateUpload(sha, environment, service))
 
             return 0
           }


### PR DESCRIPTION
### What and why?

When an SBOM is uploaded and we detect that it's a duplicate, our API will throw a `409` error now. We want to catch this error, add a message explaining it, and exit gracefully.

For SARIF, we don't return an error, so we want to add a note that only one upload is possible.

### How?

Check if it's an Axios error and it's a 409 code.

### Verification

**SBOM**
<img width="857" alt="Screenshot 2024-04-03 at 9 44 51 AM" src="https://github.com/DataDog/datadog-ci/assets/33348592/3a8cacef-e44c-421e-8ff8-b27c2c8021c9">

**SARIF**
<img width="716" alt="Screenshot 2024-04-03 at 7 49 32 PM" src="https://github.com/DataDog/datadog-ci/assets/33348592/c04401f2-2f0f-4432-aa50-6518c075c8c5">

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
