### PR TITLE
Remove deprecated features

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,20 +105,6 @@ jobs:
           DD_API_KEY: ${{ secrets.DD_API_KEY_CI_VISIBILITY }}
           DD_APP_KEY: ${{ secrets.DD_APP_KEY_CI_VISIBILITY }}
           DD_SERVICE: datadog-ci-e2e-tests-junit
-      - name: Run junit upload test (metrics), passing glob as literal string
-        run: yarn datadog-ci junit upload --service=datadog-ci-e2e-tests-junit '**/junit-reports/**' --metrics testmeasure2:60 --report-metrics sessionmeasure2:80
-        env:
-          DD_API_KEY: ${{ secrets.DD_API_KEY_CI_VISIBILITY }}
-      - name: Check that test data can be queried (metrics)
-        run: |
-          yarn add @datadog/datadog-api-client
-          yarn check-junit-upload
-        env:
-          EXTRA_TEST_QUERY_FILTER: '@testmeasure2:60'
-          EXTRA_SESSION_QUERY_FILTER: '@sessionmeasure2:80'
-          DD_API_KEY: ${{ secrets.DD_API_KEY_CI_VISIBILITY }}
-          DD_APP_KEY: ${{ secrets.DD_APP_KEY_CI_VISIBILITY }}
-          DD_SERVICE: datadog-ci-e2e-tests-junit
       - name: Run sarif upload test
         run: yarn datadog-ci sarif upload --service=datadog-ci-e2e-tests-sarif artifacts/e2e/sarif-reports
         env:

--- a/src/commands/git-metadata/upload.ts
+++ b/src/commands/git-metadata/upload.ts
@@ -37,8 +37,6 @@ export class UploadCommand extends Command {
     details: `
       This command will upload the commit details to Datadog in order to create links to your repositories inside Datadog's UI.\n
       See README for details.
-
-      Option --git-sync is DEPRECATED and will be removed in a future version.
     `,
     examples: [['Upload the current commit details', 'datadog-ci report-commits upload']],
   })
@@ -46,7 +44,6 @@ export class UploadCommand extends Command {
   private repositoryURL = Option.String('--repository-url')
   private dryRun = Option.Boolean('--dry-run', false)
   private verbose = Option.Boolean('--verbose', false)
-  private gitSync = Option.Boolean('--git-sync', false)
   private noGitSync = Option.Boolean('--no-gitsync', false)
   private directory = Option.String('--directory', '')
 
@@ -92,10 +89,6 @@ export class UploadCommand extends Command {
       )
 
       return 1
-    }
-
-    if (this.gitSync) {
-      this.logger.warn('Option --git-sync is deprecated as it is now the default behavior')
     }
 
     const metricsLogger = getMetricsLogger({

--- a/src/commands/junit/__tests__/upload.test.ts
+++ b/src/commands/junit/__tests__/upload.test.ts
@@ -348,24 +348,6 @@ describe('upload', () => {
         key2: 'value2',
       })
     })
-    test('should parse metrics argument', async () => {
-      const context = createMockContext()
-      const stdoutWriteSpy = jest.spyOn(context.stdout, 'write')
-      const command = new UploadJUnitXMLCommand()
-      const spanTags: SpanTags = command['getCustomMeasures'].call({
-        config: {},
-        context,
-        metrics: ['key1:10', 'key2:20'],
-      })
-
-      expect(stdoutWriteSpy).toHaveBeenCalledWith(
-        '⚠️ The "--metrics" option is deprecated. Please use the "--measures" option instead.\n'
-      )
-      expect(spanTags).toMatchObject({
-        key1: 10,
-        key2: 20,
-      })
-    })
     test('should parse measures argument', async () => {
       const context = createMockContext()
       const command = new UploadJUnitXMLCommand()
@@ -378,28 +360,6 @@ describe('upload', () => {
       expect(spanTags).toMatchObject({
         key1: 10,
         key2: 20,
-      })
-    })
-    test('should parse DD_METRICS environment variable', async () => {
-      process.env.DD_METRICS = 'key1:321,key2:123,key3:321.1,key4:abc,key5:-12.1'
-      const context = createMockContext()
-      const stdoutWriteSpy = jest.spyOn(context.stdout, 'write')
-      const command = new UploadJUnitXMLCommand()
-      const spanTags: SpanTags = command['getCustomMeasures'].call({
-        config: {
-          envVarMetrics: process.env.DD_METRICS,
-        },
-        context,
-      })
-
-      expect(stdoutWriteSpy).toHaveBeenCalledWith(
-        '⚠️ The "DD_METRICS" environment variable is deprecated. Please use the "DD_MEASURES" environment variable instead.\n'
-      )
-      expect(spanTags).toMatchObject({
-        key1: 321,
-        key2: 123,
-        key3: 321.1,
-        key5: -12.1,
       })
     })
     test('should parse DD_MEASURES environment variable', async () => {
@@ -432,24 +392,6 @@ describe('upload', () => {
       expect(spanTags).toMatchObject({
         key1: 'value1',
         key2: 'value2',
-      })
-    })
-    test('should parse report metrics argument', async () => {
-      const context = createMockContext()
-      const stdoutWriteSpy = jest.spyOn(context.stdout, 'write')
-      const command = new UploadJUnitXMLCommand()
-      const spanTags: SpanTags = command['getReportMeasures'].call({
-        config: {},
-        context,
-        reportMetrics: ['key1:20', 'key2:30'],
-      })
-
-      expect(stdoutWriteSpy).toHaveBeenCalledWith(
-        '⚠️ The "--report-metrics" option is deprecated. Please use the "--report-measures" option instead.\n'
-      )
-      expect(spanTags).toMatchObject({
-        key1: 20,
-        key2: 30,
       })
     })
     test('should parse report measures argument', async () => {

--- a/src/commands/junit/renderer.ts
+++ b/src/commands/junit/renderer.ts
@@ -35,12 +35,6 @@ export const renderRetriedUpload = (payload: Payload, errorMessage: string, atte
   return chalk.yellow(`[attempt ${attempt}] Retrying jUnitXML upload ${jUnitXMLPath}: ${errorMessage}\n`)
 }
 
-export const renderDeprecatedMention = (deprecatedMention: string, newMention: string, deprecatedType: string) => {
-  return chalk.yellow(
-    `${ICONS.WARNING} The "${deprecatedMention}" ${deprecatedType} is deprecated. Please use the "${newMention}" ${deprecatedType} instead.\n`
-  )
-}
-
 export const renderSuccessfulUpload = (dryRun: boolean, fileCount: number, duration: number) => {
   return chalk.green(`${dryRun ? '[DRYRUN] ' : ''}${ICONS.SUCCESS} Uploaded ${fileCount} files in ${duration} seconds.`)
 }

--- a/src/commands/junit/upload.ts
+++ b/src/commands/junit/upload.ts
@@ -40,7 +40,6 @@ import {
   renderSuccessfulGitDBSync,
   renderSuccessfulUpload,
   renderUpload,
-  renderDeprecatedMention,
 } from './renderer'
 import {isFile} from './utils'
 
@@ -122,12 +121,10 @@ export class UploadJUnitXMLCommand extends Command {
     validator: t.isBoolean(),
   })
   private maxConcurrency = Option.String('--max-concurrency', '20', {validator: validation.isInteger()})
-  private metrics = Option.Array('--metrics', {hidden: true})
   private measures = Option.Array('--measures')
   private service = Option.String('--service', {env: 'DD_SERVICE'})
   private tags = Option.Array('--tags')
   private reportTags = Option.Array('--report-tags')
-  private reportMetrics = Option.Array('--report-metrics', {hidden: true})
   private reportMeasures = Option.Array('--report-measures')
   private rawXPathTags = Option.Array('--xpath-tag')
   private gitRepositoryURL = Option.String('--git-repository-url')
@@ -353,19 +350,9 @@ export class UploadJUnitXMLCommand extends Command {
   private getCustomMeasures(): Record<string, number> {
     const envVarMetrics = this.config.envVarMetrics ? parseMetrics(this.config.envVarMetrics.split(',')) : {}
     const envVarMeasures = this.config.envVarMeasures ? parseMetrics(this.config.envVarMeasures.split(',')) : {}
-    const cliMetrics = this.metrics ? parseMetrics(this.metrics) : {}
     const cliMeasures = this.measures ? parseMetrics(this.measures) : {}
 
-    // We have renamed "metrics" to "measures", but we will still support the old names for now.
-    if (this.metrics) {
-      this.context.stdout.write(renderDeprecatedMention('--metrics', '--measures', 'option'))
-    }
-    if (this.config.envVarMetrics) {
-      this.context.stdout.write(renderDeprecatedMention('DD_METRICS', 'DD_MEASURES', 'environment variable'))
-    }
-
     return {
-      ...cliMetrics,
       ...cliMeasures,
       ...envVarMetrics,
       ...envVarMeasures,
@@ -377,16 +364,9 @@ export class UploadJUnitXMLCommand extends Command {
   }
 
   private getReportMeasures(): Record<string, number> {
-    const cliMetrics = this.reportMetrics ? parseMetrics(this.reportMetrics) : {}
     const cliMeasures = this.reportMeasures ? parseMetrics(this.reportMeasures) : {}
 
-    // We have renamed "metrics" to "measures", but we will still support the old names for now.
-    if (this.reportMetrics) {
-      this.context.stdout.write(renderDeprecatedMention('--report-metrics', '--report-measures', 'option'))
-    }
-
     return {
-      ...cliMetrics,
       ...cliMeasures,
     }
   }

--- a/src/commands/measure/__tests__/measure.test.ts
+++ b/src/commands/measure/__tests__/measure.test.ts
@@ -1,4 +1,3 @@
-import chalk from 'chalk'
 import {Cli} from 'clipanion/lib/advanced'
 
 import {MeasureCommand, parseMeasures} from '../measure'
@@ -109,37 +108,6 @@ describe('execute', () => {
     expect(code).toBe(1)
     expect(context.stderr.toString()).toContain(
       'Only providers [GitHub, GitLab, CircleCI, Buildkite, Jenkins, TeamCity, AzurePipelines] are supported'
-    )
-  })
-})
-
-describe('warnings when deprecated metric mentioned', () => {
-  test('should warn if metric command is used', async () => {
-    const cli = makeCLI()
-    const context = createMockContext() as any
-    await cli.run(['metric', '--level', 'pipeline', '--measures', 'key:1'], context)
-    expect(context.stdout.toString()).toBe(
-      chalk.yellow('[WARN] The "metric" command is deprecated. Please use the "measure" command instead.\n')
-    )
-  })
-
-  test('should double warn if metric command is used with metrics option', async () => {
-    const cli = makeCLI()
-    const context = createMockContext() as any
-    await cli.run(['metric', '--level', 'pipeline', '--metrics', 'key:1'], context)
-    expect(context.stdout.toString()).toBe(
-      chalk.yellow(
-        '[WARN] The "metric" command is deprecated. Please use the "measure" command instead.\n[WARN] The "--metrics" flag is deprecated. Please use "--measures" flag instead.\n'
-      )
-    )
-  })
-
-  test('should warn if metrics flag is used', async () => {
-    const cli = makeCLI()
-    const context = createMockContext() as any
-    await cli.run(['measure', '--level', 'pipeline', '--metrics', 'key:1'], context)
-    expect(context.stdout.toString()).toBe(
-      chalk.yellow('[WARN] The "--metrics" flag is deprecated. Please use "--measures" flag instead.\n')
     )
   })
 })

--- a/src/commands/measure/measure.ts
+++ b/src/commands/measure/measure.ts
@@ -30,7 +30,7 @@ export const parseMeasures = (measures: string[]) =>
   }, {})
 
 export class MeasureCommand extends Command {
-  public static paths = [['measure'], ['metric']]
+  public static paths = [['measure']]
 
   public static usage = Command.Usage({
     category: 'CI Visibility',
@@ -50,7 +50,6 @@ export class MeasureCommand extends Command {
   })
 
   private level = Option.String('--level')
-  private metrics = Option.Array('--metrics', {hidden: true})
   private measures = Option.Array('--measures')
   private measuresFile = Option.String('--measures-file')
   private noFail = Option.Boolean('--no-fail')
@@ -67,29 +66,17 @@ export class MeasureCommand extends Command {
   public async execute() {
     enableFips(this.fips || this.config.fips, this.fipsIgnoreError || this.config.fipsIgnoreError)
 
-    if (this.path[0] === 'metric') {
-      this.context.stdout.write(
-        chalk.yellow(`[WARN] The "metric" command is deprecated. Please use the "measure" command instead.\n`)
-      )
-    }
-
     if (this.level !== 'pipeline' && this.level !== 'job') {
       this.context.stderr.write(`${chalk.red.bold('[ERROR]')} Level must be one of [pipeline, job]\n`)
 
       return 1
     }
 
-    const cliMeasures: string[] | undefined = this.measures || this.metrics
+    const cliMeasures: string[] | undefined = this.measures
     if (!cliMeasures && !this.measuresFile) {
       this.context.stderr.write(`${chalk.red.bold('[ERROR]')} --measures or --measures-file is required\n`)
 
       return 1
-    }
-
-    if (this.metrics) {
-      this.context.stdout.write(
-        `${chalk.yellow.yellow(`[WARN] The "--metrics" flag is deprecated. Please use "--measures" flag instead.\n`)}`
-      )
     }
 
     const [measuresFromFile, valid] = parseMeasuresFile(this.context, this.measuresFile)

--- a/src/helpers/tags.ts
+++ b/src/helpers/tags.ts
@@ -24,8 +24,6 @@ export const CI_JOB_URL = 'ci.job.url'
 export const CI_JOB_NAME = 'ci.job.name'
 export const CI_STAGE_NAME = 'ci.stage.name'
 export const CI_LEVEL = '_dd.ci.level'
-// @deprecated TODO: remove this once backend is updated
-export const CI_BUILD_LEVEL = '_dd.ci.build_level'
 
 export const CI_ENV_VARS = '_dd.ci.env_vars'
 export const CI_NODE_NAME = 'ci.node.name'

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -98,28 +98,6 @@ export const resolveConfigFromFile = async <T>(
   return deepExtend(baseConfig, parsedConfig)
 }
 
-/**
- * @deprecated Use resolveConfigFromFile instead for better error management
- */
-export const parseConfigFile = async <T>(baseConfig: T, configPath?: string): Promise<T> => {
-  try {
-    const resolvedConfigPath = configPath ?? 'datadog-ci.json'
-    const parsedConfig = await getConfig(resolvedConfigPath)
-
-    return deepExtend(baseConfig, parsedConfig)
-  } catch (e) {
-    if (e.code === 'ENOENT' && configPath) {
-      throw new Error('Config file not found')
-    }
-
-    if (e instanceof SyntaxError) {
-      throw new Error('Config file is not correct JSON')
-    }
-  }
-
-  return baseConfig
-}
-
 type ProxyType =
   | 'http'
   | 'https'


### PR DESCRIPTION
### What and why?

This PR cleans up a few deprecated options and helpers to prepare for the **next major release: datadog-ci v3.0**

Details will be listed in a migration guide like https://github.com/DataDog/dd-trace-js/blob/master/MIGRATING.md

### How?

Remove deprecated options, logic, and tests.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
