### PR TITLE
Skip xfn->Lambda context injection if custom Payload is used without $

### DIFF
--- a/src/commands/stepfunctions/__tests__/helpers.test.ts
+++ b/src/commands/stepfunctions/__tests__/helpers.test.ts
@@ -68,6 +68,32 @@ describe('stepfunctions command helpers tests', () => {
       expect(shouldUpdateStepForTracesMerging(step, context, 'Lambda Invoke')).toBeTruthy()
     })
 
+    test('custom payload field not using JsonPath expression', () => {
+      const step: StepType = {
+        Type: 'Task',
+        Resource: 'arn:aws:states:::lambda:invoke',
+        Parameters: {
+          FunctionName: 'arn:aws:lambda:sa-east-1:425362991234:function:unit-test-lambda-function',
+          Payload: '{"action": "service/delete_customer"}',
+        },
+        End: true,
+      }
+      expect(shouldUpdateStepForTracesMerging(step, context, 'Lambda Invoke')).toBeFalsy()
+    })
+
+    test('custom payload field using JsonPath expression', () => {
+      const step: StepType = {
+        Type: 'Task',
+        Resource: 'arn:aws:states:::lambda:invoke',
+        Parameters: {
+          FunctionName: 'arn:aws:lambda:sa-east-1:425362991234:function:unit-test-lambda-function',
+          'Payload.$': '{"customer.$": "$.customer"}',
+        },
+        End: true,
+      }
+      expect(shouldUpdateStepForTracesMerging(step, context, 'Lambda Invoke')).toBeFalsy()
+    })
+
     test('none-lambda step should not be updated', () => {
       const step: StepType = {
         Type: 'Task',

--- a/src/commands/stepfunctions/helpers.ts
+++ b/src/commands/stepfunctions/helpers.ts
@@ -138,7 +138,7 @@ check out https://docs.datadoghq.com/serverless/step_functions/troubleshooting/\
     }
 
     // payload field not set
-    if (!step.Parameters.hasOwnProperty('Payload.$')) {
+    if (!step.Parameters.hasOwnProperty('Payload.$') && !step.Parameters.hasOwnProperty('Payload')) {
       return true
     }
 
@@ -228,6 +228,7 @@ export type StepType = {
 
 export type ParametersType = {
   'Payload.$'?: string
+  Payload?: string
   FunctionName?: string
   StateMachineArn?: string
   TableName?: string


### PR DESCRIPTION
### Problem
If a Lambda function in a State Machine has a custom `Payload` defined using `"Payload": ...`, e.g.,
```
    "Lambda Invoke": {
      "Type": "Task",
      "Resource": "arn:aws:states:::lambda:invoke",
      "OutputPath": "$.Payload",
      "Parameters": {
        "FunctionName": "...",
        "Payload": {
          "action": "service/delete_customer"
        }
      },
      ...
    }
  }
```
then context injection for the Step Function will fail with the error:
> [Error] Invalid State Machine Definition: 'SCHEMA_VALIDATION_FAILED: Cannot have both the field 'Payload.$' and the field 'Payload' at the same time at /States/Lambda Invoke/Parameters'. Failed to inject context into lambda functions' payload of arn:aws:states:sa-east-1:425362996713:stateMachine:YimingTestExpressStateMachine2

This is because our instrumentation code will add a field `"Payload.$": ...`, which duplicates with `"Payload": ...`. Right now we only check for custom `"Payload.$": ...` (with `$`, i.e. using JSONPath) but don't check for custom `"Payload": ...`.

### What

Also skip context injection when a custom `"Payload": ...` field is used (without `$`)

### Testing

#### Automated testing
Pass the added test, which would fail without the changes on `helpers.ts`

#### Manual testing

Steps:
1. change the `Payload ` field of a Lambda function to what's shown in "Problem" section
2. run `datadog-ci stepfunctions instrument`

Result: a warning is printed as expected
![image](https://github.com/user-attachments/assets/eef4be2b-a900-4cfe-abc6-2ee274c6a5a1)


### Notes

1. Thanks @agocs for bringing this up in https://github.com/DataDog/datadog-ci/pull/1443#pullrequestreview-2293937693
2. The behavior will be changed soon: we will soon allow custom `Payload` field as long as it doesn't contain `Execution` or `State` field inside. But I want to first merge this PR to make the existing behavior more clear, so the changes in future PRs will be more clear so the PRs will be easier to review.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
