### PR TITLE
[K9VULN-3031] remove service flag

### DIFF
--- a/src/commands/sarif/README.md
+++ b/src/commands/sarif/README.md
@@ -11,19 +11,17 @@ Upload your SARIF report files.
 The `upload` command uploads your SARIF report to Datadog.
 
 ```bash
-datadog-ci sarif upload [--service] [--max-concurrency] [--dry-run] [--no-verify] [--tags] <paths>
+datadog-ci sarif upload [--max-concurrency] [--dry-run] [--no-verify] [--tags] <paths>
 ```
 
 For example:
 
 ```bash
-datadog-ci sarif upload --service my-service --tags key1:value1 --tags key2:value2 sarif-reports/go-reports sarif-reports/java-reports sarif-report/single-report.sarif
+datadog-ci sarif upload --tags key1:value1 --tags key2:value2 sarif-reports/go-reports sarif-reports/java-reports sarif-report/single-report.sarif
 ```
 
 The positional arguments are the directories or file paths in which the SARIF reports are located. If you pass a folder, the CLI looks for all `.sarif` files in it.
-- `--service` should be set to the name of the service you're uploading SARIF reports from.
 - `--tags` is a array of key value pairs of the form `key:value`. This parameter sets global tags applied to all results. The upload process merges the tags passed on the command line with the tags in the `DD_TAGS` environment variable. If a key appears in both `--tags` and `DD_TAGS`, the value in `DD_TAGS` takes precedence.
-- `--env` is a string that represents the environment in which you want your tests to appear.
 - `--max-concurrency` (default: `20`): number of concurrent uploads to the API.
 - `--dry-run` (default: `false`): runs the command without the final upload step. All other checks are performed.
 - `--no-verify` (default: `false`): runs the command without performing report validation on the CLI.
@@ -47,7 +45,7 @@ To verify the command works as expected, use `--dry-run`:
 ```bash
 export DATADOG_API_KEY='<API key>'
 
-yarn launch sarif upload ./src/commands/sarif/__tests__/fixtures/valid-results.sarif --service example-upload --dry-run
+yarn launch sarif upload ./src/commands/sarif/__tests__/fixtures/valid-results.sarif --dry-run
 ```
 
 Successful output looks like the example below:
@@ -56,7 +54,6 @@ Successful output looks like the example below:
 ⚠️ DRY-RUN MODE ENABLED. WILL NOT UPLOAD SARIF REPORT
 Starting upload with concurrency 20.
 Will upload SARIF report file src/commands/sarif/__tests__/fixtures/valid-results.sarif
-service: example-upload
 [DRYRUN] Uploading SARIF report in src/commands/sarif/__tests__/fixtures/valid-results.sarif
 ✅ Uploaded 1 files in 0 seconds.
 ```

--- a/src/commands/sarif/__tests__/upload.test.ts
+++ b/src/commands/sarif/__tests__/upload.test.ts
@@ -52,17 +52,14 @@ describe('upload', () => {
           basePaths: ['./src/commands/sarif/__tests__/fixtures'],
           config: {},
           context,
-          service: 'service',
         },
         {}
       )
 
       expect(firstFile).toMatchObject({
-        service: 'service',
         reportPath: './src/commands/sarif/__tests__/fixtures/valid-no-results.sarif',
       })
       expect(secondFile).toMatchObject({
-        service: 'service',
         reportPath: './src/commands/sarif/__tests__/fixtures/valid-results.sarif',
       })
 
@@ -100,7 +97,6 @@ describe('upload', () => {
           basePaths: ['./src/commands/sarif/__tests__/fixtures/valid-results.sarif'],
           config: {},
           context,
-          service: 'service',
         },
         {}
       )
@@ -108,7 +104,6 @@ describe('upload', () => {
       expect(files.length).toEqual(1)
 
       expect(files[0]).toMatchObject({
-        service: 'service',
         reportPath: './src/commands/sarif/__tests__/fixtures/valid-results.sarif',
       })
     })
@@ -120,7 +115,6 @@ describe('upload', () => {
           basePaths: ['./src/commands/sarif/__tests__/fixtures/does-not-exist.sarif'],
           config: {},
           context,
-          service: 'service',
         },
         {}
       )
@@ -138,20 +132,16 @@ describe('upload', () => {
           ],
           config: {},
           context,
-          service: 'service',
         },
         {}
       )
       expect(firstFile).toMatchObject({
-        service: 'service',
         reportPath: './src/commands/sarif/__tests__/fixtures/valid-no-results.sarif',
       })
       expect(secondFile).toMatchObject({
-        service: 'service',
         reportPath: './src/commands/sarif/__tests__/fixtures/valid-results.sarif',
       })
       expect(thirdFile).toMatchObject({
-        service: 'service',
         reportPath: './src/commands/sarif/__tests__/fixtures/subfolder/valid-results.sarif',
       })
     })
@@ -166,7 +156,6 @@ describe('upload', () => {
           ],
           config: {},
           context,
-          service: 'service',
         },
         {}
       )
@@ -181,10 +170,7 @@ describe('execute', () => {
     const cli = makeCli()
     const context = createMockContext() as any
     process.env = {DATADOG_API_KEY: 'PLACEHOLDER'}
-    const code = await cli.run(
-      ['sarif', 'upload', '--service', 'test-service', '--env', 'ci', '--dry-run', ...paths],
-      context
-    )
+    const code = await cli.run(['sarif', 'upload', '--env', 'ci', '--dry-run', ...paths], context)
 
     return {context, code}
   }
@@ -195,7 +181,6 @@ describe('execute', () => {
     checkConsoleOutput(output, {
       basePaths: ['src/commands/sarif/__tests__/fixtures/subfolder'],
       concurrency: 20,
-      service: 'test-service',
       env: 'ci',
     })
   })
@@ -212,7 +197,6 @@ describe('execute', () => {
         'src/commands/sarif/__tests__/fixtures/another_subfolder/',
       ],
       concurrency: 20,
-      service: 'test-service',
       env: 'ci',
     })
   })
@@ -224,7 +208,6 @@ describe('execute', () => {
     checkConsoleOutput(output, {
       basePaths: [`${process.cwd()}/src/commands/sarif/__tests__/fixtures/subfolder`],
       concurrency: 20,
-      service: 'test-service',
       env: 'ci',
     })
   })
@@ -237,9 +220,9 @@ describe('execute', () => {
     expect(output[0]).toContain('DRY-RUN MODE ENABLED. WILL NOT UPLOAD SARIF REPORT')
     expect(output[1]).toContain('Starting upload with concurrency 20.')
     expect(output[2]).toContain(`Will upload SARIF report file ${path}`)
-    expect(output[3]).toContain('Only one upload per commit, env, service and tool')
+    expect(output[3]).toContain('Only one upload per commit, env and tool')
     expect(output[4]).toContain(`Preparing upload for`)
-    expect(output[4]).toContain(`env:ci service:test-service`)
+    expect(output[4]).toContain(`env:ci`)
   })
 
   test('not found file', async () => {
@@ -247,7 +230,7 @@ describe('execute', () => {
     const output = context.stdout.toString().split(os.EOL)
     const path = `${process.cwd()}/src/commands/sarif/__tests__/fixtures/not-found.sarif`
     expect(code).toBe(1)
-    expect(output[0]).toContain(`Cannot find valid SARIF report files to upload in ${path} for service test-service`)
+    expect(output[0]).toContain(`Cannot find valid SARIF report files to upload in ${path}`)
     expect(output[1]).toContain('Check the files exist and are valid.')
   })
 })
@@ -255,7 +238,6 @@ describe('execute', () => {
 interface ExpectedOutput {
   basePaths: string[]
   concurrency: number
-  service: string
   env: string
 }
 
@@ -263,7 +245,7 @@ const checkConsoleOutput = (output: string[], expected: ExpectedOutput) => {
   expect(output[0]).toContain('DRY-RUN MODE ENABLED. WILL NOT UPLOAD SARIF REPORT')
   expect(output[1]).toContain(`Starting upload with concurrency ${expected.concurrency}.`)
   expect(output[2]).toContain(`Will look for SARIF report files in ${expected.basePaths.join(', ')}`)
-  expect(output[3]).toContain('Only one upload per commit, env, service and tool')
+  expect(output[3]).toContain('Only one upload per commit, env and tool')
   expect(output[4]).toContain(`Preparing upload for`)
-  expect(output[4]).toContain(`env:${expected.env} service:${expected.service}`)
+  expect(output[4]).toContain(`env:${expected.env}`)
 }

--- a/src/commands/sarif/api.ts
+++ b/src/commands/sarif/api.ts
@@ -24,7 +24,7 @@ export const uploadSarifReport = (request: (args: AxiosRequestConfig) => AxiosPr
   write(renderUpload(sarifReport))
 
   const metadata: Record<string, any> = {
-    service: sarifReport.service,
+    service: 'datadog-ci',
     ...sarifReport.spanTags,
     event_type: 'static_analysis',
     event_format_name: 'sarif',

--- a/src/commands/sarif/interfaces.ts
+++ b/src/commands/sarif/interfaces.ts
@@ -7,7 +7,6 @@ import {SpanTags} from '../../helpers/interfaces'
 export interface Payload {
   reportPath: string
   spanTags: SpanTags
-  service: string
 }
 
 export interface APIHelper {

--- a/src/commands/sarif/renderer.ts
+++ b/src/commands/sarif/renderer.ts
@@ -76,7 +76,6 @@ export const renderUpload = (payload: Payload): string => `Uploading SARIF repor
 
 export const renderCommandInfo = (
   basePaths: string[],
-  service: string,
   env: string,
   sha: string,
   concurrency: number,
@@ -98,19 +97,17 @@ export const renderCommandInfo = (
   } else {
     fullStr += chalk.green(`Will look for SARIF report files in ${basePaths.join(', ')}\n`)
   }
-  fullStr += `Only one upload per commit, env, service and tool\n`
-  fullStr += `Preparing upload for sha:${sha} env:${env} service:${service}\n`
+  fullStr += `Only one upload per commit, env and tool\n`
+  fullStr += `Preparing upload for sha:${sha} env:${env}\n`
 
   return fullStr
 }
 
-export const renderFilesNotFound = (basePaths: string[], service: string) => {
+export const renderFilesNotFound = (basePaths: string[]) => {
   let fullStr = ''
   const paths = basePaths.length === 1 && !!path.extname(basePaths[0]) ? basePaths[0] : basePaths.join(', ')
 
-  fullStr += chalk.yellow(
-    `${ICONS.WARNING} Cannot find valid SARIF report files to upload in ${paths} for service ${service}.\n`
-  )
+  fullStr += chalk.yellow(`${ICONS.WARNING} Cannot find valid SARIF report files to upload in ${paths}.\n`)
   fullStr += chalk.yellow(`Check the files exist and are valid.\n`)
 
   return fullStr

--- a/src/commands/sarif/upload.ts
+++ b/src/commands/sarif/upload.ts
@@ -42,7 +42,7 @@ export class UploadSarifReportCommand extends Command {
       See README for details.
     `,
     examples: [
-      ['Upload all SARIF report files in current directory', 'datadog-ci sarif upload.'],
+      ['Upload all SARIF report files in current directory', 'datadog-ci sarif upload .'],
       [
         'Upload all SARIF report files in src/sarif-go-reports and src/sarif-java-reports',
         'datadog-ci sarif upload src/sarif-go-reports src/sarif-java-reports',
@@ -53,7 +53,7 @@ export class UploadSarifReportCommand extends Command {
       ],
       [
         'Upload all SARIF report files in current directory to the datadoghq.eu site',
-        'DATADOG_SITE=datadoghq.eu datadog-ci sarif upload.',
+        'DATADOG_SITE=datadoghq.eu datadog-ci sarif upload .',
       ],
     ],
   })

--- a/src/commands/sarif/upload.ts
+++ b/src/commands/sarif/upload.ts
@@ -83,7 +83,7 @@ export class UploadSarifReportCommand extends Command {
   public async execute() {
     enableFips(this.fips || this.fipsConfig.fips, this.fipsIgnoreError || this.fipsConfig.fipsIgnoreError)
 
-   // TODO(julien): remove this notice in April 2025
+    // TODO(julien): remove this notice in April 2025
     if (this.serviceFromCli) {
       this.context.stderr.write(
         'The CLI flag `--service` is deprecated and will be removed in a future version of datadog-ci\n'

--- a/src/commands/sbom/README.md
+++ b/src/commands/sbom/README.md
@@ -14,11 +14,6 @@ This command lets you upload SBOM files to the Datadog intake endpoint.
 datadog-ci sbom upload <path/to/sbom.json>
 ```
 
-### Optional arguments
-
-- `--service` should be set to the name of the service you're uploading SBOM reports from.
-- `--env` is a string that represents the environment in which you want your tests to appear.
-
 ### Environment variables
 
 The following environment variables must be defined:
@@ -32,7 +27,7 @@ The following environment variables must be defined:
 When developing software, you can try with the following command:
 
 ```bash
-yarn launch sbom upload --service <your-service> --env <your-environment> /path/to/sbom.json
+yarn launch sbom upload /path/to/sbom.json
 ```
 
 ## Further reading

--- a/src/commands/sbom/README.md
+++ b/src/commands/sbom/README.md
@@ -14,6 +14,10 @@ This command lets you upload SBOM files to the Datadog intake endpoint.
 datadog-ci sbom upload <path/to/sbom.json>
 ```
 
+### Optional arguments
+
+- `--env` is a string that represents the environment in which you want your tests to appear.
+
 ### Environment variables
 
 The following environment variables must be defined:

--- a/src/commands/sbom/upload.ts
+++ b/src/commands/sbom/upload.ts
@@ -41,11 +41,11 @@ export class UploadSbomCommand extends Command {
     details: `
       This command uploads SBOM files to Datadog for dependency tracking.
     `,
-    examples: [['Upload the SBOM file sbom.json', 'datadog-ci sbom upload --service my-service file.sbom']],
+    examples: [['Upload the SBOM file sbom.json', 'datadog-ci sbom upload file.sbom']],
   })
 
   private basePath = Option.String()
-  private service = Option.String('--service', 'datadog-ci')
+  private serviceFromCli = Option.String('--service')
   private env = Option.String('--env', 'ci')
   private tags = Option.Array('--tags')
   private debug = Option.Boolean('--debug')
@@ -73,7 +73,20 @@ export class UploadSbomCommand extends Command {
   public async execute() {
     enableFips(this.fips || this.fipsConfig.fips, this.fipsIgnoreError || this.fipsConfig.fipsIgnoreError)
 
-    const service: string = this.service
+    // remove this notice in April 2025
+    if (this.serviceFromCli !== undefined) {
+      this.context.stderr.write(
+        'CLI flag --service is deprecated and will be removed in future versions of datadog-ci\n'
+      )
+      this.context.stderr.write(
+        'To associate findings with services, consider using service/repo mapping from service catalog\n'
+      )
+      this.context.stderr.write(
+        'Learn more at https://docs.datadoghq.com/getting_started/code_security/?tab=staticcodeanalysissast#link-datadog-services-to-repository-scan-results\n'
+      )
+    }
+
+    const service = 'datadog-ci'
 
     const environment = this.env
 


### PR DESCRIPTION
### What and why?

We want to deprecate the `--service` flag as this is no longer used and service is being mapped based on the repo and service mapping.

### How?

1. We deprecate the flag for now instead or removing it completely to avoid customers failure
2. We will transition GitHub actions and remove it from GitHub actions
3. Around April 2025, we will completely remove the flag. It should give customers enough time to transition by then and our GitHub actions will be updated.


## Testing
![Screenshot 2025-01-30 at 12 26 37 PM](https://github.com/user-attachments/assets/34c5f295-44c1-46ed-a817-ebc596b8345c)
![Screenshot 2025-01-30 at 12 27 44 PM](https://github.com/user-attachments/assets/c6031f4c-2fc9-44b0-b0e1-fe17e5c27b1d)

