### PR TITLE
await calls to generatePackfiles

### DIFF
--- a/src/commands/git-metadata/gitdb.ts
+++ b/src/commands/git-metadata/gitdb.ts
@@ -320,7 +320,7 @@ const generatePackFilesForCommits = async (log: Logger, commits: string[]): Prom
     log.warn(`Failed generation of packfiles in tmpdir: ${err}`)
     log.warn(`Generating them in ${process.cwd()} instead`)
 
-    return generatePackfiles(process.cwd())
+    return await generatePackfiles(process.cwd())
   }
 }
 


### PR DESCRIPTION
### What and why?
This change adds a missing `await` to the fallback case of `generatePackFilesForCommits`.
It is more-or-less the same fix as #813, but adds it to the fallback case as well as the primary.

I'm making this because I found regressions in checkout times in our CI agents after hitting the "fallback to CWD" edge case, and it seems possible that this may be due to an orphaned `git pack-objects` that is running longer than expected.

### How?

Before, we did not await the completion of this asynchronous method, and after this change, we will.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)

I didn't do this (and neither did #813), but I believe you would unconditionally want to `await` this condition.