### PR TITLE
Fix download link for windows binaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ curl -L --fail "https://github.com/DataDog/datadog-ci/releases/latest/download/d
 #### Windows
 
 ```sh
-Invoke-WebRequest -Uri "https://github.com/DataDog/datadog-ci/releases/latest/download/datadog-ci_win-x64.exe" -OutFile "datadog-ci.exe"
+Invoke-WebRequest -Uri "https://github.com/DataDog/datadog-ci/releases/latest/download/datadog-ci_win-x64" -OutFile "datadog-ci.exe"
 ```
 
 Then, you can run `datadog-ci` commands normally:


### PR DESCRIPTION
### What and why?

Using the powershell command as given in the readme, leads to a 404 response page from github.
This is due to the fact, that the URL must not contain the *.exe* extension.

As this is somewhat of the smallest possible contribution I thought it would be okay to just send a PR for the fix instead of having a discussion on it beforehand 😉 
