### PR TITLE
v2.46.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci",
-  "version": "2.45.1",
+  "version": "2.46.0",
   "description": "Run datadog actions from the CI.",
   "repository": "https://github.com/DataDog/datadog-ci",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Release v2.46.0

- [synthetics] Trigger batch with LTDs by @Drarig29 in https://github.com/DataDog/datadog-ci/pull/1494
- [k9vuln] Validate purl by @juli1 in https://github.com/DataDog/datadog-ci/pull/1499
- Bump path-to-regexp from 0.1.11 to 0.1.12 by in https://github.com/DataDog/datadog-ci/pull/1500
- add a fips option to all existing command by @etnbrd in https://github.com/DataDog/datadog-ci/pull/1501

**Full Changelog**: https://github.com/DataDog/datadog-ci/compare/v2.45.1...v2.46.0