### PR TITLE
[SYNTH-17698] Fix local test definition variable case

### DIFF
--- a/src/commands/synthetics/__tests__/run-tests-lib.test.ts
+++ b/src/commands/synthetics/__tests__/run-tests-lib.test.ts
@@ -1078,7 +1078,7 @@ describe('run-test', () => {
               },
             },
             {
-              localTestDefinition,
+              local_test_definition: localTestDefinition,
               testOverrides: {
                 startUrl: 'fakeUrl',
               },
@@ -1095,7 +1095,7 @@ describe('run-test', () => {
           testOverrides: {startUrl: 'fakeUrl'},
         },
         {
-          localTestDefinition,
+          local_test_definition: localTestDefinition,
           suite: 'Suite with local test definitions',
           testOverrides: {startUrl: 'fakeUrl'},
         },
@@ -1115,7 +1115,7 @@ describe('run-test', () => {
               },
             },
             {
-              localTestDefinition,
+              local_test_definition: localTestDefinition,
               testOverrides: {
                 startUrl: 'fakeUrl',
               },
@@ -1129,7 +1129,7 @@ describe('run-test', () => {
         runTests.getTriggerConfigs(fakeApi, {...ciConfig, files: ['glob'], publicIds: ['bbb-bbb-bbb']}, mockReporter)
       ).resolves.toEqual([
         {
-          localTestDefinition,
+          local_test_definition: localTestDefinition,
           suite: 'Suite with local test definitions',
           testOverrides: {startUrl: 'fakeUrl'},
         },

--- a/src/commands/synthetics/interfaces.ts
+++ b/src/commands/synthetics/interfaces.ts
@@ -433,7 +433,7 @@ export interface RemoteTriggerConfig extends BaseTriggerConfig {
   id: string
 }
 export interface LocalTriggerConfig extends BaseTriggerConfig {
-  localTestDefinition: LocalTestDefinition
+  local_test_definition: LocalTestDefinition
 }
 export type TriggerConfig = RemoteTriggerConfig | LocalTriggerConfig
 

--- a/src/commands/synthetics/test.ts
+++ b/src/commands/synthetics/test.ts
@@ -50,7 +50,7 @@ export const getTestConfigs = async (
           testOverrides: replaceConfigWithTestOverrides(test.config, test.testOverrides),
           suite: suite.name,
           ...(isLocalTriggerConfig(test)
-            ? {localTestDefinition: normalizeLocalTestDefinition(test.localTestDefinition)}
+            ? {local_test_definition: normalizeLocalTestDefinition(test.local_test_definition)}
             : {id: normalizePublicId(test.id) ?? ''}),
         }
       })
@@ -86,7 +86,7 @@ export const getTest = async (
 ): Promise<{test: Test} | {errorMessage: string}> => {
   if (isLocalTriggerConfig(triggerConfig)) {
     const test = {
-      ...triggerConfig.localTestDefinition,
+      ...triggerConfig.local_test_definition,
       suite: triggerConfig.suite,
     }
 

--- a/src/commands/synthetics/utils/internal.ts
+++ b/src/commands/synthetics/utils/internal.ts
@@ -92,12 +92,12 @@ export const isTimedOutRetry = (
 }
 
 export const isLocalTriggerConfig = (triggerConfig?: TriggerConfig): triggerConfig is LocalTriggerConfig => {
-  return triggerConfig ? 'localTestDefinition' in triggerConfig : false
+  return triggerConfig ? 'local_test_definition' in triggerConfig : false
 }
 
 export const getTriggerConfigPublicId = (triggerConfig: TriggerConfig): string | undefined => {
   if (isLocalTriggerConfig(triggerConfig)) {
-    return triggerConfig.localTestDefinition.public_id
+    return triggerConfig.local_test_definition.public_id
   }
 
   return triggerConfig.id

--- a/src/commands/synthetics/utils/public.ts
+++ b/src/commands/synthetics/utils/public.ts
@@ -82,7 +82,7 @@ export const makeTestPayload = (test: Test, triggerConfig: TriggerConfig, public
   if (isLocalTriggerConfig(triggerConfig)) {
     return {
       ...getBasePayload(test, triggerConfig.testOverrides),
-      local_test_definition: triggerConfig.localTestDefinition,
+      local_test_definition: triggerConfig.local_test_definition,
     }
   }
 


### PR DESCRIPTION
### What and why?

Fixes the case of the variable containing the local test definition. Before it was in Camel Case but it should have been in snake case.

Note: There are still some instances of the Camel Case version, but it is only for variables defined in typescript as it is required by the linter.

### How?

- Change `localTestDefinition` to `local_test_definition`

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
