### PR TITLE
Fix two expected formats of role ARN

### DIFF
--- a/src/commands/stepfunctions/awsCommands.ts
+++ b/src/commands/stepfunctions/awsCommands.ts
@@ -205,7 +205,11 @@ export const attachPolicyToStateMachineIamRole = async (
   context: BaseContext,
   dryRun: boolean
 ): Promise<AttachRolePolicyCommandOutput | undefined> => {
-  const roleName = describeStateMachineCommandOutput?.roleArn?.split('/')[1]
+  let splitRoleArnList = describeStateMachineCommandOutput?.roleArn?.split('/')
+  if (splitRoleArnList === undefined) {
+    throw Error(`unexpected roleArn ${describeStateMachineCommandOutput?.roleArn} for the describeStateMachineCommandOutput ${describeStateMachineCommandOutput}`)
+  }
+  const roleName = splitRoleArnList[splitRoleArnList.length - 1]
   const policyArn = `arn:aws:iam::${accountId}:policy/${buildLogAccessPolicyName(describeStateMachineCommandOutput)}`
 
   const input = {


### PR DESCRIPTION
### What and why?

There are two formats of ARN:
1. `arn:aws:iam::425362996713:role/prodnext-statemachine-prodnextstatemachineuninstrum-htJ0SB47b7yh`
2. `arn:aws:iam::425362996713:role/service-role/StepFunctions-L2TTest-NestedStepFunctions-role-qye91on3g`

We didn't noticed that there are the second format before. This PR fix the parsing by fetching the last element from the list after splitting.

### How?

A brief description of implementation details of this PR.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
