### PR TITLE
v2.33.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci",
-  "version": "2.32.3",
+  "version": "2.33.0",
   "description": "Run datadog actions from the CI.",
   "repository": "https://github.com/DataDog/datadog-ci",
   "license": "Apache-2.0",


### PR DESCRIPTION
<!-- Release notes generated using configuration in .github/release.yml at v2.33.0 -->

## What's Changed
### CI Visibility
* [ci-visibility] Add silent option to tag command by @rodrigo-roca in https://github.com/DataDog/datadog-ci/pull/1270
* [dora] Fix typo in message by @Drarig29 in https://github.com/DataDog/datadog-ci/pull/1268
### Serverless
* [lambda] support `dotnet8` and `java21` runtimes by @astuyve in https://github.com/DataDog/datadog-ci/pull/1249
### Source Code Integration
* [git-metadata] Consistent usage of datadog site by @rpelliard in https://github.com/DataDog/datadog-ci/pull/1267
### Static Analysis
* enable diff-aware and non-diff-aware by @juli1 in https://github.com/DataDog/datadog-ci/pull/1273
* [STAL-1577] Improve SBOM/SARIF messaging by @dastrong in https://github.com/DataDog/datadog-ci/pull/1274
### Synthetics
* [SYNTH-12914] Include `?batch_id` in result links by @Drarig29 in https://github.com/DataDog/datadog-ci/pull/1255
* [SYNTH-13771] Fix "No tests to run" not being shown anymore by @Drarig29 in https://github.com/DataDog/datadog-ci/pull/1271
* [synthetics] Fix incomplete residual results message by @Drarig29 in https://github.com/DataDog/datadog-ci/pull/1269
* [synthetics] Improve warning for too many tests to trigger  by @Drarig29 in https://github.com/DataDog/datadog-ci/pull/1272


**Full Changelog**: https://github.com/DataDog/datadog-ci/compare/v2.32.3...v2.33.0

[STAL-1577]: https://datadoghq.atlassian.net/browse/STAL-1577?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SYNTH-12914]: https://datadoghq.atlassian.net/browse/SYNTH-12914?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SYNTH-13771]: https://datadoghq.atlassian.net/browse/SYNTH-13771?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ