### PR TITLE
Inject context for xfn->Lambda when no Payload exists (case 1)

### DIFF
--- a/src/commands/stepfunctions/__tests__/helpers.test.ts
+++ b/src/commands/stepfunctions/__tests__/helpers.test.ts
@@ -53,7 +53,7 @@ describe('stepfunctions command helpers tests', () => {
         End: true,
       }
       expect(injectContextForLambdaFunctions(step, context, 'Lambda Invoke')).toBeTruthy()
-      expect(step.Parameters?.['Payload.$']).toEqual('States.JsonMerge($$, $, false)')
+      expect(step.Parameters?.['Payload.$']).toEqual(`$$['Execution', 'State', 'StateMachine']`)
     })
 
     test('default payload field of $', () => {

--- a/src/commands/stepfunctions/helpers.ts
+++ b/src/commands/stepfunctions/helpers.ts
@@ -110,10 +110,6 @@ export const injectContextIntoTasks = async (
   }
 }
 
-export const addTraceContextToLambdaParameters = (Parameters: ParametersType): void => {
-  Parameters[`Payload.$`] = 'States.JsonMerge($$, $, false)'
-}
-
 export const addTraceContextToStepFunctionParameters = ({Parameters}: StepType): void => {
   if (Parameters) {
     if (!Parameters.Input) {
@@ -236,14 +232,14 @@ check out https://docs.datadoghq.com/serverless/step_functions/troubleshooting/\
 
   // payload field not set
   if (!step.Parameters.hasOwnProperty('Payload.$') && !step.Parameters.hasOwnProperty('Payload')) {
-    addTraceContextToLambdaParameters(step.Parameters)
+    step.Parameters[`Payload.$`] = `$$['Execution', 'State', 'StateMachine']`
 
     return true
   }
 
   // default payload
   if (step.Parameters['Payload.$'] === '$') {
-    addTraceContextToLambdaParameters(step.Parameters)
+    step.Parameters[`Payload.$`] = 'States.JsonMerge($$, $, false)'
 
     return true
   }


### PR DESCRIPTION
### What and why?

In Step Machine definition, if a Lambda function doesn't have `Payload` field, right now we are injecting context using
```
"Payload.$": "States.JsonMerge($$, $, false)"
```

This PR changes it to:
```
"Payload.$": "$$['Execution', 'State']"
```
which passes less information.

This is case #1 in this design doc: [Fixing Step Function Instrumentation](https://docs.google.com/document/d/18YpNVN6reCjA-dq6U1Tfs2MyLxcVnjO_N8Uy9Gm_BGM/edit)

### Testing

#### Automated testing
Pass the touched tests

#### Manual testing
##### Steps
1. Make the Lambda Execution step have no `Payload` field
2. Build the package: `yarn prepack`
3. Instrument the Step Function using `./dist/cli.js stepfunctions instrument`
4. Execute the State Machine

##### Result
1. `"Payload.$": "$$['Execution', 'State']"` was added to Lambda definition
2. TODO: question to reviewers: What product should we check to ensure context injection works this way?

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
