### PR TITLE
[SYNTH-12986] Mark runName as deprecated

### DIFF
--- a/src/commands/synthetics/reporters/junit.ts
+++ b/src/commands/synthetics/reporters/junit.ts
@@ -99,6 +99,7 @@ export interface XMLJSON {
       // https://github.com/windyroad/JUnit-Schema/blob/master/JUnit.xsd
       batch_id: string
       batch_url: string
+      // TODO SYNTH-12989: Clean up deprecated `--runName`
       name: string
       tests_critical_error: number
       tests_failed: number
@@ -120,6 +121,8 @@ interface XMLError {
 export interface Args {
   context: CommandContext
   jUnitReport?: string
+  // TODO SYNTH-12989: Clean up deprecated `--runName`
+  /** @deprecated This CLI parameter is deprecated */
   runName?: string
 }
 
@@ -202,6 +205,7 @@ export class JUnitReporter implements Reporter {
         $: {
           batch_id: '',
           batch_url: '',
+          // TODO SYNTH-12989: Clean up deprecated `--runName`
           name: runName || 'Undefined run',
           tests_critical_error: 0,
           tests_failed: 0,

--- a/src/commands/synthetics/run-tests-command.ts
+++ b/src/commands/synthetics/run-tests-command.ts
@@ -99,6 +99,8 @@ export class RunTestsCommand extends Command {
 
   public configPath = Option.String('--config', {description: `Pass a path to a ${$1('global configuration file')}.`})
   public jUnitReport = Option.String('-j,--jUnitReport', {description: 'Pass a path to a JUnit report file.'})
+  // TODO SYNTH-12989: Clean up deprecated `--runName`
+  /** @deprecated This CLI parameter is deprecated */
   public runName = Option.String('-n,--runName', {
     description: 'A name for this run, which will be included in the JUnit report file.',
   })


### PR DESCRIPTION
### What and why?

We are marking runName as deprecated and leaving comments for us to be able to clean it up easier later on when we release the new major version

### How?

Adding @depraceted and leaving some comments

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
