### PR TITLE
[synthetics] Make deprecated property `global` optional

### DIFF
--- a/src/commands/synthetics/__tests__/cli.test.ts
+++ b/src/commands/synthetics/__tests__/cli.test.ts
@@ -88,7 +88,7 @@ describe('run-test', () => {
         failOnMissingTests: true,
         failOnTimeout: false,
         files: ['my-new-file'],
-        // SYNTH-12989: Clean up deprecated `global` in favor of `defaultTestOverrides`
+        // TODO SYNTH-12989: Clean up deprecated `global` in favor of `defaultTestOverrides`
         global: {
           deviceIds: ['chrome.laptop_large'],
           locations: ['us-east-1'],
@@ -123,7 +123,7 @@ describe('run-test', () => {
     })
 
     test('override from CLI', async () => {
-      // SYNTH-12989: Clean up deprecated `global` in favor of `defaultTestOverrides`
+      // TODO SYNTH-12989: Clean up deprecated `global` in favor of `defaultTestOverrides`
       const overrideCLI: Omit<RunTestsCommandConfig, 'global' | 'defaultTestOverrides' | 'proxy'> = {
         apiKey: 'fake_api_key',
         appKey: 'fake_app_key',
@@ -209,7 +209,7 @@ describe('run-test', () => {
         apiKey: 'api_key_config_file',
         appKey: 'app_key_config_file',
         datadogSite: 'us5.datadoghq.com',
-        // SYNTH-12989: Clean up deprecated `global` in favor of `defaultTestOverrides`
+        // TODO SYNTH-12989: Clean up deprecated `global` in favor of `defaultTestOverrides`
         global: {
           pollingTimeout: 111,
           mobileApplicationVersionFilePath: './path/to/application_config_file.apk',
@@ -281,7 +281,7 @@ describe('run-test', () => {
       jest.spyOn(api, 'getApiHelper').mockImplementation(() => apiHelper as any)
 
       // Global
-      // SYNTH-12989: Clean up deprecated `global` in favor of `defaultTestOverrides`
+      // TODO SYNTH-12989: Clean up deprecated `global` in favor of `defaultTestOverrides`
       command['config'].global = {
         locations: ['aws:us-east-2'],
         mobileApplicationVersionFilePath: './path/to/application_global.apk',
@@ -351,7 +351,7 @@ describe('run-test', () => {
       expect(command['config']).toEqual({
         ...DEFAULT_COMMAND_CONFIG,
         configPath: 'src/commands/synthetics/__tests__/config-fixtures/config-with-global-polling-timeout.json',
-        // SYNTH-12989: Clean up deprecated `global` in favor of `defaultTestOverrides`
+        // TODO SYNTH-12989: Clean up deprecated `global` in favor of `defaultTestOverrides`
         global: {followRedirects: false},
         defaultTestOverrides: {followRedirects: false, pollingTimeout: 333},
         pollingTimeout: 333,

--- a/src/commands/synthetics/__tests__/run-tests-lib.test.ts
+++ b/src/commands/synthetics/__tests__/run-tests-lib.test.ts
@@ -574,14 +574,14 @@ describe('run-test', () => {
 
     test('should override and execute only publicIds that were defined in the global config', async () => {
       jest.spyOn(utils, 'getSuites').mockImplementation((() => fakeSuites) as any)
-      const configOverride = {startUrl}
+      const defaultTestOverrides = {startUrl}
 
       await expect(
         runTests.getTriggerConfigs(
           fakeApi,
           {
             ...ciConfig,
-            defaultTestOverrides: configOverride,
+            defaultTestOverrides,
             locations: ['aws:ap-northeast-1'],
             publicIds: ['abc-def-ghi', '123-456-789'],
           },
@@ -602,7 +602,7 @@ describe('run-test', () => {
 
     test('should search tests and extend global config', async () => {
       jest.spyOn(utils, 'getSuites').mockImplementation((() => fakeSuites) as any)
-      const configOverride = {startUrl}
+      const defaultTestOverrides = {startUrl}
       const searchQuery = 'fake search'
 
       await expect(
@@ -610,7 +610,7 @@ describe('run-test', () => {
           fakeApi,
           {
             ...ciConfig,
-            defaultTestOverrides: configOverride,
+            defaultTestOverrides,
             locations: ['aws:ap-northeast-1'],
             testSearchQuery: searchQuery,
           },
@@ -626,13 +626,13 @@ describe('run-test', () => {
     })
 
     test('should not use testSearchQuery if global config has defined public_ids', async () => {
-      const configOverride = {startUrl}
+      const defaultTestOverrides = {startUrl}
       const searchQuery = 'fake search'
 
       await expect(
         runTests.getTriggerConfigs(
           fakeApi,
-          {...ciConfig, defaultTestOverrides: configOverride, publicIds: ['abc-def-ghi'], testSearchQuery: searchQuery},
+          {...ciConfig, defaultTestOverrides, publicIds: ['abc-def-ghi'], testSearchQuery: searchQuery},
           mockReporter
         )
       ).resolves.toEqual([
@@ -645,14 +645,10 @@ describe('run-test', () => {
 
     test('should use given globs to get tests list', async () => {
       const getSuitesMock = jest.spyOn(utils, 'getSuites').mockImplementation((() => fakeSuites) as any)
-      const configOverride = {startUrl}
+      const defaultTestOverrides = {startUrl}
       const files = ['new glob', 'another one']
 
-      await runTests.getTriggerConfigs(
-        fakeApi,
-        {...ciConfig, defaultTestOverrides: configOverride, files},
-        mockReporter
-      )
+      await runTests.getTriggerConfigs(fakeApi, {...ciConfig, defaultTestOverrides, files}, mockReporter)
       expect(getSuitesMock).toHaveBeenCalledTimes(2)
       expect(getSuitesMock).toHaveBeenCalledWith('new glob', mockReporter)
       expect(getSuitesMock).toHaveBeenCalledWith('another one', mockReporter)
@@ -660,12 +656,12 @@ describe('run-test', () => {
 
     test('should return tests from provided suites with overrides', async () => {
       const getSuitesMock = jest.spyOn(utils, 'getSuites').mockImplementation((() => fakeSuites) as any)
-      const configOverride = {startUrl}
+      const defaultTestOverrides = {startUrl}
       const files: string[] = []
 
       const tests = await runTests.getTriggerConfigs(
         fakeApi,
-        {...ciConfig, defaultTestOverrides: configOverride, files},
+        {...ciConfig, defaultTestOverrides, files},
         mockReporter,
         fakeSuites
       )
@@ -681,12 +677,12 @@ describe('run-test', () => {
       const globSuites = [fakeSuites[1]]
 
       const getSuitesMock = jest.spyOn(utils, 'getSuites').mockImplementation((() => globSuites) as any)
-      const configOverride = {startUrl}
+      const defaultTestOverrides = {startUrl}
       const files = ['glob']
 
       const tests = await runTests.getTriggerConfigs(
         fakeApi,
-        {...ciConfig, defaultTestOverrides: configOverride, files},
+        {...ciConfig, defaultTestOverrides, files},
         mockReporter,
         userSuites
       )

--- a/src/commands/synthetics/__tests__/test.test.ts
+++ b/src/commands/synthetics/__tests__/test.test.ts
@@ -5,7 +5,7 @@ describe('getTestsFromSearchQuery', () => {
     const api = {
       searchTests: jest.fn().mockResolvedValue({tests: []}),
     }
-    // SYNTH-12989: Clean up deprecated `global` in favor of `defaultTestOverrides`
+    // TODO SYNTH-12989: Clean up deprecated `global` in favor of `defaultTestOverrides`
     const config = {global: {}, defaultTestOverrides: {}, testSearchQuery: ''}
 
     const result = await getTestsFromSearchQuery(api as any, config)
@@ -17,7 +17,7 @@ describe('getTestsFromSearchQuery', () => {
     const api = {
       searchTests: jest.fn().mockResolvedValue({tests: []}),
     }
-    // SYNTH-12989: Clean up deprecated `global` in favor of `defaultTestOverrides`
+    // TODO SYNTH-12989: Clean up deprecated `global` in favor of `defaultTestOverrides`
     const config = {global: {}, defaultTestOverrides: {}, testSearchQuery: 'my search query'}
 
     const result = await getTestsFromSearchQuery(api as any, config)

--- a/src/commands/synthetics/api.ts
+++ b/src/commands/synthetics/api.ts
@@ -29,7 +29,7 @@ import {ciTriggerApp, getDatadogHost, retry} from './utils/public'
 const MAX_RETRIES = 3
 const DELAY_BETWEEN_RETRIES = 500 // In ms
 const LARGE_DELAY_BETWEEN_RETRIES = 1000 // In ms
-// SYNTH-13709: Use the `Retry-After` header.
+// TODO SYNTH-13709: Use the `Retry-After` header.
 const DELAY_BETWEEN_429_RETRIES = 5000 // In ms
 
 interface BackendError {

--- a/src/commands/synthetics/interfaces.ts
+++ b/src/commands/synthetics/interfaces.ts
@@ -442,7 +442,7 @@ export interface RunTestsCommandConfig extends SyntheticsCIConfig {
   failOnMissingTests: boolean
   failOnTimeout: boolean
   files: string[]
-  // SYNTH-12989: Clean up deprecated `global` in favor of `defaultTestOverrides`
+  // TODO SYNTH-12989: Clean up deprecated `global` in favor of `defaultTestOverrides`
   global: UserConfigOverride
   defaultTestOverrides: UserConfigOverride
   locations: string[]

--- a/src/commands/synthetics/interfaces.ts
+++ b/src/commands/synthetics/interfaces.ts
@@ -443,7 +443,7 @@ export interface RunTestsCommandConfig extends SyntheticsCIConfig {
   failOnTimeout: boolean
   files: string[]
   // TODO SYNTH-12989: Clean up deprecated `global` in favor of `defaultTestOverrides`
-  global: UserConfigOverride
+  global?: UserConfigOverride
   defaultTestOverrides: UserConfigOverride
   locations: string[]
   mobileApplicationVersionFilePath?: string

--- a/src/commands/synthetics/run-tests-command.ts
+++ b/src/commands/synthetics/run-tests-command.ts
@@ -208,7 +208,10 @@ export class RunTestsCommand extends Command {
 
     // Use `global` only if `defaultTestOverrides` does not exist
     // TODO SYNTH-12989: Clean up deprecated `global` in favor of `defaultTestOverrides`
-    if (Object.keys(this.config.global).length !== 0 && Object.keys(this.config.defaultTestOverrides).length === 0) {
+    if (
+      Object.keys(this.config.global ?? {}).length > 0 &&
+      Object.keys(this.config.defaultTestOverrides).length === 0
+    ) {
       this.config.defaultTestOverrides = {...this.config.global}
     }
 

--- a/src/commands/synthetics/run-tests-command.ts
+++ b/src/commands/synthetics/run-tests-command.ts
@@ -35,7 +35,7 @@ export const DEFAULT_COMMAND_CONFIG: RunTestsCommandConfig = {
   failOnMissingTests: false,
   failOnTimeout: true,
   files: ['{,!(node_modules)/**/}*.synthetics.json'],
-  // SYNTH-12989: Clean up deprecated `global` in favor of `defaultTestOverrides`
+  // TODO SYNTH-12989: Clean up deprecated `global` in favor of `defaultTestOverrides`
   global: {},
   defaultTestOverrides: {},
   locations: [],
@@ -206,8 +206,8 @@ export class RunTestsCommand extends Command {
       }
     }
 
-    // Use global only if defaultTestOverrides does not exist
-    // SYNTH-12989: Clean up deprecated `global` in favor of `defaultTestOverrides`
+    // Use `global` only if `defaultTestOverrides` does not exist
+    // TODO SYNTH-12989: Clean up deprecated `global` in favor of `defaultTestOverrides`
     if (Object.keys(this.config.global).length !== 0 && Object.keys(this.config.defaultTestOverrides).length === 0) {
       this.config.defaultTestOverrides = {...this.config.global}
     }

--- a/src/commands/synthetics/run-tests-lib.ts
+++ b/src/commands/synthetics/run-tests-lib.ts
@@ -61,7 +61,7 @@ export const executeTests = async (
 
   // If both global and defaultTestOverrides exist use defaultTestOverrides
   // TODO SYNTH-12989: Clean up deprecated `global` in favor of `defaultTestOverrides`
-  if (Object.keys(config.global).length !== 0) {
+  if (Object.keys(config.global ?? {}).length > 0) {
     console.warn(
       "The 'global' property is deprecated. Please use 'defaultTestOverrides' instead.\nIf both 'global' and 'defaultTestOverrides' properties exist, 'defaultTestOverrides' is used!"
     )
@@ -186,7 +186,7 @@ export const getTriggerConfigs = async (
 ): Promise<TriggerConfig[]> => {
   // Grab the test config overrides from all the sources: default test config overrides, test files containing specific test config override, env variable, and CLI params
   const defaultTestConfigOverrides = config.defaultTestOverrides
-  // TODO: Clean up locations as part of SYNTH-12989
+  // TODO SYNTH-12989: Clean up `locations`
   const testConfigOverridesFromEnv = config.locations?.length ? {locations: config.locations} : {}
   const testsFromTestConfigs = await getTestConfigs(config, reporter, suites)
 

--- a/src/commands/synthetics/run-tests-lib.ts
+++ b/src/commands/synthetics/run-tests-lib.ts
@@ -60,7 +60,7 @@ export const executeTests = async (
   }
 
   // If both global and defaultTestOverrides exist use defaultTestOverrides
-  // SYNTH-12989: Clean up deprecated `global` in favor of `defaultTestOverrides`
+  // TODO SYNTH-12989: Clean up deprecated `global` in favor of `defaultTestOverrides`
   if (Object.keys(config.global).length !== 0) {
     console.warn(
       "The 'global' property is deprecated. Please use 'defaultTestOverrides' instead.\nIf both 'global' and 'defaultTestOverrides' properties exist, 'defaultTestOverrides' is used!"


### PR DESCRIPTION
### What and why?

The build on [our GitHub action](https://github.com/DataDog/synthetics-ci-github-action/actions/runs/8815570237/job/24197790332) is failing with this error:
```ts
src/fixtures.ts(3,14): error TS2741: Property 'defaultTestOverrides' is missing in type '{ apiKey: string; appKey: string; configPath: string; datadogSite: string; failOnCriticalErrors: false; failOnMissingTests: false; failOnTimeout: true; files: string[]; global: {}; locations: never[]; ... 6 more ...; variableStrings: never[]; }' but required in type 'RunTestsCommandConfig'.
```

We could fix it by changing `fixtures.ts` with:
```diff
export const config: synthetics.RunTestsCommandConfig = {
  apiKey: '',
  appKey: '',
  configPath: 'datadog-ci.json',
  datadogSite: 'datadoghq.com',
  failOnCriticalErrors: false,
  failOnMissingTests: false,
  failOnTimeout: true,
  files: ['{,!(node_modules)/**/}*.synthetics.json'],
  global: {},
+ defaultTestOverrides: {},
  locations: [],
  pollingTimeout: 30 * 60 * 1000,
  proxy: {protocol: 'http'},
  publicIds: [],
  selectiveRerun: false,
  subdomain: 'app',
  tunnel: false,
  variableStrings: [],
}
```

But since `global` is deprecated, we should make it optional.

### How?

- Make `global` optional
- Fix some nits

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
