### PR TITLE
[SYNTH-12985] Add properties to env variables

### DIFF
--- a/src/commands/synthetics/README.md
+++ b/src/commands/synthetics/README.md
@@ -104,6 +104,7 @@ The duration (in milliseconds) after which `datadog-ci` stops polling for test r
 `tunnel`
 : Use the [Continuous Testing Tunnel](#use-the-testing-tunnel) to execute your test batch.
 
+
 #### Use a proxy
 
 It is possible to configure a proxy to be used for outgoing connections to Datadog using the `proxy` key of the global configuration file.
@@ -156,6 +157,30 @@ For example:
 }
 ```
 **Note**: The `global` field from the global configuration file is deprecated in favor of `defaultTestOverrides`.
+
+### Configuring with Environment Variables
+
+In addition to the global configuration file and CLI arguments, you can configure the following properties using environment variables:
+
+| Property                        | Environment Variable                             |
+|---------------------------------|--------------------------------------------------|
+| apiKey                          | `DATADOG_API_KEY`                                |
+| appKey                          | `DATADOG_APP_KEY`                                |
+| configPath                      | `DATADOG_SYNTHETICS_CONFIG_PATH`                 |
+| datadogSite                     | `DATADOG_SITE`                                   |
+| failOnCriticalErrors            | `DATADOG_SYNTHETICS_FAIL_ON_CRITICAL_ERRORS`     |
+| failOnMissingTests              | `DATADOG_SYNTHETICS_FAIL_ON_MISSING_TESTS`       |
+| failOnTimeout                   | `DATADOG_SYNTHETICS_FAIL_ON_TIMEOUT`             |
+| files                           | `DATADOG_SYNTHETICS_FILES`                       |
+| jUnitReport                     | `DATADOG_SYNTHETICS_JUNIT_REPORT`                |
+| publicIds                       | `DATADOG_SYNTHETICS_PUBLIC_IDS`                  |
+| selectiveRerun                  | `DATADOG_SYNTHETICS_SELECTIVE_RERUN`             |
+| subdomain                       | `DATADOG_SUBDOMAIN`                              |
+| testSearchQuery                 | `DATADOG_SYNTHETICS_TEST_SEARCH_QUERY`           |
+| tunnel                          | `DATADOG_SYNTHETICS_TUNNEL`                      |
+| latest                          | `DATADOG_SYNTHETICS_LATEST`                      |
+| mobileApplicationId             | `DATADOG_SYNTHETICS_MOBILE_APPLICATION_ID`       |
+
 
 ### Command line options
 

--- a/src/commands/synthetics/__tests__/cli.test.ts
+++ b/src/commands/synthetics/__tests__/cli.test.ts
@@ -86,16 +86,16 @@ describe('run-test', () => {
           pollingTimeout: DEFAULT_POLLING_TIMEOUT,
           mobileApplicationVersion: overrideEnv.DATADOG_SYNTHETICS_OVERRIDE_MOBILE_APPLICATION_VERSION,
         },
-        failOnCriticalErrors: overrideEnv.DATADOG_SYNTHETICS_FAIL_ON_CRITICAL_ERRORS === 'true',
-        failOnMissingTests: overrideEnv.DATADOG_SYNTHETICS_FAIL_ON_MISSING_TESTS === 'true',
-        failOnTimeout: overrideEnv.DATADOG_SYNTHETICS_FAIL_ON_TIMEOUT === 'true',
+        failOnCriticalErrors: toBoolean(overrideEnv.DATADOG_SYNTHETICS_FAIL_ON_CRITICAL_ERRORS),
+        failOnMissingTests: toBoolean(overrideEnv.DATADOG_SYNTHETICS_FAIL_ON_MISSING_TESTS),
+        failOnTimeout: toBoolean(overrideEnv.DATADOG_SYNTHETICS_FAIL_ON_TIMEOUT),
         files: overrideEnv.DATADOG_SYNTHETICS_FILES.split(';'),
         jUnitReport: overrideEnv.DATADOG_SYNTHETICS_JUNIT_REPORT,
         publicIds: overrideEnv.DATADOG_SYNTHETICS_PUBLIC_IDS.split(';'),
-        selectiveRerun: overrideEnv.DATADOG_SYNTHETICS_SELECTIVE_RERUN === 'true',
+        selectiveRerun: toBoolean(overrideEnv.DATADOG_SYNTHETICS_SELECTIVE_RERUN),
         subdomain: overrideEnv.DATADOG_SUBDOMAIN,
         testSearchQuery: overrideEnv.DATADOG_SYNTHETICS_TEST_SEARCH_QUERY,
-        tunnel: overrideEnv.DATADOG_SYNTHETICS_TUNNEL === 'true',
+        tunnel: toBoolean(overrideEnv.DATADOG_SYNTHETICS_TUNNEL),
       })
     })
 

--- a/src/commands/synthetics/__tests__/cli.test.ts
+++ b/src/commands/synthetics/__tests__/cli.test.ts
@@ -58,6 +58,16 @@ describe('run-test', () => {
         DATADOG_SUBDOMAIN: 'custom',
         DATADOG_SYNTHETICS_OVERRIDE_DEVICE_IDS: 'chrome.laptop_large',
         DATADOG_SYNTHETICS_OVERRIDE_MOBILE_APPLICATION_VERSION: '00000000-0000-0000-0000-000000000000',
+        DATADOG_SYNTHETICS_CONFIG_PATH: 'path/to/config.json',
+        DATADOG_SYNTHETICS_FAIL_ON_CRITICAL_ERRORS: 'false',
+        DATADOG_SYNTHETICS_FAIL_ON_MISSING_TESTS: 'false',
+        DATADOG_SYNTHETICS_FAIL_ON_TIMEOUT: 'false',
+        DATADOG_SYNTHETICS_FILES: 'test-file1;test-file2;test-file3',
+        DATADOG_SYNTHETICS_JUNIT_REPORT: 'junit-report.xml',
+        DATADOG_SYNTHETICS_PUBLIC_IDS: 'a-public-id;another-public-id',
+        DATADOG_SYNTHETICS_SELECTIVE_RERUN: 'true',
+        DATADOG_SYNTHETICS_TEST_SEARCH_QUERY: 'a-search-query',
+        DATADOG_SYNTHETICS_TUNNEL: 'false',
       }
 
       process.env = overrideEnv
@@ -68,13 +78,23 @@ describe('run-test', () => {
         ...DEFAULT_COMMAND_CONFIG,
         apiKey: overrideEnv.DATADOG_API_KEY,
         appKey: overrideEnv.DATADOG_APP_KEY,
+        configPath: overrideEnv.DATADOG_SYNTHETICS_CONFIG_PATH,
         datadogSite: overrideEnv.DATADOG_SITE,
         defaultTestOverrides: {
           deviceIds: overrideEnv.DATADOG_SYNTHETICS_OVERRIDE_DEVICE_IDS.split(';'),
           pollingTimeout: DEFAULT_POLLING_TIMEOUT,
           mobileApplicationVersion: overrideEnv.DATADOG_SYNTHETICS_OVERRIDE_MOBILE_APPLICATION_VERSION,
         },
+        failOnCriticalErrors: overrideEnv.DATADOG_SYNTHETICS_FAIL_ON_CRITICAL_ERRORS === 'true',
+        failOnMissingTests: overrideEnv.DATADOG_SYNTHETICS_FAIL_ON_MISSING_TESTS === 'true',
+        failOnTimeout: overrideEnv.DATADOG_SYNTHETICS_FAIL_ON_TIMEOUT === 'true',
+        files: overrideEnv.DATADOG_SYNTHETICS_FILES.split(';'),
+        jUnitReport: overrideEnv.DATADOG_SYNTHETICS_JUNIT_REPORT,
+        publicIds: overrideEnv.DATADOG_SYNTHETICS_PUBLIC_IDS.split(';'),
+        selectiveRerun: overrideEnv.DATADOG_SYNTHETICS_SELECTIVE_RERUN === 'true',
         subdomain: overrideEnv.DATADOG_SUBDOMAIN,
+        testSearchQuery: overrideEnv.DATADOG_SYNTHETICS_TEST_SEARCH_QUERY,
+        tunnel: overrideEnv.DATADOG_SYNTHETICS_TUNNEL === 'true',
       })
     })
 
@@ -88,6 +108,7 @@ describe('run-test', () => {
         failOnMissingTests: true,
         failOnTimeout: false,
         files: ['my-new-file'],
+        jUnitReport: 'junit-report.xml',
         // TODO SYNTH-12989: Clean up deprecated `global` in favor of `defaultTestOverrides`
         global: {
           deviceIds: ['chrome.laptop_large'],
@@ -111,6 +132,7 @@ describe('run-test', () => {
         publicIds: ['ran-dom-id'],
         selectiveRerun: true,
         subdomain: 'ppa',
+        testSearchQuery: 'a-search-query',
         tunnel: true,
         variableStrings: [],
       }
@@ -133,6 +155,7 @@ describe('run-test', () => {
         failOnMissingTests: true,
         failOnTimeout: false,
         files: ['new-file'],
+        jUnitReport: 'junit-report.xml',
         locations: ['us-east-1'],
         mobileApplicationVersionFilePath: './path/to/application.apk',
         pollingTimeout: 1,
@@ -158,6 +181,7 @@ describe('run-test', () => {
       command['failOnMissingTests'] = overrideCLI.failOnMissingTests
       command['failOnTimeout'] = overrideCLI.failOnTimeout
       command['files'] = overrideCLI.files
+      command['jUnitReport'] = overrideCLI.jUnitReport
       command['mobileApplicationVersion'] = defaultTestOverrides.mobileApplicationVersion
       command['mobileApplicationVersionFilePath'] = overrideCLI.mobileApplicationVersionFilePath
       command['publicIds'] = overrideCLI.publicIds
@@ -176,6 +200,7 @@ describe('run-test', () => {
         failOnMissingTests: true,
         failOnTimeout: false,
         files: ['new-file'],
+        jUnitReport: 'junit-report.xml',
         defaultTestOverrides: {
           deviceIds: ['chrome.laptop_large'],
           pollingTimeout: DEFAULT_POLLING_TIMEOUT,

--- a/src/commands/synthetics/__tests__/config-fixtures/config-with-all-keys.json
+++ b/src/commands/synthetics/__tests__/config-fixtures/config-with-all-keys.json
@@ -9,6 +9,7 @@
   "files": [
     "my-new-file"
   ],
+  "jUnitReport": "junit-report.xml",
   "global": {
     "deviceIds": [
       "chrome.laptop_large"
@@ -41,6 +42,7 @@
   ],
   "selectiveRerun": true,
   "subdomain": "ppa",
+  "testSearchQuery": "a-search-query",
   "tunnel": true,
   "variableStrings": []
 }

--- a/src/commands/synthetics/__tests__/fixtures.ts
+++ b/src/commands/synthetics/__tests__/fixtures.ts
@@ -76,6 +76,7 @@ export const ciConfig: RunTestsCommandConfig = {
   failOnMissingTests: false,
   failOnTimeout: true,
   files: ['{,!(node_modules)/**/}*.synthetics.json'],
+  jUnitReport: '',
   global: {},
   defaultTestOverrides: {},
   locations: [],
@@ -84,6 +85,7 @@ export const ciConfig: RunTestsCommandConfig = {
   publicIds: [],
   selectiveRerun: false,
   subdomain: 'app',
+  testSearchQuery: '',
   tunnel: false,
   variableStrings: [],
 }

--- a/src/commands/synthetics/__tests__/utils/internal.test.ts
+++ b/src/commands/synthetics/__tests__/utils/internal.test.ts
@@ -31,4 +31,30 @@ describe('utils', () => {
       }
     )
   })
+
+  describe('toBoolean', () => {
+    const cases: [string | undefined, boolean | undefined][] = [
+      ['true', true],
+      ['True', true],
+      ['TRUE', true],
+      ['1', true],
+      ['false', false],
+      ['False', false],
+      ['FALSE', false],
+      ['0', false],
+      [undefined, undefined],
+      ['no', undefined],
+      ['yes', undefined],
+      ['', undefined],
+      ['  ', undefined],
+      ['randomString', undefined],
+    ]
+
+    test.each(cases)(
+      'toBoolean(%s) should return %s',
+      (input, expectedOutput) => {
+        expect(internalUtils.toBoolean(input)).toEqual(expectedOutput)
+      }
+    )
+  })
 })

--- a/src/commands/synthetics/__tests__/utils/internal.test.ts
+++ b/src/commands/synthetics/__tests__/utils/internal.test.ts
@@ -50,11 +50,8 @@ describe('utils', () => {
       ['randomString', undefined],
     ]
 
-    test.each(cases)(
-      'toBoolean(%s) should return %s',
-      (input, expectedOutput) => {
-        expect(internalUtils.toBoolean(input)).toEqual(expectedOutput)
-      }
-    )
+    test.each(cases)('toBoolean(%s) should return %s', (input, expectedOutput) => {
+      expect(internalUtils.toBoolean(input)).toEqual(expectedOutput)
+    })
   })
 })

--- a/src/commands/synthetics/interfaces.ts
+++ b/src/commands/synthetics/interfaces.ts
@@ -470,6 +470,7 @@ export interface RunTestsCommandConfig extends SyntheticsCIConfig {
   // TODO SYNTH-12989: Clean up deprecated `global` in favor of `defaultTestOverrides`
   /** @deprecated This property is deprecated, please use `defaultTestOverrides` instead. */
   global?: UserConfigOverride
+  jUnitReport?: string
   defaultTestOverrides?: UserConfigOverride
   locations: string[]
   mobileApplicationVersionFilePath?: string

--- a/src/commands/synthetics/run-tests-command.ts
+++ b/src/commands/synthetics/run-tests-command.ts
@@ -144,7 +144,6 @@ export class RunTestsCommand extends Command {
   private config: RunTestsCommandConfig = JSON.parse(JSON.stringify(DEFAULT_COMMAND_CONFIG)) // Deep copy to avoid mutation
 
   public async execute() {
-
     try {
       await this.resolveConfig()
     } catch (error) {

--- a/src/commands/synthetics/upload-application-command.ts
+++ b/src/commands/synthetics/upload-application-command.ts
@@ -10,6 +10,7 @@ import {CiError, CriticalError} from './errors'
 import {UploadApplicationCommandConfig} from './interfaces'
 import {uploadMobileApplicationVersion} from './mobile'
 import {AppUploadReporter} from './reporters/mobile/app-upload'
+import {toBoolean} from './utils/internal'
 
 export const DEFAULT_UPLOAD_COMMAND_CONFIG: UploadApplicationCommandConfig = {
   apiKey: '',
@@ -106,7 +107,11 @@ export class UploadApplicationCommand extends Command {
       removeUndefinedValues({
         apiKey: process.env.DATADOG_API_KEY,
         appKey: process.env.DATADOG_APP_KEY,
+        configPath: process.env.DATADOG_CONFIG_PATH,
         datadogSite: process.env.DATADOG_SITE,
+        mobileApplicationId: process.env.DATADOG_MOBILE_APPLICATION_ID,
+        versionName: process.env.DATADOG_VERSION_NAME,
+        latest: toBoolean(process.env.DATADOG_LATEST),
       })
     )
 

--- a/src/commands/synthetics/upload-application-command.ts
+++ b/src/commands/synthetics/upload-application-command.ts
@@ -92,8 +92,10 @@ export class UploadApplicationCommand extends Command {
   private async resolveConfig() {
     // Defaults < file < ENV < CLI
     try {
+      // Override Config Path with ENV variables
+      const overrideConfigPath = this.configPath ?? process.env.DATADOG_SYNTHETICS_CONFIG_PATH ?? 'datadog-ci.json'
       this.config = await resolveConfigFromFile(this.config, {
-        configPath: this.configPath,
+        configPath: overrideConfigPath,
         defaultConfigPaths: [this.config.configPath],
       })
     } catch (error) {

--- a/src/commands/synthetics/upload-application-command.ts
+++ b/src/commands/synthetics/upload-application-command.ts
@@ -107,11 +107,11 @@ export class UploadApplicationCommand extends Command {
       removeUndefinedValues({
         apiKey: process.env.DATADOG_API_KEY,
         appKey: process.env.DATADOG_APP_KEY,
-        configPath: process.env.DATADOG_CONFIG_PATH,
+        configPath: process.env.DATADOG_SYNTHETICS_CONFIG_PATH,
         datadogSite: process.env.DATADOG_SITE,
-        mobileApplicationId: process.env.DATADOG_MOBILE_APPLICATION_ID,
-        versionName: process.env.DATADOG_VERSION_NAME,
-        latest: toBoolean(process.env.DATADOG_LATEST),
+        mobileApplicationId: process.env.DATADOG_SYNTHETICS_MOBILE_APPLICATION_ID,
+        versionName: process.env.DATADOG_SYNTHETICS_VERSION_NAME,
+        latest: toBoolean(process.env.DATADOG_SYNTHETICS_LATEST),
       })
     )
 

--- a/src/commands/synthetics/utils/internal.ts
+++ b/src/commands/synthetics/utils/internal.ts
@@ -45,3 +45,19 @@ export const getResultIdOrLinkedResultId = (result: ResultInBatch): string => {
 
   return result.result_id
 }
+
+export const toBoolean = (env: string | undefined): boolean | undefined => {
+  if (env === undefined) {
+    return undefined
+  }
+
+  if ( env.toLowerCase() === 'true' || env === '1'){
+    return true
+  }
+
+  if ( env.toLowerCase() === 'false' || env === '0'){
+    return false
+  }
+
+  return undefined
+}

--- a/src/commands/synthetics/utils/internal.ts
+++ b/src/commands/synthetics/utils/internal.ts
@@ -51,11 +51,11 @@ export const toBoolean = (env: string | undefined): boolean | undefined => {
     return undefined
   }
 
-  if ( env.toLowerCase() === 'true' || env === '1'){
+  if (env.toLowerCase() === 'true' || env === '1') {
     return true
   }
 
-  if ( env.toLowerCase() === 'false' || env === '0'){
+  if (env.toLowerCase() === 'false' || env === '0') {
     return false
   }
 


### PR DESCRIPTION
### What and why?

Many configuration properties were not configurable through environment variables:  `configPath`, `failOnCriticalErrors`, `failOnMissingTests`,`failOnTimeout`,`files`,`jUnitReport`,`latest`,`mobileApplicationId`,`publicIds`,`selectiveRerun`,`testSearchQuery`,`tunnel` and `versionName`. This PR adds support for configuring these properties through environment variables, all prefixed with `DATADOG_SYNTHETICS_`.


### How?

We fixed this problem by adding the the missing environment variables. In this PR, we also:

- Added `jUnitReport` property to the `Global Config`
- Added `testSearchQuery` to the `DEFAULT_COMMAND_CONFIG` as it was missing
- Created a utility function `toBoolean` to convert environment variable strings to boolean values, while handling edge cases (undefined values).

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
