### PR TITLE
v2.42.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci",
-  "version": "2.41.0",
+  "version": "2.42.0",
   "description": "Run datadog actions from the CI.",
   "repository": "https://github.com/DataDog/datadog-ci",
   "license": "Apache-2.0",


### PR DESCRIPTION
<!-- Release notes generated using configuration in .github/release.yml at v2.42.0 -->

## What's Changed
### Dependencies
* [dep] Bump aws-sdk to `3.624.0` by @Drarig29 in https://github.com/DataDog/datadog-ci/pull/1416
* [dep] Align `package.json` with `yarn.lock` for GCP packages by @Drarig29 in https://github.com/DataDog/datadog-ci/pull/1418
* [dep] Bump axios to `1.7.4` by @Drarig29 in https://github.com/DataDog/datadog-ci/pull/1421
### Documentation
* Update README.md. by @peterg17 in https://github.com/DataDog/datadog-ci/pull/1411
### Static Analysis
* Add SARIF validation by @juli1 in https://github.com/DataDog/datadog-ci/pull/1404
* Add option to remove ci tags by @juli1 in https://github.com/DataDog/datadog-ci/pull/1408
* remove service and env by @juli1 in https://github.com/DataDog/datadog-ci/pull/1412
### Synthetics
* [SYNTH-15356] Wrong case with `--override` fails silently by @KarimDatadog in https://github.com/DataDog/datadog-ci/pull/1386
* [SYNTH-12977] Reorder properties by @teodor2312 in https://github.com/DataDog/datadog-ci/pull/1394
* [SYNTH-12986] Mark runName as deprecated by @teodor2312 in https://github.com/DataDog/datadog-ci/pull/1410
* [synthetics] Improve "Did you mean?" message by @Drarig29 in https://github.com/DataDog/datadog-ci/pull/1417
* [SYNTH-15833] Use batch as source of truth for `hasResultPassed()` by @Drarig29 in https://github.com/DataDog/datadog-ci/pull/1419
### Profiling
* [PROF-10235] Add symbol source and filename to elf symbols metadata by @nsavoire in https://github.com/DataDog/datadog-ci/pull/1388

## New Contributors
* @KarimDatadog made their first contribution in https://github.com/DataDog/datadog-ci/pull/1386
* @peterg17 made their first contribution in https://github.com/DataDog/datadog-ci/pull/1411

**Full Changelog**: https://github.com/DataDog/datadog-ci/compare/v2.41.0...v2.42.0