### PR TITLE
[ci] Add build job for Ubuntu ARM

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,7 +205,7 @@ jobs:
       - run: yarn install --immutable
       - run: yarn build
       - name: Create standalone binary
-        run: yarn dist-standalone -t node14-macos-x64 -o datadog-ci_darwin-x64
+        run: yarn dist-standalone -t node14-macos-arm64 -o datadog-ci_darwin-arm64
       - name: Remove dist and src folder to check that binary can stand alone
         run: |
           rm -rf dist

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,6 +147,28 @@ jobs:
       - name: Test generated standalone binary
         run: yarn dist-standalone:test
 
+  standalone-binary-test-ubuntu-arm:
+    name: Test standalone binary in ubuntu
+    runs-on:
+      group: ARM LINUX SHARED
+      labels: arm-4core-linux
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.11.0 # Use newer version to build the standalone binary
+      - run: yarn install --immutable
+      - run: yarn build
+      - name: Create standalone binary
+        run: yarn dist-standalone -t node14-linux-arm64 -o datadog-ci_linux-arm64
+      - name: Remove dist and src folder to check that binary can stand alone
+        run: |
+          rm -rf dist
+          rm -rf src
+      - name: Test generated standalone binary
+        run: yarn dist-standalone:test
+
   standalone-binary-test-windows:
     name: Test standalone binary in windows
     runs-on: windows-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,6 +158,8 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20.11.0 # Use newer version to build the standalone binary
+      - run: npm install -g yarn
+        name: Install Yarn  # Yarn is not installed by default in this runner
       - run: yarn install --immutable
       - run: yarn build
       - name: Create standalone binary

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,7 +148,7 @@ jobs:
         run: yarn dist-standalone:test
 
   standalone-binary-test-ubuntu-arm:
-    name: Test standalone binary in ubuntu
+    name: Test standalone binary in ARM ubuntu
     runs-on:
       group: ARM LINUX SHARED
       labels: arm-4core-linux

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -168,7 +168,7 @@ jobs:
       - name: Bundle library
         run: yarn build
       - name: Create standalone binary
-        run: yarn dist-standalone -t node14-macos-x64 -o datadog-ci_darwin-x64
+        run: yarn dist-standalone -t node14-macos-arm64 -o datadog-ci_darwin-arm64
       - name: Remove dist folder to check that binary can stand alone
         run: |
           rm -rf dist
@@ -186,8 +186,8 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               release_id: "${{ needs.create-draft-release.outputs.release-id }}",
-              name: 'datadog-ci_darwin-x64',
-              data: await fs.readFile('./datadog-ci_darwin-x64'),
+              name: 'datadog-ci_darwin-arm64',
+              data: await fs.readFile('./datadog-ci_darwin-arm64'),
             })
 
   # Requires an approval

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -86,6 +86,8 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20.11.0 # Use newer version to build the standalone binary
+      - run: npm install -g yarn
+        name: Install Yarn  # Yarn is not installed by default in this runner
       - name: Install project dependencies
         run: yarn install --immutable
       - name: Bundle library

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -75,6 +75,45 @@ jobs:
               data: await fs.readFile('./datadog-ci_linux-x64'),
             })
 
+  build-binary-ubuntu-arm:
+    runs-on:
+      group: ARM LINUX SHARED
+      labels: arm-4core-linux
+    needs: create-draft-release
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.11.0 # Use newer version to build the standalone binary
+      - name: Install project dependencies
+        run: yarn install --immutable
+      - name: Bundle library
+        run: yarn build
+      - name: Create standalone binary
+        run: yarn dist-standalone -t node14-linux-arm64 -o datadog-ci_linux-arm64
+      - name: Remove dist folder to check that binary can stand alone
+        run: |
+          rm -rf dist
+          rm -rf src
+      - name: Test generated standalone binary
+        run: yarn dist-standalone:test
+      - name: Upload release asset
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require("fs").promises
+
+            github.rest.repos.uploadReleaseAsset({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              release_id: "${{ needs.create-draft-release.outputs.release-id }}",
+              name: 'datadog-ci_linux-arm64',
+              data: await fs.readFile('./datadog-ci_linux-arm64'),
+            })
+
+
   build-binary-windows:
     runs-on: windows-latest
     needs: create-draft-release

--- a/standalone-e2e/standalone-binary.test.ts
+++ b/standalone-e2e/standalone-binary.test.ts
@@ -9,7 +9,7 @@ const isWin = process.platform === 'win32'
 const os = isWin ? 'win' : process.platform === 'darwin' ? 'darwin' : 'linux'
 
 const isARM = process.arch === 'arm64'
-const arch = isARM && os === 'linux' ? 'arm64' : 'x64'
+const arch = isARM ? 'arm64' : 'x64'
 
 const STANDALONE_BINARY = `datadog-ci_${os}-${arch}`
 const STANDALONE_BINARY_PATH = `${isWin ? '.\\' : './'}${STANDALONE_BINARY}${isWin ? '.exe' : ''}`

--- a/standalone-e2e/standalone-binary.test.ts
+++ b/standalone-e2e/standalone-binary.test.ts
@@ -8,7 +8,10 @@ const execPromise = promisify(exec)
 const isWin = process.platform === 'win32'
 const os = isWin ? 'win' : process.platform === 'darwin' ? 'darwin' : 'linux'
 
-const STANDALONE_BINARY = `datadog-ci_${os}-x64`
+const isARM = process.arch === 'arm64'
+const arch = isARM ? 'arm64' : 'x64'
+
+const STANDALONE_BINARY = `datadog-ci_${os}-${arch}`
 const STANDALONE_BINARY_PATH = `${isWin ? '.\\' : './'}${STANDALONE_BINARY}${isWin ? '.exe' : ''}`
 
 const sanitizeOutput = (output: string) => output.replace(/(\r\n|\n|\r)/gm, '')

--- a/standalone-e2e/standalone-binary.test.ts
+++ b/standalone-e2e/standalone-binary.test.ts
@@ -9,7 +9,7 @@ const isWin = process.platform === 'win32'
 const os = isWin ? 'win' : process.platform === 'darwin' ? 'darwin' : 'linux'
 
 const isARM = process.arch === 'arm64'
-const arch = isARM ? 'arm64' : 'x64'
+const arch = isARM && os === 'linux' ? 'arm64' : 'x64'
 
 const STANDALONE_BINARY = `datadog-ci_${os}-${arch}`
 const STANDALONE_BINARY_PATH = `${isWin ? '.\\' : './'}${STANDALONE_BINARY}${isWin ? '.exe' : ''}`


### PR DESCRIPTION
### What and why?

This PR adds a Github job that creates standalone binaries for ARM64 

### How?

Using the Github runners in ARM, I duplicated the `build-binary-ubuntu` job to generate ARM64 binaries.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
