### PR TITLE
Add quiet option to sourcemap upload

### DIFF
--- a/src/commands/sourcemaps/README.md
+++ b/src/commands/sourcemaps/README.md
@@ -42,6 +42,7 @@ In addition, some optional parameters are available:
 
 * `--max-concurrency` (default: `20`): number of concurrent upload to the API.
 * `--disable-git` (default: false): prevents the command from invoking git in the current working directory and sending repository related data to Datadog (hash, remote URL and the paths within the repository of the sources referenced in the sourcemap).
+* `--quiet` (default: false): suppresses individual line output for each upload. Success and error logs are never suppressed.
 * `--dry-run` (default: `false`): it will run the command without the final step of upload. All other checks are performed.
 * `--project-path` (default: empty): the path of the project where the sourcemaps were built. This will be stripped off from sources paths referenced in the sourcemap so they can be properly matched against tracked files paths. See details in the [dedicated section](#setting-the-project-path).
 * `--repository-url` (default: empty): overrides the repository remote with a custom URL. For example: https://github.com/my-company/my-project

--- a/src/commands/sourcemaps/upload.ts
+++ b/src/commands/sourcemaps/upload.ts
@@ -60,6 +60,7 @@ export class UploadCommand extends Command {
 
   private basePath = Option.String({required: true})
   private disableGit = Option.Boolean('--disable-git')
+  private quiet = Option.Boolean('--quiet', false)
   private dryRun = Option.Boolean('--dry-run', false)
   private maxConcurrency = Option.String('--max-concurrency', '20', {validator: validation.isInteger()})
   private minifiedPathPrefix = Option.String('--minified-path-prefix')
@@ -323,6 +324,9 @@ export class UploadCommand extends Command {
           metricsLogger.logger.increment('retries', 1)
         },
         onUpload: () => {
+          if (this.quiet) {
+            return
+          }
           this.context.stdout.write(renderUpload(sourcemap))
         },
         retries: 5,


### PR DESCRIPTION
### What and why?

Adds a quiet option to sourcemap uploads

### How?

Adds a --quiet flag.