### PR TITLE
[STAL-1727] Hard-coding source to be `ci`

### DIFF
--- a/src/commands/sbom/payload.ts
+++ b/src/commands/sbom/payload.ts
@@ -176,5 +176,6 @@ export const generatePayload = (
     dependencies,
     service,
     env,
+    scan_source: 'ci',
   }
 }

--- a/src/commands/sbom/types.ts
+++ b/src/commands/sbom/types.ts
@@ -108,5 +108,6 @@ export interface ScaRequest {
   dependencies: Dependency[]
   service: string
   env: string
+  scan_source: 'ci'
   tags: Record<string, string>
 }


### PR DESCRIPTION
### What and why?
We'd like to collect metrics on the source of scans, the potential values being `ci` and `cwp`. `local` has such negligible value that lumping them in with `ci` is tolerable. This PR hardcodes that all scans triggered from `datadog-ci` are coming from `ci` and not `cwp`.