### PR TITLE
[K9VULN] Specify `is_dev` in tests

### DIFF
--- a/src/commands/sbom/__tests__/validation.test.ts
+++ b/src/commands/sbom/__tests__/validation.test.ts
@@ -93,6 +93,7 @@ describe('validation of sbom file', () => {
         locations: [],
         is_direct: undefined,
         package_manager: 'pypi',
+        is_dev: undefined,
       })
     ).toBeFalsy()
     expect(
@@ -106,6 +107,7 @@ describe('validation of sbom file', () => {
         locations: [],
         is_direct: undefined,
         package_manager: 'pypi',
+        is_dev: undefined,
       })
     ).toBeTruthy()
     expect(
@@ -119,6 +121,7 @@ describe('validation of sbom file', () => {
         locations: [],
         is_direct: undefined,
         package_manager: 'pypi',
+        is_dev: undefined,
       })
     ).toBeTruthy()
     expect(
@@ -132,6 +135,7 @@ describe('validation of sbom file', () => {
         locations: [],
         is_direct: undefined,
         package_manager: 'pypi',
+        is_dev: undefined,
       })
     ).toBeTruthy()
   })


### PR DESCRIPTION
### What and why?

[This merge commit](https://github.com/DataDog/datadog-ci/commit/9f2b4f1158e6bb60b802fddafbc6f1803dd315ac) shows that we're failing to build the package. This PR adds the `is_dev` value to these new tests, so that they pass.
