### PR TITLE
[ci] Fix release process

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - v* # Any version tag
 
+permissions:
+  contents: write # Required for the draft release
+
 jobs:
   create-draft-release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### What and why?

Without this explicit permission (as described [here](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/controlling-permissions-for-github_token)), the `create-draft-release` [job fails with](https://github.com/DataDog/datadog-ci/actions/runs/10886997538/job/30367510208):

> (403) Resource not accessible by integration

### How?

Add an explicit permission for the `GITHUB_TOKEN`

### Review checklist

- ~~[ ] Feature or bugfix MUST have appropriate tests (unit, integration)~~
