### PR TITLE
[deployment] Fix error with `deployment mark`

### DIFF
--- a/src/commands/deployment/__tests__/mark.test.ts
+++ b/src/commands/deployment/__tests__/mark.test.ts
@@ -1,8 +1,57 @@
+import {Cli} from 'clipanion'
+
 import {createCommand} from '../../../helpers/__tests__/fixtures'
 
 import {DeploymentMarkCommand} from '../mark'
 
+const makeCLI = () => {
+  const cli = new Cli()
+  cli.register(DeploymentMarkCommand)
+
+  return cli
+}
+
+const createMockContext = () => {
+  let out = ''
+  let err = ''
+
+  return {
+    stderr: {
+      toString: () => err,
+      write: (input: string) => {
+        err += input
+      },
+    },
+    stdout: {
+      toString: () => out,
+      write: (input: string) => {
+        out += input
+      },
+    },
+  }
+}
+
 describe('mark', () => {
+  describe('execute', () => {
+    const runCLI = async () => {
+      const cli = makeCLI()
+      const context = createMockContext() as any
+
+      const code = await cli.run(['deployment', 'mark'], context)
+
+      return {context, code}
+    }
+
+    test('should fail if not running in a supported provider', async () => {
+      const {context, code} = await runCLI()
+      expect(code).toBe(1)
+      expect(context.stdout.toString()).toStrictEqual('')
+      expect(context.stderr.toString()).toContain(
+        'Only providers [GitHub, GitLab, CircleCI, Buildkite, Jenkins, TeamCity, AzurePipelines] are supported'
+      )
+    })
+  })
+
   describe('createDeploymentTags', () => {
     test('should add is rollback if present', () => {
       const command = createCommand(DeploymentMarkCommand)

--- a/src/commands/deployment/__tests__/mark.test.ts
+++ b/src/commands/deployment/__tests__/mark.test.ts
@@ -36,6 +36,9 @@ describe('mark', () => {
     const runCLI = async () => {
       const cli = makeCLI()
       const context = createMockContext() as any
+      process.env = {
+        DATADOG_API_KEY: 'PLACEHOLDER',
+      }
 
       const code = await cli.run(['deployment', 'mark'], context)
 

--- a/src/commands/tag/tag.ts
+++ b/src/commands/tag/tag.ts
@@ -41,6 +41,10 @@ export class TagCommand extends Command {
 
   public setTags(tags: string[]) {
     this.tags = tags
+
+    // When this command is used by another command (e.g. `deployment mark`), the command options are not resolved
+    // and are still Clipanion option constructors: `this.tagsFile` is not a valid path.
+    delete this.tagsFile
   }
 
   public setNoFail(noFail: boolean) {


### PR DESCRIPTION
### What and why?

This PR fixes the following error:

```bash
Type Error: The "path" argument must be of type string. Received an instance of Object
        at validateString (node:internal/validators:162:11)
        at Object.normalize (node:path:1131:5)
        at readJsonFile (/Users/corentin.girard/go/src/github.com/DataDog/datadog-ci.git/master/src/helpers/tags.ts:240:25)
        at parseTagsFile (/Users/corentin.girard/go/src/github.com/DataDog/datadog-ci.git/master/src/helpers/tags.ts:136:23)
        at TagCommand.<anonymous> (/Users/corentin.girard/go/src/github.com/DataDog/datadog-ci.git/master/src/commands/tag/tag.ts:74:48)
        at Generator.next (<anonymous>)
        at /Users/corentin.girard/go/src/github.com/DataDog/datadog-ci.git/master/src/commands/tag/tag.ts:8:71
        at new Promise (<anonymous>)
        at Object.<anonymous>.__awaiter (/Users/corentin.girard/go/src/github.com/DataDog/datadog-ci.git/master/src/commands/tag/tag.ts:4:12)
        at TagCommand.execute (/Users/corentin.girard/go/src/github.com/DataDog/datadog-ci.git/master/src/commands/tag/tag.ts:51:16)
        at DeploymentMarkCommand.<anonymous> (/Users/corentin.girard/go/src/github.com/DataDog/datadog-ci.git/master/src/commands/deployment/mark.ts:72:55)
        at Generator.next (<anonymous>)
        at /Users/corentin.girard/go/src/github.com/DataDog/datadog-ci.git/master/src/commands/deployment/mark.ts:8:71
        at new Promise (<anonymous>)
        at Object.<anonymous>.__awaiter (/Users/corentin.girard/go/src/github.com/DataDog/datadog-ci.git/master/src/commands/deployment/mark.ts:4:12)
        at DeploymentMarkCommand.execute (/Users/corentin.girard/go/src/github.com/DataDog/datadog-ci.git/master/src/commands/deployment/mark.ts:37:16)
        at DeploymentMarkCommand.validateAndExecute (/Users/corentin.girard/go/src/github.com/DataDog/datadog-ci.git/master/node_modules/clipanion/lib/advanced/Command.js:73:37)
```

When running `DD_BETA_COMMANDS_ENABLED=1 datadog-ci deployment mark`

### How?

The `validateAndExecute()` function in Clipanion is resolving `Option.*` objects into their final form, just before running `execute()`.

But since `DeploymentMarkCommand` is not extending from `TagCommand` but constructing it manually, Clipanion doesn't resolve the option fields. So we end up with `this.tagsFile` being an object instead of a string.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
