### PR TITLE
[K9VULN-2465] Add validation of package names

### DIFF
--- a/src/commands/sbom/__tests__/validation.test.ts
+++ b/src/commands/sbom/__tests__/validation.test.ts
@@ -1,4 +1,10 @@
-import {getValidator, validateFileAgainstToolRequirements, validateSbomFileAgainstSchema} from '../validation'
+import {
+  getValidator,
+  validateDependencyName,
+  validateFileAgainstToolRequirements,
+  validateSbomFileAgainstSchema,
+} from '../validation'
+import {DependencyLanguage} from '../types'
 
 const validator = getValidator()
 
@@ -69,5 +75,59 @@ describe('validation of sbom file', () => {
       validateSbomFileAgainstSchema('./src/commands/sbom/__tests__/fixtures/random-data', validator, true)
     ).toBeFalsy()
     expect(validateFileAgainstToolRequirements('./src/commands/sbom/__tests__/fixtures/random-data', true)).toBeFalsy()
+  })
+  test('should have valid package name', () => {
+    expect(
+      validateDependencyName({
+        name: 'foo bar',
+        language: DependencyLanguage.PYTHON,
+        version: undefined,
+        group: undefined,
+        licenses: [],
+        purl: '',
+        locations: [],
+        is_direct: undefined,
+        package_manager: 'pypi',
+      })
+    ).toBeFalsy()
+    expect(
+      validateDependencyName({
+        name: 'foobar',
+        language: DependencyLanguage.PYTHON,
+        version: undefined,
+        group: undefined,
+        licenses: [],
+        purl: '',
+        locations: [],
+        is_direct: undefined,
+        package_manager: 'pypi',
+      })
+    ).toBeTruthy()
+    expect(
+      validateDependencyName({
+        name: 'py',
+        language: DependencyLanguage.PYTHON,
+        version: undefined,
+        group: undefined,
+        licenses: [],
+        purl: '',
+        locations: [],
+        is_direct: undefined,
+        package_manager: 'pypi',
+      })
+    ).toBeTruthy()
+    expect(
+      validateDependencyName({
+        name: 'rx',
+        language: DependencyLanguage.PYTHON,
+        version: undefined,
+        group: undefined,
+        licenses: [],
+        purl: '',
+        locations: [],
+        is_direct: undefined,
+        package_manager: 'pypi',
+      })
+    ).toBeTruthy()
   })
 })

--- a/src/commands/sbom/__tests__/validation.test.ts
+++ b/src/commands/sbom/__tests__/validation.test.ts
@@ -1,10 +1,10 @@
+import {DependencyLanguage} from '../types'
 import {
   getValidator,
   validateDependencyName,
   validateFileAgainstToolRequirements,
   validateSbomFileAgainstSchema,
 } from '../validation'
-import {DependencyLanguage} from '../types'
 
 const validator = getValidator()
 

--- a/src/commands/sbom/payload.ts
+++ b/src/commands/sbom/payload.ts
@@ -105,6 +105,7 @@ export const generatePayload = (
 
         if (component['type'] === 'library') {
           const dependency = extractingDependency(component)
+
           if (dependency !== undefined) {
             dependencies.push(dependency)
           }

--- a/src/commands/sbom/renderer.ts
+++ b/src/commands/sbom/renderer.ts
@@ -1,6 +1,8 @@
 import chalk from 'chalk'
 
 import {getBaseUrl} from '../junit/utils'
+import {Dependency} from './types'
+import {validateDependency, validateDependencyName} from './validation'
 
 const ICONS = {
   FAILED: '❌',
@@ -73,4 +75,16 @@ export const renderSuccessfulCommand = (duration: number) => {
   )
 
   return fullStr
+}
+
+export const renderPayloadWarning = (dependencies: Dependency[]): string => {
+  let ret = ''
+
+  for (const dep of dependencies) {
+    if (!validateDependencyName(dep)) {
+      ret += `invalid dependency name ${dep.name}\n`
+    }
+  }
+
+  return ret
 }

--- a/src/commands/sbom/renderer.ts
+++ b/src/commands/sbom/renderer.ts
@@ -2,7 +2,7 @@ import chalk from 'chalk'
 
 import {getBaseUrl} from '../junit/utils'
 import {Dependency} from './types'
-import {validateDependency, validateDependencyName} from './validation'
+import {validateDependencyName} from './validation'
 
 const ICONS = {
   FAILED: '❌',

--- a/src/commands/sbom/renderer.ts
+++ b/src/commands/sbom/renderer.ts
@@ -1,6 +1,7 @@
 import chalk from 'chalk'
 
 import {getBaseUrl} from '../junit/utils'
+
 import {Dependency} from './types'
 import {validateDependencyName} from './validation'
 

--- a/src/commands/sbom/upload.ts
+++ b/src/commands/sbom/upload.ts
@@ -20,6 +20,7 @@ import {
   renderInvalidFile,
   renderInvalidPayload,
   renderNoDefaultBranch,
+  renderPayloadWarning,
   renderSuccessfulCommand,
   renderUploading,
 } from './renderer'
@@ -130,12 +131,16 @@ export class UploadSbomCommand extends Command {
     // Upload content
     try {
       const scaPayload = generatePayload(jsonContent, tags, service, environment)
+
       if (!scaPayload) {
         this.context.stdout.write(renderInvalidPayload(basePath))
 
         return 1
       }
+      this.context.stdout.write(renderPayloadWarning(scaPayload.dependencies))
+
       this.context.stdout.write(renderUploading(basePath))
+
       await api(scaPayload)
       if (this.debug) {
         this.context.stdout.write(`Upload done for ${basePath}.\n`)

--- a/src/commands/sbom/validation.ts
+++ b/src/commands/sbom/validation.ts
@@ -155,5 +155,6 @@ export const validateDependencyName = (dependency: Dependency): boolean => {
   if (dependency.language === DependencyLanguage.PYTHON && !pythonPackaNameRegex.test(dependency.name)) {
     return false
   }
+
   return true
 }

--- a/src/commands/sbom/validation.ts
+++ b/src/commands/sbom/validation.ts
@@ -8,6 +8,7 @@ import cycloneDxSchema14 from './json-schema/cyclonedx/bom-1.4.schema.json'
 import cycloneDxSchema15 from './json-schema/cyclonedx/bom-1.5.schema.json'
 import jsfSchema from './json-schema/jsf/jsf-0.82.schema.json'
 import spdxSchema from './json-schema/spdx/spdx.schema.json'
+import {Dependency, DependencyLanguage} from './types'
 
 /**
  * Get the validate function. Read all the schemas and return
@@ -145,5 +146,14 @@ export const validateFileAgainstToolRequirements = (path: string, debug: boolean
     return false
   }
 
+  return true
+}
+
+const pythonPackaNameRegex = new RegExp('^[a-zA-Z0-9][a-zA-Z0-9\\-_.]*[a-zA-Z0-9]$')
+
+export const validateDependencyName = (dependency: Dependency): boolean => {
+  if (dependency.language === DependencyLanguage.PYTHON && !pythonPackaNameRegex.test(dependency.name)) {
+    return false
+  }
   return true
 }


### PR DESCRIPTION
## What problem are you trying to solve?

Clients are sending us package names for Python with invalid characters. We want to start filtering these names. They are filtered in the API.

## Solution

Warn the user about invalid package names for Python. This is not removing for the payload as this is done by the API. It warns the user about a malformed payload.

## Testing

Added units tests

Tried locally with a SBOM and a library containing the name `cloud picke` (with a space).

![Screenshot 2024-12-23 at 8 18 53 PM](https://github.com/user-attachments/assets/f411a706-49b3-46bd-aa0f-8f5a3b44b120)

