### PR TITLE
[K9VULN-1175] Validate purl

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -49,6 +49,7 @@ inquirer-checkbox-plus-prompt,import,MIT,Copyright (c) 2018 Mohammad Anas Fares
 jest,dev,MIT,"Copyright (c) Facebook, Inc. and its affiliates."
 js-yaml,import,MIT,Copyright (C) 2011-2015 by Vitaly Puzrin
 ora,import,MIT,Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (https://sindresorhus.com)
+packageurl-js,import,MIT,Copyright (c) the purl authors
 pkg,dev,MIT,"Copyright (c) 2021 Vercel, Inc."
 prettier,dev,MIT,Copyright © James Long and contributors
 proxy,dev,MIT,Copyright (c) 2013 Nathan Rajlich <nathan@tootallnate.net>

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "js-yaml": "3.13.1",
     "jszip": "^3.10.1",
     "ora": "5.4.1",
+    "packageurl-js": "^2.0.1",
     "proxy-agent": "^6.4.0",
     "rimraf": "^3.0.2",
     "semver": "^7.5.3",

--- a/src/commands/sbom/__tests__/fixtures/sbom-invalid-purl.json
+++ b/src/commands/sbom/__tests__/fixtures/sbom-invalid-purl.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.5",
+  "version": 1,
+  "components": [
+    {
+      "bom-ref": "pkg:pypi/markupsafe",
+      "type": "library",
+      "name": "markupsafe",
+      "version": "3.1.5",
+      "purl": "invalid purl",
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{\"block\":{\"file_name\":\"requirements.txt\",\"line_start\":2,\"line_end\":2,\"column_start\":1,\"column_end\":11},\"name\":{\"file_name\":\"requirements.txt\",\"line_start\":2,\"line_end\":2,\"column_start\":1,\"column_end\":11}}"
+          }
+        ]
+      }
+    },
+    {
+      "bom-ref": "pkg:pypi/jinja2@3.1.5",
+      "type": "library",
+      "name": "jinja2",
+      "version": "3.1.5",
+      "purl": "pkg:pypi/jinja2@3.1.5",
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "{\"block\":{\"file_name\":\"requirements.txt\",\"line_start\":1,\"line_end\":1,\"column_start\":1,\"column_end\":7}}"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/src/commands/sbom/__tests__/validation.test.ts
+++ b/src/commands/sbom/__tests__/validation.test.ts
@@ -45,6 +45,11 @@ describe('validation of sbom file', () => {
       validateFileAgainstToolRequirements('./src/commands/sbom/__tests__/fixtures/trivy-4.9.json', true)
     ).toBeTruthy()
   })
+  test('SBOM with invalid purl are being rejected', () => {
+    expect(
+      validateFileAgainstToolRequirements('./src/commands/sbom/__tests__/fixtures/sbom-invalid-purl.json', true)
+    ).toBeFalsy()
+  })
   test('should validate SBOM file osv scanner - version 1.5', () => {
     // type and name of the "component" have been removed from the valid file.
     expect(

--- a/src/commands/sbom/upload.ts
+++ b/src/commands/sbom/upload.ts
@@ -109,15 +109,14 @@ export class UploadSbomCommand extends Command {
     }
 
     if (!validateSbomFileAgainstSchema(basePath, validator, !!this.debug)) {
-      if (!validateFileAgainstToolRequirements(basePath, !!this.debug)) {
-        this.context.stdout.write(renderInvalidFile(basePath))
+      this.context.stdout.write(
+        'SBOM file not fully compliant against CycloneDX 1.4 or 1.5 specifications (use --debug to get validation error)\n'
+      )
+    }
+    if (!validateFileAgainstToolRequirements(basePath, !!this.debug)) {
+      this.context.stdout.write(renderInvalidFile(basePath))
 
-        return 1
-      } else {
-        this.context.stdout.write(
-          'Invalid SBOM file but enough data to be processed (use --debug to get validation error)\n'
-        )
-      }
+      return 1
     }
 
     const jsonContent = JSON.parse(fs.readFileSync(basePath).toString('utf8'))

--- a/src/commands/sbom/validation.ts
+++ b/src/commands/sbom/validation.ts
@@ -2,6 +2,7 @@ import fs from 'fs'
 
 import Ajv from 'ajv'
 import addFormats from 'ajv-formats'
+import {PackageURL} from 'packageurl-js'
 
 import cycloneDxSchema14 from './json-schema/cyclonedx/bom-1.4.schema.json'
 import cycloneDxSchema15 from './json-schema/cyclonedx/bom-1.5.schema.json'
@@ -109,7 +110,7 @@ export const validateFileAgainstToolRequirements = (path: string, debug: boolean
       if (component['type'] === 'library') {
         const name = component['name']
 
-        if (!!component['version']) {
+        if (!component['version']) {
           continue
         }
 
@@ -119,6 +120,14 @@ export const validateFileAgainstToolRequirements = (path: string, debug: boolean
           }
 
           return false
+        } else {
+          try {
+            PackageURL.fromString(component['purl'])
+          } catch (purlError) {
+            process.stderr.write(`invalid purl ${component['purl']}: ${purlError.message}\n`)
+
+            return false
+          }
         }
       }
     }

--- a/src/commands/sbom/validation.ts
+++ b/src/commands/sbom/validation.ts
@@ -124,7 +124,9 @@ export const validateFileAgainstToolRequirements = (path: string, debug: boolean
           try {
             PackageURL.fromString(component['purl'])
           } catch (purlError) {
-            process.stderr.write(`invalid purl ${component['purl']}: ${purlError.message}\n`)
+            process.stderr.write(
+              `invalid purl ${component['purl']} for component ${component['name']}: ${purlError.message}\n`
+            )
 
             return false
           }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1944,6 +1944,7 @@ __metadata:
     js-yaml: 3.13.1
     jszip: ^3.10.1
     ora: 5.4.1
+    packageurl-js: ^2.0.1
     pkg: 5.5.2
     prettier: 2.0.5
     proxy: ^2.1.1
@@ -8980,6 +8981,13 @@ jschardet@latest:
   version: 1.0.0
   resolution: "package-json-from-dist@npm:1.0.0"
   checksum: ac706ec856a5a03f5261e4e48fa974f24feb044d51f84f8332e2af0af04fbdbdd5bbbfb9cbbe354190409bc8307c83a9e38c6672c3c8855f709afb0006a009ea
+  languageName: node
+  linkType: hard
+
+"packageurl-js@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "packageurl-js@npm:2.0.1"
+  checksum: 91998b4ef0aa5fad8993dfb611039771a5e350532f14be1c065e64a5fb26fc771880865c2c81beaf127b07700d7d74ecfeccf8ca9748b0fef19c1cd9d3f41860
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What problem are you trying to solve?

We want to prevent customer from uploading invalid requests (for example, with invalid `purl`).

## Solution

Filter the data and prevent uploading payload with invalid package url.

## Testing

Added one unit test.

Running locally

```
$ yarn launch sbom upload ./src/commands/sbom/__tests__/fixtures/sbom-invalid-purl.json             
invalid purl invalid purl: Invalid purl: missing required "pkg" scheme component
❌ Invalid SBOM report file [./src/commands/sbom/__tests__/fixtures/sbom-invalid-purl.json].
The report is not a valid SBOM or is not compliant with our json schema.
```