### PR TITLE
[STAL-2949] Make git author a mandatory field

### DIFF
--- a/src/helpers/tags.ts
+++ b/src/helpers/tags.ts
@@ -201,11 +201,12 @@ export const parseMeasuresFile = (
 }
 
 /**
- * The repository URL is mandatory in processing for the following commands: sarif and sbom.
+ * These are mandatory git fields for the following commands: sarif and sbom.
  * Note: for sarif uploads, this will fail silent on the backend.
  */
 export const mandatoryGitFields: Record<string, boolean> = {
   [GIT_REPOSITORY_URL]: true,
+  [GIT_COMMIT_AUTHOR_EMAIL]: true,
 }
 
 /**


### PR DESCRIPTION
### What and why?

We use an author email to implement billing and thus it should be a required field.

### How?

Adds the git author email tag to the mandatory fields object.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
