### PR TITLE
[SYNTH-12976] Ignore default polling timeout in override count

### DIFF
--- a/src/commands/synthetics/__tests__/cli.test.ts
+++ b/src/commands/synthetics/__tests__/cli.test.ts
@@ -522,7 +522,7 @@ describe('run-test', () => {
           content: {
             tests: [
               {config: {}, id: 'aaa-aaa-aaa'},
-              {config: {}, id: 'bbb-bbb-bbb'},
+              {config: {headers: {}}, id: 'bbb-bbb-bbb'}, // 1 config override
               {config: {}, id: 'for-bid-den'},
             ],
           },
@@ -534,7 +534,7 @@ describe('run-test', () => {
       expect(apiHelper.getTest).toHaveBeenCalledTimes(3)
 
       expect(writeMock).toHaveBeenCalledTimes(4)
-      expect(writeMock).toHaveBeenCalledWith('[aaa-aaa-aaa] Found test "aaa-aaa-aaa" (1 config override)\n')
+      expect(writeMock).toHaveBeenCalledWith('[aaa-aaa-aaa] Found test "aaa-aaa-aaa"\n')
       expect(writeMock).toHaveBeenCalledWith('[bbb-bbb-bbb] Found test "bbb-bbb-bbb" (1 config override)\n')
       expect(writeMock).toHaveBeenCalledWith(
         '\n ERROR: authorization error \nFailed to get test: query on https://app.datadoghq.com/tests/for-bid-den returned: "Forbidden"\n\n\n'

--- a/src/commands/synthetics/__tests__/utils/public.test.ts
+++ b/src/commands/synthetics/__tests__/utils/public.test.ts
@@ -72,7 +72,7 @@ import {
   UserConfigOverride,
 } from '../../interfaces'
 import * as mobile from '../../mobile'
-import {DEFAULT_COMMAND_CONFIG, MAX_TESTS_TO_TRIGGER} from '../../run-tests-command'
+import {DEFAULT_COMMAND_CONFIG, DEFAULT_POLLING_TIMEOUT, MAX_TESTS_TO_TRIGGER} from '../../run-tests-command'
 import * as utils from '../../utils/public'
 
 import {
@@ -649,6 +649,22 @@ describe('utils', () => {
         ...configOverride,
         public_id: publicId,
       })
+    })
+  })
+
+  describe('getTestOverridesCount', () => {
+    test('should count overrides', () => {
+      expect(utils.getTestOverridesCount({})).toBe(0)
+
+      // If the user sets anything, even an empty array or object, it counts as an override
+      expect(utils.getTestOverridesCount({deviceIds: []})).toBe(1)
+      expect(utils.getTestOverridesCount({headers: {}})).toBe(1)
+
+      expect(utils.getTestOverridesCount({deviceIds: ['a']})).toBe(1)
+      expect(utils.getTestOverridesCount({pollingTimeout: 123})).toBe(1)
+
+      // Should ignore the default value for the pollingTimeout
+      expect(utils.getTestOverridesCount({pollingTimeout: DEFAULT_POLLING_TIMEOUT})).toBe(0)
     })
   })
 

--- a/src/commands/synthetics/reporters/default.ts
+++ b/src/commands/synthetics/reporters/default.ts
@@ -25,6 +25,7 @@ import {
   getResultDuration,
   getResultOutcome,
   getResultUrl,
+  getTestOverridesCount,
   isDeviceIdSet,
   isResultSkippedBySelectiveRerun,
   PASSED_RESULT_OUTCOMES,
@@ -467,8 +468,9 @@ export class DefaultReporter implements MainReporter {
       return `Found test "${chalk.green.bold(test.name)}"`
     }
 
+    // TODO SYNTH-12972: Rename "config override" to "test override" in the code AND the reported message
     const getConfigOverridesPart = () => {
-      const nbConfigsOverridden = Object.keys(config).length
+      const nbConfigsOverridden = getTestOverridesCount(config)
       if (nbConfigsOverridden === 0 || executionRule === ExecutionRule.SKIPPED) {
         return ''
       }

--- a/src/commands/synthetics/utils/public.ts
+++ b/src/commands/synthetics/utils/public.ts
@@ -40,7 +40,7 @@ import {
   UserConfigOverride,
 } from '../interfaces'
 import {uploadApplicationAndOverrideConfig} from '../mobile'
-import {MAX_TESTS_TO_TRIGGER} from '../run-tests-command'
+import {DEFAULT_POLLING_TIMEOUT, MAX_TESTS_TO_TRIGGER} from '../run-tests-command'
 import {getTest} from '../test'
 import {Tunnel} from '../tunnel'
 
@@ -118,6 +118,18 @@ export const getOverriddenConfig = (
   }
 
   return overriddenConfig
+}
+
+export const getTestOverridesCount = (testOverrides: UserConfigOverride) => {
+  return Object.keys(testOverrides).reduce((count, configKey) => {
+    // We always send a value for `pollingTimeout` to the backend, even when the user doesn't override it.
+    // In that case, it shouldn't be counted.
+    if (configKey === 'pollingTimeout' && testOverrides[configKey] === DEFAULT_POLLING_TIMEOUT) {
+      return count
+    }
+
+    return count + 1
+  }, 0)
 }
 
 export const setCiTriggerApp = (source: string): void => {


### PR DESCRIPTION
### What and why?

The CLI output was showing `(1 config override)` for every test, and that was misleading since the user didn't set any custom polling timeout.

![image](https://github.com/DataDog/datadog-ci/assets/9317502/e088ac93-8abb-4086-8bd0-9e91c1c9dafd)

### How?

Do not count `pollingTimeout` if it's set to the default value.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
