### PR TITLE
[pr-labels] Allow multiple labels on PRs

### DIFF
--- a/.github/workflows/pr-required-labels.yml
+++ b/.github/workflows/pr-required-labels.yml
@@ -18,7 +18,11 @@ jobs:
       - name: At least one label required
         uses: mheap/github-action-required-labels@v5
         with:
-          mode: exactly
+          # If a PR has multiple labels, its category in the release notes will be the first one
+          # in the `categories` list in `.github/release.yml` to match any of the PR's labels.
+          #
+          # Example: `synthetics, documentation` would be categorized as "Documentation".
+          mode: minimum
           count: 1
           labels: |
             dependencies


### PR DESCRIPTION
### What and why?

Enforcing exactly 1 label is too restrictive. For example, a PR changing the docs for one command deserves 2 labels: `documentation` and the label corresponding to the command. The PR would still be categorized as "Documentation" in the release notes.

### How?

- Change `mode: exactly` to `mode: minimum`

### Review checklist

- ~~[ ] Feature or bugfix MUST have appropriate tests (unit, integration)~~
