### PR TITLE
[Synthetics] Hint the user on the missing scope in case of error

### DIFF
--- a/src/commands/synthetics/__tests__/api.test.ts
+++ b/src/commands/synthetics/__tests__/api.test.ts
@@ -508,4 +508,11 @@ describe('formatBackendErrors', () => {
     const requestError = getAxiosHttpError(403, {message: 'Forbidden'})
     expect(formatBackendErrors(requestError)).toBe('could not query https://app.datadoghq.com/example\nForbidden')
   })
+
+  test('missing scope error', () => {
+    const requestError = getAxiosHttpError(403, {errors: ['Forbidden', 'Failed permission authorization checks']})
+    expect(formatBackendErrors(requestError, 'synthetics_default_settings_read')).toBe(
+      'query on https://app.datadoghq.com/example returned:\n  - Forbidden\n  - Failed permission authorization checks\nIs the APP key granted the synthetics_default_settings_read scope?'
+    )
+  })
 })

--- a/src/commands/synthetics/__tests__/api.test.ts
+++ b/src/commands/synthetics/__tests__/api.test.ts
@@ -512,7 +512,7 @@ describe('formatBackendErrors', () => {
   test('missing scope error', () => {
     const requestError = getAxiosHttpError(403, {errors: ['Forbidden', 'Failed permission authorization checks']})
     expect(formatBackendErrors(requestError, 'synthetics_default_settings_read')).toBe(
-      'query on https://app.datadoghq.com/example returned:\n  - Forbidden\n  - Failed permission authorization checks\nIs the APP key granted the synthetics_default_settings_read scope?'
+      'query on https://app.datadoghq.com/example returned:\n  - Forbidden\n  - Failed permission authorization checks\nIs the App key granted the synthetics_default_settings_read scope?'
     )
   })
 })

--- a/src/commands/synthetics/api.ts
+++ b/src/commands/synthetics/api.ts
@@ -59,7 +59,7 @@ export const formatBackendErrors = (requestError: AxiosError<BackendError>, scop
     }
 
     if (requestError.response.status === 403 && scopeName) {
-      reportMessage.push(`Is the APP key granted the ${scopeName} scope?`)
+      reportMessage.push(`Is the App key granted the ${scopeName} scope?`)
     }
 
     return reportMessage.join('\n')

--- a/src/commands/synthetics/utils/public.ts
+++ b/src/commands/synthetics/utils/public.ts
@@ -290,7 +290,7 @@ export const getOrgSettings = async (
   try {
     return await apiHelper.getSyntheticsOrgSettings()
   } catch (e) {
-    reporter.error(`Failed to get settings: ${formatBackendErrors(e)}`)
+    reporter.error(`Failed to get settings: ${formatBackendErrors(e, 'synthetics_default_settings_read')}`)
   }
 }
 


### PR DESCRIPTION
### What and why?

An [issue](https://github.com/DataDog/datadog-ci/issues/1159) was opened because the right scope to grant an App key wasn't clear.
This PR adds an hint when the App key is missing the `synthetics_default_settings_read` scope, when reading the max parallelisation. It also introduces the possibility to provide hints for other queries.

### How?

Add a line to the error message mentioning the hint from the failed query.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
