### PR TITLE
[SYNTH-17150] Update selective rerun spelling

### DIFF
--- a/src/commands/synthetics/__tests__/reporters/__snapshots__/default.test.ts.snap
+++ b/src/commands/synthetics/__tests__/reporters/__snapshots__/default.test.ts.snap
@@ -171,7 +171,7 @@ exports[`Default reporter runEnd Case with 2 passed results, of which 1 comes fr
 
 [1mContinuous Testing Summary:[22m
 • Test Results: [32m[1m2[22m passed ([1m1[22m in a previous CI batch)[39m, [31m[1m0[22m failed[39m
-• Selective re-run: ran 1 out of 2 tests
+• Selective rerun: ran 1 out of 2 tests
 • Total Duration: 9m 28s
 "
 `;
@@ -182,7 +182,7 @@ View full summary in Datadog: [2m[36mhttps://app.datadoghq.com/synthetics/expl
 
 [1mContinuous Testing Summary:[22m
 • Test Results: [32m[1m2[22m passed ([1m1[22m in a previous CI batch)[39m, [31m[1m1[22m failed[39m, [33m[1m3[22m failed (non-blocking)[39m, [1m1[22m skipped ([33m[1m1[22m timed out[39m, [31m[1m2[22m critical errors[39m)
-• Selective re-run: ran 5 out of 6 tests
+• Selective rerun: ran 5 out of 6 tests
 • Total Duration: 9m 28s
 "
 `;

--- a/src/commands/synthetics/__tests__/reporters/junit.test.ts
+++ b/src/commands/synthetics/__tests__/reporters/junit.test.ts
@@ -208,7 +208,7 @@ describe('Junit reporter', () => {
         ...getDefaultSuiteStats(),
         errors: 0,
         failures: 1,
-        skipped: 1, // not 2 because skipped by selective re-run counts as passed
+        skipped: 1, // not 2 because skipped by selective rerun counts as passed
         tests: 3,
       })
     })

--- a/src/commands/synthetics/__tests__/run-tests-lib.test.ts
+++ b/src/commands/synthetics/__tests__/run-tests-lib.test.ts
@@ -552,7 +552,7 @@ describe('run-test', () => {
       expect(stopTunnelSpy).toHaveBeenCalledTimes(1)
     })
 
-    test('log when selective re-run is rate-limited', async () => {
+    test('log when selective rerun is rate-limited', async () => {
       jest.spyOn(utils, 'getTestsToTrigger').mockReturnValue(
         Promise.resolve({
           initialSummary: utils.createInitialSummary(),
@@ -581,11 +581,11 @@ describe('run-test', () => {
       })
 
       expect(mockReporter.error).toHaveBeenCalledWith(
-        'The selective re-run feature was rate-limited. All tests will be re-run.\n\n'
+        'The selective rerun feature was rate-limited. All tests will be re-run.\n\n'
       )
     })
 
-    test('selective re-run defaults to undefined', async () => {
+    test('selective rerun defaults to undefined', async () => {
       jest.spyOn(utils, 'getTestsToTrigger').mockReturnValue(
         Promise.resolve({
           initialSummary: utils.createInitialSummary(),

--- a/src/commands/synthetics/__tests__/utils/public.test.ts
+++ b/src/commands/synthetics/__tests__/utils/public.test.ts
@@ -1125,7 +1125,7 @@ describe('utils', () => {
           status: 'in_progress',
           results: [
             // First test
-            {...getSkippedResultInBatch()}, // skipped by selective re-run
+            {...getSkippedResultInBatch()}, // skipped by selective rerun
             // Second test
             {...getInProgressResultInBatch(), test_public_id: 'other-public-id', result_id: 'rid-2'},
           ],
@@ -1155,7 +1155,7 @@ describe('utils', () => {
       expect(mockReporter.resultReceived).toHaveBeenNthCalledWith(1, {
         ...getSkippedResultInBatch(),
       })
-      // And marked as passed because it's selective re-run
+      // And marked as passed because it's selective rerun
       const skippedResult: Result = {
         executionRule: ExecutionRule.SKIPPED,
         passed: true,

--- a/src/commands/synthetics/interfaces.ts
+++ b/src/commands/synthetics/interfaces.ts
@@ -194,7 +194,7 @@ type ServerResultInBatch = BaseResultInBatch | SkippedResultInBatch
 
 export interface ServerBatch {
   // The batch from the server contains skipped results, which we're going to remove since we don't
-  // care about skipped results internally (except when they are skipped by a selective re-run).
+  // care about skipped results internally (except when they are skipped by a selective rerun).
   results: ServerResultInBatch[]
   status: BatchStatus
 }
@@ -453,7 +453,7 @@ export interface Summary {
   // The batchId is associated to a full run of datadog-ci: multiple suites will be in the same batch.
   batchId: string
   criticalErrors: number
-  // Number of results expected by datadog-ci, prior to any selective re-run.
+  // Number of results expected by datadog-ci, prior to any selective rerun.
   expected: number
   failed: number
   failedNonBlocking: number

--- a/src/commands/synthetics/reporters/default.ts
+++ b/src/commands/synthetics/reporters/default.ts
@@ -421,7 +421,7 @@ export class DefaultReporter implements MainReporter {
 
     if (summary.previouslyPassed) {
       lines.push(
-        `• Selective re-run: ran ${summary.expected - summary.previouslyPassed} out of ${summary.expected} tests`
+        `• Selective rerun: ran ${summary.expected - summary.previouslyPassed} out of ${summary.expected} tests`
       )
     }
 

--- a/src/commands/synthetics/run-tests-lib.ts
+++ b/src/commands/synthetics/run-tests-lib.ts
@@ -149,7 +149,7 @@ export const executeTests = async (
   }
 
   if (trigger.selective_rerun_rate_limited) {
-    reporter.error('The selective re-run feature was rate-limited. All tests will be re-run.\n\n')
+    reporter.error('The selective rerun feature was rate-limited. All tests will be re-run.\n\n')
   }
 
   try {


### PR DESCRIPTION
### What and why?

The programmatic options are spelled `selectiveRerun` and we chose to spell it `selective rerun` in UI copy, so we are aligning datadog-ci.

### How?

Search & replace

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
