### PR TITLE
Skip xfn->Lambda context injection of Payload is not object (case 3)

### DIFF
--- a/src/commands/stepfunctions/__tests__/helpers.test.ts
+++ b/src/commands/stepfunctions/__tests__/helpers.test.ts
@@ -56,6 +56,19 @@ describe('stepfunctions command helpers tests', () => {
       expect(step.Parameters?.['Payload.$']).toEqual(`$$['Execution', 'State', 'StateMachine']`)
     })
 
+    test('payload is not a JSON object', () => {
+      const step: StepType = {
+        Type: 'Task',
+        Resource: 'arn:aws:states:::lambda:invoke',
+        Parameters: {
+          FunctionName: 'arn:aws:lambda:sa-east-1:425362991234:function:unit-test-lambda-function',
+          Payload: 'Just a string!',
+        },
+        End: true,
+      }
+      expect(injectContextForLambdaFunctions(step, context, 'Lambda Invoke')).toBeFalsy()
+    })
+
     test('default payload field of $', () => {
       const step: StepType = {
         Type: 'Task',

--- a/src/commands/stepfunctions/helpers.ts
+++ b/src/commands/stepfunctions/helpers.ts
@@ -237,6 +237,15 @@ check out https://docs.datadoghq.com/serverless/step_functions/troubleshooting/\
     return true
   }
 
+  // payload is not a JSON object
+  if (step.Parameters.hasOwnProperty('Payload') && typeof step.Parameters['Payload'] !== 'object') {
+    context.stdout.write(`[Warn] Step ${stepName}'s Payload field is not a JSON object. Step Functions Context Object \
+injection skipped. Your Step Functions trace will not be merged with downstream Lambda traces. To manually \
+merge these traces, check out https://docs.datadoghq.com/serverless/step_functions/troubleshooting/\n`)
+
+    return false
+  }
+
   // default payload
   if (step.Parameters['Payload.$'] === '$') {
     step.Parameters[`Payload.$`] = 'States.JsonMerge($$, $, false)'


### PR DESCRIPTION
### What
In a State Machine, if a Lambda execution step's `Payload` field is not a JSON object, e.g.
```
    "Lambda Invoke": {
      "Type": "Task",
      "Resource": "arn:aws:states:::lambda:invoke",
      "OutputPath": "$.Payload",
      "Parameters": {
        "FunctionName": "arn:aws:lambda:sa-east-1:425362996713:function:yimingPlayground",
        "Payload": "Just a string!"
      },
      "Next": "Step Functions StartExecution"
    },
```
then print a warning and skip context injection.

This is case # 3 in this design doc: [Fixing Step Function Instrumentation](https://docs.google.com/document/d/18YpNVN6reCjA-dq6U1Tfs2MyLxcVnjO_N8Uy9Gm_BGM/edit)

### Why

To inject context into Lambda payload, the payload must be a JSON dictionary. Injection can't work if payload is a string.

### Testing

#### Automated testing
Passed the added test and existing tests

#### Manual testing
##### Steps
1. Change the Lambda Execution step to have a string `Payload` field as shown in the "What" section
2. Build the package: `yarn prepack`
3. Instrument the Step Function using `./dist/cli.js stepfunctions instrument`

##### Result
A warning is printed:
<img width="756" alt="image" src="https://github.com/user-attachments/assets/65404a19-0ca9-4eb0-81d9-53831646d781">

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
