### PR TITLE
[SYNTH-9539] Report non-final attempts of a result

### DIFF
--- a/src/commands/synthetics/__tests__/fixtures.ts
+++ b/src/commands/synthetics/__tests__/fixtures.ts
@@ -38,6 +38,7 @@ import {
   TriggerConfig,
   MobileTestWithOverride,
   BaseResultInBatch,
+  ResultInBatchSkippedBySelectiveRerun,
 } from '../interfaces'
 import {AppUploadReporter} from '../reporters/mobile/app-upload'
 import {createInitialSummary} from '../utils/public'
@@ -517,6 +518,23 @@ export const getInProgressResultInBatch = (): BaseResultInBatch => {
     retries: null,
     status: 'in_progress',
     test_public_id: 'pid',
+    // eslint-disable-next-line no-null/no-null
+    timed_out: null,
+  }
+}
+
+export const getSkippedResultInBatch = (): ResultInBatchSkippedBySelectiveRerun => {
+  return {
+    test_public_id: 'pid',
+    execution_rule: ExecutionRule.SKIPPED,
+    // eslint-disable-next-line no-null/no-null
+    retries: null,
+    status: 'skipped',
+    selective_rerun: {
+      decision: 'skip',
+      reason: 'passed',
+      linked_result_id: '123',
+    },
     // eslint-disable-next-line no-null/no-null
     timed_out: null,
   }

--- a/src/commands/synthetics/__tests__/fixtures.ts
+++ b/src/commands/synthetics/__tests__/fixtures.ts
@@ -37,6 +37,7 @@ import {
   MobileApplicationUploadPartResponse,
   TriggerConfig,
   MobileTestWithOverride,
+  BaseResultInBatch,
 } from '../interfaces'
 import {AppUploadReporter} from '../reporters/mobile/app-upload'
 import {createInitialSummary} from '../utils/public'
@@ -190,6 +191,7 @@ const getBaseResult = (resultId: string, test: Test): Omit<BaseResult, 'result'>
   location: 'Frankfurt (AWS)',
   passed: true,
   resultId,
+  retries: 0,
   test,
   timedOut: false,
   timestamp: 1,
@@ -229,6 +231,7 @@ export const getTimedOutBrowserResult = (): Result => ({
     steps: [],
   },
   resultId: '1',
+  retries: 0,
   test: getBrowserTest(),
   timedOut: true,
   timestamp: 1,
@@ -288,6 +291,7 @@ export const getFailedBrowserResult = (): Result => ({
     ],
   },
   resultId: '1',
+  retries: 0,
   test: getBrowserTest(),
   timedOut: false,
   timestamp: 1,
@@ -504,17 +508,40 @@ export const getResults = (resultsFixtures: ResultFixtures[]): Result[] => {
   return results
 }
 
+export const getInProgressResultInBatch = (): BaseResultInBatch => {
+  return {
+    execution_rule: ExecutionRule.BLOCKING,
+    location: mockLocation.name,
+    result_id: 'rid',
+    // eslint-disable-next-line no-null/no-null
+    retries: null,
+    status: 'in_progress',
+    test_public_id: 'pid',
+    // eslint-disable-next-line no-null/no-null
+    timed_out: null,
+  }
+}
+
+export const getPassedResultInBatch = (): BaseResultInBatch => {
+  return {
+    ...getInProgressResultInBatch(),
+    retries: 0,
+    status: 'passed',
+    timed_out: false,
+  }
+}
+
+export const getFailedResultInBatch = (): BaseResultInBatch => {
+  return {
+    ...getInProgressResultInBatch(),
+    retries: 0,
+    status: 'failed',
+    timed_out: false,
+  }
+}
+
 export const getBatch = (): Batch => ({
-  results: [
-    {
-      execution_rule: ExecutionRule.BLOCKING,
-      location: mockLocation.name,
-      result_id: 'rid',
-      status: 'passed',
-      test_public_id: 'pid',
-      timed_out: false,
-    },
-  ],
+  results: [getPassedResultInBatch()],
   status: 'passed',
 })
 

--- a/src/commands/synthetics/__tests__/reporters/__snapshots__/default.test.ts.snap
+++ b/src/commands/synthetics/__tests__/reporters/__snapshots__/default.test.ts.snap
@@ -32,6 +32,29 @@ exports[`Default reporter resultEnd 1 API test, 1 location, 3 results: success, 
 "
 `;
 
+exports[`Default reporter resultEnd 1 API test, 3 attempts (2 failed, then passed) 1`] = `
+"[1m[31m✖[39m[22m [[1m[31mblocking[39m[22m] [[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m - [1m[31mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m (attempt 1 of 3)
+  • Total duration: 123 ms - View test run details:
+    ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=1&batch_id=123&from_ci=true[39m[22m 
+  [1m[31m✖[39m[22m [1m[31m[1mGET[22m[1m - http://fake.url[39m[22m
+[1m[31m  - Assertion failed:[39m[22m
+[1m[31m    ▶ responseTime should be less than [4m1000[24m. Actual: [4m1234[24m[39m[22m
+
+[1m[31m✖[39m[22m [[1m[31mblocking[39m[22m] [[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m - [1m[31mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m (attempt 2 of 3)
+  • Total duration: 123 ms - View test run details:
+    ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=2&batch_id=123&from_ci=true[39m[22m 
+  [1m[31m✖[39m[22m [1m[31m[1mGET[22m[1m - http://fake.url[39m[22m
+[1m[31m  - Assertion failed:[39m[22m
+[1m[31m    ▶ responseTime should be less than [4m1000[24m. Actual: [4m1234[24m[39m[22m
+
+[1m[32m✓[39m[22m [[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m - [1m[32mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m (attempt 3 of 3)
+  • Total duration: 123 ms - View test run details:
+    ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=3&batch_id=123&from_ci=true[39m[22m 
+  [1m[32m✓[39m[22m [1m[32m[1mGET[22m[1m - http://fake.url[39m[22m
+
+"
+`;
+
 exports[`Default reporter resultEnd 3 API tests, 2 passed (1 from previous CI run) 1`] = `
 "[1m[32m✓[39m[22m [[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m - [1m[32mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m
   • Total duration: 123 ms - View test run details:

--- a/src/commands/synthetics/__tests__/utils/public.test.ts
+++ b/src/commands/synthetics/__tests__/utils/public.test.ts
@@ -1409,7 +1409,7 @@ describe('utils', () => {
       expect(utils.wait).toHaveBeenCalledTimes(2)
     })
 
-    test('correct number of pass and timeout results', async () => {
+    test('correct number of passed and timed out results', async () => {
       const pollTimeoutResult: PollResult = {...deepExtend({}, pollResult), resultID: 'another-id'}
       const batchWithTimeoutResult: Batch = {
         ...batch,

--- a/src/commands/synthetics/batch.ts
+++ b/src/commands/synthetics/batch.ts
@@ -12,7 +12,7 @@ import {
   ResultInBatch,
   Test,
 } from './interfaces'
-import {isResultInBatchSkippedBySelectiveRerun, getResultIdOrLinkedResultId} from './utils/internal'
+import {isResultInBatchSkippedBySelectiveRerun, getResultIdOrLinkedResultId, hasRetries} from './utils/internal'
 import {wait, getAppBaseURL, hasResultPassed} from './utils/public'
 
 const POLLING_INTERVAL = 5000 // In ms
@@ -25,7 +25,7 @@ export const waitForBatchToFinish = async (
   reporter: MainReporter
 ): Promise<Result[]> => {
   const safeDeadline = Date.now() + maxPollingTimeout + 3 * POLLING_INTERVAL
-  const emittedResultIndexes = new Set<number>()
+  const emittedResultIds = new Set<string>()
   let oldIncompleteResultIds = new Set<string>()
 
   while (true) {
@@ -36,7 +36,7 @@ export const waitForBatchToFinish = async (
     // But `safeDeadlineReached` is a safety in case it fails to do that on time.
     const shouldContinuePolling = batch.status === 'in_progress' && !safeDeadlineReached
 
-    const newlyReceivedResults = reportReceivedResults(batch, emittedResultIndexes, reporter)
+    const newlyReceivedResults = reportReceivedResults(batch, emittedResultIds, reporter)
 
     const resultIdsToFetch = getResultIdsToFetch(
       shouldContinuePolling,
@@ -51,7 +51,7 @@ export const waitForBatchToFinish = async (
       shouldContinuePolling,
       batch,
       newlyReceivedResults,
-      emittedResultIndexes,
+      emittedResultIds,
       oldIncompleteResultIds,
       incompleteResultIds,
       reporter
@@ -93,7 +93,7 @@ const getResultsToReport = (
   shouldContinuePolling: boolean,
   batch: Batch,
   newlyReceivedResults: ResultInBatch[],
-  emittedResultIndexes: Set<number>,
+  emittedResultIds: Set<string>,
   oldIncompleteResultIds: Set<string>,
   incompleteResultIds: Set<string>,
   reporter: MainReporter
@@ -114,7 +114,7 @@ const getResultsToReport = (
   //  - Still in progress (from the batch POV): they were never emitted.
   //  - Or still incomplete (from the poll results POV): report them with their incomplete data and a warning.
   const residualResults = excludeSkipped(batch.results).filter(
-    (r, index) => !emittedResultIndexes.has(index) || incompleteResultIds.has(r.result_id)
+    (r) => !emittedResultIds.has(r.result_id) || incompleteResultIds.has(r.result_id)
   )
 
   const errors: string[] = []
@@ -131,12 +131,16 @@ const getResultsToReport = (
   return resultsToReport.concat(residualResults)
 }
 
-const reportReceivedResults = (batch: Batch, emittedResultIndexes: Set<number>, reporter: MainReporter) => {
+const reportReceivedResults = (batch: Batch, emittedResultIds: Set<string>, reporter: MainReporter) => {
   const receivedResults: ResultInBatch[] = []
 
   for (const [index, result] of batch.results.entries()) {
-    if (result.status !== 'in_progress' && !emittedResultIndexes.has(index)) {
-      emittedResultIndexes.add(index)
+    // Skipped results aren't reported in detail in the terminal output, but they are still reported by `resultReceived()`.
+    const resultId = result.status === 'skipped' ? `skipped-${index}` : result.result_id
+
+    // The result is reported if it has a final status, or if it's a non-final result.
+    if ((result.status !== 'in_progress' || hasRetries(result)) && !emittedResultIds.has(resultId)) {
+      emittedResultIds.add(resultId)
       reporter.resultReceived(result)
       receivedResults.push(result)
     }
@@ -244,6 +248,7 @@ const getResultFromBatch = (
     ),
     result: pollResult.result,
     resultId: getResultIdOrLinkedResultId(resultInBatch),
+    retries: resultInBatch.retries || 0,
     selectiveRerun: resultInBatch.selective_rerun,
     test: deepExtend({}, test, pollResult.check),
     timedOut: hasTimedOut,

--- a/src/commands/synthetics/interfaces.ts
+++ b/src/commands/synthetics/interfaces.ts
@@ -133,6 +133,8 @@ export interface BaseResult {
   passed: boolean
   result: ServerResult
   resultId: string
+  // Number of retries, including this result.
+  retries: number
   selectiveRerun?: SelectiveRerunDecision
   // Original test for this result, including overrides if any.
   test: Test
@@ -141,7 +143,7 @@ export interface BaseResult {
 }
 
 // Inside this type, `.resultId` is a linked result ID from a previous batch.
-export type ResultSkippedBySelectiveRerun = Omit<BaseResult, 'location' | 'result' | 'timestamp'> & {
+export type ResultSkippedBySelectiveRerun = Omit<BaseResult, 'location' | 'result' | 'retries' | 'timestamp'> & {
   executionRule: ExecutionRule.SKIPPED
   selectiveRerun: Extract<SelectiveRerunDecision, {decision: 'skip'}>
 }
@@ -154,6 +156,7 @@ export interface BaseResultInBatch {
   execution_rule: ExecutionRule
   location: string
   result_id: string
+  retries: number | null
   selective_rerun?: SelectiveRerunDecision
   status: Status
   test_public_id: string
@@ -250,6 +253,9 @@ export interface ServerTest {
     min_location_failed: number
     mobileApplication?: MobileApplication
     tick_every: number
+    retry?: {
+      count?: number
+    }
   }
   overall_state: number
   overall_state_modified: string

--- a/src/commands/synthetics/reporters/default.ts
+++ b/src/commands/synthetics/reporters/default.ts
@@ -250,14 +250,32 @@ const renderExecutionResult = (test: Test, execution: Result, baseUrl: string, b
 
 const getResultIdentificationSuffix = (execution: Result, setColor: chalk.Chalk) => {
   if (hasResult(execution)) {
-    const {result} = execution
+    const {result, passed, retries, test} = execution
     const location = execution.location ? setColor(`location: ${chalk.bold(execution.location)}`) : ''
     const device = result && isDeviceIdSet(result) ? ` - ${setColor(`device: ${chalk.bold(result.device.id)}`)}` : ''
+    const attempt = getAttemptSuffix(passed, retries, test)
 
-    return ` - ${location}${device}`
+    return ` - ${location}${device}${attempt}`
   }
 
   return ''
+}
+
+const getAttemptSuffix = (passed: boolean, retries: number, test: Test) => {
+  const currentAttempt = retries + 1
+  const maxAttempts = (test.options.retry?.count ?? 0) + 1
+
+  if (maxAttempts === 1) {
+    // No need to talk about "attempts" if retries aren't configured.
+    return ''
+  }
+
+  if (passed && retries === 0) {
+    // No need to display anything if the test passed on the first attempt
+    return ''
+  }
+
+  return ` (attempt ${currentAttempt} of ${maxAttempts})`
 }
 
 const getResultIconAndColor = (resultOutcome: ResultOutcome): [string, chalk.Chalk] => {

--- a/src/commands/synthetics/utils/internal.ts
+++ b/src/commands/synthetics/utils/internal.ts
@@ -29,6 +29,16 @@ export const hasResult = (result: Result): result is BaseResult => {
   return !isResultSkippedBySelectiveRerun(result)
 }
 
+/**
+ * Most properties (like `retries`) are populated by the backend as soon as we receive a result, even if it's a non-final result.
+ *
+ * If the test is configured to be retried and the first attempt fails,
+ * `retries` is set to `0` and the result is kept `in_progress` until the final result is received.
+ */
+export const hasRetries = (result: ResultInBatch): result is ResultInBatch & {retries: number} => {
+  return Number.isInteger(result.retries)
+}
+
 export const isResultInBatchSkippedBySelectiveRerun = (
   result: ResultInBatch
 ): result is ResultInBatchSkippedBySelectiveRerun => {

--- a/src/commands/synthetics/utils/public.ts
+++ b/src/commands/synthetics/utils/public.ts
@@ -186,11 +186,11 @@ export const hasResultPassed = (
     return true
   }
 
-  if (typeof serverResult.passed !== 'undefined') {
+  if (serverResult.passed !== undefined) {
     return serverResult.passed
   }
 
-  if (typeof serverResult.failure !== 'undefined') {
+  if (serverResult.failure !== undefined) {
     return false
   }
 


### PR DESCRIPTION
### What and why?

Every 5 second when the batch is fetched, if a non-final attempt is detected, it's now reported. Before this PR, we used to only report the final attempt.

**Visual:**

<img width="846" alt="image" src="https://github.com/DataDog/datadog-ci/assets/9317502/1636479c-9ba9-4642-abf2-2d3653b05102">


### How?

Following a recent backend change, all properties of a batch result are updated with non-final attempts (e.g. `retries`, `duration`, `result_id`), and the `status` stays `in_progress` for backwards compatibility.

The main change of this PR is changing from `emittedResultIndexes` to `emittedResultIds`, so that we can report multiple results per result index (i.e. each attempt).

Note that **if the retries are too quick** (less than the polling cycle of 5 seconds), they won't be detected and reported by datadog-ci. For that reason, we may have a single ${{\color{Green}{\textsf{  Passed\ (attempt 3 of 3)\}}}}\$ result, without the attempts 1 and 2 (which brings more information than before anyway).

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
