### PR TITLE
[SYNTH-15171] Fix multiple test configs with same id bug

### DIFF
--- a/src/commands/synthetics/__tests__/run-tests-lib.test.ts
+++ b/src/commands/synthetics/__tests__/run-tests-lib.test.ts
@@ -847,5 +847,85 @@ describe('run-test', () => {
       ])
       expect(getSuitesMock).toHaveBeenCalled()
     })
+    test('should handle test configurations with the same test ID correctly', async () => {
+      const conf5 = {
+        tests: [
+          {
+            id: 'abc-abc-abc',
+            testOverrides: {
+              allowInsecureCertificates: true,
+              basicAuth: {username: 'test', password: 'test'},
+              body: '{"fakeContent":true}',
+              bodyType: 'application/json',
+              cookies: 'name1=value1;name2=value2;',
+              defaultStepTimeout: 15,
+              deviceIds: ['chrome.laptop_large'],
+              executionRule: 'non-blocking',
+              followRedirects: true,
+              headers: {NEW_HEADER: 'NEW VALUE'},
+              locations: ['aws:us-east-1'],
+              mobileApplicationVersion: '01234567-8888-9999-abcd-efffffffffff',
+              mobileApplicationVersionFilePath: 'path/to/application.apk',
+              pollingTimeout: 30000,
+              retry: {count: 2, interval: 300},
+              testTimeout: 300,
+              variables: {MY_VARIABLE: 'new title'},
+            },
+          },
+          {
+            id: 'abc-abc-abc',
+            testOverrides: {
+              executionRule: 'skipped',
+            },
+          },
+        ],
+      }
+      jest.spyOn(utils, 'getSuites').mockImplementation((() => [
+        {
+          content: conf5,
+          name: 'Suite with duplicate IDs',
+        },
+      ]) as any)
+
+      const defaultTestOverrides = {locations: ['aws:us-east-1'], startUrl: 'fakeUrl'}
+
+      await expect(
+        runTests.getTriggerConfigs(fakeApi, {...ciConfig, defaultTestOverrides}, mockReporter)
+      ).resolves.toEqual([
+        {
+          testOverrides: {
+            allowInsecureCertificates: true,
+            basicAuth: {username: 'test', password: 'test'},
+            body: '{"fakeContent":true}',
+            bodyType: 'application/json',
+            cookies: 'name1=value1;name2=value2;',
+            defaultStepTimeout: 15,
+            deviceIds: ['chrome.laptop_large'],
+            executionRule: 'non-blocking',
+            followRedirects: true,
+            headers: {NEW_HEADER: 'NEW VALUE'},
+            locations: ['aws:us-east-1'],
+            mobileApplicationVersion: '01234567-8888-9999-abcd-efffffffffff',
+            mobileApplicationVersionFilePath: 'path/to/application.apk',
+            pollingTimeout: 30000,
+            retry: {count: 2, interval: 300},
+            testTimeout: 300,
+            variables: {MY_VARIABLE: 'new title'},
+            startUrl: 'fakeUrl',
+          },
+          id: 'abc-abc-abc',
+          suite: 'Suite with duplicate IDs',
+        },
+        {
+          testOverrides: {
+            executionRule: 'skipped',
+            startUrl: 'fakeUrl',
+            locations: ['aws:us-east-1'],
+          },
+          id: 'abc-abc-abc',
+          suite: 'Suite with duplicate IDs',
+        },
+      ])
+    })
   })
 })

--- a/src/commands/synthetics/run-tests-lib.ts
+++ b/src/commands/synthetics/run-tests-lib.ts
@@ -198,8 +198,17 @@ export const getTriggerConfigs = async (
 
   // Create the overrides required for the list of tests to trigger
   const triggerConfigs = testIdsToTrigger.map((id) => {
-    const testFromSearchQuery = testsFromSearchQuery.find((test) => test.id === id)
-    const testFromTestConfigs = testsFromTestConfigs.find((test) => test.id === id)
+    const testIndexFromSearchQuery = testsFromSearchQuery.findIndex((test) => test.id === id)
+    let testFromSearchQuery
+    if (testIndexFromSearchQuery >= 0) {
+      testFromSearchQuery = testsFromSearchQuery.splice(testIndexFromSearchQuery, 1)[0]
+    }
+
+    const testIndexFromTestConfigs = testsFromTestConfigs.findIndex((test) => test.id === id)
+    let testFromTestConfigs
+    if (testIndexFromTestConfigs >= 0) {
+      testFromTestConfigs = testsFromTestConfigs.splice(testIndexFromTestConfigs, 1)[0]
+    }
 
     return {
       id,


### PR DESCRIPTION
### What and why?

We discovered a bug where having multiple test configs with the same test id would result in only the first occurence being used multiple time. This was caused by the usage of the `find` function in `getTriggerConfigs` in `run-tests-lib.ts:202`. Check out the [ticket](https://datadoghq.atlassian.net/browse/SYNTH-15171) for more context on how the bug was discovered and how to reproduce it.

### How?

- Use `findIndex` and `splice` to remove a test from `testsFromTestConfigs` once it has been found.
- Add test coverage for this issue.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
