### PR TITLE
[SYNTH-13898] Inform when selective re-run is rate-limited

### DIFF
--- a/src/commands/synthetics/__tests__/fixtures.ts
+++ b/src/commands/synthetics/__tests__/fixtures.ts
@@ -72,6 +72,7 @@ export const mockReporter: MainReporter = {
 export const ciConfig: RunTestsCommandConfig = {
   apiKey: '',
   appKey: '',
+  batchTimeout: 2 * 60 * 1000,
   configPath: 'datadog-ci.json',
   datadogSite: 'datadoghq.com',
   failOnCriticalErrors: false,
@@ -82,7 +83,6 @@ export const ciConfig: RunTestsCommandConfig = {
   global: {},
   defaultTestOverrides: {},
   locations: [],
-  pollingTimeout: 2 * 60 * 1000,
   proxy: {protocol: 'http'},
   publicIds: [],
   selectiveRerun: false,

--- a/src/commands/synthetics/__tests__/run-tests-lib.test.ts
+++ b/src/commands/synthetics/__tests__/run-tests-lib.test.ts
@@ -580,7 +580,7 @@ describe('run-test', () => {
       })
 
       expect(mockReporter.error).toHaveBeenCalledWith(
-        'The selective re-run feature was rate-limited. All tests will be re-run.'
+        'The selective re-run feature was rate-limited. All tests will be re-run.\n\n'
       )
     })
   })

--- a/src/commands/synthetics/__tests__/run-tests-lib.test.ts
+++ b/src/commands/synthetics/__tests__/run-tests-lib.test.ts
@@ -551,6 +551,38 @@ describe('run-test', () => {
       )
       expect(stopTunnelSpy).toHaveBeenCalledTimes(1)
     })
+
+    test('log when selective re-run is rate-limited', async () => {
+      jest.spyOn(utils, 'getTestsToTrigger').mockReturnValue(
+        Promise.resolve({
+          initialSummary: utils.createInitialSummary(),
+          overriddenTestsToTrigger: [],
+          tests: [{options: {ci: {executionRule: ExecutionRule.BLOCKING}}, public_id: 'aaa-aaa-aaa'} as any],
+        })
+      )
+      jest.spyOn(utils, 'runTests').mockImplementation(async () => ({
+        batch_id: 'bid',
+        locations: [],
+        selective_rerun_rate_limited: true,
+      }))
+
+      const apiHelper = {
+        getBatch: () => ({results: []}),
+        getTunnelPresignedURL: () => ({url: 'url'}),
+        pollResults: () => [getApiResult('1', getApiTest())],
+        triggerTests: () => mockTestTriggerResponse,
+      }
+      jest.spyOn(api, 'getApiHelper').mockImplementation(() => apiHelper as any)
+
+      await runTests.executeTests(mockReporter, {
+        ...ciConfig,
+        publicIds: ['aaa-aaa-aaa'],
+      })
+
+      expect(mockReporter.error).toHaveBeenCalledWith(
+        'The selective re-run feature was rate-limited. All tests will be re-run.'
+      )
+    })
   })
 
   describe('executeWithDetails', () => {

--- a/src/commands/synthetics/compatibility.ts
+++ b/src/commands/synthetics/compatibility.ts
@@ -50,7 +50,7 @@ export const replacePollingTimeoutWithBatchTimeout = (
 ): number | undefined => {
   // At this point, `global` should already have been moved to `defaultTestOverrides`
   const pollingTimeout = pollingTimeoutCliParam ?? config.defaultTestOverrides?.pollingTimeout ?? config.pollingTimeout
-  const isPollingTimeoutUsed = pollingTimeout !== DEFAULT_POLLING_TIMEOUT
+  const isPollingTimeoutUsed = pollingTimeout !== undefined && pollingTimeout !== DEFAULT_POLLING_TIMEOUT
 
   if (isPollingTimeoutUsed && warnDeprecatedPollingTimeout) {
     reporter.error(

--- a/src/commands/synthetics/interfaces.ts
+++ b/src/commands/synthetics/interfaces.ts
@@ -320,6 +320,7 @@ export interface LocationsMapping {
 export interface Trigger {
   batch_id: string
   locations: Location[]
+  selective_rerun_rate_limited?: boolean
 }
 
 export interface RetryConfig {

--- a/src/commands/synthetics/run-tests-lib.ts
+++ b/src/commands/synthetics/run-tests-lib.ts
@@ -149,7 +149,7 @@ export const executeTests = async (
   }
 
   if (trigger.selective_rerun_rate_limited) {
-    reporter.error('The selective re-run feature was rate-limited. All tests will be re-run.')
+    reporter.error('The selective re-run feature was rate-limited. All tests will be re-run.\n\n')
   }
 
   try {

--- a/src/commands/synthetics/run-tests-lib.ts
+++ b/src/commands/synthetics/run-tests-lib.ts
@@ -148,6 +148,10 @@ export const executeTests = async (
     throw new CriticalError('TRIGGER_TESTS_FAILED', error.message)
   }
 
+  if (trigger.selective_rerun_rate_limited) {
+    reporter.error('The selective re-run feature was rate-limited. All tests will be re-run.')
+  }
+
   try {
     // TODO SYNTH-12989: Remove the `maxPollingTimeout` calculation when `pollingTimeout` is removed
     const maxPollingTimeout = Math.max(


### PR DESCRIPTION
### What and why?

When the internal query that the selective re-run feature does is rate-limited, the endpoint still returns a 200, and re-runs all tests (ignoring the selective re-run).

In that case, the backend now returns a `selective_rerun_rate_limited` property. This PR adds a log to inform when that happens.

Demo with a rate-limit on staging:
<img width="941" alt="image" src="https://github.com/DataDog/datadog-ci/assets/9317502/bec64133-bedd-4b85-bb31-3e33fd99454f">


### How?

- Update the interface and add a log.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
