### PR TITLE
[SYNTH-16108] Show error stack trace and cause

### DIFF
--- a/src/__mocks__/util.js
+++ b/src/__mocks__/util.js
@@ -2,7 +2,7 @@ const util = jest.requireActual('util')
 const originalInspect = util.inspect
 
 const newInspect = (object, options) => {
-  return originalInspect(object, {...options, colors: false, depth: options.depth})
+  return originalInspect(object, {...options, colors: false, depth: options?.depth})
 }
 
 Object.assign(newInspect, originalInspect)

--- a/src/commands/synthetics/__tests__/cli.test.ts
+++ b/src/commands/synthetics/__tests__/cli.test.ts
@@ -1399,7 +1399,9 @@ describe('run-test', () => {
       expect(writeMock).toHaveBeenCalledWith('[aaa-aaa-aaa] Found test "aaa-aaa-aaa"\n')
       expect(writeMock).toHaveBeenCalledWith('[bbb-bbb-bbb] Found test "bbb-bbb-bbb" (1 test override)\n')
       expect(writeMock).toHaveBeenCalledWith(
-        '\n ERROR: authorization error \nFailed to get test: query on https://app.datadoghq.com/tests/for-bid-den returned: "Forbidden"\n\n\n'
+        expect.stringContaining(
+          '\n ERROR: authorization error \nCriticalError: Failed to get test: query on https://app.datadoghq.com/tests/for-bid-den returned: "Forbidden"'
+        )
       )
       expect(writeMock).toHaveBeenCalledWith(
         'Credentials refused, make sure `apiKey`, `appKey` and `datadogSite` are correct.\n'

--- a/src/commands/synthetics/__tests__/utils/__snapshots__/public.test.ts.snap
+++ b/src/commands/synthetics/__tests__/utils/__snapshots__/public.test.ts.snap
@@ -25,7 +25,12 @@ exports[`utils reportCiError should report AUTHORIZATION_ERROR error 1`] = `
     [
       "
 [41m[1m ERROR: authorization error [22m[49m
-
+CiError: 
+    at someFunction (someFile.js:42:42)
+    at someFunction (someFile.js:42:42) {
+  code: 'AUTHORIZATION_ERROR',
+  cause: undefined
+}
 
 ",
     ],
@@ -45,7 +50,12 @@ exports[`utils reportCiError should report INVALID_CONFIG error 1`] = `
     [
       "
 [41m[1m ERROR: invalid config [22m[49m
-
+CiError: 
+    at someFunction (someFile.js:42:42)
+    at someFunction (someFile.js:42:42) {
+  code: 'INVALID_CONFIG',
+  cause: undefined
+}
 
 ",
     ],
@@ -118,7 +128,7 @@ exports[`utils reportCiError should report NO_TESTS_TO_RUN error 1`] = `
   "calls": [
     [
       "
-[41m[1m ERROR: No tests to run [22m[49m
+[41m[1m ERROR: no tests to run [22m[49m
 
 
 ",
@@ -139,7 +149,12 @@ exports[`utils reportCiError should report POLL_RESULTS_FAILED error 1`] = `
     [
       "
 [41m[1m ERROR: unable to poll test results [22m[49m
-
+CiError: 
+    at someFunction (someFile.js:42:42)
+    at someFunction (someFile.js:42:42) {
+  code: 'POLL_RESULTS_FAILED',
+  cause: undefined
+}
 
 ",
     ],
@@ -159,7 +174,12 @@ exports[`utils reportCiError should report TOO_MANY_TESTS_TO_TRIGGER error 1`] =
     [
       "
 [41m[1m ERROR: too many tests to trigger [22m[49m
-
+CiError: 
+    at someFunction (someFile.js:42:42)
+    at someFunction (someFile.js:42:42) {
+  code: 'TOO_MANY_TESTS_TO_TRIGGER',
+  cause: undefined
+}
 
 ",
     ],
@@ -179,7 +199,12 @@ exports[`utils reportCiError should report TRIGGER_TESTS_FAILED error 1`] = `
     [
       "
 [41m[1m ERROR: unable to trigger tests [22m[49m
-
+CiError: 
+    at someFunction (someFile.js:42:42)
+    at someFunction (someFile.js:42:42) {
+  code: 'TRIGGER_TESTS_FAILED',
+  cause: undefined
+}
 
 ",
     ],
@@ -199,7 +224,12 @@ exports[`utils reportCiError should report TUNNEL_START_FAILED error 1`] = `
     [
       "
 [41m[1m ERROR: unable to start tunnel [22m[49m
-
+CiError: 
+    at someFunction (someFile.js:42:42)
+    at someFunction (someFile.js:42:42) {
+  code: 'TUNNEL_START_FAILED',
+  cause: undefined
+}
 
 ",
     ],
@@ -218,8 +248,13 @@ exports[`utils reportCiError should report UNAVAILABLE_TEST_CONFIG error 1`] = `
   "calls": [
     [
       "
-[41m[1m ERROR: unable to obtain test configurations with search query [22m[49m
-
+[41m[1m ERROR: unable to obtain test configurations [22m[49m
+CiError: 
+    at someFunction (someFile.js:42:42)
+    at someFunction (someFile.js:42:42) {
+  code: 'UNAVAILABLE_TEST_CONFIG',
+  cause: undefined
+}
 
 ",
     ],
@@ -239,7 +274,12 @@ exports[`utils reportCiError should report UNAVAILABLE_TUNNEL_CONFIG error 1`] =
     [
       "
 [41m[1m ERROR: unable to get tunnel configuration [22m[49m
-
+CiError: 
+    at someFunction (someFile.js:42:42)
+    at someFunction (someFile.js:42:42) {
+  code: 'UNAVAILABLE_TUNNEL_CONFIG',
+  cause: undefined
+}
 
 ",
     ],
@@ -259,7 +299,12 @@ exports[`utils reportCiError should report default Error if no CiError was match
     [
       "
 [41m[1m ERROR [22m[49m
-
+CiError: 
+    at someFunction (someFile.js:42:42)
+    at someFunction (someFile.js:42:42) {
+  code: 'ERROR',
+  cause: undefined
+}
 
 ",
     ],

--- a/src/commands/synthetics/__tests__/utils/__snapshots__/public.test.ts.snap
+++ b/src/commands/synthetics/__tests__/utils/__snapshots__/public.test.ts.snap
@@ -29,7 +29,7 @@ CiError:
     at someFunction (someFile.js:42:42)
     at someFunction (someFile.js:42:42) {
   code: 'AUTHORIZATION_ERROR',
-  cause: undefined
+  [cause]: undefined
 }
 
 ",
@@ -54,7 +54,7 @@ CiError:
     at someFunction (someFile.js:42:42)
     at someFunction (someFile.js:42:42) {
   code: 'INVALID_CONFIG',
-  cause: undefined
+  [cause]: undefined
 }
 
 ",
@@ -153,7 +153,7 @@ CiError:
     at someFunction (someFile.js:42:42)
     at someFunction (someFile.js:42:42) {
   code: 'POLL_RESULTS_FAILED',
-  cause: undefined
+  [cause]: undefined
 }
 
 ",
@@ -178,7 +178,7 @@ CiError:
     at someFunction (someFile.js:42:42)
     at someFunction (someFile.js:42:42) {
   code: 'TOO_MANY_TESTS_TO_TRIGGER',
-  cause: undefined
+  [cause]: undefined
 }
 
 ",
@@ -203,7 +203,7 @@ CiError:
     at someFunction (someFile.js:42:42)
     at someFunction (someFile.js:42:42) {
   code: 'TRIGGER_TESTS_FAILED',
-  cause: undefined
+  [cause]: undefined
 }
 
 ",
@@ -228,7 +228,7 @@ CiError:
     at someFunction (someFile.js:42:42)
     at someFunction (someFile.js:42:42) {
   code: 'TUNNEL_START_FAILED',
-  cause: undefined
+  [cause]: undefined
 }
 
 ",
@@ -253,7 +253,7 @@ CiError:
     at someFunction (someFile.js:42:42)
     at someFunction (someFile.js:42:42) {
   code: 'UNAVAILABLE_TEST_CONFIG',
-  cause: undefined
+  [cause]: undefined
 }
 
 ",
@@ -278,7 +278,7 @@ CiError:
     at someFunction (someFile.js:42:42)
     at someFunction (someFile.js:42:42) {
   code: 'UNAVAILABLE_TUNNEL_CONFIG',
-  cause: undefined
+  [cause]: undefined
 }
 
 ",
@@ -303,7 +303,7 @@ CiError:
     at someFunction (someFile.js:42:42)
     at someFunction (someFile.js:42:42) {
   code: 'ERROR',
-  cause: undefined
+  [cause]: undefined
 }
 
 ",

--- a/src/commands/synthetics/__tests__/utils/public.test.ts
+++ b/src/commands/synthetics/__tests__/utils/public.test.ts
@@ -2164,6 +2164,14 @@ describe('utils', () => {
       jest.spyOn(util, 'inspect').mockImplementation((error) => {
         error.stack = `Error: ${error.message}\n    at someFunction (someFile.js:42:42)\n    at someFunction (someFile.js:42:42)`
 
+        // Node 14 doesn't show the `[cause]` in the stack trace as shown here: https://nodejs.org/api/errors.html#errorcause
+        // So we mock it here to align the unit tests' snapshots across all Node.js versions on which we run Jest in the CI.
+        if (process.version.startsWith('v14')) {
+          error.cause = undefined
+
+          return originalInspect(error).replace('cause: undefined', '[cause]: undefined')
+        }
+
         return originalInspect(error)
       })
     })

--- a/src/commands/synthetics/__tests__/utils/public.test.ts
+++ b/src/commands/synthetics/__tests__/utils/public.test.ts
@@ -41,6 +41,7 @@ jest.mock('path', () => {
 import child_process from 'child_process'
 import * as fs from 'fs'
 import process from 'process'
+import util from 'util'
 
 import type * as path from 'path'
 
@@ -450,7 +451,7 @@ describe('utils', () => {
 
       await expect(() =>
         utils.getTestAndOverrideConfig(api, triggerConfig, mockReporter, getSummary())
-      ).rejects.toThrow('Failed to get test: could not query https://app.datadoghq.com/example\nForbidden\n')
+      ).rejects.toThrow('Failed to get test: could not query https://app.datadoghq.com/example\nForbidden')
     })
 
     test('Passes when public ID is valid', async () => {
@@ -1731,7 +1732,7 @@ describe('utils', () => {
           mockReporter
         )
       ).rejects.toThrow(
-        'Failed to poll results: could not query https://app.datadoghq.com/example\nPoll results server error\n'
+        'Failed to poll results: could not query https://app.datadoghq.com/example\nPoll results server error'
       )
 
       expect(pollResultsMock).toHaveBeenCalledWith([result.resultId])
@@ -1757,7 +1758,7 @@ describe('utils', () => {
           mockReporter
         )
       ).rejects.toThrow(
-        'Failed to get batch: could not query https://app.datadoghq.com/example\nGet batch server error\n'
+        'Failed to get batch: could not query https://app.datadoghq.com/example\nGet batch server error'
       )
 
       expect(getBatchMock).toHaveBeenCalledWith(trigger.batch_id)
@@ -2158,6 +2159,15 @@ describe('utils', () => {
   })
 
   describe('reportCiError', () => {
+    const originalInspect = jest.requireActual('util').inspect
+    beforeEach(() => {
+      jest.spyOn(util, 'inspect').mockImplementation((error) => {
+        error.stack = `Error: ${error.message}\n    at someFunction (someFile.js:42:42)\n    at someFunction (someFile.js:42:42)`
+
+        return originalInspect(error)
+      })
+    })
+
     test.each([
       'NO_TESTS_TO_RUN',
       'MISSING_TESTS',

--- a/src/commands/synthetics/api.ts
+++ b/src/commands/synthetics/api.ts
@@ -313,7 +313,7 @@ export const determineRetryDelay = (
   }
 }
 
-const isEndpointError = (error: Error): error is EndpointError => error instanceof EndpointError
+export const isEndpointError = (error: Error): error is EndpointError => error instanceof EndpointError
 
 const getErrorHttpStatus = (error: Error): number | undefined =>
   isEndpointError(error) ? error.status : isAxiosError(error) ? error.response?.status : undefined

--- a/src/commands/synthetics/batch.ts
+++ b/src/commands/synthetics/batch.ts
@@ -264,7 +264,7 @@ const getBatch = async (api: APIHelper, batchId: string): Promise<Batch> => {
 
     return batch
   } catch (e) {
-    throw new EndpointError(`Failed to get batch: ${formatBackendErrors(e)}\n`, e.response?.status)
+    throw new EndpointError(`Failed to get batch: ${formatBackendErrors(e)}`, e.response?.status)
   }
 }
 
@@ -285,7 +285,7 @@ const getPollResultMap = async (api: APIHelper, resultIds: string[]) => {
 
     return {pollResultMap, incompleteResultIds}
   } catch (e) {
-    throw new EndpointError(`Failed to poll results: ${formatBackendErrors(e)}\n`, e.response?.status)
+    throw new EndpointError(`Failed to poll results: ${formatBackendErrors(e)}`, e.response?.status)
   }
 }
 

--- a/src/commands/synthetics/errors.ts
+++ b/src/commands/synthetics/errors.ts
@@ -37,9 +37,8 @@ export type CriticalCiErrorCode = typeof criticalErrorCodes[number]
 export type CiErrorCode = NonCriticalCiErrorCode | CriticalCiErrorCode
 
 export class CiError extends Error {
-  // TODO: Use native `cause` property when targeting Node.js 16
-  constructor(public code: CiErrorCode, message?: string, public cause?: Error) {
-    super(message)
+  constructor(public code: CiErrorCode, message?: string, cause?: Error) {
+    super(message, {cause})
   }
 
   public toJson() {

--- a/src/commands/synthetics/mobile.ts
+++ b/src/commands/synthetics/mobile.ts
@@ -64,7 +64,7 @@ export const uploadMobileApplication = async (
   try {
     multipartPresignedUrlsResponse = await api.getMobileApplicationPresignedURLs(applicationId, appSize, parts)
   } catch (e) {
-    throw new EndpointError(`Failed to get presigned URL: ${formatBackendErrors(e)}\n`, e.response?.status)
+    throw new EndpointError(`Failed to get presigned URL: ${formatBackendErrors(e)}`, e.response?.status)
   }
 
   let uploadPartResponses: MobileApplicationUploadPartResponse[]
@@ -74,7 +74,7 @@ export const uploadMobileApplication = async (
       multipartPresignedUrlsResponse.multipart_presigned_urls_params
     )
   } catch (e) {
-    throw new EndpointError(`Failed to upload mobile application: ${formatBackendErrors(e)}\n`, e.response?.status)
+    throw new EndpointError(`Failed to upload mobile application: ${formatBackendErrors(e)}`, e.response?.status)
   }
 
   const {upload_id: uploadId, key} = multipartPresignedUrlsResponse.multipart_presigned_urls_params
@@ -89,7 +89,7 @@ export const uploadMobileApplication = async (
     )
   } catch (e) {
     throw new EndpointError(
-      `Failed to complete upload mobile application: ${formatBackendErrors(e)}\n`,
+      `Failed to complete upload mobile application: ${formatBackendErrors(e)}`,
       e.response?.status
     )
   }
@@ -103,7 +103,7 @@ export const uploadMobileApplication = async (
     try {
       appUploadResponse = await api.pollMobileApplicationUploadResponse(jobId)
     } catch (e) {
-      throw new EndpointError(`Failed to validate mobile application: ${formatBackendErrors(e)}\n`, e.response?.status)
+      throw new EndpointError(`Failed to validate mobile application: ${formatBackendErrors(e)}`, e.response?.status)
     }
 
     if (appUploadResponse.status !== 'pending') {

--- a/src/commands/synthetics/test.ts
+++ b/src/commands/synthetics/test.ts
@@ -85,6 +85,6 @@ export const getTest = async (
       return {errorMessage: `[${chalk.bold.dim(id)}] ${chalk.yellow.bold('Test not found')}: ${errorMessage}`}
     }
 
-    throw new EndpointError(`Failed to get test: ${formatBackendErrors(error)}\n`, error.response?.status)
+    throw new EndpointError(`Failed to get test: ${formatBackendErrors(error)}`, error.response?.status)
   }
 }

--- a/src/commands/synthetics/test.ts
+++ b/src/commands/synthetics/test.ts
@@ -58,13 +58,17 @@ export const getTestsFromSearchQuery = async (
     return []
   }
 
-  const testSearchResults = await api.searchTests(testSearchQuery)
+  try {
+    const testSearchResults = await api.searchTests(testSearchQuery)
 
-  return testSearchResults.tests.map((test) => ({
-    testOverrides: defaultTestOverrides ?? {},
-    id: test.public_id,
-    suite: `Query: ${testSearchQuery}`,
-  }))
+    return testSearchResults.tests.map((test) => ({
+      testOverrides: defaultTestOverrides ?? {},
+      id: test.public_id,
+      suite: `Query: ${testSearchQuery}`,
+    }))
+  } catch (e) {
+    throw new EndpointError(`Failed to search tests with query: ${formatBackendErrors(e)}`, e.response?.status)
+  }
 }
 
 export const getTest = async (

--- a/src/commands/synthetics/utils/public.ts
+++ b/src/commands/synthetics/utils/public.ts
@@ -2,7 +2,7 @@ import {exec} from 'child_process'
 import * as fs from 'fs'
 import * as path from 'path'
 import process from 'process'
-import {promisify} from 'util'
+import {inspect, promisify} from 'util'
 
 import chalk from 'chalk'
 import glob from 'glob'
@@ -859,7 +859,7 @@ export const pluralize = (word: string, count: number): string => (count === 1 ?
 export const reportCiError = (error: CiError, reporter: MainReporter) => {
   switch (error.code) {
     case 'NO_TESTS_TO_RUN':
-      reporter.error(`\n${chalk.bgRed.bold(' ERROR: No tests to run ')}\n${error.message}\n\n`)
+      reporter.error(`\n${chalk.bgRed.bold(' ERROR: no tests to run ')}\n${error.message}\n\n`)
       break
     case 'MISSING_TESTS':
       reporter.error(`\n${chalk.bgRed.bold(' ERROR: some tests are missing ')}\n${error.message}\n\n`)
@@ -867,11 +867,11 @@ export const reportCiError = (error: CiError, reporter: MainReporter) => {
 
     // Critical command errors
     case 'AUTHORIZATION_ERROR':
-      reporter.error(`\n${chalk.bgRed.bold(' ERROR: authorization error ')}\n${error.message}\n\n`)
+      reporter.error(`\n${chalk.bgRed.bold(' ERROR: authorization error ')}\n${inspect(error)}\n\n`)
       reporter.log('Credentials refused, make sure `apiKey`, `appKey` and `datadogSite` are correct.\n')
       break
     case 'INVALID_CONFIG':
-      reporter.error(`\n${chalk.bgRed.bold(' ERROR: invalid config ')}\n${error.message}\n\n`)
+      reporter.error(`\n${chalk.bgRed.bold(' ERROR: invalid config ')}\n${inspect(error)}\n\n`)
       break
     case 'MISSING_APP_KEY':
       reporter.error(`Missing ${chalk.red.bold('DATADOG_APP_KEY')} in your environment.\n`)
@@ -880,30 +880,28 @@ export const reportCiError = (error: CiError, reporter: MainReporter) => {
       reporter.error(`Missing ${chalk.red.bold('DATADOG_API_KEY')} in your environment.\n`)
       break
     case 'POLL_RESULTS_FAILED':
-      reporter.error(`\n${chalk.bgRed.bold(' ERROR: unable to poll test results ')}\n${error.message}\n\n`)
+      reporter.error(`\n${chalk.bgRed.bold(' ERROR: unable to poll test results ')}\n${inspect(error)}\n\n`)
       break
     case 'BATCH_TIMEOUT_RUNAWAY':
-      reporter.error(`\n${chalk.bgRed.bold(' ERROR: batch timeout runaway ')}\n${error.message}\n\n`)
+      reporter.error(`\n${chalk.bgRed.bold(' ERROR: batch timeout runaway ')}\n${inspect(error)}\n\n`)
       break
     case 'TUNNEL_START_FAILED':
-      reporter.error(`\n${chalk.bgRed.bold(' ERROR: unable to start tunnel ')}\n${error.message}\n\n`)
+      reporter.error(`\n${chalk.bgRed.bold(' ERROR: unable to start tunnel ')}\n${inspect(error)}\n\n`)
       break
     case 'TOO_MANY_TESTS_TO_TRIGGER':
-      reporter.error(`\n${chalk.bgRed.bold(' ERROR: too many tests to trigger ')}\n${error.message}\n\n`)
+      reporter.error(`\n${chalk.bgRed.bold(' ERROR: too many tests to trigger ')}\n${inspect(error)}\n\n`)
       break
     case 'TRIGGER_TESTS_FAILED':
-      reporter.error(`\n${chalk.bgRed.bold(' ERROR: unable to trigger tests ')}\n${error.message}\n\n`)
+      reporter.error(`\n${chalk.bgRed.bold(' ERROR: unable to trigger tests ')}\n${inspect(error)}\n\n`)
       break
     case 'UNAVAILABLE_TEST_CONFIG':
-      reporter.error(
-        `\n${chalk.bgRed.bold(' ERROR: unable to obtain test configurations with search query ')}\n${error.message}\n\n`
-      )
+      reporter.error(`\n${chalk.bgRed.bold(' ERROR: unable to obtain test configurations ')}\n${inspect(error)}\n\n`)
       break
     case 'UNAVAILABLE_TUNNEL_CONFIG':
-      reporter.error(`\n${chalk.bgRed.bold(' ERROR: unable to get tunnel configuration ')}\n${error.message}\n\n`)
+      reporter.error(`\n${chalk.bgRed.bold(' ERROR: unable to get tunnel configuration ')}\n${inspect(error)}\n\n`)
       break
 
     default:
-      reporter.error(`\n${chalk.bgRed.bold(' ERROR ')}\n${error.message}\n\n`)
+      reporter.error(`\n${chalk.bgRed.bold(' ERROR ')}\n${inspect(error)}\n\n`)
   }
 }

--- a/src/commands/synthetics/utils/public.ts
+++ b/src/commands/synthetics/utils/public.ts
@@ -620,7 +620,7 @@ export const runTests = async (
     const errorMessage = formatBackendErrors(e)
     const testIds = testsToTrigger.map((t) => t.public_id).join(',')
     // Rewrite error message
-    throw new EndpointError(`[${testIds}] Failed to trigger tests: ${errorMessage}\n`, e.response?.status)
+    throw new EndpointError(`[${testIds}] Failed to trigger tests: ${errorMessage}`, e.response?.status)
   }
 }
 

--- a/src/commands/synthetics/utils/public.ts
+++ b/src/commands/synthetics/utils/public.ts
@@ -9,6 +9,7 @@ import glob from 'glob'
 
 import {getCommonAppBaseURL} from '../../../helpers/app'
 import {getCIMetadata} from '../../../helpers/ci'
+import {coerceError} from '../../../helpers/errors'
 import {GIT_COMMIT_MESSAGE} from '../../../helpers/tags'
 import {pick} from '../../../helpers/utils'
 
@@ -256,7 +257,9 @@ export const getSuites = async (GLOB: string, reporter: MainReporter): Promise<S
 
         return {name: suiteName, content: JSON.parse(content)}
       } catch (e) {
-        throw new Error(`Unable to read and parse the test file ${file}`)
+        throw new Error(`Unable to read and parse the test file ${file}`, {
+          cause: coerceError(e),
+        })
       }
     })
   )

--- a/src/helpers/errors.ts
+++ b/src/helpers/errors.ts
@@ -1,1 +1,15 @@
 export class InvalidConfigurationError extends Error {}
+
+export class CoercedError extends Error {
+  constructor(message: string, public originalType: string) {
+    super(message)
+  }
+}
+
+export const coerceError = (error: unknown): Error | CoercedError => {
+  if (!!error && typeof error === 'object' && 'message' in error) {
+    return error as Error
+  } else {
+    return new CoercedError(String(error), typeof error)
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,7 @@
     "allowSyntheticDefaultImports": true,
     "useUnknownInCatchVariables": false,
     "esModuleInterop": true,
-    "lib": ["es2020"],
+    "lib": ["es2022"],
     "resolveJsonModule": true
   },
   "include": ["src/**/*"]


### PR DESCRIPTION
### What and why?

**Before:**
```sh
$ yarn launch synthetics run-tests -s 'test:('

 ERROR: unable to obtain test configurations with search query 
Request failed with status code 400
```

**After:**
```sh
$ yarn launch synthetics run-tests -s 'test:('

 ERROR: unable to obtain test configurations 
CriticalError: Failed to search tests with query: query on https://api.datadoghq.com/api/v1/synthetics/tests/search returned: "Make sure there is no missing parentheses"
    at /Users/corentin.girard/go/src/github.com/DataDog/datadog-ci.git/master/src/commands/synthetics/run-tests-lib.ts:85:11
    at Generator.throw (<anonymous>)
    at rejected (/Users/corentin.girard/go/src/github.com/DataDog/datadog-ci.git/master/src/commands/synthetics/run-tests-lib.ts:6:65)
    at processTicksAndRejections (node:internal/process/task_queues:95:5) {
  code: 'UNAVAILABLE_TEST_CONFIG',
  [cause]: EndpointError: Failed to search tests with query: query on https://api.datadoghq.com/api/v1/synthetics/tests/search returned: "Make sure there is no missing parentheses"
      at /Users/corentin.girard/go/src/github.com/DataDog/datadog-ci.git/master/src/commands/synthetics/test.ts:81:11
      at Generator.throw (<anonymous>)
      at rejected (/Users/corentin.girard/go/src/github.com/DataDog/datadog-ci.git/master/src/commands/synthetics/test.ts:6:65)
      at processTicksAndRejections (node:internal/process/task_queues:95:5) {
    status: 400
  }
}
```

### How?

For each error that we catch and want to re-throw, we now attach it as a **cause** on the new error.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
