### PR TITLE
[SYNTH-17149] Fix selective rerun org-wide default setting not used

### DIFF
--- a/src/commands/synthetics/README.md
+++ b/src/commands/synthetics/README.md
@@ -409,7 +409,7 @@ List of IDs for the Synthetic tests you want to trigger.
 
 #### `selectiveRerun`
 
-A boolean flag to only run the tests which failed in the previous test batches. Use the `--no-selectiveRerun` CLI flag to force a full run if your configuration enables it by default.
+A boolean flag to only run the tests which failed in the previous test batches. By default, the [organization default setting](https://app.datadoghq.com/synthetics/settings/continuous-testing) is used. Use the `--no-selectiveRerun` CLI flag or `selectiveRerun: false` to force a full run.
 
 **Configuration options**
 

--- a/src/commands/synthetics/__tests__/fixtures.ts
+++ b/src/commands/synthetics/__tests__/fixtures.ts
@@ -82,7 +82,6 @@ export const ciConfig: RunTestsCommandConfig = {
   locations: [],
   proxy: {protocol: 'http'},
   publicIds: [],
-  selectiveRerun: false,
   subdomain: 'app',
   testSearchQuery: '',
   tunnel: false,

--- a/src/commands/synthetics/interfaces.ts
+++ b/src/commands/synthetics/interfaces.ts
@@ -509,7 +509,8 @@ export interface RunTestsCommandConfig extends SyntheticsCIConfig {
   /** @deprecated This property is deprecated, please use `batchTimeout` in the global configuration file or `--batchTimeout` instead. */
   pollingTimeout?: number
   publicIds: string[]
-  selectiveRerun: boolean
+  /** Whether to only run the tests which failed in the previous test batches. By default, the organization default setting is used. */
+  selectiveRerun?: boolean
   subdomain: string
   testSearchQuery?: string
   tunnel: boolean

--- a/src/commands/synthetics/run-tests-command.ts
+++ b/src/commands/synthetics/run-tests-command.ts
@@ -56,7 +56,6 @@ export const DEFAULT_COMMAND_CONFIG: RunTestsCommandConfig = {
   pollingTimeout: DEFAULT_POLLING_TIMEOUT,
   proxy: {protocol: 'http'},
   publicIds: [],
-  selectiveRerun: false,
   subdomain: 'app',
   testSearchQuery: '',
   tunnel: false,

--- a/src/commands/synthetics/utils/public.ts
+++ b/src/commands/synthetics/utils/public.ts
@@ -595,7 +595,7 @@ export const getTestsToTrigger = async (
 export const runTests = async (
   api: APIHelper,
   testsToTrigger: TestPayload[],
-  selectiveRerun = false,
+  selectiveRerun?: boolean,
   batchTimeout = DEFAULT_BATCH_TIMEOUT
 ): Promise<Trigger> => {
   // TODO SYNTH-12989: Remove this when `pollingTimeout` is removed


### PR DESCRIPTION
### What and why?

This PR fixes a bug where datadog-ci was always overriding the default setting to false except if `--selectiveRerun` was passed.

### How?

Make the `selectiveRerun` setting optional in datadog-ci so that it defaults to the backend's org-wide default setting. The user can pass `--selectiveRerun` or `--no-selectiveRerun` to override the org-wide default setting.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
