### PR TITLE
add override cli argument

### DIFF
--- a/src/commands/synthetics/__tests__/cli.test.ts
+++ b/src/commands/synthetics/__tests__/cli.test.ts
@@ -4,7 +4,13 @@ import {createCommand} from '../../../helpers/__tests__/fixtures'
 import * as ciUtils from '../../../helpers/utils'
 
 import * as api from '../api'
-import {RunTestsCommandConfig, ServerTest, UploadApplicationCommandConfig, UserConfigOverride} from '../interfaces'
+import {
+  ExecutionRule,
+  RunTestsCommandConfig,
+  ServerTest,
+  UploadApplicationCommandConfig,
+  UserConfigOverride,
+} from '../interfaces'
 import {DEFAULT_COMMAND_CONFIG, DEFAULT_POLLING_TIMEOUT, RunTestsCommand} from '../run-tests-command'
 import {DEFAULT_UPLOAD_COMMAND_CONFIG, UploadApplicationCommand} from '../upload-application-command'
 import {toBoolean, toNumber, toExecutionRule} from '../utils/internal'
@@ -220,6 +226,21 @@ describe('run-test', () => {
       const defaultTestOverrides: UserConfigOverride = {
         deviceIds: ['chrome.laptop_large'],
         mobileApplicationVersion: '00000000-0000-0000-0000-000000000000',
+        allowInsecureCertificates: true,
+        body: 'a body',
+        bodyType: 'bodyType',
+        defaultStepTimeout: 42,
+        executionRule: ExecutionRule.BLOCKING,
+        followRedirects: true,
+        pollingTimeout: 42,
+        resourceUrlSubstitutionRegexes: ['regex1', 'regex42'],
+        retry: {
+          count: 5,
+          interval: 42,
+        },
+        startUrl: 'startUrl',
+        startUrlSubstitutionRegex: 'startUrlSubstitutionRegex',
+        testTimeout: 42,
       }
 
       const command = createCommand(RunTestsCommand)
@@ -239,6 +260,21 @@ describe('run-test', () => {
       command['subdomain'] = overrideCLI.subdomain
       command['tunnel'] = overrideCLI.tunnel
       command['testSearchQuery'] = overrideCLI.testSearchQuery
+      command['overrides'] = [
+        `allowInsecureCertificates=${defaultTestOverrides.allowInsecureCertificates}`,
+        `body=${defaultTestOverrides.body}`,
+        `bodyType=${defaultTestOverrides.bodyType}`,
+        `defaultStepTimeout=${defaultTestOverrides.defaultStepTimeout}`,
+        `executionRule=${defaultTestOverrides.executionRule}`,
+        `followRedirects=${defaultTestOverrides.followRedirects}`,
+        `retry.count=${defaultTestOverrides.retry?.count}`,
+        `retry.interval=${defaultTestOverrides.retry?.interval}`,
+        `startUrl=${defaultTestOverrides.startUrl}`,
+        `startUrlSubstitutionRegex=${defaultTestOverrides.startUrlSubstitutionRegex}`,
+        `testTimeout=${defaultTestOverrides.testTimeout}`,
+        'resourceUrlSubstitutionRegexes=regex1',
+        'resourceUrlSubstitutionRegexes=regex42',
+      ]
 
       await command['resolveConfig']()
       expect(command['config']).toEqual({
@@ -257,6 +293,19 @@ describe('run-test', () => {
           pollingTimeout: DEFAULT_POLLING_TIMEOUT,
           mobileApplicationVersion: '00000000-0000-0000-0000-000000000000',
           mobileApplicationVersionFilePath: './path/to/application.apk',
+          allowInsecureCertificates: true,
+          body: 'a body',
+          bodyType: 'bodyType',
+          defaultStepTimeout: 42,
+          executionRule: ExecutionRule.BLOCKING,
+          followRedirects: true,
+          retry: {
+            count: 5,
+            interval: 42,
+          },
+          startUrl: 'startUrl',
+          startUrlSubstitutionRegex: 'startUrlSubstitutionRegex',
+          testTimeout: 42,
         },
         publicIds: ['ran-dom-id'],
         subdomain: 'new-sub-domain',

--- a/src/commands/synthetics/run-tests-command.ts
+++ b/src/commands/synthetics/run-tests-command.ts
@@ -12,7 +12,7 @@ import {MainReporter, Reporter, Result, RunTestsCommandConfig, Summary} from './
 import {DefaultReporter} from './reporters/default'
 import {JUnitReporter} from './reporters/junit'
 import {executeTests} from './run-tests-lib'
-import {toBoolean, toNumber, toExecutionRule} from './utils/internal'
+import {toBoolean, toNumber, toExecutionRule, validateAndParseOverrides} from './utils/internal'
 import {
   getExitReason,
   getOrgSettings,
@@ -117,6 +117,9 @@ export class RunTestsCommand extends Command {
   })
   private mobileApplicationVersionFilePath = Option.String('--mobileApp,--mobileApplicationVersionFilePath', {
     description: 'Override the application version for all Synthetic mobile application tests.',
+  })
+  private overrides = Option.Array('--override', {
+    description: 'Override specific test properties.',
   })
   private pollingTimeout = Option.String('--pollingTimeout', {
     description:
@@ -244,7 +247,7 @@ export class RunTestsCommand extends Command {
     )
 
     // Override with OVERRIDE ENV variables
-    const retryConfig = deepExtend(
+    const envOverrideRetryConfig = deepExtend(
       this.config.defaultTestOverrides?.retry ?? {},
       removeUndefinedValues({
         count: toNumber(process.env.DATADOG_SYNTHETICS_OVERRIDE_RETRY_COUNT),
@@ -265,7 +268,7 @@ export class RunTestsCommand extends Command {
         resourceUrlSubstitutionRegexes: process.env.DATADOG_SYNTHETICS_OVERRIDE_RESOURCE_URL_SUBSTITUTION_REGEXES?.split(
           ';'
         ),
-        retry: Object.keys(retryConfig).length > 0 ? retryConfig : undefined,
+        retry: Object.keys(envOverrideRetryConfig).length > 0 ? envOverrideRetryConfig : undefined,
         startUrl: process.env.DATADOG_SYNTHETICS_OVERRIDE_START_URL,
         startUrlSubstitutionRegex: process.env.DATADOG_SYNTHETICS_OVERRIDE_START_URL_SUBSTITUTION_REGEX,
         testTimeout: toNumber(process.env.DATADOG_SYNTHETICS_OVERRIDE_TEST_TIMEOUT),
@@ -294,6 +297,14 @@ export class RunTestsCommand extends Command {
     )
 
     // Override with Global CLI parameters
+    const validatedOverrides = validateAndParseOverrides(this.overrides)
+    const cliOverrideRetryConfig = deepExtend(
+      this.config.defaultTestOverrides?.retry ?? {},
+      removeUndefinedValues({
+        count: validatedOverrides['retry.count'],
+        interval: validatedOverrides['retry.interval'],
+      })
+    )
     this.config.defaultTestOverrides = deepExtend(
       this.config.defaultTestOverrides,
       removeUndefinedValues({
@@ -303,6 +314,16 @@ export class RunTestsCommand extends Command {
         variables: parseVariablesFromCli(this.variableStrings, (log) => this.reporter.log(log)),
         pollingTimeout:
           this.pollingTimeout ?? this.config.defaultTestOverrides?.pollingTimeout ?? this.config.pollingTimeout,
+        allowInsecureCertificates: validatedOverrides.allowInsecureCertificates,
+        body: validatedOverrides.body,
+        bodyType: validatedOverrides.bodyType,
+        defaultStepTimeout: validatedOverrides.defaultStepTimeout,
+        executionRule: validatedOverrides.executionRule,
+        followRedirects: validatedOverrides.followRedirects,
+        retry: Object.keys(cliOverrideRetryConfig).length > 0 ? cliOverrideRetryConfig : undefined,
+        startUrl: validatedOverrides.startUrl,
+        startUrlSubstitutionRegex: validatedOverrides.startUrlSubstitutionRegex,
+        testTimeout: validatedOverrides.testTimeout,
       })
     )
 


### PR DESCRIPTION
### What and why?

We wanted to add an option for testOverrides properties to be configured through the `--override` CLI parameter, which is a clipanion command array. This PR adds CLI support for the following properties: `allowInsecureCertificates`, `body`, `bodyType`, `defaultStepTimeout`, `executionRule`, `followRedirects`,  `resourceUrlSubstitutionRegexes`, `retry`, `startUrl`, `startUrlSubstitutionRegex` and `testTimeout`. Here is a brief example of how the new CLI option should be used:

```
datadog-ci synthetics run-tests \
  --public-id aaa-bbb-ccc \
  --override testTimeout=999 \
  --override startUrlSubstitutionRegex="s/prod/staging/" \
  --override allowInsecureCertificates=true
```

### How?

- Created a new `--override` CLI option
- Added a validator and parser to process every parameter passed through the `--override` option

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)

