### PR TITLE
[SYNTH-12971] Rename global to defaultTestOverrides

### DIFF
--- a/src/commands/synthetics/README.md
+++ b/src/commands/synthetics/README.md
@@ -155,7 +155,7 @@ For example:
   "tunnel": true
 }
 ```
-**Note**: A `global` filed was present in the global configuration file. This field is now deprecated and replaced by `defaultTestOverrides`.
+**Note**: The `global` field from the global configuration file is deprecated in favor of `defaultTestOverrides`.
 
 ### Command line options
 
@@ -222,7 +222,7 @@ For example:
   "tunnel": true
 }
 ```
-**Note**: A `global` filed was present in the global configuration file. This field is now deprecated and replaced by `defaultTestOverrides`.
+**Note**: The `global` field from the global configuration file is deprecated in favor of `defaultTestOverrides`.
 
 ## Run tests
 

--- a/src/commands/synthetics/README.md
+++ b/src/commands/synthetics/README.md
@@ -79,7 +79,7 @@ See below for the list of advanced options in the global configuration file. For
 `files`
 : Glob patterns to detect Synthetic test [configuration files](#test-files).
 
-`global`
+`defaultTestOverrides`
 : Overrides for Synthetic tests applied to all tests.
 
 `mobileApplicationVersionFilePath`
@@ -123,7 +123,7 @@ For example:
   "failOnMissingTests": false,
   "failOnTimeout": true,
   "files": ["{,!(node_modules)/**/}*.synthetics.json"],
-  "global": {
+  "defaultTestOverrides": {
     "allowInsecureCertificates": true,
     "basicAuth": {"username": "test", "password": "test"},
     "body": "{\"fakeContent\":true}",
@@ -155,6 +155,7 @@ For example:
   "tunnel": true
 }
 ```
+**Note**: A `global` filed was present in the global configuration file. This field is now deprecated and replaced by `defaultTestOverrides`.
 
 ### Command line options
 
@@ -187,7 +188,7 @@ For example:
   "failOnMissingTests": true,
   "failOnTimeout": true,
   "files": ["{,!(node_modules)/**/}*.synthetics.json"],
-  "global": {
+  "defaultTestOverrides": {
     "allowInsecureCertificates": true,
     "basicAuth": {"username": "test", "password": "test"},
     "body": "{\"fakeContent\":true}",
@@ -221,6 +222,7 @@ For example:
   "tunnel": true
 }
 ```
+**Note**: A `global` filed was present in the global configuration file. This field is now deprecated and replaced by `defaultTestOverrides`.
 
 ## Run tests
 

--- a/src/commands/synthetics/__tests__/cli.test.ts
+++ b/src/commands/synthetics/__tests__/cli.test.ts
@@ -69,7 +69,7 @@ describe('run-test', () => {
         apiKey: overrideEnv.DATADOG_API_KEY,
         appKey: overrideEnv.DATADOG_APP_KEY,
         datadogSite: overrideEnv.DATADOG_SITE,
-        global: {
+        defaultTestOverrides: {
           deviceIds: overrideEnv.DATADOG_SYNTHETICS_OVERRIDE_DEVICE_IDS.split(';'),
           pollingTimeout: DEFAULT_POLLING_TIMEOUT,
           mobileApplicationVersion: overrideEnv.DATADOG_SYNTHETICS_OVERRIDE_MOBILE_APPLICATION_VERSION,
@@ -176,8 +176,7 @@ describe('run-test', () => {
         failOnMissingTests: true,
         failOnTimeout: false,
         files: ['new-file'],
-        // TODO: Clean up global as part of SYNTH-12989
-        global: {
+        defaultTestOverrides: {
           deviceIds: ['chrome.laptop_large'],
           pollingTimeout: DEFAULT_POLLING_TIMEOUT,
           mobileApplicationVersion: '00000000-0000-0000-0000-000000000000',
@@ -210,6 +209,7 @@ describe('run-test', () => {
         apiKey: 'api_key_config_file',
         appKey: 'app_key_config_file',
         datadogSite: 'us5.datadoghq.com',
+        // TODO: Clean up global as part of SYNTH-12989
         global: {
           pollingTimeout: 111,
           mobileApplicationVersionFilePath: './path/to/application_config_file.apk',
@@ -233,6 +233,10 @@ describe('run-test', () => {
         appKey: 'app_key_env',
         datadogSite: 'us5.datadoghq.com',
         global: {
+          pollingTimeout: 111,
+          mobileApplicationVersionFilePath: './path/to/application_config_file.apk',
+        },
+        defaultTestOverrides: {
           pollingTimeout: 333,
           mobileApplicationVersionFilePath: './path/to/application_cli.apk',
         },
@@ -347,7 +351,9 @@ describe('run-test', () => {
       expect(command['config']).toEqual({
         ...DEFAULT_COMMAND_CONFIG,
         configPath: 'src/commands/synthetics/__tests__/config-fixtures/config-with-global-polling-timeout.json',
-        global: {followRedirects: false, pollingTimeout: 333},
+        // TODO: Clean up global as part of SYNTH-12989
+        global: {followRedirects: false},
+        defaultTestOverrides: {followRedirects: false, pollingTimeout: 333},
         pollingTimeout: 333,
       })
     })

--- a/src/commands/synthetics/__tests__/cli.test.ts
+++ b/src/commands/synthetics/__tests__/cli.test.ts
@@ -88,6 +88,7 @@ describe('run-test', () => {
         failOnMissingTests: true,
         failOnTimeout: false,
         files: ['my-new-file'],
+        // TODO: Clean up global as part of SYNTH-12989
         global: {
           deviceIds: ['chrome.laptop_large'],
           locations: ['us-east-1'],
@@ -122,6 +123,7 @@ describe('run-test', () => {
     })
 
     test('override from CLI', async () => {
+      // TODO: Clean up global as part of SYNTH-12989
       const overrideCLI: Omit<RunTestsCommandConfig, 'global' | 'defaultTestOverrides' | 'proxy'> = {
         apiKey: 'fake_api_key',
         appKey: 'fake_app_key',
@@ -174,6 +176,7 @@ describe('run-test', () => {
         failOnMissingTests: true,
         failOnTimeout: false,
         files: ['new-file'],
+        // TODO: Clean up global as part of SYNTH-12989
         global: {
           deviceIds: ['chrome.laptop_large'],
           pollingTimeout: DEFAULT_POLLING_TIMEOUT,

--- a/src/commands/synthetics/__tests__/cli.test.ts
+++ b/src/commands/synthetics/__tests__/cli.test.ts
@@ -95,6 +95,13 @@ describe('run-test', () => {
           mobileApplicationVersion: '00000000-0000-0000-0000-000000000000',
           mobileApplicationVersionFilePath: './path/to/application.apk',
         },
+        defaultTestOverrides: {
+          deviceIds: ['chrome.laptop_large'],
+          locations: ['us-east-1'],
+          pollingTimeout: 2,
+          mobileApplicationVersion: '00000000-0000-0000-0000-000000000000',
+          mobileApplicationVersionFilePath: './path/to/application.apk',
+        },
         locations: [],
         pollingTimeout: 1,
         proxy: {
@@ -115,7 +122,7 @@ describe('run-test', () => {
     })
 
     test('override from CLI', async () => {
-      const overrideCLI: Omit<RunTestsCommandConfig, 'global' | 'proxy'> = {
+      const overrideCLI: Omit<RunTestsCommandConfig, 'global' | 'defaultTestOverrides' | 'proxy'> = {
         apiKey: 'fake_api_key',
         appKey: 'fake_app_key',
         configPath: 'src/commands/synthetics/__tests__/config-fixtures/empty-config-file.json',
@@ -267,7 +274,12 @@ describe('run-test', () => {
       jest.spyOn(api, 'getApiHelper').mockImplementation(() => apiHelper as any)
 
       // Global
+      // TODO: Clean up global as part of SYNTH-12989
       command['config'].global = {
+        locations: ['aws:us-east-2'],
+        mobileApplicationVersionFilePath: './path/to/application_global.apk',
+      }
+      command['config'].defaultTestOverrides = {
         locations: ['aws:us-east-2'],
         mobileApplicationVersionFilePath: './path/to/application_global.apk',
       }

--- a/src/commands/synthetics/__tests__/cli.test.ts
+++ b/src/commands/synthetics/__tests__/cli.test.ts
@@ -88,7 +88,7 @@ describe('run-test', () => {
         failOnMissingTests: true,
         failOnTimeout: false,
         files: ['my-new-file'],
-        // TODO: Clean up global as part of SYNTH-12989
+        // SYNTH-12989: Clean up deprecated `global` in favor of `defaultTestOverrides`
         global: {
           deviceIds: ['chrome.laptop_large'],
           locations: ['us-east-1'],
@@ -123,7 +123,7 @@ describe('run-test', () => {
     })
 
     test('override from CLI', async () => {
-      // TODO: Clean up global as part of SYNTH-12989
+      // SYNTH-12989: Clean up deprecated `global` in favor of `defaultTestOverrides`
       const overrideCLI: Omit<RunTestsCommandConfig, 'global' | 'defaultTestOverrides' | 'proxy'> = {
         apiKey: 'fake_api_key',
         appKey: 'fake_app_key',
@@ -209,7 +209,7 @@ describe('run-test', () => {
         apiKey: 'api_key_config_file',
         appKey: 'app_key_config_file',
         datadogSite: 'us5.datadoghq.com',
-        // TODO: Clean up global as part of SYNTH-12989
+        // SYNTH-12989: Clean up deprecated `global` in favor of `defaultTestOverrides`
         global: {
           pollingTimeout: 111,
           mobileApplicationVersionFilePath: './path/to/application_config_file.apk',
@@ -281,7 +281,7 @@ describe('run-test', () => {
       jest.spyOn(api, 'getApiHelper').mockImplementation(() => apiHelper as any)
 
       // Global
-      // TODO: Clean up global as part of SYNTH-12989
+      // SYNTH-12989: Clean up deprecated `global` in favor of `defaultTestOverrides`
       command['config'].global = {
         locations: ['aws:us-east-2'],
         mobileApplicationVersionFilePath: './path/to/application_global.apk',
@@ -351,7 +351,7 @@ describe('run-test', () => {
       expect(command['config']).toEqual({
         ...DEFAULT_COMMAND_CONFIG,
         configPath: 'src/commands/synthetics/__tests__/config-fixtures/config-with-global-polling-timeout.json',
-        // TODO: Clean up global as part of SYNTH-12989
+        // SYNTH-12989: Clean up deprecated `global` in favor of `defaultTestOverrides`
         global: {followRedirects: false},
         defaultTestOverrides: {followRedirects: false, pollingTimeout: 333},
         pollingTimeout: 333,

--- a/src/commands/synthetics/__tests__/config-fixtures/config-with-all-keys.json
+++ b/src/commands/synthetics/__tests__/config-fixtures/config-with-all-keys.json
@@ -20,6 +20,17 @@
     "mobileApplicationVersion": "00000000-0000-0000-0000-000000000000",
     "mobileApplicationVersionFilePath": "./path/to/application.apk"
   },
+  "defaultTestOverrides": {
+    "deviceIds": [
+      "chrome.laptop_large"
+    ],
+    "locations": [
+      "us-east-1"
+    ],
+    "pollingTimeout": 2,
+    "mobileApplicationVersion": "00000000-0000-0000-0000-000000000000",
+    "mobileApplicationVersionFilePath": "./path/to/application.apk"
+  },
   "locations": [],
   "pollingTimeout": 1,
   "proxy": {

--- a/src/commands/synthetics/__tests__/fixtures.ts
+++ b/src/commands/synthetics/__tests__/fixtures.ts
@@ -73,6 +73,7 @@ export const ciConfig: RunTestsCommandConfig = {
   failOnTimeout: true,
   files: ['{,!(node_modules)/**/}*.synthetics.json'],
   global: {},
+  defaultTestOverrides: {},
   locations: [],
   pollingTimeout: 2 * 60 * 1000,
   proxy: {protocol: 'http'},

--- a/src/commands/synthetics/__tests__/run-tests-lib.test.ts
+++ b/src/commands/synthetics/__tests__/run-tests-lib.test.ts
@@ -555,7 +555,7 @@ describe('run-test', () => {
       await expect(
         runTests.getTriggerConfigs(
           fakeApi,
-          {...ciConfig, global: configOverride, locations: ['aws:ap-northeast-1']},
+          {...ciConfig, defaultTestOverrides: configOverride, locations: ['aws:ap-northeast-1']},
           mockReporter
         )
       ).resolves.toEqual([
@@ -581,7 +581,7 @@ describe('run-test', () => {
           fakeApi,
           {
             ...ciConfig,
-            global: configOverride,
+            defaultTestOverrides: configOverride,
             locations: ['aws:ap-northeast-1'],
             publicIds: ['abc-def-ghi', '123-456-789'],
           },
@@ -608,7 +608,12 @@ describe('run-test', () => {
       await expect(
         runTests.getTriggerConfigs(
           fakeApi,
-          {...ciConfig, global: configOverride, locations: ['aws:ap-northeast-1'], testSearchQuery: searchQuery},
+          {
+            ...ciConfig,
+            defaultTestOverrides: configOverride,
+            locations: ['aws:ap-northeast-1'],
+            testSearchQuery: searchQuery,
+          },
           mockReporter
         )
       ).resolves.toEqual([
@@ -627,7 +632,7 @@ describe('run-test', () => {
       await expect(
         runTests.getTriggerConfigs(
           fakeApi,
-          {...ciConfig, global: configOverride, publicIds: ['abc-def-ghi'], testSearchQuery: searchQuery},
+          {...ciConfig, defaultTestOverrides: configOverride, publicIds: ['abc-def-ghi'], testSearchQuery: searchQuery},
           mockReporter
         )
       ).resolves.toEqual([
@@ -643,7 +648,11 @@ describe('run-test', () => {
       const configOverride = {startUrl}
       const files = ['new glob', 'another one']
 
-      await runTests.getTriggerConfigs(fakeApi, {...ciConfig, global: configOverride, files}, mockReporter)
+      await runTests.getTriggerConfigs(
+        fakeApi,
+        {...ciConfig, defaultTestOverrides: configOverride, files},
+        mockReporter
+      )
       expect(getSuitesMock).toHaveBeenCalledTimes(2)
       expect(getSuitesMock).toHaveBeenCalledWith('new glob', mockReporter)
       expect(getSuitesMock).toHaveBeenCalledWith('another one', mockReporter)
@@ -656,7 +665,7 @@ describe('run-test', () => {
 
       const tests = await runTests.getTriggerConfigs(
         fakeApi,
-        {...ciConfig, global: configOverride, files},
+        {...ciConfig, defaultTestOverrides: configOverride, files},
         mockReporter,
         fakeSuites
       )
@@ -677,7 +686,7 @@ describe('run-test', () => {
 
       const tests = await runTests.getTriggerConfigs(
         fakeApi,
-        {...ciConfig, global: configOverride, files},
+        {...ciConfig, defaultTestOverrides: configOverride, files},
         mockReporter,
         userSuites
       )

--- a/src/commands/synthetics/__tests__/run-tests-lib.test.ts
+++ b/src/commands/synthetics/__tests__/run-tests-lib.test.ts
@@ -550,12 +550,12 @@ describe('run-test', () => {
 
     test('should extend global config and execute all tests from Test Config when no publicIds were defined', async () => {
       jest.spyOn(utils, 'getSuites').mockImplementation((() => fakeSuites) as any)
-      const configOverride = {startUrl}
+      const defaultTestOverrides = {startUrl}
 
       await expect(
         runTests.getTriggerConfigs(
           fakeApi,
-          {...ciConfig, defaultTestOverrides: configOverride, locations: ['aws:ap-northeast-1']},
+          {...ciConfig, defaultTestOverrides, locations: ['aws:ap-northeast-1']},
           mockReporter
         )
       ).resolves.toEqual([

--- a/src/commands/synthetics/__tests__/test.test.ts
+++ b/src/commands/synthetics/__tests__/test.test.ts
@@ -5,7 +5,7 @@ describe('getTestsFromSearchQuery', () => {
     const api = {
       searchTests: jest.fn().mockResolvedValue({tests: []}),
     }
-    // TODO: Clean up global as part of SYNTH-12989
+    // SYNTH-12989: Clean up deprecated `global` in favor of `defaultTestOverrides`
     const config = {global: {}, defaultTestOverrides: {}, testSearchQuery: ''}
 
     const result = await getTestsFromSearchQuery(api as any, config)
@@ -17,7 +17,7 @@ describe('getTestsFromSearchQuery', () => {
     const api = {
       searchTests: jest.fn().mockResolvedValue({tests: []}),
     }
-    // TODO: Clean up global as part of SYNTH-12989
+    // SYNTH-12989: Clean up deprecated `global` in favor of `defaultTestOverrides`
     const config = {global: {}, defaultTestOverrides: {}, testSearchQuery: 'my search query'}
 
     const result = await getTestsFromSearchQuery(api as any, config)

--- a/src/commands/synthetics/__tests__/test.test.ts
+++ b/src/commands/synthetics/__tests__/test.test.ts
@@ -5,7 +5,8 @@ describe('getTestsFromSearchQuery', () => {
     const api = {
       searchTests: jest.fn().mockResolvedValue({tests: []}),
     }
-    const config = {global: {}, testSearchQuery: ''}
+    // TODO: Clean up global as part of SYNTH-12989
+    const config = {global: {}, defaultTestOverrides: {}, testSearchQuery: ''}
 
     const result = await getTestsFromSearchQuery(api as any, config)
 
@@ -16,7 +17,8 @@ describe('getTestsFromSearchQuery', () => {
     const api = {
       searchTests: jest.fn().mockResolvedValue({tests: []}),
     }
-    const config = {global: {}, testSearchQuery: 'my search query'}
+    // TODO: Clean up global as part of SYNTH-12989
+    const config = {global: {}, defaultTestOverrides: {}, testSearchQuery: 'my search query'}
 
     const result = await getTestsFromSearchQuery(api as any, config)
 

--- a/src/commands/synthetics/interfaces.ts
+++ b/src/commands/synthetics/interfaces.ts
@@ -442,7 +442,9 @@ export interface RunTestsCommandConfig extends SyntheticsCIConfig {
   failOnMissingTests: boolean
   failOnTimeout: boolean
   files: string[]
+  // TODO: Clean up global as part of SYNTH-12989
   global: UserConfigOverride
+  defaultTestOverrides: UserConfigOverride
   locations: string[]
   mobileApplicationVersionFilePath?: string
   pollingTimeout: number

--- a/src/commands/synthetics/interfaces.ts
+++ b/src/commands/synthetics/interfaces.ts
@@ -442,7 +442,7 @@ export interface RunTestsCommandConfig extends SyntheticsCIConfig {
   failOnMissingTests: boolean
   failOnTimeout: boolean
   files: string[]
-  // TODO: Clean up global as part of SYNTH-12989
+  // SYNTH-12989: Clean up deprecated `global` in favor of `defaultTestOverrides`
   global: UserConfigOverride
   defaultTestOverrides: UserConfigOverride
   locations: string[]

--- a/src/commands/synthetics/run-tests-command.ts
+++ b/src/commands/synthetics/run-tests-command.ts
@@ -208,10 +208,9 @@ export class RunTestsCommand extends Command {
 
     // Use global only if defaultTestOverrides does not exist
     // TODO: Clean up global as part of SYNTH-12989
-    if (this.config.global && !this.config.defaultTestOverrides) {
-      this.config.defaultTestOverrides = this.config.global
+    if (Object.keys(this.config.global).length !== 0 && Object.keys(this.config.defaultTestOverrides).length === 0) {
+      this.config.defaultTestOverrides = {...this.config.global}
     }
-    console.log(this.config)
 
     // Override with ENV variables
     this.config = deepExtend(

--- a/src/commands/synthetics/run-tests-command.ts
+++ b/src/commands/synthetics/run-tests-command.ts
@@ -35,7 +35,7 @@ export const DEFAULT_COMMAND_CONFIG: RunTestsCommandConfig = {
   failOnMissingTests: false,
   failOnTimeout: true,
   files: ['{,!(node_modules)/**/}*.synthetics.json'],
-  // TODO: Clean up global as part of SYNTH-12989
+  // SYNTH-12989: Clean up deprecated `global` in favor of `defaultTestOverrides`
   global: {},
   defaultTestOverrides: {},
   locations: [],
@@ -207,7 +207,7 @@ export class RunTestsCommand extends Command {
     }
 
     // Use global only if defaultTestOverrides does not exist
-    // TODO: Clean up global as part of SYNTH-12989
+    // SYNTH-12989: Clean up deprecated `global` in favor of `defaultTestOverrides`
     if (Object.keys(this.config.global).length !== 0 && Object.keys(this.config.defaultTestOverrides).length === 0) {
       this.config.defaultTestOverrides = {...this.config.global}
     }

--- a/src/commands/synthetics/run-tests-lib.ts
+++ b/src/commands/synthetics/run-tests-lib.ts
@@ -61,14 +61,14 @@ export const executeTests = async (
 
   // If both global and defaultTestOverrides exist use defaultTestOverrides
   // TODO: Clean up global as part of SYNTH-12989
-  if (config.global) {
+  if (Object.keys(config.global).length !== 0) {
     console.warn(
       "The 'global' property is deprecated. Please use 'defaultTestOverrides' instead.\nIf both 'global' and 'defaultTestOverrides' properties exist, 'defaultTestOverrides' is used!"
     )
 
     // if config.defaultTestOverrides does not exist because executeTests was called directly, use global instead
-    if (!config.defaultTestOverrides) {
-      config.defaultTestOverrides = config.global
+    if (Object.keys(config.defaultTestOverrides).length === 0) {
+      config.defaultTestOverrides = {...config.global}
     }
   }
 

--- a/src/commands/synthetics/run-tests-lib.ts
+++ b/src/commands/synthetics/run-tests-lib.ts
@@ -60,7 +60,7 @@ export const executeTests = async (
   }
 
   // If both global and defaultTestOverrides exist use defaultTestOverrides
-  // TODO: Clean up global as part of SYNTH-12989
+  // SYNTH-12989: Clean up deprecated `global` in favor of `defaultTestOverrides`
   if (Object.keys(config.global).length !== 0) {
     console.warn(
       "The 'global' property is deprecated. Please use 'defaultTestOverrides' instead.\nIf both 'global' and 'defaultTestOverrides' properties exist, 'defaultTestOverrides' is used!"

--- a/src/commands/synthetics/run-tests-lib.ts
+++ b/src/commands/synthetics/run-tests-lib.ts
@@ -59,6 +59,19 @@ export const executeTests = async (
     }
   }
 
+  // If both global and defaultTestOverrides exist use defaultTestOverrides
+  // TODO: Clean up global as part of SYNTH-12989
+  if (config.global) {
+    console.warn(
+      "The 'global' property is deprecated. Please use 'defaultTestOverrides' instead.\nIf both 'global' and 'defaultTestOverrides' properties exist, 'defaultTestOverrides' is used!"
+    )
+
+    // if config.defaultTestOverrides does not exist because executeTests was called directly, use global instead
+    if (!config.defaultTestOverrides) {
+      config.defaultTestOverrides = config.global
+    }
+  }
+
   try {
     triggerConfigs = await getTriggerConfigs(api, config, reporter, suites)
   } catch (error) {
@@ -172,7 +185,7 @@ export const getTriggerConfigs = async (
   suites?: Suite[]
 ): Promise<TriggerConfig[]> => {
   // Grab the test config overrides from all the sources: default test config overrides, test files containing specific test config override, env variable, and CLI params
-  const defaultTestConfigOverrides = config.global
+  const defaultTestConfigOverrides = config.defaultTestOverrides
   // TODO: Clean up locations as part of SYNTH-12989
   const testConfigOverridesFromEnv = config.locations?.length ? {locations: config.locations} : {}
   const testsFromTestConfigs = await getTestConfigs(config, reporter, suites)

--- a/src/commands/synthetics/test.ts
+++ b/src/commands/synthetics/test.ts
@@ -30,9 +30,9 @@ export const getTestConfigs = async (
 
 export const getTestsFromSearchQuery = async (
   api: APIHelper,
-  config: Pick<RunTestsCommandConfig, 'global' | 'testSearchQuery'>
-) => {
-  const {global: globalConfigOverride, testSearchQuery} = config
+  config: Pick<RunTestsCommandConfig, 'defaultTestOverrides' | 'testSearchQuery'>
+): Promise<TriggerConfig[] | []> => {
+  const {defaultTestOverrides, testSearchQuery} = config
 
   // Empty search queries are not allowed.
   if (!testSearchQuery) {
@@ -42,7 +42,7 @@ export const getTestsFromSearchQuery = async (
   const testSearchResults = await api.searchTests(testSearchQuery)
 
   return testSearchResults.tests.map((test) => ({
-    config: globalConfigOverride,
+    config: defaultTestOverrides,
     id: test.public_id,
     suite: `Query: ${testSearchQuery}`,
   }))


### PR DESCRIPTION
### What and why?

Renaming `global` field in the Global Config to `defaultTestOverrides`. This is done becase having it named global is confusing. We've moved to a intermediary state where we're still backwards compatible and a ticket for the eventual clean up has been created and linked in the appropriate places

### How?

Created a new field called `defaultTestOverrides` and if it's not defined but `global` is we copy over to it whatever is in `global`. Otherwise we just use `defaultTestOverrides` as is. The rest of the code has been transitioned to use `defaultTestOverrides`

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
