### PR TITLE
Print warning if traces merging is skipped for Lambda in Step Function

### DIFF
--- a/src/commands/stepfunctions/__tests__/helpers.test.ts
+++ b/src/commands/stepfunctions/__tests__/helpers.test.ts
@@ -1,4 +1,5 @@
 import {DescribeStateMachineCommandOutput, LogLevel} from '@aws-sdk/client-sfn'
+import {BaseContext} from 'clipanion'
 
 import {
   buildArn,
@@ -16,7 +17,18 @@ import {
 
 import {describeStateMachineFixture} from './fixtures/aws-resources'
 
+const createMockContext = (): BaseContext => {
+  return {
+    stdout: {
+      write: (input: string) => {
+        return true
+      },
+    },
+  } as BaseContext
+}
+
 describe('stepfunctions command helpers tests', () => {
+  const context = createMockContext()
   describe('shouldUpdateStepForTracesMerging test', () => {
     test('already has JsonMerge added to payload field', () => {
       const step: StepType = {
@@ -28,7 +40,7 @@ describe('stepfunctions command helpers tests', () => {
         },
         End: true,
       }
-      expect(shouldUpdateStepForTracesMerging(step)).toBeFalsy()
+      expect(shouldUpdateStepForTracesMerging(step, context, 'Lambda Invoke')).toBeFalsy()
     })
 
     test('no payload field', () => {
@@ -40,7 +52,7 @@ describe('stepfunctions command helpers tests', () => {
         },
         End: true,
       }
-      expect(shouldUpdateStepForTracesMerging(step)).toBeTruthy()
+      expect(shouldUpdateStepForTracesMerging(step, context, 'Lambda Invoke')).toBeTruthy()
     })
 
     test('default payload field of $', () => {
@@ -53,7 +65,7 @@ describe('stepfunctions command helpers tests', () => {
         },
         End: true,
       }
-      expect(shouldUpdateStepForTracesMerging(step)).toBeTruthy()
+      expect(shouldUpdateStepForTracesMerging(step, context, 'Lambda Invoke')).toBeTruthy()
     })
 
     test('none-lambda step should not be updated', () => {
@@ -65,7 +77,7 @@ describe('stepfunctions command helpers tests', () => {
         },
         End: true,
       }
-      expect(shouldUpdateStepForTracesMerging(step)).toBeFalsy()
+      expect(shouldUpdateStepForTracesMerging(step, context, 'DynamoDB Update')).toBeFalsy()
     })
 
     test('legacy lambda api should not be updated', () => {
@@ -74,7 +86,7 @@ describe('stepfunctions command helpers tests', () => {
         Resource: 'arn:aws:lambda:sa-east-1:601427271234:function:hello-function',
         End: true,
       }
-      expect(shouldUpdateStepForTracesMerging(step)).toBeFalsy()
+      expect(shouldUpdateStepForTracesMerging(step, context, 'Legacy Lambda')).toBeFalsy()
     })
   })
 


### PR DESCRIPTION
### Background
The context injection for Lambda in Step Function requires the Lambda function requires the Lambda definition to be like
```
    "Lambda Invoke": {
      ...
      "Parameters": {
        ...
        "Payload.$": "$"
      },
```

If the user has a custom `Payload.$` field, context injection will be skipped, but no error/warning message will be printed.

### What

Print a warning message if context injection is skipped if:
1. `Parameters` field doesn't exist for the Lambda function, or
2. there's a custom `Payload.$` field

### Why

To make it transparent to users what won't work.

### How?

Print the messages

### Testing
#### Missing Parameters field
I wasn't able to test this because Parameters field is required when editing the State Machine from AWS Management Console. Should we remove this if-check?
<img width="777" alt="Screenshot 2024-09-10 at 5 43 44 PM" src="https://github.com/user-attachments/assets/6e785df0-4a9a-4c2c-b234-933f9a92da50">

Update: We are going to keep this if-check as @agocs suggested:
> This if statement prevents datadog-ci from crashing if parameters is missing for whatever reason.

#### Custom Payload field
Message printed as expected:
<img width="758" alt="image" src="https://github.com/user-attachments/assets/6d839f98-5ddc-4c57-82f3-9cfe941c1451">

#### Happy case
`datadog-ci stepfunctions instrument` finishes with no error

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
