### PR TITLE
add a fips option to all existing commands

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,7 +141,7 @@ jobs:
       - run: yarn install --immutable
       - run: yarn build
       - name: Create standalone binary
-        run: yarn dist-standalone -t node14-linux-x64 -o datadog-ci_linux-x64
+        run: yarn dist-standalone -t node18-linux-x64 -o datadog-ci_linux-x64
       - name: Remove dist and src folder to check that binary can stand alone
         run: |
           rm -rf dist
@@ -165,7 +165,7 @@ jobs:
       - run: yarn install --immutable
       - run: yarn build
       - name: Create standalone binary
-        run: yarn dist-standalone -t node14-linux-arm64 -o datadog-ci_linux-arm64
+        run: yarn dist-standalone -t node18-linux-arm64 -o datadog-ci_linux-arm64
       - name: Remove dist and src folder to check that binary can stand alone
         run: |
           rm -rf dist
@@ -185,7 +185,7 @@ jobs:
       - run: yarn install --immutable
       - run: yarn build:win
       - name: Create standalone binary
-        run: yarn dist-standalone -t node14-win-x64 -o datadog-ci_win-x64
+        run: yarn dist-standalone -t node18-win-x64 -o datadog-ci_win-x64
       - name: Remove dist and src folder to check that binary can stand alone
         run: |
           rm dist -r
@@ -207,7 +207,7 @@ jobs:
       - run: yarn install --immutable
       - run: yarn build
       - name: Create standalone binary
-        run: yarn dist-standalone -t node14-macos-x64 -o datadog-ci_darwin-x64
+        run: yarn dist-standalone -t node18-macos-x64 -o datadog-ci_darwin-x64
       - name: Remove dist and src folder to check that binary can stand alone
         run: |
           rm -rf dist
@@ -227,7 +227,7 @@ jobs:
       - run: yarn install --immutable
       - run: yarn build
       - name: Create standalone binary
-        run: yarn dist-standalone -t node14-macos-arm64 -o datadog-ci_darwin-arm64
+        run: yarn dist-standalone -t node18-macos-arm64 -o datadog-ci_darwin-arm64
       - name: Remove dist and src folder to check that binary can stand alone
         run: |
           rm -rf dist

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Bundle library
         run: yarn build
       - name: Create standalone binary
-        run: yarn dist-standalone -t node14-linux-x64 -o datadog-ci_linux-x64
+        run: yarn dist-standalone -t node18-linux-x64 -o datadog-ci_linux-x64
       - name: Remove dist folder to check that binary can stand alone
         run: |
           rm -rf dist
@@ -96,7 +96,7 @@ jobs:
       - name: Bundle library
         run: yarn build
       - name: Create standalone binary
-        run: yarn dist-standalone -t node14-linux-arm64 -o datadog-ci_linux-arm64
+        run: yarn dist-standalone -t node18-linux-arm64 -o datadog-ci_linux-arm64
       - name: Remove dist folder to check that binary can stand alone
         run: |
           rm -rf dist
@@ -132,7 +132,7 @@ jobs:
       - name: Bundle library
         run: yarn build:win
       - name: Create standalone binary
-        run: yarn dist-standalone -t node14-win-x64 -o datadog-ci_win-x64
+        run: yarn dist-standalone -t node18-win-x64 -o datadog-ci_win-x64
       - name: Remove dist folder to check that binary can stand alone
         run: |
           rm dist -r
@@ -170,7 +170,7 @@ jobs:
       - name: Bundle library
         run: yarn build
       - name: Create standalone binary
-        run: yarn dist-standalone -t node14-macos-x64 -o datadog-ci_darwin-x64
+        run: yarn dist-standalone -t node18-macos-x64 -o datadog-ci_darwin-x64
       - name: Remove dist folder to check that binary can stand alone
         run: |
           rm -rf dist
@@ -206,7 +206,7 @@ jobs:
       - name: Bundle library
         run: yarn build
       - name: Create standalone binary
-        run: yarn dist-standalone -t node14-macos-arm64 -o datadog-ci_darwin-arm64
+        run: yarn dist-standalone -t node18-macos-arm64 -o datadog-ci_darwin-arm64
       - name: Remove dist folder to check that binary can stand alone
         run: |
           rm -rf dist

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ The `fips` option allows `datadog-ci` to use a FIPS cryptographic module provide
 **Note**: `datadog-ci` cannot assert if such a provider is available, and doesn't throw any error if the provider is not FIPS validated.
 
 Node.js versions below 17 are incompatible with OpenSSL 3, which provides FIPS support.
-If you are using a Node.js version below 17, enabling the `fips` option will cause the command to throw an error.
+If you are using a Node.js version below 17, enabling the `fips` option causes the command to throw an error.
 The option `fips-ignore-error` ignores this error.
 The released `datadog-ci` binary now uses Node.js version 18 to be compatible with OpenSSL 3.
 

--- a/README.md
+++ b/README.md
@@ -115,6 +115,31 @@ The following are **beta** commands, you can enable them with with `DD_BETA_COMM
 #### `gate`
 - `evaluate`: Evaluate [Quality Gates](src/commands/gate) rules in Datadog. [📚](https://docs.datadoghq.com/quality_gates/)
 
+
+### FIPS support
+
+The `fips` option allow `datadog-ci` to use a FIPS cryptographic module provider, if the OpenSSL library installed on the host system provides it.
+`datadog-ci` cannot assert if such a provider is available, and won't throw any error in case the provider is not FIPS compliant.
+
+However, node version below 17 are incompatible with OpenSSL 3 which provides FIPS support.
+In this case, enabling the `fips` option will cause the command to throw an error.
+The option `fips-ignore-error` is meant to ignore this error.
+
+#### `fips`
+Enable FIPS support by datadog-ci, given a FIPS provider is installed on the host system.
+If no FIPS provider is installed, no error are raised.
+
+ENV variable: DATADOG_FIPS=True
+CLI param: `--fips`
+
+#### `fips-ignore-error`
+Ignore node errors in case FIPS cannot be enabled on the host system.
+The absence of error doesn't imply FIPS is successfully enabled.
+
+ENV variable: DATADOG_FIPS_IGNORE_ERROR=True
+CLI param: `--fips-ignore-error`
+
+
 ## More ways to install the CLI
 
 ### Standalone binary

--- a/README.md
+++ b/README.md
@@ -118,25 +118,28 @@ The following are **beta** commands, you can enable them with with `DD_BETA_COMM
 
 ### FIPS support
 
-The `fips` option allow `datadog-ci` to use a FIPS cryptographic module provider, if the OpenSSL library installed on the host system provides it.
-`datadog-ci` cannot assert if such a provider is available, and won't throw any error in case the provider is not FIPS compliant.
+The `fips` option allows `datadog-ci` to use a FIPS cryptographic module provider if the OpenSSL library installed on the host system provides it.
 
-However, node version below 17 are incompatible with OpenSSL 3 which provides FIPS support.
-In this case, enabling the `fips` option will cause the command to throw an error.
-The option `fips-ignore-error` is meant to ignore this error.
+**Note**: `datadog-ci` cannot assert if such a provider is available, and doesn't throw any error if the provider is not FIPS validated.
+
+Node.js versions below 17 are incompatible with OpenSSL 3, which provides FIPS support.
+If you are using a Node.js version below 17, enabling the `fips` option will cause the command to throw an error.
+The option `fips-ignore-error` ignores this error.
+The released `datadog-ci` binary now uses Node.js version 18 to be compatible with OpenSSL 3.
 
 #### `fips`
-Enable FIPS support by datadog-ci, given a FIPS provider is installed on the host system.
-If no FIPS provider is installed, no error are raised.
+Enable `datadog-ci` FIPS support if a FIPS validated provider is installed on the host system.
+If you do not have a FIPS provider installed, `datadog-ci` does not raise an error.
 
-ENV variable: DATADOG_FIPS=True
+ENV variable: `DATADOG_FIPS=true`
 CLI param: `--fips`
 
 #### `fips-ignore-error`
-Ignore node errors in case FIPS cannot be enabled on the host system.
-The absence of error doesn't imply FIPS is successfully enabled.
+Ignore Node.js errors if FIPS cannot be enabled on the host system.
 
-ENV variable: DATADOG_FIPS_IGNORE_ERROR=True
+**Note**: the absence of an error doesn't indicate that FIPS is enabled successfully.
+
+ENV variable: `DATADOG_FIPS_IGNORE_ERROR=true`
 CLI param: `--fips-ignore-error`
 
 

--- a/package.json
+++ b/package.json
@@ -143,7 +143,7 @@
     "eslint-plugin-prefer-arrow": "^1.2.3",
     "eslint-plugin-prettier": "4.0.0",
     "jest": "29.6.2",
-    "pkg": "5.5.2",
+    "pkg": "5.8.1",
     "prettier": "2.0.5",
     "proxy": "^2.1.1",
     "ts-jest": "29.1.1",

--- a/src/__tests__/cli.test.ts
+++ b/src/__tests__/cli.test.ts
@@ -1,51 +1,97 @@
+// import crypto from 'crypto'
+
 import {Builtins, CommandClass} from 'clipanion'
 
 // Test all commands, including beta ones.
 process.env.DD_BETA_COMMANDS_ENABLED = '1'
 
 import {cli, BETA_COMMANDS} from '../cli'
+import {enableFips} from '../helpers/fips'
 
 const builtins: CommandClass[] = [Builtins.HelpCommand, Builtins.VersionCommand]
 
+jest.mock('../helpers/fips')
+
 describe('cli', () => {
+  const commands = Array.from(cli['registrations'].keys())
+  const userDefinedCommands = commands.filter((command) => !builtins.includes(command))
+  const commandPaths: {command: CommandClass; commandPath: string[]}[] = []
+  for (const command of userDefinedCommands) {
+    for (const commandPath of command.paths ?? []) {
+      commandPaths.push({command, commandPath})
+    }
+  }
+
+  const cases: [string, string, string[], CommandClass][] = commandPaths.map(({command, commandPath}) => {
+    const [rootPath, subPath] = commandPath
+    const commandName = BETA_COMMANDS.includes(rootPath) ? `${rootPath} (beta)` : rootPath // e.g. synthetics
+    const subcommandName = subPath || '<root>' // e.g. run-tests
+
+    return [commandName, subcommandName, commandPath, command]
+  })
+
   describe('all commands have the right metadata', () => {
-    const commands = Array.from(cli['registrations'].keys())
-    const userDefinedCommands = commands.filter((command) => !builtins.includes(command))
+    test.each(cases)('%s %s', (commandName, _subcommandName, _commandPath, command) => {
+      expect(command).toHaveProperty('paths')
+      expect(command).toHaveProperty('usage')
 
-    const cases: [string, [string, CommandClass][]][] = Object.entries(
-      userDefinedCommands.reduce((acc, command) => {
-        const commandRootPath = command.paths?.[0][0] || 'unknown' // e.g. synthetics
-        const commandName = BETA_COMMANDS.includes(commandRootPath) ? `${commandRootPath} (beta)` : commandRootPath
-        const subcommandName = command.paths?.[0].slice(1).join(' ') || '<root>' // e.g. run-tests
-        const newCase: [string, CommandClass] = [subcommandName, command]
+      if (commandName !== 'version') {
+        // Please categorize the commands by product. You can refer to the CODEOWNERS file.
+        // eslint-disable-next-line jest/no-conditional-expect
+        expect(command.usage).toHaveProperty('category')
+      }
 
-        return {
-          ...acc,
-          [commandName]: [...(acc[commandName] ?? []), newCase],
-        }
-      }, {} as Record<string, [string, CommandClass][]>)
-    )
+      // You should at least document the command with a description, otherwise it will show as "undocumented" in `--help`.
+      expect(command.usage).toHaveProperty('description')
 
-    describe.each(cases)('%s', (commandName, subcommandCases) => {
-      test.each(subcommandCases)('%s', (_, command) => {
-        expect(command).toHaveProperty('paths')
-        expect(command).toHaveProperty('usage')
+      // Please end your description with a period.
+      expect(command.usage?.description).toMatch(/\.$/)
 
-        if (commandName !== 'version') {
-          // Please categorize the commands by product. You can refer to the CODEOWNERS file.
-          // eslint-disable-next-line jest/no-conditional-expect
-          expect(command.usage).toHaveProperty('category')
-        }
+      // Please uppercase the first letter of the category and description.
+      expect(command.usage?.category?.charAt(0)).toStrictEqual(command.usage?.category?.charAt(0).toUpperCase())
+      expect(command.usage?.description?.charAt(0)).toStrictEqual(command.usage?.description?.charAt(0).toUpperCase())
+    })
+  })
 
-        // You should at least document the command with a description, otherwise it will show as "undocumented" in `--help`.
-        expect(command.usage).toHaveProperty('description')
+  describe('fips', () => {
+    const mockedEnableFips = enableFips as jest.MockedFunction<typeof enableFips>
+    mockedEnableFips.mockImplementation(() => true)
 
-        // Please end your description with a period.
-        expect(command.usage?.description).toMatch(/\.$/)
+    // Without the required options, the commands are not executed at all
+    const requiredOptions: Record<string, string[]> = {
+      'dora deployment': ['--started-at', '0', '--dry-run'],
+      'dsyms upload': ['.', '--dry-run'],
+      'elf-symbols upload': ['non-existing-file', '--dry-run'],
+      'gate evaluate': ['--no-wait', '--dry-run'],
+      'junit upload': ['.', '--dry-run'],
+      'sarif upload': ['.', '--dry-run'],
+      'sbom upload': ['.'],
+      'sourcemaps upload': ['.', '--dry-run'],
+      trace: ['id', '--dry-run'],
+    }
 
-        // Please uppercase the first letter of the category and description.
-        expect(command.usage?.category?.charAt(0)).toStrictEqual(command.usage?.category?.charAt(0).toUpperCase())
-        expect(command.usage?.description?.charAt(0)).toStrictEqual(command.usage?.description?.charAt(0).toUpperCase())
+    // version doesn't support --fips option
+    const fipsCases = cases.filter(([commandName]) => !['version'].includes(commandName))
+
+    describe.each(fipsCases)('%s %s', (_commandName, _subcommandName, commandPath) => {
+      const command = [...commandPath, ...(requiredOptions[commandPath.join(' ')] ?? [])]
+
+      test('supports the --fips option', async () => {
+        // When running the command with the --fips option
+        const exitCode = await cli.run([...command, '--fips'])
+
+        // The command calls the enableFips function with the right parameters
+        expect([0, 1]).toContain(exitCode)
+        expect(mockedEnableFips).toHaveBeenCalledWith(true, false)
+      })
+
+      test('supports the --fips-ignore-error option', async () => {
+        // When running the command with the --fips and --fips-ignore-error options
+        const exitCode = await cli.run([...command, '--fips', '--fips-ignore-error'])
+
+        // The command calls the enableFips function with the right parameters
+        expect([0, 1]).toContain(exitCode)
+        expect(mockedEnableFips).toHaveBeenCalledWith(true, true)
       })
     })
   })

--- a/src/commands/deployment/mark.ts
+++ b/src/commands/deployment/mark.ts
@@ -1,5 +1,9 @@
 import {Command, Option} from 'clipanion'
 
+import {FIPS_ENV_VAR, FIPS_IGNORE_ERROR_ENV_VAR} from '../../constants'
+import {toBoolean} from '../../helpers/env'
+import {enableFips} from '../../helpers/fips'
+
 import {TagCommand} from '../tag/tag'
 
 import {
@@ -51,7 +55,16 @@ export class DeploymentMarkCommand extends Command {
   })
   private tags = Option.Array('--tags')
 
+  private fips = Option.Boolean('--fips', false)
+  private fipsIgnoreError = Option.Boolean('--fips-ignore-error', false)
+  private config = {
+    fips: toBoolean(process.env[FIPS_ENV_VAR]) ?? false,
+    fipsIgnoreError: toBoolean(process.env[FIPS_IGNORE_ERROR_ENV_VAR]) ?? false,
+  }
+
   public async execute() {
+    enableFips(this.fips || this.config.fips, this.fipsIgnoreError || this.config.fipsIgnoreError)
+
     const tagJobCommand = new TagCommand()
     tagJobCommand.setLevel('job')
     tagJobCommand.setTags(this.createJobDeploymentTags())

--- a/src/commands/elf-symbols/upload.ts
+++ b/src/commands/elf-symbols/upload.ts
@@ -4,8 +4,11 @@ import path from 'path'
 import {Command, Option} from 'clipanion'
 import glob from 'glob'
 
+import {FIPS_ENV_VAR, FIPS_IGNORE_ERROR_ENV_VAR} from '../../constants'
 import {newApiKeyValidator} from '../../helpers/apikey'
 import {doWithMaxConcurrency} from '../../helpers/concurrency'
+import {toBoolean} from '../../helpers/env'
+import {enableFips} from '../../helpers/fips'
 import {RepositoryData, getRepositoryData, newSimpleGit} from '../../helpers/git/format-git-sourcemaps-data'
 import {MetricsLogger, getMetricsLogger} from '../../helpers/metrics'
 import {MultipartValue, UploadStatus} from '../../helpers/upload'
@@ -68,7 +71,16 @@ export class UploadCommand extends Command {
   }
   private gitData?: RepositoryData
 
+  private fips = Option.Boolean('--fips', false)
+  private fipsIgnoreError = Option.Boolean('--fips-ignore-error', false)
+  private fipsConfig = {
+    fips: toBoolean(process.env[FIPS_ENV_VAR]) ?? false,
+    fipsIgnoreError: toBoolean(process.env[FIPS_IGNORE_ERROR_ENV_VAR]) ?? false,
+  }
+
   public async execute() {
+    enableFips(this.fips || this.fipsConfig.fips, this.fipsIgnoreError || this.fipsConfig.fipsIgnoreError)
+
     if (!(await this.verifyParameters())) {
       return 1
     }

--- a/src/commands/junit/upload.ts
+++ b/src/commands/junit/upload.ts
@@ -8,8 +8,11 @@ import {XMLParser, XMLValidator} from 'fast-xml-parser'
 import glob from 'glob'
 import * as t from 'typanion'
 
+import {FIPS_ENV_VAR, FIPS_IGNORE_ERROR_ENV_VAR} from '../../constants'
 import {getCISpanTags} from '../../helpers/ci'
 import {doWithMaxConcurrency} from '../../helpers/concurrency'
+import {toBoolean} from '../../helpers/env'
+import {enableFips} from '../../helpers/fips'
 import {getGitMetadata} from '../../helpers/git/format-git-span-data'
 import {SpanTags, RequestBuilder} from '../../helpers/interfaces'
 import {Logger, LogLevel} from '../../helpers/logger'
@@ -133,18 +136,25 @@ export class UploadJUnitXMLCommand extends Command {
     tolerateBoolean: true,
   })
 
+  private fips = Option.Boolean('--fips', false)
+  private fipsIgnoreError = Option.Boolean('--fips-ignore-error', false)
+
   private config = {
     apiKey: process.env.DATADOG_API_KEY || process.env.DD_API_KEY,
     env: process.env.DD_ENV,
     envVarTags: process.env.DD_TAGS,
     envVarMetrics: process.env.DD_METRICS,
     envVarMeasures: process.env.DD_MEASURES,
+    fips: toBoolean(process.env[FIPS_ENV_VAR]) ?? false,
+    fipsIgnoreError: toBoolean(process.env[FIPS_IGNORE_ERROR_ENV_VAR]) ?? false,
   }
 
   private xpathTags?: Record<string, string>
   private logger: Logger = new Logger((s: string) => this.context.stdout.write(s), LogLevel.INFO)
 
   public async execute() {
+    enableFips(this.fips || this.config.fips, this.fipsIgnoreError || this.config.fipsIgnoreError)
+
     this.logger.setLogLevel(this.verbose ? LogLevel.DEBUG : LogLevel.INFO)
     this.logger.setShouldIncludeTime(this.verbose)
 

--- a/src/commands/lambda/uninstrument.ts
+++ b/src/commands/lambda/uninstrument.ts
@@ -4,6 +4,9 @@ import {AwsCredentialIdentity} from '@aws-sdk/types'
 import chalk from 'chalk'
 import {Command, Option} from 'clipanion'
 
+import {FIPS_ENV_VAR, FIPS_IGNORE_ERROR_ENV_VAR} from '../../constants'
+import {toBoolean} from '../../helpers/env'
+import {enableFips} from '../../helpers/fips'
 import {requestConfirmation} from '../../helpers/prompt'
 import * as helperRenderer from '../../helpers/renderer'
 import {DEFAULT_CONFIG_PATHS, resolveConfigFromFile} from '../../helpers/utils'
@@ -66,7 +69,16 @@ export class UninstrumentCommand extends Command {
 
   private credentials?: AwsCredentialIdentity
 
+  private fips = Option.Boolean('--fips', false)
+  private fipsIgnoreError = Option.Boolean('--fips-ignore-error', false)
+  private fipsConfig = {
+    fips: toBoolean(process.env[FIPS_ENV_VAR]) ?? false,
+    fipsIgnoreError: toBoolean(process.env[FIPS_IGNORE_ERROR_ENV_VAR]) ?? false,
+  }
+
   public async execute(): Promise<0 | 1> {
+    enableFips(this.fips || this.fipsConfig.fips, this.fipsIgnoreError || this.fipsConfig.fipsIgnoreError)
+
     this.context.stdout.write(instrumentRenderer.renderLambdaHeader(Object.getPrototypeOf(this), this.dryRun))
 
     const lambdaConfig = {lambda: this.config}

--- a/src/commands/react-native/codepush.ts
+++ b/src/commands/react-native/codepush.ts
@@ -2,6 +2,10 @@ import {exec} from 'child_process'
 
 import {Cli, Command, Option} from 'clipanion'
 
+import {FIPS_ENV_VAR, FIPS_IGNORE_ERROR_ENV_VAR} from '../../constants'
+import {toBoolean} from '../../helpers/env'
+import {enableFips} from '../../helpers/fips'
+
 import {CodepushHistoryCommandError, CodepushHistoryParseError, NoCodepushReleaseError} from './errors'
 import {RNPlatform, RN_SUPPORTED_PLATFORMS} from './interfaces'
 import {UploadCommand} from './upload'
@@ -49,7 +53,16 @@ export class CodepushCommand extends Command {
 
   private releaseVersion?: string
 
+  private fips = Option.Boolean('--fips', false)
+  private fipsIgnoreError = Option.Boolean('--fips-ignore-error', false)
+  private config = {
+    fips: toBoolean(process.env[FIPS_ENV_VAR]) ?? false,
+    fipsIgnoreError: toBoolean(process.env[FIPS_IGNORE_ERROR_ENV_VAR]) ?? false,
+  }
+
   public async execute() {
+    enableFips(this.fips || this.config.fips, this.fipsIgnoreError || this.config.fipsIgnoreError)
+
     if (!this.service) {
       this.context.stderr.write('Missing service\n')
 

--- a/src/commands/react-native/xcode.ts
+++ b/src/commands/react-native/xcode.ts
@@ -5,6 +5,9 @@ import {sep} from 'path'
 
 import {Cli, Command, Option} from 'clipanion'
 
+import {FIPS_ENV_VAR, FIPS_IGNORE_ERROR_ENV_VAR} from '../../constants'
+import {toBoolean} from '../../helpers/env'
+import {enableFips} from '../../helpers/fips'
 import {parsePlist} from '../../helpers/plist'
 
 import {UploadCommand} from './upload'
@@ -78,7 +81,16 @@ export class XCodeCommand extends Command {
 
   private scriptPath = Option.String({required: false}) // Positional
 
+  private fips = Option.Boolean('--fips', false)
+  private fipsIgnoreError = Option.Boolean('--fips-ignore-error', false)
+  private config = {
+    fips: toBoolean(process.env[FIPS_ENV_VAR]) ?? false,
+    fipsIgnoreError: toBoolean(process.env[FIPS_IGNORE_ERROR_ENV_VAR]) ?? false,
+  }
+
   public async execute() {
+    enableFips(this.fips || this.config.fips, this.fipsIgnoreError || this.config.fipsIgnoreError)
+
     this.service = process.env.SERVICE_NAME_IOS || this.service || process.env.PRODUCT_BUNDLE_IDENTIFIER
 
     if (!this.infoPlistPath && process.env.PROJECT_DIR && process.env.INFOPLIST_FILE) {

--- a/src/commands/synthetics/__tests__/cli.test.ts
+++ b/src/commands/synthetics/__tests__/cli.test.ts
@@ -1,6 +1,7 @@
 import {Cli} from 'clipanion/lib/advanced'
 
 import {createCommand, getAxiosError} from '../../../helpers/__tests__/fixtures'
+import {toBoolean, toNumber, toStringMap} from '../../../helpers/env'
 import * as ciUtils from '../../../helpers/utils'
 
 import * as api from '../api'
@@ -14,7 +15,7 @@ import {
 } from '../interfaces'
 import {DEFAULT_COMMAND_CONFIG, RunTestsCommand} from '../run-tests-command'
 import {DEFAULT_UPLOAD_COMMAND_CONFIG, UploadApplicationCommand} from '../upload-application-command'
-import {toBoolean, toNumber, toExecutionRule, toStringMap} from '../utils/internal'
+import {toExecutionRule} from '../utils/internal'
 import * as utils from '../utils/public'
 
 import {getApiTest, getTestSuite, mockApi, mockTestTriggerResponse} from './fixtures'
@@ -562,7 +563,7 @@ describe('run-test', () => {
     //
     // (config file < ENV < CLI < test file) => execute tests
 
-    describe('override precedence - config file < ENV < CLI < test file', () => {
+    describe('override precedence - [config file < ENV < CLI < test file]', () => {
       const configFile = {
         apiKey: 'config_file_api_key',
         appKey: 'config_file_app_key',

--- a/src/commands/synthetics/__tests__/utils/internal.test.ts
+++ b/src/commands/synthetics/__tests__/utils/internal.test.ts
@@ -3,10 +3,7 @@ import {
   getOverriddenExecutionRule,
   hasResultPassed,
   parseOverrideValue,
-  toBoolean,
   toExecutionRule,
-  toNumber,
-  toStringMap,
   validateAndParseOverrides,
 } from '../../utils/internal'
 
@@ -71,48 +68,6 @@ describe('utils', () => {
     })
   })
 
-  describe('toBoolean', () => {
-    const cases: [string | undefined, boolean | undefined][] = [
-      ['true', true],
-      ['True', true],
-      ['TRUE', true],
-      ['1', true],
-      ['false', false],
-      ['False', false],
-      ['FALSE', false],
-      ['0', false],
-      [undefined, undefined],
-      ['no', undefined],
-      ['yes', undefined],
-      ['', undefined],
-      ['  ', undefined],
-      ['randomString', undefined],
-    ]
-
-    test.each(cases)('toBoolean(%s) should return %s', (input, expectedOutput) => {
-      expect(toBoolean(input)).toEqual(expectedOutput)
-    })
-  })
-
-  describe('toNumber', () => {
-    const cases: [string | undefined, number | undefined][] = [
-      ['42', 42],
-      ['0', 0],
-      ['-1', -1],
-      ['3.14', 3.14], // Floats should be supported
-      ['  42', 42], // Leading whitespace should be ignored
-      ['0042', 42], // Leading zeros should be ignored
-      ['', undefined],
-      ['  ', undefined],
-      ['randomString', undefined],
-      ['NaN', undefined],
-      [undefined, undefined],
-    ]
-
-    test.each(cases)('toNumber(%s) should return %s', (input, expectedOutput) => {
-      expect(toNumber(input)).toEqual(expectedOutput)
-    })
-  })
   describe('toExecutionRule', () => {
     const cases: [string | undefined, ExecutionRule | undefined][] = [
       ['blocking', ExecutionRule.BLOCKING],
@@ -128,39 +83,6 @@ describe('utils', () => {
     ]
     test.each(cases)('toExecutionRule(%s) should return %s', (input, expectedOutput) => {
       expect(toExecutionRule(input)).toEqual(expectedOutput)
-    })
-  })
-
-  describe('toStringMap', () => {
-    const cases: [string | undefined, {[key: string]: string} | undefined][] = [
-      ['{"key1":"value1","key2":"value2"}', {key1: 'value1', key2: 'value2'}],
-      ['{"key1": "value1", "key2": "value2"}', {key1: 'value1', key2: 'value2'}],
-      [
-        `{
-        "key1": "value1",
-        "key2": "value2"
-      }`,
-        {key1: 'value1', key2: 'value2'},
-      ], // Multiline JSON should be supported
-      ["{'key1': 'value1', 'key2': 'value2'}", {key1: 'value1', key2: 'value2'}], // Single quotes should be supported
-      [
-        "{'key1': 'value with space 1', 'key2': 'value with space 2'}",
-        {key1: 'value with space 1', key2: 'value with space 2'},
-      ], // Values with spaces should also be supported
-      ['{"key1":"value1"}', {key1: 'value1'}],
-      ['{}', {}],
-      ['', undefined],
-      ['invalid json', undefined],
-      ['{"key1": "value1", "key2": 2}', undefined], // Non-string value should result in undefined
-      ['null', undefined],
-      ['42', undefined],
-      [undefined, undefined],
-      ['   ', undefined],
-      ['{"key1": "value1", "key2": "value2"} extra', undefined], // Extra text should result in undefined
-    ]
-
-    test.each(cases)('toStringMap(%s) should return %s', (input, expectedOutput) => {
-      expect(toStringMap(input)).toEqual(expectedOutput)
     })
   })
 

--- a/src/commands/synthetics/utils/internal.ts
+++ b/src/commands/synthetics/utils/internal.ts
@@ -1,3 +1,5 @@
+import {toBoolean, toNumber, StringMap} from '../../../helpers/env'
+
 import {
   BaseResult,
   BasicAuthCredentials,
@@ -103,36 +105,6 @@ export const getResultIdOrLinkedResultId = (result: ResultInBatch): string => {
   return result.result_id
 }
 
-export const toBoolean = (env: string | undefined): boolean | undefined => {
-  if (env === undefined) {
-    return undefined
-  }
-
-  if (env.toLowerCase() === 'true' || env === '1') {
-    return true
-  }
-
-  if (env.toLowerCase() === 'false' || env === '0') {
-    return false
-  }
-
-  return undefined
-}
-
-export const toNumber = (env: string | undefined): number | undefined => {
-  if (env === undefined || env.trim() === '') {
-    return undefined
-  }
-
-  const number = Number(env)
-
-  if (isNaN(number)) {
-    return undefined
-  }
-
-  return number
-}
-
 export const toExecutionRule = (env: string | undefined): ExecutionRule | undefined => {
   if (env === undefined) {
     return undefined
@@ -144,31 +116,6 @@ export const toExecutionRule = (env: string | undefined): ExecutionRule | undefi
 
   return undefined
 }
-
-export const toStringMap = (env: string | undefined): StringMap | undefined => {
-  if (env === undefined) {
-    return undefined
-  }
-  const cleanedEnv = env.replace(/'/g, '"')
-
-  try {
-    const parsed = JSON.parse(cleanedEnv)
-    // eslint-disable-next-line no-null/no-null
-    if (typeof parsed === 'object' && parsed !== null) {
-      for (const key in parsed as object) {
-        if (typeof parsed[key] !== 'string') {
-          return undefined
-        }
-      }
-
-      return parsed as StringMap
-    }
-  } catch (error) {
-    return undefined
-  }
-}
-
-type StringMap = {[key: string]: string}
 
 type AccumulatorBaseConfigOverride = Omit<
   UserConfigOverride,

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -14,6 +14,10 @@ export const DATADOG_SITES: string[] = [
   DATADOG_SITE_GOV,
 ]
 
+// Common env vars
+export const FIPS_ENV_VAR = 'DATADOG_FIPS'
+export const FIPS_IGNORE_ERROR_ENV_VAR = 'DATADOG_FIPS_IGNORE_ERROR'
+
 export const CONTENT_TYPE_HEADER = 'Content-Type'
 export const CONTENT_TYPE_VALUE_PROTOBUF = 'application/x-protobuf'
 export const CONTENT_TYPE_VALUE_JSON = 'application/json'

--- a/src/helpers/__tests__/env.test.ts
+++ b/src/helpers/__tests__/env.test.ts
@@ -1,0 +1,76 @@
+import {toBoolean, toNumber, toStringMap} from '../env'
+
+describe('toBoolean', () => {
+  const cases: [string | undefined, boolean | undefined][] = [
+    ['true', true],
+    ['True', true],
+    ['TRUE', true],
+    ['1', true],
+    ['false', false],
+    ['False', false],
+    ['FALSE', false],
+    ['0', false],
+    [undefined, undefined],
+    ['no', undefined],
+    ['yes', undefined],
+    ['', undefined],
+    ['  ', undefined],
+    ['randomString', undefined],
+  ]
+
+  test.each(cases)('toBoolean(%s) should return %s', (input, expectedOutput) => {
+    expect(toBoolean(input)).toEqual(expectedOutput)
+  })
+})
+
+describe('toNumber', () => {
+  const cases: [string | undefined, number | undefined][] = [
+    ['42', 42],
+    ['0', 0],
+    ['-1', -1],
+    ['3.14', 3.14], // Floats should be supported
+    ['  42', 42], // Leading whitespace should be ignored
+    ['0042', 42], // Leading zeros should be ignored
+    ['', undefined],
+    ['  ', undefined],
+    ['randomString', undefined],
+    ['NaN', undefined],
+    [undefined, undefined],
+  ]
+
+  test.each(cases)('toNumber(%s) should return %s', (input, expectedOutput) => {
+    expect(toNumber(input)).toEqual(expectedOutput)
+  })
+})
+describe('toStringMap', () => {
+  const cases: [string | undefined, {[key: string]: string} | undefined][] = [
+    ['{"key1":"value1","key2":"value2"}', {key1: 'value1', key2: 'value2'}],
+    ['{"key1": "value1", "key2": "value2"}', {key1: 'value1', key2: 'value2'}],
+    [
+      `{
+      "key1": "value1",
+      "key2": "value2"
+    }`,
+      {key1: 'value1', key2: 'value2'},
+    ], // Multiline JSON should be supported
+    ["{'key1': 'value1', 'key2': 'value2'}", {key1: 'value1', key2: 'value2'}], // Single quotes should be supported
+    [
+      "{'key1': 'value with space 1', 'key2': 'value with space 2'}",
+      {key1: 'value with space 1', key2: 'value with space 2'},
+    ], // Values with spaces should also be supported
+    ['{"key1":"value1"}', {key1: 'value1'}],
+    ['{}', {}],
+    ['', undefined],
+    ['invalid json', undefined],
+    ['{"key1": "value1", "key2": 2}', undefined], // Non-string value should result in undefined
+    ['null', undefined],
+    ['42', undefined],
+    [undefined, undefined],
+    ['   ', undefined],
+    ['{"key1": "value1", "key2": "value2"} extra', undefined], // Extra text should result in undefined
+  ]
+
+  test.each(cases)('toStringMap(%s) should return %s', (input, expectedOutput) => {
+    expect(toStringMap(input)).toEqual(expectedOutput)
+  })
+})

--- a/src/helpers/__tests__/fips.test.ts
+++ b/src/helpers/__tests__/fips.test.ts
@@ -1,0 +1,32 @@
+import crypto from 'crypto'
+
+import {enableFips} from '../fips'
+
+jest.mock('crypto')
+
+const unsupportedFipsError = new Error('error:0F06D065:common libcrypto routines:FIPS_mode_set:fips mode not supported')
+
+const mockedSetFips = crypto.setFips as jest.MockedFunction<typeof crypto.setFips>
+mockedSetFips.mockImplementation(() => {
+  throw unsupportedFipsError
+})
+
+test('enableFips throws when setFips throws', () => {
+  expect(() => enableFips(true)).toThrow(unsupportedFipsError)
+  expect(mockedSetFips).toHaveBeenCalledWith(true)
+})
+
+test("enableFips doesn't call setFips when fips set to true", () => {
+  expect(() => enableFips(false)).not.toThrow()
+  expect(mockedSetFips).not.toHaveBeenCalled()
+})
+
+test('enableFips throws when setFips throws and fipsIgnoreError set to true', () => {
+  expect(() => enableFips(true, false)).toThrow(unsupportedFipsError)
+  expect(mockedSetFips).toHaveBeenCalledWith(true)
+})
+
+test("enableFips doesn't throw when setFips throw and fipsIgnoreError set to true", () => {
+  expect(() => enableFips(true, true)).not.toThrow()
+  expect(mockedSetFips).toHaveBeenCalledWith(true)
+})

--- a/src/helpers/env.ts
+++ b/src/helpers/env.ts
@@ -1,0 +1,54 @@
+export const toBoolean = (env: string | undefined): boolean | undefined => {
+  if (env === undefined) {
+    return undefined
+  }
+
+  if (env.toLowerCase() === 'true' || env === '1') {
+    return true
+  }
+
+  if (env.toLowerCase() === 'false' || env === '0') {
+    return false
+  }
+
+  return undefined
+}
+
+export const toNumber = (env: string | undefined): number | undefined => {
+  if (env === undefined || env.trim() === '') {
+    return undefined
+  }
+
+  const number = Number(env)
+
+  if (isNaN(number)) {
+    return undefined
+  }
+
+  return number
+}
+
+export const toStringMap = (env: string | undefined): StringMap | undefined => {
+  if (env === undefined) {
+    return undefined
+  }
+  const cleanedEnv = env.replace(/'/g, '"')
+
+  try {
+    const parsed = JSON.parse(cleanedEnv)
+    // eslint-disable-next-line no-null/no-null
+    if (typeof parsed === 'object' && parsed !== null) {
+      for (const key in parsed as object) {
+        if (typeof parsed[key] !== 'string') {
+          return undefined
+        }
+      }
+
+      return parsed as StringMap
+    }
+  } catch (error) {
+    return undefined
+  }
+}
+
+export type StringMap = {[key: string]: string}

--- a/src/helpers/fips.ts
+++ b/src/helpers/fips.ts
@@ -1,0 +1,16 @@
+import crypto from 'crypto'
+
+export const enableFips = (fips: boolean, ignoreError = false) => {
+  try {
+    // FIX-ME The mark command is calling tag.execute function, and when doing so, the fips option
+    // is not reduced to a boolean, but remains a clipanion option, mistakenly enabling fips.
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-boolean-literal-compare
+    if (fips === true) {
+      crypto.setFips(true)
+    }
+  } catch (error) {
+    if (!ignoreError) {
+      throw error
+    }
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -846,6 +846,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/generator@npm:7.18.2":
+  version: 7.18.2
+  resolution: "@babel/generator@npm:7.18.2"
+  dependencies:
+    "@babel/types": ^7.18.2
+    "@jridgewell/gen-mapping": ^0.3.0
+    jsesc: ^2.5.1
+  checksum: d0661e95532ddd97566d41fec26355a7b28d1cbc4df95fe80cc084c413342935911b48db20910708db39714844ddd614f61c2ec4cca3fb10181418bdcaa2e7a3
+  languageName: node
+  linkType: hard
+
 "@babel/generator@npm:^7.24.8, @babel/generator@npm:^7.24.9, @babel/generator@npm:^7.7.2, @babel/generator@npm:^7.8.0":
   version: 7.24.10
   resolution: "@babel/generator@npm:7.24.10"
@@ -1056,6 +1067,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-string-parser@npm:^7.18.10, @babel/helper-string-parser@npm:^7.25.9":
+  version: 7.25.9
+  resolution: "@babel/helper-string-parser@npm:7.25.9"
+  checksum: 6435ee0849e101681c1849868278b5aee82686ba2c1e27280e5e8aca6233af6810d39f8e4e693d2f2a44a3728a6ccfd66f72d71826a94105b86b731697cdfa99
+  languageName: node
+  linkType: hard
+
 "@babel/helper-string-parser@npm:^7.24.8":
   version: 7.24.8
   resolution: "@babel/helper-string-parser@npm:7.24.8"
@@ -1063,7 +1081,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-validator-identifier@npm:^7.15.7, @babel/helper-validator-identifier@npm:^7.24.7":
+"@babel/helper-validator-identifier@npm:^7.18.6, @babel/helper-validator-identifier@npm:^7.25.9":
+  version: 7.25.9
+  resolution: "@babel/helper-validator-identifier@npm:7.25.9"
+  checksum: 5b85918cb1a92a7f3f508ea02699e8d2422fe17ea8e82acd445006c0ef7520fbf48e3dbcdaf7b0a1d571fc3a2715a29719e5226636cb6042e15fe6ed2a590944
+  languageName: node
+  linkType: hard
+
+"@babel/helper-validator-identifier@npm:^7.24.7":
   version: 7.24.7
   resolution: "@babel/helper-validator-identifier@npm:7.24.7"
   checksum: 6799ab117cefc0ecd35cd0b40ead320c621a298ecac88686a14cffceaac89d80cdb3c178f969861bf5fa5e4f766648f9161ea0752ecfe080d8e89e3147270257
@@ -1111,12 +1136,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/parser@npm:7.16.2":
-  version: 7.16.2
-  resolution: "@babel/parser@npm:7.16.2"
+"@babel/parser@npm:7.18.4":
+  version: 7.18.4
+  resolution: "@babel/parser@npm:7.18.4"
   bin:
     parser: ./bin/babel-parser.js
-  checksum: e8ceef8214adf55beaae80fff1647ae6535e17af592749a6f3fd3ed1081bbb1474fd88bf4d3470ec8bc0082843a6d23445e9e08b03e91831458acc6fd37d7bc9
+  checksum: e05b2dc720c4b200e088258f3c2a2de5041c140444edc38181d1217b10074e881a7133162c5b62356061f26279f08df5a06ec14c5842996ee8601ad03c57a44f
   languageName: node
   linkType: hard
 
@@ -1845,13 +1870,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/types@npm:7.16.0":
-  version: 7.16.0
-  resolution: "@babel/types@npm:7.16.0"
+"@babel/types@npm:7.19.0":
+  version: 7.19.0
+  resolution: "@babel/types@npm:7.19.0"
   dependencies:
-    "@babel/helper-validator-identifier": ^7.15.7
+    "@babel/helper-string-parser": ^7.18.10
+    "@babel/helper-validator-identifier": ^7.18.6
     to-fast-properties: ^2.0.0
-  checksum: 5b483da5c6e6f2394fba7ee1da8787a0c9cddd33491271c4da702e49e6faf95ce41d7c8bf9a4ee47f2ef06bdb35096f4d0f6ae4b5bea35ebefe16309d22344b7
+  checksum: 9b346715a68aeede70ba9c685a144b0b26c53bcd595d448e24c8fa8df4d5956a5712e56ebadb7c85dcc32f218ee42788e37b93d50d3295c992072224cb3ef3fe
   languageName: node
   linkType: hard
 
@@ -1863,6 +1889,16 @@ __metadata:
     "@babel/helper-validator-identifier": ^7.24.7
     to-fast-properties: ^2.0.0
   checksum: 15cb05c45be5d4c49a749575d3742bd005d0e2e850c13fb462754983a5bc1063fbc8f6566246fc064e3e8b21a5a75a37a948f1b3f27189cc90b236fee93f5e51
+  languageName: node
+  linkType: hard
+
+"@babel/types@npm:^7.18.2":
+  version: 7.26.0
+  resolution: "@babel/types@npm:7.26.0"
+  dependencies:
+    "@babel/helper-string-parser": ^7.25.9
+    "@babel/helper-validator-identifier": ^7.25.9
+  checksum: a3dd37dabac693018872da96edb8c1843a605c1bfacde6c3f504fba79b972426a6f24df70aa646356c0c1b19bdd2c722c623c684a996c002381071680602280d
   languageName: node
   linkType: hard
 
@@ -1944,7 +1980,7 @@ __metadata:
     js-yaml: 3.13.1
     jszip: ^3.10.1
     ora: 5.4.1
-    pkg: 5.5.2
+    pkg: 5.8.1
     prettier: 2.0.5
     proxy: ^2.1.1
     proxy-agent: ^6.4.0
@@ -2526,7 +2562,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jridgewell/gen-mapping@npm:^0.3.5":
+"@jridgewell/gen-mapping@npm:^0.3.0, @jridgewell/gen-mapping@npm:^0.3.5":
   version: 0.3.5
   resolution: "@jridgewell/gen-mapping@npm:0.3.5"
   dependencies:
@@ -4074,13 +4110,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ansi-regex@npm:^2.0.0":
-  version: 2.1.1
-  resolution: "ansi-regex@npm:2.1.1"
-  checksum: 190abd03e4ff86794f338a31795d262c1dfe8c91f7e01d04f13f646f1dcb16c5800818f886047876f1272f065570ab86b24b99089f8b68a0e11ff19aed4ca8f1
-  languageName: node
-  linkType: hard
-
 "ansi-regex@npm:^5.0.1":
   version: 5.0.1
   resolution: "ansi-regex@npm:5.0.1"
@@ -4134,23 +4163,6 @@ __metadata:
     normalize-path: ^3.0.0
     picomatch: ^2.0.4
   checksum: 3e044fd6d1d26545f235a9fe4d7a534e2029d8e59fa7fd9f2a6eb21230f6b5380ea1eaf55136e60cbf8e613544b3b766e7a6fa2102e2a3a117505466e3025dc2
-  languageName: node
-  linkType: hard
-
-"aproba@npm:^1.0.3":
-  version: 1.2.0
-  resolution: "aproba@npm:1.2.0"
-  checksum: 0fca141966559d195072ed047658b6e6c4fe92428c385dd38e288eacfc55807e7b4989322f030faff32c0f46bb0bc10f1e0ac32ec22d25315a1e5bbc0ebb76dc
-  languageName: node
-  linkType: hard
-
-"are-we-there-yet@npm:~1.1.2":
-  version: 1.1.7
-  resolution: "are-we-there-yet@npm:1.1.7"
-  dependencies:
-    delegates: ^1.0.0
-    readable-stream: ^2.0.6
-  checksum: 70d251719c969b2745bfe5ddf3ebaefa846a636e90a6d5212573676af5d6670e15457761d4725731e19cbebdce42c4ab0cbedf23ab047f2a08274985aa10a3c7
   languageName: node
   linkType: hard
 
@@ -4826,13 +4838,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"code-point-at@npm:^1.0.0":
-  version: 1.1.0
-  resolution: "code-point-at@npm:1.1.0"
-  checksum: 17d5666611f9b16d64fdf48176d9b7fb1c7d1c1607a189f7e600040a11a6616982876af148230336adb7d8fe728a559f743a4e29db3747e3b1a32fa7f4529681
-  languageName: node
-  linkType: hard
-
 "collect-v8-coverage@npm:^1.0.0":
   version: 1.0.2
   resolution: "collect-v8-coverage@npm:1.0.2"
@@ -4885,13 +4890,6 @@ __metadata:
   version: 0.0.1
   resolution: "concat-map@npm:0.0.1"
   checksum: 902a9f5d8967a3e2faf138d5cb784b9979bad2e6db5357c5b21c568df4ebe62bcb15108af1b2253744844eb964fc023fbd9afbbbb6ddd0bcc204c6fb5b7bf3af
-  languageName: node
-  linkType: hard
-
-"console-control-strings@npm:^1.0.0, console-control-strings@npm:~1.1.0":
-  version: 1.1.0
-  resolution: "console-control-strings@npm:1.1.0"
-  checksum: 8755d76787f94e6cf79ce4666f0c5519906d7f5b02d4b884cf41e11dcd759ed69c57da0670afd9236d229a46e0f9cf519db0cd829c6dca820bb5a5c3def584ed
   languageName: node
   linkType: hard
 
@@ -5107,12 +5105,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"decompress-response@npm:^4.2.0":
-  version: 4.2.1
-  resolution: "decompress-response@npm:4.2.1"
+"decompress-response@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "decompress-response@npm:6.0.0"
   dependencies:
-    mimic-response: ^2.0.0
-  checksum: 4e783ca4dfe9417354d61349750fe05236f565a4415a6ca20983a311be2371debaedd9104c0b0e7b36e5f167aeaae04f84f1a0b3f8be4162f1d7d15598b8fdba
+    mimic-response: ^3.1.0
+  checksum: d377cf47e02d805e283866c3f50d3d21578b779731e8c5072d6ce8c13cc31493db1c2f6784da9d1d5250822120cefa44f1deab112d5981015f2e17444b763812
   languageName: node
   linkType: hard
 
@@ -5212,19 +5210,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"delegates@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "delegates@npm:1.0.0"
-  checksum: a51744d9b53c164ba9c0492471a1a2ffa0b6727451bdc89e31627fdf4adda9d51277cfcbfb20f0a6f08ccb3c436f341df3e92631a3440226d93a8971724771fd
-  languageName: node
-  linkType: hard
-
-"detect-libc@npm:^1.0.3":
-  version: 1.0.3
-  resolution: "detect-libc@npm:1.0.3"
-  bin:
-    detect-libc: ./bin/detect-libc.js
-  checksum: daaaed925ffa7889bd91d56e9624e6c8033911bb60f3a50a74a87500680652969dbaab9526d1e200a4c94acf80fc862a22131841145a0a8482d60a99c24f4a3e
+"detect-libc@npm:^2.0.0":
+  version: 2.0.3
+  resolution: "detect-libc@npm:2.0.3"
+  checksum: 2ba6a939ae55f189aea996ac67afceb650413c7a34726ee92c40fb0deb2400d57ef94631a8a3f052055eea7efb0f99a9b5e6ce923415daa3e68221f963cfc27d
   languageName: node
   linkType: hard
 
@@ -5576,7 +5565,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"escodegen@npm:^2.0.0, escodegen@npm:^2.1.0":
+"escodegen@npm:^2.1.0":
   version: 2.1.0
   resolution: "escodegen@npm:2.1.0"
   dependencies:
@@ -6379,22 +6368,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"gauge@npm:~2.7.3":
-  version: 2.7.4
-  resolution: "gauge@npm:2.7.4"
-  dependencies:
-    aproba: ^1.0.3
-    console-control-strings: ^1.0.0
-    has-unicode: ^2.0.0
-    object-assign: ^4.1.0
-    signal-exit: ^3.0.0
-    string-width: ^1.0.1
-    strip-ansi: ^3.0.1
-    wide-align: ^1.1.0
-  checksum: a89b53cee65579b46832e050b5f3a79a832cc422c190de79c6b8e2e15296ab92faddde6ddf2d376875cbba2b043efa99b9e1ed8124e7365f61b04e3cee9d40ee
-  languageName: node
-  linkType: hard
-
 "gaxios@npm:^6.0.0, gaxios@npm:^6.1.1":
   version: 6.7.0
   resolution: "gaxios@npm:6.7.0"
@@ -6571,7 +6544,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"globby@npm:^11.0.4, globby@npm:^11.1.0":
+"globby@npm:^11.1.0":
   version: 11.1.0
   resolution: "globby@npm:11.1.0"
   dependencies:
@@ -6719,10 +6692,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"has-unicode@npm:^2.0.0":
-  version: 2.0.1
-  resolution: "has-unicode@npm:2.0.1"
-  checksum: 1eab07a7436512db0be40a710b29b5dc21fa04880b7f63c9980b706683127e3c1b57cb80ea96d47991bdae2dfe479604f6a1ba410106ee1046a41d1bd0814400
+"has@npm:^1.0.3":
+  version: 1.0.4
+  resolution: "has@npm:1.0.4"
+  checksum: 8a11ba062e0627c9578a1d08285401e39f1d071a9692ddf793199070edb5648b21c774dd733e2a181edd635bf6862731885f476f4ccf67c998d7a5ff7cef2550
   languageName: node
   linkType: hard
 
@@ -7057,6 +7030,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-core-module@npm:2.9.0":
+  version: 2.9.0
+  resolution: "is-core-module@npm:2.9.0"
+  dependencies:
+    has: ^1.0.3
+  checksum: b27034318b4b462f1c8f1dfb1b32baecd651d891a4e2d1922135daeff4141dfced2b82b07aef83ef54275c4a3526aa38da859223664d0868ca24182badb784ce
+  languageName: node
+  linkType: hard
+
 "is-core-module@npm:^2.13.0, is-core-module@npm:^2.13.1":
   version: 2.15.0
   resolution: "is-core-module@npm:2.15.0"
@@ -7088,15 +7070,6 @@ __metadata:
   version: 2.1.1
   resolution: "is-extglob@npm:2.1.1"
   checksum: df033653d06d0eb567461e58a7a8c9f940bd8c22274b94bf7671ab36df5719791aae15eef6d83bbb5e23283967f2f984b8914559d4449efda578c775c4be6f85
-  languageName: node
-  linkType: hard
-
-"is-fullwidth-code-point@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "is-fullwidth-code-point@npm:1.0.0"
-  dependencies:
-    number-is-nan: ^1.0.0
-  checksum: 4d46a7465a66a8aebcc5340d3b63a56602133874af576a9ca42c6f0f4bd787a743605771c5f246db77da96605fefeffb65fc1dbe862dcc7328f4b4d03edf5a57
   languageName: node
   linkType: hard
 
@@ -8349,10 +8322,10 @@ jschardet@latest:
   languageName: node
   linkType: hard
 
-"mimic-response@npm:^2.0.0":
-  version: 2.1.0
-  resolution: "mimic-response@npm:2.1.0"
-  checksum: 014fad6ab936657e5f2f48bd87af62a8e928ebe84472aaf9e14fec4fcb31257a5edff77324d8ac13ddc6685ba5135cf16e381efac324e5f174fb4ddbf902bf07
+"mimic-response@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "mimic-response@npm:3.1.0"
+  checksum: 25739fee32c17f433626bf19f016df9036b75b3d84a3046c7d156e72ec963dd29d7fc8a302f55a3d6c5a4ff24259676b15d915aad6480815a969ff2ec0836867
   languageName: node
   linkType: hard
 
@@ -8604,12 +8577,12 @@ jschardet@latest:
   languageName: node
   linkType: hard
 
-"node-abi@npm:^2.21.0":
-  version: 2.30.1
-  resolution: "node-abi@npm:2.30.1"
+"node-abi@npm:^3.3.0":
+  version: 3.71.0
+  resolution: "node-abi@npm:3.71.0"
   dependencies:
-    semver: ^5.4.1
-  checksum: 3f4b0c912ce4befcd7ceab4493ba90b51d60dfcc90f567c93f731d897ef8691add601cb64c181683b800f21d479d68f9a6e15d8ab8acd16a5706333b9e30a881
+    semver: ^7.3.5
+  checksum: d7f34c294c0351b636688a792e41493840cc195f64a76ecdc35eb0c1682d86e633a932b03e924395b0d2f52ca1db5046898839d57bcfb5819226e64e922b0617
   languageName: node
   linkType: hard
 
@@ -8723,32 +8696,6 @@ jschardet@latest:
   dependencies:
     path-key: ^3.0.0
   checksum: 5374c0cea4b0bbfdfae62da7bbdf1e1558d338335f4cacf2515c282ff358ff27b2ecb91ffa5330a8b14390ac66a1e146e10700440c1ab868208430f56b5f4d23
-  languageName: node
-  linkType: hard
-
-"npmlog@npm:^4.0.1":
-  version: 4.1.2
-  resolution: "npmlog@npm:4.1.2"
-  dependencies:
-    are-we-there-yet: ~1.1.2
-    console-control-strings: ~1.1.0
-    gauge: ~2.7.3
-    set-blocking: ~2.0.0
-  checksum: edbda9f95ec20957a892de1839afc6fb735054c3accf6fbefe767bac9a639fd5cea2baeac6bd2bcd50a85cb54924d57d9886c81c7fbc2332c2ddd19227504192
-  languageName: node
-  linkType: hard
-
-"number-is-nan@npm:^1.0.0":
-  version: 1.0.1
-  resolution: "number-is-nan@npm:1.0.1"
-  checksum: 13656bc9aa771b96cef209ffca31c31a03b507ca6862ba7c3f638a283560620d723d52e626d57892c7fff475f4c36ac07f0600f14544692ff595abff214b9ffb
-  languageName: node
-  linkType: hard
-
-"object-assign@npm:^4.1.0":
-  version: 4.1.1
-  resolution: "object-assign@npm:4.1.1"
-  checksum: fcc6e4ea8c7fe48abfbb552578b1c53e0d194086e2e6bbbf59e0a536381a292f39943c6e9628af05b5528aa5e3318bb30d6b2e53cadaf5b8fe9e12c4b69af23f
   languageName: node
   linkType: hard
 
@@ -9100,9 +9047,9 @@ jschardet@latest:
   languageName: node
   linkType: hard
 
-"pkg-fetch@npm:3.2.6":
-  version: 3.2.6
-  resolution: "pkg-fetch@npm:3.2.6"
+"pkg-fetch@npm:3.4.2":
+  version: 3.4.2
+  resolution: "pkg-fetch@npm:3.4.2"
   dependencies:
     chalk: ^4.1.2
     fs-extra: ^9.1.0
@@ -9114,29 +9061,28 @@ jschardet@latest:
     yargs: ^16.2.0
   bin:
     pkg-fetch: lib-es5/bin.js
-  checksum: ca62a39fbcf7dd7f096f425e9e24e685d6831104fae034ce6ec8445402253443d74f3f70c5192631ccccd86d09edb4fae8a3ed2eb5c03a8d1d2be67c6229004f
+  checksum: e0f73cedf6cb8882e4d998700031443e6542d213f9817d66deb03fb89c122ca7f7505f11401f85a760a2d3951f9b793d0f78782be220c46c56ccf70f9915812a
   languageName: node
   linkType: hard
 
-"pkg@npm:5.5.2":
-  version: 5.5.2
-  resolution: "pkg@npm:5.5.2"
+"pkg@npm:5.8.1":
+  version: 5.8.1
+  resolution: "pkg@npm:5.8.1"
   dependencies:
-    "@babel/parser": 7.16.2
-    "@babel/types": 7.16.0
+    "@babel/generator": 7.18.2
+    "@babel/parser": 7.18.4
+    "@babel/types": 7.19.0
     chalk: ^4.1.2
-    escodegen: ^2.0.0
     fs-extra: ^9.1.0
-    globby: ^11.0.4
+    globby: ^11.1.0
     into-stream: ^6.0.0
-    minimist: ^1.2.5
+    is-core-module: 2.9.0
+    minimist: ^1.2.6
     multistream: ^4.1.0
-    pkg-fetch: 3.2.6
-    prebuild-install: 6.1.4
-    progress: ^2.0.3
-    resolve: ^1.20.0
+    pkg-fetch: 3.4.2
+    prebuild-install: 7.1.1
+    resolve: ^1.22.0
     stream-meter: ^1.0.4
-    tslib: 2.3.1
   peerDependencies:
     node-notifier: ">=9.0.1"
   peerDependenciesMeta:
@@ -9144,7 +9090,7 @@ jschardet@latest:
       optional: true
   bin:
     pkg: lib-es5/bin.js
-  checksum: 8f3309cef1080b45d7abaa3b95dd7cfb00ae6867bfb4a30e52c078b781482040f24a7e65e90618e5d33339d788ad3aeda4d89bffeee7042e2f868799ca6d182f
+  checksum: 5e750e716c3426706ea1fbd26832faf6a3ab8376b99f20aeb9c40fd48ad48e7b51375cd077b77669f3bfbefee69cc8111f49e0ca39e353fd0fc2dff95a57f822
   languageName: node
   linkType: hard
 
@@ -9162,26 +9108,25 @@ jschardet@latest:
   languageName: node
   linkType: hard
 
-"prebuild-install@npm:6.1.4":
-  version: 6.1.4
-  resolution: "prebuild-install@npm:6.1.4"
+"prebuild-install@npm:7.1.1":
+  version: 7.1.1
+  resolution: "prebuild-install@npm:7.1.1"
   dependencies:
-    detect-libc: ^1.0.3
+    detect-libc: ^2.0.0
     expand-template: ^2.0.3
     github-from-package: 0.0.0
     minimist: ^1.2.3
     mkdirp-classic: ^0.5.3
     napi-build-utils: ^1.0.1
-    node-abi: ^2.21.0
-    npmlog: ^4.0.1
+    node-abi: ^3.3.0
     pump: ^3.0.0
     rc: ^1.2.7
-    simple-get: ^3.0.3
+    simple-get: ^4.0.0
     tar-fs: ^2.0.0
     tunnel-agent: ^0.6.0
   bin:
     prebuild-install: bin.js
-  checksum: de4313eda821305912af922700a2db04bb8e77fe8aa9c2788550f1000c026cbefc82da468ec0c0a37764c5417bd8169dbd540928535fb38d00bb9bbd673dd217
+  checksum: dbf96d0146b6b5827fc8f67f72074d2e19c69628b9a7a0a17d0fad1bf37e9f06922896972e074197fc00a52eae912993e6ef5a0d471652f561df5cb516f3f467
   languageName: node
   linkType: hard
 
@@ -9402,7 +9347,7 @@ jschardet@latest:
   languageName: node
   linkType: hard
 
-"readable-stream@npm:^2.0.0, readable-stream@npm:^2.0.6, readable-stream@npm:^2.1.4, readable-stream@npm:~2.3.6":
+"readable-stream@npm:^2.0.0, readable-stream@npm:^2.1.4, readable-stream@npm:~2.3.6":
   version: 2.3.8
   resolution: "readable-stream@npm:2.3.8"
   dependencies:
@@ -9739,13 +9684,6 @@ jschardet@latest:
   languageName: node
   linkType: hard
 
-"set-blocking@npm:~2.0.0":
-  version: 2.0.0
-  resolution: "set-blocking@npm:2.0.0"
-  checksum: 6e65a05f7cf7ebdf8b7c75b101e18c0b7e3dff4940d480efed8aad3a36a4005140b660fa1d804cb8bce911cac290441dc728084a30504d3516ac2ff7ad607b02
-  languageName: node
-  linkType: hard
-
 "set-function-length@npm:^1.2.1":
   version: 1.2.2
   resolution: "set-function-length@npm:1.2.2"
@@ -9814,7 +9752,7 @@ jschardet@latest:
   languageName: node
   linkType: hard
 
-"signal-exit@npm:^3.0.0, signal-exit@npm:^3.0.2, signal-exit@npm:^3.0.3, signal-exit@npm:^3.0.7":
+"signal-exit@npm:^3.0.2, signal-exit@npm:^3.0.3, signal-exit@npm:^3.0.7":
   version: 3.0.7
   resolution: "signal-exit@npm:3.0.7"
   checksum: a2f098f247adc367dffc27845853e9959b9e88b01cb301658cfe4194352d8d2bb32e18467c786a7fe15f1d44b233ea35633d076d5e737870b7139949d1ab6318
@@ -9835,14 +9773,14 @@ jschardet@latest:
   languageName: node
   linkType: hard
 
-"simple-get@npm:^3.0.3":
-  version: 3.1.1
-  resolution: "simple-get@npm:3.1.1"
+"simple-get@npm:^4.0.0":
+  version: 4.0.1
+  resolution: "simple-get@npm:4.0.1"
   dependencies:
-    decompress-response: ^4.2.0
+    decompress-response: ^6.0.0
     once: ^1.3.1
     simple-concat: ^1.0.0
-  checksum: 80195e70bf171486e75c31e28e5485468195cc42f85940f8b45c4a68472160144d223eb4d07bc82ef80cb974b7c401db021a540deb2d34ac4b3b8883da2d6401
+  checksum: e4132fd27cf7af230d853fa45c1b8ce900cb430dd0a3c6d3829649fe4f2b26574c803698076c4006450efb0fad2ba8c5455fbb5755d4b0a5ec42d4f12b31d27e
   languageName: node
   linkType: hard
 
@@ -10088,7 +10026,7 @@ jschardet@latest:
   languageName: node
   linkType: hard
 
-"string-width-cjs@npm:string-width@^4.2.0, string-width@npm:^1.0.2 || 2 || 3 || 4, string-width@npm:^4.1.0, string-width@npm:^4.2.0, string-width@npm:^4.2.3":
+"string-width-cjs@npm:string-width@^4.2.0, string-width@npm:^4.1.0, string-width@npm:^4.2.0, string-width@npm:^4.2.3":
   version: 4.2.3
   resolution: "string-width@npm:4.2.3"
   dependencies:
@@ -10096,17 +10034,6 @@ jschardet@latest:
     is-fullwidth-code-point: ^3.0.0
     strip-ansi: ^6.0.1
   checksum: e52c10dc3fbfcd6c3a15f159f54a90024241d0f149cf8aed2982a2d801d2e64df0bf1dc351cf8e95c3319323f9f220c16e740b06faecd53e2462df1d2b5443fb
-  languageName: node
-  linkType: hard
-
-"string-width@npm:^1.0.1":
-  version: 1.0.2
-  resolution: "string-width@npm:1.0.2"
-  dependencies:
-    code-point-at: ^1.0.0
-    is-fullwidth-code-point: ^1.0.0
-    strip-ansi: ^3.0.0
-  checksum: 5c79439e95bc3bd7233a332c5f5926ab2ee90b23816ed4faa380ce3b2576d7800b0a5bb15ae88ed28737acc7ea06a518c2eef39142dd727adad0e45c776cd37e
   languageName: node
   linkType: hard
 
@@ -10179,15 +10106,6 @@ jschardet@latest:
   dependencies:
     ansi-regex: ^5.0.1
   checksum: f3cd25890aef3ba6e1a74e20896c21a46f482e93df4a06567cebf2b57edabb15133f1f94e57434e0a958d61186087b1008e89c94875d019910a213181a14fc8c
-  languageName: node
-  linkType: hard
-
-"strip-ansi@npm:^3.0.0, strip-ansi@npm:^3.0.1":
-  version: 3.0.1
-  resolution: "strip-ansi@npm:3.0.1"
-  dependencies:
-    ansi-regex: ^2.0.0
-  checksum: 9b974de611ce5075c70629c00fa98c46144043db92ae17748fb780f706f7a789e9989fd10597b7c2053ae8d1513fd707816a91f1879b2f71e6ac0b6a863db465
   languageName: node
   linkType: hard
 
@@ -10508,13 +10426,6 @@ jschardet@latest:
     minimist: ^1.2.6
     strip-bom: ^3.0.0
   checksum: 59f35407a390d9482b320451f52a411a256a130ff0e7543d18c6f20afab29ac19fbe55c360a93d6476213cc335a4d76ce90f67df54c4e9037f7d240920832201
-  languageName: node
-  linkType: hard
-
-"tslib@npm:2.3.1":
-  version: 2.3.1
-  resolution: "tslib@npm:2.3.1"
-  checksum: de17a98d4614481f7fcb5cd53ffc1aaf8654313be0291e1bfaee4b4bb31a20494b7d218ff2e15017883e8ea9626599b3b0e0229c18383ba9dce89da2adf15cb9
   languageName: node
   linkType: hard
 
@@ -10896,15 +10807,6 @@ jschardet@latest:
   bin:
     node-which: bin/which.js
   checksum: f17e84c042592c21e23c8195108cff18c64050b9efb8459589116999ea9da6dd1509e6a1bac3aeebefd137be00fabbb61b5c2bc0aa0f8526f32b58ee2f545651
-  languageName: node
-  linkType: hard
-
-"wide-align@npm:^1.1.0":
-  version: 1.1.5
-  resolution: "wide-align@npm:1.1.5"
-  dependencies:
-    string-width: ^1.0.2 || 2 || 3 || 4
-  checksum: d5fc37cd561f9daee3c80e03b92ed3e84d80dde3365a8767263d03dacfc8fa06b065ffe1df00d8c2a09f731482fcacae745abfbb478d4af36d0a891fad4834d3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### What and why?

This PR enables the `fips` and `fips-ignore-error`  options:

The `fips` option enables FIPS at the node level. It still requires an OpenSSL provider supporting fips.
The default OpenSSL provider in OpenSSL version 3 supports FIPS, but is not FIPS compliant. To be FIPS compliant, a validated provider must be installed on the host system: https://github.com/openssl/openssl/blob/master/README-FIPS.md

FIPS is not supported below node 16. In this case, `datadog-ci` will throw an error and exit. To ignore this error and continue the execution anyway, you can provide the `fips-ignore-error` option.

With version 17 and onward, node is compatible with OpenSSL 3, which supports FIPS. However there is no way for `datadog-ci` to enforce the OpenSSL provider is FIPS *compliant*, even though enabling the `fips` option should ensure it's only using cyphers compatible with FIPS.

> A cryptographic module is only FIPS validated after it has gone through the complex FIPS 140 validation process. As this process takes a very long time, it is not possible to validate every minor release of OpenSSL.

#### `fips`
ENV variable: DATADOG_FIPS=True
CLI param: `--fips`

#### `fips-ignore-error`
ENV variable: DATADOG_FIPS_IGNORE_ERROR=True
CLI param: `--fips-ignore-error`

### How?

These new options are added to all of the existing commands. For each of these command, an `enableFips` function is called before anything else in the execution.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
