### PR TITLE
[synthetics] Improve "Did you mean?" message

### DIFF
--- a/src/commands/synthetics/__tests__/utils/internal.test.ts
+++ b/src/commands/synthetics/__tests__/utils/internal.test.ts
@@ -219,30 +219,30 @@ describe('utils', () => {
 
       it('should suggest correction for invalid case of valid keys', () => {
         let overrides = ['startURL=blah']
-        expect(() => validateAndParseOverrides(overrides)).toThrow('Invalid key: startURL. Did you mean: startUrl?')
+        expect(() => validateAndParseOverrides(overrides)).toThrow('Invalid key: startURL. Did you mean `startUrl`?')
 
         // resourceUrlSubstitutionRegexe is missing the plural "s"
         overrides = ['resourceUrlSubstitutionRegexe=blah']
         expect(() => validateAndParseOverrides(overrides)).toThrow(
-          'Invalid key: resourceUrlSubstitutionRegexe. Did you mean: resourceUrlSubstitutionRegexes?'
+          'Invalid key: resourceUrlSubstitutionRegexe. Did you mean `resourceUrlSubstitutionRegexes`?'
         )
 
         overrides = ['startUrlSubstitution=blah']
         expect(() => validateAndParseOverrides(overrides)).toThrow(
-          'Invalid key: startUrlSubstitution. Did you mean: startUrlSubstitutionRegex?'
+          'Invalid key: startUrlSubstitution. Did you mean `startUrlSubstitutionRegex`?'
         )
 
         overrides = ['startUrlS=blah']
-        expect(() => validateAndParseOverrides(overrides)).toThrow('Invalid key: startUrlS. Did you mean: startUrl?')
+        expect(() => validateAndParseOverrides(overrides)).toThrow('Invalid key: startUrlS. Did you mean `startUrl`?')
 
         overrides = ['startUrlSub=blah']
-        expect(() => validateAndParseOverrides(overrides)).toThrow('Invalid key: startUrlSub. Did you mean: startUrl?')
+        expect(() => validateAndParseOverrides(overrides)).toThrow('Invalid key: startUrlSub. Did you mean `startUrl`?')
 
         // Levenshtein distance > 5 should not suggest a correction
         overrides = ['startUrlSubsti=blah']
         expect(() => validateAndParseOverrides(overrides)).toThrow('Invalid key: startUrlSubsti')
 
-        // resourceUrlSubstitutionRegexes or startUrlSubstitutionRegexes : We can't make a suggestion
+        // resourceUrlSubstitutionRegexes or startUrlSubstitutionRegexes: we can't make a suggestion
         overrides = ['UrlSubstitutionRegexes=blah']
         expect(() => validateAndParseOverrides(overrides)).toThrow('Invalid key: UrlSubstitutionRegexes')
       })

--- a/src/commands/synthetics/utils/internal.ts
+++ b/src/commands/synthetics/utils/internal.ts
@@ -302,7 +302,7 @@ export const validateAndParseOverrides = (overrides: string[] | undefined): Accu
             throw new Error(`Invalid key: ${key}`)
           }
 
-          throw new Error(`Invalid key: ${key}. Did you mean: ${closestKey}?`)
+          throw new Error(`Invalid key: ${key}. Did you mean \`${closestKey}\`?`)
       }
 
       return acc


### PR DESCRIPTION
### What and why?

"Did you mean: something?" is a grammar mistake. The sentence should not contain a colon at all.

### How?

Change the message.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
