### PR TITLE
v2.40.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci",
-  "version": "2.40.0",
+  "version": "2.40.1",
   "description": "Run datadog actions from the CI.",
   "repository": "https://github.com/DataDog/datadog-ci",
   "license": "Apache-2.0",


### PR DESCRIPTION
## What's Changed
### CI Visibility
* Fix a bug on the `trace` command where the reporting URL was incorrect in some datadog sites. https://github.com/DataDog/datadog-ci/pull/1387

**Full Changelog**: https://github.com/DataDog/datadog-ci/compare/v2.40.0...v2.40.1