### PR TITLE
Add option to remove ci tags

### DIFF
--- a/src/commands/sarif/upload.ts
+++ b/src/commands/sarif/upload.ts
@@ -62,6 +62,7 @@ export class UploadSarifReportCommand extends Command {
   private service = Option.String('--service')
   private tags = Option.Array('--tags')
   private noVerify = Option.Boolean('--no-verify', false)
+  private noCiTags = Option.Boolean('--no-ci-tags', false)
 
   private config: DatadogCiConfig = {
     apiKey: process.env.DATADOG_API_KEY || process.env.DD_API_KEY,
@@ -93,7 +94,7 @@ export class UploadSarifReportCommand extends Command {
     // Always using the posix version to avoid \ on Windows.
     this.basePaths = this.basePaths.map((basePath) => path.posix.normalize(basePath))
 
-    const spanTags = await getSpanTags(this.config, this.tags)
+    const spanTags = await getSpanTags(this.config, this.tags, !this.noCiTags)
 
     // Check if we have all the mandatory git fields
     const spanTagsKeys = Object.keys(spanTags)

--- a/src/commands/sbom/__tests__/payload.test.ts
+++ b/src/commands/sbom/__tests__/payload.test.ts
@@ -20,7 +20,7 @@ describe('generation of payload', () => {
       env: undefined,
       envVarTags: undefined,
     }
-    const tags = await getSpanTags(config, [])
+    const tags = await getSpanTags(config, [], true)
 
     const payload = generatePayload(sbomContent, tags, 'service', 'env')
     expect(payload).not.toBeNull()
@@ -46,7 +46,7 @@ describe('generation of payload', () => {
       env: undefined,
       envVarTags: undefined,
     }
-    const tags = await getSpanTags(config, [])
+    const tags = await getSpanTags(config, [], true)
 
     const payload = generatePayload(sbomContent, tags, 'service', 'env')
     expect(payload).not.toBeNull()
@@ -72,7 +72,7 @@ describe('generation of payload', () => {
       env: undefined,
       envVarTags: undefined,
     }
-    const tags = await getSpanTags(config, [])
+    const tags = await getSpanTags(config, [], true)
 
     const payload = generatePayload(sbomContent, tags, 'service', 'env')
 
@@ -93,7 +93,7 @@ describe('generation of payload', () => {
       env: undefined,
       envVarTags: undefined,
     }
-    const tags = await getSpanTags(config, [])
+    const tags = await getSpanTags(config, [], true)
 
     const payload = generatePayload(sbomContent, tags, 'service', 'env')
 
@@ -114,7 +114,7 @@ describe('generation of payload', () => {
       env: undefined,
       envVarTags: undefined,
     }
-    const tags = await getSpanTags(config, [])
+    const tags = await getSpanTags(config, [], true)
 
     const payload = generatePayload(sbomContent, tags, 'service', 'env')
 
@@ -139,7 +139,7 @@ describe('generation of payload', () => {
       env: undefined,
       envVarTags: undefined,
     }
-    const tags = await getSpanTags(config, [])
+    const tags = await getSpanTags(config, [], true)
 
     const payload = generatePayload(sbomContent, tags, 'service', 'env')
 
@@ -162,7 +162,7 @@ describe('generation of payload', () => {
       env: undefined,
       envVarTags: undefined,
     }
-    const tags = await getSpanTags(config, [])
+    const tags = await getSpanTags(config, [], true)
 
     const payload = generatePayload(sbomContent, tags, 'service', 'env')
 
@@ -188,7 +188,7 @@ describe('generation of payload', () => {
       env: undefined,
       envVarTags: undefined,
     }
-    const tags = await getSpanTags(config, [])
+    const tags = await getSpanTags(config, [], true)
 
     const payload = generatePayload(sbomContent, tags, 'service', 'env')
 
@@ -212,7 +212,7 @@ describe('generation of payload', () => {
       env: undefined,
       envVarTags: undefined,
     }
-    const tags = await getSpanTags(config, [])
+    const tags = await getSpanTags(config, [], true)
 
     const payload = generatePayload(sbomContent, tags, 'service', 'env')
 
@@ -278,7 +278,7 @@ describe('generation of payload', () => {
       env: undefined,
       envVarTags: undefined,
     }
-    const tags = await getSpanTags(config, [])
+    const tags = await getSpanTags(config, [], true)
 
     const payload = generatePayload(sbomContent, tags, 'service', 'env')
 

--- a/src/commands/sbom/upload.ts
+++ b/src/commands/sbom/upload.ts
@@ -38,6 +38,7 @@ export class UploadSbomCommand extends Command {
   private env = Option.String('--env')
   private tags = Option.Array('--tags')
   private debug = Option.Boolean('--debug')
+  private noCiTags = Option.Boolean('--no-ci-tags', false)
 
   private config = {
     apiKey: process.env.DATADOG_API_KEY || process.env.DD_API_KEY,
@@ -92,7 +93,7 @@ export class UploadSbomCommand extends Command {
       this.config.appKey
     )
 
-    const tags = await getSpanTags(this.config, this.tags)
+    const tags = await getSpanTags(this.config, this.tags, !this.noCiTags)
 
     // Check if we have all the mandatory git fields
     const spanTagsKeys = Object.keys(tags)

--- a/src/helpers/__tests__/tags.test.ts
+++ b/src/helpers/__tests__/tags.test.ts
@@ -45,7 +45,8 @@ describe('getSpanTags', () => {
         env: process.env.DD_ENV,
         envVarTags: process.env.DD_TAGS,
       },
-      undefined
+      undefined,
+      true
     )
     expect(spanTags).toMatchObject({
       env: 'ci',
@@ -60,7 +61,8 @@ describe('getSpanTags', () => {
         env: undefined,
         envVarTags: undefined,
       },
-      ['key1:value1', 'key2:value2']
+      ['key1:value1', 'key2:value2'],
+      true
     )
     expect(spanTags).toMatchObject({
       key1: 'value1',

--- a/src/helpers/tags.ts
+++ b/src/helpers/tags.ts
@@ -118,9 +118,14 @@ export const mandatoryGitFields: Record<string, boolean> = {
  * Get the tags to upload results in CI for the following commands: sarif and sbom.
  * @param config - the configuration of the CLI
  * @param additionalTags - additional tags passed, generally from the command line.
+ * @param includeCiTags - include CI tags or not
  */
-export const getSpanTags = async (config: DatadogCiConfig, additionalTags: string[] | undefined): Promise<SpanTags> => {
-  const ciSpanTags = getCISpanTags()
+export const getSpanTags = async (
+  config: DatadogCiConfig,
+  additionalTags: string[] | undefined,
+  includeCiTags: boolean
+): Promise<SpanTags> => {
+  const ciSpanTags = includeCiTags ? getCISpanTags() : []
   const gitSpanTags = await getGitMetadata()
   const userGitSpanTags = getUserGitSpanTags()
 


### PR DESCRIPTION
### What and why?

We want to provide the option for customer to disable CI tags. We have a custom who runs their pipeline from a centralize devops repo (call it repoA). Then, the job from this repo clone other repositories (for example, repoB) and analyze them.

However, when reporting the data, `datadog-ci` uses the environment variable from the CI runners. In this case, the results will appear from repoA whereas it should appear as repoB.

### How?

Add an option to disable ci tags.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
