### PR TITLE
[gate evaluate] Add `options.pull_request_sha` to the `datadog-ci gate evaluate` payload

### DIFF
--- a/src/commands/gate/api.ts
+++ b/src/commands/gate/api.ts
@@ -21,6 +21,7 @@ export const evaluateGateRules = (
           no_wait: evaluateRequest.options.noWait,
           dry_run: evaluateRequest.options.dryRun,
           is_last_retry: evaluateRequest.options.isLastRetry,
+          pull_request_sha: evaluateRequest.options.pull_request_sha,
         },
       },
     },

--- a/src/commands/gate/evaluate.ts
+++ b/src/commands/gate/evaluate.ts
@@ -8,8 +8,9 @@ import {v4 as uuidv4} from 'uuid'
 import {getCISpanTags} from '../../helpers/ci'
 import {getGitMetadata} from '../../helpers/git/format-git-span-data'
 import {SpanTags} from '../../helpers/interfaces'
+import {Logger, LogLevel} from '../../helpers/logger'
 import {retryRequest} from '../../helpers/retry'
-import {GIT_HEAD_SHA, parseTags} from '../../helpers/tags'
+import {GIT_HEAD_SHA, GIT_BASE_REF, parseTags} from '../../helpers/tags'
 import {getUserGitSpanTags} from '../../helpers/user-provided-git'
 import * as validation from '../../helpers/validation'
 
@@ -77,6 +78,8 @@ export class GateEvaluateCommand extends Command {
   private userScope = Option.Array('--scope')
   private tags = Option.Array('--tags')
 
+  private logger: Logger = new Logger((s: string) => this.context.stdout.write(s), LogLevel.INFO)
+
   private config = {
     apiKey: process.env.DD_API_KEY,
     appKey: process.env.DD_APP_KEY,
@@ -91,9 +94,15 @@ export class GateEvaluateCommand extends Command {
 
     const api = this.getApiHelper()
     const spanTags = await this.getSpanTags()
-    const headSha = spanTags[GIT_HEAD_SHA]
-    if (headSha) {
-      options.pull_request_sha = headSha
+    const headRef = spanTags[GIT_BASE_REF]
+
+    if (headRef) {
+      const headSha = spanTags[GIT_HEAD_SHA]
+      if (headSha) {
+        options.pull_request_sha = headSha
+      } else {
+        this.logger.warn('Detected a pull request run but HEAD commit SHA could not be calculated')
+      }
     }
 
     const userScope = this.userScope ? parseScope(this.userScope) : {}

--- a/src/commands/gate/evaluate.ts
+++ b/src/commands/gate/evaluate.ts
@@ -101,7 +101,7 @@ export class GateEvaluateCommand extends Command {
       if (headSha) {
         options.pull_request_sha = headSha
       } else {
-        this.logger.warn('Detected a pull request run but HEAD commit SHA could not be calculated')
+        this.logger.warn('Detected a pull request run but HEAD commit SHA could not be extracted.')
       }
     }
 

--- a/src/commands/gate/interfaces.ts
+++ b/src/commands/gate/interfaces.ts
@@ -1,8 +1,7 @@
-import {Writable} from 'stream'
-
 import type {AxiosPromise} from 'axios'
+import type {Writable} from 'stream'
 
-import {SpanTags} from '../../helpers/interfaces'
+import type {SpanTags} from '../../helpers/interfaces'
 
 export interface Payload {
   requestId: string
@@ -16,6 +15,7 @@ export interface PayloadOptions {
   dryRun: boolean
   noWait: boolean
   isLastRetry?: boolean
+  pull_request_sha?: string
 }
 
 export interface EvaluationResponsePayload {

--- a/src/helpers/ci.ts
+++ b/src/helpers/ci.ts
@@ -24,6 +24,7 @@ import {
   GIT_SHA,
   GIT_TAG,
   GIT_HEAD_SHA,
+  GIT_BASE_REF,
 } from './tags'
 import {getUserCISpanTags, getUserGitSpanTags} from './user-provided-git'
 import {
@@ -264,6 +265,7 @@ export const getCISpanTags = (): SpanTags | undefined => {
 
       if (headSha) {
         tags[GIT_HEAD_SHA] = headSha
+        tags[GIT_BASE_REF] = GITHUB_BASE_REF
       }
     }
   }

--- a/src/helpers/ci.ts
+++ b/src/helpers/ci.ts
@@ -23,9 +23,16 @@ import {
   GIT_REPOSITORY_URL,
   GIT_SHA,
   GIT_TAG,
+  GIT_HEAD_SHA,
 } from './tags'
 import {getUserCISpanTags, getUserGitSpanTags} from './user-provided-git'
-import {normalizeRef, removeEmptyValues, removeUndefinedValues, filterSensitiveInfoFromRepository} from './utils'
+import {
+  normalizeRef,
+  removeEmptyValues,
+  removeUndefinedValues,
+  filterSensitiveInfoFromRepository,
+  getGitHeadShaFromGitHubWebhookPayload,
+} from './utils'
 
 export const CI_ENGINES = {
   APPVEYOR: 'appveyor',
@@ -218,6 +225,7 @@ export const getCISpanTags = (): SpanTags | undefined => {
       GITHUB_REPOSITORY,
       GITHUB_SERVER_URL,
       GITHUB_RUN_ATTEMPT,
+      GITHUB_BASE_REF,
     } = env
     const repositoryUrl = `${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}.git`
     let pipelineURL = `${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}`
@@ -248,6 +256,12 @@ export const getCISpanTags = (): SpanTags | undefined => {
         GITHUB_RUN_ID,
         GITHUB_RUN_ATTEMPT,
       }),
+    }
+    if (GITHUB_BASE_REF) { // it's a pull_request or pull_request_target trigger
+      const headSha = getGitHeadShaFromGitHubWebhookPayload()
+      if (headSha) {
+        tags[GIT_HEAD_SHA] = headSha
+      }
     }
   }
 

--- a/src/helpers/ci.ts
+++ b/src/helpers/ci.ts
@@ -257,8 +257,11 @@ export const getCISpanTags = (): SpanTags | undefined => {
         GITHUB_RUN_ATTEMPT,
       }),
     }
-    if (GITHUB_BASE_REF) { // it's a pull_request or pull_request_target trigger
+
+    if (GITHUB_BASE_REF) {
+      // GITHUB_BASE_REF is defined if it's a pull_request or pull_request_target trigger
       const headSha = getGitHeadShaFromGitHubWebhookPayload()
+
       if (headSha) {
         tags[GIT_HEAD_SHA] = headSha
       }

--- a/src/helpers/ci.ts
+++ b/src/helpers/ci.ts
@@ -261,11 +261,11 @@ export const getCISpanTags = (): SpanTags | undefined => {
 
     if (GITHUB_BASE_REF) {
       // GITHUB_BASE_REF is defined if it's a pull_request or pull_request_target trigger
+      tags[GIT_BASE_REF] = GITHUB_BASE_REF
       const headSha = getGitHeadShaFromGitHubWebhookPayload()
 
       if (headSha) {
         tags[GIT_HEAD_SHA] = headSha
-        tags[GIT_BASE_REF] = GITHUB_BASE_REF
       }
     }
   }

--- a/src/helpers/interfaces.ts
+++ b/src/helpers/interfaces.ts
@@ -25,6 +25,7 @@ import {
   GIT_REPOSITORY_URL,
   GIT_SHA,
   GIT_TAG,
+  GIT_HEAD_SHA,
   SERVICE,
 } from './tags'
 
@@ -94,6 +95,7 @@ export type SpanTag =
   | typeof CI_NODE_NAME
   | typeof CI_NODE_LABELS
   | typeof SERVICE
+  | typeof GIT_HEAD_SHA
 
 export type SpanTags = Partial<Record<SpanTag, string>>
 

--- a/src/helpers/interfaces.ts
+++ b/src/helpers/interfaces.ts
@@ -27,6 +27,7 @@ import {
   GIT_TAG,
   GIT_HEAD_SHA,
   SERVICE,
+  GIT_BASE_REF,
 } from './tags'
 
 export interface Metadata {
@@ -96,6 +97,7 @@ export type SpanTag =
   | typeof CI_NODE_LABELS
   | typeof SERVICE
   | typeof GIT_HEAD_SHA
+  | typeof GIT_BASE_REF
 
 export type SpanTags = Partial<Record<SpanTag, string>>
 

--- a/src/helpers/tags.ts
+++ b/src/helpers/tags.ts
@@ -34,6 +34,7 @@ export const GIT_COMMIT_COMMITTER_NAME = 'git.commit.committer.name'
 export const GIT_COMMIT_MESSAGE = 'git.commit.message'
 export const GIT_SHA = 'git.commit.sha'
 export const GIT_TAG = 'git.tag'
+export const GIT_HEAD_SHA = 'git.commit.head_sha'
 
 // General
 export const SPAN_TYPE = 'span.type'

--- a/src/helpers/tags.ts
+++ b/src/helpers/tags.ts
@@ -35,6 +35,7 @@ export const GIT_COMMIT_MESSAGE = 'git.commit.message'
 export const GIT_SHA = 'git.commit.sha'
 export const GIT_TAG = 'git.tag'
 export const GIT_HEAD_SHA = 'git.commit.head_sha'
+export const GIT_BASE_REF = 'git.commit.base_ref'
 
 // General
 export const SPAN_TYPE = 'span.type'

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -1,5 +1,5 @@
 import {exec} from 'child_process'
-import fs, {existsSync} from 'fs'
+import fs, {existsSync, readFileSync} from 'fs'
 import {promisify} from 'util'
 
 import type {SpanTag, SpanTags} from './interfaces'
@@ -412,3 +412,24 @@ export const execute = (cmd: string, cwd?: string): Promise<{stderr: string; std
     cwd,
     maxBuffer: 5 * 1024 * 5000,
   })
+
+type GitHubWebhookPayload = {
+  pull_request: {
+    head: {
+      sha: string
+    }
+  }
+}
+
+export const getGitHeadShaFromGitHubWebhookPayload = () => {
+  if (!process.env.GITHUB_EVENT_PATH) {
+    return ''
+  }
+  try {
+    const parsedContents = JSON.parse(readFileSync(process.env.GITHUB_EVENT_PATH, 'utf8')) as GitHubWebhookPayload
+
+    return parsedContents.pull_request.head.sha
+  } catch (e) {
+    return ''
+  }
+}


### PR DESCRIPTION
### What and why?

Whenever a github action is triggered through a `pull_request` or `pull_request_target`, the `GITHUB_SHA` env var does not point to the head of the branch but to a merge commit that GH does on the spot. 

After this change, in addition to `GITHUB_SHA` we also grab `git.commit.head_sha` by reading `GITHUB_EVENT_PATH`, which is, according to [github](https://docs.github.com/en/actions/learn-github-actions/variables):

> The path to the file on the runner that contains the full event webhook payload. For example, /github/workflow/event.json.

This new tag is also passed as part of `options.pull_request_sha` in the `gate evaluate` payload. 

### How?

Read file in `process.env.GITHUB_EVENT_PATH` and grab `event.pull_request.head.sha`

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
