### PR TITLE
v2.38.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci",
-  "version": "2.37.0",
+  "version": "2.38.0",
   "description": "Run datadog actions from the CI.",
   "repository": "https://github.com/DataDog/datadog-ci",
   "license": "Apache-2.0",


### PR DESCRIPTION
<!-- Release notes generated using configuration in .github/release.yml at v2.38.0 -->

## What's Changed
### Dependencies
* [dep] Bump @grpc/grpc-js to `1.10.9` by @Drarig29 in https://github.com/DataDog/datadog-ci/pull/1337
* [dep] Bump braces to `3.0.3` by @Drarig29 in https://github.com/DataDog/datadog-ci/pull/1342
### Documentation
* DOCS-8127 Continuous Testing and CI/CD Configuration Edit by @alai97 in https://github.com/DataDog/datadog-ci/pull/1329
### CI Visibility
* Remove unnecessary console.log in the `measure` command by @ManuelPalenzuelaDD in https://github.com/DataDog/datadog-ci/pull/1321
* Improve measure command error handling by @rodrigo-roca in https://github.com/DataDog/datadog-ci/pull/1323
### Serverless
* Add step function context to nested step function calls by @agocs in https://github.com/DataDog/datadog-ci/pull/1325
### Static Analysis
* [STAL-2267] Make version optional in SBOM by @dastrong in https://github.com/DataDog/datadog-ci/pull/1335
### Synthetics
* [SYNTH-12983] Add testOverrides properties to env variables by @AntoineDona in https://github.com/DataDog/datadog-ci/pull/1320
* [SYNTH-12983] Add `--override` CLI argument by @AntoineDona in https://github.com/DataDog/datadog-ci/pull/1327
* [SYNTH-12984] Add  complex overrides to `--override` CLI argument by @AntoineDona in https://github.com/DataDog/datadog-ci/pull/1330
* [synthetics] Parameterize unit tests for deprecated usages by @Drarig29 in https://github.com/DataDog/datadog-ci/pull/1340
### Profiling
* Explore .dot directories when uploading elf symbols by @nsavoire in https://github.com/DataDog/datadog-ci/pull/1328
* [PROF-9872] Improve elf-symbols upload command by @nsavoire in https://github.com/DataDog/datadog-ci/pull/1331
### Chores
* [codeowners] Add maintainer team everywhere by @Drarig29 in https://github.com/DataDog/datadog-ci/pull/1319
* [ci] Add build job for Ubuntu ARM by @gjulianm in https://github.com/DataDog/datadog-ci/pull/1333

## New Contributors
* @gjulianm made their first contribution in https://github.com/DataDog/datadog-ci/pull/1333
* @agocs made their first contribution in https://github.com/DataDog/datadog-ci/pull/1325

**Full Changelog**: https://github.com/DataDog/datadog-ci/compare/v2.37.0...v2.38.0

[STAL-2267]: https://datadoghq.atlassian.net/browse/STAL-2267?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SYNTH-12983]: https://datadoghq.atlassian.net/browse/SYNTH-12983?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ