### PR TITLE
fix: print a better message if Step Function context injection is already set up

### DIFF
--- a/src/commands/stepfunctions/helpers.ts
+++ b/src/commands/stepfunctions/helpers.ts
@@ -150,6 +150,13 @@ check out https://docs.datadoghq.com/serverless/step_functions/troubleshooting/\
     return true
   }
 
+  // context injection is already set up
+  if (step.Parameters['Payload.$'] === 'States.JsonMerge($$, $, false)') {
+    context.stdout.write(` Step ${stepName}: Context injection is already set up. Skipping context injection.\n`)
+
+    return false
+  }
+
   // custom payload
   context.stdout
     .write(`[Warn] Step ${stepName} has a custom Payload field. Step Functions Context Object injection skipped. \
@@ -201,6 +208,13 @@ merge these traces, check out https://docs.datadoghq.com/serverless/step_functio
 
   if (!step.Parameters.Input['CONTEXT.$'] && !step.Parameters.Input['CONTEXT']) {
     return true
+  }
+
+  // context injection is already set up
+  if (step.Parameters.Input['CONTEXT.$'] === 'States.JsonMerge($$, $, false)') {
+    context.stdout.write(` Step ${stepName}: Context injection is already set up. Skipping context injection.\n`)
+
+    return false
   }
 
   context.stdout


### PR DESCRIPTION
### Problem
https://github.com/DataDog/datadog-ci/pull/1443 and https://github.com/DataDog/datadog-ci/pull/1447 introduce a bug that when context injection is already set up for a Lambda or a Step Function in a Step Function, a warning will be printed, saying context injection won't work, which is wrong:
![image](https://github.com/user-attachments/assets/5ec27ce7-ba55-4b6f-a033-17494e10ae39)
![image](https://github.com/user-attachments/assets/9d0dfaa7-059e-4c02-92eb-4dcf1f0503a1)

### What
If context injection is already set up, i.e.
- a Lambda has `"Payload.$": "States.JsonMerge($$, $, false)"`
- a Step Function has `"CONTEXT.$": "States.JsonMerge($$, $, false)"`

then print a better error message:
> Context injection is already set up. Skipping context injection.

### Testing
Run `datadog-ci stepfunctions instrument` command twice. The second time, these messages were printed:
<img width="721" alt="image" src="https://github.com/user-attachments/assets/48f853ed-9e94-4b2c-bb58-6cac8eb0c1d4">

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
