### PR TITLE
[SYNTH-18427] Change `local_test_definition` back to `localTestDefinition`

### DIFF
--- a/src/commands/synthetics/__tests__/import-tests-lib.test.ts
+++ b/src/commands/synthetics/__tests__/import-tests-lib.test.ts
@@ -31,7 +31,7 @@ describe('import-tests', () => {
       const mockLTD = {
         tests: [
           {
-            local_test_definition: {
+            localTestDefinition: {
               ...mockTestWithoutUnsupportedFields,
             },
           },
@@ -68,13 +68,13 @@ describe('import-tests', () => {
       const mockLTD = {
         tests: [
           {
-            local_test_definition: {
+            localTestDefinition: {
               ...mockTestWithoutUnsupportedFields,
               public_id: config['publicIds'][0],
             },
           },
           {
-            local_test_definition: {
+            localTestDefinition: {
               ...mockTestWithoutUnsupportedFields,
               public_id: config['publicIds'][1],
             },
@@ -113,7 +113,7 @@ describe('import-tests', () => {
       const mockLTD = {
         tests: [
           {
-            local_test_definition: {
+            localTestDefinition: {
               ...mockTestWithoutUnsupportedFields,
             },
           },
@@ -152,13 +152,13 @@ describe('import-tests', () => {
 
       const mockTriggerConfig: TriggerConfig[] = [
         {
-          local_test_definition: {
+          localTestDefinition: {
             ...mockTest,
             public_id: 'abc-def-ghi',
           },
         },
         {
-          local_test_definition: {
+          localTestDefinition: {
             ...mockTest,
             public_id: config['publicIds'][0],
           },
@@ -170,20 +170,20 @@ describe('import-tests', () => {
       const expectedLTD = {
         tests: [
           {
-            local_test_definition: {
+            localTestDefinition: {
               ...mockTest,
               public_id: 'abc-def-ghi',
             },
           },
           {
-            local_test_definition: {
+            localTestDefinition: {
               ...mockTestWithoutUnsupportedFields,
               public_id: config['publicIds'][0],
               name: 'Some other name',
             },
           },
           {
-            local_test_definition: {
+            localTestDefinition: {
               ...mockTestWithoutUnsupportedFields,
               public_id: config['publicIds'][1],
             },

--- a/src/commands/synthetics/__tests__/multilocator.test.ts
+++ b/src/commands/synthetics/__tests__/multilocator.test.ts
@@ -11,7 +11,7 @@ import {getBrowserTest, getBrowserResult, mockReporter, getStep} from './fixture
 describe('multilocator', () => {
   let mockConfig: ImportTestsCommandConfig
   let mockResults: Result[]
-  let mockTestConfig: {tests: {local_test_definition: LocalTestDefinition}[]}
+  let mockTestConfig: {tests: {localTestDefinition: LocalTestDefinition}[]}
 
   const browserTest = getBrowserTest('test-1')
   // eslint-disable-next-line @typescript-eslint/naming-convention
@@ -34,7 +34,7 @@ describe('multilocator', () => {
     mockTestConfig = {
       tests: [
         {
-          local_test_definition: {
+          localTestDefinition: {
             ...baseBrowserLTD,
             public_id: 'test-1',
             steps: [{params: {element: {}}}, {params: {element: {}}}],
@@ -53,7 +53,7 @@ describe('multilocator', () => {
       await updateLTDMultiLocators(mockReporter, mockConfig, mockResults)
 
       expect(tests.getTestConfigs).toHaveBeenCalledWith(mockConfig, mockReporter)
-      const steps = mockTestConfig.tests[0].local_test_definition.steps ?? []
+      const steps = mockTestConfig.tests[0].localTestDefinition.steps ?? []
       expect(steps[1].params.element?.multiLocator).toEqual({
         ab: 'xpath-1',
       })
@@ -96,7 +96,7 @@ describe('multilocator', () => {
     })
     test('should throw an error if multiple LTDs with the same publicId are found', async () => {
       mockTestConfig.tests.push({
-        local_test_definition: {
+        localTestDefinition: {
           ...baseBrowserLTD,
           public_id: 'test-1', // Duplicate public_id
           steps: [{params: {element: {}}}],

--- a/src/commands/synthetics/__tests__/run-tests-lib.test.ts
+++ b/src/commands/synthetics/__tests__/run-tests-lib.test.ts
@@ -1078,7 +1078,7 @@ describe('run-test', () => {
               },
             },
             {
-              local_test_definition: localTestDefinition,
+              localTestDefinition,
               testOverrides: {
                 startUrl: 'fakeUrl',
               },
@@ -1095,7 +1095,7 @@ describe('run-test', () => {
           testOverrides: {startUrl: 'fakeUrl'},
         },
         {
-          local_test_definition: localTestDefinition,
+          localTestDefinition,
           suite: 'Suite with local test definitions',
           testOverrides: {startUrl: 'fakeUrl'},
         },
@@ -1115,7 +1115,7 @@ describe('run-test', () => {
               },
             },
             {
-              local_test_definition: localTestDefinition,
+              localTestDefinition,
               testOverrides: {
                 startUrl: 'fakeUrl',
               },
@@ -1129,7 +1129,7 @@ describe('run-test', () => {
         runTests.getTriggerConfigs(fakeApi, {...ciConfig, files: ['glob'], publicIds: ['bbb-bbb-bbb']}, mockReporter)
       ).resolves.toEqual([
         {
-          local_test_definition: localTestDefinition,
+          localTestDefinition,
           suite: 'Suite with local test definitions',
           testOverrides: {startUrl: 'fakeUrl'},
         },

--- a/src/commands/synthetics/import-tests-lib.ts
+++ b/src/commands/synthetics/import-tests-lib.ts
@@ -54,13 +54,13 @@ export const importTests = async (reporter: MainReporter, config: ImportTestsCom
 
     if (test.type === 'browser') {
       const testWithSteps = await api.getTestWithType(publicId, test.type)
-      localTriggerConfig = {local_test_definition: removeUnsupportedLTDFields(testWithSteps)}
+      localTriggerConfig = {localTestDefinition: removeUnsupportedLTDFields(testWithSteps)}
     } else if (test.type === 'mobile') {
       reporter.error('Unsupported test type: mobile\n')
 
       return
     } else {
-      localTriggerConfig = {local_test_definition: removeUnsupportedLTDFields(test)}
+      localTriggerConfig = {localTestDefinition: removeUnsupportedLTDFields(test)}
     }
     testConfigFromBackend.tests.push(localTriggerConfig)
   }
@@ -86,7 +86,7 @@ const overwriteTestConfig = (testConfigFromBackend: TestConfig, testConfigFromFi
       (t) =>
         isLocalTriggerConfig(t) &&
         isLocalTriggerConfig(test) &&
-        t.local_test_definition.public_id === test.local_test_definition.public_id
+        t.localTestDefinition.public_id === test.localTestDefinition.public_id
     )
 
     if (index !== -1) {

--- a/src/commands/synthetics/interfaces.ts
+++ b/src/commands/synthetics/interfaces.ts
@@ -483,7 +483,7 @@ export interface RemoteTriggerConfig extends BaseTriggerConfig {
   id: string
 }
 export interface LocalTriggerConfig extends BaseTriggerConfig {
-  local_test_definition: LocalTestDefinition
+  localTestDefinition: LocalTestDefinition
 }
 export type TriggerConfig = RemoteTriggerConfig | LocalTriggerConfig
 

--- a/src/commands/synthetics/multilocator.ts
+++ b/src/commands/synthetics/multilocator.ts
@@ -91,8 +91,8 @@ const overwriteMultiLocatorsInTestConfig = (
   for (const publicId of Object.keys(multiLocatorMap)) {
     const test = findUniqueLocalTestDefinition(testConfigFromFile, publicId)
 
-    if (test && isLocalTriggerConfig(test) && test.local_test_definition.steps) {
-      const steps = test.local_test_definition.steps
+    if (test && isLocalTriggerConfig(test) && test.localTestDefinition.steps) {
+      const steps = test.localTestDefinition.steps
       for (const [stepIndex, step] of steps.entries()) {
         const multiLocator = multiLocatorMap[publicId][stepIndex]
         if (multiLocator) {
@@ -109,7 +109,7 @@ const overwriteMultiLocatorsInTestConfig = (
 }
 const findUniqueLocalTestDefinition = (testConfig: TestConfig, publicId: string): TriggerConfig => {
   const matchingTests = testConfig.tests.filter(
-    (t) => isLocalTriggerConfig(t) && t.local_test_definition.public_id === publicId
+    (t) => isLocalTriggerConfig(t) && t.localTestDefinition.public_id === publicId
   )
 
   if (matchingTests.length > 1) {

--- a/src/commands/synthetics/test.ts
+++ b/src/commands/synthetics/test.ts
@@ -51,7 +51,7 @@ export const getTestConfigs = async (
           testOverrides: replaceConfigWithTestOverrides(test.config, test.testOverrides),
           suite: suite.name,
           ...(isLocalTriggerConfig(test)
-            ? {local_test_definition: normalizeLocalTestDefinition(test.local_test_definition)}
+            ? {localTestDefinition: normalizeLocalTestDefinition(test.localTestDefinition)}
             : {id: normalizePublicId(test.id) ?? ''}),
         }
       })
@@ -87,7 +87,7 @@ export const getTest = async (
 ): Promise<{test: Test} | {errorMessage: string}> => {
   if (isLocalTriggerConfig(triggerConfig)) {
     const test = {
-      ...triggerConfig.local_test_definition,
+      ...triggerConfig.localTestDefinition,
       suite: triggerConfig.suite,
     }
 

--- a/src/commands/synthetics/utils/internal.ts
+++ b/src/commands/synthetics/utils/internal.ts
@@ -93,7 +93,7 @@ export const isTimedOutRetry = (
 }
 
 export const isLocalTriggerConfig = (triggerConfig?: TriggerConfig): triggerConfig is LocalTriggerConfig => {
-  return triggerConfig ? 'local_test_definition' in triggerConfig : false
+  return triggerConfig ? 'localTestDefinition' in triggerConfig : false
 }
 
 export const isBrowserServerResult = (serverResult: ServerResult): serverResult is BrowserServerResult => {
@@ -102,7 +102,7 @@ export const isBrowserServerResult = (serverResult: ServerResult): serverResult 
 
 export const getTriggerConfigPublicId = (triggerConfig: TriggerConfig): string | undefined => {
   if (isLocalTriggerConfig(triggerConfig)) {
-    return triggerConfig.local_test_definition.public_id
+    return triggerConfig.localTestDefinition.public_id
   }
 
   return triggerConfig.id

--- a/src/commands/synthetics/utils/public.ts
+++ b/src/commands/synthetics/utils/public.ts
@@ -82,7 +82,7 @@ export const makeTestPayload = (test: Test, triggerConfig: TriggerConfig, public
   if (isLocalTriggerConfig(triggerConfig)) {
     return {
       ...getBasePayload(test, triggerConfig.testOverrides),
-      local_test_definition: triggerConfig.local_test_definition,
+      local_test_definition: triggerConfig.localTestDefinition,
     }
   }
 


### PR DESCRIPTION
### What and why?

We want all top-level properties in `.synthetics.json` files to be camelCase. The `localTestDefinition` property contains an LTD object that the backend can accept verbatim (i.e. it includes some properties in snake_case).

### How?

Rename properties

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
