### PR TITLE
Remove unnecessary console.log in the `measure` command

### DIFF
--- a/src/commands/measure/measure.ts
+++ b/src/commands/measure/measure.ts
@@ -52,7 +52,6 @@ export class MeasureCommand extends Command {
   }
 
   public async execute() {
-    console.log(this.path)
     if (this.path[0] === 'metric') {
       this.context.stdout.write(
         chalk.yellow(`[WARN] The "metric" command is deprecated. Please use the "measure" command instead.\n`)


### PR DESCRIPTION
### What and why?

https://github.com/DataDog/datadog-ci/pull/1205 introduced a `console.log` in the `measure` command that had been used for debugging. We shouldn't have this in the command.

@rodrigo-roca nice catch 💯 

### How?

A brief description of implementation details of this PR.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
