### PR TITLE
[SYNTH-14569] Send validator extracted-metadata for temporary apps

### DIFF
--- a/src/commands/synthetics/__tests__/fixtures.ts
+++ b/src/commands/synthetics/__tests__/fixtures.ts
@@ -639,6 +639,12 @@ export const MOBILE_PRESIGNED_UPLOAD_PARTS: MobileApplicationUploadPart[] = [
 export const APP_UPLOAD_POLL_RESULTS: MobileAppUploadResult = {
   status: 'complete',
   is_valid: true,
+  valid_app_result: {
+    app_version_uuid: 'appVersionUuid',
+    extracted_metadata: {
+      metadataKey: 'metadataValue',
+    },
+  },
 }
 
 export const APP_UPLOAD_SIZE_AND_PARTS = {

--- a/src/commands/synthetics/__tests__/mobile.test.ts
+++ b/src/commands/synthetics/__tests__/mobile.test.ts
@@ -224,12 +224,12 @@ describe('mobile', () => {
       ])
     })
 
-    test('setUploadedAppFileName', () => {
+    test('setUploadedAppFileNameAndExtractedMetadata', () => {
       const cache = new mobile.AppUploadCache()
       cache.setAppCacheKeys(triggerConfigs, testsAndConfigsOverride)
-      cache.setUploadedAppFileName('appPath1', 'appId1', 'fileName')
+      cache.setUploadedAppFileName('appPath1', 'appId1', 'fileName', {key: 'value'})
 
-      expect(cache.getUploadedAppFileName('appPath1', 'appId1')).toBe('fileName')
+      expect(cache.getUploadedAppFileName('appPath1', 'appId1')).toEqual({fileName: 'fileName', extractedMetadata: {key: 'value'}})
     })
   })
 
@@ -237,13 +237,15 @@ describe('mobile', () => {
     test('mobileApplicationVersionFilePath', () => {
       const test = getMobileTest()
       const overriddenConfig = getTestPayload({public_id: test.public_id})
-      mobile.overrideMobileConfig(overriddenConfig, test.options.mobileApplication.applicationId, 'fileName')
+      const extractedMetadata = {key: 'value'}
+      mobile.overrideMobileConfig(overriddenConfig, test.options.mobileApplication.applicationId, 'fileName', undefined, extractedMetadata)
 
       expect(overriddenConfig.mobileApplication).toEqual({
         applicationId: test.options.mobileApplication.applicationId,
         referenceId: 'fileName',
         referenceType: 'temporary',
       })
+      expect(overriddenConfig.appExtractedMetadata).toEqual(extractedMetadata)
     })
 
     test('mobileApplicationVersion', () => {
@@ -266,11 +268,13 @@ describe('mobile', () => {
     test('Temporary takes precedence over version', () => {
       const test = getMobileTest()
       const overriddenConfig = getTestPayload({public_id: test.public_id})
+      const extractedMetadata = {key: 'value'}
       mobile.overrideMobileConfig(
         overriddenConfig,
         test.options.mobileApplication.applicationId,
         'fileName',
-        'androidVersionId'
+        'androidVersionId',
+        extractedMetadata
       )
 
       expect(overriddenConfig.mobileApplication).toEqual({
@@ -278,6 +282,7 @@ describe('mobile', () => {
         referenceId: 'fileName',
         referenceType: 'temporary',
       })
+      expect(overriddenConfig.appExtractedMetadata).toEqual(extractedMetadata)
     })
   })
 
@@ -335,10 +340,10 @@ describe('mobile', () => {
       expect(appUploadReporterReportSuccessSpy).toHaveBeenCalledTimes(1)
       expect(overrideMobileConfigSpy).toHaveBeenCalledTimes(5)
       expect(overrideMobileConfigSpy.mock.calls).toEqual([
-        [testsAndConfigsOverride[0].overriddenConfig, 'appId1', 'fileName-appId1', undefined],
-        [testsAndConfigsOverride[1].overriddenConfig, 'appId2', 'fileName-appId2', undefined],
-        [testsAndConfigsOverride[2].overriddenConfig, 'appId1', 'fileName-appId1', undefined],
-        [testsAndConfigsOverride[3].overriddenConfig, 'appId3', 'fileName-appId3', undefined],
+        [testsAndConfigsOverride[0].overriddenConfig, 'appId1', 'fileName-appId1', undefined, {metadataKey: 'metadataValue'}],
+        [testsAndConfigsOverride[1].overriddenConfig, 'appId2', 'fileName-appId2', undefined, {metadataKey: 'metadataValue'}],
+        [testsAndConfigsOverride[2].overriddenConfig, 'appId1', 'fileName-appId1', undefined, {metadataKey: 'metadataValue'}],
+        [testsAndConfigsOverride[3].overriddenConfig, 'appId3', 'fileName-appId3', undefined, {metadataKey: 'metadataValue'}],
         [
           testsAndConfigsOverride[4].overriddenConfig,
           'appId4',

--- a/src/commands/synthetics/__tests__/mobile.test.ts
+++ b/src/commands/synthetics/__tests__/mobile.test.ts
@@ -229,7 +229,10 @@ describe('mobile', () => {
       cache.setAppCacheKeys(triggerConfigs, testsAndConfigsOverride)
       cache.setUploadedAppFileName('appPath1', 'appId1', 'fileName', {key: 'value'})
 
-      expect(cache.getUploadedAppFileName('appPath1', 'appId1')).toEqual({fileName: 'fileName', extractedMetadata: {key: 'value'}})
+      expect(cache.getUploadedAppFileName('appPath1', 'appId1')).toEqual({
+        fileName: 'fileName',
+        extractedMetadata: {key: 'value'},
+      })
     })
   })
 
@@ -238,7 +241,13 @@ describe('mobile', () => {
       const test = getMobileTest()
       const overriddenConfig = getTestPayload({public_id: test.public_id})
       const extractedMetadata = {key: 'value'}
-      mobile.overrideMobileConfig(overriddenConfig, test.options.mobileApplication.applicationId, 'fileName', undefined, extractedMetadata)
+      mobile.overrideMobileConfig(
+        overriddenConfig,
+        test.options.mobileApplication.applicationId,
+        'fileName',
+        undefined,
+        extractedMetadata
+      )
 
       expect(overriddenConfig.mobileApplication).toEqual({
         applicationId: test.options.mobileApplication.applicationId,
@@ -340,10 +349,34 @@ describe('mobile', () => {
       expect(appUploadReporterReportSuccessSpy).toHaveBeenCalledTimes(1)
       expect(overrideMobileConfigSpy).toHaveBeenCalledTimes(5)
       expect(overrideMobileConfigSpy.mock.calls).toEqual([
-        [testsAndConfigsOverride[0].overriddenConfig, 'appId1', 'fileName-appId1', undefined, {metadataKey: 'metadataValue'}],
-        [testsAndConfigsOverride[1].overriddenConfig, 'appId2', 'fileName-appId2', undefined, {metadataKey: 'metadataValue'}],
-        [testsAndConfigsOverride[2].overriddenConfig, 'appId1', 'fileName-appId1', undefined, {metadataKey: 'metadataValue'}],
-        [testsAndConfigsOverride[3].overriddenConfig, 'appId3', 'fileName-appId3', undefined, {metadataKey: 'metadataValue'}],
+        [
+          testsAndConfigsOverride[0].overriddenConfig,
+          'appId1',
+          'fileName-appId1',
+          undefined,
+          {metadataKey: 'metadataValue'},
+        ],
+        [
+          testsAndConfigsOverride[1].overriddenConfig,
+          'appId2',
+          'fileName-appId2',
+          undefined,
+          {metadataKey: 'metadataValue'},
+        ],
+        [
+          testsAndConfigsOverride[2].overriddenConfig,
+          'appId1',
+          'fileName-appId1',
+          undefined,
+          {metadataKey: 'metadataValue'},
+        ],
+        [
+          testsAndConfigsOverride[3].overriddenConfig,
+          'appId3',
+          'fileName-appId3',
+          undefined,
+          {metadataKey: 'metadataValue'},
+        ],
         [
           testsAndConfigsOverride[4].overriddenConfig,
           'appId4',

--- a/src/commands/synthetics/interfaces.ts
+++ b/src/commands/synthetics/interfaces.ts
@@ -356,6 +356,7 @@ export interface UserConfigOverride extends BaseConfigOverride {
 
 export interface ServerConfigOverride extends BaseConfigOverride {
   mobileApplication?: MobileApplication
+  appExtractedMetadata?: MobileAppExtractedMetadata
 }
 
 export interface BatchOptions {
@@ -530,8 +531,10 @@ type MobileInvalidAppResult = {
   invalid_message: string
 }
 
+export type MobileAppExtractedMetadata = Record<string, unknown>
+
 type MobileValidAppResult = {
-  extracted_metadata: Record<string, unknown>
+  extracted_metadata: MobileAppExtractedMetadata
   app_version_uuid: string
 }
 

--- a/src/commands/synthetics/mobile.ts
+++ b/src/commands/synthetics/mobile.ts
@@ -170,7 +170,12 @@ export class AppUploadCache {
     return this.cache[appPath][appId]
   }
 
-  public setUploadedAppFileName(appPath: string, appId: string, fileName: string, extractedMetadata?: MobileAppExtractedMetadata): void {
+  public setUploadedAppFileName(
+    appPath: string,
+    appId: string,
+    fileName: string,
+    extractedMetadata?: MobileAppExtractedMetadata
+  ): void {
     this.cache[appPath][appId] = {fileName, extractedMetadata}
   }
 }
@@ -268,7 +273,12 @@ export const uploadMobileApplicationsAndUpdateOverrideConfigs = async (
     appUploadReporter.renderProgress(appsToUpload.length - index)
     try {
       const {appUploadResponse, fileName} = await uploadMobileApplication(api, item.appPath, item.appId)
-      appUploadCache.setUploadedAppFileName(item.appPath, item.appId, fileName, appUploadResponse.valid_app_result?.extracted_metadata)
+      appUploadCache.setUploadedAppFileName(
+        item.appPath,
+        item.appId,
+        fileName,
+        appUploadResponse.valid_app_result?.extracted_metadata
+      )
     } catch (error) {
       appUploadReporter.reportFailure(item)
       throw error
@@ -284,7 +294,13 @@ export const uploadMobileApplicationsAndUpdateOverrideConfigs = async (
       const cacheEntry = appPath ? appUploadCache.getUploadedAppFileName(appPath, appId) : undefined
       const fileName = cacheEntry?.fileName
       const extractedMetadata = cacheEntry?.extractedMetadata
-      overrideMobileConfig(item.overriddenConfig, appId, fileName, userConfigOverride.mobileApplicationVersion, extractedMetadata)
+      overrideMobileConfig(
+        item.overriddenConfig,
+        appId,
+        fileName,
+        userConfigOverride.mobileApplicationVersion,
+        extractedMetadata
+      )
     }
   }
 }

--- a/src/commands/synthetics/mobile.ts
+++ b/src/commands/synthetics/mobile.ts
@@ -4,6 +4,7 @@ import fs from 'fs'
 import {APIHelper, EndpointError, formatBackendErrors, getApiHelper} from './api'
 import {CiError, CriticalError} from './errors'
 import {
+  MobileAppExtractedMetadata,
   MobileAppUploadResult,
   MobileApplicationUploadPart,
   MobileApplicationUploadPartResponse,
@@ -133,8 +134,10 @@ export const uploadMobileApplication = async (
   return {appUploadResponse, fileName: multipartPresignedUrlsResponse.file_name}
 }
 
+type AppUploadCacheEntry = {fileName: string; extractedMetadata?: MobileAppExtractedMetadata}
+
 export class AppUploadCache {
-  private cache: {[applicationFilePath: string]: {[applicationId: string]: string | undefined}} = {}
+  private cache: {[applicationFilePath: string]: {[applicationId: string]: AppUploadCacheEntry | undefined}} = {}
 
   public setAppCacheKeys(triggerConfigs: TriggerConfig[], testsAndConfigsOverride: MobileTestWithOverride[]): void {
     for (const [index, item] of testsAndConfigsOverride.entries()) {
@@ -163,12 +166,12 @@ export class AppUploadCache {
     return appsToUpload
   }
 
-  public getUploadedAppFileName(appPath: string, appId: string): string | undefined {
+  public getUploadedAppFileName(appPath: string, appId: string): AppUploadCacheEntry | undefined {
     return this.cache[appPath][appId]
   }
 
-  public setUploadedAppFileName(appPath: string, appId: string, fileName: string): void {
-    this.cache[appPath][appId] = fileName
+  public setUploadedAppFileName(appPath: string, appId: string, fileName: string, extractedMetadata?: MobileAppExtractedMetadata): void {
+    this.cache[appPath][appId] = {fileName, extractedMetadata}
   }
 }
 
@@ -176,7 +179,8 @@ export const overrideMobileConfig = (
   overriddenTest: TestPayload,
   appId: string,
   tempFileName?: string,
-  mobileApplicationVersion?: string
+  mobileApplicationVersion?: string,
+  extractedMetadata?: MobileAppExtractedMetadata
 ) => {
   if (tempFileName) {
     overriddenTest.mobileApplication = {
@@ -184,6 +188,7 @@ export const overrideMobileConfig = (
       referenceId: tempFileName,
       referenceType: 'temporary',
     }
+    overriddenTest.appExtractedMetadata = extractedMetadata
   } else if (mobileApplicationVersion) {
     overriddenTest.mobileApplication = {
       applicationId: appId,
@@ -262,8 +267,8 @@ export const uploadMobileApplicationsAndUpdateOverrideConfigs = async (
   for (const [index, item] of appsToUpload.entries()) {
     appUploadReporter.renderProgress(appsToUpload.length - index)
     try {
-      const {fileName} = await uploadMobileApplication(api, item.appPath, item.appId)
-      appUploadCache.setUploadedAppFileName(item.appPath, item.appId, fileName)
+      const {appUploadResponse, fileName} = await uploadMobileApplication(api, item.appPath, item.appId)
+      appUploadCache.setUploadedAppFileName(item.appPath, item.appId, fileName, appUploadResponse.valid_app_result?.extracted_metadata)
     } catch (error) {
       appUploadReporter.reportFailure(item)
       throw error
@@ -276,8 +281,10 @@ export const uploadMobileApplicationsAndUpdateOverrideConfigs = async (
       const appId = item.test.options.mobileApplication.applicationId
       const userConfigOverride = triggerConfigs[index].testOverrides ?? {}
       const appPath = userConfigOverride.mobileApplicationVersionFilePath
-      const fileName = appPath && appUploadCache.getUploadedAppFileName(appPath, appId)
-      overrideMobileConfig(item.overriddenConfig, appId, fileName, userConfigOverride.mobileApplicationVersion)
+      const cacheEntry = appPath ? appUploadCache.getUploadedAppFileName(appPath, appId) : undefined
+      const fileName = cacheEntry?.fileName
+      const extractedMetadata = cacheEntry?.extractedMetadata
+      overrideMobileConfig(item.overriddenConfig, appId, fileName, userConfigOverride.mobileApplicationVersion, extractedMetadata)
     }
   }
 }


### PR DESCRIPTION


### What and why?

Mobile app validator sends back extracted application metadata about the users app. For temporary apps, this *only* gets passed back to datadog-ci (it isn't persisted anywhere), so datadog-ci must pass it back up when running the test with a temporary app.

### How?

Take `extracted_metadata` from app-validator response and send it along with the run-test API call to backend

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
