### PR TITLE
[PROF-9872] Improve elf-symbols upload command

### DIFF
--- a/src/commands/elf-symbols/renderer.ts
+++ b/src/commands/elf-symbols/renderer.ts
@@ -12,7 +12,7 @@ export interface UploadInfo {
   platform: string
 }
 
-export const renderCommandInfo = (dryRun: boolean, symbolsLocation: string) => {
+export const renderCommandInfo = (dryRun: boolean, symbolsLocations: string[]) => {
   let fullString = ''
   if (dryRun) {
     fullString += chalk.yellow(`${ICONS.WARNING} DRY-RUN MODE ENABLED. WILL NOT UPLOAD SYMBOLS\n`)
@@ -20,7 +20,7 @@ export const renderCommandInfo = (dryRun: boolean, symbolsLocation: string) => {
   const startStr = chalk.green('Starting upload. \n')
 
   fullString += startStr
-  fullString += chalk.green(`Uploading symbols from location ${symbolsLocation}\n`)
+  fullString += chalk.green(`Uploading symbols from location(s): ${symbolsLocations.join(' ')}\n`)
 
   fullString += chalk.green(
     `After upload is successful symbol files will be processed and ready to use within the next 5 minutes.\n`


### PR DESCRIPTION
### What and why?

* `symbols-location` is now a positional argument
* Allow multiple input locations
* Ignore unreadable directories
    `glob` throws an error when it encounter an unreadable directory.
    Pass `strict: false`, to make `glob` ignore these errors and then later
    recheck if directories are readable and emit a warning if not.
    Top-level directory being unreadable results in a an error.


### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
