### PR TITLE
Change Serverless team in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -24,9 +24,9 @@ src/commands/react-native     @DataDog/datadog-ci @DataDog/rum-mobile
 src/commands/sourcemaps       @DataDog/datadog-ci @DataDog/rum-browser
 
 ## Serverless (label: serverless)
-src/commands/lambda         @DataDog/datadog-ci @DataDog/serverless
-src/commands/stepfunctions  @DataDog/datadog-ci @DataDog/serverless
-src/commands/cloud-run      @DataDog/datadog-ci @DataDog/serverless
+src/commands/lambda         @DataDog/datadog-ci @DataDog/serverless-onboarding-enablement
+src/commands/stepfunctions  @DataDog/datadog-ci @DataDog/serverless-onboarding-enablement
+src/commands/cloud-run      @DataDog/datadog-ci @DataDog/serverless-onboarding-enablement
 
 ## Source Code Integration (label: source-code-integration)
 src/commands/git-metadata  @DataDog/datadog-ci @DataDog/source-code-integration


### PR DESCRIPTION
Changing from Serverless team to serverless-onboarding-enablement subteam

### What and why?

Serverless team is too large, and people may not look at PRs. Changing to ONE team, which is a better owner. Also, team members will be added as a reviewer in a Round Robin way.

### How?

A brief description of implementation details of this PR.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
