### PR TITLE
v2.40.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci",
-  "version": "2.40.2",
+  "version": "2.40.3",
   "description": "Run datadog actions from the CI.",
   "repository": "https://github.com/DataDog/datadog-ci",
   "license": "Apache-2.0",


### PR DESCRIPTION
<!-- Release notes generated using configuration in .github/release.yml at v2.40.3 -->

## What's Changed
### Dependencies
* [dep] Upgrade google-auth-library to `9.12.0` by @Drarig29 in https://github.com/DataDog/datadog-ci/pull/1397
* Revert "[dep] Bump glob to `11.0.0` (#1381)" by @Drarig29 in https://github.com/DataDog/datadog-ci/pull/1398


**Full Changelog**: https://github.com/DataDog/datadog-ci/compare/v2.40.2...v2.40.3