### PR TITLE
[SYNTH-17719] Command to deploy LTDs

### DIFF
--- a/src/commands/synthetics/__tests__/cli.test.ts
+++ b/src/commands/synthetics/__tests__/cli.test.ts
@@ -5,9 +5,11 @@ import {toBoolean, toNumber, toStringMap} from '../../../helpers/env'
 import * as ciUtils from '../../../helpers/utils'
 
 import * as api from '../api'
+import {DEFAULT_DEPLOY_TESTS_COMMAND_CONFIG, DeployTestsCommand} from '../deploy-tests-command'
 import {DEFAULT_IMPORT_TESTS_COMMAND_CONFIG, ImportTestsCommand} from '../import-tests-command'
 import {
   CookiesObject,
+  DeployTestsCommandConfig,
   ExecutionRule,
   ImportTestsCommandConfig,
   RunTestsCommandConfig,
@@ -1704,6 +1706,123 @@ describe('import-tests', () => {
       await command['resolveConfig']()
       expect(command['config']).toEqual({
         ...DEFAULT_IMPORT_TESTS_COMMAND_CONFIG,
+        apiKey: 'api_key_cli',
+        appKey: 'app_key_env',
+        datadogSite: 'us5.datadoghq.com',
+      })
+    })
+  })
+})
+
+describe('deploy-tests', () => {
+  beforeEach(() => {
+    process.env = {}
+    jest.restoreAllMocks()
+  })
+
+  describe('resolveConfig', () => {
+    beforeEach(() => {
+      process.env = {}
+    })
+
+    test('override from ENV', async () => {
+      const overrideEnv = {
+        DATADOG_API_KEY: 'fake_api_key',
+        DATADOG_APP_KEY: 'fake_app_key',
+        DATADOG_SYNTHETICS_CONFIG_PATH: 'path/to/config.json',
+        DATADOG_SITE: 'datadoghq.eu',
+        DATADOG_SUBDOMAIN: 'custom',
+        DATADOG_SYNTHETICS_FILES: 'test-file1;test-file2;test-file3',
+        DATADOG_SYNTHETICS_PUBLIC_IDS: 'a-public-id;another-public-id',
+      }
+
+      process.env = overrideEnv
+      const command = createCommand(DeployTestsCommand)
+
+      await command['resolveConfig']()
+      expect(command['config']).toEqual({
+        ...DEFAULT_DEPLOY_TESTS_COMMAND_CONFIG,
+        apiKey: overrideEnv.DATADOG_API_KEY,
+        appKey: overrideEnv.DATADOG_APP_KEY,
+        configPath: overrideEnv.DATADOG_SYNTHETICS_CONFIG_PATH,
+        datadogSite: overrideEnv.DATADOG_SITE,
+        files: overrideEnv.DATADOG_SYNTHETICS_FILES?.split(';'),
+        publicIds: overrideEnv.DATADOG_SYNTHETICS_PUBLIC_IDS?.split(';'),
+        subdomain: overrideEnv.DATADOG_SUBDOMAIN,
+      })
+    })
+
+    test('override from config file', async () => {
+      const expectedConfig: DeployTestsCommandConfig = {
+        apiKey: 'fake_api_key',
+        appKey: 'fake_app_key',
+        configPath: 'src/commands/synthetics/__tests__/config-fixtures/deploy-tests-config-with-all-keys.json',
+        datadogSite: 'datadoghq.eu',
+        files: ['my-new-file'],
+        proxy: {protocol: 'http'},
+        publicIds: ['ran-dom-id1'],
+        subdomain: 'ppa',
+      }
+
+      const command = createCommand(DeployTestsCommand)
+      command['configPath'] = 'src/commands/synthetics/__tests__/config-fixtures/deploy-tests-config-with-all-keys.json'
+
+      await command['resolveConfig']()
+      expect(command['config']).toEqual(expectedConfig)
+    })
+
+    test('override from CLI', async () => {
+      const overrideCLI: Omit<DeployTestsCommandConfig, 'proxy'> = {
+        apiKey: 'fake_api_key_cli',
+        appKey: 'fake_app_key_cli',
+        configPath: 'src/commands/synthetics/__tests__/config-fixtures/empty-config-file.json',
+        datadogSite: 'datadoghq.cli',
+        files: ['new-file'],
+        publicIds: ['ran-dom-id2'],
+        subdomain: 'subdomain-from-cli',
+      }
+
+      const command = createCommand(DeployTestsCommand)
+      command['apiKey'] = overrideCLI.apiKey
+      command['appKey'] = overrideCLI.appKey
+      command['configPath'] = overrideCLI.configPath
+      command['datadogSite'] = overrideCLI.datadogSite
+      command['files'] = overrideCLI.files
+      command['publicIds'] = overrideCLI.publicIds
+      command['subdomain'] = overrideCLI.subdomain
+
+      await command['resolveConfig']()
+      expect(command['config']).toEqual({
+        ...DEFAULT_DEPLOY_TESTS_COMMAND_CONFIG,
+        apiKey: 'fake_api_key_cli',
+        appKey: 'fake_app_key_cli',
+        configPath: 'src/commands/synthetics/__tests__/config-fixtures/empty-config-file.json',
+        datadogSite: 'datadoghq.cli',
+        files: ['new-file'],
+        publicIds: ['ran-dom-id2'],
+        subdomain: 'subdomain-from-cli',
+      })
+    })
+
+    test('override from config file < ENV < CLI', async () => {
+      jest.spyOn(ciUtils, 'resolveConfigFromFile').mockImplementationOnce(async <T>(baseConfig: T) => ({
+        ...baseConfig,
+        apiKey: 'api_key_config_file',
+        appKey: 'app_key_config_file',
+        datadogSite: 'us5.datadoghq.com',
+      }))
+
+      process.env = {
+        DATADOG_API_KEY: 'api_key_env',
+        DATADOG_APP_KEY: 'app_key_env',
+      }
+
+      const command = createCommand(DeployTestsCommand)
+      command['apiKey'] = 'api_key_cli'
+
+      await command['resolveConfig']()
+      expect(command['config']).toEqual({
+        ...DEFAULT_DEPLOY_TESTS_COMMAND_CONFIG,
         apiKey: 'api_key_cli',
         appKey: 'app_key_env',
         datadogSite: 'us5.datadoghq.com',

--- a/src/commands/synthetics/__tests__/config-fixtures/deploy-tests-config-with-all-keys.json
+++ b/src/commands/synthetics/__tests__/config-fixtures/deploy-tests-config-with-all-keys.json
@@ -1,0 +1,9 @@
+{
+  "apiKey": "fake_api_key",
+  "appKey": "fake_app_key",
+  "configPath": "fake-datadog-ci.json",
+  "datadogSite": "datadoghq.eu",
+  "files": ["my-new-file"],
+  "publicIds": ["ran-dom-id1"],
+  "subdomain": "ppa"
+}

--- a/src/commands/synthetics/__tests__/deploy-tests-lib.test.ts
+++ b/src/commands/synthetics/__tests__/deploy-tests-lib.test.ts
@@ -74,21 +74,5 @@ describe('deploy-tests', () => {
       const {public_id, monitor_id, ...expectedUpdate} = getApiTest('123-456-789')
       expect(apiHelper.editTest).toHaveBeenNthCalledWith(1, '123-456-789', expectedUpdate)
     })
-
-    it('fails if public ids are not unique', async () => {
-      const config = DEFAULT_DEPLOY_TESTS_COMMAND_CONFIG
-      config['publicIds'] = ['123-456-789']
-
-      jest
-        .spyOn(tests, 'getTestConfigs')
-        .mockImplementation(async () => [
-          {local_test_definition: getApiLocalTestDefinition('123-456-789')},
-          {local_test_definition: getApiLocalTestDefinition('123-456-789')},
-        ])
-
-      await expect(deployTests(mockReporter, config)).rejects.toThrow(
-        'Cannot have multiple local test definitions with same publicId: 123-456-789.'
-      )
-    })
   })
 })

--- a/src/commands/synthetics/__tests__/deploy-tests-lib.test.ts
+++ b/src/commands/synthetics/__tests__/deploy-tests-lib.test.ts
@@ -1,0 +1,94 @@
+import * as api from '../api'
+import {DEFAULT_DEPLOY_TESTS_COMMAND_CONFIG} from '../deploy-tests-command'
+import {deployTests} from '../deploy-tests-lib'
+import * as tests from '../test'
+
+import {getApiLocalTestDefinition, getApiTest, mockApi, mockReporter} from './fixtures'
+
+describe('deploy-tests', () => {
+  describe('deployTests', () => {
+    it('deploys local test definitions as new versions of main test definitions', async () => {
+      const config = DEFAULT_DEPLOY_TESTS_COMMAND_CONFIG
+
+      jest
+        .spyOn(tests, 'getTestConfigs')
+        .mockImplementation(async () => [
+          {local_test_definition: getApiLocalTestDefinition('123-456-789')},
+          {local_test_definition: getApiLocalTestDefinition('987-654-321')},
+        ])
+
+      const apiHelper = mockApi({
+        getTest: jest.fn(async (publicId: string) => {
+          return getApiTest(publicId)
+        }),
+        editTest: jest.fn(),
+      })
+      jest.spyOn(api, 'getApiHelper').mockImplementation(() => apiHelper as any)
+
+      await deployTests(mockReporter, config)
+
+      expect(tests.getTestConfigs).toHaveBeenCalledTimes(1)
+      expect(apiHelper.getTest).toHaveBeenCalledTimes(2)
+      expect(apiHelper.editTest).toHaveBeenCalledTimes(2)
+
+      expect(apiHelper.getTest).toHaveBeenNthCalledWith(1, '123-456-789')
+      expect(apiHelper.getTest).toHaveBeenNthCalledWith(2, '987-654-321')
+
+      // eslint-disable-next-line @typescript-eslint/naming-convention, prefer-const
+      let {public_id, monitor_id, ...expectedUpdate} = getApiTest('123-456-789')
+      expect(apiHelper.editTest).toHaveBeenNthCalledWith(1, '123-456-789', expectedUpdate)
+
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      ;({public_id, monitor_id, ...expectedUpdate} = getApiTest('987-654-321'))
+      expect(apiHelper.editTest).toHaveBeenNthCalledWith(2, '987-654-321', expectedUpdate)
+    })
+
+    it('supports specifying public ids', async () => {
+      const config = DEFAULT_DEPLOY_TESTS_COMMAND_CONFIG
+      config['publicIds'] = ['123-456-789']
+
+      jest
+        .spyOn(tests, 'getTestConfigs')
+        .mockImplementation(async () => [
+          {local_test_definition: getApiLocalTestDefinition('123-456-789')},
+          {local_test_definition: getApiLocalTestDefinition('987-654-321')},
+        ])
+
+      const apiHelper = mockApi({
+        getTest: jest.fn(async (publicId: string) => {
+          return getApiTest(publicId)
+        }),
+        editTest: jest.fn(),
+      })
+      jest.spyOn(api, 'getApiHelper').mockImplementation(() => apiHelper as any)
+
+      await deployTests(mockReporter, config)
+
+      expect(tests.getTestConfigs).toHaveBeenCalledTimes(1)
+      expect(apiHelper.getTest).toHaveBeenCalledTimes(1)
+      expect(apiHelper.editTest).toHaveBeenCalledTimes(1)
+
+      expect(apiHelper.getTest).toHaveBeenNthCalledWith(1, '123-456-789')
+
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      const {public_id, monitor_id, ...expectedUpdate} = getApiTest('123-456-789')
+      expect(apiHelper.editTest).toHaveBeenNthCalledWith(1, '123-456-789', expectedUpdate)
+    })
+
+    it('fails if public ids are not unique', async () => {
+      const config = DEFAULT_DEPLOY_TESTS_COMMAND_CONFIG
+      config['publicIds'] = ['123-456-789']
+
+      jest
+        .spyOn(tests, 'getTestConfigs')
+        .mockImplementation(async () => [
+          {local_test_definition: getApiLocalTestDefinition('123-456-789')},
+          {local_test_definition: getApiLocalTestDefinition('123-456-789')},
+        ])
+
+      await expect(deployTests(mockReporter, config)).rejects.toThrow(
+        'Cannot have multiple local test definitions with same publicId: 123-456-789.'
+      )
+    })
+  })
+})

--- a/src/commands/synthetics/__tests__/deploy-tests-lib.test.ts
+++ b/src/commands/synthetics/__tests__/deploy-tests-lib.test.ts
@@ -13,8 +13,8 @@ describe('deploy-tests', () => {
       jest
         .spyOn(tests, 'getTestConfigs')
         .mockImplementation(async () => [
-          {local_test_definition: getApiLocalTestDefinition('123-456-789')},
-          {local_test_definition: getApiLocalTestDefinition('987-654-321')},
+          {localTestDefinition: getApiLocalTestDefinition('123-456-789')},
+          {localTestDefinition: getApiLocalTestDefinition('987-654-321')},
         ])
 
       const apiHelper = mockApi({
@@ -50,8 +50,8 @@ describe('deploy-tests', () => {
       jest
         .spyOn(tests, 'getTestConfigs')
         .mockImplementation(async () => [
-          {local_test_definition: getApiLocalTestDefinition('123-456-789')},
-          {local_test_definition: getApiLocalTestDefinition('987-654-321')},
+          {localTestDefinition: getApiLocalTestDefinition('123-456-789')},
+          {localTestDefinition: getApiLocalTestDefinition('987-654-321')},
         ])
 
       const apiHelper = mockApi({

--- a/src/commands/synthetics/__tests__/fixtures.ts
+++ b/src/commands/synthetics/__tests__/fixtures.ts
@@ -37,6 +37,7 @@ import {
   ServerResult,
   APIConfiguration,
   ServerTest,
+  LocalTestDefinition,
 } from '../interfaces'
 import {AppUploadReporter} from '../reporters/mobile/app-upload'
 import {createInitialSummary} from '../utils/public'
@@ -80,7 +81,10 @@ export const ciConfig: RunTestsCommandConfig = {
   variableStrings: [],
 }
 
-export const getApiTest = (publicId = 'abc-def-ghi', opts: Partial<ServerTest> = {}): ServerTest => ({
+export const getApiLocalTestDefinition = (
+  publicId = 'abc-def-ghi',
+  opts: Partial<LocalTestDefinition> = {}
+): LocalTestDefinition & {public_id: string} => ({
   config: {
     assertions: [],
     request: {
@@ -92,18 +96,22 @@ export const getApiTest = (publicId = 'abc-def-ghi', opts: Partial<ServerTest> =
     variables: [],
   },
   locations: [],
-  message: '',
-  monitor_id: 0,
   name: 'Test name',
   options: {
     device_ids: [],
   },
   public_id: publicId,
-  status: 'live',
   subtype: 'http',
-  tags: [],
   type: 'api',
   ...opts,
+})
+
+export const getApiTest = (publicId = 'abc-def-ghi', opts: Partial<LocalTestDefinition> = {}): ServerTest => ({
+  ...getApiLocalTestDefinition(publicId, opts),
+  message: '',
+  monitor_id: 0,
+  status: 'live',
+  tags: [],
 })
 
 export const getBrowserTest = (

--- a/src/commands/synthetics/__tests__/fixtures.ts
+++ b/src/commands/synthetics/__tests__/fixtures.ts
@@ -605,6 +605,7 @@ export const mockApi = (override?: Partial<APIHelper>): APIHelper => {
     getMobileApplicationPresignedURLs: jest.fn(),
     getTest: jest.fn(),
     getTestWithType: jest.fn(),
+    editTest: jest.fn(),
     getSyntheticsOrgSettings: jest.fn(),
     getTunnelPresignedURL: jest.fn(),
     pollResults: jest.fn(),

--- a/src/commands/synthetics/api.ts
+++ b/src/commands/synthetics/api.ts
@@ -110,6 +110,23 @@ const getTestWithType = (request: (args: AxiosRequestConfig) => AxiosPromise<Ser
   return resp.data
 }
 
+const editTest = (request: (args: AxiosRequestConfig) => AxiosPromise<Trigger>) => async (
+  testId: string,
+  data: ServerTest
+) => {
+  const resp = await retryRequest(
+    {
+      data,
+      method: 'PUT',
+      url: `/synthetics/tests/${testId}`,
+    },
+    request,
+    {retryOn429: true}
+  )
+
+  return resp.data
+}
+
 const searchTests = (request: (args: AxiosRequestConfig) => AxiosPromise<TestSearchResult>) => async (
   query: string
 ) => {
@@ -369,6 +386,7 @@ export const apiConstructor = (configuration: APIConfiguration) => {
     getMobileApplicationPresignedURLs: getMobileApplicationPresignedURLs(requestUnstable),
     getTest: getTest(request),
     getTestWithType: getTestWithType(request),
+    editTest: editTest(request),
     getSyntheticsOrgSettings: getSyntheticsOrgSettings(request),
     getTunnelPresignedURL: getTunnelPresignedURL(requestIntake),
     pollResults: pollResults(request),

--- a/src/commands/synthetics/cli.ts
+++ b/src/commands/synthetics/cli.ts
@@ -1,5 +1,6 @@
+import {DeployTestsCommand} from './deploy-tests-command'
 import {ImportTestsCommand} from './import-tests-command'
 import {RunTestsCommand} from './run-tests-command'
 import {UploadApplicationCommand} from './upload-application-command'
 
-module.exports = [RunTestsCommand, UploadApplicationCommand, ImportTestsCommand]
+module.exports = [RunTestsCommand, UploadApplicationCommand, ImportTestsCommand, DeployTestsCommand]

--- a/src/commands/synthetics/deploy-tests-command.ts
+++ b/src/commands/synthetics/deploy-tests-command.ts
@@ -35,13 +35,13 @@ export class DeployTestsCommand extends Command {
 
   public static usage = Command.Usage({
     category: 'Synthetics',
-    description: 'Deploy Local Test Definitions as scheduled tests in Datadog.',
+    description: 'Deploy Local Test Definitions as Main Test Definitions in Datadog.',
     details: `
-      This command deploys Local Test Definitions as scheduled tests in Datadog, usually when a feature branch is merged.
+      This command deploys Local Test Definitions as Main Test Definitions in Datadog, usually when a feature branch is merged or during a deployment.
     `,
     examples: [
       [
-        'Explicitly specify multiple tests to run',
+        'Explicitly specify the local test definitions to deploy',
         'datadog-ci synthetics deploy-tests --public-id pub-lic-id1 --public-id pub-lic-id2',
       ],
       [

--- a/src/commands/synthetics/deploy-tests-command.ts
+++ b/src/commands/synthetics/deploy-tests-command.ts
@@ -14,7 +14,7 @@ import {DeployTestsCommandConfig, MainReporter, Reporter, RunTestsCommandConfig}
 import {DefaultReporter} from './reporters/default'
 import {getReporter, reportCiError} from './utils/public'
 
-export const DEFAULT_COMMAND_CONFIG: DeployTestsCommandConfig = {
+export const DEFAULT_DEPLOY_TESTS_COMMAND_CONFIG: DeployTestsCommandConfig = {
   apiKey: '',
   appKey: '',
   configPath: 'datadog-ci.json',
@@ -66,7 +66,7 @@ export class DeployTestsCommand extends Command {
   })
 
   private reporter!: MainReporter
-  private config: RunTestsCommandConfig = JSON.parse(JSON.stringify(DEFAULT_COMMAND_CONFIG)) // Deep copy to avoid mutation
+  private config: RunTestsCommandConfig = JSON.parse(JSON.stringify(DEFAULT_DEPLOY_TESTS_COMMAND_CONFIG)) // Deep copy to avoid mutation
 
   private logger: Logger = new Logger((s: string) => {
     this.context.stdout.write(s)

--- a/src/commands/synthetics/deploy-tests-command.ts
+++ b/src/commands/synthetics/deploy-tests-command.ts
@@ -1,0 +1,152 @@
+import {Command, Option} from 'clipanion'
+import deepExtend from 'deep-extend'
+import terminalLink from 'terminal-link'
+
+import {FIPS_ENV_VAR, FIPS_IGNORE_ERROR_ENV_VAR} from '../../constants'
+import {toBoolean} from '../../helpers/env'
+import {enableFips} from '../../helpers/fips'
+import {Logger, LogLevel} from '../../helpers/logger'
+import {removeUndefinedValues, resolveConfigFromFile} from '../../helpers/utils'
+
+import {deployTests} from './deploy-tests-lib'
+import {CiError} from './errors'
+import {DeployTestsCommandConfig, MainReporter, Reporter, RunTestsCommandConfig} from './interfaces'
+import {DefaultReporter} from './reporters/default'
+import {getReporter, reportCiError} from './utils/public'
+
+export const DEFAULT_COMMAND_CONFIG: DeployTestsCommandConfig = {
+  apiKey: '',
+  appKey: '',
+  configPath: 'datadog-ci.json',
+  datadogSite: 'datadoghq.com',
+  files: [],
+  proxy: {protocol: 'http'},
+  publicIds: [],
+  subdomain: 'app',
+}
+
+const configurationLink = 'https://docs.datadoghq.com/continuous_testing/cicd_integrations/configuration'
+
+const $1 = (text: string) => terminalLink(text, `${configurationLink}#global-configuration-file-options`)
+const $2 = (text: string) => terminalLink(text, `${configurationLink}#test-files`)
+
+export class DeployTestsCommand extends Command {
+  public static paths = [['synthetics', 'deploy-tests']]
+
+  public static usage = Command.Usage({
+    category: 'Synthetics',
+    description: 'Deploy Local Test Definitions as scheduled tests in Datadog.',
+    details: `
+      This command deploys Local Test Definitions as scheduled tests in Datadog, usually when a feature branch is merged.
+    `,
+    examples: [
+      [
+        'Explicitly specify multiple tests to run',
+        'datadog-ci synthetics deploy-tests --public-id pub-lic-id1 --public-id pub-lic-id2',
+      ],
+      [
+        'Override the default glob pattern',
+        'datadog-ci synthetics deploy-tests -f ./component-1/**/*.synthetics.json -f ./component-2/**/*.synthetics.json',
+      ],
+    ],
+  })
+
+  public configPath = Option.String('--config', {description: `Pass a path to a ${$1('global configuration file')}.`})
+
+  private apiKey = Option.String('--apiKey', {description: 'The API key used to query the Datadog API.'})
+  private appKey = Option.String('--appKey', {description: 'The application key used to query the Datadog API.'})
+  private datadogSite = Option.String('--datadogSite', {description: 'The Datadog instance to which request is sent.'})
+  private files = Option.Array('-f,--files', {
+    description: `Glob pattern to detect Synthetic test ${$2('configuration files')}}.`,
+  })
+  private publicIds = Option.Array('-p,--public-id', {description: 'Specify a test to run.'})
+  private subdomain = Option.String('--subdomain', {
+    description:
+      'The name of the custom subdomain set to access your Datadog application. If the URL used to access Datadog is `myorg.datadoghq.com`, the `subdomain` value needs to be set to `myorg`.',
+  })
+
+  private reporter!: MainReporter
+  private config: RunTestsCommandConfig = JSON.parse(JSON.stringify(DEFAULT_COMMAND_CONFIG)) // Deep copy to avoid mutation
+
+  private logger: Logger = new Logger((s: string) => {
+    this.context.stdout.write(s)
+  }, LogLevel.INFO)
+
+  private fips = Option.Boolean('--fips', false)
+  private fipsIgnoreError = Option.Boolean('--fips-ignore-error', false)
+  private fipsConfig = {
+    fips: toBoolean(process.env[FIPS_ENV_VAR]) ?? false,
+    fipsIgnoreError: toBoolean(process.env[FIPS_IGNORE_ERROR_ENV_VAR]) ?? false,
+  }
+
+  public async execute() {
+    enableFips(this.fips || this.fipsConfig.fips, this.fipsIgnoreError || this.fipsConfig.fipsIgnoreError)
+
+    const reporters: Reporter[] = [new DefaultReporter(this)]
+    this.reporter = getReporter(reporters)
+
+    try {
+      await this.resolveConfig()
+    } catch (error) {
+      if (error instanceof CiError) {
+        reportCiError(error, this.reporter)
+      }
+
+      return 1
+    }
+
+    try {
+      await deployTests(this.reporter, this.config)
+    } catch (error) {
+      this.logger.error(`Error: ${error.message}`)
+
+      return 1
+    }
+  }
+
+  private async resolveConfig() {
+    // Defaults < file < ENV < CLI
+
+    // Override with config file variables (e.g. datadog-ci.json)
+    try {
+      // Override Config Path with ENV variables
+      const overrideConfigPath = this.configPath ?? process.env.DATADOG_SYNTHETICS_CONFIG_PATH ?? 'datadog-ci.json'
+      this.config = await resolveConfigFromFile(this.config, {
+        configPath: overrideConfigPath,
+        defaultConfigPaths: [this.config.configPath],
+      })
+    } catch (error) {
+      if (this.configPath) {
+        throw error
+      }
+    }
+
+    // Override with ENV variables
+    this.config = deepExtend(
+      this.config,
+      removeUndefinedValues({
+        apiKey: process.env.DATADOG_API_KEY,
+        appKey: process.env.DATADOG_APP_KEY,
+        configPath: process.env.DATADOG_SYNTHETICS_CONFIG_PATH, // Only used for debugging
+        datadogSite: process.env.DATADOG_SITE,
+        files: process.env.DATADOG_SYNTHETICS_FILES?.split(';'),
+        publicIds: process.env.DATADOG_SYNTHETICS_PUBLIC_IDS?.split(';'),
+        subdomain: process.env.DATADOG_SUBDOMAIN,
+      })
+    )
+
+    // Override with CLI parameters
+    this.config = deepExtend(
+      this.config,
+      removeUndefinedValues({
+        apiKey: this.apiKey,
+        appKey: this.appKey,
+        configPath: this.configPath,
+        datadogSite: this.datadogSite,
+        files: this.files,
+        publicIds: this.publicIds,
+        subdomain: this.subdomain,
+      })
+    )
+  }
+}

--- a/src/commands/synthetics/deploy-tests-lib.ts
+++ b/src/commands/synthetics/deploy-tests-lib.ts
@@ -28,12 +28,13 @@ export const deployTests = async (reporter: MainReporter, config: DeployTestsCom
   })
 
   for (const localTestDefinition of localTestDefinitionsToDeploy) {
+    // SYNTH-18434: public ID should be made required
     const publicId = localTestDefinition.local_test_definition.public_id!
 
     try {
       await deployLocalTestDefinition(api, localTestDefinition)
 
-      // SYNTH-17840: the edit test endpoint should return a version in the response, so we can print it in the logs and see it in version history
+      // SYNTH-18527: the edit test endpoint should return a version in the response, so we can print it in the logs and see it in version history
       const baseUrl = getCommonAppBaseURL(config.datadogSite, config.subdomain)
       const testLink = `${baseUrl}synthetics/details/${publicId}`
 
@@ -46,8 +47,6 @@ export const deployTests = async (reporter: MainReporter, config: DeployTestsCom
       )
     }
   }
-
-  reporter.log(`Deployed local test definitions defined in ${config.files[0]}\n`)
 }
 
 const deployLocalTestDefinition = async (api: APIHelper, test: LocalTriggerConfig): Promise<void> => {
@@ -56,7 +55,7 @@ const deployLocalTestDefinition = async (api: APIHelper, test: LocalTriggerConfi
 
   const existingRemoteTest = await api.getTest(publicId)
 
-  // XXX: We should detect noop updates in the backend
+  // SYNTH-18528: the client should not have to handle the merge for partial update
   const newRemoteTest = removeUnsupportedEditTestFields({
     ...existingRemoteTest,
     ...test.local_test_definition,

--- a/src/commands/synthetics/deploy-tests-lib.ts
+++ b/src/commands/synthetics/deploy-tests-lib.ts
@@ -1,0 +1,93 @@
+import {getCommonAppBaseURL} from '../../helpers/app'
+
+import {APIHelper, EndpointError, formatBackendErrors, getApiHelper} from './api'
+import {DeployTestsCommandConfig, LocalTriggerConfig, MainReporter, ServerTest, TestConfig} from './interfaces'
+import {findUniqueLocalTestDefinition} from './local-test-definition'
+import {getTestConfigs} from './test'
+import {isLocalTriggerConfig} from './utils/internal'
+
+export const deployTests = async (reporter: MainReporter, config: DeployTestsCommandConfig): Promise<void> => {
+  const api = getApiHelper(config)
+
+  reporter.log('Deploying tests...\n\n')
+
+  const testConfigFromFile: TestConfig = {
+    tests: await getTestConfigs(config, reporter),
+  }
+
+  if (config.publicIds.length > 0) {
+    testConfigFromFile.tests = testConfigFromFile.tests.filter(
+      (test) =>
+        isLocalTriggerConfig(test) &&
+        test.local_test_definition.public_id &&
+        config.publicIds.includes(test.local_test_definition.public_id)
+    )
+  }
+
+  const publicIds = new Set(
+    testConfigFromFile.tests.flatMap((test) =>
+      isLocalTriggerConfig(test) && test.local_test_definition.public_id ? [test.local_test_definition.public_id] : []
+    )
+  )
+
+  for (const publicId of publicIds) {
+    const test = findUniqueLocalTestDefinition(testConfigFromFile, publicId)
+
+    try {
+      await deployLocalTestDefinition(api, test)
+
+      // SYNTH-17840: the edit test endpoint should return a version in the response, so we can print it in the logs and see it in version history
+      const baseUrl = getCommonAppBaseURL(config.datadogSite, config.subdomain)
+      const testLink = `${baseUrl}synthetics/details/${publicId}`
+
+      reporter.log(`New version successfully deployed for main test definition ${publicId}:\n  ⎋ ${testLink}\n\n`)
+    } catch (e) {
+      const errorMessage = formatBackendErrors(e)
+      throw new EndpointError(
+        `[${publicId}] Failed to update main test definition: ${errorMessage}\n`,
+        e.response?.status
+      )
+    }
+  }
+
+  reporter.log(`Deployed local test definitions defined in ${config.files[0]}\n`)
+}
+
+const deployLocalTestDefinition = async (api: APIHelper, test: LocalTriggerConfig): Promise<void> => {
+  // SYNTH-18434: public ID should be made required
+  const publicId = test.local_test_definition.public_id!
+
+  const existingRemoteTest = await api.getTest(publicId)
+
+  // XXX: We should detect noop updates in the backend
+  const newRemoteTest = removeUnsupportedEditTestFields({
+    ...existingRemoteTest,
+    ...test.local_test_definition,
+    config: {
+      ...existingRemoteTest.config,
+      ...test.local_test_definition.config,
+    },
+    options: {
+      ...existingRemoteTest.options,
+      ...test.local_test_definition.options,
+    },
+  })
+
+  await api.editTest(publicId, newRemoteTest)
+}
+
+const removeUnsupportedEditTestFields = (testConfig: ServerTest): ServerTest => {
+  const editTestPayload = {...testConfig} as Partial<ServerTest>
+  delete editTestPayload.creator
+  delete editTestPayload.monitor_id
+  delete editTestPayload.created_at
+  delete editTestPayload.modified_at
+  delete editTestPayload.public_id
+
+  // Only remove bindings if they are null to make validation happy
+  if (editTestPayload.options && !editTestPayload.options.bindings) {
+    delete editTestPayload.options.bindings
+  }
+
+  return editTestPayload as ServerTest
+}

--- a/src/commands/synthetics/deploy-tests-lib.ts
+++ b/src/commands/synthetics/deploy-tests-lib.ts
@@ -16,11 +16,11 @@ export const deployTests = async (reporter: MainReporter, config: DeployTestsCom
       return []
     }
 
-    if (!triggerConfig.local_test_definition.public_id) {
+    if (!triggerConfig.localTestDefinition.public_id) {
       throw new Error('Local test definition is missing a public_id')
     }
 
-    if (config.publicIds.length > 0 && !config.publicIds.includes(triggerConfig.local_test_definition.public_id)) {
+    if (config.publicIds.length > 0 && !config.publicIds.includes(triggerConfig.localTestDefinition.public_id)) {
       return []
     }
 
@@ -29,7 +29,7 @@ export const deployTests = async (reporter: MainReporter, config: DeployTestsCom
 
   for (const localTestDefinition of localTestDefinitionsToDeploy) {
     // SYNTH-18434: public ID should be made required
-    const publicId = localTestDefinition.local_test_definition.public_id!
+    const publicId = localTestDefinition.localTestDefinition.public_id!
 
     try {
       await deployLocalTestDefinition(api, localTestDefinition)
@@ -51,21 +51,21 @@ export const deployTests = async (reporter: MainReporter, config: DeployTestsCom
 
 const deployLocalTestDefinition = async (api: APIHelper, test: LocalTriggerConfig): Promise<void> => {
   // SYNTH-18434: public ID should be made required
-  const publicId = test.local_test_definition.public_id!
+  const publicId = test.localTestDefinition.public_id!
 
   const existingRemoteTest = await api.getTest(publicId)
 
   // SYNTH-18528: the client should not have to handle the merge for partial update
   const newRemoteTest = removeUnsupportedEditTestFields({
     ...existingRemoteTest,
-    ...test.local_test_definition,
+    ...test.localTestDefinition,
     config: {
       ...existingRemoteTest.config,
-      ...test.local_test_definition.config,
+      ...test.localTestDefinition.config,
     },
     options: {
       ...existingRemoteTest.options,
-      ...test.local_test_definition.options,
+      ...test.localTestDefinition.options,
     },
   })
 

--- a/src/commands/synthetics/import-tests-lib.ts
+++ b/src/commands/synthetics/import-tests-lib.ts
@@ -3,6 +3,7 @@ import {writeFile} from 'fs/promises'
 import {getApiHelper} from './api'
 import {
   ImportTestsCommandConfig,
+  LocalTestDefinition,
   LocalTriggerConfig,
   MainReporter,
   ServerTest,
@@ -99,7 +100,7 @@ const overwriteTestConfig = (testConfigFromBackend: TestConfig, testConfigFromFi
   return testConfigFromFile
 }
 
-const removeUnsupportedLTDFields = (testConfig: ServerTest): ServerTest => {
+const removeUnsupportedLTDFields = (testConfig: ServerTest): LocalTestDefinition => {
   for (const field of BASE_FIELDS_TRIM) {
     delete testConfig[field]
   }

--- a/src/commands/synthetics/interfaces.ts
+++ b/src/commands/synthetics/interfaces.ts
@@ -290,6 +290,7 @@ interface Options {
 // TODO SYNTH-17944 Remove unsupported fields
 
 export interface OptionsWithUnsupportedFields extends Options {
+  bindings?: null | unknown[]
   min_failure_duration?: number
   min_location_failed?: any
   monitor_name?: string
@@ -662,4 +663,11 @@ export interface ImportTestsCommandConfig extends SyntheticsCIConfig {
   files: string[]
   publicIds: string[]
   testSearchQuery?: string
+}
+
+export interface DeployTestsCommandConfig extends SyntheticsCIConfig {
+  configPath: string
+  files: string[]
+  publicIds: string[]
+  subdomain: string
 }

--- a/src/commands/synthetics/local-test-definition.ts
+++ b/src/commands/synthetics/local-test-definition.ts
@@ -1,0 +1,18 @@
+import {LocalTriggerConfig, TestConfig} from './interfaces'
+import {isLocalTriggerConfig} from './utils/internal'
+
+export const findUniqueLocalTestDefinition = (testConfig: TestConfig, publicId: string): LocalTriggerConfig => {
+  const matchingTests = testConfig.tests.flatMap((t) =>
+    isLocalTriggerConfig(t) && t.local_test_definition.public_id === publicId ? [t] : []
+  )
+
+  if (matchingTests.length > 1) {
+    throw new Error(`Cannot have multiple local test definitions with same publicId: ${publicId}.`)
+  }
+
+  if (matchingTests.length === 0) {
+    throw new Error(`No local test definition found with publicId ${publicId}.`)
+  }
+
+  return matchingTests[0]
+}

--- a/src/commands/synthetics/local-test-definition.ts
+++ b/src/commands/synthetics/local-test-definition.ts
@@ -3,7 +3,7 @@ import {isLocalTriggerConfig} from './utils/internal'
 
 export const findUniqueLocalTestDefinition = (testConfig: TestConfig, publicId: string): LocalTriggerConfig => {
   const matchingTests = testConfig.tests.flatMap((t) =>
-    isLocalTriggerConfig(t) && t.local_test_definition.public_id === publicId ? [t] : []
+    isLocalTriggerConfig(t) && t.localTestDefinition.public_id === publicId ? [t] : []
   )
 
   if (matchingTests.length > 1) {

--- a/src/commands/synthetics/multilocator.ts
+++ b/src/commands/synthetics/multilocator.ts
@@ -92,8 +92,8 @@ const overwriteMultiLocatorsInTestConfig = (
   for (const publicId of Object.keys(multiLocatorMap)) {
     const test = findUniqueLocalTestDefinition(testConfigFromFile, publicId)
 
-    if (test && test.local_test_definition.steps) {
-      const steps = test.local_test_definition.steps
+    if (test && test.localTestDefinition.steps) {
+      const steps = test.localTestDefinition.steps
       for (const [stepIndex, step] of steps.entries()) {
         const multiLocator = multiLocatorMap[publicId][stepIndex]
         if (multiLocator) {

--- a/src/commands/synthetics/test.ts
+++ b/src/commands/synthetics/test.ts
@@ -15,13 +15,14 @@ import {
   TriggerConfig,
   LocalTestDefinition,
   ImportTestsCommandConfig,
+  DeployTestsCommandConfig,
 } from './interfaces'
 import {DEFAULT_TEST_CONFIG_FILES_GLOB} from './run-tests-command'
 import {isLocalTriggerConfig} from './utils/internal'
 import {getSuites, normalizePublicId} from './utils/public'
 
 export const getTestConfigs = async (
-  config: RunTestsCommandConfig | ImportTestsCommandConfig,
+  config: RunTestsCommandConfig | ImportTestsCommandConfig | DeployTestsCommandConfig,
   reporter: MainReporter,
   suites: Suite[] = []
 ): Promise<TriggerConfig[]> => {
@@ -30,7 +31,13 @@ export const getTestConfigs = async (
   // Only auto-discover with the default glob when the user **doesn't give any clue** about which tests to run.
   // If they give any clue (e.g. `publicIds`) without explicitly passing `files`,
   // they might be running the command from their home folder so we shouldn't auto-discover for performance reasons.
-  if (config.publicIds.length === 0 && files.length === 0 && suites.length === 0 && !config.testSearchQuery) {
+  if (
+    config.publicIds.length === 0 &&
+    files.length === 0 &&
+    suites.length === 0 &&
+    'testSearchQuery' in config &&
+    !config.testSearchQuery
+  ) {
     files.push(DEFAULT_TEST_CONFIG_FILES_GLOB)
   }
 


### PR DESCRIPTION
### What and why?

This PR adds a command to deploy LTDs as main tests. For now, it only supports deploying the LTDs from a single test file.

It also focuses on API tests only. Browser tests will be supported later.

### How?

To deploy all LTDs inside the given file:
```bash
yarn launch synthetics deploy-tests -f path/to/single-test-file.synthetics.json
```

To deploy some LTDs inside the given file:
```bash
yarn launch synthetics deploy-tests -f path/to/single-test-file.synthetics.json -p 123-456-789
```

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
