### PR TITLE
[dep] Bump `path-to-regexp` to `6.3.0`

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -9051,16 +9051,16 @@ jschardet@latest:
   linkType: hard
 
 "path-to-regexp@npm:^0.1.2":
-  version: 0.1.10
-  resolution: "path-to-regexp@npm:0.1.10"
-  checksum: ab7a3b7a0b914476d44030340b0a65d69851af2a0f33427df1476100ccb87d409c39e2182837a96b98fb38c4ef2ba6b87bdad62bb70a2c153876b8061760583c
+  version: 0.1.11
+  resolution: "path-to-regexp@npm:0.1.11"
+  checksum: 02665d2795ae458f24b2f62cc7f4e8c3334d65dbd4e49a50b0494cf28d69f645ce6bf51404eab7bbf717dd36809a2c83785a54a3dda776e8fe1811ada0ba32fd
   languageName: node
   linkType: hard
 
 "path-to-regexp@npm:^6.2.1":
-  version: 6.2.2
-  resolution: "path-to-regexp@npm:6.2.2"
-  checksum: b7b0005c36f5099f9ed1fb20a820d2e4ed1297ffe683ea1d678f5e976eb9544f01debb281369dabdc26da82e6453901bf71acf2c7ed14b9243536c2a45286c33
+  version: 6.3.0
+  resolution: "path-to-regexp@npm:6.3.0"
+  checksum: eca78602e6434a1b6799d511d375ec044e8d7e28f5a48aa5c28d57d8152fb52f3fc62fb1cfc5dfa2198e1f041c2a82ed14043d75740a2fe60e91b5089a153250
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### What and why?

Closes https://github.com/DataDog/datadog-ci/security/dependabot/49

This package is used by 2 `devDependencies`: `aws-sdk-client-mock` and `dd-trace`.

### How?

Bump the dependency with `yarn resolution`

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
