### PR TITLE
[ci] Bring back x64 macOS binary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,7 +159,7 @@ jobs:
         with:
           node-version: 20.11.0 # Use newer version to build the standalone binary
       - run: npm install -g yarn
-        name: Install Yarn  # Yarn is not installed by default in this runner
+        name: Install Yarn # Yarn is not installed by default in this runner
       - run: yarn install --immutable
       - run: yarn build
       - name: Create standalone binary
@@ -195,6 +195,26 @@ jobs:
     name: Test standalone binary in macOS
     # macOS-latest is an arm64 image, but the standalone binary is built against `node14-macos-x64` (downloaded by `pkg`)
     # https://github.com/actions/runner-images#available-images
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.11.0 # Use newer version to build the standalone binary
+      - run: yarn install --immutable
+      - run: yarn build
+      - name: Create standalone binary
+        run: yarn dist-standalone -t node14-macos-x64 -o datadog-ci_darwin-x64
+      - name: Remove dist and src folder to check that binary can stand alone
+        run: |
+          rm -rf dist
+          rm -rf src
+      - name: Test generated standalone binary
+        run: yarn dist-standalone:test
+
+  standalone-binary-test-macos-arm:
+    name: Test standalone binary in macOS
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,9 +193,9 @@ jobs:
 
   standalone-binary-test-macos:
     name: Test standalone binary in macOS
-    # macOS-latest is an arm64 image, but the standalone binary is built against `node14-macos-x64` (downloaded by `pkg`)
+    # `macos-latest-large` is an x64 image, and we need it to run the standalone tests
     # https://github.com/actions/runner-images#available-images
-    runs-on: macos-latest
+    runs-on: macos-latest-large
     steps:
       - uses: actions/checkout@v4
       - name: Install node
@@ -214,7 +214,7 @@ jobs:
         run: yarn dist-standalone:test
 
   standalone-binary-test-macos-arm:
-    name: Test standalone binary in macOS
+    name: Test standalone binary in ARM macOS
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -152,9 +152,9 @@ jobs:
             })
 
   build-binary-macos:
-    # macOS-latest is an arm64 image, but the standalone binary is built against `node14-macos-x64` (downloaded by `pkg`)
+    # `macos-latest-large` is an x64 image, and we need it to run the standalone tests
     # https://github.com/actions/runner-images#available-images
-    runs-on: macos-latest
+    runs-on: macos-latest-large
     needs: create-draft-release
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -87,7 +87,7 @@ jobs:
         with:
           node-version: 20.11.0 # Use newer version to build the standalone binary
       - run: npm install -g yarn
-        name: Install Yarn  # Yarn is not installed by default in this runner
+        name: Install Yarn # Yarn is not installed by default in this runner
       - name: Install project dependencies
         run: yarn install --immutable
       - name: Bundle library
@@ -114,7 +114,6 @@ jobs:
               name: 'datadog-ci_linux-arm64',
               data: await fs.readFile('./datadog-ci_linux-arm64'),
             })
-
 
   build-binary-windows:
     runs-on: windows-latest
@@ -155,6 +154,42 @@ jobs:
   build-binary-macos:
     # macOS-latest is an arm64 image, but the standalone binary is built against `node14-macos-x64` (downloaded by `pkg`)
     # https://github.com/actions/runner-images#available-images
+    runs-on: macos-latest
+    needs: create-draft-release
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.11.0 # Use newer version to build the standalone binary
+      - name: Install project dependencies
+        run: yarn install --immutable
+      - name: Bundle library
+        run: yarn build
+      - name: Create standalone binary
+        run: yarn dist-standalone -t node14-macos-x64 -o datadog-ci_darwin-x64
+      - name: Remove dist folder to check that binary can stand alone
+        run: |
+          rm -rf dist
+          rm -rf src
+      - name: Test generated standalone binary
+        run: yarn dist-standalone:test
+      - name: Upload release asset
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require("fs").promises
+
+            github.rest.repos.uploadReleaseAsset({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              release_id: "${{ needs.create-draft-release.outputs.release-id }}",
+              name: 'datadog-ci_darwin-x64',
+              data: await fs.readFile('./datadog-ci_darwin-x64'),
+            })
+
+  build-binary-macos-arm:
     runs-on: macos-latest
     needs: create-draft-release
     steps:


### PR DESCRIPTION
### What and why?

In #1333, we renamed the `datadog-ci_darwin-x64` binary to `datadog-ci_darwin-arm64` for alignment, but didn't keep the original `datadog-ci_darwin-x64`.

This PR updates the CI to build both `datadog-ci_darwin-x64` and `datadog-ci_darwin-arm64`.

### How?

Use `macos-latest-large`, which is an x64 image.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
