### PR TITLE
Add explicit function return type for Lambda and Step Function code

### DIFF
--- a/src/commands/lambda/flare.ts
+++ b/src/commands/lambda/flare.ts
@@ -83,7 +83,7 @@ export class LambdaFlareCommand extends Command {
    * Lambda function and sends them to Datadog support.
    * @returns 0 if the command ran successfully, 1 otherwise.
    */
-  public async execute() {
+  public async execute(): Promise<0 | 1> {
     this.context.stdout.write(helpersRenderer.renderFlareHeader('Lambda', this.isDryRun))
 
     // Validate function name
@@ -425,7 +425,7 @@ export class LambdaFlareCommand extends Command {
  * @param config
  * @returns a summarized config
  */
-export const summarizeConfig = (config: any) => {
+export const summarizeConfig = (config: any): any => {
   const summarizedConfig: any = {}
   for (const key in config) {
     if (SUMMARIZED_FIELDS.has(key)) {
@@ -450,7 +450,7 @@ export const getLogStreamNames = async (
   logGroupName: string,
   startMillis?: number,
   endMillis?: number
-) => {
+): Promise<string[]> => {
   const config = {
     logGroupName,
     descending: true,
@@ -507,7 +507,7 @@ export const getLogEvents = async (
   logStreamName: string,
   startMillis?: number,
   endMillis?: number
-) => {
+): Promise<OutputLogEvent[]> => {
   const config: any = {
     logGroupName,
     logStreamName,
@@ -537,7 +537,12 @@ export const getLogEvents = async (
  * @param endMillis end time in milliseconds or undefined if no end time is specified
  * @returns a map of log stream names to log events or an empty map if no logs are found
  */
-export const getAllLogs = async (region: string, functionName: string, startMillis?: number, endMillis?: number) => {
+export const getAllLogs = async (
+  region: string,
+  functionName: string,
+  startMillis?: number,
+  endMillis?: number
+): Promise<Map<string, OutputLogEvent[]>> => {
   const logs = new Map<string, OutputLogEvent[]>()
   const cwlClient = new CloudWatchLogsClient({region, retryStrategy: EXPONENTIAL_BACKOFF_RETRY_STRATEGY})
   if (functionName.startsWith('arn:aws')) {
@@ -574,7 +579,11 @@ export const getAllLogs = async (region: string, functionName: string, startMill
  * @returns the tags or an empty object if no tags are found
  * @throws Error if the tags cannot be retrieved
  */
-export const getTags = async (lambdaClient: LambdaClient, region: string, arn: string) => {
+export const getTags = async (
+  lambdaClient: LambdaClient,
+  region: string,
+  arn: string
+): Promise<Record<string, string>> => {
   if (!arn.startsWith('arn:aws')) {
     throw Error(`Invalid function ARN: ${arn}`)
   }
@@ -601,7 +610,7 @@ export const getTags = async (lambdaClient: LambdaClient, region: string, arn: s
  * @param filePaths the list of file paths
  * @returns a mapping of file paths to new file names
  */
-export const getUniqueFileNames = (filePaths: Set<string>) => {
+export const getUniqueFileNames = (filePaths: Set<string>): Map<string, string> => {
   // Count occurrences of each filename
   const fileNameCount: {[fileName: string]: number} = {}
   filePaths.forEach((filePath) => {
@@ -634,7 +643,7 @@ export const getUniqueFileNames = (filePaths: Set<string>) => {
  * @param logEvents array of log events
  * @returns the CSV string
  */
-export const convertToCSV = (logEvents: OutputLogEvent[]) => {
+export const convertToCSV = (logEvents: OutputLogEvent[]): string => {
   const rows = [['timestamp', 'datetime', 'message']]
   for (const logEvent of logEvents) {
     const timestamp = `"${logEvent.timestamp ?? ''}"`
@@ -653,7 +662,7 @@ export const convertToCSV = (logEvents: OutputLogEvent[]) => {
 /**
  * @param ms number of milliseconds to sleep
  */
-export const sleep = async (ms: number) => {
+export const sleep = async (ms: number): Promise<void> => {
   await new Promise((resolve) => setTimeout(resolve, ms))
 }
 
@@ -661,7 +670,7 @@ export const sleep = async (ms: number) => {
  * Get the framework used based on the files in the directory
  * @returns the framework used or undefined if no framework is found
  */
-export const getFramework = () => {
+export const getFramework = (): string => {
   const frameworks = new Set<DeploymentFrameworks>()
   const files = fs.readdirSync(process.cwd())
   files.forEach((file) => {
@@ -683,7 +692,11 @@ export const getFramework = () => {
  * @param isDryRun whether or not this is a dry run
  * @param config Lambda function configuration
  */
-export const generateInsightsFile = (insightsFilePath: string, isDryRun: boolean, config: FunctionConfiguration) => {
+export const generateInsightsFile = (
+  insightsFilePath: string,
+  isDryRun: boolean,
+  config: FunctionConfiguration
+): void => {
   const lines: string[] = []
   // Header
   lines.push('# Flare Insights')

--- a/src/commands/lambda/functions/instrument.ts
+++ b/src/commands/lambda/functions/instrument.ts
@@ -156,7 +156,7 @@ export const calculateUpdateRequest = async (
   settings: InstrumentationSettings,
   region: string,
   runtime: Runtime
-) => {
+): Promise<UpdateFunctionConfigurationCommandInput | undefined> => {
   const oldEnvVars: Record<string, string> = {...config.Environment?.Variables}
   const changedEnvVars: Record<string, string> = {}
   const functionARN = config.FunctionArn

--- a/src/commands/lambda/functions/uninstrument.ts
+++ b/src/commands/lambda/functions/uninstrument.ts
@@ -116,7 +116,10 @@ export const getUninstrumentedFunctionConfigsFromRegEx = async (
   return functionsToUpdate
 }
 
-export const calculateUpdateRequest = (config: LFunctionConfiguration, runtime: Runtime) => {
+export const calculateUpdateRequest = (
+  config: LFunctionConfiguration,
+  runtime: Runtime
+): UpdateFunctionConfigurationRequest | undefined => {
   const oldEnvVars: Record<string, string> = {...config.Environment?.Variables}
   const functionARN = config.FunctionArn
 

--- a/src/commands/lambda/instrument.ts
+++ b/src/commands/lambda/instrument.ts
@@ -83,7 +83,7 @@ export class InstrumentCommand extends Command {
 
   private credentials?: AwsCredentialIdentity
 
-  public async execute() {
+  public async execute(): Promise<0 | 1> {
     this.context.stdout.write(instrumentRenderer.renderLambdaHeader(Object.getPrototypeOf(this), this.dryRun))
 
     const lambdaConfig = {lambda: this.config}
@@ -392,7 +392,7 @@ export class InstrumentCommand extends Command {
     return {commitSha: currentStatus.hash, gitRemote}
   }
 
-  private async uploadGitData() {
+  private async uploadGitData(): Promise<void> {
     const cli = new Cli()
     cli.register(UploadCommand)
     if ((await cli.run(['git-metadata', 'upload'], this.context)) !== 0) {
@@ -499,7 +499,7 @@ export class InstrumentCommand extends Command {
     }
   }
 
-  private printPlannedActions(configs: FunctionConfiguration[]) {
+  private printPlannedActions(configs: FunctionConfiguration[]): void {
     const willUpdate = willUpdateFunctionConfigs(configs)
     if (!willUpdate) {
       this.context.stdout.write(instrumentRenderer.renderNoUpdatesApplied(this.dryRun))
@@ -568,7 +568,7 @@ export class InstrumentCommand extends Command {
     }
   }
 
-  private setEnvServiceVersion() {
+  private setEnvServiceVersion(): void {
     this.environment = process.env[ENVIRONMENT_ENV_VAR] || undefined
     this.service = process.env[SERVICE_ENV_VAR] || undefined
     this.version = process.env[VERSION_ENV_VAR] || undefined

--- a/src/commands/lambda/loggroup.ts
+++ b/src/commands/lambda/loggroup.ts
@@ -10,6 +10,7 @@ import {
   DescribeSubscriptionFiltersCommandInput,
   PutSubscriptionFilterCommand,
   PutSubscriptionFilterCommandInput,
+  SubscriptionFilter,
 } from '@aws-sdk/client-cloudwatch-logs'
 
 import {SUBSCRIPTION_FILTER_NAME} from './constants'
@@ -24,7 +25,10 @@ export enum SubscriptionState {
 
 const MAX_LOG_GROUP_SUBSCRIPTIONS = 2
 
-export const applyLogGroupConfig = async (client: CloudWatchLogsClient, config: LogGroupConfiguration) => {
+export const applyLogGroupConfig = async (
+  client: CloudWatchLogsClient,
+  config: LogGroupConfiguration
+): Promise<void> => {
   const {createLogGroupCommandInput, deleteSubscriptionFilterCommandInput, putSubscriptionFilterCommandInput} = config
   if (createLogGroupCommandInput !== undefined) {
     await createLogGroup(client, createLogGroupCommandInput)
@@ -37,7 +41,10 @@ export const applyLogGroupConfig = async (client: CloudWatchLogsClient, config: 
   }
 }
 
-export const createLogGroup = async (client: CloudWatchLogsClient, input: CreateLogGroupCommandInput) => {
+export const createLogGroup = async (
+  client: CloudWatchLogsClient,
+  input: CreateLogGroupCommandInput
+): Promise<void> => {
   const command = new CreateLogGroupCommand(input)
   await client.send(command)
 }
@@ -50,7 +57,10 @@ export const deleteSubscriptionFilter = async (
   await client.send(command)
 }
 
-export const putSubscriptionFilter = async (client: CloudWatchLogsClient, input: PutSubscriptionFilterCommandInput) => {
+export const putSubscriptionFilter = async (
+  client: CloudWatchLogsClient,
+  input: PutSubscriptionFilterCommandInput
+): Promise<void> => {
   const command = new PutSubscriptionFilterCommand(input)
   await client.send(command)
 }
@@ -59,7 +69,7 @@ export const calculateLogGroupUpdateRequest = async (
   client: CloudWatchLogsClient,
   logGroupName: string,
   forwarderARN: string
-) => {
+): Promise<LogGroupConfiguration | undefined> => {
   const config: LogGroupConfiguration = {
     logGroupName,
     putSubscriptionFilterCommandInput: {
@@ -99,7 +109,7 @@ export const calculateLogGroupRemoveRequest = async (
   client: CloudWatchLogsClient,
   logGroupName: string,
   forwarderARN: string
-) => {
+): Promise<LogGroupConfiguration> => {
   const config: LogGroupConfiguration = {
     logGroupName,
   }
@@ -140,7 +150,7 @@ export const getSubscriptionFilterState = async (
   client: CloudWatchLogsClient,
   logGroupName: string,
   forwarderARN: string
-) => {
+): Promise<SubscriptionState> => {
   const subscriptionFilters = await getSubscriptionFilters(client, logGroupName)
   if (subscriptionFilters === undefined || subscriptionFilters.length === 0) {
     return SubscriptionState.Empty
@@ -162,7 +172,10 @@ export const getSubscriptionFilterState = async (
   return SubscriptionState.WrongDestinationUnowned
 }
 
-export const getSubscriptionFilters = async (client: CloudWatchLogsClient, logGroupName: string) => {
+export const getSubscriptionFilters = async (
+  client: CloudWatchLogsClient,
+  logGroupName: string
+): Promise<SubscriptionFilter[] | undefined> => {
   const input: DescribeSubscriptionFiltersCommandInput = {
     logGroupName,
   }

--- a/src/commands/lambda/prompt.ts
+++ b/src/commands/lambda/prompt.ts
@@ -208,7 +208,7 @@ export const functionSelectionQuestion = (functionNames: string[]): typeof check
   },
 })
 
-export const requestAWSCredentials = async () => {
+export const requestAWSCredentials = async (): Promise<void> => {
   try {
     const awsCredentialsAnswers = await inquirer.prompt(awsCredentialsQuestions)
     process.env[AWS_ACCESS_KEY_ID_ENV_VAR] = awsCredentialsAnswers[AWS_ACCESS_KEY_ID_ENV_VAR]
@@ -223,7 +223,7 @@ export const requestAWSCredentials = async () => {
   }
 }
 
-export const requestAWSRegion = async (defaultRegion?: string) => {
+export const requestAWSRegion = async (defaultRegion?: string): Promise<void> => {
   try {
     const awsRegionAnswer = await inquirer.prompt(awsRegionQuestion(defaultRegion))
     process.env[AWS_DEFAULT_REGION_ENV_VAR] = awsRegionAnswer[AWS_DEFAULT_REGION_ENV_VAR]
@@ -234,7 +234,7 @@ export const requestAWSRegion = async (defaultRegion?: string) => {
   }
 }
 
-export const requestDatadogEnvVars = async () => {
+export const requestDatadogEnvVars = async (): Promise<void> => {
   try {
     const envSite = process.env[CI_SITE_ENV_VAR]
     let selectedDatadogSite = envSite
@@ -258,7 +258,7 @@ export const requestDatadogEnvVars = async () => {
   }
 }
 
-export const requestEnvServiceVersion = async () => {
+export const requestEnvServiceVersion = async (): Promise<void> => {
   try {
     const envQuestionAnswer = await inquirer.prompt(envQuestion)
     const inputedEnvQuestionAnswer = envQuestionAnswer[ENVIRONMENT_ENV_VAR]
@@ -278,7 +278,7 @@ export const requestEnvServiceVersion = async () => {
   }
 }
 
-export const requestFunctionSelection = async (functionNames: string[]) => {
+export const requestFunctionSelection = async (functionNames: string[]): Promise<any> => {
   try {
     const selectedFunctionsAnswer: any = await inquirer.prompt(functionSelectionQuestion(functionNames))
 

--- a/src/commands/lambda/tags.ts
+++ b/src/commands/lambda/tags.ts
@@ -13,7 +13,7 @@ import {version} from '../../helpers/version'
 import {TAG_VERSION_NAME} from './constants'
 import {TagConfiguration} from './interfaces'
 
-export const applyTagConfig = async (lambdaClient: LambdaClient, config: TagConfiguration) => {
+export const applyTagConfig = async (lambdaClient: LambdaClient, config: TagConfiguration): Promise<void> => {
   const {tagResourceCommandInput, untagResourceCommandInput} = config
   if (tagResourceCommandInput !== undefined) {
     await tagResource(lambdaClient, tagResourceCommandInput)
@@ -23,17 +23,20 @@ export const applyTagConfig = async (lambdaClient: LambdaClient, config: TagConf
   }
 }
 
-export const tagResource = async (client: LambdaClient, input: TagResourceCommandInput) => {
+export const tagResource = async (client: LambdaClient, input: TagResourceCommandInput): Promise<void> => {
   const command = new TagResourceCommand(input)
   await client.send(command)
 }
 
-export const untagResource = async (client: LambdaClient, input: UntagResourceCommandInput) => {
+export const untagResource = async (client: LambdaClient, input: UntagResourceCommandInput): Promise<void> => {
   const command = new UntagResourceCommand(input)
   await client.send(command)
 }
 
-export const calculateTagUpdateRequest = async (lambdaClient: LambdaClient, functionARN: string) => {
+export const calculateTagUpdateRequest = async (
+  lambdaClient: LambdaClient,
+  functionARN: string
+): Promise<TagConfiguration | undefined> => {
   const config: TagConfiguration = {}
 
   const versionTagPresent = await hasVersionTag(lambdaClient, functionARN)
@@ -52,7 +55,10 @@ export const calculateTagUpdateRequest = async (lambdaClient: LambdaClient, func
   return
 }
 
-export const calculateTagRemoveRequest = async (lambdaClient: LambdaClient, functionARN: string) => {
+export const calculateTagRemoveRequest = async (
+  lambdaClient: LambdaClient,
+  functionARN: string
+): Promise<TagConfiguration | undefined> => {
   const config: TagConfiguration = {}
   const versionTagPresent = await hasVersionTag(lambdaClient, functionARN)
   if (versionTagPresent) {

--- a/src/commands/lambda/uninstrument.ts
+++ b/src/commands/lambda/uninstrument.ts
@@ -66,7 +66,7 @@ export class UninstrumentCommand extends Command {
 
   private credentials?: AwsCredentialIdentity
 
-  public async execute() {
+  public async execute(): Promise<0 | 1> {
     this.context.stdout.write(instrumentRenderer.renderLambdaHeader(Object.getPrototypeOf(this), this.dryRun))
 
     const lambdaConfig = {lambda: this.config}
@@ -278,7 +278,7 @@ export class UninstrumentCommand extends Command {
     return 0
   }
 
-  private printPlannedActions(configs: FunctionConfiguration[]) {
+  private printPlannedActions(configs: FunctionConfiguration[]): void {
     const willUpdate = willUpdateFunctionConfigs(configs)
 
     if (!willUpdate) {

--- a/src/commands/stepfunctions/instrument.ts
+++ b/src/commands/stepfunctions/instrument.ts
@@ -62,7 +62,7 @@ export class InstrumentStepFunctionsCommand extends Command {
   )
   private propagateUpstreamTrace = Option.Boolean('--propagate-upstream-trace', false)
 
-  public async execute() {
+  public async execute(): Promise<0 | 1> {
     let validationError = false
     if (typeof this.forwarderArn !== 'string') {
       this.context.stdout.write('[Error] `--forwarder` is required\n')

--- a/src/commands/stepfunctions/uninstrument.ts
+++ b/src/commands/stepfunctions/uninstrument.ts
@@ -43,7 +43,7 @@ export class UninstrumentStepFunctionsCommand extends Command {
     {hidden: true}
   )
 
-  public async execute() {
+  public async execute(): Promise<0 | 1> {
     let validationError = false
     let hasChanges = false
 


### PR DESCRIPTION
### What and why?

Add explicit return type for most functions in
- `src/commands/lambda`
- `src/commands/stepfunctions` 

to make code more readable, improving developer experience.

The return type for some functions is complicated (>= 4 lines long), and I'm not adding explicit return type for them because I think it would make code verbose and less readable.

### How?

N/A

### Testing

No new failure in `npm test`

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
