### PR TITLE
[SYNTH-15675] Fix bug where timed out retries are not reported

### DIFF
--- a/src/commands/synthetics/__tests__/utils/public.test.ts
+++ b/src/commands/synthetics/__tests__/utils/public.test.ts
@@ -841,6 +841,7 @@ describe('utils', () => {
       selectiveRerun: undefined,
       test: apiTest,
       timedOut: false,
+      timedOutRetry: false,
       timestamp: 0,
     }
     const pollResult: PollResult = {
@@ -1314,7 +1315,7 @@ describe('utils', () => {
         'bid'
       )
       expect(mockReporter.error).toHaveBeenCalledWith(
-        'The full information for result rid was incomplete at the end of the batch.\n\n'
+        'The information for result rid of test pid was incomplete at the end of the batch.\n\n'
       )
 
       // Do not report when there are no tests to wait anymore
@@ -1366,11 +1367,12 @@ describe('utils', () => {
         ...result,
         result: {
           ...result.result,
-          failure: {code: 'TIMEOUT', message: 'The batch timed out before receiving the result.'},
+          failure: {code: 'TIMEOUT', message: 'The batch timed out before receiving the retry.'},
           passed: false,
         },
         resultId: '3',
         timedOut: true,
+        timedOutRetry: true,
       }
 
       expect(
@@ -1492,10 +1494,11 @@ describe('utils', () => {
           ...result,
           result: {
             ...result.result,
-            failure: {code: 'TIMEOUT', message: 'The batch timed out before receiving the result.'},
+            failure: {code: 'TIMEOUT', message: 'The batch timed out before receiving the retry.'},
             passed: false,
           },
           timedOut: true,
+          timedOutRetry: true,
         },
       ])
     })
@@ -1526,10 +1529,11 @@ describe('utils', () => {
           ...result,
           result: {
             ...result.result,
-            failure: {code: 'TIMEOUT', message: 'The batch timed out before receiving the result.'},
+            failure: {code: 'TIMEOUT', message: 'The batch timed out before receiving the retry.'},
             passed: false,
           },
           timedOut: true,
+          timedOutRetry: true,
         },
       ])
     })
@@ -1599,12 +1603,13 @@ describe('utils', () => {
           ...result,
           passed: true, // because `failOnTimeout` is false
           timedOut: true,
+          timedOutRetry: true,
           resultId: pollTimeoutResult.resultID,
           result: {
             ...result.result,
             failure: {
               code: 'TIMEOUT',
-              message: 'The batch timed out before receiving the result.',
+              message: 'The batch timed out before receiving the retry.',
             },
             passed: false,
           },

--- a/src/commands/synthetics/batch.ts
+++ b/src/commands/synthetics/batch.ts
@@ -113,6 +113,8 @@ const getResultsToReport = (
     .filter((r) => isResultInBatchSkippedBySelectiveRerun(r) || !incompleteResultIds.has(r.result_id))
     .concat(newlyCompleteResults)
 
+  const resultIdsToReport = new Set(getResultIds(resultsToReport))
+
   if (shouldContinuePolling) {
     return resultsToReport
   }
@@ -122,7 +124,10 @@ const getResultsToReport = (
   //  - Still incomplete (the poll results endpoint didn't find it): log a warning and report with incomplete data
   //  - Timed out although fast retries were configured: log a warning and report with incomplete data
   const residualResults = excludeSkipped(batch.results).filter(
-    (r) => !emittedResultIds.has(r.result_id) || incompleteResultIds.has(r.result_id) || isTimedOutRetry(r)
+    (r) =>
+      !emittedResultIds.has(r.result_id) ||
+      incompleteResultIds.has(r.result_id) ||
+      (!resultIdsToReport.has(r.result_id) && isTimedOutRetry(r))
   )
 
   const errors: string[] = []

--- a/src/commands/synthetics/interfaces.ts
+++ b/src/commands/synthetics/interfaces.ts
@@ -140,6 +140,7 @@ export interface BaseResult {
   test: Test
   timedOut: boolean
   timestamp: number
+  timedOutRetry?: boolean
 }
 
 // Inside this type, `.resultId` is a linked result ID from a previous batch.

--- a/src/commands/synthetics/reporters/default.ts
+++ b/src/commands/synthetics/reporters/default.ts
@@ -220,7 +220,9 @@ const renderExecutionResult = (test: Test, execution: Result, baseUrl: string, b
 
   const outputLines = [resultIdentification]
 
-  // Unhealthy test results don't have a duration or result URL
+  // Unhealthy test results don't have a duration or result URL.
+  // On the other hand, timed out retries still have the data from the last received result,
+  // so we don't show the duration or result URL to avoid confusion.
   if (hasResult(execution) && !execution.result.unhealthy && !execution.timedOutRetry) {
     const duration = getResultDuration(execution.result)
     const durationText = duration ? ` Total duration: ${duration} ms -` : ''
@@ -276,6 +278,7 @@ const getAttemptSuffix = (passed: boolean, retries: number, test: Test, timedOut
   }
 
   if (timedOutRetry) {
+    // The attempt number of the last received result + 1, in order to refer to the retry.
     return ` (attempt ${currentAttempt + 1} of ${maxAttempts})`
   }
 

--- a/src/commands/synthetics/utils/internal.ts
+++ b/src/commands/synthetics/utils/internal.ts
@@ -30,13 +30,23 @@ export const hasResult = (result: Result): result is BaseResult => {
 }
 
 /**
- * Most properties (like `retries`) are populated by the backend as soon as we receive a result, even if it's a non-final result.
- *
- * If the test is configured to be retried and the first attempt fails,
- * `retries` is set to `0` and the result is kept `in_progress` until the final result is received.
+ * When the test is configured to be retried and the first attempt fails, `retries` is set to `0`
+ * and the result is kept `in_progress` until the final result is received.
  */
-export const hasRetries = (result: ResultInBatch): result is ResultInBatch & {retries: number} => {
+const hasRetries = (result: ResultInBatch): result is ResultInBatch & {retries: number} => {
   return Number.isInteger(result.retries)
+}
+
+export const isNonFinalResult = (
+  result: ResultInBatch
+): result is ResultInBatch & {retries: number; status: 'in_progress'} => {
+  return hasRetries(result) && result.status === 'in_progress'
+}
+
+export const isTimedOutRetry = (
+  result: ResultInBatch
+): result is ResultInBatch & {retries: number; timed_out: true} => {
+  return hasRetries(result) && !!result.timed_out
 }
 
 export const isResultInBatchSkippedBySelectiveRerun = (


### PR DESCRIPTION
### What and why?

We recently discovered a bug where timed out fast retries were not reported as fast retries. This lead to `executeTests` exiting without the reporter spinner being stopped.

This was due to the fact that `getResultsToReport` didn’t handle still non-final results after the end of a batch, resulting in an empty `resultsToReport` array. This PR patches this issue.

### How?

- Add the still non-final fast retry results to the `residualResults` 

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
