### PR TITLE
[SYNTH-16168] Increase batch limit to 1000

### DIFF
--- a/src/commands/synthetics/__tests__/utils/__snapshots__/public.test.ts.snap
+++ b/src/commands/synthetics/__tests__/utils/__snapshots__/public.test.ts.snap
@@ -5,7 +5,7 @@ exports[`utils getTestsToTrigger too many tests to trigger trim and warn if from
   "calls": [
     [
       [
-        "[33mThe search query returned 110 tests, only the first [1m100[22m will be triggered.[39m
+        "[33mThe search query returned 1010 tests, only the first [1m1000[22m will be triggered.[39m
 [33m[39m",
       ],
     ],

--- a/src/commands/synthetics/run-tests-command.ts
+++ b/src/commands/synthetics/run-tests-command.ts
@@ -28,7 +28,7 @@ import {
   reportExitLogs,
 } from './utils/public'
 
-export const MAX_TESTS_TO_TRIGGER = 100
+export const MAX_TESTS_TO_TRIGGER = 1000
 
 export const DEFAULT_BATCH_TIMEOUT = 30 * 60 * 1000
 /** @deprecated Please use `DEFAULT_BATCH_TIMEOUT` instead. */


### PR DESCRIPTION
### What and why?

This PR increases the datadog-ci limit for a batch from the arbitrary value of 100, to align it with the backend value of 1000.

### Review checklist

- [ ] ~Feature or bugfix MUST have appropriate tests (unit, integration)~ -> N/A
