### PR TITLE
check rule existence in extensions

### DIFF
--- a/src/commands/sarif/__tests__/fixtures/test_validation/rules-in-extensions.sarif
+++ b/src/commands/sarif/__tests__/fixtures/test_validation/rules-in-extensions.sarif
@@ -1,0 +1,67 @@
+{
+  "version": "2.1.0",
+  "$schema": "http://json.schemastore.org/sarif-2.1.0-rtm.5",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "name": "ESLint",
+          "informationUri": "https://eslint.org",
+          "rules": [
+          ],
+          "version": "7.32.0"
+        },
+          "extensions": [
+            {
+                "name": "my-extension",
+                "rules": [
+                    {
+                      "id": "@typescript-eslint/no-unused-vars",
+                      "helpUri": "https://github.com/typescript-eslint/typescript-eslint/blob/v4.33.0/packages/eslint-plugin/docs/rules/no-unused-vars.md",
+                      "properties": {
+                        "category": "Variables"
+                      },
+                      "shortDescription": {
+                        "text": "Disallow unused variables"
+                      }
+                    }
+                ]
+            }
+          ]
+      },
+      "artifacts": [
+        {
+          "location": {
+            "uri": "file:///foo/bar/myfile.test.ts"
+          }
+        }
+      ],
+      "results": [
+        {
+          "level": "error",
+          "message": {
+            "text": "'foobar' is assigned a value but never used. Allowed unused vars must match /_/u."
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "file:///foo/bar/myfile.test.ts",
+                  "index": 0
+                },
+                "region": {
+                  "startLine": 7,
+                  "startColumn": 7,
+                  "endLine": 7,
+                  "endColumn": 14
+                }
+              }
+            }
+          ],
+          "ruleId": "@typescript-eslint/no-unused-vars",
+          "ruleIndex": 0
+        }
+      ]
+    }
+  ]
+}

--- a/src/commands/sarif/__tests__/validation.test.ts
+++ b/src/commands/sarif/__tests__/validation.test.ts
@@ -10,4 +10,8 @@ describe('validation', () => {
     expect(err.length).toBe(1)
     expect(err[0]).toBe('result references rule my-rule-id but rule not found in the tool section')
   })
+  test('rules can be in extensions', () => {
+    const err = checkForError('./src/commands/sarif/__tests__/fixtures/test_validation/rules-in-extensions.sarif')
+    expect(err.length).toBe(0)
+  })
 })

--- a/src/commands/sarif/validation.ts
+++ b/src/commands/sarif/validation.ts
@@ -58,6 +58,18 @@ export const checkForError = (filePath: string): string[] => {
           }
         }
       }
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      if ('tool' in run && 'extensions' in run['tool']) {
+        for (const extension of run['tool']['extensions']) {
+          if ('rules' in extension) {
+            for (const rule of extension['rules']) {
+              if ('id' in rule) {
+                rules.push(rule['id'])
+              }
+            }
+          }
+        }
+      }
 
       if ('results' in run) {
         for (const result of run['results']) {


### PR DESCRIPTION
### What and why?

We check that the SARIF file is valid to check that all rules are defined. We currently check in the tool section and not in the extensions. When processing a SARIF file that does have rules in extensions, it fails.

### How?

Detect rules in extensions

