### PR TITLE
Revert "[dep] Bump glob to `11.0.0` (#1381)"

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "fast-xml-parser": "^4.4.1",
     "form-data": "4.0.0",
     "fuzzy": "^0.1.3",
-    "glob": "^11.0.0",
+    "glob": "^7.1.4",
     "google-auth-library": "^9.12.0",
     "inquirer": "^8.2.5",
     "inquirer-checkbox-plus-prompt": "^1.4.2",

--- a/src/commands/dsyms/__tests__/upload.test.ts
+++ b/src/commands/dsyms/__tests__/upload.test.ts
@@ -3,7 +3,7 @@ import {EOL, platform} from 'os'
 import path from 'path'
 
 import {Cli} from 'clipanion/lib/advanced'
-import {glob} from 'glob'
+import glob from 'glob'
 
 import * as APIKeyHelpers from '../../../helpers/apikey'
 import {buildPath} from '../../../helpers/utils'
@@ -308,13 +308,13 @@ describe('execute', () => {
     expect(output[4]).toContain('Will use temporary intermediate directory: ')
     expect(output[5]).toContain('Will use temporary upload directory: ')
     expect(output[6]).toContain(
-      'Uploading 3BC12422-63CC-30E8-B916-E5006CE3286C.zip (DDTest, arch: arm64, UUID: 3BC12422-63CC-30E8-B916-E5006CE3286C)'
-    )
-    expect(output[7]).toContain(
       'Uploading C8469F85-B060-3085-B69D-E46C645560EA.zip (DDTest, arch: armv7, UUID: C8469F85-B060-3085-B69D-E46C645560EA)'
     )
-    expect(output[8]).toContain(
+    expect(output[7]).toContain(
       'Uploading 06EE3D68-D605-3E92-B92D-2F48C02A505E.zip (DDTest, arch: arm64, UUID: 06EE3D68-D605-3E92-B92D-2F48C02A505E)'
+    )
+    expect(output[8]).toContain(
+      'Uploading 3BC12422-63CC-30E8-B916-E5006CE3286C.zip (DDTest, arch: arm64, UUID: 3BC12422-63CC-30E8-B916-E5006CE3286C)'
     )
     expect(output[11]).toContain('Handled 3 dSYMs with success')
   })
@@ -334,13 +334,13 @@ describe('execute', () => {
     expect(output[4]).toContain('Will use temporary intermediate directory: ')
     expect(output[5]).toContain('Will use temporary upload directory: ')
     expect(output[6]).toContain(
-      'Uploading 3BC12422-63CC-30E8-B916-E5006CE3286C.zip (DDTest, arch: arm64, UUID: 3BC12422-63CC-30E8-B916-E5006CE3286C)'
-    )
-    expect(output[7]).toContain(
       'Uploading C8469F85-B060-3085-B69D-E46C645560EA.zip (DDTest, arch: armv7, UUID: C8469F85-B060-3085-B69D-E46C645560EA)'
     )
-    expect(output[8]).toContain(
+    expect(output[7]).toContain(
       'Uploading 06EE3D68-D605-3E92-B92D-2F48C02A505E.zip (DDTest, arch: arm64, UUID: 06EE3D68-D605-3E92-B92D-2F48C02A505E)'
+    )
+    expect(output[8]).toContain(
+      'Uploading 3BC12422-63CC-30E8-B916-E5006CE3286C.zip (DDTest, arch: arm64, UUID: 3BC12422-63CC-30E8-B916-E5006CE3286C)'
     )
     expect(output[11]).toContain('Handled 3 dSYMs with success')
   })
@@ -362,13 +362,13 @@ describe('execute', () => {
     expect(output[4]).toContain('Will use temporary intermediate directory: ')
     expect(output[5]).toContain('Will use temporary upload directory: ')
     expect(output[6]).toContain(
-      'Uploading 3BC12422-63CC-30E8-B916-E5006CE3286C.zip (DDTest, arch: arm64, UUID: 3BC12422-63CC-30E8-B916-E5006CE3286C)'
-    )
-    expect(output[7]).toContain(
       'Uploading C8469F85-B060-3085-B69D-E46C645560EA.zip (DDTest, arch: armv7, UUID: C8469F85-B060-3085-B69D-E46C645560EA)'
     )
-    expect(output[8]).toContain(
+    expect(output[7]).toContain(
       'Uploading 06EE3D68-D605-3E92-B92D-2F48C02A505E.zip (DDTest, arch: arm64, UUID: 06EE3D68-D605-3E92-B92D-2F48C02A505E)'
+    )
+    expect(output[8]).toContain(
+      'Uploading 3BC12422-63CC-30E8-B916-E5006CE3286C.zip (DDTest, arch: arm64, UUID: 3BC12422-63CC-30E8-B916-E5006CE3286C)'
     )
     expect(output[11]).toContain('Handled 3 dSYMs with success')
   })

--- a/src/commands/dsyms/__tests__/utils.test.ts
+++ b/src/commands/dsyms/__tests__/utils.test.ts
@@ -1,6 +1,6 @@
 import fs, {promises} from 'fs'
 
-import {glob} from 'glob'
+import glob from 'glob'
 
 import {buildPath} from '../../../helpers/utils'
 

--- a/src/commands/dsyms/upload.ts
+++ b/src/commands/dsyms/upload.ts
@@ -3,7 +3,7 @@ import path from 'path'
 
 import chalk from 'chalk'
 import {Command, Option} from 'clipanion'
-import {glob} from 'glob'
+import glob from 'glob'
 
 import {ApiKeyValidator, newApiKeyValidator} from '../../helpers/apikey'
 import {doWithMaxConcurrency} from '../../helpers/concurrency'

--- a/src/commands/elf-symbols/upload.ts
+++ b/src/commands/elf-symbols/upload.ts
@@ -1,7 +1,7 @@
 import fs from 'fs'
 
 import {Command, Option} from 'clipanion'
-import {glob} from 'glob'
+import glob from 'glob'
 
 import {newApiKeyValidator} from '../../helpers/apikey'
 import {doWithMaxConcurrency} from '../../helpers/concurrency'
@@ -178,7 +178,8 @@ export class UploadCommand extends Command {
 
     const stat = await fs.promises.stat(symbolsLocation)
     if (stat.isDirectory()) {
-      paths = await glob(buildPath(symbolsLocation, '**'), {dot: true, dotRelative: true})
+      // strict: false is needed to avoid throwing an error if a directory is not readable
+      paths = glob.sync(buildPath(symbolsLocation, '**'), {dot: true, strict: false, silent: true})
       reportFailure = (message: string) => this.context.stdout.write(renderWarning(message))
 
       // throw an error if top-level directory is not readable

--- a/src/commands/flutter-symbols/__tests__/upload.test.ts
+++ b/src/commands/flutter-symbols/__tests__/upload.test.ts
@@ -129,10 +129,10 @@ describe('flutter-symbol upload', () => {
       const files = command['getFlutterSymbolFiles'](searchDir)
 
       expect(files).toEqual([
-        `${searchDir}/app.ios-arm64.symbols`,
-        `${searchDir}/app.android-x64.symbols`,
-        `${searchDir}/app.android-arm64.symbols`,
         `${searchDir}/app.android-arm.symbols`,
+        `${searchDir}/app.android-arm64.symbols`,
+        `${searchDir}/app.android-x64.symbols`,
+        `${searchDir}/app.ios-arm64.symbols`,
       ])
     })
   })

--- a/src/commands/flutter-symbols/upload.ts
+++ b/src/commands/flutter-symbols/upload.ts
@@ -1,7 +1,7 @@
 import fs from 'fs'
 
 import {Command, Option} from 'clipanion'
-import {glob} from 'glob'
+import glob from 'glob'
 import yaml from 'js-yaml'
 import semver from 'semver'
 
@@ -199,7 +199,7 @@ export class UploadCommand extends Command {
   }
 
   private getFlutterSymbolFiles(dartSymbolLocation: string): string[] {
-    const symbolPaths = glob.sync(buildPath(dartSymbolLocation, '*.symbols'), {dotRelative: true})
+    const symbolPaths = glob.sync(buildPath(dartSymbolLocation, '*.symbols'))
 
     return symbolPaths
   }

--- a/src/commands/junit/__tests__/upload.test.ts
+++ b/src/commands/junit/__tests__/upload.test.ts
@@ -49,10 +49,10 @@ describe('upload', () => {
       )
 
       expect(firstFile).toMatchObject({
-        xmlPath: './src/commands/junit/__tests__/fixtures/java-report.xml',
+        xmlPath: './src/commands/junit/__tests__/fixtures/go-report.xml',
       })
       expect(secondFile).toMatchObject({
-        xmlPath: './src/commands/junit/__tests__/fixtures/go-report.xml',
+        xmlPath: './src/commands/junit/__tests__/fixtures/java-report.xml',
       })
 
       const output = context.stdout.toString()
@@ -128,10 +128,10 @@ describe('upload', () => {
         {}
       )
       expect(firstFile).toMatchObject({
-        xmlPath: './src/commands/junit/__tests__/fixtures/java-report.xml',
+        xmlPath: './src/commands/junit/__tests__/fixtures/go-report.xml',
       })
       expect(secondFile).toMatchObject({
-        xmlPath: './src/commands/junit/__tests__/fixtures/go-report.xml',
+        xmlPath: './src/commands/junit/__tests__/fixtures/java-report.xml',
       })
       expect(thirdFile).toMatchObject({
         xmlPath: './src/commands/junit/__tests__/fixtures/subfolder/js-report.xml',
@@ -154,10 +154,10 @@ describe('upload', () => {
         {}
       )
       expect(firstFile).toMatchObject({
-        xmlPath: './src/commands/junit/__tests__/fixtures/junit.xml/valid-report.xml',
+        xmlPath: './src/commands/junit/__tests__/fixtures/junit.xml/valid-report-2.xml',
       })
       expect(secondFile).toMatchObject({
-        xmlPath: './src/commands/junit/__tests__/fixtures/junit.xml/valid-report-2.xml',
+        xmlPath: './src/commands/junit/__tests__/fixtures/junit.xml/valid-report.xml',
       })
     })
     test('should not have repeated files', async () => {
@@ -268,11 +268,11 @@ describe('upload', () => {
       const fileNames = files.map((file) => file.xmlPath)
 
       expect(fileNames).toEqual([
-        './src/commands/junit/__tests__/fixtures/java-report.xml',
-        './src/commands/junit/__tests__/fixtures/go-report.xml',
-        './src/commands/junit/__tests__/fixtures/subfolder/js-report.xml',
-        './src/commands/junit/__tests__/fixtures/junit.xml/valid-report.xml',
-        './src/commands/junit/__tests__/fixtures/junit.xml/valid-report-2.xml',
+        'src/commands/junit/__tests__/fixtures/go-report.xml',
+        'src/commands/junit/__tests__/fixtures/java-report.xml',
+        'src/commands/junit/__tests__/fixtures/junit.xml/valid-report-2.xml',
+        'src/commands/junit/__tests__/fixtures/junit.xml/valid-report.xml',
+        'src/commands/junit/__tests__/fixtures/subfolder/js-report.xml',
       ])
     })
     test('should fetch nested folders and ignore non xml files', async () => {
@@ -294,11 +294,11 @@ describe('upload', () => {
       const fileNames = files.map((file) => file.xmlPath)
 
       expect(fileNames).toEqual([
-        './src/commands/junit/__tests__/fixtures/java-report.xml',
-        './src/commands/junit/__tests__/fixtures/go-report.xml',
-        './src/commands/junit/__tests__/fixtures/subfolder/js-report.xml',
-        './src/commands/junit/__tests__/fixtures/junit.xml/valid-report.xml',
-        './src/commands/junit/__tests__/fixtures/junit.xml/valid-report-2.xml',
+        'src/commands/junit/__tests__/fixtures/go-report.xml',
+        'src/commands/junit/__tests__/fixtures/java-report.xml',
+        'src/commands/junit/__tests__/fixtures/junit.xml/valid-report-2.xml',
+        'src/commands/junit/__tests__/fixtures/junit.xml/valid-report.xml',
+        'src/commands/junit/__tests__/fixtures/subfolder/js-report.xml',
       ])
     })
   })

--- a/src/commands/junit/upload.ts
+++ b/src/commands/junit/upload.ts
@@ -5,7 +5,7 @@ import path from 'path'
 import chalk from 'chalk'
 import {Command, Option} from 'clipanion'
 import {XMLParser, XMLValidator} from 'fast-xml-parser'
-import {glob} from 'glob'
+import glob from 'glob'
 import * as t from 'typanion'
 
 import {getCISpanTags} from '../../helpers/ci'
@@ -286,9 +286,7 @@ export class UploadJUnitXMLCommand extends Command {
           globPattern = buildPath(basePath, '*.xml')
         }
 
-        const filesToUpload = glob
-          .sync(globPattern, {dotRelative: true})
-          .filter((file) => path.extname(file) === '.xml')
+        const filesToUpload = glob.sync(globPattern).filter((file) => path.extname(file) === '.xml')
 
         return acc.concat(filesToUpload)
       }, [])

--- a/src/commands/sarif/__tests__/upload.test.ts
+++ b/src/commands/sarif/__tests__/upload.test.ts
@@ -59,11 +59,11 @@ describe('upload', () => {
 
       expect(firstFile).toMatchObject({
         service: 'service',
-        reportPath: './src/commands/sarif/__tests__/fixtures/valid-results.sarif',
+        reportPath: './src/commands/sarif/__tests__/fixtures/valid-no-results.sarif',
       })
       expect(secondFile).toMatchObject({
         service: 'service',
-        reportPath: './src/commands/sarif/__tests__/fixtures/valid-no-results.sarif',
+        reportPath: './src/commands/sarif/__tests__/fixtures/valid-results.sarif',
       })
 
       const getInvalidJsonUnexpectedTokenErrorMessage = () => {
@@ -146,11 +146,11 @@ describe('upload', () => {
       )
       expect(firstFile).toMatchObject({
         service: 'service',
-        reportPath: './src/commands/sarif/__tests__/fixtures/valid-results.sarif',
+        reportPath: './src/commands/sarif/__tests__/fixtures/valid-no-results.sarif',
       })
       expect(secondFile).toMatchObject({
         service: 'service',
-        reportPath: './src/commands/sarif/__tests__/fixtures/valid-no-results.sarif',
+        reportPath: './src/commands/sarif/__tests__/fixtures/valid-results.sarif',
       })
       expect(thirdFile).toMatchObject({
         service: 'service',

--- a/src/commands/sarif/upload.ts
+++ b/src/commands/sarif/upload.ts
@@ -7,7 +7,7 @@ import Ajv from 'ajv'
 import addFormats from 'ajv-formats'
 import chalk from 'chalk'
 import {Command, Option} from 'clipanion'
-import {glob} from 'glob'
+import glob from 'glob'
 
 import {doWithMaxConcurrency} from '../../helpers/concurrency'
 import {DatadogCiConfig} from '../../helpers/config'
@@ -195,7 +195,7 @@ export class UploadSarifReportCommand extends Command {
         return acc.concat(fs.existsSync(basePath) ? [basePath] : [])
       }
 
-      return acc.concat(glob.sync(buildPath(basePath, '*.sarif'), {dotRelative: true}))
+      return acc.concat(glob.sync(buildPath(basePath, '*.sarif')))
     }, [])
 
     const validUniqueFiles = [...new Set(sarifReports)].filter((sarifReport) => {

--- a/src/commands/sourcemaps/upload.ts
+++ b/src/commands/sourcemaps/upload.ts
@@ -3,7 +3,7 @@ import {URL} from 'url'
 
 import chalk from 'chalk'
 import {Command, Option} from 'clipanion'
-import {glob} from 'glob'
+import glob from 'glob'
 
 import {ApiKeyValidator, newApiKeyValidator} from '../../helpers/apikey'
 import {getBaseSourcemapIntakeUrl} from '../../helpers/base-intake-url'

--- a/src/commands/synthetics/__tests__/utils/public.test.ts
+++ b/src/commands/synthetics/__tests__/utils/public.test.ts
@@ -46,7 +46,7 @@ import type * as path from 'path'
 
 import {default as axios} from 'axios'
 import deepExtend from 'deep-extend'
-import {glob} from 'glob'
+import glob from 'glob'
 
 process.env.DATADOG_SYNTHETICS_CI_TRIGGER_APP = 'env_default'
 
@@ -112,10 +112,10 @@ describe('utils', () => {
       file2: '{"tests":"file2"}',
     }
 
-    jest.spyOn(glob, 'glob').mockResolvedValue(FILES)
     ;(fs.readFile as any).mockImplementation((path: 'file1' | 'file2', opts: any, callback: any) =>
       callback(undefined, FILES_CONTENT[path])
     )
+    ;(glob as any).mockImplementation((query: string, callback: (e: any, v: any) => void) => callback(undefined, FILES))
     ;(child_process.exec as any).mockImplementation(
       (command: string, callback: (error: any, stdout: string, stderr: string) => void) => callback(undefined, '.', '')
     )

--- a/src/commands/synthetics/utils/public.ts
+++ b/src/commands/synthetics/utils/public.ts
@@ -5,7 +5,7 @@ import process from 'process'
 import {promisify} from 'util'
 
 import chalk from 'chalk'
-import {glob} from 'glob'
+import glob from 'glob'
 
 import {getCommonAppBaseURL} from '../../../helpers/app'
 import {getCIMetadata} from '../../../helpers/ci'
@@ -238,7 +238,7 @@ export const getResultOutcome = (result: Result): ResultOutcome => {
 export const getSuites = async (GLOB: string, reporter: MainReporter): Promise<Suite[]> => {
   reporter.log(`Finding files matching ${path.resolve(process.cwd(), GLOB)}\n`)
 
-  const files: string[] = await glob(GLOB)
+  const files: string[] = await promisify(glob)(GLOB)
   if (files.length) {
     reporter.log(`\nGot test files:\n${files.map((file) => `  - ${file}\n`).join('')}\n`)
   } else {

--- a/src/commands/unity-symbols/upload.ts
+++ b/src/commands/unity-symbols/upload.ts
@@ -2,7 +2,7 @@ import fs from 'fs'
 import path, {basename} from 'path'
 
 import {Command, Option} from 'clipanion'
-import {glob} from 'glob'
+import glob from 'glob'
 
 import {newApiKeyValidator} from '../../helpers/apikey'
 import {doWithMaxConcurrency} from '../../helpers/concurrency'

--- a/yarn.lock
+++ b/yarn.lock
@@ -1943,7 +1943,7 @@ __metadata:
     fast-xml-parser: ^4.4.1
     form-data: 4.0.0
     fuzzy: ^0.1.3
-    glob: ^11.0.0
+    glob: ^7.1.4
     google-auth-library: ^9.12.0
     inquirer: ^8.2.5
     inquirer-checkbox-plus-prompt: ^1.4.2


### PR DESCRIPTION
### What and why?

This PR reverts #1381.

The functionality works fine on all versions of Node.js that we support, but glob@11 officially dropped support for Node.js versions below 20.

### How?

Revert the PR.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
