### PR TITLE
Add step function context to nested step function calls

### DIFF
--- a/src/commands/stepfunctions/__tests__/helpers.test.ts
+++ b/src/commands/stepfunctions/__tests__/helpers.test.ts
@@ -199,6 +199,19 @@ describe('stepfunctions command helpers tests', () => {
       }
       expect(shouldUpdateStepForStepFunctionContextInjection(step)).toBeTruthy()
     })
+
+    test('is false when Input is an object that contains a CONTEXT key', () => {
+      const step: StepType = {
+        Type: 'Task',
+        Resource: 'arn:aws:states:::states:startExecution.sync:2',
+        Parameters: {
+          StateMachineArn: 'arn:aws:states:us-east-1:425362996713:stateMachine:agocs_inner_state_machine',
+          Input: {'CONTEXT.$': 'blah'},
+        },
+        End: true,
+      }
+      expect(shouldUpdateStepForStepFunctionContextInjection(step)).toBeFalsy()
+    })
   })
 
   describe('inject context for StepFunctions', () => {

--- a/src/commands/stepfunctions/__tests__/helpers.test.ts
+++ b/src/commands/stepfunctions/__tests__/helpers.test.ts
@@ -11,6 +11,7 @@ import {
   shouldUpdateStepForTracesMerging,
   StepType,
   injectContextForStepFunctions,
+  shouldUpdateStepForStepFunctionContextInjection,
 } from '../helpers'
 
 import {describeStateMachineFixture} from './fixtures/aws-resources'
@@ -170,6 +171,33 @@ describe('stepfunctions command helpers tests', () => {
       expect(arnObject.region).toBe('us-east-1')
       expect(arnObject.accountId).toBe('000000000000')
       expect(arnObject.resourceName).toBe('ExampleStepFunction')
+    })
+  })
+
+  describe('shouldUpdateStepForStepFunctionContextInjection', () => {
+    test('is true for an empty object', () => {
+      const step: StepType = {
+        Type: 'Task',
+        Resource: 'arn:aws:states:::states:startExecution.sync:2',
+        Parameters: {
+          StateMachineArn: 'arn:aws:states:us-east-1:425362996713:stateMachine:agocs_inner_state_machine',
+          Input: {},
+        },
+        End: true,
+      }
+      expect(shouldUpdateStepForStepFunctionContextInjection(step)).toBeTruthy()
+    })
+
+    test('is true for undefined', () => {
+      const step: StepType = {
+        Type: 'Task',
+        Resource: 'arn:aws:states:::states:startExecution.sync:2',
+        Parameters: {
+          StateMachineArn: 'arn:aws:states:us-east-1:425362996713:stateMachine:agocs_inner_state_machine',
+        },
+        End: true,
+      }
+      expect(shouldUpdateStepForStepFunctionContextInjection(step)).toBeTruthy()
     })
   })
 

--- a/src/commands/stepfunctions/__tests__/helpers.test.ts
+++ b/src/commands/stepfunctions/__tests__/helpers.test.ts
@@ -10,6 +10,7 @@ import {
   buildLogAccessPolicyName,
   shouldUpdateStepForTracesMerging,
   StepType,
+  injectContextForStepFunctions,
 } from '../helpers'
 
 import {describeStateMachineFixture} from './fixtures/aws-resources'
@@ -169,6 +170,24 @@ describe('stepfunctions command helpers tests', () => {
       expect(arnObject.region).toBe('us-east-1')
       expect(arnObject.accountId).toBe('000000000000')
       expect(arnObject.resourceName).toBe('ExampleStepFunction')
+    })
+  })
+
+  describe('inject context for StepFunctions', () => {
+    test('injects context into a step function invocation', () => {
+      const step: StepType = {
+        Type: 'Task',
+        Resource: 'arn:aws:states:::states:startExecution.sync:2',
+        Parameters: {
+          StateMachineArn: 'arn:aws:states:us-east-1:425362996713:stateMachine:agocs_inner_state_machine',
+          Input: {},
+        },
+        End: true,
+      }
+
+      const changed = injectContextForStepFunctions(step)
+      expect(changed).toBeTruthy()
+      expect(step.Parameters?.Input).toEqual({'CONTEXT.$': 'States.JsonMerge($$, $, false)'})
     })
   })
 

--- a/src/commands/stepfunctions/__tests__/instrument.test.ts
+++ b/src/commands/stepfunctions/__tests__/instrument.test.ts
@@ -18,7 +18,7 @@ describe('stepfunctions instrument test', () => {
     aws = require('../awsCommands')
     helpers = require('../helpers')
     helpers.applyChanges = jest.fn().mockImplementation(() => false)
-    helpers.injectContextIntoLambdaPayload = jest.fn().mockImplementation()
+    helpers.injectContextIntoTasks = jest.fn().mockImplementation()
     cli = new Cli()
     cli.register(InstrumentStepFunctionsCommand)
   })
@@ -474,7 +474,7 @@ describe('stepfunctions instrument test', () => {
         ],
         context
       )
-      expect(helpers.injectContextIntoLambdaPayload).toHaveBeenCalledTimes(1)
+      expect(helpers.injectContextIntoTasks).toHaveBeenCalledTimes(1)
       expect(exitCode).toBe(0)
     })
 
@@ -490,7 +490,7 @@ describe('stepfunctions instrument test', () => {
         ],
         context
       )
-      expect(helpers.injectContextIntoLambdaPayload).toHaveBeenCalledTimes(0)
+      expect(helpers.injectContextIntoTasks).toHaveBeenCalledTimes(0)
       expect(exitCode).toBe(0)
     })
   })

--- a/src/commands/stepfunctions/helpers.ts
+++ b/src/commands/stepfunctions/helpers.ts
@@ -189,13 +189,14 @@ export type StepType = {
 export type ParametersType = {
   'Payload.$'?: string
   FunctionName?: string
+  StateMachineArn?: string
   TableName?: string
   Input?: {
     'CONTEXT.$'?: string
   }
 }
 
-function injectContextForLambdaFunctions(step: StepType, context: BaseContext, stepName: string) {
+const injectContextForLambdaFunctions = (step: StepType, context: BaseContext, stepName: string): boolean => {
   if (shouldUpdateStepForTracesMerging(step)) {
     addTraceContextToLambdaParameters(step)
 
@@ -211,7 +212,7 @@ function injectContextForLambdaFunctions(step: StepType, context: BaseContext, s
   return false
 }
 
-function injectContextForStepFunctions(step: StepType) {
+export const injectContextForStepFunctions = (step: StepType): boolean => {
   if (shouldUpdateStepForStepFunctionContextInjection(step)) {
     addTraceContextToStepFunctionParameters(step)
 

--- a/src/commands/stepfunctions/helpers.ts
+++ b/src/commands/stepfunctions/helpers.ts
@@ -117,7 +117,7 @@ export const addTraceContextToLambdaParameters = ({Parameters}: StepType): void 
 
 export const addTraceContextToStepFunctionParameters = ({Parameters}: StepType): void => {
   if (Parameters) {
-    if (!Parameters.Input){
+    if (!Parameters.Input) {
       Parameters.Input = {}
     }
     Parameters.Input['CONTEXT.$'] = 'States.JsonMerge($$, $, false)'
@@ -157,13 +157,13 @@ export const shouldUpdateStepForStepFunctionContextInjection = (step: StepType):
     if (!step.Parameters) {
       return false
     }
-    if (!step.Parameters.Input){
+    if (!step.Parameters.Input) {
       return true
     }
-    if (typeof step.Parameters.Input !== "object"){
+    if (typeof step.Parameters.Input !== 'object') {
       return false
     }
-    if (!step.Parameters.Input['CONTEXT.$']){
+    if (!step.Parameters.Input['CONTEXT.$']) {
       return true
     }
   }
@@ -198,6 +198,7 @@ export type ParametersType = {
 function injectContextForLambdaFunctions(step: StepType, context: BaseContext, stepName: string) {
   if (shouldUpdateStepForTracesMerging(step)) {
     addTraceContextToLambdaParameters(step)
+
     return true
   } else if (step.Resource?.startsWith('arn:aws:lambda')) {
     context.stdout.write(
@@ -206,13 +207,16 @@ function injectContextForLambdaFunctions(step: StepType, context: BaseContext, s
           More details can be found on https://docs.aws.amazon.com/step-functions/latest/dg/connect-lambda.html \n`
     )
   }
+
   return false
 }
 
 function injectContextForStepFunctions(step: StepType) {
-  if (shouldUpdateStepForStepFunctionContextInjection(step)){
+  if (shouldUpdateStepForStepFunctionContextInjection(step)) {
     addTraceContextToStepFunctionParameters(step)
+
     return true
   }
+
   return false
 }

--- a/src/commands/stepfunctions/helpers.ts
+++ b/src/commands/stepfunctions/helpers.ts
@@ -80,7 +80,7 @@ export const buildLogAccessPolicyName = (stepFunction: DescribeStateMachineComma
   return `LogsDeliveryAccessPolicy-${stepFunction.name}`
 }
 
-export const injectContextIntoLambdaPayload = async (
+export const injectContextIntoTasks = async (
   describeStateMachineCommandOutput: DescribeStateMachineCommandOutput,
   stepFunctionsClient: SFNClient,
   context: BaseContext,
@@ -94,16 +94,8 @@ export const injectContextIntoLambdaPayload = async (
   for (const stepName in definitionObj.States) {
     if (definitionObj.States.hasOwnProperty(stepName)) {
       const step = definitionObj.States[stepName]
-      if (shouldUpdateStepForTracesMerging(step)) {
-        updateStepObject(step)
-        definitionHasBeenUpdated = true
-      } else if (step.Resource?.startsWith('arn:aws:lambda')) {
-        context.stdout.write(
-          `[Warn] Step ${stepName} may be using the basic legacy integration, which does not support merging lambda trace(s) with Step Functions trace. 
-          To merge lambda trace(s) with Step Functions trace, please consider using the latest integration. 
-          More details can be found on https://docs.aws.amazon.com/step-functions/latest/dg/connect-lambda.html \n`
-        )
-      }
+      definitionHasBeenUpdated = injectContextForLambdaFunctions(step, context, stepName)
+      definitionHasBeenUpdated = injectContextForStepFunctions(step)
     }
   }
   if (definitionHasBeenUpdated) {
@@ -117,9 +109,18 @@ export const injectContextIntoLambdaPayload = async (
   }
 }
 
-export const updateStepObject = ({Parameters}: StepType): void => {
+export const addTraceContextToLambdaParameters = ({Parameters}: StepType): void => {
   if (Parameters) {
     Parameters[`Payload.$`] = 'States.JsonMerge($$, $, false)'
+  }
+}
+
+export const addTraceContextToStepFunctionParameters = ({Parameters}: StepType): void => {
+  if (Parameters) {
+    if (!Parameters.Input){
+      Parameters.Input = {}
+    }
+    Parameters.Input['CONTEXT.$'] = 'States.JsonMerge($$, $, false)'
   }
 }
 
@@ -135,6 +136,34 @@ export const shouldUpdateStepForTracesMerging = (step: StepType): boolean => {
     }
     // default payload
     if (step.Parameters['Payload.$'] === '$') {
+      return true
+    }
+  }
+
+  return false
+}
+
+// Truth table
+// Input                    | Expected
+// -------------------------|---------
+// Empty object             | true
+// undefined                | true
+// not object               | false
+// object without CONTEXT.$ | true
+// object with CONTEXT.$    | false
+export const shouldUpdateStepForStepFunctionContextInjection = (step: StepType): boolean => {
+  // is default lambda api
+  if (step.Resource?.startsWith('arn:aws:states:::states:startExecution')) {
+    if (!step.Parameters) {
+      return false
+    }
+    if (!step.Parameters.Input){
+      return true
+    }
+    if (typeof step.Parameters.Input !== "object"){
+      return false
+    }
+    if (!step.Parameters.Input['CONTEXT.$']){
       return true
     }
   }
@@ -161,4 +190,29 @@ export type ParametersType = {
   'Payload.$'?: string
   FunctionName?: string
   TableName?: string
+  Input?: {
+    'CONTEXT.$'?: string
+  }
+}
+
+function injectContextForLambdaFunctions(step: StepType, context: BaseContext, stepName: string) {
+  if (shouldUpdateStepForTracesMerging(step)) {
+    addTraceContextToLambdaParameters(step)
+    return true
+  } else if (step.Resource?.startsWith('arn:aws:lambda')) {
+    context.stdout.write(
+      `[Warn] Step ${stepName} may be using the basic legacy integration, which does not support merging lambda trace(s) with Step Functions trace. 
+          To merge lambda trace(s) with Step Functions trace, please consider using the latest integration. 
+          More details can be found on https://docs.aws.amazon.com/step-functions/latest/dg/connect-lambda.html \n`
+    )
+  }
+  return false
+}
+
+function injectContextForStepFunctions(step: StepType) {
+  if (shouldUpdateStepForStepFunctionContextInjection(step)){
+    addTraceContextToStepFunctionParameters(step)
+    return true
+  }
+  return false
 }

--- a/src/commands/stepfunctions/instrument.ts
+++ b/src/commands/stepfunctions/instrument.ts
@@ -354,12 +354,7 @@ export class InstrumentStepFunctionsCommand extends Command {
       if (this.mergeStepFunctionAndLambdaTraces || this.propagateUpstreamTrace) {
         // Not putting the update operation into the business logic of logs subscription. This will
         // add additional API call, but it would also allow easier testing and cleaner code.
-        await injectContextIntoTasks(
-          describeStateMachineCommandOutput,
-          stepFunctionsClient,
-          this.context,
-          this.dryRun
-        )
+        await injectContextIntoTasks(describeStateMachineCommandOutput, stepFunctionsClient, this.context, this.dryRun)
       }
     }
     if (!hasChanges) {

--- a/src/commands/stepfunctions/instrument.ts
+++ b/src/commands/stepfunctions/instrument.ts
@@ -23,7 +23,7 @@ import {
   isValidArn,
   parseArn,
   getStepFunctionLogGroupArn,
-  injectContextIntoLambdaPayload,
+  injectContextIntoTasks,
 } from './helpers'
 
 const cliVersion = version
@@ -60,6 +60,7 @@ export class InstrumentStepFunctionsCommand extends Command {
     '-mlt,--merge-lambda-traces,--merge-step-function-and-lambda-traces',
     false
   )
+  private propagateUpstreamTrace = Option.Boolean('--propagate-upstream-trace', false)
 
   public async execute() {
     let validationError = false
@@ -350,10 +351,10 @@ export class InstrumentStepFunctionsCommand extends Command {
         hasChanges = true
       }
 
-      if (this.mergeStepFunctionAndLambdaTraces) {
+      if (this.mergeStepFunctionAndLambdaTraces || this.propagateUpstreamTrace) {
         // Not putting the update operation into the business logic of logs subscription. This will
         // add additional API call, but it would also allow easier testing and cleaner code.
-        await injectContextIntoLambdaPayload(
+        await injectContextIntoTasks(
           describeStateMachineCommandOutput,
           stepFunctionsClient,
           this.context,


### PR DESCRIPTION
### What and why?
Adds the step function context to the state definition when a step function calls another stepfunction. This is gated behind the `--propagate-upstream-trace` or `--merge-step-function-and-lambda-traces` flags.

### How?

A brief description of implementation details of this PR.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
