### PR TITLE
Print warning if traces merging from xfn to xfn is skipped

### DIFF
--- a/src/commands/stepfunctions/__tests__/helpers.test.ts
+++ b/src/commands/stepfunctions/__tests__/helpers.test.ts
@@ -1,4 +1,5 @@
 import {DescribeStateMachineCommandOutput, LogLevel} from '@aws-sdk/client-sfn'
+import {BaseContext} from 'clipanion'
 
 import {
   buildArn,
@@ -16,7 +17,18 @@ import {
 
 import {describeStateMachineFixture} from './fixtures/aws-resources'
 
+const createMockContext = (): BaseContext => {
+  return {
+    stdout: {
+      write: (input: string) => {
+        return true
+      },
+    },
+  } as BaseContext
+}
+
 describe('stepfunctions command helpers tests', () => {
+  const context = createMockContext()
   describe('shouldUpdateStepForTracesMerging test', () => {
     test('already has JsonMerge added to payload field', () => {
       const step: StepType = {
@@ -28,7 +40,7 @@ describe('stepfunctions command helpers tests', () => {
         },
         End: true,
       }
-      expect(shouldUpdateStepForTracesMerging(step)).toBeFalsy()
+      expect(shouldUpdateStepForTracesMerging(step, context, 'Lambda Invoke')).toBeFalsy()
     })
 
     test('no payload field', () => {
@@ -40,7 +52,7 @@ describe('stepfunctions command helpers tests', () => {
         },
         End: true,
       }
-      expect(shouldUpdateStepForTracesMerging(step)).toBeTruthy()
+      expect(shouldUpdateStepForTracesMerging(step, context, 'Lambda Invoke')).toBeTruthy()
     })
 
     test('default payload field of $', () => {
@@ -53,7 +65,7 @@ describe('stepfunctions command helpers tests', () => {
         },
         End: true,
       }
-      expect(shouldUpdateStepForTracesMerging(step)).toBeTruthy()
+      expect(shouldUpdateStepForTracesMerging(step, context, 'Lambda Invoke')).toBeTruthy()
     })
 
     test('none-lambda step should not be updated', () => {
@@ -65,7 +77,7 @@ describe('stepfunctions command helpers tests', () => {
         },
         End: true,
       }
-      expect(shouldUpdateStepForTracesMerging(step)).toBeFalsy()
+      expect(shouldUpdateStepForTracesMerging(step, context, 'DynamoDB Update')).toBeFalsy()
     })
 
     test('legacy lambda api should not be updated', () => {
@@ -74,7 +86,7 @@ describe('stepfunctions command helpers tests', () => {
         Resource: 'arn:aws:lambda:sa-east-1:601427271234:function:hello-function',
         End: true,
       }
-      expect(shouldUpdateStepForTracesMerging(step)).toBeFalsy()
+      expect(shouldUpdateStepForTracesMerging(step, context, 'Legacy Lambda')).toBeFalsy()
     })
   })
 

--- a/src/commands/stepfunctions/__tests__/helpers.test.ts
+++ b/src/commands/stepfunctions/__tests__/helpers.test.ts
@@ -197,7 +197,9 @@ describe('stepfunctions command helpers tests', () => {
         },
         End: true,
       }
-      expect(shouldUpdateStepForStepFunctionContextInjection(step)).toBeTruthy()
+      expect(
+        shouldUpdateStepForStepFunctionContextInjection(step, context, 'Step Functions StartExecution')
+      ).toBeTruthy()
     })
 
     test('is true for undefined', () => {
@@ -209,7 +211,9 @@ describe('stepfunctions command helpers tests', () => {
         },
         End: true,
       }
-      expect(shouldUpdateStepForStepFunctionContextInjection(step)).toBeTruthy()
+      expect(
+        shouldUpdateStepForStepFunctionContextInjection(step, context, 'Step Functions StartExecution')
+      ).toBeTruthy()
     })
 
     test('is false when Input is an object that contains a CONTEXT key', () => {
@@ -222,7 +226,9 @@ describe('stepfunctions command helpers tests', () => {
         },
         End: true,
       }
-      expect(shouldUpdateStepForStepFunctionContextInjection(step)).toBeFalsy()
+      expect(
+        shouldUpdateStepForStepFunctionContextInjection(step, context, 'Step Functions StartExecution')
+      ).toBeFalsy()
     })
   })
 
@@ -238,7 +244,7 @@ describe('stepfunctions command helpers tests', () => {
         End: true,
       }
 
-      const changed = injectContextForStepFunctions(step)
+      const changed = injectContextForStepFunctions(step, context, 'Step Functions StartExecution')
       expect(changed).toBeTruthy()
       expect(step.Parameters?.Input).toEqual({'CONTEXT.$': 'States.JsonMerge($$, $, false)'})
     })


### PR DESCRIPTION
### Why?
Let's say Step Function A executes Step Function B. If B:
1. doesn't have a `Parameters` field, or
2. its `Parameters.Input` field is not a JSON object
3. its `Parameters.Input` field has a custom `CONTEXT.$` field

traces merging will be skipped, but no warning message will be printed.

### What
Print a warning message in these cases to let users know what won't work.

### Testing

#### 1. Missing Parameters field

I wasn't able to test this because `Parameters` field is required when editing the State Machine from AWS Management Console.

<img width="913" alt="Screenshot 2024-09-12 at 12 51 26 PM" src="https://github.com/user-attachments/assets/e04c6c2b-9f80-4d4b-a5a9-0c513f7ad095">

#### 2. `Parameters.Input` field is not a JSON object

##### Steps
1. Change the Step Function execution step to be like:
```
    "Step Functions StartExecution": {
      "Type": "Task",
      "Resource": "arn:aws:states:::states:startExecution",
      "Parameters": {
        "StateMachineArn": "...",
        "Input": "Input!"
      },
      "End": true
    }
```
2. Run `datadog-ci stepfunctions instrument` command

##### Result
A warning message is printed as expected:
<img width="758" alt="image" src="https://github.com/user-attachments/assets/33e9f380-5981-44b8-b93e-a0a33cabcdf2">

#### 3. custom `CONTEXT.$`
<img width="759" alt="image" src="https://github.com/user-attachments/assets/97b10e58-d911-45eb-b974-5065f3928931">

#### 4. Happy case

`datadog-ci stepfunctions instrument` finishes with no error

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
