### PR TITLE
[dep] Bump glob to `11.0.0`

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "fast-xml-parser": "^4.2.5",
     "form-data": "4.0.0",
     "fuzzy": "^0.1.3",
-    "glob": "7.1.4",
+    "glob": "^11.0.0",
     "google-auth-library": "^8.9.0",
     "inquirer": "^8.2.5",
     "inquirer-checkbox-plus-prompt": "^1.4.2",

--- a/src/commands/dsyms/__tests__/upload.test.ts
+++ b/src/commands/dsyms/__tests__/upload.test.ts
@@ -3,7 +3,7 @@ import {EOL, platform} from 'os'
 import path from 'path'
 
 import {Cli} from 'clipanion/lib/advanced'
-import glob from 'glob'
+import {glob} from 'glob'
 
 import * as APIKeyHelpers from '../../../helpers/apikey'
 import {buildPath} from '../../../helpers/utils'
@@ -308,13 +308,13 @@ describe('execute', () => {
     expect(output[4]).toContain('Will use temporary intermediate directory: ')
     expect(output[5]).toContain('Will use temporary upload directory: ')
     expect(output[6]).toContain(
-      'Uploading C8469F85-B060-3085-B69D-E46C645560EA.zip (DDTest, arch: armv7, UUID: C8469F85-B060-3085-B69D-E46C645560EA)'
+      'Uploading 3BC12422-63CC-30E8-B916-E5006CE3286C.zip (DDTest, arch: arm64, UUID: 3BC12422-63CC-30E8-B916-E5006CE3286C)'
     )
     expect(output[7]).toContain(
-      'Uploading 06EE3D68-D605-3E92-B92D-2F48C02A505E.zip (DDTest, arch: arm64, UUID: 06EE3D68-D605-3E92-B92D-2F48C02A505E)'
+      'Uploading C8469F85-B060-3085-B69D-E46C645560EA.zip (DDTest, arch: armv7, UUID: C8469F85-B060-3085-B69D-E46C645560EA)'
     )
     expect(output[8]).toContain(
-      'Uploading 3BC12422-63CC-30E8-B916-E5006CE3286C.zip (DDTest, arch: arm64, UUID: 3BC12422-63CC-30E8-B916-E5006CE3286C)'
+      'Uploading 06EE3D68-D605-3E92-B92D-2F48C02A505E.zip (DDTest, arch: arm64, UUID: 06EE3D68-D605-3E92-B92D-2F48C02A505E)'
     )
     expect(output[11]).toContain('Handled 3 dSYMs with success')
   })
@@ -334,13 +334,13 @@ describe('execute', () => {
     expect(output[4]).toContain('Will use temporary intermediate directory: ')
     expect(output[5]).toContain('Will use temporary upload directory: ')
     expect(output[6]).toContain(
-      'Uploading C8469F85-B060-3085-B69D-E46C645560EA.zip (DDTest, arch: armv7, UUID: C8469F85-B060-3085-B69D-E46C645560EA)'
+      'Uploading 3BC12422-63CC-30E8-B916-E5006CE3286C.zip (DDTest, arch: arm64, UUID: 3BC12422-63CC-30E8-B916-E5006CE3286C)'
     )
     expect(output[7]).toContain(
-      'Uploading 06EE3D68-D605-3E92-B92D-2F48C02A505E.zip (DDTest, arch: arm64, UUID: 06EE3D68-D605-3E92-B92D-2F48C02A505E)'
+      'Uploading C8469F85-B060-3085-B69D-E46C645560EA.zip (DDTest, arch: armv7, UUID: C8469F85-B060-3085-B69D-E46C645560EA)'
     )
     expect(output[8]).toContain(
-      'Uploading 3BC12422-63CC-30E8-B916-E5006CE3286C.zip (DDTest, arch: arm64, UUID: 3BC12422-63CC-30E8-B916-E5006CE3286C)'
+      'Uploading 06EE3D68-D605-3E92-B92D-2F48C02A505E.zip (DDTest, arch: arm64, UUID: 06EE3D68-D605-3E92-B92D-2F48C02A505E)'
     )
     expect(output[11]).toContain('Handled 3 dSYMs with success')
   })
@@ -362,13 +362,13 @@ describe('execute', () => {
     expect(output[4]).toContain('Will use temporary intermediate directory: ')
     expect(output[5]).toContain('Will use temporary upload directory: ')
     expect(output[6]).toContain(
-      'Uploading C8469F85-B060-3085-B69D-E46C645560EA.zip (DDTest, arch: armv7, UUID: C8469F85-B060-3085-B69D-E46C645560EA)'
+      'Uploading 3BC12422-63CC-30E8-B916-E5006CE3286C.zip (DDTest, arch: arm64, UUID: 3BC12422-63CC-30E8-B916-E5006CE3286C)'
     )
     expect(output[7]).toContain(
-      'Uploading 06EE3D68-D605-3E92-B92D-2F48C02A505E.zip (DDTest, arch: arm64, UUID: 06EE3D68-D605-3E92-B92D-2F48C02A505E)'
+      'Uploading C8469F85-B060-3085-B69D-E46C645560EA.zip (DDTest, arch: armv7, UUID: C8469F85-B060-3085-B69D-E46C645560EA)'
     )
     expect(output[8]).toContain(
-      'Uploading 3BC12422-63CC-30E8-B916-E5006CE3286C.zip (DDTest, arch: arm64, UUID: 3BC12422-63CC-30E8-B916-E5006CE3286C)'
+      'Uploading 06EE3D68-D605-3E92-B92D-2F48C02A505E.zip (DDTest, arch: arm64, UUID: 06EE3D68-D605-3E92-B92D-2F48C02A505E)'
     )
     expect(output[11]).toContain('Handled 3 dSYMs with success')
   })

--- a/src/commands/dsyms/__tests__/utils.test.ts
+++ b/src/commands/dsyms/__tests__/utils.test.ts
@@ -1,6 +1,6 @@
 import fs, {promises} from 'fs'
 
-import glob from 'glob'
+import {glob} from 'glob'
 
 import {buildPath} from '../../../helpers/utils'
 

--- a/src/commands/dsyms/upload.ts
+++ b/src/commands/dsyms/upload.ts
@@ -3,7 +3,7 @@ import path from 'path'
 
 import chalk from 'chalk'
 import {Command, Option} from 'clipanion'
-import glob from 'glob'
+import {glob} from 'glob'
 
 import {ApiKeyValidator, newApiKeyValidator} from '../../helpers/apikey'
 import {doWithMaxConcurrency} from '../../helpers/concurrency'

--- a/src/commands/elf-symbols/upload.ts
+++ b/src/commands/elf-symbols/upload.ts
@@ -1,7 +1,7 @@
 import fs from 'fs'
 
 import {Command, Option} from 'clipanion'
-import glob from 'glob'
+import {glob} from 'glob'
 
 import {newApiKeyValidator} from '../../helpers/apikey'
 import {doWithMaxConcurrency} from '../../helpers/concurrency'
@@ -178,8 +178,7 @@ export class UploadCommand extends Command {
 
     const stat = await fs.promises.stat(symbolsLocation)
     if (stat.isDirectory()) {
-      // strict: false is needed to avoid throwing an error if a directory is not readable
-      paths = glob.sync(buildPath(symbolsLocation, '**'), {dot: true, strict: false, silent: true})
+      paths = await glob(buildPath(symbolsLocation, '**'), {dot: true, dotRelative: true})
       reportFailure = (message: string) => this.context.stdout.write(renderWarning(message))
 
       // throw an error if top-level directory is not readable

--- a/src/commands/flutter-symbols/__tests__/upload.test.ts
+++ b/src/commands/flutter-symbols/__tests__/upload.test.ts
@@ -129,10 +129,10 @@ describe('flutter-symbol upload', () => {
       const files = command['getFlutterSymbolFiles'](searchDir)
 
       expect(files).toEqual([
-        `${searchDir}/app.android-arm.symbols`,
-        `${searchDir}/app.android-arm64.symbols`,
-        `${searchDir}/app.android-x64.symbols`,
         `${searchDir}/app.ios-arm64.symbols`,
+        `${searchDir}/app.android-x64.symbols`,
+        `${searchDir}/app.android-arm64.symbols`,
+        `${searchDir}/app.android-arm.symbols`,
       ])
     })
   })

--- a/src/commands/flutter-symbols/upload.ts
+++ b/src/commands/flutter-symbols/upload.ts
@@ -1,7 +1,7 @@
 import fs from 'fs'
 
 import {Command, Option} from 'clipanion'
-import glob from 'glob'
+import {glob} from 'glob'
 import yaml from 'js-yaml'
 import semver from 'semver'
 
@@ -199,7 +199,7 @@ export class UploadCommand extends Command {
   }
 
   private getFlutterSymbolFiles(dartSymbolLocation: string): string[] {
-    const symbolPaths = glob.sync(buildPath(dartSymbolLocation, '*.symbols'))
+    const symbolPaths = glob.sync(buildPath(dartSymbolLocation, '*.symbols'), {dotRelative: true})
 
     return symbolPaths
   }

--- a/src/commands/junit/__tests__/upload.test.ts
+++ b/src/commands/junit/__tests__/upload.test.ts
@@ -49,10 +49,10 @@ describe('upload', () => {
       )
 
       expect(firstFile).toMatchObject({
-        xmlPath: './src/commands/junit/__tests__/fixtures/go-report.xml',
+        xmlPath: './src/commands/junit/__tests__/fixtures/java-report.xml',
       })
       expect(secondFile).toMatchObject({
-        xmlPath: './src/commands/junit/__tests__/fixtures/java-report.xml',
+        xmlPath: './src/commands/junit/__tests__/fixtures/go-report.xml',
       })
 
       const output = context.stdout.toString()
@@ -128,10 +128,10 @@ describe('upload', () => {
         {}
       )
       expect(firstFile).toMatchObject({
-        xmlPath: './src/commands/junit/__tests__/fixtures/go-report.xml',
+        xmlPath: './src/commands/junit/__tests__/fixtures/java-report.xml',
       })
       expect(secondFile).toMatchObject({
-        xmlPath: './src/commands/junit/__tests__/fixtures/java-report.xml',
+        xmlPath: './src/commands/junit/__tests__/fixtures/go-report.xml',
       })
       expect(thirdFile).toMatchObject({
         xmlPath: './src/commands/junit/__tests__/fixtures/subfolder/js-report.xml',
@@ -154,10 +154,10 @@ describe('upload', () => {
         {}
       )
       expect(firstFile).toMatchObject({
-        xmlPath: './src/commands/junit/__tests__/fixtures/junit.xml/valid-report-2.xml',
+        xmlPath: './src/commands/junit/__tests__/fixtures/junit.xml/valid-report.xml',
       })
       expect(secondFile).toMatchObject({
-        xmlPath: './src/commands/junit/__tests__/fixtures/junit.xml/valid-report.xml',
+        xmlPath: './src/commands/junit/__tests__/fixtures/junit.xml/valid-report-2.xml',
       })
     })
     test('should not have repeated files', async () => {
@@ -268,11 +268,11 @@ describe('upload', () => {
       const fileNames = files.map((file) => file.xmlPath)
 
       expect(fileNames).toEqual([
-        'src/commands/junit/__tests__/fixtures/go-report.xml',
-        'src/commands/junit/__tests__/fixtures/java-report.xml',
-        'src/commands/junit/__tests__/fixtures/junit.xml/valid-report-2.xml',
-        'src/commands/junit/__tests__/fixtures/junit.xml/valid-report.xml',
-        'src/commands/junit/__tests__/fixtures/subfolder/js-report.xml',
+        './src/commands/junit/__tests__/fixtures/java-report.xml',
+        './src/commands/junit/__tests__/fixtures/go-report.xml',
+        './src/commands/junit/__tests__/fixtures/subfolder/js-report.xml',
+        './src/commands/junit/__tests__/fixtures/junit.xml/valid-report.xml',
+        './src/commands/junit/__tests__/fixtures/junit.xml/valid-report-2.xml',
       ])
     })
     test('should fetch nested folders and ignore non xml files', async () => {
@@ -294,11 +294,11 @@ describe('upload', () => {
       const fileNames = files.map((file) => file.xmlPath)
 
       expect(fileNames).toEqual([
-        'src/commands/junit/__tests__/fixtures/go-report.xml',
-        'src/commands/junit/__tests__/fixtures/java-report.xml',
-        'src/commands/junit/__tests__/fixtures/junit.xml/valid-report-2.xml',
-        'src/commands/junit/__tests__/fixtures/junit.xml/valid-report.xml',
-        'src/commands/junit/__tests__/fixtures/subfolder/js-report.xml',
+        './src/commands/junit/__tests__/fixtures/java-report.xml',
+        './src/commands/junit/__tests__/fixtures/go-report.xml',
+        './src/commands/junit/__tests__/fixtures/subfolder/js-report.xml',
+        './src/commands/junit/__tests__/fixtures/junit.xml/valid-report.xml',
+        './src/commands/junit/__tests__/fixtures/junit.xml/valid-report-2.xml',
       ])
     })
   })

--- a/src/commands/junit/upload.ts
+++ b/src/commands/junit/upload.ts
@@ -5,7 +5,7 @@ import path from 'path'
 import chalk from 'chalk'
 import {Command, Option} from 'clipanion'
 import {XMLParser, XMLValidator} from 'fast-xml-parser'
-import glob from 'glob'
+import {glob} from 'glob'
 import * as t from 'typanion'
 
 import {getCISpanTags} from '../../helpers/ci'
@@ -286,7 +286,9 @@ export class UploadJUnitXMLCommand extends Command {
           globPattern = buildPath(basePath, '*.xml')
         }
 
-        const filesToUpload = glob.sync(globPattern).filter((file) => path.extname(file) === '.xml')
+        const filesToUpload = glob
+          .sync(globPattern, {dotRelative: true})
+          .filter((file) => path.extname(file) === '.xml')
 
         return acc.concat(filesToUpload)
       }, [])

--- a/src/commands/sarif/__tests__/upload.test.ts
+++ b/src/commands/sarif/__tests__/upload.test.ts
@@ -59,11 +59,11 @@ describe('upload', () => {
 
       expect(firstFile).toMatchObject({
         service: 'service',
-        reportPath: './src/commands/sarif/__tests__/fixtures/valid-no-results.sarif',
+        reportPath: './src/commands/sarif/__tests__/fixtures/valid-results.sarif',
       })
       expect(secondFile).toMatchObject({
         service: 'service',
-        reportPath: './src/commands/sarif/__tests__/fixtures/valid-results.sarif',
+        reportPath: './src/commands/sarif/__tests__/fixtures/valid-no-results.sarif',
       })
 
       const getInvalidJsonUnexpectedTokenErrorMessage = () => {
@@ -146,11 +146,11 @@ describe('upload', () => {
       )
       expect(firstFile).toMatchObject({
         service: 'service',
-        reportPath: './src/commands/sarif/__tests__/fixtures/valid-no-results.sarif',
+        reportPath: './src/commands/sarif/__tests__/fixtures/valid-results.sarif',
       })
       expect(secondFile).toMatchObject({
         service: 'service',
-        reportPath: './src/commands/sarif/__tests__/fixtures/valid-results.sarif',
+        reportPath: './src/commands/sarif/__tests__/fixtures/valid-no-results.sarif',
       })
       expect(thirdFile).toMatchObject({
         service: 'service',

--- a/src/commands/sarif/upload.ts
+++ b/src/commands/sarif/upload.ts
@@ -7,7 +7,7 @@ import Ajv from 'ajv'
 import addFormats from 'ajv-formats'
 import chalk from 'chalk'
 import {Command, Option} from 'clipanion'
-import glob from 'glob'
+import {glob} from 'glob'
 
 import {doWithMaxConcurrency} from '../../helpers/concurrency'
 import {DatadogCiConfig} from '../../helpers/config'
@@ -195,7 +195,7 @@ export class UploadSarifReportCommand extends Command {
         return acc.concat(fs.existsSync(basePath) ? [basePath] : [])
       }
 
-      return acc.concat(glob.sync(buildPath(basePath, '*.sarif')))
+      return acc.concat(glob.sync(buildPath(basePath, '*.sarif'), {dotRelative: true}))
     }, [])
 
     const validUniqueFiles = [...new Set(sarifReports)].filter((sarifReport) => {

--- a/src/commands/sourcemaps/upload.ts
+++ b/src/commands/sourcemaps/upload.ts
@@ -3,7 +3,7 @@ import {URL} from 'url'
 
 import chalk from 'chalk'
 import {Command, Option} from 'clipanion'
-import glob from 'glob'
+import {glob} from 'glob'
 
 import {ApiKeyValidator, newApiKeyValidator} from '../../helpers/apikey'
 import {getBaseSourcemapIntakeUrl} from '../../helpers/base-intake-url'

--- a/src/commands/synthetics/__tests__/utils/public.test.ts
+++ b/src/commands/synthetics/__tests__/utils/public.test.ts
@@ -46,7 +46,7 @@ import type * as path from 'path'
 
 import {default as axios} from 'axios'
 import deepExtend from 'deep-extend'
-import glob from 'glob'
+import {glob} from 'glob'
 
 process.env.DATADOG_SYNTHETICS_CI_TRIGGER_APP = 'env_default'
 
@@ -112,10 +112,10 @@ describe('utils', () => {
       file2: '{"tests":"file2"}',
     }
 
+    jest.spyOn(glob, 'glob').mockResolvedValue(FILES)
     ;(fs.readFile as any).mockImplementation((path: 'file1' | 'file2', opts: any, callback: any) =>
       callback(undefined, FILES_CONTENT[path])
     )
-    ;(glob as any).mockImplementation((query: string, callback: (e: any, v: any) => void) => callback(undefined, FILES))
     ;(child_process.exec as any).mockImplementation(
       (command: string, callback: (error: any, stdout: string, stderr: string) => void) => callback(undefined, '.', '')
     )

--- a/src/commands/synthetics/utils/public.ts
+++ b/src/commands/synthetics/utils/public.ts
@@ -5,7 +5,7 @@ import process from 'process'
 import {promisify} from 'util'
 
 import chalk from 'chalk'
-import glob from 'glob'
+import {glob} from 'glob'
 
 import {getCommonAppBaseURL} from '../../../helpers/app'
 import {getCIMetadata} from '../../../helpers/ci'
@@ -238,7 +238,7 @@ export const getResultOutcome = (result: Result): ResultOutcome => {
 export const getSuites = async (GLOB: string, reporter: MainReporter): Promise<Suite[]> => {
   reporter.log(`Finding files matching ${path.resolve(process.cwd(), GLOB)}\n`)
 
-  const files: string[] = await promisify(glob)(GLOB)
+  const files: string[] = await glob(GLOB)
   if (files.length) {
     reporter.log(`\nGot test files:\n${files.map((file) => `  - ${file}\n`).join('')}\n`)
   } else {

--- a/src/commands/unity-symbols/__tests__/upload.test.ts
+++ b/src/commands/unity-symbols/__tests__/upload.test.ts
@@ -231,11 +231,11 @@ describe('unity-symbols upload', () => {
       expect(errorOutput).toBe(renderMissingDir(`${fixtureDir}/missing-dir`))
     })
 
-    const getExpectedMetadata = (arch: string, gitCommitSha?: string, gitRespositoryUrl?: string) => ({
+    const getExpectedMetadata = (arch: string, gitCommitSha?: string, gitRepositoryUrl?: string) => ({
       arch,
       cli_version: cliVersion,
       ...(gitCommitSha && {git_commit_sha: gitCommitSha}),
-      ...(gitRespositoryUrl && {git_repository_url: gitRespositoryUrl}),
+      ...(gitRepositoryUrl && {git_repository_url: gitRepositoryUrl}),
       build_id: 'fake-build-id',
       type: 'ndk_symbol_file',
     })

--- a/src/commands/unity-symbols/upload.ts
+++ b/src/commands/unity-symbols/upload.ts
@@ -2,7 +2,7 @@ import fs from 'fs'
 import path, {basename} from 'path'
 
 import {Command, Option} from 'clipanion'
-import glob from 'glob'
+import {glob} from 'glob'
 
 import {newApiKeyValidator} from '../../helpers/apikey'
 import {doWithMaxConcurrency} from '../../helpers/concurrency'

--- a/yarn.lock
+++ b/yarn.lock
@@ -1944,7 +1944,7 @@ __metadata:
     fast-xml-parser: ^4.2.5
     form-data: 4.0.0
     fuzzy: ^0.1.3
-    glob: 7.1.4
+    glob: ^11.0.0
     google-auth-library: ^8.9.0
     inquirer: ^8.2.5
     inquirer-checkbox-plus-prompt: ^1.4.2
@@ -6481,20 +6481,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"glob@npm:7.1.4":
-  version: 7.1.4
-  resolution: "glob@npm:7.1.4"
-  dependencies:
-    fs.realpath: ^1.0.0
-    inflight: ^1.0.4
-    inherits: 2
-    minimatch: ^3.0.4
-    once: ^1.3.0
-    path-is-absolute: ^1.0.0
-  checksum: f52480fc82b1e66e52990f0f2e7306447d12294c83fbbee0395e761ad1178172012a7cc0673dbf4810baac400fc09bf34484c08b5778c216403fd823db281716
-  languageName: node
-  linkType: hard
-
 "glob@npm:^10.2.2, glob@npm:^10.3.10":
   version: 10.3.10
   resolution: "glob@npm:10.3.10"
@@ -6507,6 +6493,22 @@ __metadata:
   bin:
     glob: dist/esm/bin.mjs
   checksum: 4f2fe2511e157b5a3f525a54092169a5f92405f24d2aed3142f4411df328baca13059f4182f1db1bf933e2c69c0bd89e57ae87edd8950cba8c7ccbe84f721cf3
+  languageName: node
+  linkType: hard
+
+"glob@npm:^11.0.0":
+  version: 11.0.0
+  resolution: "glob@npm:11.0.0"
+  dependencies:
+    foreground-child: ^3.1.0
+    jackspeak: ^4.0.1
+    minimatch: ^10.0.0
+    minipass: ^7.1.2
+    package-json-from-dist: ^1.0.0
+    path-scurry: ^2.0.0
+  bin:
+    glob: dist/esm/bin.mjs
+  checksum: 8a2dd914d5776987be5244624d9491bbcaf19f2387e06783737003ff696ebfd2264190c47014f8709c1c02d8bc892f17660cf986c587b107e194c0a3151ab333
   languageName: node
   linkType: hard
 
@@ -7349,6 +7351,19 @@ __metadata:
     "@pkgjs/parseargs":
       optional: true
   checksum: 57d43ad11eadc98cdfe7496612f6bbb5255ea69fe51ea431162db302c2a11011642f50cfad57288bd0aea78384a0612b16e131944ad8ecd09d619041c8531b54
+  languageName: node
+  linkType: hard
+
+"jackspeak@npm:^4.0.1":
+  version: 4.0.1
+  resolution: "jackspeak@npm:4.0.1"
+  dependencies:
+    "@isaacs/cliui": ^8.0.2
+    "@pkgjs/parseargs": ^0.11.0
+  dependenciesMeta:
+    "@pkgjs/parseargs":
+      optional: true
+  checksum: 7989d19eddeff0631ef653df413e26290db77dc3791438bd12b56bed1c0b24d5d535fdfec13cf35775cd5b47f8ee57d36fd0bceaf2df672b1f523533fd4184cc
   languageName: node
   linkType: hard
 
@@ -8230,6 +8245,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lru-cache@npm:^11.0.0":
+  version: 11.0.0
+  resolution: "lru-cache@npm:11.0.0"
+  checksum: c29385f9369b1a566e1db9eda9a4b12f6507de906e5720ca12844dd775b7139c42b8e5837e7d5162bcc292ce4d3eecfa74ec2856c6afcc0caa2e3c9ea3a17f27
+  languageName: node
+  linkType: hard
+
 "lru-cache@npm:^5.1.1":
   version: 5.1.1
   resolution: "lru-cache@npm:5.1.1"
@@ -8360,6 +8382,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"minimatch@npm:^10.0.0":
+  version: 10.0.1
+  resolution: "minimatch@npm:10.0.1"
+  dependencies:
+    brace-expansion: ^2.0.1
+  checksum: f5b63c2f30606091a057c5f679b067f84a2cd0ffbd2dbc9143bda850afd353c7be81949ff11ae0c86988f07390eeca64efd7143ee05a0dab37f6c6b38a2ebb6c
+  languageName: node
+  linkType: hard
+
 "minimatch@npm:^3.0.4, minimatch@npm:^3.0.5, minimatch@npm:^3.1.1, minimatch@npm:^3.1.2":
   version: 3.1.2
   resolution: "minimatch@npm:3.1.2"
@@ -8456,6 +8487,13 @@ __metadata:
   version: 7.0.4
   resolution: "minipass@npm:7.0.4"
   checksum: 87585e258b9488caf2e7acea242fd7856bbe9a2c84a7807643513a338d66f368c7d518200ad7b70a508664d408aa000517647b2930c259a8b1f9f0984f344a21
+  languageName: node
+  linkType: hard
+
+"minipass@npm:^7.1.2":
+  version: 7.1.2
+  resolution: "minipass@npm:7.1.2"
+  checksum: 2bfd325b95c555f2b4d2814d49325691c7bee937d753814861b0b49d5edcda55cbbf22b6b6a60bb91eddac8668771f03c5ff647dcd9d0f798e9548b9cdc46ee3
   languageName: node
   linkType: hard
 
@@ -8987,6 +9025,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"package-json-from-dist@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "package-json-from-dist@npm:1.0.0"
+  checksum: ac706ec856a5a03f5261e4e48fa974f24feb044d51f84f8332e2af0af04fbdbdd5bbbfb9cbbe354190409bc8307c83a9e38c6672c3c8855f709afb0006a009ea
+  languageName: node
+  linkType: hard
+
 "pako@npm:~1.0.2":
   version: 1.0.11
   resolution: "pako@npm:1.0.11"
@@ -9050,6 +9095,16 @@ __metadata:
     lru-cache: ^9.1.1 || ^10.0.0
     minipass: ^5.0.0 || ^6.0.2 || ^7.0.0
   checksum: e2557cff3a8fb8bc07afdd6ab163a92587884f9969b05bbbaf6fe7379348bfb09af9ed292af12ed32398b15fb443e81692047b786d1eeb6d898a51eb17ed7d90
+  languageName: node
+  linkType: hard
+
+"path-scurry@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "path-scurry@npm:2.0.0"
+  dependencies:
+    lru-cache: ^11.0.0
+    minipass: ^7.1.2
+  checksum: 9953ce3857f7e0796b187a7066eede63864b7e1dfc14bf0484249801a5ab9afb90d9a58fc533ebb1b552d23767df8aa6a2c6c62caf3f8a65f6ce336a97bbb484
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### What and why?

Related to https://github.com/DataDog/datadog-ci/issues/1378

### How?

Differences with the old version:
- The algorithm was rewritten, and the order of results has changed
- A `dotRelative` option was added to keep `./`: https://github.com/isaacs/node-glob/issues/495
- The `silent` and `strict` options were removed:
  > Any readdir errors are simply treated as "the directory could not be read", and it is treated as a normal file entry instead, like shells do. (see [changelog.md](https://github.com/isaacs/node-glob/blob/main/changelog.md#90))

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
