### PR TITLE
Refactor xfn Lambda injection code my merging two functions

### DIFF
--- a/src/commands/stepfunctions/__tests__/helpers.test.ts
+++ b/src/commands/stepfunctions/__tests__/helpers.test.ts
@@ -9,7 +9,7 @@ import {
   getStepFunctionLogGroupArn,
   parseArn,
   buildLogAccessPolicyName,
-  shouldUpdateStepForTracesMerging,
+  injectContextForLambdaFunctions,
   StepType,
   injectContextForStepFunctions,
   shouldUpdateStepForStepFunctionContextInjection,
@@ -29,7 +29,7 @@ const createMockContext = (): BaseContext => {
 
 describe('stepfunctions command helpers tests', () => {
   const context = createMockContext()
-  describe('shouldUpdateStepForTracesMerging test', () => {
+  describe('injectContextForLambdaFunctions test', () => {
     test('already has JsonMerge added to payload field', () => {
       const step: StepType = {
         Type: 'Task',
@@ -40,7 +40,7 @@ describe('stepfunctions command helpers tests', () => {
         },
         End: true,
       }
-      expect(shouldUpdateStepForTracesMerging(step, context, 'Lambda Invoke')).toBeFalsy()
+      expect(injectContextForLambdaFunctions(step, context, 'Lambda Invoke')).toBeFalsy()
     })
 
     test('no payload field', () => {
@@ -52,7 +52,8 @@ describe('stepfunctions command helpers tests', () => {
         },
         End: true,
       }
-      expect(shouldUpdateStepForTracesMerging(step, context, 'Lambda Invoke')).toBeTruthy()
+      expect(injectContextForLambdaFunctions(step, context, 'Lambda Invoke')).toBeTruthy()
+      expect(step.Parameters?.['Payload.$']).toEqual('States.JsonMerge($$, $, false)')
     })
 
     test('default payload field of $', () => {
@@ -65,7 +66,8 @@ describe('stepfunctions command helpers tests', () => {
         },
         End: true,
       }
-      expect(shouldUpdateStepForTracesMerging(step, context, 'Lambda Invoke')).toBeTruthy()
+      expect(injectContextForLambdaFunctions(step, context, 'Lambda Invoke')).toBeTruthy()
+      expect(step.Parameters?.['Payload.$']).toEqual('States.JsonMerge($$, $, false)')
     })
 
     test('custom payload field not using JsonPath expression', () => {
@@ -78,7 +80,7 @@ describe('stepfunctions command helpers tests', () => {
         },
         End: true,
       }
-      expect(shouldUpdateStepForTracesMerging(step, context, 'Lambda Invoke')).toBeFalsy()
+      expect(injectContextForLambdaFunctions(step, context, 'Lambda Invoke')).toBeFalsy()
     })
 
     test('custom payload field using JsonPath expression', () => {
@@ -91,7 +93,7 @@ describe('stepfunctions command helpers tests', () => {
         },
         End: true,
       }
-      expect(shouldUpdateStepForTracesMerging(step, context, 'Lambda Invoke')).toBeFalsy()
+      expect(injectContextForLambdaFunctions(step, context, 'Lambda Invoke')).toBeFalsy()
     })
 
     test('none-lambda step should not be updated', () => {
@@ -103,7 +105,7 @@ describe('stepfunctions command helpers tests', () => {
         },
         End: true,
       }
-      expect(shouldUpdateStepForTracesMerging(step, context, 'DynamoDB Update')).toBeFalsy()
+      expect(injectContextForLambdaFunctions(step, context, 'DynamoDB Update')).toBeFalsy()
     })
 
     test('legacy lambda api should not be updated', () => {
@@ -112,7 +114,7 @@ describe('stepfunctions command helpers tests', () => {
         Resource: 'arn:aws:lambda:sa-east-1:601427271234:function:hello-function',
         End: true,
       }
-      expect(shouldUpdateStepForTracesMerging(step, context, 'Legacy Lambda')).toBeFalsy()
+      expect(injectContextForLambdaFunctions(step, context, 'Legacy Lambda')).toBeFalsy()
     })
   })
 

--- a/src/commands/stepfunctions/helpers.ts
+++ b/src/commands/stepfunctions/helpers.ts
@@ -96,7 +96,7 @@ export const injectContextIntoTasks = async (
       const step = definitionObj.States[stepName]
       const lambdaUpdated = injectContextForLambdaFunctions(step, context, stepName)
       const stepUpdated = injectContextForStepFunctions(step, context, stepName)
-      definitionHasBeenUpdated = lambdaUpdated || stepUpdated
+      definitionHasBeenUpdated = definitionHasBeenUpdated || lambdaUpdated || stepUpdated
     }
   }
   if (definitionHasBeenUpdated) {


### PR DESCRIPTION
### What
Currently the `injectContextForLambdaFunctions()` function roughly looks like this:
```
const injectContextForLambdaFunctions = (...): boolean => {
  if (shouldUpdateStepForTracesMerging()) {
    addTraceContextToLambdaParameters()
    return true
  }
  return false
}
```
It calls `shouldUpdateStepForTracesMerging()`.

This PR merges the two functions by moving the code of `shouldUpdateStepForTracesMerging()` into `injectContextForLambdaFunctions()`.

# Why?
We will soon have different instrumentation strategies depending on the existing state of Lambda definition, so `shouldUpdateStepForTracesMerging()` which has a boolean return value will no longer work.

Design doc: [Fixing Step Function Instrumentation](https://docs.google.com/document/d/18YpNVN6reCjA-dq6U1Tfs2MyLxcVnjO_N8Uy9Gm_BGM/edit#bookmark=id.pczh1xpu3h9y)
A short description of what changes this PR introduces and why.

### Testing

Passed the touched automated tests

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)