### PR TITLE
v2.40.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci",
-  "version": "2.40.1",
+  "version": "2.40.2",
   "description": "Run datadog actions from the CI.",
   "repository": "https://github.com/DataDog/datadog-ci",
   "license": "Apache-2.0",


### PR DESCRIPTION
<!-- Release notes generated using configuration in .github/release.yml at v2.40.2 -->

## What's Changed
### Dependencies
* [dep] Bump glob to `11.0.0` by @Drarig29 in https://github.com/DataDog/datadog-ci/pull/1381
* [dep] Bump rimraf to `6.0.1` by @Drarig29 in https://github.com/DataDog/datadog-ci/pull/1382
* [dep] Bump fast-xml-parser to `4.4.1` by @Drarig29 in https://github.com/DataDog/datadog-ci/pull/1392
### Documentation
* [SYNTH-12979] Document the use of proxy by @teodor2312 in https://github.com/DataDog/datadog-ci/pull/1384
### CI Visibility
* [ci-visibility] Fix bug on trace command URL by @rodrigo-roca in https://github.com/DataDog/datadog-ci/pull/1387
### Synthetics
* [SYNTH-14523] Only auto-discover with default glob when nothing given by @Drarig29 in https://github.com/DataDog/datadog-ci/pull/1377
* [Synthetics] Hint the user on the missing scope in case of error by @etnbrd in https://github.com/DataDog/datadog-ci/pull/1393


**Full Changelog**: https://github.com/DataDog/datadog-ci/compare/v2.40.1...v2.40.2

[SYNTH-12979]: https://datadoghq.atlassian.net/browse/SYNTH-12979?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SYNTH-14523]: https://datadoghq.atlassian.net/browse/SYNTH-14523?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ