### PR TITLE
[STAL-2668] Remove app key requirement

### DIFF
--- a/src/commands/sbom/README.md
+++ b/src/commands/sbom/README.md
@@ -24,7 +24,6 @@ datadog-ci sbom upload <path/to/sbom.json>
 The following environment variables must be defined:
 
  - `DD_SITE`: the [Datadog site](https://docs.datadoghq.com/getting_started/site/#access-the-datadog-site)
- - `DD_APP_KEY`: the App key to use
  - `DD_API_KEY`: the API key to use
 
 ## Development

--- a/src/commands/sbom/api.ts
+++ b/src/commands/sbom/api.ts
@@ -14,10 +14,7 @@ const maxBodyLength = Infinity
  * Get the function to upload our results to the intake.
  * @param apiKey
  */
-export const getApiHelper = (
-  apiKey: string,
-  appKey: string
-): ((scaRequest: ScaRequest) => AxiosPromise<AxiosResponse>) => {
+export const getApiHelper = (apiKey: string): ((scaRequest: ScaRequest) => AxiosPromise<AxiosResponse>) => {
   /**
    * function used to marshall and send the data
    * @param request - the AXIOS element used to send the request
@@ -49,7 +46,7 @@ export const getApiHelper = (
   // Get the intake name
   const url = getBaseUrl()
   // Get the AXIOS request/response function
-  const requestIntake = getRequestBuilder({baseUrl: url, apiKey, appKey})
+  const requestIntake = getRequestBuilder({baseUrl: url, apiKey})
 
   return uploadSBomPayload(requestIntake)
 }

--- a/src/commands/sbom/upload.ts
+++ b/src/commands/sbom/upload.ts
@@ -42,7 +42,6 @@ export class UploadSbomCommand extends Command {
 
   private config = {
     apiKey: process.env.DATADOG_API_KEY || process.env.DD_API_KEY,
-    appKey: process.env.DATADOG_APP_KEY || process.env.DD_APP_KEY || '',
     env: process.env.DD_ENV,
     envVarTags: process.env.DD_TAGS,
   }
@@ -68,17 +67,8 @@ export class UploadSbomCommand extends Command {
       return 1
     }
 
-    if (!this.config.appKey) {
-      this.context.stderr.write('APP key not defined, define the environment variable DD_APP_KEY.\n')
-
-      return 1
-    }
-
     // Get the API helper to send the payload
-    const api: (sbomPayload: ScaRequest) => AxiosPromise<AxiosResponse> = getApiHelper(
-      this.config.apiKey,
-      this.config.appKey
-    )
+    const api: (sbomPayload: ScaRequest) => AxiosPromise<AxiosResponse> = getApiHelper(this.config.apiKey)
 
     const tags = await getSpanTags(this.config, this.tags, !this.noCiTags)
 


### PR DESCRIPTION
### What and why?

We removed the requirement for an application key to be required to upload an SBOM.

### How?

Removes the application key from the code and from the command documentation.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
