### PR TITLE
Skip xfn->xfn context injection if custom Payload is used without $

### DIFF
--- a/src/commands/stepfunctions/__tests__/helpers.test.ts
+++ b/src/commands/stepfunctions/__tests__/helpers.test.ts
@@ -68,6 +68,32 @@ describe('stepfunctions command helpers tests', () => {
       expect(shouldUpdateStepForTracesMerging(step, context, 'Lambda Invoke')).toBeTruthy()
     })
 
+    test('custom payload field not using JsonPath expression', () => {
+      const step: StepType = {
+        Type: 'Task',
+        Resource: 'arn:aws:states:::lambda:invoke',
+        Parameters: {
+          FunctionName: 'arn:aws:lambda:sa-east-1:425362991234:function:unit-test-lambda-function',
+          Payload: '{"action": "service/delete_customer"}',
+        },
+        End: true,
+      }
+      expect(shouldUpdateStepForTracesMerging(step, context, 'Lambda Invoke')).toBeFalsy()
+    })
+
+    test('custom payload field using JsonPath expression', () => {
+      const step: StepType = {
+        Type: 'Task',
+        Resource: 'arn:aws:states:::lambda:invoke',
+        Parameters: {
+          FunctionName: 'arn:aws:lambda:sa-east-1:425362991234:function:unit-test-lambda-function',
+          'Payload.$': '{"customer.$": "$.customer"}',
+        },
+        End: true,
+      }
+      expect(shouldUpdateStepForTracesMerging(step, context, 'Lambda Invoke')).toBeFalsy()
+    })
+
     test('none-lambda step should not be updated', () => {
       const step: StepType = {
         Type: 'Task',

--- a/src/commands/stepfunctions/__tests__/helpers.test.ts
+++ b/src/commands/stepfunctions/__tests__/helpers.test.ts
@@ -242,13 +242,28 @@ describe('stepfunctions command helpers tests', () => {
       ).toBeTruthy()
     })
 
-    test('is false when Input is an object that contains a CONTEXT key', () => {
+    test('is false when Input is an object that contains a CONTEXT key using JSONPath expression', () => {
       const step: StepType = {
         Type: 'Task',
         Resource: 'arn:aws:states:::states:startExecution.sync:2',
         Parameters: {
           StateMachineArn: 'arn:aws:states:us-east-1:425362996713:stateMachine:agocs_inner_state_machine',
           Input: {'CONTEXT.$': 'blah'},
+        },
+        End: true,
+      }
+      expect(
+        shouldUpdateStepForStepFunctionContextInjection(step, context, 'Step Functions StartExecution')
+      ).toBeFalsy()
+    })
+
+    test('is false when Input is an object that contains a CONTEXT key not using JSONPath expression', () => {
+      const step: StepType = {
+        Type: 'Task',
+        Resource: 'arn:aws:states:::states:startExecution.sync:2',
+        Parameters: {
+          StateMachineArn: 'arn:aws:states:us-east-1:425362996713:stateMachine:agocs_inner_state_machine',
+          Input: {CONTEXT: 'blah'},
         },
         End: true,
       }

--- a/src/commands/stepfunctions/helpers.ts
+++ b/src/commands/stepfunctions/helpers.ts
@@ -138,7 +138,7 @@ check out https://docs.datadoghq.com/serverless/step_functions/troubleshooting/\
     }
 
     // payload field not set
-    if (!step.Parameters.hasOwnProperty('Payload.$')) {
+    if (!step.Parameters.hasOwnProperty('Payload.$') && !step.Parameters.hasOwnProperty('Payload')) {
       return true
     }
 
@@ -228,6 +228,7 @@ export type StepType = {
 
 export type ParametersType = {
   'Payload.$'?: string
+  Payload?: string
   FunctionName?: string
   StateMachineArn?: string
   TableName?: string

--- a/src/commands/stepfunctions/helpers.ts
+++ b/src/commands/stepfunctions/helpers.ts
@@ -196,7 +196,7 @@ merge these traces, check out https://docs.datadoghq.com/serverless/step_functio
       return false
     }
 
-    if (!step.Parameters.Input['CONTEXT.$']) {
+    if (!step.Parameters.Input['CONTEXT.$'] && !step.Parameters.Input['CONTEXT']) {
       return true
     }
 
@@ -234,6 +234,7 @@ export type ParametersType = {
   TableName?: string
   Input?: {
     'CONTEXT.$'?: string
+    CONTEXT?: string
   }
 }
 


### PR DESCRIPTION


### Problem
If a Lambda function in a State Machine has a custom `Payload` defined using `"Payload": ...`, e.g.,
```
    "Step Functions StartExecution": {
      "Type": "Task",
      "Resource": "arn:aws:states:::states:startExecution",
      "Parameters": {
        "StateMachineArn": "xxx",
        "Input": {
          "CONTEXT": "Context!"
        }
      },
      "End": true
    }
```
then context injection for the Step Function will fail with the error:
> [Error] Invalid State Machine Definition: 'SCHEMA_VALIDATION_FAILED: Cannot have both the field 'CONTEXT.$' and the field 'CONTEXT' at the same time at /States/Step Functions StartExecution/Parameters'. Failed to inject context into lambda functions' payload of arn:aws:states:sa-east-1:425362996713:stateMachine:YimingTestExpressStateMachine2 

This is because our instrumentation code will add a field `"CONTEXT.$": ...`, which duplicates with `"CONTEXT": ...`. Right now we only check for custom `"CONTEXT.$": ...` (with `$`, i.e. using JSONPath) but don't check for custom `"CONTEXT": ...`.

### What

Also skip context injection when a custom `"CONTEXT": ...` field is used (without `$`)

### Testing

#### Automated testing
Pass the added test, which would fail without the changes on `helpers.ts`

#### Manual testing

Steps:
1. change the `CONTEXT` field of a Lambda function to what's shown in "Problem" section
2. run `datadog-ci stepfunctions instrument`

Result: a warning is printed as expected
<img width="757" alt="image" src="https://github.com/user-attachments/assets/591229f2-336e-4be2-a48b-bc5eb18b72b0">

### Notes

1. Thanks @agocs for bringing this up in https://github.com/DataDog/datadog-ci/pull/1443#pullrequestreview-2293937693
2. The behavior will be changed soon: we will soon allow custom `CONTEXT` field as long as it doesn't contain `Execution` or `State` field inside. But I want to first merge this PR to make the existing behavior more clear, so the changes in future PRs will be more clear so the PRs will be easier to review.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
