### PR TITLE
fix: xfn context injection skipped if no update on last step

### DIFF
--- a/src/commands/stepfunctions/helpers.ts
+++ b/src/commands/stepfunctions/helpers.ts
@@ -96,7 +96,7 @@ export const injectContextIntoTasks = async (
       const step = definitionObj.States[stepName]
       const lambdaUpdated = injectContextForLambdaFunctions(step, context, stepName)
       const stepUpdated = injectContextForStepFunctions(step, context, stepName)
-      definitionHasBeenUpdated = lambdaUpdated || stepUpdated
+      definitionHasBeenUpdated = definitionHasBeenUpdated || lambdaUpdated || stepUpdated
     }
   }
   if (definitionHasBeenUpdated) {


### PR DESCRIPTION
### Background
A Step Function can have multiple steps. Some steps may execute Lambda functions. Some steps may execute other Step Functions. When instrumenting a Step Function, we want to inject necessary context into both Lambda functions and child Step Functions.

### Problem
If the last step doesn't need to be updated, e.g. if it's neither a Lambda function nor a Step Function, then context injection will be skipped. This is because the flag `definitionHasBeenUpdated` isn't updated properly.

### What
Fix the usage of the flag so that if any part of definition is updated, this flag will be true.

### Testing
#### Steps
1. Create a State Machine where
    - the Lambda step is not instrumented
    - the last step doesn't need to be updated
2. Instrument the Step Function by running `datadog-ci stepfunctions instrument`
#### Result
Before:
- `definitionHasBeenUpdated` was false finally.
- No change was applied.

After:
- `definitionHasBeenUpdated` was true finally.
- Changes were applied.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
