### PR TITLE
[ci] Fix macOS jobs failing to download Node.js 14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,7 +136,7 @@ jobs:
       - name: Install node
         uses: actions/setup-node@v4
         with:
-          node-version: '14.18.3'
+          node-version: 14.18.3
       - run: yarn install --immutable
       - run: yarn build
       - name: Create standalone binary
@@ -156,7 +156,7 @@ jobs:
       - name: Install node
         uses: actions/setup-node@v4
         with:
-          node-version: '14.18.3'
+          node-version: 14.18.3
       - run: yarn install --immutable
       - run: yarn build:win
       - name: Create standalone binary
@@ -176,7 +176,7 @@ jobs:
       - name: Install node
         uses: actions/setup-node@v4
         with:
-          node-version: '14.18.3'
+          node-version: 14.18.3
       - run: yarn install --immutable
       - run: yarn build
       - name: Create standalone binary
@@ -224,7 +224,6 @@ jobs:
           sca_enabled: true
           diff_aware: false
 
-
   check-licenses:
     name: Check licenses
     runs-on: ubuntu-latest
@@ -234,7 +233,7 @@ jobs:
       - name: Install node
         uses: actions/setup-node@v4
         with:
-          node-version: '14'
+          node-version: 14.18.3
       # The install step has been added here such that the `.yarn/install-state.gz` file is generated. This file is used
       # by the script `check-licenses` below.
       - run: yarn install --immutable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,7 +170,7 @@ jobs:
 
   standalone-binary-test-macos:
     name: Test standalone binary in macOS
-    # macOS-latest is an arm64 image, but the standalone binary is built against `node14-macos-x64`, which is downloaded by `pkg`
+    # macOS-latest is an arm64 image, but the standalone binary is built against `node14-macos-x64` (downloaded by `pkg`)
     # https://github.com/actions/runner-images#available-images
     runs-on: macos-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,7 +136,7 @@ jobs:
       - name: Install node
         uses: actions/setup-node@v4
         with:
-          node-version: 14.18.3
+          node-version: 20.11.0 # Use newer version to build the standalone binary
       - run: yarn install --immutable
       - run: yarn build
       - name: Create standalone binary
@@ -156,7 +156,7 @@ jobs:
       - name: Install node
         uses: actions/setup-node@v4
         with:
-          node-version: 14.18.3
+          node-version: 20.11.0 # Use newer version to build the standalone binary
       - run: yarn install --immutable
       - run: yarn build:win
       - name: Create standalone binary
@@ -170,13 +170,15 @@ jobs:
 
   standalone-binary-test-macos:
     name: Test standalone binary in macOS
+    # macOS-latest is an arm64 image, but the standalone binary is built against `node14-macos-x64`, which is downloaded by `pkg`
+    # https://github.com/actions/runner-images#available-images
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
       - name: Install node
         uses: actions/setup-node@v4
         with:
-          node-version: 14.18.3
+          node-version: 20.11.0 # Use newer version to build the standalone binary
       - run: yarn install --immutable
       - run: yarn build
       - name: Create standalone binary

--- a/.github/workflows/publish-prerelease.yml
+++ b/.github/workflows/publish-prerelease.yml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '14'
+          node-version: 14.18.3
       - run: |
           # Isolate the tag and exit if none found
           IFS='-' read -ra ARR_TAG <<< $TAG

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Install node
         uses: actions/setup-node@v4
         with:
-          node-version: 14.18.3
+          node-version: 20.11.0 # Use newer version to build the standalone binary # Use newer version to build the standalone binary
       - name: Install project dependencies
         run: yarn install --immutable
       - name: Bundle library
@@ -83,7 +83,7 @@ jobs:
       - name: Install node
         uses: actions/setup-node@v4
         with:
-          node-version: 14.18.3
+          node-version: 20.11.0 # Use newer version to build the standalone binary
       - name: Install project dependencies
         run: yarn install --immutable
       - name: Bundle library
@@ -112,6 +112,8 @@ jobs:
             })
 
   build-binary-macos:
+    # macOS-latest is an arm64 image, but the standalone binary is built against `node14-macos-x64`, which is downloaded by `pkg`
+    # https://github.com/actions/runner-images#available-images
     runs-on: macos-latest
     needs: create-draft-release
     steps:
@@ -119,7 +121,7 @@ jobs:
       - name: Install node
         uses: actions/setup-node@v4
         with:
-          node-version: 14.18.3
+          node-version: 20.11.0 # Use newer version to build the standalone binary
       - name: Install project dependencies
         run: yarn install --immutable
       - name: Bundle library

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Install node
         uses: actions/setup-node@v4
         with:
-          node-version: '14.18.3'
+          node-version: 14.18.3
       - name: Install project dependencies
         run: yarn install --immutable
       - name: Bundle library
@@ -83,7 +83,7 @@ jobs:
       - name: Install node
         uses: actions/setup-node@v4
         with:
-          node-version: '14.18.3'
+          node-version: 14.18.3
       - name: Install project dependencies
         run: yarn install --immutable
       - name: Bundle library
@@ -119,7 +119,7 @@ jobs:
       - name: Install node
         uses: actions/setup-node@v4
         with:
-          node-version: '14.18.3'
+          node-version: 14.18.3
       - name: Install project dependencies
         run: yarn install --immutable
       - name: Bundle library
@@ -156,7 +156,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '14'
+          node-version: 14.18.3
       - run: yarn
       - run: yarn npm publish
         env:

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -112,7 +112,7 @@ jobs:
             })
 
   build-binary-macos:
-    # macOS-latest is an arm64 image, but the standalone binary is built against `node14-macos-x64`, which is downloaded by `pkg`
+    # macOS-latest is an arm64 image, but the standalone binary is built against `node14-macos-x64` (downloaded by `pkg`)
     # https://github.com/actions/runner-images#available-images
     runs-on: macos-latest
     needs: create-draft-release

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Install node
         uses: actions/setup-node@v4
         with:
-          node-version: 20.11.0 # Use newer version to build the standalone binary # Use newer version to build the standalone binary
+          node-version: 20.11.0 # Use newer version to build the standalone binary
       - name: Install project dependencies
         run: yarn install --immutable
       - name: Bundle library


### PR DESCRIPTION
### What and why?

https://github.blog/changelog/2024-04-01-macos-14-sonoma-is-generally-available-and-the-latest-macos-runner-image/

Yesterday, the `macos-latest` tag changed:
- From [macOS 12](https://github.com/actions/runner-images/releases/tag/macOS-12%2F20240412.2) (x64) ([example passing run](https://github.com/DataDog/datadog-ci/actions/runs/8807444673/job/24176654538))
- To [macOS 14 arm64](https://github.com/actions/runner-images/releases/tag/macos-14-arm64%2F20240422.3) ([example failing run](https://github.com/DataDog/datadog-ci/actions/runs/8815899406/job/24199749613))

Corresponding docs PR: https://github.com/actions/runner-images/pull/9601

Because of this change, the `setup-node` job started failing with:

```bash
Unable to find Node version '14.18.3' for platform darwin and architecture arm64
```

The reason is that there is no `node-14.18.3-darwin-arm64.tar.gz` asset in this release, probably because Node.js 14 was never compiled for darwin arm64:
- https://github.com/actions/node-versions/releases/tag/14.18.3-1681282640

### How?

- Stay up-to-date and still use the `macos-latest` runner, which is now lighter and on arm64
- Use Node.js `14.18.3` for all jobs, except when building the standalone binary because `pkg` downloads the right Node.js binary anyway.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
