### PR TITLE
[SYNTH-16456] Make server result optional in `Result`

### DIFF
--- a/src/commands/synthetics/__tests__/fixtures.ts
+++ b/src/commands/synthetics/__tests__/fixtures.ts
@@ -177,6 +177,7 @@ export const getSummary = (): Summary => ({
 })
 
 const getBaseResult = (resultId: string, test: Test): Omit<BaseResult, 'result'> => ({
+  duration: 1000,
   executionRule: ExecutionRule.BLOCKING,
   location: 'Frankfurt (AWS)',
   passed: true,
@@ -192,12 +193,16 @@ export const getBrowserResult = (
   resultId: string,
   test: Test,
   resultOpts: Partial<BrowserServerResult> = {}
-): BaseResult => ({
+): BaseResult & {result: ServerResult} => ({
   ...getBaseResult(resultId, test),
   result: getBrowserServerResult(resultOpts),
 })
 
-export const getApiResult = (resultId: string, test: Test, resultOpts: Partial<ApiServerResult> = {}): BaseResult => ({
+export const getApiResult = (
+  resultId: string,
+  test: Test,
+  resultOpts: Partial<ApiServerResult> = {}
+): BaseResult & {result: ServerResult} => ({
   ...getBaseResult(resultId, test),
   result: getApiServerResult(resultOpts),
 })
@@ -208,7 +213,7 @@ export const getIncompleteServerResult = (): ServerResult => {
 
 export const getBrowserServerResult = (opts: Partial<BrowserServerResult> = {}): BrowserServerResult => ({
   device: {height: 1100, id: 'chrome.laptop_large', width: 1440},
-  duration: 0,
+  duration: 1000,
   passed: true,
   startUrl: '',
   stepDetails: [],
@@ -216,6 +221,7 @@ export const getBrowserServerResult = (opts: Partial<BrowserServerResult> = {}):
 })
 
 export const getTimedOutBrowserResult = (): Result => ({
+  duration: 0,
   executionRule: ExecutionRule.BLOCKING,
   location: 'Location name',
   passed: false,
@@ -234,12 +240,13 @@ export const getTimedOutBrowserResult = (): Result => ({
 })
 
 export const getFailedBrowserResult = (): Result => ({
+  duration: 22000,
   executionRule: ExecutionRule.BLOCKING,
   location: 'Location name',
   passed: false,
   result: {
     device: {height: 1100, id: 'chrome.laptop_large', width: 1440},
-    duration: 20000,
+    duration: 22000,
     failure: {code: 'STEP_TIMEOUT', message: 'Step failed because it took more than 20 seconds.'},
     passed: false,
     startUrl: 'https://example.org/',
@@ -259,7 +266,7 @@ export const getFailedBrowserResult = (): Result => ({
       {
         ...getStep(),
         allowFailure: true,
-        description: 'Navigate',
+        description: 'Navigate again',
         duration: 1000,
         error: 'Navigation failure',
         skipped: true,
@@ -272,10 +279,9 @@ export const getFailedBrowserResult = (): Result => ({
       {
         ...getStep(),
         description: 'Assert',
-        duration: 1000,
-        error: 'Step failure',
+        duration: 20000,
+        error: 'Step timeout',
         publicId: 'abc-def-hij',
-        skipped: true,
         stepId: 3,
         type: 'assertElementContent',
         url: 'https://example.org/',
@@ -303,13 +309,13 @@ export const getApiServerResult = (opts: Partial<ApiServerResult> = {}): ApiServ
   ],
   passed: true,
   timings: {
-    total: 123,
+    total: 1000,
   },
   ...opts,
 })
 
 export const getMultiStepsServerResult = (): MultiStepsServerResult => ({
-  duration: 123,
+  duration: 1000,
   passed: true,
   steps: [],
 })
@@ -507,6 +513,7 @@ export const getResults = (resultsFixtures: ResultFixtures[]): Result[] => {
 
 export const getInProgressResultInBatch = (): BaseResultInBatch => {
   return {
+    duration: 0,
     execution_rule: ExecutionRule.BLOCKING,
     location: mockLocation.name,
     result_id: 'rid',
@@ -543,6 +550,7 @@ export const getSkippedResultInBatch = (): ResultInBatchSkippedBySelectiveRerun 
 export const getPassedResultInBatch = (): BaseResultInBatch => {
   return {
     ...getInProgressResultInBatch(),
+    duration: 1000,
     retries: 0,
     status: 'passed',
     timed_out: false,
@@ -552,6 +560,7 @@ export const getPassedResultInBatch = (): BaseResultInBatch => {
 export const getFailedResultInBatch = (): BaseResultInBatch => {
   return {
     ...getInProgressResultInBatch(),
+    duration: 1000,
     retries: 0,
     status: 'failed',
     timed_out: false,

--- a/src/commands/synthetics/__tests__/reporters/__snapshots__/default.test.ts.snap
+++ b/src/commands/synthetics/__tests__/reporters/__snapshots__/default.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`Default reporter resultEnd 1 API test, 1 location, 1 result: success 1`] = `
 "[1m[32m✓[39m[22m [[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m - [1m[32mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m
-  • Total duration: 123 ms - View test run details:
+  • Total duration: 1000 ms - View test run details:
     ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=1&batch_id=123&from_ci=true[39m[22m
   [1m[32m✓[39m[22m [1m[32m[1mGET[22m[1m - http://fake.url[39m[22m
 
@@ -11,19 +11,19 @@ exports[`Default reporter resultEnd 1 API test, 1 location, 1 result: success 1`
 
 exports[`Default reporter resultEnd 1 API test, 1 location, 3 results: success, failed non-blocking, failed blocking 1`] = `
 "[1m[32m✓[39m[22m [[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m - [1m[32mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m
-  • Total duration: 123 ms - View test run details:
+  • Total duration: 1000 ms - View test run details:
     ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=1&batch_id=123&from_ci=true[39m[22m
   [1m[32m✓[39m[22m [1m[32m[1mGET[22m[1m - http://fake.url[39m[22m
 
 [1m[33m✖[39m[22m [[1m[33mnon-blocking[39m[22m] [[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m - [1m[33mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m
-  • Total duration: 123 ms - View test run details:
+  • Total duration: 1000 ms - View test run details:
     ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=2&batch_id=123&from_ci=true[39m[22m
   [1m[33m✖[39m[22m [1m[33m[1mGET[22m[1m - http://fake.url[39m[22m
 [1m[33m  - Assertion failed:[39m[22m
 [1m[33m    ▶ responseTime should be less than [4m1000[24m. Actual: [4m1234[24m[39m[22m
 
 [1m[31m✖[39m[22m [[1m[31mblocking[39m[22m] [[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m - [1m[31mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m
-  • Total duration: 123 ms - View test run details:
+  • Total duration: 1000 ms - View test run details:
     ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=3&batch_id=123&from_ci=true[39m[22m
   [1m[31m✖[39m[22m [1m[31m[1mGET[22m[1m - http://fake.url[39m[22m
 [1m[31m  - Assertion failed:[39m[22m
@@ -34,7 +34,7 @@ exports[`Default reporter resultEnd 1 API test, 1 location, 3 results: success, 
 
 exports[`Default reporter resultEnd 3 API tests, 2 passed (1 from previous CI run) 1`] = `
 "[1m[32m✓[39m[22m [[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m - [1m[32mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m
-  • Total duration: 123 ms - View test run details:
+  • Total duration: 1000 ms - View test run details:
     ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=1001&batch_id=123&from_ci=true[39m[22m
   [1m[32m✓[39m[22m [1m[32m[1mGET[22m[1m - http://fake.url[39m[22m
 
@@ -43,7 +43,7 @@ exports[`Default reporter resultEnd 3 API tests, 2 passed (1 from previous CI ru
     ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=0002&batch_id=123&from_ci=true[39m[22m
 
 [1m[32m✓[39m[22m [2m(edited) [22m[[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m - [1m[32mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m
-  • Total duration: 123 ms - View test run details:
+  • Total duration: 1000 ms - View test run details:
     ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=1003&batch_id=123&from_ci=true[39m[22m
   [1m[32m✓[39m[22m [1m[32m[1mGET[22m[1m - http://fake.url[39m[22m
 
@@ -52,17 +52,17 @@ exports[`Default reporter resultEnd 3 API tests, 2 passed (1 from previous CI ru
 
 exports[`Default reporter resultEnd 3 Browser tests: failed blocking, timed out, global failure 1`] = `
 "[1m[31m✖[39m[22m [[1m[31mblocking[39m[22m] [[1m[2mabc-def-ghi[22m[22m] [1mTest name[22m - [1m[31mlocation: [1mLocation name[22m[1m[39m[22m - [1m[31mdevice: [1mchrome.laptop_large[22m[1m[39m[22m
-  • Total duration: 20000 ms - View test run details:
+  • Total duration: 22000 ms - View test run details:
     ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/abc-def-ghi/result/1?batch_id=123&from_ci=true[39m[22m
 [31m    [[1mSTEP_TIMEOUT[22m] - [2mStep failed because it took more than 20 seconds.[22m[39m
     [1m[32m✓[39m[22m | [1m1000[22mms - Navigate to start URL
     [2mhttps://example.org/[22m
-    [1m[31m✖[39m[22m | [1m1000[22mms - Navigate
+    [1m[31m✖[39m[22m | [1m1000[22mms - Navigate again
     [2mhttps://example.org/[22m
     [31m[2mNavigation failure[22m[39m
-    [1m[31m✖[39m[22m | [1m1000[22mms - Assert
+    [1m[31m✖[39m[22m | [1m[31m20000[39m[22mms - Assert
     [2mvalue[22m
-    [31m[2mStep failure[22m[39m
+    [31m[2mStep timeout[22m[39m
     [1m[33m⇢[39m[22m | 3 skipped steps
 
 [1m[31m✖[39m[22m [[1m[31mblocking[39m[22m] [[1m[2mabc-def-ghi[22m[22m] [1mTest name[22m - [1m[31mlocation: [1mLocation name[22m[1m[39m[22m
@@ -80,21 +80,21 @@ exports[`Default reporter resultEnd 3 Browser tests: failed blocking, timed out,
 
 exports[`Default reporter resultEnd Incomplete API and Browser tests - passed and failed 1`] = `
 "[1m[31m✖[39m[22m [[1m[31mblocking[39m[22m] [[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m - [1m[31mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m
-  • View test run details:
+  • Total duration: 1000 ms - View test run details:
     ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=1&batch_id=123&from_ci=true[39m[22m
   [1m[31m✖[39m[22m [1m[31m[1mGET[22m[1m - http://fake.url[39m[22m
 
 [1m[32m✓[39m[22m [[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m - [1m[32mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m
-  • View test run details:
+  • Total duration: 1000 ms - View test run details:
     ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=2&batch_id=123&from_ci=true[39m[22m
   [1m[32m✓[39m[22m [1m[32m[1mGET[22m[1m - http://fake.url[39m[22m
 
 [1m[31m✖[39m[22m [[1m[31mblocking[39m[22m] [[1m[2mbbb-bbb-bbb[22m[22m] [1mTest name[22m - [1m[31mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m
-  • View test run details:
+  • Total duration: 1000 ms - View test run details:
     ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/bbb-bbb-bbb/result/3?batch_id=123&from_ci=true[39m[22m
 
 [1m[32m✓[39m[22m [[1m[2mbbb-bbb-bbb[22m[22m] [1mTest name[22m - [1m[32mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m
-  • View test run details:
+  • Total duration: 1000 ms - View test run details:
     ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/bbb-bbb-bbb/result/4?batch_id=123&from_ci=true[39m[22m
 
 "
@@ -102,14 +102,14 @@ exports[`Default reporter resultEnd Incomplete API and Browser tests - passed an
 
 exports[`Default reporter resultEnd Retryable test - Edge case: fails, then retry times out 1`] = `
 "[1m[31m✖[39m[22m [[1m[31mblocking[39m[22m] [[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m - [1m[31mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m ([2mattempt 1 of 2, retrying…[22m)
-  • Total duration: 123 ms - View test run details:
+  • Total duration: 1000 ms - View test run details:
     ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=0&batch_id=123&from_ci=true[39m[22m
   [1m[31m✖[39m[22m [1m[31m[1mGET[22m[1m - http://fake.url[39m[22m
 [1m[31m  - Assertion failed:[39m[22m
 [1m[31m    ▶ responseTime should be less than [4m1000[24m. Actual: [4m1234[24m[39m[22m
 
 [1m[31m✖[39m[22m [[1m[31mblocking[39m[22m] [[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m - [1m[31mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m ([2mattempt 2, done[22m)
-  • Total duration: 123 ms - View test run details:
+  • Total duration: 1000 ms - View test run details:
     ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=0&batch_id=123&from_ci=true[39m[22m (previous attempt)
   [1m[31m✖[39m[22m [1m[31m[1mGET[22m[1m - http://fake.url[39m[22m
 [31m    [[1mTIMEOUT[22m] - [2mThe batch timed out before receiving the retry.[22m[39m
@@ -119,14 +119,14 @@ exports[`Default reporter resultEnd Retryable test - Edge case: fails, then retr
 
 exports[`Default reporter resultEnd Retryable test - Usual case: passes after 1 retry only 1`] = `
 "[1m[31m✖[39m[22m [[1m[31mblocking[39m[22m] [[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m - [1m[31mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m ([2mattempt 1 of 3, retrying…[22m)
-  • Total duration: 123 ms - View test run details:
+  • Total duration: 1000 ms - View test run details:
     ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=0&batch_id=123&from_ci=true[39m[22m
   [1m[31m✖[39m[22m [1m[31m[1mGET[22m[1m - http://fake.url[39m[22m
 [1m[31m  - Assertion failed:[39m[22m
 [1m[31m    ▶ responseTime should be less than [4m1000[24m. Actual: [4m1234[24m[39m[22m
 
 [1m[32m✓[39m[22m [[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m - [1m[32mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m ([2mattempt 2, done[22m)
-  • Total duration: 123 ms - View test run details:
+  • Total duration: 1000 ms - View test run details:
     ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=1&batch_id=123&from_ci=true[39m[22m
   [1m[32m✓[39m[22m [1m[32m[1mGET[22m[1m - http://fake.url[39m[22m
 
@@ -135,21 +135,21 @@ exports[`Default reporter resultEnd Retryable test - Usual case: passes after 1 
 
 exports[`Default reporter resultEnd Retryable test - Usual case: passes after max retries 1`] = `
 "[1m[31m✖[39m[22m [[1m[31mblocking[39m[22m] [[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m - [1m[31mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m ([2mattempt 1 of 3, retrying…[22m)
-  • Total duration: 123 ms - View test run details:
+  • Total duration: 1000 ms - View test run details:
     ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=0&batch_id=123&from_ci=true[39m[22m
   [1m[31m✖[39m[22m [1m[31m[1mGET[22m[1m - http://fake.url[39m[22m
 [1m[31m  - Assertion failed:[39m[22m
 [1m[31m    ▶ responseTime should be less than [4m1000[24m. Actual: [4m1234[24m[39m[22m
 
 [1m[31m✖[39m[22m [[1m[31mblocking[39m[22m] [[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m - [1m[31mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m ([2mattempt 2 of 3, retrying…[22m)
-  • Total duration: 123 ms - View test run details:
+  • Total duration: 1000 ms - View test run details:
     ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=1&batch_id=123&from_ci=true[39m[22m
   [1m[31m✖[39m[22m [1m[31m[1mGET[22m[1m - http://fake.url[39m[22m
 [1m[31m  - Assertion failed:[39m[22m
 [1m[31m    ▶ responseTime should be less than [4m1000[24m. Actual: [4m1234[24m[39m[22m
 
 [1m[32m✓[39m[22m [[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m - [1m[32mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m ([2mattempt 3, done[22m)
-  • Total duration: 123 ms - View test run details:
+  • Total duration: 1000 ms - View test run details:
     ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=2&batch_id=123&from_ci=true[39m[22m
   [1m[32m✓[39m[22m [1m[32m[1mGET[22m[1m - http://fake.url[39m[22m
 
@@ -325,7 +325,7 @@ exports[`Default reporter testsWait the spinner text is updated and cleared at t
 exports[`Default reporter testsWait the spinner text is updated and cleared at the end (in CI: false) 2`] = `
 "View pending summary in Datadog: [2m[36mhttps://app.datadoghq.com/synthetics/explorer/ci?batchResultId=123[39m[22m
 [1m[32m✓[39m[22m [[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m - [1m[32mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m
-  • Total duration: 123 ms - View test run details:
+  • Total duration: 1000 ms - View test run details:
     ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=rid&batch_id=123&from_ci=true[39m[22m
   [1m[32m✓[39m[22m [1m[32m[1mGET[22m[1m - http://fake.url[39m[22m
 
@@ -335,7 +335,7 @@ exports[`Default reporter testsWait the spinner text is updated and cleared at t
 exports[`Default reporter testsWait the spinner text is updated and cleared at the end (in CI: false) 3`] = `
 "View pending summary in Datadog: [2m[36mhttps://app.datadoghq.com/synthetics/explorer/ci?batchResultId=123[39m[22m
 [1m[32m✓[39m[22m [[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m - [1m[32mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m
-  • Total duration: 123 ms - View test run details:
+  • Total duration: 1000 ms - View test run details:
     ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=rid&batch_id=123&from_ci=true[39m[22m
   [1m[32m✓[39m[22m [1m[32m[1mGET[22m[1m - http://fake.url[39m[22m
 
@@ -346,7 +346,7 @@ exports[`Default reporter testsWait the spinner text is updated and cleared at t
 exports[`Default reporter testsWait the spinner text is updated and cleared at the end (in CI: false) 4`] = `
 "View pending summary in Datadog: [2m[36mhttps://app.datadoghq.com/synthetics/explorer/ci?batchResultId=123[39m[22m
 [1m[32m✓[39m[22m [[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m - [1m[32mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m
-  • Total duration: 123 ms - View test run details:
+  • Total duration: 1000 ms - View test run details:
     ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=rid&batch_id=123&from_ci=true[39m[22m
   [1m[32m✓[39m[22m [1m[32m[1mGET[22m[1m - http://fake.url[39m[22m
  [36m⠹[39m Waiting for the batch to end…
@@ -367,7 +367,7 @@ exports[`Default reporter testsWait the spinner text is updated and cleared at t
 - Waiting for [1m[36m2[39m[22m tests [90m(aaa-aaa-aaa, bbb-bbb-bbb)[39m…
 
 [1m[32m✓[39m[22m [[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m - [1m[32mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m
-  • Total duration: 123 ms - View test run details:
+  • Total duration: 1000 ms - View test run details:
     ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=rid&batch_id=123&from_ci=true[39m[22m
   [1m[32m✓[39m[22m [1m[32m[1mGET[22m[1m - http://fake.url[39m[22m
 
@@ -380,7 +380,7 @@ exports[`Default reporter testsWait the spinner text is updated and cleared at t
 - Waiting for [1m[36m2[39m[22m tests [90m(aaa-aaa-aaa, bbb-bbb-bbb)[39m…
 
 [1m[32m✓[39m[22m [[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m - [1m[32mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m
-  • Total duration: 123 ms - View test run details:
+  • Total duration: 1000 ms - View test run details:
     ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=rid&batch_id=123&from_ci=true[39m[22m
   [1m[32m✓[39m[22m [1m[32m[1mGET[22m[1m - http://fake.url[39m[22m
 
@@ -397,7 +397,7 @@ exports[`Default reporter testsWait the spinner text is updated and cleared at t
 - Waiting for [1m[36m2[39m[22m tests [90m(aaa-aaa-aaa, bbb-bbb-bbb)[39m…
 
 [1m[32m✓[39m[22m [[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m - [1m[32mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m
-  • Total duration: 123 ms - View test run details:
+  • Total duration: 1000 ms - View test run details:
     ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=rid&batch_id=123&from_ci=true[39m[22m
   [1m[32m✓[39m[22m [1m[32m[1mGET[22m[1m - http://fake.url[39m[22m
 

--- a/src/commands/synthetics/__tests__/reporters/junit.test.ts
+++ b/src/commands/synthetics/__tests__/reporters/junit.test.ts
@@ -505,14 +505,14 @@ describe('GitLab test report compatibility', () => {
         step: 'Assert',
         type: 'assertion',
       },
-      _: 'Step failure',
+      _: 'Step timeout',
     }
 
     expect(testCase.$).toHaveProperty('classname', 'tests.json') // Suite
     expect(testCase.$).toHaveProperty('name', name) // Name
     expect(testCase.$).toHaveProperty('file', 'tests.json') // Filename
     expect(testCase.failure).toStrictEqual([failure]) // Status
-    expect(testCase.$).toHaveProperty('time', 20) // Duration
+    expect(testCase.$).toHaveProperty('time', 22) // Duration
   })
 
   test('the icon in the Status column is correct (blocking vs. non-blocking)', () => {

--- a/src/commands/synthetics/__tests__/utils/public.test.ts
+++ b/src/commands/synthetics/__tests__/utils/public.test.ts
@@ -831,7 +831,8 @@ describe('utils', () => {
 
     const batch: Batch = getBatch()
     const apiTest = getApiTest('pid')
-    const result: Result = {
+    const result: BaseResult & {result: ServerResult} = {
+      duration: 1000,
       executionRule: ExecutionRule.BLOCKING,
       initialResultId: undefined,
       isNonFinal: false,
@@ -1035,6 +1036,7 @@ describe('utils', () => {
             // Second test
             {
               ...getInProgressResultInBatch(), // stays in progress
+              duration: 1000,
               retries: 0, // `retries` is set => first attempt failed, but will be fast retried
               test_public_id: 'other-public-id',
               timed_out: false,
@@ -1054,6 +1056,7 @@ describe('utils', () => {
       // One result received
       expect(mockReporter.resultReceived).toHaveBeenNthCalledWith(3, {
         ...batch.results[0],
+        duration: 1000,
         status: 'in_progress',
         test_public_id: 'other-public-id',
         result_id: 'rid-3',
@@ -1428,8 +1431,9 @@ describe('utils', () => {
         ],
       })
 
-      const expectedDeadlineResult = {
+      const expectedDeadlineResult: Result = {
         ...result,
+        duration: 0,
         result: {
           ...result.result,
           failure: {

--- a/src/commands/synthetics/batch.ts
+++ b/src/commands/synthetics/batch.ts
@@ -252,6 +252,7 @@ const getResultFromBatch = (
   const isUnhealthy = pollResult.result.unhealthy ?? false
 
   return {
+    duration: resultInBatch.duration,
     executionRule: resultInBatch.execution_rule,
     initialResultId: resultInBatch.initial_result_id,
     isNonFinal: isNonFinalResult(resultInBatch),

--- a/src/commands/synthetics/interfaces.ts
+++ b/src/commands/synthetics/interfaces.ts
@@ -127,6 +127,8 @@ export type SelectiveRerunDecision =
     }
 
 export interface BaseResult {
+  /** Duration of the result in milliseconds. */
+  duration: number
   executionRule: ExecutionRule
   initialResultId?: string
   /** Whether the result is an intermediary result that is expected to be retried. */
@@ -134,7 +136,7 @@ export interface BaseResult {
   location: string
   /** Whether the result is passed or not, according to `failOnCriticalErrors` and `failOnTimeout`. */
   passed: boolean
-  result: ServerResult
+  result?: ServerResult
   resultId: string
   /** Number of retries, including this result. */
   retries: number
@@ -149,7 +151,7 @@ export interface BaseResult {
 // Inside this type, `.resultId` is a linked result ID from a previous batch.
 export type ResultSkippedBySelectiveRerun = Omit<
   BaseResult,
-  'location' | 'result' | 'retries' | 'maxRetries' | 'timestamp'
+  'duration' | 'location' | 'result' | 'retries' | 'maxRetries' | 'timestamp'
 > & {
   executionRule: ExecutionRule.SKIPPED
   selectiveRerun: Extract<SelectiveRerunDecision, {decision: 'skip'}>
@@ -161,6 +163,7 @@ type Status = 'passed' | 'failed' | 'in_progress' | 'skipped'
 type BatchStatus = 'passed' | 'failed' | 'in_progress'
 
 export interface BaseResultInBatch {
+  duration: number
   execution_rule: ExecutionRule
   initial_result_id?: string
   location: string
@@ -173,7 +176,7 @@ export interface BaseResultInBatch {
   timed_out: boolean | null
 }
 
-type SkippedResultInBatch = Omit<BaseResultInBatch, 'location' | 'result_id'> & {
+type SkippedResultInBatch = Omit<BaseResultInBatch, 'duration' | 'location' | 'result_id'> & {
   execution_rule: ExecutionRule.SKIPPED
   status: 'skipped'
 }

--- a/src/commands/synthetics/utils/internal.ts
+++ b/src/commands/synthetics/utils/internal.ts
@@ -8,6 +8,7 @@ import {
   ResultInBatch,
   ResultInBatchSkippedBySelectiveRerun,
   RetryConfig,
+  ServerResult,
   Test,
   TestNotFound,
   TestSkipped,
@@ -48,8 +49,12 @@ export const hasResultPassed = (
   return result.status === 'passed'
 }
 
-export const hasResult = (result: Result): result is BaseResult => {
+export const isBaseResult = (result: Result): result is BaseResult => {
   return !isResultSkippedBySelectiveRerun(result)
+}
+
+export const hasDefinedResult = (result: Result): result is BaseResult & {result: ServerResult} => {
+  return !isResultSkippedBySelectiveRerun(result) && result.result !== undefined
 }
 
 /**

--- a/src/commands/synthetics/utils/public.ts
+++ b/src/commands/synthetics/utils/public.ts
@@ -48,7 +48,7 @@ import {DEFAULT_BATCH_TIMEOUT, DEFAULT_POLLING_TIMEOUT, MAX_TESTS_TO_TRIGGER} fr
 import {getTest} from '../test'
 import {Tunnel} from '../tunnel'
 
-import {getOverriddenExecutionRule, hasResult, isMobileTestWithOverride} from './internal'
+import {getOverriddenExecutionRule, hasDefinedResult, isMobileTestWithOverride} from './internal'
 
 const TEMPLATE_REGEX = /{{\s*([^{}]*?)\s*}}/g
 export const PUBLIC_ID_REGEX = /\b[a-z0-9]{3}-[a-z0-9]{3}-[a-z0-9]{3}\b/
@@ -179,12 +179,12 @@ export const isTestSupportedByTunnel = (test: Test) => {
  * @deprecated The concept of `ServerResult` is internal and not the source of truth for a result's status. This function has no public equivalent.
  */
 export const hasResultPassed = (
-  serverResult: ServerResult,
+  serverResult: ServerResult | undefined,
   hasTimedOut: boolean,
   failOnCriticalErrors: boolean,
   failOnTimeout: boolean
 ): boolean => {
-  if (serverResult.unhealthy && !failOnCriticalErrors) {
+  if (serverResult?.unhealthy && !failOnCriticalErrors) {
     return true
   }
 
@@ -192,11 +192,11 @@ export const hasResultPassed = (
     return true
   }
 
-  if (serverResult.passed !== undefined) {
+  if (serverResult?.passed !== undefined) {
     return serverResult.passed
   }
 
-  if (serverResult.failure !== undefined) {
+  if (serverResult?.failure !== undefined) {
     return false
   }
 
@@ -362,6 +362,9 @@ export const createInitialSummary = (): InitialSummary => ({
   timedOut: 0,
 })
 
+/**
+ * @deprecated Please use `Result.duration` instead.
+ */
 export const getResultDuration = (result: ServerResult): number => {
   if ('duration' in result) {
     return Math.round(result.duration)
@@ -752,7 +755,7 @@ export const renderResults = ({
       summary.timedOut++
     }
 
-    if (hasResult(result) && result.result.unhealthy && !config.failOnCriticalErrors) {
+    if (hasDefinedResult(result) && result.result.unhealthy && !config.failOnCriticalErrors) {
       summary.criticalErrors++
     }
 


### PR DESCRIPTION
### What and why?

The source of truth for a result is the batch and not the server result (which we poll with the `/poll_results` endpoint).

The server result corresponding to a batch result may happen to never be available, and in that case datadog-ci should fall back to the source of truth (the batch) instead of failing.

When such thing happens for a result, a warning log is printed (`The information for result {resultId} of test {publicId} was incomplete at the end of the batch.`) and the `Result.result` property will be `undefined`.

### How?

- Make `Result.result` optional
- Update fixtures and tests

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
