### PR TITLE
v2.41.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci",
-  "version": "2.40.3",
+  "version": "2.41.0",
   "description": "Run datadog actions from the CI.",
   "repository": "https://github.com/DataDog/datadog-ci",
   "license": "Apache-2.0",


### PR DESCRIPTION
<!-- Release notes generated using configuration in .github/release.yml at v2.41.0 -->

## What's Changed
### Dependencies
* Revert "[dep] Bump rimraf to `6.0.1` (#1382)" by @Drarig29 in https://github.com/DataDog/datadog-ci/pull/1401
### CI Visibility
* [ci-visibility] Create deployment correlate subcommand by @rodrigo-roca in https://github.com/DataDog/datadog-ci/pull/1245


**Full Changelog**: https://github.com/DataDog/datadog-ci/compare/v2.40.3...v2.41.0