### PR TITLE
[SYNTH-15150] Add the rest of the missing test cases

### DIFF
--- a/src/commands/synthetics/__tests__/cli.test.ts
+++ b/src/commands/synthetics/__tests__/cli.test.ts
@@ -542,8 +542,6 @@ describe('run-test', () => {
     //
     // (config file < ENV < CLI < test file) => execute tests
 
-    // TODO: Since we have "n choose k" = "4 choose 2" = ⁴C₂ = 6 possible combinations of "A < B",
-    //       we should refactor the following 2 tests into 6 smaller tests, each testing a single override behavior.
     describe('override precedence - config file < ENV < CLI < test file', () => {
       const configFile = {
         apiKey: 'config_file_api_key',


### PR DESCRIPTION
### What and why?

- #1373 (← **you are here**)
- #1365

In a previous PR, we added missing test cases for the parameters override precedence.

> When aligning the datadog-ci variables, we realised that a lot of test cases were missing to check the parameters override precedence. This PR adds a part of the missing test cases by refactoring override from config file < ENV < CLI into smaller tests ...

In this PR, we add the rest of the missing test cases, that are: `config file < test file`, `ENV < test file ` and `CLI < test file`

### How?

- Add `config file < test file` overriding test
- Add `ENV < test file ` overriding test
- Add `CLI < test file` overriding test
- Remove the now useless `parameters override precedence: global < ENV < test file` test

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
