### PR TITLE
[STAL-3155] Specify which git tags are missing

### DIFF
--- a/src/commands/sarif/renderer.ts
+++ b/src/commands/sarif/renderer.ts
@@ -35,7 +35,7 @@ export const renderMissingTags = (missingTags: string[]) => {
   fullStr += chalk.red(`${ICONS.WARNING}  There are missing git tags in ${styledPath}:\n`)
   missingTags.forEach((tag: string) => {
     fullStr += chalk.red(` - ${tag}\n`)
-  });
+  })
   fullStr += chalk.red(`To fix this, ensure that the git information above is available for your commit.\n`)
 
   return fullStr

--- a/src/commands/sarif/renderer.ts
+++ b/src/commands/sarif/renderer.ts
@@ -28,15 +28,15 @@ export const renderInvalidFile = (sarifReport: string, errorMessages: string[]) 
   return fullStr
 }
 
-export const renderMissingSpan = (errorMessage: string) => {
-  const currentPath = `[${chalk.bold.dim(process.cwd())}]`
+export const renderMissingTags = (missingTags: string[]) => {
+  const styledPath = `[${chalk.bold.dim(process.cwd())}]`
 
   let fullStr = ''
-  fullStr += chalk.yellow(`${ICONS.WARNING}  Validation failed: ${errorMessage}.\n`)
-  fullStr += chalk.yellow(
-    `Upload attempted from ${currentPath}. Is this the directory for which this analysis was run?\n`
-  )
-  fullStr += chalk.yellow(`The upload must come from a directory with a ".git" directory.\n`)
+  fullStr += chalk.red(`${ICONS.WARNING}  There are missing git tags in ${styledPath}:\n`)
+  missingTags.forEach((tag: string) => {
+    fullStr += chalk.red(` - ${tag}\n`)
+  });
+  fullStr += chalk.red(`To fix this, ensure that the git information above is available for your commit.\n`)
 
   return fullStr
 }

--- a/src/commands/sarif/renderer.ts
+++ b/src/commands/sarif/renderer.ts
@@ -32,7 +32,7 @@ export const renderMissingTags = (missingTags: string[]) => {
   const styledPath = `[${chalk.bold.dim(process.cwd())}]`
 
   let fullStr = ''
-  fullStr += chalk.red(`${ICONS.WARNING}  There are missing git tags in ${styledPath}:\n`)
+  fullStr += chalk.red(`There are missing git tags in ${styledPath}:\n`)
   missingTags.forEach((tag: string) => {
     fullStr += chalk.red(` - ${tag}\n`)
   })

--- a/src/commands/sbom/renderer.ts
+++ b/src/commands/sbom/renderer.ts
@@ -28,19 +28,6 @@ export const renderInvalidPayload = (sbomReport: string) => {
   return fullStr
 }
 
-export const renderMissingSpan = (errorMessage: string) => {
-  const currentPath = `[${chalk.bold.dim(process.cwd())}]`
-
-  let fullStr = ''
-  fullStr += chalk.yellow(`${ICONS.WARNING}  Validation failed: ${errorMessage}.\n`)
-  fullStr += chalk.yellow(
-    `Upload attempted from ${currentPath}. Is this the directory for which this analysis was run?\n`
-  )
-  fullStr += chalk.yellow(`The upload must come from a directory with a ".git" directory.\n`)
-
-  return fullStr
-}
-
 export const renderDuplicateUpload = (sha: string, env: string, service: string) => {
   let fullStr = ''
   fullStr += chalk.red(`${ICONS.WARNING}  Duplicate SBOM upload detected\n`)

--- a/src/helpers/tags.ts
+++ b/src/helpers/tags.ts
@@ -203,12 +203,16 @@ export const parseMeasuresFile = (
 }
 
 /**
- * These are mandatory git fields for the following commands: sarif and sbom.
- * Note: for sarif uploads, this will fail silent on the backend.
+ * These are required git tags for the following commands: sarif and sbom.
  */
-export const mandatoryGitFields: Record<string, boolean> = {
+export const REQUIRED_GIT_TAGS: Record<string, boolean> = {
   [GIT_REPOSITORY_URL]: true,
+  [GIT_BRANCH]: true,
+  [GIT_SHA]: true,
   [GIT_COMMIT_AUTHOR_EMAIL]: true,
+  [GIT_COMMIT_AUTHOR_NAME]: true,
+  [GIT_COMMIT_COMMITTER_EMAIL]: true,
+  [GIT_COMMIT_COMMITTER_NAME]: true,
 }
 
 /**


### PR DESCRIPTION
### What and why?

We should NOT upload SARIF results when a required git tag is absent. We've extended the list of fields to be more accurate with our current product.

When a git tag is missing we don't specify which one is required, so we now keep track and list them out so they are visible to users.

### Verification

Removed my committer email from getting sent and ran the commands.

<img width="619" alt="Screenshot 2024-11-11 at 3 59 04 PM" src="https://github.com/user-attachments/assets/e6f1c238-db79-4e4b-8032-66195ce47d83">

<img width="616" alt="Screenshot 2024-11-11 at 3 53 02 PM" src="https://github.com/user-attachments/assets/b601f88d-c338-4bbf-86c5-4593157b90dd">

### Review checklist

- [X] Feature or bugfix MUST have appropriate tests (unit, integration)
