### PR TITLE
[dep] Bump fast-xml-parser to `4.4.1`

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "@types/retry": "0.12.0",
     "aws-sdk-client-mock": "2.1.1",
     "aws-sdk-client-mock-jest": "2.1.1",
-    "fast-xml-parser@npm:4.2.4": "4.2.5",
     "ini": "1.3.7",
     "kind-of@^6.0.0": "6.0.3"
   },
@@ -87,7 +86,7 @@
     "datadog-metrics": "0.9.3",
     "deep-extend": "0.6.0",
     "deep-object-diff": "^1.1.9",
-    "fast-xml-parser": "^4.2.5",
+    "fast-xml-parser": "^4.4.1",
     "form-data": "4.0.0",
     "fuzzy": "^0.1.3",
     "glob": "^11.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1940,7 +1940,7 @@ __metadata:
     eslint-plugin-no-null: ^1.0.2
     eslint-plugin-prefer-arrow: ^1.2.3
     eslint-plugin-prettier: 4.0.0
-    fast-xml-parser: ^4.2.5
+    fast-xml-parser: ^4.4.1
     form-data: 4.0.0
     fuzzy: ^0.1.3
     glob: ^11.0.0
@@ -6033,14 +6033,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-xml-parser@npm:^4.2.5":
-  version: 4.3.6
-  resolution: "fast-xml-parser@npm:4.3.6"
+"fast-xml-parser@npm:^4.4.1":
+  version: 4.4.1
+  resolution: "fast-xml-parser@npm:4.4.1"
   dependencies:
     strnum: ^1.0.5
   bin:
     fxparser: src/cli/cli.js
-  checksum: 12795c55f4564699c3cee13f7e892423244ac1125775e9b85bf948a1d4b65352da8f688d334bad530972288bb7ee0cf3d2605088d475123fce40d95003f045fa
+  checksum: f440c01cd141b98789ae777503bcb6727393296094cc82924ae9f88a5b971baa4eec7e65306c7e07746534caa661fc83694ff437d9012dc84dee39dfbfaab947
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### What and why?

Fixes https://github.com/DataDog/datadog-ci/security/dependabot/44

### How?

Bump the `fast-xml-parser` dependency.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
