### PR TITLE
Fix DD-EVP-ORIGIN header values

### DIFF
--- a/src/commands/flutter-symbols/helpers.ts
+++ b/src/commands/flutter-symbols/helpers.ts
@@ -10,13 +10,13 @@ export const getFlutterRequestBuilder = (apiKey: string, cliVersion: string, sit
     apiKey,
     baseUrl: getBaseSourcemapIntakeUrl(site),
     headers: new Map([
-      ['DD-EVP-ORIGIN', 'datadog-ci flutter-symbols'],
+      ['DD-EVP-ORIGIN', 'datadog-ci_flutter-symbols'],
       ['DD-EVP-ORIGIN-VERSION', cliVersion],
     ]),
     overrideUrl: 'api/v2/srcmap',
   })
 
-// This function exists partially just to make mocking networkc calls easier.
+// This function exists partially just to make mocking network calls easier.
 export const uploadMultipartHelper = async (
   requestBuilder: RequestBuilder,
   payload: MultipartPayload,

--- a/src/commands/git-metadata/library.ts
+++ b/src/commands/git-metadata/library.ts
@@ -76,7 +76,7 @@ const uploadToSrcmapTrack = async (apiKey: string, datadogSite: string, payload:
     apiKey,
     baseUrl: 'https://sourcemap-intake.' + datadogSite,
     headers: new Map([
-      ['DD-EVP-ORIGIN', 'datadog-ci sci'],
+      ['DD-EVP-ORIGIN', 'datadog-ci_sci'],
       ['DD-EVP-ORIGIN-VERSION', version],
     ]),
     overrideUrl: 'api/v2/srcmap',

--- a/src/commands/git-metadata/upload.ts
+++ b/src/commands/git-metadata/upload.ts
@@ -207,7 +207,7 @@ export class UploadCommand extends Command {
       apiKey,
       baseUrl: getBaseIntakeUrl(),
       headers: new Map([
-        ['DD-EVP-ORIGIN', 'datadog-ci git-metadata'],
+        ['DD-EVP-ORIGIN', 'datadog-ci_git-metadata'],
         ['DD-EVP-ORIGIN-VERSION', this.cliVersion],
       ]),
       overrideUrl: 'api/v2/srcmap',

--- a/src/commands/react-native/upload.ts
+++ b/src/commands/react-native/upload.ts
@@ -265,7 +265,7 @@ export class UploadCommand extends Command {
       apiKey: this.config.apiKey,
       baseUrl: getBaseSourcemapIntakeUrl(this.config.datadogSite),
       headers: new Map([
-        ['DD-EVP-ORIGIN', 'datadog-ci react-native'],
+        ['DD-EVP-ORIGIN', 'datadog-ci_react-native'],
         ['DD-EVP-ORIGIN-VERSION', this.cliVersion],
       ]),
       overrideUrl: 'api/v2/srcmap',

--- a/src/commands/sourcemaps/upload.ts
+++ b/src/commands/sourcemaps/upload.ts
@@ -241,7 +241,7 @@ export class UploadCommand extends Command {
       apiKey: this.config.apiKey,
       baseUrl: getBaseSourcemapIntakeUrl(this.config.datadogSite),
       headers: new Map([
-        ['DD-EVP-ORIGIN', 'datadog-ci sourcemaps'],
+        ['DD-EVP-ORIGIN', 'datadog-ci_sourcemaps'],
         ['DD-EVP-ORIGIN-VERSION', this.cliVersion],
       ]),
       overrideUrl: 'api/v2/srcmap',

--- a/src/commands/unity-symbols/helpers.ts
+++ b/src/commands/unity-symbols/helpers.ts
@@ -8,7 +8,7 @@ export const getUnityRequestBuilder = (apiKey: string, cliVersion: string, site:
     apiKey,
     baseUrl: getBaseSourcemapIntakeUrl(site),
     headers: new Map([
-      ['DD-EVP-ORIGIN', 'datadog-ci unity-symbols'],
+      ['DD-EVP-ORIGIN', 'datadog-ci_unity-symbols'],
       ['DD-EVP-ORIGIN-VERSION', cliVersion],
     ]),
     overrideUrl: 'api/v2/srcmap',


### PR DESCRIPTION
### What and why?

Intake doesn't allow to have a space in the header value, so the whole header is dropped. This PR fixes that.

Alternatively we can have just `datadog-ci` everywhere.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
