### PR TITLE
remove service and env

### DIFF
--- a/src/commands/sarif/README.md
+++ b/src/commands/sarif/README.md
@@ -20,10 +20,10 @@ For example:
 datadog-ci sarif upload --service my-service --tags key1:value1 --tags key2:value2 sarif-reports/go-reports sarif-reports/java-reports sarif-report/single-report.sarif
 ```
 
-- The positional arguments are the directories or file paths in which the SARIF reports are located. If you pass a folder, the CLI looks for all `.sarif` files in it.
-- `--service` (default: `DD_SERVICE` env var) should be set to the name of the service you're uploading SARIF reports for.
+The positional arguments are the directories or file paths in which the SARIF reports are located. If you pass a folder, the CLI looks for all `.sarif` files in it.
+- `--service` should be set to the name of the service you're uploading SARIF reports from.
 - `--tags` is a array of key value pairs of the form `key:value`. This parameter sets global tags applied to all results. The upload process merges the tags passed on the command line with the tags in the `DD_TAGS` environment variable. If a key appears in both `--tags` and `DD_TAGS`, the value in `DD_TAGS` takes precedence.
-- `--env` (default: `DD_ENV` env var) is a string that represents the environment in which you want your tests to appear.
+- `--env` is a string that represents the environment in which you want your tests to appear.
 - `--max-concurrency` (default: `20`): number of concurrent uploads to the API.
 - `--dry-run` (default: `false`): runs the command without the final upload step. All other checks are performed.
 - `--no-verify` (default: `false`): runs the command without performing report validation on the CLI.
@@ -33,10 +33,8 @@ datadog-ci sarif upload --service my-service --tags key1:value1 --tags key2:valu
 Additionally, you may configure the `sarif` command with environment variables:
 
 - `DATADOG_API_KEY` or `DD_API_KEY` (**required**): API key used to authenticate the requests.
-- `DD_ENV`: The environment in which your test results appear.
-- `DD_SERVICE`: Specify a service.
 - `DD_TAGS`: Set global tags applied to all spans. The format must be `key1:value1,key2:value2`. The upload process merges the tags passed on the command line with the tags in the `--tags` parameter. If a key appears in both `--tags` and `DD_TAGS`, the value in `DD_TAGS` takes precedence.
-- `DATADOG_SITE`: choose your Datadog site, for example, datadoghq.com or datadoghq.eu.
+- `DATADOG_SITE` or `DD_SITE`: choose your Datadog site, for example, datadoghq.com or datadoghq.eu.
 
 ### Optional dependencies
 

--- a/src/commands/sarif/upload.ts
+++ b/src/commands/sarif/upload.ts
@@ -57,9 +57,9 @@ export class UploadSarifReportCommand extends Command {
 
   private basePaths = Option.Rest({required: 1})
   private dryRun = Option.Boolean('--dry-run', false)
-  private env = Option.String('--env')
+  private env = Option.String('--env', 'ci')
   private maxConcurrency = Option.String('--max-concurrency', '20', {validator: validation.isInteger()})
-  private service = Option.String('--service')
+  private service = Option.String('--service', 'datadog-ci')
   private tags = Option.Array('--tags')
   private noVerify = Option.Boolean('--no-verify', false)
   private noCiTags = Option.Boolean('--no-ci-tags', false)
@@ -71,15 +71,6 @@ export class UploadSarifReportCommand extends Command {
   }
 
   public async execute() {
-    if (!this.service) {
-      this.service = process.env.DD_SERVICE
-    }
-
-    if (!this.service) {
-      this.context.stderr.write('Missing service\n')
-
-      return 1
-    }
     if (!this.basePaths || !this.basePaths.length) {
       this.context.stderr.write('Missing basePath\n')
 
@@ -196,7 +187,7 @@ export class UploadSarifReportCommand extends Command {
     })
 
     return validUniqueFiles.map((sarifReport) => ({
-      service: this.service!,
+      service: this.service,
       reportPath: sarifReport,
       spanTags,
     }))

--- a/src/commands/sbom/README.md
+++ b/src/commands/sbom/README.md
@@ -31,7 +31,8 @@ The following environment variables must be defined:
 
 When developing software, you can try with the following command:
 
-```bashyarn launch sbom upload --service <your-service> --env <your-environment> /path/to/sbom.json
+```bash
+yarn launch sbom upload --service <your-service> --env <your-environment> /path/to/sbom.json
 ```
 
 ## Further reading

--- a/src/commands/sbom/README.md
+++ b/src/commands/sbom/README.md
@@ -1,19 +1,23 @@
 # SBOM command
 
-<div class="alert alert-warning"><strong>Warning:</strong> The <code>SBOM upload</code> command is in beta. It requires you to set <code>DD_BETA_COMMANDS_ENABLED=1</code>, and should not be used in production.</div>
-
 This command lets you upload SBOM files to the Datadog intake endpoint.
 
 
 ## Supported Formats
 
  - CycloneDX 1.4
+ - CycloneDX 1.5
 
 ## Usage
 
 ```bash
-DD_BETA_COMMANDS_ENABLED=1 datadog-ci sbom upload --service <my-service> <path/to/sbom.json>
+datadog-ci sbom upload <path/to/sbom.json>
 ```
+
+### Optional arguments
+
+- `--service` should be set to the name of the service you're uploading SBOM reports from.
+- `--env` is a string that represents the environment in which you want your tests to appear.
 
 ### Environment variables
 
@@ -22,15 +26,12 @@ The following environment variables must be defined:
  - `DD_SITE`: the [Datadog site](https://docs.datadoghq.com/getting_started/site/#access-the-datadog-site)
  - `DD_APP_KEY`: the App key to use
  - `DD_API_KEY`: the API key to use
- - `DD_SERVICE`: the Datadog service you use (if `--service` not specified)
-
 
 ## Development
 
 When developing software, you can try with the following command:
 
-```bash
-DD_BETA_COMMANDS_ENABLED=1 yarn launch sbom upload --service <your-service> --env <your-environment> /path/to/sbom.json
+```bashyarn launch sbom upload --service <your-service> --env <your-environment> /path/to/sbom.json
 ```
 
 ## Further reading

--- a/src/commands/sbom/upload.ts
+++ b/src/commands/sbom/upload.ts
@@ -34,8 +34,8 @@ export class UploadSbomCommand extends Command {
   })
 
   private basePaths = Option.Rest({required: 1})
-  private service = Option.String('--service')
-  private env = Option.String('--env')
+  private service = Option.String('--service', 'datadog-ci')
+  private env = Option.String('--env', 'ci')
   private tags = Option.Array('--tags')
   private debug = Option.Boolean('--debug')
   private noCiTags = Option.Boolean('--no-ci-tags', false)
@@ -52,22 +52,9 @@ export class UploadSbomCommand extends Command {
    * compliant with their schema and upload them to datadog.
    */
   public async execute() {
-    const service: string | undefined = this.service || process.env.DD_SERVICE
+    const service: string = this.service
 
-    if (!service) {
-      this.context.stderr.write('Missing service\n')
-
-      return 1
-    }
-
-    const environment: string | undefined = this.env || this.config.env
-    this.config.env = environment
-
-    if (!environment) {
-      this.context.stderr.write('Missing env\n')
-
-      return 1
-    }
+    const environment = this.env
 
     if (!this.basePaths || !this.basePaths.length) {
       this.context.stderr.write('Missing basePath\n')


### PR DESCRIPTION
### What and why?

We remove the `service` and `env` as mandatory arguments for the `sarif` and `abom` command. We put a default value. This default value will then be hidden from the user. It can used for graphs but not going to be surfaced in the product.

### How?

Put a default value in the argument

### Test


<img width="1221" alt="Screenshot 2024-08-07 at 6 27 01 PM" src="https://github.com/user-attachments/assets/63966964-0811-4219-9ec1-a6ef65b90c35">

