### PR TITLE
[SYNTH-14523] Only auto-discover with default glob when nothing given

### DIFF
--- a/src/commands/synthetics/__tests__/fixtures.ts
+++ b/src/commands/synthetics/__tests__/fixtures.ts
@@ -78,7 +78,7 @@ export const ciConfig: RunTestsCommandConfig = {
   failOnCriticalErrors: false,
   failOnMissingTests: false,
   failOnTimeout: true,
-  files: ['{,!(node_modules)/**/}*.synthetics.json'],
+  files: [],
   jUnitReport: '',
   global: {},
   defaultTestOverrides: {},

--- a/src/commands/synthetics/__tests__/run-tests-lib.test.ts
+++ b/src/commands/synthetics/__tests__/run-tests-lib.test.ts
@@ -767,12 +767,11 @@ describe('run-test', () => {
         )
       ).resolves.toEqual([
         {
-          testOverrides: {deviceIds: ['chrome.laptop_large'], startUrl, locations: ['aws:ap-northeast-1']},
+          testOverrides: {startUrl, locations},
           id: 'abc-def-ghi',
-          suite: 'Suite 1',
         },
         {
-          testOverrides: {startUrl, locations: ['aws:ap-northeast-1']},
+          testOverrides: {startUrl, locations},
           id: '123-456-789',
         },
       ])

--- a/src/commands/synthetics/run-tests-command.ts
+++ b/src/commands/synthetics/run-tests-command.ts
@@ -34,6 +34,8 @@ export const DEFAULT_BATCH_TIMEOUT = 30 * 60 * 1000
 /** @deprecated Please use `DEFAULT_BATCH_TIMEOUT` instead. */
 export const DEFAULT_POLLING_TIMEOUT = DEFAULT_BATCH_TIMEOUT
 
+export const DEFAULT_TEST_CONFIG_FILES_GLOB = '{,!(node_modules)/**/}*.synthetics.json'
+
 export const DEFAULT_COMMAND_CONFIG: RunTestsCommandConfig = {
   apiKey: '',
   appKey: '',
@@ -44,7 +46,7 @@ export const DEFAULT_COMMAND_CONFIG: RunTestsCommandConfig = {
   failOnCriticalErrors: false,
   failOnMissingTests: false,
   failOnTimeout: true,
-  files: ['{,!(node_modules)/**/}*.synthetics.json'],
+  files: [],
   // TODO SYNTH-12989: Clean up deprecated `global` in favor of `defaultTestOverrides`
   global: {},
   jUnitReport: '',

--- a/src/commands/synthetics/run-tests-lib.ts
+++ b/src/commands/synthetics/run-tests-lib.ts
@@ -23,7 +23,7 @@ import {
 } from './interfaces'
 import {DefaultReporter, getTunnelReporter} from './reporters/default'
 import {JUnitReporter} from './reporters/junit'
-import {DEFAULT_BATCH_TIMEOUT, DEFAULT_COMMAND_CONFIG} from './run-tests-command'
+import {DEFAULT_BATCH_TIMEOUT, DEFAULT_COMMAND_CONFIG, DEFAULT_TEST_CONFIG_FILES_GLOB} from './run-tests-command'
 import {getTestConfigs, getTestsFromSearchQuery} from './test'
 import {Tunnel} from './tunnel'
 import {
@@ -250,11 +250,6 @@ export const executeWithDetails = async (
   const localConfig = {
     ...DEFAULT_COMMAND_CONFIG,
     ...runConfig,
-  }
-
-  // We don't want to have default globs in case suites are given.
-  if (!runConfig.files && suites?.length) {
-    localConfig.files = []
   }
 
   // Handle reporters for the run.


### PR DESCRIPTION
### What and why?

This PR fixes a regression introduced by #1214:

- The user has tests A, B and C defined in configuration files, with specific overrides that **are important** ⚠️.
- The user relies on the auto-discovery:
  - They are omitting the `--files` argument, thus defaulting to `{,!(node_modules)/**/}*.synthetics.json`
- Just to test something locally, they want to use `--public-id A` to "focus" on test A and only run that test.

#### Before #1214

Passing a `--public-id` would disable the auto-discover → the specific overrides **would not be loaded** → the test wouldn't behave as expected ❌ 

#### After #1214

Passing a `--public-id` now keeps the auto-discover → **config files containing the specific overrides are discovered** → test A is run and configured properly ✅ 

#### The problem

Sadly, this came with a big performance impact when running `datadog-ci` from the user's home directory with just a `--public-id` parameter, because the CLI is traversing the whole disk (from the home directory).

### How?

Go back to the previous behavior, unless `--files` is set explicitly:

- Only auto-discover with the default glob if the user doesn't give any clue what to run.
- If they give `publicIds` only, we shouldn't auto-discover for performance reasons. (old behavior)
- If they give `publicIds` and `files`, then only the given `publicIds` are run and the test config files are applied on them. (keeping the intended fix from [#1214](https://github.com/DataDog/datadog-ci/pull/1214))

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
