### PR TITLE
Improve measure command error handling

### DIFF
--- a/src/commands/measure/measure.ts
+++ b/src/commands/measure/measure.ts
@@ -1,4 +1,5 @@
-import {AxiosError} from 'axios'
+import type {AxiosError} from 'axios'
+
 import chalk from 'chalk'
 import {Command, Option} from 'clipanion'
 

--- a/src/commands/measure/measure.ts
+++ b/src/commands/measure/measure.ts
@@ -4,6 +4,7 @@ import {Command, Option} from 'clipanion'
 import {getCIEnv, PROVIDER_TO_DISPLAY_NAME} from '../../helpers/ci'
 import {retryRequest} from '../../helpers/retry'
 import {getApiHostForSite, getRequestBuilder} from '../../helpers/utils'
+import { AxiosError } from "axios";
 
 export const parseMeasures = (measures: string[]) =>
   measures.reduce((acc, keyValue) => {
@@ -152,11 +153,18 @@ export class MeasureCommand extends Command {
         retries: 5,
       })
     } catch (error) {
-      this.context.stderr.write(`${chalk.red.bold('[ERROR]')} Could not send measures: ${error.message}\n`)
+      this.handleError(error as AxiosError)
 
       return 1
     }
 
     return 0
+  }
+
+  private handleError(error: AxiosError) {
+    this.context.stderr.write(
+      `${chalk.red.bold('[ERROR]')} Could not send measures: ` +
+        `${error.response ? JSON.stringify(error.response.data, undefined, 2) : ''}\n`
+    )
   }
 }

--- a/src/commands/measure/measure.ts
+++ b/src/commands/measure/measure.ts
@@ -1,10 +1,10 @@
+import {AxiosError} from 'axios'
 import chalk from 'chalk'
 import {Command, Option} from 'clipanion'
 
 import {getCIEnv, PROVIDER_TO_DISPLAY_NAME} from '../../helpers/ci'
 import {retryRequest} from '../../helpers/retry'
 import {getApiHostForSite, getRequestBuilder} from '../../helpers/utils'
-import { AxiosError } from "axios";
 
 export const parseMeasures = (measures: string[]) =>
   measures.reduce((acc, keyValue) => {


### PR DESCRIPTION
### What and why?

Closes #856 

Makes errors more descriptive to the user for the `measure` command. For example if the API validation fails because we send more than 20 measures in a single command:

Before: 
```
Could not send measures: Request failed with status code 400
```

After:
```
Could not send measures: {
  "errors": [
    "API input validation failed: {'metrics': ['Length must be between 1 and 20.']}"
  ]
}
```

### How?

Looking into error.response instead of error.message.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
