### PR TITLE
[codeowners] Add maintainer team everywhere

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,54 +4,54 @@
 # Commands (grouped by product)
 
 ## CI Visibility (label: ci-visibility)
-src/commands/junit         @DataDog/ci-app-libraries
-src/commands/gate          @DataDog/ci-app-libraries
-src/commands/metric        @DataDog/ci-app-libraries
-src/commands/tag           @DataDog/ci-app-libraries
-src/commands/trace         @DataDog/ci-app-libraries
-src/commands/dora          @DataDog/ci-app-libraries
-src/commands/deployment    @DataDog/ci-app-libraries
+src/commands/junit         @DataDog/datadog-ci @DataDog/ci-app-libraries
+src/commands/gate          @DataDog/datadog-ci @DataDog/ci-app-libraries
+src/commands/metric        @DataDog/datadog-ci @DataDog/ci-app-libraries
+src/commands/tag           @DataDog/datadog-ci @DataDog/ci-app-libraries
+src/commands/trace         @DataDog/datadog-ci @DataDog/ci-app-libraries
+src/commands/dora          @DataDog/datadog-ci @DataDog/ci-app-libraries
+src/commands/deployment    @DataDog/datadog-ci @DataDog/ci-app-libraries
 
 ## Static Analysis (label: static-analysis)
-src/commands/sarif   @DataDog/static-analysis-core
-src/commands/sbom    @DataDog/static-analysis-core
+src/commands/sarif   @DataDog/datadog-ci @DataDog/static-analysis-core
+src/commands/sbom    @DataDog/datadog-ci @DataDog/static-analysis-core
 
 ## RUM (label: rum)
-src/commands/dsyms            @DataDog/rum-mobile
-src/commands/flutter-symbols  @DataDog/rum-mobile
-src/commands/unity-symbols    @Datadog/rum-mobile
-src/commands/react-native     @DataDog/rum-mobile
-src/commands/sourcemaps       @DataDog/rum-browser
+src/commands/dsyms            @DataDog/datadog-ci @DataDog/rum-mobile
+src/commands/flutter-symbols  @DataDog/datadog-ci @DataDog/rum-mobile
+src/commands/unity-symbols    @DataDog/datadog-ci @Datadog/rum-mobile
+src/commands/react-native     @DataDog/datadog-ci @DataDog/rum-mobile
+src/commands/sourcemaps       @DataDog/datadog-ci @DataDog/rum-browser
 
 ## Serverless (label: serverless)
-src/commands/lambda         @DataDog/serverless
-src/commands/stepfunctions  @DataDog/serverless
-src/commands/cloud-run      @DataDog/serverless
+src/commands/lambda         @DataDog/datadog-ci @DataDog/serverless
+src/commands/stepfunctions  @DataDog/datadog-ci @DataDog/serverless
+src/commands/cloud-run      @DataDog/datadog-ci @DataDog/serverless
 
 ## Source Code Integration (label: source-code-integration)
-src/commands/git-metadata  @DataDog/source-code-integration
+src/commands/git-metadata  @DataDog/datadog-ci @DataDog/source-code-integration
 
 ## Synthetics (label: synthetics)
-src/commands/synthetics  @DataDog/synthetics-ct
+src/commands/synthetics  @DataDog/datadog-ci @DataDog/synthetics-ct
 
 ## Profiling (label: profiling)
-src/commands/elf-symbols  @DataDog/profiling-native
+src/commands/elf-symbols  @DataDog/datadog-ci @DataDog/profiling-native
 
 # Shared utilities
 
 ## Git
-src/helpers/git  @DataDog/ci-app-libraries @DataDog/source-code-integration
+src/helpers/git  @DataDog/datadog-ci @DataDog/ci-app-libraries @DataDog/source-code-integration
 
 ## CI
-src/helpers/file.ts                              @DataDog/ci-app-libraries
-src/helpers/ci.ts                                @DataDog/ci-app-libraries @DataDog/synthetics-ct
-src/helpers/tags.ts                              @DataDog/ci-app-libraries @DataDog/synthetics-ct
-src/helpers/user-provided-git.ts                 @DataDog/ci-app-libraries @DataDog/synthetics-ct
-src/helpers/**tests**/ci-env                     @DataDog/ci-app-libraries @DataDog/synthetics-ct
-src/helpers/**tests**/ci.test.ts                 @DataDog/ci-app-libraries @DataDog/synthetics-ct
-src/helpers/**tests**/tags.test.ts               @DataDog/ci-app-libraries @DataDog/synthetics-ct
-src/helpers/**tests**/user-provided-git.test.ts  @DataDog/ci-app-libraries @DataDog/synthetics-ct
+src/helpers/file.ts                              @DataDog/datadog-ci @DataDog/ci-app-libraries
+src/helpers/ci.ts                                @DataDog/datadog-ci @DataDog/ci-app-libraries @DataDog/synthetics-ct
+src/helpers/tags.ts                              @DataDog/datadog-ci @DataDog/ci-app-libraries @DataDog/synthetics-ct
+src/helpers/user-provided-git.ts                 @DataDog/datadog-ci @DataDog/ci-app-libraries @DataDog/synthetics-ct
+src/helpers/**tests**/ci-env                     @DataDog/datadog-ci @DataDog/ci-app-libraries @DataDog/synthetics-ct
+src/helpers/**tests**/ci.test.ts                 @DataDog/datadog-ci @DataDog/ci-app-libraries @DataDog/synthetics-ct
+src/helpers/**tests**/tags.test.ts               @DataDog/datadog-ci @DataDog/ci-app-libraries @DataDog/synthetics-ct
+src/helpers/**tests**/user-provided-git.test.ts  @DataDog/datadog-ci @DataDog/ci-app-libraries @DataDog/synthetics-ct
 
 
 # Documentation
-*.md  @DataDog/documentation
+*.md  @DataDog/datadog-ci @DataDog/documentation


### PR DESCRIPTION
### What and why?

Add the @DataDog/datadog-ci team as reviewer to every PR.

CODEOWNERS files **aren't additive**: lines appearing after `* @DataDog/datadog-ci` are **overriding** the owners.

### How?

- Add `@DataDog/datadog-ci` everywhere

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
