### PR TITLE
Update code ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,8 +13,8 @@ src/commands/dora          @DataDog/datadog-ci @DataDog/ci-app-libraries
 src/commands/deployment    @DataDog/datadog-ci @DataDog/ci-app-libraries
 
 ## Static Analysis (label: static-analysis)
-src/commands/sarif   @DataDog/datadog-ci @DataDog/static-analysis-core
-src/commands/sbom    @DataDog/datadog-ci @DataDog/static-analysis-core
+src/commands/sarif   @DataDog/datadog-ci @DataDog/k9-vm-ast
+src/commands/sbom    @DataDog/datadog-ci @DataDog/k9-vm-sca
 
 ## RUM (label: rum)
 src/commands/dsyms            @DataDog/datadog-ci @DataDog/rum-mobile


### PR DESCRIPTION
## What problem are you trying to solve?

The `sbom` command should be owned by the `k9-vm-sca` team while the `sarif` command should be owned by the `k9-vm-ast` team.

## Solution

Updating permissions accordingly.