### PR TITLE
[SYNTH-18215] Save multilocator in ltd

### DIFF
--- a/src/commands/synthetics/__tests__/multilocator.test.ts
+++ b/src/commands/synthetics/__tests__/multilocator.test.ts
@@ -71,7 +71,9 @@ describe('multilocator', () => {
 
       expect(tests.getTestConfigs).not.toHaveBeenCalled()
       expect(fsPromises.writeFile).not.toHaveBeenCalled()
-      expect(mockReporter.log).toHaveBeenCalledWith(expect.stringContaining('No MultiLocator updates found. No changes will be made.'))
+      expect(mockReporter.log).toHaveBeenCalledWith(
+        expect.stringContaining('No MultiLocator updates found. No changes will be made.')
+      )
     })
 
     test('should not overwrite file if user declines update prompt', async () => {

--- a/src/commands/synthetics/__tests__/multilocator.test.ts
+++ b/src/commands/synthetics/__tests__/multilocator.test.ts
@@ -71,6 +71,7 @@ describe('multilocator', () => {
 
       expect(tests.getTestConfigs).not.toHaveBeenCalled()
       expect(fsPromises.writeFile).not.toHaveBeenCalled()
+      expect(mockReporter.log).toHaveBeenCalledWith(expect.stringContaining('No MultiLocator updates found. No changes will be made.'))
     })
 
     test('should not overwrite file if user declines update prompt', async () => {
@@ -80,6 +81,7 @@ describe('multilocator', () => {
 
       expect(tests.getTestConfigs).not.toHaveBeenCalled()
       expect(fsPromises.writeFile).not.toHaveBeenCalled()
+      expect(mockReporter.log).toHaveBeenCalledWith(expect.stringContaining('MultiLocator updates aborted by user.'))
     })
 
     test('should handle errors during file write gracefully', async () => {
@@ -88,7 +90,7 @@ describe('multilocator', () => {
       await expect(updateLTDMultiLocators(mockReporter, mockConfig, mockResults)).resolves.not.toThrow()
 
       expect(fsPromises.writeFile).toHaveBeenCalled()
-      expect(mockReporter.error).toHaveBeenCalledWith(expect.stringContaining('Error writing file'))
+      expect(mockReporter.error).toHaveBeenCalledWith(expect.stringContaining('Error writing to file'))
     })
     test('should throw an error if multiple LTDs with the same publicId are found', async () => {
       mockTestConfig.tests.push({

--- a/src/commands/synthetics/__tests__/multilocator.test.ts
+++ b/src/commands/synthetics/__tests__/multilocator.test.ts
@@ -1,7 +1,7 @@
 jest.mock('fs/promises')
 import * as fsPromises from 'fs/promises'
 
-import {ImportTestsCommandConfig, TestConfig, Result} from '../interfaces'
+import {ImportTestsCommandConfig, Result, LocalTestDefinition} from '../interfaces'
 import * as multilocator from '../multilocator'
 import {updateLTDMultiLocators} from '../multilocator'
 import * as tests from '../test'
@@ -11,7 +11,11 @@ import {getBrowserTest, getBrowserResult, mockReporter, getStep} from './fixture
 describe('multilocator', () => {
   let mockConfig: ImportTestsCommandConfig
   let mockResults: Result[]
-  let mockTestConfig: TestConfig
+  let mockTestConfig: {tests: {local_test_definition: LocalTestDefinition}[]}
+
+  const browserTest = getBrowserTest('test-1')
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  const {message, monitor_id, status, tags, ...baseBrowserLTD} = browserTest
 
   beforeEach(() => {
     jest.restoreAllMocks()
@@ -19,7 +23,7 @@ describe('multilocator', () => {
 
     mockConfig = {files: ['test.json']} as ImportTestsCommandConfig
     mockResults = [
-      getBrowserResult('result-1', getBrowserTest('test-1'), {
+      getBrowserResult('result-1', browserTest, {
         stepDetails: [
           getStep(), // Step 0 (ignored)
           getStep(),
@@ -31,12 +35,13 @@ describe('multilocator', () => {
       tests: [
         {
           local_test_definition: {
+            ...baseBrowserLTD,
             public_id: 'test-1',
             steps: [{params: {element: {}}}, {params: {element: {}}}],
           },
         },
       ],
-    } as TestConfig
+    }
 
     jest.spyOn(tests, 'getTestConfigs').mockResolvedValue(mockTestConfig.tests)
     jest.spyOn(multilocator, 'promptUser').mockResolvedValue(true)
@@ -47,9 +52,9 @@ describe('multilocator', () => {
     test('should update MultiLocators when updates exist and user confirms', async () => {
       await updateLTDMultiLocators(mockReporter, mockConfig, mockResults)
 
-      const testDefinition = mockTestConfig.tests[0] as any
       expect(tests.getTestConfigs).toHaveBeenCalledWith(mockConfig, mockReporter)
-      expect(testDefinition.local_test_definition.steps[1].params.element.multiLocator).toEqual({
+      const steps = mockTestConfig.tests[0].local_test_definition.steps ?? []
+      expect(steps[1].params.element?.multiLocator).toEqual({
         ab: 'xpath-1',
       })
       expect(fsPromises.writeFile).toHaveBeenCalledWith('test.json', expect.any(String), 'utf8')
@@ -84,6 +89,31 @@ describe('multilocator', () => {
 
       expect(fsPromises.writeFile).toHaveBeenCalled()
       expect(mockReporter.error).toHaveBeenCalledWith(expect.stringContaining('Error writing file'))
+    })
+    test('should throw an error if multiple LTDs with the same publicId are found', async () => {
+      mockTestConfig.tests.push({
+        local_test_definition: {
+          ...baseBrowserLTD,
+          public_id: 'test-1', // Duplicate public_id
+          steps: [{params: {element: {}}}],
+        },
+      })
+
+      await expect(updateLTDMultiLocators(mockReporter, mockConfig, mockResults)).rejects.toThrow(
+        `Cannot have multiple local test definitions with same publicId: test-1.`
+      )
+
+      expect(fsPromises.writeFile).not.toHaveBeenCalled()
+    })
+
+    test('should throw an error if no LTD with the publicId is found', async () => {
+      jest.spyOn(tests, 'getTestConfigs').mockResolvedValue([])
+
+      await expect(updateLTDMultiLocators(mockReporter, mockConfig, mockResults)).rejects.toThrow(
+        `No local test definition found with publicId test-1.`
+      )
+
+      expect(fsPromises.writeFile).not.toHaveBeenCalled()
     })
   })
 })

--- a/src/commands/synthetics/__tests__/multilocator.test.ts
+++ b/src/commands/synthetics/__tests__/multilocator.test.ts
@@ -1,0 +1,89 @@
+jest.mock('fs/promises')
+import * as fsPromises from 'fs/promises'
+
+import {ImportTestsCommandConfig, TestConfig, Result} from '../interfaces'
+import * as multilocator from '../multilocator'
+import {updateLTDMultiLocators} from '../multilocator'
+import * as tests from '../test'
+
+import {getBrowserTest, getBrowserResult, mockReporter, getStep} from './fixtures'
+
+describe('multilocator', () => {
+  let mockConfig: ImportTestsCommandConfig
+  let mockResults: Result[]
+  let mockTestConfig: TestConfig
+
+  beforeEach(() => {
+    jest.restoreAllMocks()
+    jest.clearAllMocks()
+
+    mockConfig = {files: ['test.json']} as ImportTestsCommandConfig
+    mockResults = [
+      getBrowserResult('result-1', getBrowserTest('test-1'), {
+        stepDetails: [
+          getStep(), // Step 0 (ignored)
+          getStep(),
+          {...getStep(), stepElementUpdates: {multiLocator: {ab: 'xpath-1'}}},
+        ],
+      }),
+    ]
+    mockTestConfig = {
+      tests: [
+        {
+          local_test_definition: {
+            public_id: 'test-1',
+            steps: [{params: {element: {}}}, {params: {element: {}}}],
+          },
+        },
+      ],
+    } as TestConfig
+
+    jest.spyOn(tests, 'getTestConfigs').mockResolvedValue(mockTestConfig.tests)
+    jest.spyOn(multilocator, 'promptUser').mockResolvedValue(true)
+    jest.spyOn(fsPromises, 'writeFile').mockImplementation(async () => Promise.resolve())
+  })
+
+  describe('updateLTDMultiLocators', () => {
+    test('should update MultiLocators when updates exist and user confirms', async () => {
+      await updateLTDMultiLocators(mockReporter, mockConfig, mockResults)
+
+      const testDefinition = mockTestConfig.tests[0] as any
+      expect(tests.getTestConfigs).toHaveBeenCalledWith(mockConfig, mockReporter)
+      expect(testDefinition.local_test_definition.steps[1].params.element.multiLocator).toEqual({
+        ab: 'xpath-1',
+      })
+      expect(fsPromises.writeFile).toHaveBeenCalledWith('test.json', expect.any(String), 'utf8')
+    })
+
+    test('should not modify tests when no MultiLocators exist', async () => {
+      mockResults = [
+        getBrowserResult('result-1', getBrowserTest('test-1'), {
+          stepDetails: [getStep(), {...getStep(), stepElementUpdates: {}}], // No ML updates
+        }),
+      ]
+
+      await updateLTDMultiLocators(mockReporter, mockConfig, mockResults)
+
+      expect(tests.getTestConfigs).not.toHaveBeenCalled()
+      expect(fsPromises.writeFile).not.toHaveBeenCalled()
+    })
+
+    test('should not overwrite file if user declines update prompt', async () => {
+      jest.spyOn(multilocator, 'promptUser').mockResolvedValue(false)
+
+      await updateLTDMultiLocators(mockReporter, mockConfig, mockResults)
+
+      expect(tests.getTestConfigs).not.toHaveBeenCalled()
+      expect(fsPromises.writeFile).not.toHaveBeenCalled()
+    })
+
+    test('should handle errors during file write gracefully', async () => {
+      jest.spyOn(fsPromises, 'writeFile').mockRejectedValue(new Error('Write failed'))
+
+      await expect(updateLTDMultiLocators(mockReporter, mockConfig, mockResults)).resolves.not.toThrow()
+
+      expect(fsPromises.writeFile).toHaveBeenCalled()
+      expect(mockReporter.error).toHaveBeenCalledWith(expect.stringContaining('Error writing file'))
+    })
+  })
+})

--- a/src/commands/synthetics/errors.ts
+++ b/src/commands/synthetics/errors.ts
@@ -22,6 +22,7 @@ const criticalErrorCodes = [
   'INVALID_MOBILE_APP_UPLOAD_PARAMETERS',
   'MOBILE_APP_UPLOAD_TIMEOUT',
   'UNKNOWN_MOBILE_APP_UPLOAD_FAILURE',
+  'LTD_MULTILOCATORS_UPDATE_FAILED',
 ] as const
 export type CriticalCiErrorCode = typeof criticalErrorCodes[number]
 

--- a/src/commands/synthetics/import-tests-lib.ts
+++ b/src/commands/synthetics/import-tests-lib.ts
@@ -42,13 +42,13 @@ const STEP_FIELDS_TRIM: (keyof TestStepWithUnsupportedFields)[] = ['public_id']
 
 export const importTests = async (reporter: MainReporter, config: ImportTestsCommandConfig): Promise<void> => {
   const api = getApiHelper(config)
-  console.log('Importing tests...')
+  reporter.log('Importing tests...\n')
   const testConfigFromBackend: TestConfig = {
     tests: [],
   }
 
   for (const publicId of config.publicIds) {
-    console.log(`Fetching test with public_id: ${publicId}`)
+    reporter.log(`Fetching test with public_id: ${publicId}\n`)
     let localTriggerConfig: LocalTriggerConfig
     const test = await api.getTest(publicId)
 
@@ -56,7 +56,7 @@ export const importTests = async (reporter: MainReporter, config: ImportTestsCom
       const testWithSteps = await api.getTestWithType(publicId, test.type)
       localTriggerConfig = {local_test_definition: removeUnsupportedLTDFields(testWithSteps)}
     } else if (test.type === 'mobile') {
-      console.error('Unsupported test type: mobile')
+      reporter.error('Unsupported test type: mobile\n')
 
       return
     } else {
@@ -75,9 +75,9 @@ export const importTests = async (reporter: MainReporter, config: ImportTestsCom
   const jsonString = JSON.stringify(testConfig, null, 2)
   try {
     await writeFile(config.files[0], jsonString, 'utf8')
-    console.log(`Object has been written to ${config.files[0]}`)
+    reporter.log(`Object has been written to ${config.files[0]}\n`)
   } catch (error) {
-    console.error('Error writing file:', error)
+    reporter.error(`Error writing file: ${error}\n`)
   }
 }
 

--- a/src/commands/synthetics/import-tests-lib.ts
+++ b/src/commands/synthetics/import-tests-lib.ts
@@ -71,11 +71,10 @@ export const importTests = async (reporter: MainReporter, config: ImportTestsCom
 
   const testConfig = overwriteTestConfig(testConfigFromBackend, testConfigFromFile)
 
-  // eslint-disable-next-line no-null/no-null
-  const jsonString = JSON.stringify(testConfig, null, 2)
+  const jsonString = JSON.stringify(testConfig, undefined, 2)
   try {
     await writeFile(config.files[0], jsonString, 'utf8')
-    reporter.log(`Object has been written to ${config.files[0]}\n`)
+    reporter.log(`Local test definition written to ${config.files[0]}\n`)
   } catch (error) {
     reporter.error(`Error writing file: ${error}\n`)
   }
@@ -111,7 +110,7 @@ const removeUnsupportedLTDFields = (testConfig: ServerTest): ServerTest => {
   for (const step of testConfig.steps || []) {
     if ('element' in step.params && !!step.params.element) {
       if ('multiLocator' in step.params.element && !!step.params.element.multiLocator) {
-        if ('ab' in step.params.element.multiLocator && !!step.params.element.multiLocator.ab) {
+        if ('ab' in step.params.element.multiLocator && typeof step.params.element.multiLocator.ab === 'string') {
           if (!step.params.element.userLocator) {
             step.params.element.userLocator = {
               values: [

--- a/src/commands/synthetics/interfaces.ts
+++ b/src/commands/synthetics/interfaces.ts
@@ -236,7 +236,7 @@ export interface Step {
 }
 
 export interface MultiLocator {
-  [key: string]: any
+  [key: string]: unknown
 }
 
 // TODO SYNTH-17944 Remove unsupported fields
@@ -246,7 +246,7 @@ export interface TestStepWithUnsupportedFields {
   params: {
     element?: {
       multiLocator?: MultiLocator
-      userLocator?: any
+      userLocator?: unknown
     }
   }
 }

--- a/src/commands/synthetics/interfaces.ts
+++ b/src/commands/synthetics/interfaces.ts
@@ -220,6 +220,9 @@ export interface Step {
   publicId?: string
   skipped: boolean
   stepId: number
+  stepElementUpdates?: {
+    multiLocator?: MultiLocator
+  }
   subTestPublicId?: string
   subTestStepDetails?: Step[]
   type: string
@@ -232,11 +235,20 @@ export interface Step {
   }[]
 }
 
+export interface MultiLocator {
+  [key: string]: any
+}
+
 // TODO SYNTH-17944 Remove unsupported fields
 
 export interface TestStepWithUnsupportedFields {
   public_id?: string
-  params: any
+  params: {
+    element?: {
+      multiLocator?: MultiLocator
+      userLocator?: any
+    }
+  }
 }
 
 export interface LocalTestDefinition {

--- a/src/commands/synthetics/multilocator.ts
+++ b/src/commands/synthetics/multilocator.ts
@@ -37,7 +37,7 @@ export const updateLTDMultiLocators = async (
     'MultiLocator updates found. Do you want to apply them to your local test definition?'
   )
   if (!userConfirmed) {
-    return reporter.log('\nMultilocator updates aborted by user.\n')
+    return reporter.log('\nMultiLocator updates aborted by user.\n')
   }
 
   reporter.log('\nApplying MultiLocator updates...\n\n')
@@ -50,13 +50,13 @@ export const updateLTDMultiLocators = async (
   try {
     // eslint-disable-next-line no-null/no-null
     await writeFile(config.files[0], JSON.stringify(testConfig, null, 2), 'utf8')
-    reporter.log(`${ICONS.SUCCESS} Multilocator updates have been successfully applied in ${config.files[0]}\n`)
+    reporter.log(`${ICONS.SUCCESS} MultiLocator updates have been successfully applied in ${config.files[0]}\n`)
   } catch (error) {
-    reporter.error(`${ICONS.FAILED} Error writing file: ${error}\n`)
+    reporter.error(`${ICONS.FAILED} Error writing to file: ${error}\n`)
   }
 }
 
-export const getMultiLocatorsFromResults = (results: Result[]): MultiLocatorMap => {
+const getMultiLocatorsFromResults = (results: Result[]): MultiLocatorMap => {
   const multiLocatorMap: MultiLocatorMap = {}
 
   for (const result of results) {
@@ -87,8 +87,8 @@ const isBaseResult = (result: Result): result is BaseResult => {
   return (result as BaseResult).result !== undefined
 }
 
-const isBrowserServerResult = (result: ServerResult): result is BrowserServerResult => {
-  return (result as BrowserServerResult).stepDetails !== undefined
+const isBrowserServerResult = (serverResult: ServerResult): serverResult is BrowserServerResult => {
+  return (serverResult as BrowserServerResult).stepDetails !== undefined
 }
 
 export const promptUser = async (message: string): Promise<boolean> => {
@@ -111,7 +111,7 @@ const overwriteMultiLocatorsInTestConfig = (
     const test = findUniqueLocalTestDefinition(testConfigFromFile, publicId)
 
     if (test && isLocalTriggerConfig(test) && test.local_test_definition.steps) {
-      const steps = test.local_test_definition.steps || []
+      const steps = test.local_test_definition.steps
       for (const [stepIndex, step] of steps.entries()) {
         const multiLocator = multiLocatorMap[publicId][stepIndex]
         if (multiLocator) {

--- a/src/commands/synthetics/multilocator.ts
+++ b/src/commands/synthetics/multilocator.ts
@@ -1,0 +1,134 @@
+import {writeFile} from 'fs/promises'
+
+import inquirer from 'inquirer'
+
+import {
+  Result,
+  BaseResult,
+  MultiLocator,
+  ServerResult,
+  BrowserServerResult,
+  TestConfig,
+  ImportTestsCommandConfig,
+  MainReporter,
+} from './interfaces'
+import {ICONS} from './reporters/constants'
+import {getTestConfigs} from './test'
+import {isLocalTriggerConfig} from './utils/internal'
+
+type MultiLocatorMap = {[key: string]: (MultiLocator | undefined)[]}
+
+export const updateLTDMultiLocators = async (
+  reporter: MainReporter,
+  config: ImportTestsCommandConfig,
+  results: Result[]
+) => {
+  reporter.log('Checking for MultiLocator updates...\r')
+  const multiLocatorMap = getMultiLocatorsFromResults(results)
+
+  const hasMLUpdates = Object.values(multiLocatorMap).some((steps) => steps.some((ml) => ml !== undefined))
+
+  if (!hasMLUpdates) {
+    return reporter.log('No MultiLocator updates found. No changes will be made.\n')
+  }
+
+  const userConfirmed = await promptUser(
+    'MultiLocator updates found. Do you want to apply them to your local test definition?'
+  )
+  if (!userConfirmed) {
+    return reporter.log('\nMultilocator updates aborted by user.\n')
+  }
+
+  reporter.log('\nApplying MultiLocator updates...\n\n')
+  const testConfigFromFile: TestConfig = {
+    tests: await getTestConfigs(config, reporter),
+  }
+
+  const testConfig = overwriteMultiLocatorsInTestConfig(multiLocatorMap, testConfigFromFile)
+
+  try {
+    // eslint-disable-next-line no-null/no-null
+    await writeFile(config.files[0], JSON.stringify(testConfig, null, 2), 'utf8')
+    reporter.log(`${ICONS.SUCCESS} Multilocator updates have been successfully applied in ${config.files[0]}\n`)
+  } catch (error) {
+    reporter.error(`${ICONS.FAILED} Error writing file: ${error}\n`)
+  }
+}
+
+export const getMultiLocatorsFromResults = (results: Result[]): MultiLocatorMap => {
+  const multiLocatorMap: MultiLocatorMap = {}
+
+  for (const result of results) {
+    const publicId = result.test.public_id
+    if (publicId === undefined) {
+      continue
+    }
+
+    const stepMLUpdates: (MultiLocator | undefined)[] = []
+
+    if (isBaseResult(result) && result.result && isBrowserServerResult(result.result)) {
+      const steps = result.result.stepDetails.slice(1) // Skip first step (navigation)
+      for (const step of steps) {
+        const multiLocator = step.stepElementUpdates?.multiLocator
+        stepMLUpdates.push(multiLocator)
+      }
+    }
+
+    if (stepMLUpdates.some((ml) => ml !== undefined)) {
+      multiLocatorMap[publicId] = stepMLUpdates
+    }
+  }
+
+  return multiLocatorMap
+}
+
+const isBaseResult = (result: Result): result is BaseResult => {
+  return (result as BaseResult).result !== undefined
+}
+
+const isBrowserServerResult = (result: ServerResult): result is BrowserServerResult => {
+  return (result as BrowserServerResult).stepDetails !== undefined
+}
+
+export const promptUser = async (message: string): Promise<boolean> => {
+  const question: inquirer.ConfirmQuestion<{confirm: boolean}> = {
+    type: 'confirm',
+    name: 'confirm',
+    message,
+    default: false,
+  }
+  const {confirm} = await inquirer.prompt([question])
+
+  return confirm
+}
+
+const overwriteMultiLocatorsInTestConfig = (
+  multiLocatorMap: MultiLocatorMap,
+  testConfigFromFile: TestConfig
+): TestConfig => {
+  for (const publicId of Object.keys(multiLocatorMap)) {
+    const index = testConfigFromFile.tests.findIndex(
+      (t) => isLocalTriggerConfig(t) && t.local_test_definition.public_id === publicId
+    )
+
+    if (index !== -1) {
+      const test = testConfigFromFile.tests[index]
+      if (isLocalTriggerConfig(test) && test.local_test_definition.steps) {
+        const steps = test.local_test_definition.steps || []
+        for (const [stepIndex, step] of steps.entries()) {
+          const multiLocator = multiLocatorMap[publicId][stepIndex]
+          if (multiLocator) {
+            if (step.params.element === undefined) {
+              throw new Error(`[Multilocator Update] Step ${stepIndex} in test ${publicId} does not have an element`)
+            }
+            step.params.element.multiLocator = multiLocator
+          }
+        }
+      }
+    } else {
+      throw new Error(`[Multilocator Update] Could not find test with publicId ${publicId} in the local test config`)
+    }
+  }
+
+  return testConfigFromFile
+}

--- a/src/commands/synthetics/multilocator.ts
+++ b/src/commands/synthetics/multilocator.ts
@@ -14,7 +14,7 @@ export const updateLTDMultiLocators = async (
   config: ImportTestsCommandConfig,
   results: Result[]
 ) => {
-  reporter.log('Checking for MultiLocator updates...\r')
+  reporter.log('Checking for MultiLocator updates...\r') // replaced by next log
   const multiLocatorMap = getMultiLocatorsFromResults(results)
 
   const hasMLUpdates = Object.values(multiLocatorMap).some((steps) => steps.some((ml) => ml !== undefined))

--- a/src/commands/synthetics/run-tests-lib.ts
+++ b/src/commands/synthetics/run-tests-lib.ts
@@ -190,6 +190,10 @@ export const executeTests = async (
       throw error
     }
 
+    if (error instanceof CriticalError && error.code === 'LTD_MULTILOCATORS_UPDATE_FAILED') {
+      throw error
+    }
+
     throw new CriticalError('POLL_RESULTS_FAILED', error.message)
   } finally {
     await stopTunnel()

--- a/src/commands/synthetics/run-tests-lib.ts
+++ b/src/commands/synthetics/run-tests-lib.ts
@@ -21,6 +21,7 @@ import {
   TriggerConfig,
   WrapperConfig,
 } from './interfaces'
+import {updateLTDMultiLocators} from './multilocator'
 import {DefaultReporter, getTunnelReporter} from './reporters/default'
 import {JUnitReporter} from './reporters/junit'
 import {DEFAULT_BATCH_TIMEOUT, DEFAULT_COMMAND_CONFIG} from './run-tests-command'
@@ -170,6 +171,12 @@ export const executeTests = async (
       reporter,
       tunnel
     )
+
+    try {
+      await updateLTDMultiLocators(reporter, config, results)
+    } catch (error) {
+      throw new CriticalError('LTD_MULTILOCATORS_UPDATE_FAILED', error.message)
+    }
 
     return {
       results,

--- a/src/commands/synthetics/utils/internal.ts
+++ b/src/commands/synthetics/utils/internal.ts
@@ -5,6 +5,7 @@ import {
   BaseResult,
   BaseTestPayload,
   BasicAuthCredentials,
+  BrowserServerResult,
   CookiesObject,
   ExecutionRule,
   LocalTriggerConfig,
@@ -93,6 +94,10 @@ export const isTimedOutRetry = (
 
 export const isLocalTriggerConfig = (triggerConfig?: TriggerConfig): triggerConfig is LocalTriggerConfig => {
   return triggerConfig ? 'local_test_definition' in triggerConfig : false
+}
+
+export const isBrowserServerResult = (serverResult: ServerResult): serverResult is BrowserServerResult => {
+  return (serverResult as BrowserServerResult).stepDetails !== undefined
 }
 
 export const getTriggerConfigPublicId = (triggerConfig: TriggerConfig): string | undefined => {

--- a/src/commands/synthetics/utils/public.ts
+++ b/src/commands/synthetics/utils/public.ts
@@ -891,6 +891,11 @@ export const reportCiError = (error: CiError, reporter: MainReporter) => {
     case 'UNAVAILABLE_TUNNEL_CONFIG':
       reporter.error(`\n${chalk.bgRed.bold(' ERROR: unable to get tunnel configuration ')}\n${error.message}\n\n`)
       break
+    case 'LTD_MULTILOCATORS_UPDATE_FAILED':
+      reporter.error(
+        `\n${chalk.bgRed.bold(' ERROR: unable to update multilocators in local test definition')}\n${error.message}\n\n`
+      )
+      break
 
     default:
       reporter.error(`\n${chalk.bgRed.bold(' ERROR ')}\n${error.message}\n\n`)


### PR DESCRIPTION
### What and why?

This PR implements Multilocator updates in local test definitions. 

### How?

We parse the Multilocator from the poll_results response, prompt the user asking if he wants to update his local test definitions with the new Multilocator and then save the changes in the selected file with `-f` (only works with 1 file, just like the `import-test` function )

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
