### PR TITLE
[SYNTH-15833] Use batch as source of truth for `hasResultPassed()`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,8 @@ jobs:
     name: End-to-end test the package
     runs-on: ubuntu-latest
     needs: build-and-test
+    env:
+      FORCE_COLOR: 1
 
     steps:
       - uses: actions/checkout@v4

--- a/src/commands/synthetics/__tests__/fixtures.ts
+++ b/src/commands/synthetics/__tests__/fixtures.ts
@@ -39,6 +39,7 @@ import {
   MobileTestWithOverride,
   BaseResultInBatch,
   ResultInBatchSkippedBySelectiveRerun,
+  ServerResult,
 } from '../interfaces'
 import {AppUploadReporter} from '../reporters/mobile/app-upload'
 import {createInitialSummary} from '../utils/public'
@@ -211,6 +212,10 @@ export const getApiResult = (resultId: string, test: Test, resultOpts: Partial<A
   ...getBaseResult(resultId, test),
   result: getApiServerResult(resultOpts),
 })
+
+export const getIncompleteServerResult = (): ServerResult => {
+  return ({eventType: 'created'} as unknown) as ServerResult
+}
 
 export const getBrowserServerResult = (opts: Partial<BrowserServerResult> = {}): BrowserServerResult => ({
   device: {height: 1100, id: 'chrome.laptop_large', width: 1440},

--- a/src/commands/synthetics/__tests__/reporters/__snapshots__/default.test.ts.snap
+++ b/src/commands/synthetics/__tests__/reporters/__snapshots__/default.test.ts.snap
@@ -73,7 +73,7 @@ exports[`Default reporter resultEnd 3 API tests, 2 passed (1 from previous CI ru
 "
 `;
 
-exports[`Default reporter resultEnd 3 Browser test: failed blocking, timed out, global failure 1`] = `
+exports[`Default reporter resultEnd 3 Browser tests: failed blocking, timed out, global failure 1`] = `
 "[1m[31m✖[39m[22m [[1m[31mblocking[39m[22m] [[1m[2mabc-def-ghi[22m[22m] [1mTest name[22m - [1m[31mlocation: [1mLocation name[22m[1m[39m[22m - [1m[31mdevice: [1mchrome.laptop_large[22m[1m[39m[22m
   • Total duration: 20000 ms - View test run details:
     ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/abc-def-ghi/result/1?batch_id=123&from_ci=true[39m[22m 
@@ -97,6 +97,28 @@ exports[`Default reporter resultEnd 3 Browser test: failed blocking, timed out, 
   • View test run details:
     ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/abc-def-ghi/result/1?batch_id=123&from_ci=true[39m[22m 
 [31m    [[1mFAILURE_CODE[22m] - [2mFailure message[22m[39m
+
+"
+`;
+
+exports[`Default reporter resultEnd Incomplete API and Browser tests - passed and failed 1`] = `
+"[1m[31m✖[39m[22m [[1m[31mblocking[39m[22m] [[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m - [1m[31mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m
+  • View test run details:
+    ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=1&batch_id=123&from_ci=true[39m[22m 
+  [1m[31m✖[39m[22m [1m[31m[1mGET[22m[1m - http://fake.url[39m[22m
+
+[1m[32m✓[39m[22m [[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m - [1m[32mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m
+  • View test run details:
+    ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=2&batch_id=123&from_ci=true[39m[22m 
+  [1m[32m✓[39m[22m [1m[32m[1mGET[22m[1m - http://fake.url[39m[22m
+
+[1m[31m✖[39m[22m [[1m[31mblocking[39m[22m] [[1m[2mbbb-bbb-bbb[22m[22m] [1mTest name[22m - [1m[31mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m
+  • View test run details:
+    ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/bbb-bbb-bbb/result/3?batch_id=123&from_ci=true[39m[22m 
+
+[1m[32m✓[39m[22m [[1m[2mbbb-bbb-bbb[22m[22m] [1mTest name[22m - [1m[32mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m
+  • View test run details:
+    ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/bbb-bbb-bbb/result/4?batch_id=123&from_ci=true[39m[22m 
 
 "
 `;
@@ -242,13 +264,19 @@ exports[`Default reporter testTrigger Skipped test, with 2 test overrides 1`] = 
 `;
 
 exports[`Default reporter testsWait outputs triggered tests 1`] = `
-"- Waiting for [1m[36m11[39m[22m tests [90m(abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, …)[39m…
+"View pending summary in Datadog: [2m[36mhttps://app.datadoghq.com/synthetics/explorer/ci?batchResultId=123[39m[22m
+
+
+- Waiting for [1m[36m11[39m[22m tests [90m(abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, …)[39m…
 
 "
 `;
 
 exports[`Default reporter testsWait outputs triggered tests with skipped count 1`] = `
-"- Waiting for [1m[36m11[39m[22m tests (skipping [1m[36m3[39m[22m already successful) [90m(abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, …)[39m…
+"View pending summary in Datadog: [2m[36mhttps://app.datadoghq.com/synthetics/explorer/ci?batchResultId=123[39m[22m
+
+
+- Waiting for [1m[36m11[39m[22m tests (skipping [1m[36m3[39m[22m already successful) [90m(abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, abc-def-ghi, …)[39m…
 
 "
 `;

--- a/src/commands/synthetics/__tests__/utils/internal.test.ts
+++ b/src/commands/synthetics/__tests__/utils/internal.test.ts
@@ -1,6 +1,7 @@
-import {ExecutionRule} from '../../interfaces'
+import {ExecutionRule, ResultInBatch} from '../../interfaces'
 import {
   getOverriddenExecutionRule,
+  hasResultPassed,
   parseOverrideValue,
   toBoolean,
   toExecutionRule,
@@ -38,6 +39,31 @@ describe('utils', () => {
         ).toEqual(expectedRule)
       }
     )
+  })
+
+  describe('hasResultPassed', () => {
+    test('result', () => {
+      const result = {status: 'passed'} as ResultInBatch
+      expect(hasResultPassed(result, false, false, {failOnCriticalErrors: false, failOnTimeout: true})).toBe(true)
+      expect(hasResultPassed(result, false, false, {failOnCriticalErrors: true, failOnTimeout: true})).toBe(true)
+      result.status = 'failed'
+      expect(hasResultPassed(result, false, false, {failOnCriticalErrors: false, failOnTimeout: true})).toBe(false)
+      expect(hasResultPassed(result, false, false, {failOnCriticalErrors: true, failOnTimeout: true})).toBe(false)
+    })
+
+    test('unhealthy result', () => {
+      const result = {} as ResultInBatch
+      const isUnhealthy = true // comes from the server result
+      expect(hasResultPassed(result, isUnhealthy, false, {failOnCriticalErrors: false, failOnTimeout: true})).toBe(true)
+      expect(hasResultPassed(result, isUnhealthy, false, {failOnCriticalErrors: true, failOnTimeout: true})).toBe(false)
+    })
+
+    test('timed out result', () => {
+      const result = {} as ResultInBatch
+      const hasTimedOut = true // batch timed out or safe deadline
+      expect(hasResultPassed(result, false, hasTimedOut, {failOnCriticalErrors: true, failOnTimeout: true})).toBe(false)
+      expect(hasResultPassed(result, false, hasTimedOut, {failOnCriticalErrors: true, failOnTimeout: false})).toBe(true)
+    })
   })
 
   describe('toBoolean', () => {

--- a/src/commands/synthetics/__tests__/utils/public.test.ts
+++ b/src/commands/synthetics/__tests__/utils/public.test.ts
@@ -1313,7 +1313,7 @@ describe('utils', () => {
       // Result 3 was available instantly
       expect(mockReporter.resultEnd).toHaveBeenNthCalledWith(2, {...result, resultId: 'rid-3'}, MOCK_BASE_URL, 'bid')
 
-      // Result 1 never became available (but the backend says it did not pass)
+      // Result 1 never became available (but the batch says it did not pass)
       expect(mockReporter.resultEnd).toHaveBeenNthCalledWith(
         3,
         {

--- a/src/commands/synthetics/batch.ts
+++ b/src/commands/synthetics/batch.ts
@@ -12,8 +12,13 @@ import {
   ResultInBatch,
   Test,
 } from './interfaces'
-import {isResultInBatchSkippedBySelectiveRerun, getResultIdOrLinkedResultId, hasRetries} from './utils/internal'
-import {wait, getAppBaseURL, hasResultPassed} from './utils/public'
+import {
+  isResultInBatchSkippedBySelectiveRerun,
+  getResultIdOrLinkedResultId,
+  hasRetries,
+  hasResultPassed,
+} from './utils/internal'
+import {wait, getAppBaseURL} from './utils/public'
 
 const POLLING_INTERVAL = 5000 // In ms
 
@@ -237,15 +242,12 @@ const getResultFromBatch = (
     pollResult.result.passed = false
   }
 
+  const isUnhealthy = pollResult.result.unhealthy ?? false
+
   return {
     executionRule: resultInBatch.execution_rule,
     location: getLocation(resultInBatch.location, test),
-    passed: hasResultPassed(
-      pollResult.result,
-      hasTimedOut,
-      options.failOnCriticalErrors ?? false,
-      options.failOnTimeout ?? false
-    ),
+    passed: hasResultPassed(resultInBatch, isUnhealthy, hasTimedOut, options),
     result: pollResult.result,
     resultId: getResultIdOrLinkedResultId(resultInBatch),
     retries: resultInBatch.retries || 0,

--- a/src/commands/synthetics/interfaces.ts
+++ b/src/commands/synthetics/interfaces.ts
@@ -151,6 +151,7 @@ export type ResultSkippedBySelectiveRerun = Omit<BaseResult, 'location' | 'resul
 export type Result = BaseResult | ResultSkippedBySelectiveRerun
 
 type Status = 'passed' | 'failed' | 'in_progress' | 'skipped'
+type BatchStatus = 'passed' | 'failed' | 'in_progress'
 
 export interface BaseResultInBatch {
   execution_rule: ExecutionRule
@@ -176,7 +177,7 @@ export type ResultInBatch = BaseResultInBatch | ResultInBatchSkippedBySelectiveR
 
 export interface Batch {
   results: ResultInBatch[]
-  status: Status
+  status: BatchStatus
 }
 
 type ServerResultInBatch = BaseResultInBatch | SkippedResultInBatch
@@ -185,7 +186,7 @@ export interface ServerBatch {
   // The batch from the server contains skipped results, which we're going to remove since we don't
   // care about skipped results internally (except when they are skipped by a selective re-run).
   results: ServerResultInBatch[]
-  status: Status
+  status: BatchStatus
 }
 
 export interface Vitals {

--- a/src/commands/synthetics/utils/internal.ts
+++ b/src/commands/synthetics/utils/internal.ts
@@ -27,6 +27,26 @@ export const getOverriddenExecutionRule = (
   }
 }
 
+export const hasResultPassed = (
+  result: ResultInBatch,
+  isUnhealthy: boolean,
+  hasTimedOut: boolean,
+  options: {
+    failOnCriticalErrors?: boolean
+    failOnTimeout?: boolean
+  }
+): boolean => {
+  if (isUnhealthy && !options.failOnCriticalErrors) {
+    return true
+  }
+
+  if (hasTimedOut && !options.failOnTimeout) {
+    return true
+  }
+
+  return result.status === 'passed'
+}
+
 export const hasResult = (result: Result): result is BaseResult => {
   return !isResultSkippedBySelectiveRerun(result)
 }

--- a/src/commands/synthetics/utils/public.ts
+++ b/src/commands/synthetics/utils/public.ts
@@ -174,6 +174,9 @@ export const isTestSupportedByTunnel = (test: Test) => {
   )
 }
 
+/**
+ * @deprecated The concept of `ServerResult` is internal and not the source of truth for a result's status. This function has no public equivalent.
+ */
 export const hasResultPassed = (
   serverResult: ServerResult,
   hasTimedOut: boolean,


### PR DESCRIPTION
### What and why?

This PR fixes a bug where results without the complete information (server result from the polling endpoint) are reported as passed by default, even when the batch says the result failed.

### How?

Change the source of truth for `hasResultPassed()` to be the `ResultInBatch`, instead of the `ServerResult`.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
