### PR TITLE
v2.38.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci",
-  "version": "2.38.0",
+  "version": "2.38.1",
   "description": "Run datadog actions from the CI.",
   "repository": "https://github.com/DataDog/datadog-ci",
   "license": "Apache-2.0",


### PR DESCRIPTION
<!-- Release notes generated using configuration in .github/release.yml at v2.38.1 -->

## What's Changed
### Documentation
* Add --propagate-upstream-trace to Step Function README by @agocs in https://github.com/DataDog/datadog-ci/pull/1350
### Synthetics
* [SYNTH-14569] Send validator extracted-metadata for temporary apps by @kevin-pietsch in https://github.com/DataDog/datadog-ci/pull/1343
### Chores
* [ci] Bring back x64 macOS binary by @Drarig29 in https://github.com/DataDog/datadog-ci/pull/1348


**Full Changelog**: https://github.com/DataDog/datadog-ci/compare/v2.38.0...v2.38.1

[SYNTH-14569]: https://datadoghq.atlassian.net/browse/SYNTH-14569?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ