### PR TITLE
[git-metadata] Update command limitations

### DIFF
--- a/src/commands/git-metadata/README.md
+++ b/src/commands/git-metadata/README.md
@@ -33,7 +33,7 @@ datadog-ci git-metadata upload
 
 #### Limitations
 
-This command will only report commits in the current HEAD's history, with a commit date within the last 30 days and up to 1,000 commits.
+The `git-metadata` command only reports commits in the current HEAD's history with a commit date within the last 30 days. The command outputs a maximum of 1,000 commits.
 
 The repository URL is inferred from the remote named `origin` (or the first remote if none are named `origin`). The value can be overridden by using the `--repository-url` flag.
 For example: The remote `git@github.com:Datadog/example.git` will create links that point to `https://github.com/Datadog/example`.

--- a/src/commands/git-metadata/README.md
+++ b/src/commands/git-metadata/README.md
@@ -33,7 +33,7 @@ datadog-ci git-metadata upload
 
 #### Limitations
 
-This command will only report commits with a commit date within the last 30 days.
+This command will only report commits with a commit date within the last 30 days, up to 1,000 commits.
 
 The repository URL is inferred from the remote named `origin` (or the first remote if none are named `origin`). The value can be overridden by using the `--repository-url` flag.
 For example: The remote `git@github.com:Datadog/example.git` will create links that point to `https://github.com/Datadog/example`.

--- a/src/commands/git-metadata/README.md
+++ b/src/commands/git-metadata/README.md
@@ -33,6 +33,8 @@ datadog-ci git-metadata upload
 
 #### Limitations
 
+This command will only report commits with a commit date within the last 30 days.
+
 The repository URL is inferred from the remote named `origin` (or the first remote if none are named `origin`). The value can be overridden by using the `--repository-url` flag.
 For example: The remote `git@github.com:Datadog/example.git` will create links that point to `https://github.com/Datadog/example`.
 

--- a/src/commands/git-metadata/README.md
+++ b/src/commands/git-metadata/README.md
@@ -33,7 +33,7 @@ datadog-ci git-metadata upload
 
 #### Limitations
 
-This command will only report commits with a commit date within the last 30 days, up to 1,000 commits.
+This command will only report commits in the current HEAD's history, with a commit date within the last 30 days and up to 1,000 commits.
 
 The repository URL is inferred from the remote named `origin` (or the first remote if none are named `origin`). The value can be overridden by using the `--repository-url` flag.
 For example: The remote `git@github.com:Datadog/example.git` will create links that point to `https://github.com/Datadog/example`.


### PR DESCRIPTION
### What and why?

Updates the readme for the `git-metadata` command to document the 30d limitation.


