### PR TITLE
[ci] Fix flaky artifact upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,10 +55,9 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: sarif-datadog-ci.sarif
+          name: sarif-datadog-ci-${{ matrix.version }}.sarif
           path: sarif-datadog-ci.sarif
           if-no-files-found: error
-          overwrite: true
 
   e2e-test:
     strategy:


### PR DESCRIPTION
### What and why?

When I made #1242, I explicitly said that I had used [`overwrite: true` to keep the original behavior](https://github.com/DataDog/datadog-ci/pull/1242#issuecomment-2007119811) of overwriting `sarif-datadog-ci.sarif` because we only cared about one.

But turns out that [`overwrite: true` isn't atomic](https://github.com/actions/upload-artifact/issues/506#issuecomment-2093302327), so it's not intended for parallel jobs with a matrix.

### How?

- Add `${{ matrix.version }}` to the artifact name

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
