### PR TITLE
[SYNTH-14344] Do not require etag from app part upload

### DIFF
--- a/src/commands/synthetics/__tests__/api.test.ts
+++ b/src/commands/synthetics/__tests__/api.test.ts
@@ -292,14 +292,11 @@ describe('dd-api', () => {
       2: 'https://myaccount.blob.core.windows.net/mycontainer/myblob2',
     }
 
-    const result = await uploadMobileApplicationPart(
-      MOBILE_PRESIGNED_UPLOAD_PARTS,
-      {
-        ...MOBILE_PRESIGNED_URLS_PAYLOAD.multipart_presigned_urls_params,
-        // override fixture with our cutsom azure urls
-        urls,
-      }
-    )
+    const result = await uploadMobileApplicationPart(MOBILE_PRESIGNED_UPLOAD_PARTS, {
+      ...MOBILE_PRESIGNED_URLS_PAYLOAD.multipart_presigned_urls_params,
+      // override fixture with azure urls
+      urls,
+    })
 
     expect(result).toEqual([
       {ETag: '', PartNumber: 1},

--- a/src/commands/synthetics/__tests__/api.test.ts
+++ b/src/commands/synthetics/__tests__/api.test.ts
@@ -264,13 +264,50 @@ describe('dd-api', () => {
     const spy = jest.spyOn(axios, 'create').mockImplementation((() => mockRequest) as any)
     const api = apiConstructor(apiConfiguration)
     const {uploadMobileApplicationPart} = api
-    await uploadMobileApplicationPart(
+    const result = await uploadMobileApplicationPart(
       MOBILE_PRESIGNED_UPLOAD_PARTS,
       MOBILE_PRESIGNED_URLS_PAYLOAD.multipart_presigned_urls_params
     )
 
+    expect(result).toEqual([
+      {ETag: '123', PartNumber: 1},
+      {ETag: '123', PartNumber: 2},
+    ])
+
     const callArg = mockRequest.mock.calls[0][0]
     expect(callArg.url).toBe(MOBILE_PRESIGNED_URLS_PAYLOAD.multipart_presigned_urls_params.urls[1])
+    expect(mockRequest).toHaveBeenCalledTimes(MOBILE_PRESIGNED_UPLOAD_PARTS.length)
+    spy.mockRestore()
+  })
+
+  test('should return empty ETag when doing azure part upload', async () => {
+    const mockRequest = jest.fn()
+    mockRequest.mockReturnValue({status: 200, headers: {}})
+    const spy = jest.spyOn(axios, 'create').mockImplementation((() => mockRequest) as any)
+    const api = apiConstructor(apiConfiguration)
+    const {uploadMobileApplicationPart} = api
+
+    const urls = {
+      1: 'https://myaccount.blob.core.windows.net/mycontainer/myblob1',
+      2: 'https://myaccount.blob.core.windows.net/mycontainer/myblob2',
+    }
+
+    const result = await uploadMobileApplicationPart(
+      MOBILE_PRESIGNED_UPLOAD_PARTS,
+      {
+        ...MOBILE_PRESIGNED_URLS_PAYLOAD.multipart_presigned_urls_params,
+        // override fixture with our cutsom azure urls
+        urls,
+      }
+    )
+
+    expect(result).toEqual([
+      {ETag: '', PartNumber: 1},
+      {ETag: '', PartNumber: 2},
+    ])
+
+    const callArg = mockRequest.mock.calls[0][0]
+    expect(callArg.url).toBe(urls[1])
     expect(mockRequest).toHaveBeenCalledTimes(MOBILE_PRESIGNED_UPLOAD_PARTS.length)
     spy.mockRestore()
   })

--- a/src/commands/synthetics/api.ts
+++ b/src/commands/synthetics/api.ts
@@ -220,7 +220,7 @@ const uploadMobileApplicationPart = (request: (args: AxiosRequestConfig) => Axio
       request
     )
 
-    // Azure part-upload does not return ETag -- set to empty string
+    // Azure part-upload does not return ETag headers, so our backend ignores it for Azure
     const quotedEtag = isAzureUrl(presignedUrl) ? '' : (resp.headers.etag as string)
 
     return {

--- a/src/commands/synthetics/api.ts
+++ b/src/commands/synthetics/api.ts
@@ -221,9 +221,7 @@ const uploadMobileApplicationPart = (request: (args: AxiosRequestConfig) => Axio
     )
 
     // Azure part-upload does not return ETag -- set to empty string
-    const quotedEtag = isAzureUrl(presignedUrl)
-        ? ''
-        : resp.headers.etag as string
+    const quotedEtag = isAzureUrl(presignedUrl) ? '' : (resp.headers.etag as string)
 
     return {
       ETag: quotedEtag.replace(/"/g, ''),
@@ -373,7 +371,6 @@ export const getApiHelper = (config: APIHelperConfig): APIHelper => {
     baseUrl: getDatadogHost({useIntake: false, apiVersion: 'v1', config}),
     proxyOpts: config.proxy,
   })
-
 }
 
 const isAzureUrl = (presignedUrl: string) => {

--- a/src/commands/synthetics/api.ts
+++ b/src/commands/synthetics/api.ts
@@ -221,7 +221,9 @@ const uploadMobileApplicationPart = (request: (args: AxiosRequestConfig) => Axio
     )
 
     // Azure part-upload does not return ETag -- set to empty string
-    const quotedEtag = (resp.headers.etag || '') as string
+    const quotedEtag = isAzureUrl(presignedUrl)
+        ? ''
+        : resp.headers.etag as string
 
     return {
       ETag: quotedEtag.replace(/"/g, ''),
@@ -371,4 +373,10 @@ export const getApiHelper = (config: APIHelperConfig): APIHelper => {
     baseUrl: getDatadogHost({useIntake: false, apiVersion: 'v1', config}),
     proxyOpts: config.proxy,
   })
+
+}
+
+const isAzureUrl = (presignedUrl: string) => {
+  // https://learn.microsoft.com/en-us/rest/api/storageservices/put-blob-from-url?tabs=microsoft-entra-id#request
+  return presignedUrl.includes('.blob.core.windows.net')
 }

--- a/src/commands/synthetics/api.ts
+++ b/src/commands/synthetics/api.ts
@@ -220,7 +220,8 @@ const uploadMobileApplicationPart = (request: (args: AxiosRequestConfig) => Axio
       request
     )
 
-    const quotedEtag = resp.headers.etag as string
+    // Azure part-upload does not return ETag -- set to empty string
+    const quotedEtag = (resp.headers.etag || '') as string
 
     return {
       ETag: quotedEtag.replace(/"/g, ''),


### PR DESCRIPTION
### What and why?

Do not require the etag header be returned when uploading mobile application parts. Azure strictly does not return the etag header.

### How?

Just default to empty string for etag field when completing upload. The backend for azure expects this behavior

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
