### PR TITLE
[STAL-2160] Show message when default branch not found

### DIFF
--- a/src/commands/sbom/renderer.ts
+++ b/src/commands/sbom/renderer.ts
@@ -55,7 +55,10 @@ export const renderNoDefaultBranch = (repositoryUrl: string) => {
   let fullStr = ''
 
   fullStr += chalk.red(`Default branch not found for repository ${repositoryUrl}\n`)
-  fullStr += chalk.red(`Define a default branch in the repository settings on Datadog and run the analysis again\n`)
+  fullStr += chalk.red(`Fix this issue by either:\n`)
+  fullStr += chalk.red(` - define a default branch in the repository settings on Datadog\n`)
+  fullStr += chalk.red(` - push result from your default branch first\n\n`)
+  fullStr += chalk.red(`Run an analysis once the issue is resolved\n`)
 
   return fullStr
 }

--- a/src/commands/sbom/renderer.ts
+++ b/src/commands/sbom/renderer.ts
@@ -51,6 +51,15 @@ export const renderDuplicateUpload = (sha: string, env: string, service: string)
   return fullStr
 }
 
+export const renderNoDefaultBranch = (repositoryUrl: string) => {
+  let fullStr = ''
+
+  fullStr += chalk.red(`Default branch not found for repository ${repositoryUrl}\n`)
+  fullStr += chalk.red(`Define a default branch in the repository settings on Datadog and run the analysis again\n`)
+
+  return fullStr
+}
+
 export const renderFailedUpload = (sbomReport: string, error: any) => {
   const reportPath = `[${chalk.bold.dim(sbomReport)}]`
 

--- a/src/commands/sbom/upload.ts
+++ b/src/commands/sbom/upload.ts
@@ -5,7 +5,7 @@ import Ajv from 'ajv'
 import {AxiosPromise, AxiosResponse, isAxiosError} from 'axios'
 import {Command, Option} from 'clipanion'
 
-import {GIT_SHA, getSpanTags, mandatoryGitFields} from '../../helpers/tags'
+import {GIT_SHA, getSpanTags, mandatoryGitFields, GIT_REPOSITORY_URL} from '../../helpers/tags'
 
 import {getApiHelper} from './api'
 import {generatePayload} from './payload'
@@ -15,6 +15,7 @@ import {
   renderInvalidFile,
   renderInvalidPayload,
   renderMissingSpan,
+  renderNoDefaultBranch,
   renderSuccessfulCommand,
   renderUploading,
 } from './renderer'
@@ -134,6 +135,13 @@ export class UploadSbomCommand extends Command {
           this.context.stderr.write(renderDuplicateUpload(sha, environment, service))
 
           return 0
+        }
+
+        if (error.response?.status === 412) {
+          const repositoryUrl = tags[GIT_REPOSITORY_URL] || 'url-not-found'
+          this.context.stderr.write(renderNoDefaultBranch(repositoryUrl))
+
+          return 1
         }
       }
 


### PR DESCRIPTION
### What and why?

Customer with no default branch have their upload rejected. They reach out support. We want to add a message that indicates how to troubleshoot so that the users can troubleshoot and fix the issue themselves.

### How?

When the default branch is not found, the server will return an error code 412. When we receive this error, we show then a message to invite the user to define a default branch.