### PR TITLE
[RUM] Add DD-EVP-ORIGIN headers to the dsyms upload command

### DIFF
--- a/src/commands/dsyms/upload.ts
+++ b/src/commands/dsyms/upload.ts
@@ -184,6 +184,10 @@ export class UploadCommand extends Command {
     return getRequestBuilder({
       apiKey: this.config.apiKey,
       baseUrl: getBaseIntakeUrl(this.config.datadogSite),
+      headers: new Map([
+        ['DD-EVP-ORIGIN', 'datadog-ci_dsyms'],
+        ['DD-EVP-ORIGIN-VERSION', this.cliVersion],
+      ]),
       overrideUrl: 'api/v2/srcmap',
     })
   }


### PR DESCRIPTION
### What and why?

This PR adds `DD-EVP-ORIGIN` and `DD-EVP-ORIGIN-VERSION` headers to the `dsyms` upload command the same way as it is done for other platform-specific commands (e.g. `react-native`, etc.).

This is needed for the usage metrics.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
