### PR TITLE
v2.44.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci",
-  "version": "2.43.0",
+  "version": "2.44.0",
   "description": "Run datadog actions from the CI.",
   "repository": "https://github.com/DataDog/datadog-ci",
   "license": "Apache-2.0",


### PR DESCRIPTION
<!-- Release notes generated using configuration in .github/release.yml at v2.44.0 -->

## What's Changed
### CI Visibility
* Read pull_request and pull_request_target event info from GHA by @juan-fernandez in https://github.com/DataDog/datadog-ci/pull/1473
* Add option to pass config shas manually on `correlate` command by @rodrigo-roca in https://github.com/DataDog/datadog-ci/pull/1479
* [SDCI] Remove correlate command flaky test by @rodrigo-roca in https://github.com/DataDog/datadog-ci/pull/1485
### Serverless
* Refactor sfn->sfn context injection code by merging two functions by @lym953 in https://github.com/DataDog/datadog-ci/pull/1466
* Refactor sfn->sfn context injection code by merging two functions (2) by @lym953 in https://github.com/DataDog/datadog-ci/pull/1467
* Support sfn->sfn context injection case 3 by @lym953 in https://github.com/DataDog/datadog-ci/pull/1468
* Handle another case when sfn->Lambda context injection is already set… by @lym953 in https://github.com/DataDog/datadog-ci/pull/1470
* Revamp SFN->SFN context injection by @lym953 in https://github.com/DataDog/datadog-ci/pull/1471
### Static Analysis
* Propagating CycloneDx information by @marcwieserdev in https://github.com/DataDog/datadog-ci/pull/1453
* [STAL-2949] Make git author a mandatory field by @dastrong in https://github.com/DataDog/datadog-ci/pull/1472
### Synthetics
* [SYNTH-16381] Add setCookies override by @AntoineDona in https://github.com/DataDog/datadog-ci/pull/1478
* [SYNTH-16456] Make server result optional in `Result` by @Drarig29 in https://github.com/DataDog/datadog-ci/pull/1483
* [SYNTH-16456] Postpone reporting results on 404 by @Drarig29 in https://github.com/DataDog/datadog-ci/pull/1480

## New Contributors
* @marcwieserdev made their first contribution in https://github.com/DataDog/datadog-ci/pull/1453

**Full Changelog**: https://github.com/DataDog/datadog-ci/compare/v2.43.0...v2.44.0

[STAL-2949]: https://datadoghq.atlassian.net/browse/STAL-2949?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ