### PR TITLE
chore(deps): bump @aws-sdk/core from 3.535.0 to 3.621.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "@aws-sdk/client-iam": "^3.535.0",
     "@aws-sdk/client-lambda": "^3.536.0",
     "@aws-sdk/client-sfn": "^3.535.0",
-    "@aws-sdk/core": "^3.535.0",
+    "@aws-sdk/core": "^3.621.0",
     "@aws-sdk/credential-provider-ini": "^3.535.0",
     "@aws-sdk/credential-providers": "^3.535.0",
     "@google-cloud/logging": "^11.0.0",


### PR DESCRIPTION
### What and why?

Fix fast-xml-parser vulnerable to ReDOS at currency parsing.

@datadog/datadog-ci requires fast-xml-parser via a transitive dependency on @aws-sdk/core

Release notes: https://github.com/aws/aws-sdk-js-v3/releases/tag/v3.621.0

### How?

Version bump

### Review checklist

- [N/A] Feature or bugfix MUST have appropriate tests (unit, integration)
