### PR TITLE
RN: Override iOS upload version with ENV var

### DIFF
--- a/src/commands/react-native/README.md
+++ b/src/commands/react-native/README.md
@@ -140,7 +140,15 @@ This command can be called from an XCode build phase to execute the `react-nativ
 
 The upload only happens when your target has a "Release" build configuration; that prevents overwriting existing source maps when running a build with another configuration such as "Debug".
 
-You can use the same environment variables as the `upload` command: `DATADOG_API_KEY` (required), `DATADOG_SITE`, and `DATADOG_SOURCEMAP_INTAKE_URL`.
+You can use the same environment variables as the `upload` command: 
+
+| Environment Variable           | Description                                                                                                                                                     |
+| ------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `DATADOG_API_KEY`              | Your Datadog API key. (REQUIRED)
+| `DATADOG_SITE`                 | Optional Datadog site (datadoghq.com, [us3, us5].datadoghq.com, datadoghq.eu, ddog-gov.com, ap1.datadoghq.com). By default, the requests are sent to Datadog US.
+| `DATADOG_SOURCEMAP_INTAKE_URL` | Optional variable to override the full URL for the intake endpoint.
+| `DATADOG_RELEASE_VERSION`      | Optional variable to override the version name for sourcemaps upload
+
 
 #### For React Native >= 0.69:
 

--- a/src/commands/react-native/xcode.ts
+++ b/src/commands/react-native/xcode.ts
@@ -347,6 +347,10 @@ export class XCodeCommand extends Command {
   }
 
   private getReleaseVersion = (): string | null => {
+    if (process.env.DATADOG_RELEASE_VERSION) {
+      return process.env.DATADOG_RELEASE_VERSION;
+    }
+
     try {
       const releaseVersion = this.getPlistValue('CFBundleShortVersionString')
 


### PR DESCRIPTION
### What and why?

Introduces a way to override the version name for the upload of iOS React Native sourcemaps, using an environment variable.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
