### PR TITLE
[K9VULN-2266] Support `is-dev` property from `osv-scanner`

### DIFF
--- a/src/commands/sbom/__tests__/fixtures/sbom.1.5.ok.json
+++ b/src/commands/sbom/__tests__/fixtures/sbom.1.5.ok.json
@@ -160,6 +160,10 @@
         {
           "name": "osv-scanner:package-manager",
           "value": "Npm"
+        },
+        {
+          "name": "osv-scanner:is-dev",
+          "value": "true"
         }
       ]
     },

--- a/src/commands/sbom/__tests__/payload.test.ts
+++ b/src/commands/sbom/__tests__/payload.test.ts
@@ -72,6 +72,9 @@ describe('generation of payload', () => {
     const directDependencies = payload?.dependencies.filter((d) => d.is_direct)
     expect(directDependencies?.length).toBe(1)
 
+    const devDependencies = payload?.dependencies.filter((d) => d.is_dev)
+    expect(devDependencies?.length).toBe(1)
+
     const dependenciesWithPackageManager = payload?.dependencies.filter((d) => d.package_manager.length > 0)
     expect(dependenciesWithPackageManager?.length).toBe(1)
 

--- a/src/commands/sbom/constants.ts
+++ b/src/commands/sbom/constants.ts
@@ -2,4 +2,5 @@ export const API_ENDPOINT = 'api/v2/static-analysis-sca/dependencies'
 
 export const PACKAGE_MANAGER_PROPERTY_KEY = 'osv-scanner:package-manager'
 export const IS_DEPENDENCY_DIRECT_PROPERTY_KEY = 'osv-scanner:is-direct'
+export const IS_DEPENDENCY_DEV_ENVIRONMENT_PROPERTY_KEY = 'osv-scanner:is-dev'
 export const FILE_PACKAGE_PROPERTY_KEY = 'osv-scanner:package'

--- a/src/commands/sbom/payload.ts
+++ b/src/commands/sbom/payload.ts
@@ -12,7 +12,12 @@ import {
   GIT_SHA,
 } from '../../helpers/tags'
 
-import {FILE_PACKAGE_PROPERTY_KEY, IS_DEPENDENCY_DIRECT_PROPERTY_KEY, PACKAGE_MANAGER_PROPERTY_KEY} from './constants'
+import {
+  FILE_PACKAGE_PROPERTY_KEY,
+  IS_DEPENDENCY_DEV_ENVIRONMENT_PROPERTY_KEY,
+  IS_DEPENDENCY_DIRECT_PROPERTY_KEY,
+  PACKAGE_MANAGER_PROPERTY_KEY,
+} from './constants'
 import {getLanguageFromComponent} from './language'
 import {Relations, Dependency, File, Location, LocationFromFile, Locations, ScaRequest} from './types'
 
@@ -187,11 +192,14 @@ const extractingDependency = (component: any): Dependency | undefined => {
 
   let packageManager = ''
   let isDirect
+  let isDev
   for (const property of component['properties'] ?? []) {
     if (property['name'] === PACKAGE_MANAGER_PROPERTY_KEY) {
       packageManager = property['value']
     } else if (property['name'] === IS_DEPENDENCY_DIRECT_PROPERTY_KEY) {
       isDirect = property['value'].toLowerCase() === 'true' ? true : undefined
+    } else if (property['name'] === IS_DEPENDENCY_DEV_ENVIRONMENT_PROPERTY_KEY) {
+      isDev = property['value'].toLowerCase() === 'true' ? true : undefined
     }
   }
 
@@ -204,6 +212,7 @@ const extractingDependency = (component: any): Dependency | undefined => {
     purl,
     locations,
     is_direct: isDirect,
+    is_dev: isDev,
     package_manager: packageManager,
   }
 

--- a/src/commands/sbom/types.ts
+++ b/src/commands/sbom/types.ts
@@ -94,6 +94,7 @@ export interface Dependency {
   purl: string
   locations: undefined | Locations[]
   is_direct: undefined | boolean
+  is_dev: undefined | boolean
   package_manager: string
 }
 


### PR DESCRIPTION
### What and why?

Support the `is-dev` property from `osv-scanner` by propagating it when it's present.

### Review checklist

- [X] Feature or bugfix MUST have appropriate tests (unit, integration)
