### PR TITLE
[SYNTH-15675] Report timed out retries

### DIFF
--- a/src/commands/synthetics/__tests__/batch.test.ts
+++ b/src/commands/synthetics/__tests__/batch.test.ts
@@ -1,16 +1,49 @@
-import {getResultsToReport} from '../batch'
+import {getResultsToReport, reportReceivedResults} from '../batch'
 import {Batch, ResultInBatch} from '../interfaces'
 
-import {getFailedResultInBatch, mockReporter} from './fixtures'
+import {
+  getFailedResultInBatch,
+  getInProgressResultInBatch,
+  getPassedResultInBatch,
+  getSkippedResultInBatch,
+  mockReporter,
+} from './fixtures'
 
 describe('getResultsToReport', () => {
-  describe('shouldContinuePolling: false', () => {
-    test('timed out retry', () => {
+  test.each([false])('timed out retry - shouldContinuePolling=%s', (shouldContinuePolling: boolean) => {
+    const timedOutRetry: ResultInBatch = {
+      ...getFailedResultInBatch(),
+      retries: 0,
+      max_retries: 1,
+      timed_out: true, // Can only be true when the backend timed out the batch, i.e. `shouldContinuePolling` is false.
+    }
+
+    const batch: Batch = {
+      status: 'failed',
+      results: [timedOutRetry],
+    }
+
+    const resultsToReport = getResultsToReport(
+      shouldContinuePolling,
+      batch,
+      [],
+      new Set(['rid']),
+      new Set(),
+      new Set(),
+      mockReporter
+    )
+
+    expect(resultsToReport).toStrictEqual([timedOutRetry])
+  })
+
+  test.each([false])(
+    'timed out retry never emitted before - shouldContinuePolling=%s',
+    (shouldContinuePolling: boolean) => {
       const timedOutRetry: ResultInBatch = {
         ...getFailedResultInBatch(),
         retries: 0,
         max_retries: 1,
-        timed_out: true,
+        timed_out: true, // Can only be true when the backend timed out the batch, i.e. `shouldContinuePolling` is false.
       }
 
       const batch: Batch = {
@@ -18,9 +51,90 @@ describe('getResultsToReport', () => {
         results: [timedOutRetry],
       }
 
-      const resultsToReport = getResultsToReport(false, batch, [], new Set(['rid']), new Set(), new Set(), mockReporter)
+      const resultsToReport = getResultsToReport(
+        shouldContinuePolling,
+        batch,
+        [timedOutRetry],
+        new Set(),
+        new Set(),
+        new Set(),
+        mockReporter
+      )
 
       expect(resultsToReport).toStrictEqual([timedOutRetry])
-    })
+    }
+  )
+})
+
+describe('reportReceivedResults', () => {
+  test('skipped', () => {
+    const skippedResult = getSkippedResultInBatch()
+
+    const batch: Batch = {
+      status: 'failed',
+      results: [skippedResult],
+    }
+
+    const emittedResultIds = new Set<string>()
+    const receivedResults = reportReceivedResults(batch, emittedResultIds, mockReporter)
+
+    expect(receivedResults).toStrictEqual([skippedResult])
+    expect(emittedResultIds).toContain('skipped-0')
+    expect(mockReporter.resultReceived).toHaveBeenCalledWith(skippedResult)
+  })
+
+  test('final', () => {
+    const result = getPassedResultInBatch()
+
+    const batch: Batch = {
+      status: 'passed',
+      results: [result],
+    }
+
+    const emittedResultIds = new Set<string>()
+    const receivedResults = reportReceivedResults(batch, emittedResultIds, mockReporter)
+
+    expect(receivedResults).toStrictEqual([result])
+    expect(emittedResultIds).toContain('rid')
+    expect(mockReporter.resultReceived).toHaveBeenCalledWith(result)
+  })
+
+  test('non final', () => {
+    const result: ResultInBatch = {
+      ...getInProgressResultInBatch(),
+      retries: 0,
+      max_retries: 1,
+    }
+
+    const batch: Batch = {
+      status: 'in_progress',
+      results: [result],
+    }
+
+    const emittedResultIds = new Set<string>()
+    const receivedResults = reportReceivedResults(batch, emittedResultIds, mockReporter)
+
+    expect(receivedResults).toStrictEqual([result])
+    expect(emittedResultIds).toContain('rid')
+    expect(mockReporter.resultReceived).toHaveBeenCalledWith(result)
+  })
+
+  test('timed out', () => {
+    const timedOut: ResultInBatch = {
+      ...getFailedResultInBatch(),
+      timed_out: true,
+    }
+
+    const batch: Batch = {
+      status: 'failed',
+      results: [timedOut],
+    }
+
+    const emittedResultIds = new Set<string>()
+    const receivedResults = reportReceivedResults(batch, emittedResultIds, mockReporter)
+
+    expect(receivedResults).toStrictEqual([timedOut])
+    expect(emittedResultIds).toContain('rid')
+    expect(mockReporter.resultReceived).toHaveBeenCalledWith(timedOut)
   })
 })

--- a/src/commands/synthetics/__tests__/batch.test.ts
+++ b/src/commands/synthetics/__tests__/batch.test.ts
@@ -1,0 +1,26 @@
+import {getResultsToReport} from '../batch'
+import {Batch, ResultInBatch} from '../interfaces'
+
+import {getFailedResultInBatch, mockReporter} from './fixtures'
+
+describe('getResultsToReport', () => {
+  describe('shouldContinuePolling: false', () => {
+    test('timed out retry', () => {
+      const timedOutRetry: ResultInBatch = {
+        ...getFailedResultInBatch(),
+        retries: 0,
+        max_retries: 1,
+        timed_out: true,
+      }
+
+      const batch: Batch = {
+        status: 'failed',
+        results: [timedOutRetry],
+      }
+
+      const resultsToReport = getResultsToReport(false, batch, [], new Set(['rid']), new Set(), new Set(), mockReporter)
+
+      expect(resultsToReport).toStrictEqual([timedOutRetry])
+    })
+  })
+})

--- a/src/commands/synthetics/__tests__/fixtures.ts
+++ b/src/commands/synthetics/__tests__/fixtures.ts
@@ -195,6 +195,7 @@ const getBaseResult = (resultId: string, test: Test): Omit<BaseResult, 'result'>
   passed: true,
   resultId,
   retries: 0,
+  maxRetries: 0,
   test,
   timedOut: false,
   timestamp: 1,
@@ -239,6 +240,7 @@ export const getTimedOutBrowserResult = (): Result => ({
   },
   resultId: '1',
   retries: 0,
+  maxRetries: 0,
   test: getBrowserTest(),
   timedOut: true,
   timestamp: 1,
@@ -299,6 +301,7 @@ export const getFailedBrowserResult = (): Result => ({
   },
   resultId: '1',
   retries: 0,
+  maxRetries: 0,
   test: getBrowserTest(),
   timedOut: false,
   timestamp: 1,
@@ -522,6 +525,8 @@ export const getInProgressResultInBatch = (): BaseResultInBatch => {
     result_id: 'rid',
     // eslint-disable-next-line no-null/no-null
     retries: null,
+    // eslint-disable-next-line no-null/no-null
+    max_retries: null,
     status: 'in_progress',
     test_public_id: 'pid',
     // eslint-disable-next-line no-null/no-null
@@ -535,6 +540,8 @@ export const getSkippedResultInBatch = (): ResultInBatchSkippedBySelectiveRerun 
     execution_rule: ExecutionRule.SKIPPED,
     // eslint-disable-next-line no-null/no-null
     retries: null,
+    // eslint-disable-next-line no-null/no-null
+    max_retries: null,
     status: 'skipped',
     selective_rerun: {
       decision: 'skip',

--- a/src/commands/synthetics/__tests__/reporters/__snapshots__/default.test.ts.snap
+++ b/src/commands/synthetics/__tests__/reporters/__snapshots__/default.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`Default reporter resultEnd 1 API test, 1 location, 1 result: success 1`] = `
 "[1m[32m✓[39m[22m [[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m - [1m[32mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m
   • Total duration: 123 ms - View test run details:
-    ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=1&batch_id=123&from_ci=true[39m[22m 
+    ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=1&batch_id=123&from_ci=true[39m[22m
   [1m[32m✓[39m[22m [1m[32m[1mGET[22m[1m - http://fake.url[39m[22m
 
 "
@@ -12,19 +12,19 @@ exports[`Default reporter resultEnd 1 API test, 1 location, 1 result: success 1`
 exports[`Default reporter resultEnd 1 API test, 1 location, 3 results: success, failed non-blocking, failed blocking 1`] = `
 "[1m[32m✓[39m[22m [[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m - [1m[32mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m
   • Total duration: 123 ms - View test run details:
-    ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=1&batch_id=123&from_ci=true[39m[22m 
+    ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=1&batch_id=123&from_ci=true[39m[22m
   [1m[32m✓[39m[22m [1m[32m[1mGET[22m[1m - http://fake.url[39m[22m
 
 [1m[33m✖[39m[22m [[1m[33mnon-blocking[39m[22m] [[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m - [1m[33mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m
   • Total duration: 123 ms - View test run details:
-    ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=2&batch_id=123&from_ci=true[39m[22m 
+    ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=2&batch_id=123&from_ci=true[39m[22m
   [1m[33m✖[39m[22m [1m[33m[1mGET[22m[1m - http://fake.url[39m[22m
 [1m[33m  - Assertion failed:[39m[22m
 [1m[33m    ▶ responseTime should be less than [4m1000[24m. Actual: [4m1234[24m[39m[22m
 
 [1m[31m✖[39m[22m [[1m[31mblocking[39m[22m] [[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m - [1m[31mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m
   • Total duration: 123 ms - View test run details:
-    ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=3&batch_id=123&from_ci=true[39m[22m 
+    ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=3&batch_id=123&from_ci=true[39m[22m
   [1m[31m✖[39m[22m [1m[31m[1mGET[22m[1m - http://fake.url[39m[22m
 [1m[31m  - Assertion failed:[39m[22m
 [1m[31m    ▶ responseTime should be less than [4m1000[24m. Actual: [4m1234[24m[39m[22m
@@ -35,7 +35,7 @@ exports[`Default reporter resultEnd 1 API test, 1 location, 3 results: success, 
 exports[`Default reporter resultEnd 3 API tests, 2 passed (1 from previous CI run) 1`] = `
 "[1m[32m✓[39m[22m [[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m - [1m[32mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m
   • Total duration: 123 ms - View test run details:
-    ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=1001&batch_id=123&from_ci=true[39m[22m 
+    ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=1001&batch_id=123&from_ci=true[39m[22m
   [1m[32m✓[39m[22m [1m[32m[1mGET[22m[1m - http://fake.url[39m[22m
 
 [1m[32m✓[39m[22m [[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m
@@ -44,7 +44,7 @@ exports[`Default reporter resultEnd 3 API tests, 2 passed (1 from previous CI ru
 
 [1m[32m✓[39m[22m [2m(edited) [22m[[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m - [1m[32mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m
   • Total duration: 123 ms - View test run details:
-    ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=1003&batch_id=123&from_ci=true[39m[22m 
+    ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=1003&batch_id=123&from_ci=true[39m[22m
   [1m[32m✓[39m[22m [1m[32m[1mGET[22m[1m - http://fake.url[39m[22m
 
 "
@@ -53,7 +53,7 @@ exports[`Default reporter resultEnd 3 API tests, 2 passed (1 from previous CI ru
 exports[`Default reporter resultEnd 3 Browser tests: failed blocking, timed out, global failure 1`] = `
 "[1m[31m✖[39m[22m [[1m[31mblocking[39m[22m] [[1m[2mabc-def-ghi[22m[22m] [1mTest name[22m - [1m[31mlocation: [1mLocation name[22m[1m[39m[22m - [1m[31mdevice: [1mchrome.laptop_large[22m[1m[39m[22m
   • Total duration: 20000 ms - View test run details:
-    ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/abc-def-ghi/result/1?batch_id=123&from_ci=true[39m[22m 
+    ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/abc-def-ghi/result/1?batch_id=123&from_ci=true[39m[22m
 [31m    [[1mSTEP_TIMEOUT[22m] - [2mStep failed because it took more than 20 seconds.[22m[39m
     [1m[32m✓[39m[22m | [1m1000[22mms - Navigate to start URL
     [2mhttps://example.org/[22m
@@ -72,7 +72,7 @@ exports[`Default reporter resultEnd 3 Browser tests: failed blocking, timed out,
 
 [1m[31m✖[39m[22m [[1m[31mblocking[39m[22m] [[1m[2mabc-def-ghi[22m[22m] [1mTest name[22m - [1m[31mlocation: [1mLocation name[22m[1m[39m[22m
   • View test run details:
-    ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/abc-def-ghi/result/1?batch_id=123&from_ci=true[39m[22m 
+    ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/abc-def-ghi/result/1?batch_id=123&from_ci=true[39m[22m
 [31m    [[1mFAILURE_CODE[22m] - [2mFailure message[22m[39m
 
 "
@@ -81,34 +81,34 @@ exports[`Default reporter resultEnd 3 Browser tests: failed blocking, timed out,
 exports[`Default reporter resultEnd Incomplete API and Browser tests - passed and failed 1`] = `
 "[1m[31m✖[39m[22m [[1m[31mblocking[39m[22m] [[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m - [1m[31mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m
   • View test run details:
-    ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=1&batch_id=123&from_ci=true[39m[22m 
+    ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=1&batch_id=123&from_ci=true[39m[22m
   [1m[31m✖[39m[22m [1m[31m[1mGET[22m[1m - http://fake.url[39m[22m
 
 [1m[32m✓[39m[22m [[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m - [1m[32mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m
   • View test run details:
-    ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=2&batch_id=123&from_ci=true[39m[22m 
+    ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=2&batch_id=123&from_ci=true[39m[22m
   [1m[32m✓[39m[22m [1m[32m[1mGET[22m[1m - http://fake.url[39m[22m
 
 [1m[31m✖[39m[22m [[1m[31mblocking[39m[22m] [[1m[2mbbb-bbb-bbb[22m[22m] [1mTest name[22m - [1m[31mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m
   • View test run details:
-    ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/bbb-bbb-bbb/result/3?batch_id=123&from_ci=true[39m[22m 
+    ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/bbb-bbb-bbb/result/3?batch_id=123&from_ci=true[39m[22m
 
 [1m[32m✓[39m[22m [[1m[2mbbb-bbb-bbb[22m[22m] [1mTest name[22m - [1m[32mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m
   • View test run details:
-    ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/bbb-bbb-bbb/result/4?batch_id=123&from_ci=true[39m[22m 
+    ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/bbb-bbb-bbb/result/4?batch_id=123&from_ci=true[39m[22m
 
 "
 `;
 
 exports[`Default reporter resultEnd Retryable test - Edge case: fails, then retry times out 1`] = `
-"[1m[31m✖[39m[22m [[1m[31mblocking[39m[22m] [[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m - [1m[31mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m (attempt 1 of 2)
+"[1m[31m✖[39m[22m [[1m[31mblocking[39m[22m] [[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m - [1m[31mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m ([2mattempt 1 of 2, retrying…[22m)
   • Total duration: 123 ms - View test run details:
-    ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=0&batch_id=123&from_ci=true[39m[22m 
+    ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=0&batch_id=123&from_ci=true[39m[22m
   [1m[31m✖[39m[22m [1m[31m[1mGET[22m[1m - http://fake.url[39m[22m
 [1m[31m  - Assertion failed:[39m[22m
 [1m[31m    ▶ responseTime should be less than [4m1000[24m. Actual: [4m1234[24m[39m[22m
 
-[1m[31m✖[39m[22m [[1m[31mblocking[39m[22m] [[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m - [1m[31mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m (attempt 2 of 2)
+[1m[31m✖[39m[22m [[1m[31mblocking[39m[22m] [[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m - [1m[31mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m ([2mattempt 2, success[22m)
   • Total duration: 123 ms - View test run details:
     ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=0&batch_id=123&from_ci=true[39m[22m (previous attempt)
   [1m[31m✖[39m[22m [1m[31m[1mGET[22m[1m - http://fake.url[39m[22m
@@ -118,39 +118,39 @@ exports[`Default reporter resultEnd Retryable test - Edge case: fails, then retr
 `;
 
 exports[`Default reporter resultEnd Retryable test - Usual case: passes after 1 retry only 1`] = `
-"[1m[31m✖[39m[22m [[1m[31mblocking[39m[22m] [[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m - [1m[31mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m (attempt 1 of 3)
+"[1m[31m✖[39m[22m [[1m[31mblocking[39m[22m] [[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m - [1m[31mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m ([2mattempt 1 of 3, retrying…[22m)
   • Total duration: 123 ms - View test run details:
-    ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=0&batch_id=123&from_ci=true[39m[22m 
+    ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=0&batch_id=123&from_ci=true[39m[22m
   [1m[31m✖[39m[22m [1m[31m[1mGET[22m[1m - http://fake.url[39m[22m
 [1m[31m  - Assertion failed:[39m[22m
 [1m[31m    ▶ responseTime should be less than [4m1000[24m. Actual: [4m1234[24m[39m[22m
 
-[1m[32m✓[39m[22m [[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m - [1m[32mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m (attempt 2)
+[1m[32m✓[39m[22m [[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m - [1m[32mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m ([2mattempt 2, success[22m)
   • Total duration: 123 ms - View test run details:
-    ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=1&batch_id=123&from_ci=true[39m[22m 
+    ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=1&batch_id=123&from_ci=true[39m[22m
   [1m[32m✓[39m[22m [1m[32m[1mGET[22m[1m - http://fake.url[39m[22m
 
 "
 `;
 
 exports[`Default reporter resultEnd Retryable test - Usual case: passes after max retries 1`] = `
-"[1m[31m✖[39m[22m [[1m[31mblocking[39m[22m] [[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m - [1m[31mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m (attempt 1 of 3)
+"[1m[31m✖[39m[22m [[1m[31mblocking[39m[22m] [[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m - [1m[31mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m ([2mattempt 1 of 3, retrying…[22m)
   • Total duration: 123 ms - View test run details:
-    ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=0&batch_id=123&from_ci=true[39m[22m 
+    ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=0&batch_id=123&from_ci=true[39m[22m
   [1m[31m✖[39m[22m [1m[31m[1mGET[22m[1m - http://fake.url[39m[22m
 [1m[31m  - Assertion failed:[39m[22m
 [1m[31m    ▶ responseTime should be less than [4m1000[24m. Actual: [4m1234[24m[39m[22m
 
-[1m[31m✖[39m[22m [[1m[31mblocking[39m[22m] [[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m - [1m[31mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m (attempt 2 of 3)
+[1m[31m✖[39m[22m [[1m[31mblocking[39m[22m] [[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m - [1m[31mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m ([2mattempt 2 of 3, retrying…[22m)
   • Total duration: 123 ms - View test run details:
-    ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=1&batch_id=123&from_ci=true[39m[22m 
+    ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=1&batch_id=123&from_ci=true[39m[22m
   [1m[31m✖[39m[22m [1m[31m[1mGET[22m[1m - http://fake.url[39m[22m
 [1m[31m  - Assertion failed:[39m[22m
 [1m[31m    ▶ responseTime should be less than [4m1000[24m. Actual: [4m1234[24m[39m[22m
 
-[1m[32m✓[39m[22m [[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m - [1m[32mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m (attempt 3)
+[1m[32m✓[39m[22m [[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m - [1m[32mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m ([2mattempt 3, success[22m)
   • Total duration: 123 ms - View test run details:
-    ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=2&batch_id=123&from_ci=true[39m[22m 
+    ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=2&batch_id=123&from_ci=true[39m[22m
   [1m[32m✓[39m[22m [1m[32m[1mGET[22m[1m - http://fake.url[39m[22m
 
 "
@@ -326,7 +326,7 @@ exports[`Default reporter testsWait the spinner text is updated and cleared at t
 "View pending summary in Datadog: [2m[36mhttps://app.datadoghq.com/synthetics/explorer/ci?batchResultId=123[39m[22m
 [1m[32m✓[39m[22m [[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m - [1m[32mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m
   • Total duration: 123 ms - View test run details:
-    ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=rid&batch_id=123&from_ci=true[39m[22m 
+    ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=rid&batch_id=123&from_ci=true[39m[22m
   [1m[32m✓[39m[22m [1m[32m[1mGET[22m[1m - http://fake.url[39m[22m
 
 "
@@ -336,7 +336,7 @@ exports[`Default reporter testsWait the spinner text is updated and cleared at t
 "View pending summary in Datadog: [2m[36mhttps://app.datadoghq.com/synthetics/explorer/ci?batchResultId=123[39m[22m
 [1m[32m✓[39m[22m [[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m - [1m[32mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m
   • Total duration: 123 ms - View test run details:
-    ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=rid&batch_id=123&from_ci=true[39m[22m 
+    ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=rid&batch_id=123&from_ci=true[39m[22m
   [1m[32m✓[39m[22m [1m[32m[1mGET[22m[1m - http://fake.url[39m[22m
 
  [36m⠙[39m Waiting for [1m[36m1[39m[22m test [90m(aaa-aaa-aaa)[39m…
@@ -347,7 +347,7 @@ exports[`Default reporter testsWait the spinner text is updated and cleared at t
 "View pending summary in Datadog: [2m[36mhttps://app.datadoghq.com/synthetics/explorer/ci?batchResultId=123[39m[22m
 [1m[32m✓[39m[22m [[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m - [1m[32mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m
   • Total duration: 123 ms - View test run details:
-    ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=rid&batch_id=123&from_ci=true[39m[22m 
+    ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=rid&batch_id=123&from_ci=true[39m[22m
   [1m[32m✓[39m[22m [1m[32m[1mGET[22m[1m - http://fake.url[39m[22m
  [36m⠹[39m Waiting for the batch to end…
 "
@@ -368,7 +368,7 @@ exports[`Default reporter testsWait the spinner text is updated and cleared at t
 
 [1m[32m✓[39m[22m [[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m - [1m[32mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m
   • Total duration: 123 ms - View test run details:
-    ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=rid&batch_id=123&from_ci=true[39m[22m 
+    ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=rid&batch_id=123&from_ci=true[39m[22m
   [1m[32m✓[39m[22m [1m[32m[1mGET[22m[1m - http://fake.url[39m[22m
 
 "
@@ -381,7 +381,7 @@ exports[`Default reporter testsWait the spinner text is updated and cleared at t
 
 [1m[32m✓[39m[22m [[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m - [1m[32mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m
   • Total duration: 123 ms - View test run details:
-    ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=rid&batch_id=123&from_ci=true[39m[22m 
+    ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=rid&batch_id=123&from_ci=true[39m[22m
   [1m[32m✓[39m[22m [1m[32m[1mGET[22m[1m - http://fake.url[39m[22m
 
 - Waiting for [1m[36m1[39m[22m test [90m(aaa-aaa-aaa)[39m…
@@ -398,7 +398,7 @@ exports[`Default reporter testsWait the spinner text is updated and cleared at t
 
 [1m[32m✓[39m[22m [[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m - [1m[32mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m
   • Total duration: 123 ms - View test run details:
-    ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=rid&batch_id=123&from_ci=true[39m[22m 
+    ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=rid&batch_id=123&from_ci=true[39m[22m
   [1m[32m✓[39m[22m [1m[32m[1mGET[22m[1m - http://fake.url[39m[22m
 
 - Waiting for [1m[36m1[39m[22m test [90m(aaa-aaa-aaa)[39m…

--- a/src/commands/synthetics/__tests__/reporters/__snapshots__/default.test.ts.snap
+++ b/src/commands/synthetics/__tests__/reporters/__snapshots__/default.test.ts.snap
@@ -32,29 +32,6 @@ exports[`Default reporter resultEnd 1 API test, 1 location, 3 results: success, 
 "
 `;
 
-exports[`Default reporter resultEnd 1 API test, 3 attempts (2 failed, then passed) 1`] = `
-"[1m[31m✖[39m[22m [[1m[31mblocking[39m[22m] [[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m - [1m[31mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m (attempt 1 of 3)
-  • Total duration: 123 ms - View test run details:
-    ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=1&batch_id=123&from_ci=true[39m[22m 
-  [1m[31m✖[39m[22m [1m[31m[1mGET[22m[1m - http://fake.url[39m[22m
-[1m[31m  - Assertion failed:[39m[22m
-[1m[31m    ▶ responseTime should be less than [4m1000[24m. Actual: [4m1234[24m[39m[22m
-
-[1m[31m✖[39m[22m [[1m[31mblocking[39m[22m] [[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m - [1m[31mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m (attempt 2 of 3)
-  • Total duration: 123 ms - View test run details:
-    ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=2&batch_id=123&from_ci=true[39m[22m 
-  [1m[31m✖[39m[22m [1m[31m[1mGET[22m[1m - http://fake.url[39m[22m
-[1m[31m  - Assertion failed:[39m[22m
-[1m[31m    ▶ responseTime should be less than [4m1000[24m. Actual: [4m1234[24m[39m[22m
-
-[1m[32m✓[39m[22m [[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m - [1m[32mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m (attempt 3 of 3)
-  • Total duration: 123 ms - View test run details:
-    ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=3&batch_id=123&from_ci=true[39m[22m 
-  [1m[32m✓[39m[22m [1m[32m[1mGET[22m[1m - http://fake.url[39m[22m
-
-"
-`;
-
 exports[`Default reporter resultEnd 3 API tests, 2 passed (1 from previous CI run) 1`] = `
 "[1m[32m✓[39m[22m [[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m - [1m[32mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m
   • Total duration: 123 ms - View test run details:
@@ -119,6 +96,62 @@ exports[`Default reporter resultEnd Incomplete API and Browser tests - passed an
 [1m[32m✓[39m[22m [[1m[2mbbb-bbb-bbb[22m[22m] [1mTest name[22m - [1m[32mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m
   • View test run details:
     ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/bbb-bbb-bbb/result/4?batch_id=123&from_ci=true[39m[22m 
+
+"
+`;
+
+exports[`Default reporter resultEnd Retryable test - Edge case: fails, then retry times out 1`] = `
+"[1m[31m✖[39m[22m [[1m[31mblocking[39m[22m] [[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m - [1m[31mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m (attempt 1 of 2)
+  • Total duration: 123 ms - View test run details:
+    ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=0&batch_id=123&from_ci=true[39m[22m 
+  [1m[31m✖[39m[22m [1m[31m[1mGET[22m[1m - http://fake.url[39m[22m
+[1m[31m  - Assertion failed:[39m[22m
+[1m[31m    ▶ responseTime should be less than [4m1000[24m. Actual: [4m1234[24m[39m[22m
+
+[1m[31m✖[39m[22m [[1m[31mblocking[39m[22m] [[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m - [1m[31mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m (attempt 2 of 2)
+  • Total duration: 123 ms - View test run details:
+    ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=0&batch_id=123&from_ci=true[39m[22m (previous attempt)
+  [1m[31m✖[39m[22m [1m[31m[1mGET[22m[1m - http://fake.url[39m[22m
+[31m    [[1mTIMEOUT[22m] - [2mThe batch timed out before receiving the retry.[22m[39m
+
+"
+`;
+
+exports[`Default reporter resultEnd Retryable test - Usual case: passes after 1 retry only 1`] = `
+"[1m[31m✖[39m[22m [[1m[31mblocking[39m[22m] [[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m - [1m[31mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m (attempt 1 of 3)
+  • Total duration: 123 ms - View test run details:
+    ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=0&batch_id=123&from_ci=true[39m[22m 
+  [1m[31m✖[39m[22m [1m[31m[1mGET[22m[1m - http://fake.url[39m[22m
+[1m[31m  - Assertion failed:[39m[22m
+[1m[31m    ▶ responseTime should be less than [4m1000[24m. Actual: [4m1234[24m[39m[22m
+
+[1m[32m✓[39m[22m [[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m - [1m[32mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m (attempt 2)
+  • Total duration: 123 ms - View test run details:
+    ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=1&batch_id=123&from_ci=true[39m[22m 
+  [1m[32m✓[39m[22m [1m[32m[1mGET[22m[1m - http://fake.url[39m[22m
+
+"
+`;
+
+exports[`Default reporter resultEnd Retryable test - Usual case: passes after max retries 1`] = `
+"[1m[31m✖[39m[22m [[1m[31mblocking[39m[22m] [[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m - [1m[31mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m (attempt 1 of 3)
+  • Total duration: 123 ms - View test run details:
+    ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=0&batch_id=123&from_ci=true[39m[22m 
+  [1m[31m✖[39m[22m [1m[31m[1mGET[22m[1m - http://fake.url[39m[22m
+[1m[31m  - Assertion failed:[39m[22m
+[1m[31m    ▶ responseTime should be less than [4m1000[24m. Actual: [4m1234[24m[39m[22m
+
+[1m[31m✖[39m[22m [[1m[31mblocking[39m[22m] [[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m - [1m[31mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m (attempt 2 of 3)
+  • Total duration: 123 ms - View test run details:
+    ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=1&batch_id=123&from_ci=true[39m[22m 
+  [1m[31m✖[39m[22m [1m[31m[1mGET[22m[1m - http://fake.url[39m[22m
+[1m[31m  - Assertion failed:[39m[22m
+[1m[31m    ▶ responseTime should be less than [4m1000[24m. Actual: [4m1234[24m[39m[22m
+
+[1m[32m✓[39m[22m [[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m - [1m[32mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m (attempt 3)
+  • Total duration: 123 ms - View test run details:
+    ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=2&batch_id=123&from_ci=true[39m[22m 
+  [1m[32m✓[39m[22m [1m[32m[1mGET[22m[1m - http://fake.url[39m[22m
 
 "
 `;

--- a/src/commands/synthetics/__tests__/utils/internal.test.ts
+++ b/src/commands/synthetics/__tests__/utils/internal.test.ts
@@ -64,6 +64,11 @@ describe('utils', () => {
       expect(hasResultPassed(result, false, hasTimedOut, {failOnCriticalErrors: true, failOnTimeout: true})).toBe(false)
       expect(hasResultPassed(result, false, hasTimedOut, {failOnCriticalErrors: true, failOnTimeout: false})).toBe(true)
     })
+
+    test('in-progress result', () => {
+      const result = {status: 'in_progress'} as ResultInBatch // failed non-final result (retry expected)
+      expect(hasResultPassed(result, false, false, {failOnCriticalErrors: true, failOnTimeout: true})).toBe(false)
+    })
   })
 
   describe('toBoolean', () => {

--- a/src/commands/synthetics/__tests__/utils/public.test.ts
+++ b/src/commands/synthetics/__tests__/utils/public.test.ts
@@ -833,6 +833,8 @@ describe('utils', () => {
     const apiTest = getApiTest('pid')
     const result: Result = {
       executionRule: ExecutionRule.BLOCKING,
+      initialResultId: undefined,
+      isNonFinal: false,
       location: mockLocation.display_name,
       passed: true,
       result: getBrowserServerResult({passed: true}),
@@ -1058,7 +1060,7 @@ describe('utils', () => {
       })
       expect(mockReporter.resultEnd).toHaveBeenNthCalledWith(
         3,
-        {...result, resultId: 'rid-3', passed: false}, // the first attempt failed, so it's being retried
+        {...result, isNonFinal: true, resultId: 'rid-3', passed: false}, // the first attempt failed, so it's being retried
         MOCK_BASE_URL,
         'bid'
       )

--- a/src/commands/synthetics/__tests__/utils/public.test.ts
+++ b/src/commands/synthetics/__tests__/utils/public.test.ts
@@ -838,6 +838,7 @@ describe('utils', () => {
       result: getBrowserServerResult({passed: true}),
       resultId: 'rid',
       retries: 0,
+      maxRetries: 0,
       selectiveRerun: undefined,
       test: apiTest,
       timedOut: false,
@@ -1326,7 +1327,7 @@ describe('utils', () => {
         'bid'
       )
       expect(mockReporter.error).toHaveBeenCalledWith(
-        'The full information for result rid was incomplete at the end of the batch.\n\n'
+        'The information for result rid of test pid was incomplete at the end of the batch.\n\n'
       )
 
       // Do not report when there are no tests to wait anymore

--- a/src/commands/synthetics/batch.ts
+++ b/src/commands/synthetics/batch.ts
@@ -299,6 +299,12 @@ const getPollResultMap = async (api: APIHelper, resultIds: string[]) => {
   }
 }
 
+/**
+ * A residual result is either:
+ * - Still incomplete (from the poll results POV): report it with incomplete data and a warning. 
+ * - Still in progress (from the batch POV): it was never emitted.  
+ * - A timed out retry.
+ */
 const isResidualResult = (
   result: BaseResultInBatch,
   emittedResultIds: Set<string>,

--- a/src/commands/synthetics/batch.ts
+++ b/src/commands/synthetics/batch.ts
@@ -301,8 +301,8 @@ const getPollResultMap = async (api: APIHelper, resultIds: string[]) => {
 
 /**
  * A residual result is either:
- * - Still incomplete (from the poll results POV): report it with incomplete data and a warning. 
- * - Still in progress (from the batch POV): it was never emitted.  
+ * - Still incomplete (from the poll results POV): report it with incomplete data and a warning.
+ * - Still in progress (from the batch POV): it was never emitted.
  * - A timed out retry.
  */
 const isResidualResult = (

--- a/src/commands/synthetics/interfaces.ts
+++ b/src/commands/synthetics/interfaces.ts
@@ -128,22 +128,29 @@ export type SelectiveRerunDecision =
 
 export interface BaseResult {
   executionRule: ExecutionRule
+  initialResultId?: string
+  /** Whether the result is an intermediary result that is expected to be retried. */
+  isNonFinal?: boolean
   location: string
-  // `.passed` here combines `result.passed` and `failOnCriticalErrors` and `failOnTimeout`
+  /** Whether the result is passed or not, according to `failOnCriticalErrors` and `failOnTimeout`. */
   passed: boolean
   result: ServerResult
   resultId: string
-  // Number of retries, including this result.
+  /** Number of retries, including this result. */
   retries: number
+  maxRetries: number
   selectiveRerun?: SelectiveRerunDecision
-  // Original test for this result, including overrides if any.
+  /** Original test for this result, including overrides if any. */
   test: Test
   timedOut: boolean
   timestamp: number
 }
 
 // Inside this type, `.resultId` is a linked result ID from a previous batch.
-export type ResultSkippedBySelectiveRerun = Omit<BaseResult, 'location' | 'result' | 'retries' | 'timestamp'> & {
+export type ResultSkippedBySelectiveRerun = Omit<
+  BaseResult,
+  'location' | 'result' | 'retries' | 'maxRetries' | 'timestamp'
+> & {
   executionRule: ExecutionRule.SKIPPED
   selectiveRerun: Extract<SelectiveRerunDecision, {decision: 'skip'}>
 }
@@ -155,9 +162,11 @@ type BatchStatus = 'passed' | 'failed' | 'in_progress'
 
 export interface BaseResultInBatch {
   execution_rule: ExecutionRule
+  initial_result_id?: string
   location: string
   result_id: string
   retries: number | null
+  max_retries: number | null
   selective_rerun?: SelectiveRerunDecision
   status: Status
   test_public_id: string

--- a/src/commands/synthetics/reporters/default.ts
+++ b/src/commands/synthetics/reporters/default.ts
@@ -229,7 +229,7 @@ const renderExecutionResult = (test: Test, execution: Result, baseUrl: string, b
     const resultUrlStatus = getResultUrlSuffix(execution)
 
     outputLines.push(`  •${durationText} View test run details:`)
-    outputLines.push(`    ⎋ ${chalk.dim.cyan(resultUrl)} ${resultUrlStatus}`)
+    outputLines.push(`    ⎋ ${chalk.dim.cyan(resultUrl)}${resultUrlStatus}`)
   }
 
   if (isResultSkippedBySelectiveRerun(execution)) {
@@ -267,11 +267,11 @@ export const getResultUrlSuffix = (execution: Result) => {
     const timedOutRetry = isTimedOutRetry(retries, maxRetries, timedOut)
 
     if (timedOutRetry) {
-      return '(previous attempt)'
+      return ' (previous attempt)'
     }
 
     if (timedOut) {
-      return '(not yet received)'
+      return ' (not yet received)'
     }
   }
 
@@ -292,17 +292,20 @@ const getAttemptSuffix = (passed: boolean, retries: number, maxRetries: number, 
     return ''
   }
 
+  const attempt = (current: number, max: number) => {
+    if (!passed && current < max) {
+      return chalk.dim(`attempt ${current} of ${max}, retrying…`)
+    }
+
+    return chalk.dim(`attempt ${current}, success`)
+  }
+
   if (isTimedOutRetry(retries, maxRetries, timedOut)) {
     // Current attempt is still that of the last received result, so we increment it to refer to the expected retry.
-    return ` (attempt ${currentAttempt + 1} of ${maxAttempts})`
+    return ` (${attempt(currentAttempt + 1, maxAttempts)})`
   }
 
-  if (passed) {
-    // Having 'of' for a passed result is redundant, and is confusing when we have "✅ attempt 1 of 2".
-    return ` (attempt ${currentAttempt})`
-  }
-
-  return ` (attempt ${currentAttempt} of ${maxAttempts})`
+  return ` (${attempt(currentAttempt, maxAttempts)})`
 }
 
 const getResultIconAndColor = (resultOutcome: ResultOutcome): [string, chalk.Chalk] => {

--- a/src/commands/synthetics/utils/internal.ts
+++ b/src/commands/synthetics/utils/internal.ts
@@ -52,13 +52,21 @@ export const hasResult = (result: Result): result is BaseResult => {
 }
 
 /**
- * Most properties (like `retries`) are populated by the backend as soon as we receive a result, even if it's a non-final result.
- *
- * If the test is configured to be retried and the first attempt fails,
- * `retries` is set to `0` and the result is kept `in_progress` until the final result is received.
+ * When the test is configured to be retried and the first attempt fails, `retries` is set to `0`
+ * and the result is kept `in_progress` until the final result is received.
  */
-export const hasRetries = (result: ResultInBatch): result is ResultInBatch & {retries: number} => {
-  return Number.isInteger(result.retries)
+export const isNonFinalResult = (
+  result: ResultInBatch
+): result is ResultInBatch & {retries: number; status: 'in_progress'} => {
+  return result.status === 'in_progress' && Number.isInteger(result.retries)
+}
+
+export const isTimedOutRetry = (
+  retries: number | null,
+  maxRetries: number | null,
+  timedOut: boolean | null
+): boolean => {
+  return !!timedOut && (retries ?? 0) < (maxRetries ?? 0)
 }
 
 export const isResultInBatchSkippedBySelectiveRerun = (


### PR DESCRIPTION
### What and why?

This PR fixes a bug where timed out retries were sometimes not reported.

Bug description:
- If a result (e.g. result ID 1) is an intermediate failed result (expected to be retried), its result ID is saved as reported,
- Now, if the retry times out, then the result ID is unchanged, resulting in datadog-ci thinking the result was already reported.

### How?

In a backend PR, we added the `max_retries` property.

If the result is `timed_out && retries < max_retries`, then we report it as a residual result.

This PR also fixes the JUnit reporter by not saving intermediate results in the JUnit file, and adds a few properties (`retries`, `max_retries`, `initial_result_id`) to results in the JUnit file.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
