### PR TITLE
[SYNTH-12989] Remove deprecated CLI parameters

### DIFF
--- a/src/commands/synthetics/README.md
+++ b/src/commands/synthetics/README.md
@@ -201,7 +201,6 @@ The following is a list of the changes:
 
 * The `global` field from the global configuration file is deprecated in favor of `defaultTestOverrides`.
 * The `config` field from the test configuration file is deprecated in favor of `testOverrides`.
-* The env variable `DATADOG_SYNTHETICS_LOCATIONS` has been deprecated in favor of `DATADOG_SYNTHETICS_OVERRIDE_LOCATIONS`
 
 ## Run Tests Command
 

--- a/src/commands/synthetics/README.md
+++ b/src/commands/synthetics/README.md
@@ -201,8 +201,6 @@ The following is a list of the changes:
 
 * The `global` field from the global configuration file is deprecated in favor of `defaultTestOverrides`.
 * The `config` field from the test configuration file is deprecated in favor of `testOverrides`.
-* The `pollingTimeout` option and `--pollingTimeout` CLI parameter, that were on the **Global Configuration** level, are deprecated in favor of `batchTimeout` and `--batchTimeout`, respectively.
-* The `pollingTimeout` option, on the **Test Configuration** level, is deprecated in favor of `batchTimeout` in the global configuration file, or the `--batchTimeout` CLI parameter.
 * The env variable `DATADOG_SYNTHETICS_LOCATIONS` has been deprecated in favor of `DATADOG_SYNTHETICS_OVERRIDE_LOCATIONS`
 
 ## Run Tests Command

--- a/src/commands/synthetics/__tests__/cli.test.ts
+++ b/src/commands/synthetics/__tests__/cli.test.ts
@@ -570,7 +570,7 @@ describe('run-test', () => {
             testTimeout: toNumber(overrideEnv.DATADOG_SYNTHETICS_OVERRIDE_TEST_TIMEOUT),
             variables: toStringMap(overrideEnv.DATADOG_SYNTHETICS_OVERRIDE_VARIABLES),
 
-            // Added to make test pass, we currently don't have an ENV variable for `mobileApplicationVersionFilePath`.
+            // XXX: Added to make the test pass as we don't have an ENV variable for `mobileApplicationVersionFilePath`.
             mobileApplicationVersionFilePath: configFile.defaultTestOverrides.mobileApplicationVersionFilePath,
           },
           failOnCriticalErrors: toBoolean(overrideEnv.DATADOG_SYNTHETICS_FAIL_ON_CRITICAL_ERRORS),
@@ -584,9 +584,10 @@ describe('run-test', () => {
           testSearchQuery: overrideEnv.DATADOG_SYNTHETICS_TEST_SEARCH_QUERY,
           tunnel: toBoolean(overrideEnv.DATADOG_SYNTHETICS_TUNNEL),
 
-          // All the following variables should be removed in the future, as they are either deprecated or misaligned (no ENV variable for now)
           // TODO SYNTH-12989: Clean up deprecated `global` in favor of `defaultTestOverrides`
           global: {},
+
+          // XXX: Added to make the test pass as we use well-known ENV variables to configure the proxy.
           proxy: configFile.proxy,
         }
 
@@ -706,8 +707,7 @@ describe('run-test', () => {
 
         await command['resolveConfig']()
 
-        // TODO SYNTH-12989: Clean up deprecated `global`, `mobileApplicationVersionFilePath`, `proxy`, etc.
-        // This fixes are only here for the test to run, and to maintain backward compatibility.
+        // TODO SYNTH-12989: Clean up deprecated `global`
         const {mobileApplicationVersionFilePath, ...filteredOverrideCLI} = overrideCLI
         const expectedCLIOverrideResult = {
           ...filteredOverrideCLI,
@@ -872,8 +872,7 @@ describe('run-test', () => {
 
         await command['resolveConfig']()
 
-        // TODO SYNTH-12989: Clean up deprecated `global`, `mobileApplicationVersionFilePath`, `proxy` etc.
-        // This fixes are only here for the test to run, and to maintain backward compatibility.
+        // TODO SYNTH-12989: Clean up deprecated `global`
         const {mobileApplicationVersionFilePath, ...filteredOverrideCLI} = overrideCLI
         const expectedCLIOverrideResult = {
           ...filteredOverrideCLI,

--- a/src/commands/synthetics/__tests__/cli.test.ts
+++ b/src/commands/synthetics/__tests__/cli.test.ts
@@ -28,7 +28,6 @@ test('all option flags are supported', async () => {
     'appKey',
     'config',
     'datadogSite',
-    'deviceIds',
     'failOnCriticalErrors',
     'failOnMissingTests',
     'failOnTimeout',
@@ -327,8 +326,6 @@ describe('run-test', () => {
       command['batchTimeout'] = overrideCLI.batchTimeout
       command['configPath'] = overrideCLI.configPath
       command['datadogSite'] = overrideCLI.datadogSite
-      // TODO SYNTH-12989: Clean up deprecated `--deviceIds` in favor of `--override deviceIds="dev1;dev2;..."`
-      command['deviceIds'] = ['my-old-device']
       command['failOnCriticalErrors'] = overrideCLI.failOnCriticalErrors
       command['failOnMissingTests'] = overrideCLI.failOnMissingTests
       command['failOnTimeout'] = overrideCLI.failOnTimeout
@@ -423,19 +420,6 @@ describe('run-test', () => {
         subdomain: 'new-sub-domain',
         testSearchQuery: 'a-search-query',
         tunnel: true,
-      })
-    })
-
-    // TODO SYNTH-12989: Clean up deprecated `--deviceIds` in favor of `--override deviceIds="dev1;dev2;..."`
-    test("CLI parameter '--deviceIds' still works (deprecated)", async () => {
-      const command = createCommand(RunTestsCommand)
-      command['deviceIds'] = ['dev1', 'dev2']
-      await command['resolveConfig']()
-      expect(command['config']).toEqual({
-        ...DEFAULT_COMMAND_CONFIG,
-        defaultTestOverrides: {
-          deviceIds: ['dev1', 'dev2'],
-        },
       })
     })
 
@@ -681,8 +665,6 @@ describe('run-test', () => {
         command['batchTimeout'] = overrideCLI.batchTimeout
         command['configPath'] = overrideCLI.configPath
         command['datadogSite'] = overrideCLI.datadogSite
-        // TODO SYNTH-12989: Clean up deprecated `--deviceIds` in favor of `--override deviceIds="dev1;dev2;..."`
-        command['deviceIds'] = ['my-old-device']
         command['failOnCriticalErrors'] = overrideCLI.failOnCriticalErrors
         command['failOnMissingTests'] = overrideCLI.failOnMissingTests
         command['failOnTimeout'] = overrideCLI.failOnTimeout
@@ -849,8 +831,6 @@ describe('run-test', () => {
         command['batchTimeout'] = overrideCLI.batchTimeout
         command['configPath'] = overrideCLI.configPath
         command['datadogSite'] = overrideCLI.datadogSite
-        // TODO SYNTH-12989: Clean up deprecated `--deviceIds` in favor of `--override deviceIds="dev1;dev2;..."`
-        command['deviceIds'] = ['my-old-device']
         command['failOnCriticalErrors'] = overrideCLI.failOnCriticalErrors
         command['failOnMissingTests'] = overrideCLI.failOnMissingTests
         command['failOnTimeout'] = overrideCLI.failOnTimeout
@@ -1087,8 +1067,6 @@ describe('run-test', () => {
           variables: {cliVar1: 'value1', cliVar2: 'value2'},
         }
 
-        // TODO SYNTH-12989: Clean up deprecated `--deviceIds` in favor of `--override deviceIds="dev1;dev2;..."`
-        command['deviceIds'] = ['my-old-device']
         command['mobileApplicationVersion'] = defaultTestOverrides.mobileApplicationVersion
         command['overrides'] = [
           `allowInsecureCertificates=${defaultTestOverrides.allowInsecureCertificates}`,

--- a/src/commands/synthetics/__tests__/cli.test.ts
+++ b/src/commands/synthetics/__tests__/cli.test.ts
@@ -75,8 +75,6 @@ describe('run-test', () => {
         DATADOG_SYNTHETICS_FAIL_ON_TIMEOUT: 'false',
         DATADOG_SYNTHETICS_FILES: 'test-file1;test-file2;test-file3',
         DATADOG_SYNTHETICS_JUNIT_REPORT: 'junit-report.xml',
-        // TODO SYNTH-12989: Clean up `locations` that should only be part of the testOverrides
-        DATADOG_SYNTHETICS_LOCATIONS: 'Wonderland;FarFarAway',
         DATADOG_SYNTHETICS_PUBLIC_IDS: 'a-public-id;another-public-id',
         DATADOG_SYNTHETICS_SELECTIVE_RERUN: 'true',
         DATADOG_SYNTHETICS_TEST_SEARCH_QUERY: 'a-search-query',
@@ -255,8 +253,6 @@ describe('run-test', () => {
           variables: {titleVariable: 'new value'},
         },
         jUnitReport: 'junit-report.xml',
-        // TODO SYNTH-12989: Clean up `locations` that should only be part of test overrides
-        locations: [],
         proxy: {
           protocol: 'https',
         },
@@ -512,8 +508,6 @@ describe('run-test', () => {
         // TODO SYNTH-12989: Clean up deprecated `global` in favor of `defaultTestOverrides`
         global: {},
         jUnitReport: 'junit-report-from-config-file.xml',
-        // TODO SYNTH-12989: Clean up `locations` that should only be part of the testOverrides
-        locations: ['location_1_from_config_file', 'location_2_from_config_file'],
         proxy: {protocol: 'http'},
         publicIds: ['public-id-from-config-file'],
         selectiveRerun: false,
@@ -542,8 +536,6 @@ describe('run-test', () => {
           DATADOG_SYNTHETICS_FAIL_ON_TIMEOUT: 'true',
           DATADOG_SYNTHETICS_FILES: '1_from_env.json;2_from_env.json',
           DATADOG_SYNTHETICS_JUNIT_REPORT: 'junit-report-from-env.xml',
-          // TODO SYNTH-12989: Clean up `locations` that should only be part of the testOverrides
-          DATADOG_SYNTHETICS_LOCATIONS: 'Wonderland;FarFarAway',
           DATADOG_SYNTHETICS_PUBLIC_IDS: 'a-public-id-from-env;another-public-id-from-env',
           DATADOG_SYNTHETICS_SELECTIVE_RERUN: 'true',
           DATADOG_SYNTHETICS_TEST_SEARCH_QUERY: 'a-search-query-from-env',
@@ -602,7 +594,6 @@ describe('run-test', () => {
             executionRule: toExecutionRule(overrideEnv.DATADOG_SYNTHETICS_OVERRIDE_EXECUTION_RULE),
             followRedirects: toBoolean(overrideEnv.DATADOG_SYNTHETICS_OVERRIDE_FOLLOW_REDIRECTS),
             headers: toStringMap(overrideEnv.DATADOG_SYNTHETICS_OVERRIDE_HEADERS),
-            // TODO SYNTH-12989: Clean up `locations` that should only be part of the testOverrides
             locations: overrideEnv.DATADOG_SYNTHETICS_OVERRIDE_LOCATIONS.split(';'),
             mobileApplicationVersion: overrideEnv.DATADOG_SYNTHETICS_OVERRIDE_MOBILE_APPLICATION_VERSION,
             resourceUrlSubstitutionRegexes: overrideEnv.DATADOG_SYNTHETICS_OVERRIDE_RESOURCE_URL_SUBSTITUTION_REGEXES?.split(
@@ -634,8 +625,6 @@ describe('run-test', () => {
           // All the following variables should be removed in the future, as they are either deprecated or misaligned (no ENV variable for now)
           // TODO SYNTH-12989: Clean up deprecated `global` in favor of `defaultTestOverrides`
           global: {},
-          // TODO SYNTH-12989: Clean up `locations` that should only be part of the testOverrides
-          locations: configFile.locations,
           proxy: configFile.proxy,
           variableStrings: configFile.variableStrings,
         }
@@ -767,7 +756,6 @@ describe('run-test', () => {
         const {mobileApplicationVersionFilePath, ...filteredOverrideCLI} = overrideCLI
         const expectedCLIOverrideResult = {
           ...filteredOverrideCLI,
-          locations: configFile.locations,
           global: {},
           defaultTestOverrides: {
             ...defaultTestOverrides,
@@ -794,8 +782,6 @@ describe('run-test', () => {
           DATADOG_SYNTHETICS_FAIL_ON_TIMEOUT: 'true',
           DATADOG_SYNTHETICS_FILES: '1_from_env.json;2_from_env.json',
           DATADOG_SYNTHETICS_JUNIT_REPORT: 'junit-report-from-env.xml',
-          // TODO SYNTH-12989: Clean up `locations` that should only be part of the testOverrides
-          DATADOG_SYNTHETICS_LOCATIONS: 'Wonderland;FarFarAway',
           DATADOG_SYNTHETICS_PUBLIC_IDS: 'a-public-id-from-env;another-public-id-from-env',
           DATADOG_SYNTHETICS_SELECTIVE_RERUN: 'true',
           DATADOG_SYNTHETICS_TEST_SEARCH_QUERY: 'a-search-query-from-env',
@@ -938,12 +924,11 @@ describe('run-test', () => {
 
         await command['resolveConfig']()
 
-        // TODO SYNTH-12989: Clean up deprecated `global`, `location`, `variableStrings`, `mobileApplicationVersionFilePath`, `proxy` etc.
+        // TODO SYNTH-12989: Clean up deprecated `global`, `variableStrings`, `mobileApplicationVersionFilePath`, `proxy` etc.
         // This fixes are only here for the test to run, and to maintain backward compatibility.
         const {mobileApplicationVersionFilePath, ...filteredOverrideCLI} = overrideCLI
         const expectedCLIOverrideResult = {
           ...filteredOverrideCLI,
-          locations: [],
           global: {},
           defaultTestOverrides: {
             ...defaultTestOverrides,
@@ -1071,8 +1056,6 @@ describe('run-test', () => {
           DATADOG_SYNTHETICS_OVERRIDE_FOLLOW_REDIRECTS: 'true',
           DATADOG_SYNTHETICS_OVERRIDE_HEADERS:
             "{'Content-Type': 'application/json', 'Authorization': 'Bearer token from env'}",
-          // TODO SYNTH-12989: Clean up `locations` that should only be part of the testOverrides
-          DATADOG_SYNTHETICS_LOCATIONS: 'Wonderland;FarFarAway',
           DATADOG_SYNTHETICS_OVERRIDE_LOCATIONS: 'location_1_from_env;location_2_from_env',
           DATADOG_SYNTHETICS_OVERRIDE_MOBILE_APPLICATION_VERSION: 'env-00000000-0000-0000-0000-000000000000',
           DATADOG_SYNTHETICS_OVERRIDE_RESOURCE_URL_SUBSTITUTION_REGEXES: 'env-regex1;env-regex2',

--- a/src/commands/synthetics/__tests__/cli.test.ts
+++ b/src/commands/synthetics/__tests__/cli.test.ts
@@ -216,7 +216,6 @@ describe('run-test', () => {
           locations: ['aws:us-west-1'],
           mobileApplicationVersion: '00000000-0000-0000-0000-000000000000',
           mobileApplicationVersionFilePath: './path/to/application.apk',
-          pollingTimeout: 3,
           retry: {count: 2, interval: 300},
           startUrl: '{{URL}}?static_hash={{STATIC_HASH}}',
           startUrlSubstitutionRegex: 's/(https://www.)(.*)/$1extra-$2/',
@@ -249,7 +248,6 @@ describe('run-test', () => {
           locations: ['aws:us-west-1'],
           mobileApplicationVersion: '00000000-0000-0000-0000-000000000000',
           mobileApplicationVersionFilePath: './path/to/application.apk',
-          pollingTimeout: 2, // not overridden (backwards compatibility not supported)
           retry: {count: 2, interval: 300},
           startUrl: '{{URL}}?static_hash={{STATIC_HASH}}',
           startUrlSubstitutionRegex: 's/(https://www.)(.*)/$1extra-$2/',
@@ -259,8 +257,6 @@ describe('run-test', () => {
         jUnitReport: 'junit-report.xml',
         // TODO SYNTH-12989: Clean up `locations` that should only be part of test overrides
         locations: [],
-        // TODO SYNTH-12989: Clean up `pollingTimeout` in favor of `batchTimeout`
-        pollingTimeout: 1,
         proxy: {
           protocol: 'https',
         },
@@ -285,7 +281,7 @@ describe('run-test', () => {
       const overrideCLI: Omit<RunTestsCommandConfig, 'global' | 'defaultTestOverrides' | 'proxy'> = {
         apiKey: 'fake_api_key',
         appKey: 'fake_app_key',
-        batchTimeout: 1, // not used in the first test case
+        batchTimeout: 1,
         configPath: 'src/commands/synthetics/__tests__/config-fixtures/empty-config-file.json',
         datadogSite: 'datadoghq.eu',
         failOnCriticalErrors: true,
@@ -294,7 +290,6 @@ describe('run-test', () => {
         files: ['new-file'],
         jUnitReport: 'junit-report.xml',
         mobileApplicationVersionFilePath: './path/to/application.apk',
-        pollingTimeout: 2,
         publicIds: ['ran-dom-id2'],
         selectiveRerun: true,
         subdomain: 'new-sub-domain',
@@ -321,8 +316,6 @@ describe('run-test', () => {
         headers: {'Content-Type': 'application/json', Authorization: 'Bearer token'},
         locations: ['us-east-1', 'us-west-1'],
         mobileApplicationVersion: '00000000-0000-0000-0000-000000000000',
-        // TODO SYNTH-12989: Clean up `pollingTimeout` from `defaultTestOverrides`
-        pollingTimeout: 3,
         resourceUrlSubstitutionRegexes: [
           's/(https://www.)(.*)/$1extra-$2',
           'https://example.com(.*)|http://subdomain.example.com$1',
@@ -340,7 +333,7 @@ describe('run-test', () => {
       const command = createCommand(RunTestsCommand)
       command['apiKey'] = overrideCLI.apiKey
       command['appKey'] = overrideCLI.appKey
-      // `command['batchTimeout']` not used in the first test case
+      command['batchTimeout'] = overrideCLI.batchTimeout
       command['configPath'] = overrideCLI.configPath
       command['datadogSite'] = overrideCLI.datadogSite
       // TODO SYNTH-12989: Clean up deprecated `--deviceIds` in favor of `--override deviceIds="dev1;dev2;..."`
@@ -352,8 +345,6 @@ describe('run-test', () => {
       command['jUnitReport'] = overrideCLI.jUnitReport
       command['mobileApplicationVersion'] = defaultTestOverrides.mobileApplicationVersion
       command['mobileApplicationVersionFilePath'] = overrideCLI.mobileApplicationVersionFilePath
-      // TODO SYNTH-12989: Clean up `pollingTimeout` in favor of `batchTimeout`
-      command['pollingTimeout'] = overrideCLI.pollingTimeout
       command['publicIds'] = overrideCLI.publicIds
       command['selectiveRerun'] = overrideCLI.selectiveRerun
       command['subdomain'] = overrideCLI.subdomain
@@ -378,8 +369,6 @@ describe('run-test', () => {
         `headers.Content-Type=${defaultTestOverrides.headers ? defaultTestOverrides.headers['Content-Type'] : ''}`,
         `headers.Authorization=${defaultTestOverrides.headers?.Authorization}`,
         `locations=${defaultTestOverrides.locations?.join(';')}`,
-        // TODO SYNTH-12989: Clean up `pollingTimeout` in favor of `batchTimeout`
-        `pollingTimeout=${defaultTestOverrides.pollingTimeout}`,
         `retry.count=${defaultTestOverrides.retry?.count}`,
         `retry.interval=${defaultTestOverrides.retry?.interval}`,
         `startUrl=${defaultTestOverrides.startUrl}`,
@@ -390,67 +379,6 @@ describe('run-test', () => {
         `variables.var2=${defaultTestOverrides.variables?.var2}`,
       ]
 
-      await command['resolveConfig']()
-      expect(command['config']).toEqual({
-        ...DEFAULT_COMMAND_CONFIG,
-        apiKey: 'fake_api_key',
-        appKey: 'fake_app_key',
-        batchTimeout: 2,
-        configPath: 'src/commands/synthetics/__tests__/config-fixtures/empty-config-file.json',
-        datadogSite: 'datadoghq.eu',
-        defaultTestOverrides: {
-          allowInsecureCertificates: true,
-          basicAuth: {
-            password: 'password',
-            username: 'username',
-          },
-          body: 'a body',
-          bodyType: 'bodyType',
-          cookies: {
-            value: 'name1=value1;name2=value2;',
-            append: true,
-          },
-          setCookies: {
-            value: 'name1=value1 \n name2=value2; Domain=example.com \n name3=value3; Secure; HttpOnly',
-            append: true,
-          },
-          defaultStepTimeout: 42,
-          deviceIds: ['chrome.laptop_large', 'chrome.laptop_small', 'firefox.laptop_large'],
-          executionRule: ExecutionRule.BLOCKING,
-          followRedirects: true,
-          headers: {'Content-Type': 'application/json', Authorization: 'Bearer token'},
-          locations: ['us-east-1', 'us-west-1'],
-          mobileApplicationVersion: '00000000-0000-0000-0000-000000000000',
-          mobileApplicationVersionFilePath: './path/to/application.apk',
-          // TODO SYNTH-12989: Clean up `pollingTimeout` from `defaultTestOverrides`
-          resourceUrlSubstitutionRegexes: [
-            's/(https://www.)(.*)/$1extra-$2',
-            'https://example.com(.*)|http://subdomain.example.com$1',
-          ],
-          retry: {
-            count: 5,
-            interval: 42,
-          },
-          startUrl: 'startUrl',
-          startUrlSubstitutionRegex: 'startUrlSubstitutionRegex',
-          testTimeout: 42,
-          variables: {var1: 'value1', var2: 'value2'},
-        },
-        failOnCriticalErrors: true,
-        failOnMissingTests: true,
-        failOnTimeout: false,
-        files: ['new-file'],
-        jUnitReport: 'junit-report.xml',
-        pollingTimeout: 2,
-        publicIds: ['ran-dom-id2'],
-        selectiveRerun: true,
-        subdomain: 'new-sub-domain',
-        testSearchQuery: 'a-search-query',
-        tunnel: true,
-      })
-
-      // TODO SYNTH-12989: Merge those 2 test cases when `pollingTimeout` is removed
-      command['batchTimeout'] = overrideCLI.batchTimeout // when both are used, `batchTimeout` takes precedence
       await command['resolveConfig']()
       expect(command['config']).toEqual({
         ...DEFAULT_COMMAND_CONFIG,
@@ -483,7 +411,6 @@ describe('run-test', () => {
           locations: ['us-east-1', 'us-west-1'],
           mobileApplicationVersion: '00000000-0000-0000-0000-000000000000',
           mobileApplicationVersionFilePath: './path/to/application.apk',
-          // TODO SYNTH-12989: Clean up `pollingTimeout` from `defaultTestOverrides`
           resourceUrlSubstitutionRegexes: [
             's/(https://www.)(.*)/$1extra-$2',
             'https://example.com(.*)|http://subdomain.example.com$1',
@@ -495,10 +422,7 @@ describe('run-test', () => {
           startUrl: 'startUrl',
           startUrlSubstitutionRegex: 'startUrlSubstitutionRegex',
           testTimeout: 42,
-          variables: {
-            var1: 'value1',
-            var2: 'value2',
-          },
+          variables: {var1: 'value1', var2: 'value2'},
         },
         failOnCriticalErrors: true,
         failOnMissingTests: true,
@@ -506,7 +430,6 @@ describe('run-test', () => {
         files: ['new-file'],
         jUnitReport: 'junit-report.xml',
         publicIds: ['ran-dom-id2'],
-        pollingTimeout: 1,
         selectiveRerun: true,
         subdomain: 'new-sub-domain',
         testSearchQuery: 'a-search-query',
@@ -537,21 +460,6 @@ describe('run-test', () => {
         defaultTestOverrides: {
           variables: {var1: 'value1', var2: 'value2'},
         },
-      })
-    })
-
-    test("Root config file 'pollingTimeout' still works (deprecated)", async () => {
-      const command = createCommand(RunTestsCommand)
-      command.configPath = 'src/commands/synthetics/__tests__/config-fixtures/config-with-global-polling-timeout.json'
-      await command['resolveConfig']()
-      expect(command['config']).toEqual({
-        ...DEFAULT_COMMAND_CONFIG,
-        batchTimeout: 333,
-        configPath: 'src/commands/synthetics/__tests__/config-fixtures/config-with-global-polling-timeout.json',
-        // TODO SYNTH-12989: Clean up deprecated `global` in favor of `defaultTestOverrides`
-        global: {followRedirects: false},
-        defaultTestOverrides: {followRedirects: false},
-        pollingTimeout: 333,
       })
     })
 
@@ -590,7 +498,6 @@ describe('run-test', () => {
           headers: {'Config-File': 'This is a mess'},
           mobileApplicationVersion: '00000000-0000-0000-0000-000000000000-config-file',
           mobileApplicationVersionFilePath: './path/to/application-from-config-file.apk',
-          pollingTimeout: 2,
           retry: {count: 2, interval: 300},
           resourceUrlSubstitutionRegexes: ['regex1-from-config-file', 'regex2-from-config-file'],
           startUrl: '{{URL}}?static_hash={{STATIC_HASH}}',
@@ -710,9 +617,8 @@ describe('run-test', () => {
             testTimeout: toNumber(overrideEnv.DATADOG_SYNTHETICS_OVERRIDE_TEST_TIMEOUT),
             variables: toStringMap(overrideEnv.DATADOG_SYNTHETICS_OVERRIDE_VARIABLES),
 
-            // Added to make the test work, should be changed in the future when cleaning up
+            // Added to make test pass, we currently don't have an ENV variable for `mobileApplicationVersionFilePath`.
             mobileApplicationVersionFilePath: configFile.defaultTestOverrides.mobileApplicationVersionFilePath,
-            pollingTimeout: configFile.defaultTestOverrides.pollingTimeout,
           },
           failOnCriticalErrors: toBoolean(overrideEnv.DATADOG_SYNTHETICS_FAIL_ON_CRITICAL_ERRORS),
           failOnMissingTests: toBoolean(overrideEnv.DATADOG_SYNTHETICS_FAIL_ON_MISSING_TESTS),
@@ -730,7 +636,6 @@ describe('run-test', () => {
           global: {},
           // TODO SYNTH-12989: Clean up `locations` that should only be part of the testOverrides
           locations: configFile.locations,
-          pollingTimeout: 1,
           proxy: configFile.proxy,
           variableStrings: configFile.variableStrings,
         }
@@ -760,7 +665,6 @@ describe('run-test', () => {
           files: ['new-file-from-cli'],
           jUnitReport: 'junit-report-from-cli.xml',
           mobileApplicationVersionFilePath: './path/to/application-from-cli.apk',
-          pollingTimeout: 10,
           publicIds: ['public-id-from-cli'],
           selectiveRerun: true,
           subdomain: 'subdomain-from-cli',
@@ -822,7 +726,6 @@ describe('run-test', () => {
         command['jUnitReport'] = overrideCLI.jUnitReport
         command['mobileApplicationVersion'] = defaultTestOverrides.mobileApplicationVersion
         command['mobileApplicationVersionFilePath'] = overrideCLI.mobileApplicationVersionFilePath
-        command['pollingTimeout'] = overrideCLI.pollingTimeout
         command['publicIds'] = overrideCLI.publicIds
         command['selectiveRerun'] = overrideCLI.selectiveRerun
         command['subdomain'] = overrideCLI.subdomain
@@ -869,9 +772,7 @@ describe('run-test', () => {
           defaultTestOverrides: {
             ...defaultTestOverrides,
             mobileApplicationVersionFilePath,
-            pollingTimeout: configFile.defaultTestOverrides.pollingTimeout,
           },
-          pollingTimeout: 1,
           proxy: configFile.proxy,
           variableStrings: configFile.variableStrings,
         }
@@ -938,7 +839,6 @@ describe('run-test', () => {
           files: ['file-from-cli-1;file-from-cli-2'],
           jUnitReport: 'junit-report-from-cli.xml',
           mobileApplicationVersionFilePath: './path/to/application-from-cli.apk',
-          pollingTimeout: 10,
           publicIds: ['public-id-from-cli-1', 'public-id-from-cli-2'],
           selectiveRerun: false,
           subdomain: 'subdomain-from-cli',
@@ -1002,7 +902,6 @@ describe('run-test', () => {
         command['jUnitReport'] = overrideCLI.jUnitReport
         command['mobileApplicationVersion'] = defaultTestOverrides.mobileApplicationVersion
         command['mobileApplicationVersionFilePath'] = overrideCLI.mobileApplicationVersionFilePath
-        command['pollingTimeout'] = overrideCLI.pollingTimeout
         command['publicIds'] = overrideCLI.publicIds
         command['selectiveRerun'] = overrideCLI.selectiveRerun
         command['subdomain'] = overrideCLI.subdomain
@@ -1050,7 +949,6 @@ describe('run-test', () => {
             ...defaultTestOverrides,
             mobileApplicationVersionFilePath,
           },
-          pollingTimeout: 1,
           proxy: {protocol: 'http'},
           variableStrings: [],
         }
@@ -1084,7 +982,6 @@ describe('run-test', () => {
         headers: {'Content-Type': 'application/json', Authorization: 'Bearer token from test file'},
         locations: ['test-file-loc-1', 'test-file-loc-2'],
         mobileApplicationVersion: 'test-file-00000000-0000-0000-0000-000000000000',
-        pollingTimeout: 32,
         resourceUrlSubstitutionRegexes: [
           'from-test-file-regex1',
           's/(https://www.)(.*)/$1extra-$2',
@@ -1225,7 +1122,6 @@ describe('run-test', () => {
           headers: {'Content-Type': 'application/json', Authorization: 'Bearer token from cli'},
           locations: ['cli-loc-1', 'cli-loc-2'],
           mobileApplicationVersion: 'cli-00000000-0000-0000-0000-000000000000',
-          pollingTimeout: 12,
           resourceUrlSubstitutionRegexes: [
             'from-cli-regex1',
             's/(https://www.)(.*)/$1extra-$2',

--- a/src/commands/synthetics/__tests__/cli.test.ts
+++ b/src/commands/synthetics/__tests__/cli.test.ts
@@ -41,7 +41,6 @@ test('all option flags are supported', async () => {
     'search',
     'subdomain',
     'tunnel',
-    'variable',
   ]
 
   const cli = new Cli()
@@ -261,8 +260,6 @@ describe('run-test', () => {
         subdomain: 'ppa',
         testSearchQuery: 'a-search-query',
         tunnel: true,
-        // TODO SYNTH-12989: Clean up deprecated `variableStrings` in favor of `variables` in `defaultTestOverrides`.
-        variableStrings: [],
       }
 
       const command = createCommand(RunTestsCommand)
@@ -291,8 +288,6 @@ describe('run-test', () => {
         subdomain: 'new-sub-domain',
         testSearchQuery: 'a-search-query',
         tunnel: true,
-        // TODO SYNTH-12989: Clean up deprecated `variableStrings` in favor of `variables` in `defaultTestOverrides`.
-        variableStrings: ['var3=value3', 'var4=value4'],
       }
       /** Values passed to `--override`. */
       const defaultTestOverrides: UserConfigOverride = {
@@ -346,8 +341,6 @@ describe('run-test', () => {
       command['subdomain'] = overrideCLI.subdomain
       command['tunnel'] = overrideCLI.tunnel
       command['testSearchQuery'] = overrideCLI.testSearchQuery
-      // TODO SYNTH-12989: Clean up deprecated `variableStrings` in favor of `variables` in `defaultTestOverrides`.
-      command['variableStrings'] = overrideCLI.variableStrings
       command['overrides'] = [
         `allowInsecureCertificates=${defaultTestOverrides.allowInsecureCertificates}`,
         `basicAuth.password=${defaultTestOverrides.basicAuth?.password}`,
@@ -446,19 +439,6 @@ describe('run-test', () => {
       })
     })
 
-    // TODO SYNTH-12989: Clean up deprecated `variableStrings` in favor of `variables` in `defaultTestOverrides`.
-    test("CLI parameter '--variable' still works (deprecated)", async () => {
-      const command = createCommand(RunTestsCommand)
-      command['variableStrings'] = ['var1=value1', 'var2=value2']
-      await command['resolveConfig']()
-      expect(command['config']).toEqual({
-        ...DEFAULT_COMMAND_CONFIG,
-        defaultTestOverrides: {
-          variables: {var1: 'value1', var2: 'value2'},
-        },
-      })
-    })
-
     // We have 2 code paths that handle different levels of configuration overrides:
     //  1)  config file (configuration of datadog-ci)             <   ENV (environment variables)   <   CLI (command flags)
     //  2)  global (global config object, aka. `config.global`)   <   ENV (environment variables)   <   test file (test configuration)
@@ -514,8 +494,6 @@ describe('run-test', () => {
         subdomain: 'subdomain_from_config_file',
         testSearchQuery: 'a-search-query-from-config-file',
         tunnel: false,
-        // TODO SYNTH-12989: Clean up deprecated `variableStrings` in favor of `variables` in `defaultTestOverrides`.
-        variableStrings: ['configVar1=configValue1', 'configVar2=configValue2'],
       }
 
       test('config file < ENV', async () => {
@@ -626,7 +604,6 @@ describe('run-test', () => {
           // TODO SYNTH-12989: Clean up deprecated `global` in favor of `defaultTestOverrides`
           global: {},
           proxy: configFile.proxy,
-          variableStrings: configFile.variableStrings,
         }
 
         process.env = overrideEnv
@@ -659,8 +636,6 @@ describe('run-test', () => {
           subdomain: 'subdomain-from-cli',
           testSearchQuery: 'a-search-query-from-cli',
           tunnel: true,
-          // TODO SYNTH-12989: Clean up deprecated `variableStrings` in favor of `variables` in `defaultTestOverrides`.
-          variableStrings: ['cliVar3=value3', 'cliVar4=value4'],
         }
         const defaultTestOverrides: UserConfigOverride = {
           allowInsecureCertificates: false,
@@ -720,8 +695,6 @@ describe('run-test', () => {
         command['subdomain'] = overrideCLI.subdomain
         command['tunnel'] = overrideCLI.tunnel
         command['testSearchQuery'] = overrideCLI.testSearchQuery
-        // TODO SYNTH-12989: Clean up deprecated `variableStrings` in favor of `variables` in `defaultTestOverrides`.
-        command['variableStrings'] = overrideCLI.variableStrings
         command['overrides'] = [
           `allowInsecureCertificates=${defaultTestOverrides.allowInsecureCertificates}`,
           `basicAuth.password=${defaultTestOverrides.basicAuth?.password}`,
@@ -751,7 +724,7 @@ describe('run-test', () => {
 
         await command['resolveConfig']()
 
-        // TODO SYNTH-12989: Clean up deprecated `global`, `location`, `variableStrings`, `mobileApplicationVersionFilePath`, `proxy`, etc.
+        // TODO SYNTH-12989: Clean up deprecated `global`, `mobileApplicationVersionFilePath`, `proxy`, etc.
         // This fixes are only here for the test to run, and to maintain backward compatibility.
         const {mobileApplicationVersionFilePath, ...filteredOverrideCLI} = overrideCLI
         const expectedCLIOverrideResult = {
@@ -762,7 +735,6 @@ describe('run-test', () => {
             mobileApplicationVersionFilePath,
           },
           proxy: configFile.proxy,
-          variableStrings: configFile.variableStrings,
         }
 
         expect(command['config']).toEqual(expectedCLIOverrideResult)
@@ -830,8 +802,6 @@ describe('run-test', () => {
           subdomain: 'subdomain-from-cli',
           testSearchQuery: 'a-search-query-from-cli',
           tunnel: true,
-          // TODO SYNTH-12989: Clean up deprecated `variableStrings` in favor of `variables` in `defaultTestOverrides`.
-          variableStrings: ['cliVar3=value3', 'cliVar4=value4'],
         }
         const defaultTestOverrides: UserConfigOverride = {
           allowInsecureCertificates: false,
@@ -893,8 +863,6 @@ describe('run-test', () => {
         command['subdomain'] = overrideCLI.subdomain
         command['tunnel'] = overrideCLI.tunnel
         command['testSearchQuery'] = overrideCLI.testSearchQuery
-        // TODO SYNTH-12989: Clean up deprecated `variableStrings` in favor of `variables` in `defaultTestOverrides`.
-        command['variableStrings'] = overrideCLI.variableStrings
         command['overrides'] = [
           `allowInsecureCertificates=${defaultTestOverrides.allowInsecureCertificates}`,
           `basicAuth.password=${defaultTestOverrides.basicAuth?.password}`,
@@ -924,7 +892,7 @@ describe('run-test', () => {
 
         await command['resolveConfig']()
 
-        // TODO SYNTH-12989: Clean up deprecated `global`, `variableStrings`, `mobileApplicationVersionFilePath`, `proxy` etc.
+        // TODO SYNTH-12989: Clean up deprecated `global`, `mobileApplicationVersionFilePath`, `proxy` etc.
         // This fixes are only here for the test to run, and to maintain backward compatibility.
         const {mobileApplicationVersionFilePath, ...filteredOverrideCLI} = overrideCLI
         const expectedCLIOverrideResult = {
@@ -935,7 +903,6 @@ describe('run-test', () => {
             mobileApplicationVersionFilePath,
           },
           proxy: {protocol: 'http'},
-          variableStrings: [],
         }
         expect(command['config']).toEqual(expectedCLIOverrideResult)
       })

--- a/src/commands/synthetics/__tests__/config-fixtures/config-with-all-keys.json
+++ b/src/commands/synthetics/__tests__/config-fixtures/config-with-all-keys.json
@@ -30,7 +30,6 @@
     "locations": ["aws:us-west-1"],
     "mobileApplicationVersion": "00000000-0000-0000-0000-000000000000",
     "mobileApplicationVersionFilePath": "./path/to/application.apk",
-    "pollingTimeout": 2,
     "retry": {"count": 2, "interval": 300},
     "startUrl": "{{URL}}?static_hash={{STATIC_HASH}}",
     "startUrlSubstitutionRegex": "s/(https://www.)(.*)/$1extra-$2/",
@@ -58,7 +57,6 @@
     "locations": ["aws:us-west-1"],
     "mobileApplicationVersion": "00000000-0000-0000-0000-000000000000",
     "mobileApplicationVersionFilePath": "./path/to/application.apk",
-    "pollingTimeout": 3,
     "retry": {"count": 2, "interval": 300},
     "startUrl": "{{URL}}?static_hash={{STATIC_HASH}}",
     "startUrlSubstitutionRegex": "s/(https://www.)(.*)/$1extra-$2/",
@@ -66,7 +64,6 @@
     "variables": {"titleVariable": "new value"}
   },
   "locations": [],
-  "pollingTimeout": 4,
   "proxy": {
     "protocol": "https"
   },

--- a/src/commands/synthetics/__tests__/config-fixtures/config-with-all-keys.json
+++ b/src/commands/synthetics/__tests__/config-fixtures/config-with-all-keys.json
@@ -63,7 +63,6 @@
     "testTimeout": 200000,
     "variables": {"titleVariable": "new value"}
   },
-  "locations": [],
   "proxy": {
     "protocol": "https"
   },

--- a/src/commands/synthetics/__tests__/config-fixtures/config-with-all-keys.json
+++ b/src/commands/synthetics/__tests__/config-fixtures/config-with-all-keys.json
@@ -70,6 +70,5 @@
   "selectiveRerun": true,
   "subdomain": "ppa",
   "testSearchQuery": "a-search-query",
-  "tunnel": true,
-  "variableStrings": []
+  "tunnel": true
 }

--- a/src/commands/synthetics/__tests__/config-fixtures/config-with-global-polling-timeout.json
+++ b/src/commands/synthetics/__tests__/config-fixtures/config-with-global-polling-timeout.json
@@ -1,6 +1,0 @@
-{
-  "global": {
-    "followRedirects": false
-  },
-  "pollingTimeout": 333
-}

--- a/src/commands/synthetics/__tests__/fixtures.ts
+++ b/src/commands/synthetics/__tests__/fixtures.ts
@@ -76,7 +76,6 @@ export const ciConfig: RunTestsCommandConfig = {
   subdomain: 'app',
   testSearchQuery: '',
   tunnel: false,
-  variableStrings: [],
 }
 
 export const getApiTest = (publicId = 'abc-def-ghi', opts: Partial<ServerTest> = {}): ServerTest => ({

--- a/src/commands/synthetics/__tests__/fixtures.ts
+++ b/src/commands/synthetics/__tests__/fixtures.ts
@@ -71,7 +71,6 @@ export const ciConfig: RunTestsCommandConfig = {
   jUnitReport: '',
   global: {},
   defaultTestOverrides: {},
-  locations: [],
   proxy: {protocol: 'http'},
   publicIds: [],
   subdomain: 'app',

--- a/src/commands/synthetics/__tests__/reporters/junit.test.ts
+++ b/src/commands/synthetics/__tests__/reporters/junit.test.ts
@@ -37,7 +37,7 @@ describe('Junit reporter', () => {
   const commandMock: Args = {
     context: ({stdout: {write: writeMock}} as unknown) as BaseContext,
     jUnitReport: 'junit',
-    runName: 'Test Suite name',
+    runName: 'Custom run name',
   }
 
   let reporter: JUnitReporter
@@ -124,7 +124,7 @@ describe('Junit reporter', () => {
       expect(reporter['json'].testsuites.$).toStrictEqual({
         batch_id: BATCH_ID,
         batch_url: `${MOCK_BASE_URL}synthetics/explorer/ci?batchResultId=${BATCH_ID}`,
-        name: 'Test Suite name',
+        name: 'Custom run name',
         tests_critical_error: 1,
         tests_failed: 2,
         tests_failed_non_blocking: 3,
@@ -393,7 +393,7 @@ describe('GitLab test report compatibility', () => {
   const commandMock: Args = {
     context: ({stdout: {write: writeMock}} as unknown) as BaseContext,
     jUnitReport: 'junit',
-    runName: 'Test Suite name',
+    runName: 'Custom run name',
   }
 
   let reporter: JUnitReporter

--- a/src/commands/synthetics/__tests__/run-tests-lib.test.ts
+++ b/src/commands/synthetics/__tests__/run-tests-lib.test.ts
@@ -71,7 +71,6 @@ describe('run-test', () => {
           selectiveRerun: false,
           subdomain: 'app',
           tunnel: false,
-          variableStrings: [], // deprecated
         })
       ).rejects.toThrow(new CiError('NO_TESTS_TO_RUN'))
     })
@@ -98,8 +97,6 @@ describe('run-test', () => {
           selectiveRerun: false,
           subdomain: 'app',
           tunnel: false,
-          // TODO SYNTH-12989: Clean up deprecated `variableStrings`
-          variableStrings: [],
         })
       ).rejects.toThrow(new CiError('NO_TESTS_TO_RUN'))
     })

--- a/src/commands/synthetics/__tests__/run-tests-lib.test.ts
+++ b/src/commands/synthetics/__tests__/run-tests-lib.test.ts
@@ -90,7 +90,7 @@ describe('run-test', () => {
           failOnMissingTests: false,
           failOnTimeout: true,
           files: ['{,!(node_modules)/**/}*.synthetics.json'],
-          // TODO SYNTH-12989: Clean up deprecated `global` and `locations`
+          // TODO SYNTH-12989: Clean up deprecated `global`
           global: {},
           proxy: {protocol: 'http'},
           publicIds: [],

--- a/src/commands/synthetics/__tests__/run-tests-lib.test.ts
+++ b/src/commands/synthetics/__tests__/run-tests-lib.test.ts
@@ -67,7 +67,6 @@ describe('run-test', () => {
           files: ['{,!(node_modules)/**/}*.synthetics.json'],
           global: {}, // deprecated
           locations: [], // deprecated
-          pollingTimeout: 2 * 60 * 1000,
           proxy: {protocol: 'http'},
           publicIds: [],
           selectiveRerun: false,
@@ -96,7 +95,6 @@ describe('run-test', () => {
           // TODO SYNTH-12989: Clean up deprecated `global` and `locations`
           global: {},
           locations: [],
-          pollingTimeout: 2 * 60 * 1000,
           proxy: {protocol: 'http'},
           publicIds: [],
           selectiveRerun: false,
@@ -1009,7 +1007,6 @@ describe('run-test', () => {
                 locations: ['aws:us-east-1'],
                 mobileApplicationVersion: '01234567-8888-9999-abcd-efffffffffff',
                 mobileApplicationVersionFilePath: 'path/to/application.apk',
-                pollingTimeout: 30000,
                 retry: {count: 2, interval: 300},
                 testTimeout: 300,
                 variables: {MY_VARIABLE: 'new title'},
@@ -1047,7 +1044,6 @@ describe('run-test', () => {
             locations: ['aws:us-east-1'],
             mobileApplicationVersion: '01234567-8888-9999-abcd-efffffffffff',
             mobileApplicationVersionFilePath: 'path/to/application.apk',
-            pollingTimeout: 30000,
             retry: {count: 2, interval: 300},
             testTimeout: 300,
             variables: {MY_VARIABLE: 'new title'},

--- a/src/commands/synthetics/__tests__/utils/public.test.ts
+++ b/src/commands/synthetics/__tests__/utils/public.test.ts
@@ -60,7 +60,7 @@ import {
   Test,
   UserConfigOverride,
 } from '../../interfaces'
-import {DEFAULT_COMMAND_CONFIG, DEFAULT_POLLING_TIMEOUT} from '../../run-tests-command'
+import {DEFAULT_COMMAND_CONFIG} from '../../run-tests-command'
 import * as utils from '../../utils/public'
 
 import {
@@ -302,7 +302,6 @@ describe('utils', () => {
         followRedirects: true,
         headers: {'header-name': 'value'},
         locations: ['location'],
-        pollingTimeout: 60 * 1000,
         retry: {count: 5, interval: 30},
         startUrl: 'http://127.0.0.1:60/newPath',
         startUrlSubstitutionRegex: '.*',
@@ -327,10 +326,6 @@ describe('utils', () => {
       expect(utils.getTestOverridesCount({headers: {}})).toBe(1)
 
       expect(utils.getTestOverridesCount({deviceIds: ['a']})).toBe(1)
-      expect(utils.getTestOverridesCount({pollingTimeout: 123})).toBe(1)
-
-      // Should ignore the default value for the pollingTimeout
-      expect(utils.getTestOverridesCount({pollingTimeout: DEFAULT_POLLING_TIMEOUT})).toBe(0)
     })
   })
 

--- a/src/commands/synthetics/__tests__/utils/public.test.ts
+++ b/src/commands/synthetics/__tests__/utils/public.test.ts
@@ -447,18 +447,6 @@ describe('utils', () => {
     })
   })
 
-  test('parseVariablesFromCli', () => {
-    const mockLogFunction = (message: string) => undefined
-    expect(utils.parseVariablesFromCli(['TEST=42'], mockLogFunction)).toEqual({TEST: '42'})
-    expect(utils.parseVariablesFromCli(['TEST=42 with some spaces'], mockLogFunction)).toEqual({
-      TEST: '42 with some spaces',
-    })
-    expect(utils.parseVariablesFromCli(['TEST=42=43=44'], mockLogFunction)).toEqual({TEST: '42=43=44'})
-    expect(utils.parseVariablesFromCli(['TEST='], mockLogFunction)).toEqual({TEST: ''})
-    expect(utils.parseVariablesFromCli([''], mockLogFunction)).toBeUndefined()
-    expect(utils.parseVariablesFromCli(undefined, mockLogFunction)).toBeUndefined()
-  })
-
   describe('sortResultsByOutcome', () => {
     const results: Result[] = getResults([
       {executionRule: ExecutionRule.NON_BLOCKING, passed: false},

--- a/src/commands/synthetics/batch.ts
+++ b/src/commands/synthetics/batch.ts
@@ -40,12 +40,8 @@ export const runTests = async (
   selectiveRerun?: boolean,
   batchTimeout = DEFAULT_BATCH_TIMEOUT
 ): Promise<Trigger> => {
-  // TODO SYNTH-12989: Remove this when `pollingTimeout` is removed
-  // Although the backend is backwards compatible, let's stop sending deprecated properties
-  const tests = testsToTrigger.map(({pollingTimeout, ...otherProperties}) => ({...otherProperties}))
-
   const payload: Payload = {
-    tests,
+    tests: testsToTrigger,
     options: {
       batch_timeout: batchTimeout,
       selective_rerun: selectiveRerun,

--- a/src/commands/synthetics/compatibility.ts
+++ b/src/commands/synthetics/compatibility.ts
@@ -1,34 +1,5 @@
 import {MainReporter, RunTestsCommandConfig, Suite, UserConfigOverride} from './interfaces'
 
-export const moveLocationsToTestOverrides = (
-  config: RunTestsCommandConfig,
-  reporter: MainReporter,
-  warnDeprecatedLocations = false
-): RunTestsCommandConfig => {
-  const isLocationsUsedInRoot = (config.locations ?? []).length !== 0
-  // At this point, `global` should already have been moved to `defaultTestOverrides`
-  const isLocationsUsedInDefaultTestOverrides = (config.defaultTestOverrides?.locations ?? []).length !== 0
-
-  if (isLocationsUsedInRoot && warnDeprecatedLocations) {
-    reporter.error(
-      "The 'locations' property should not be used at the root level of the global configuration file. Please put it in 'defaultTestOverrides' instead.\n If 'locations' exists in both places, only the one in 'defaultTestOverrides' is used!\n"
-    )
-  }
-
-  // If the user hasn't migrated and is still using `locations` at the root level, move it in the `defaultTestOverrides`
-  if (!isLocationsUsedInDefaultTestOverrides && isLocationsUsedInRoot) {
-    return {
-      ...config,
-      defaultTestOverrides: {
-        ...config.defaultTestOverrides,
-        locations: config.locations,
-      },
-    }
-  }
-
-  return config
-}
-
 export const replaceConfigWithTestOverrides = (
   config: UserConfigOverride | undefined,
   testOverrides: UserConfigOverride | undefined

--- a/src/commands/synthetics/compatibility.ts
+++ b/src/commands/synthetics/compatibility.ts
@@ -1,5 +1,4 @@
 import {MainReporter, RunTestsCommandConfig, Suite, UserConfigOverride} from './interfaces'
-import {DEFAULT_BATCH_TIMEOUT, DEFAULT_POLLING_TIMEOUT} from './run-tests-command'
 
 export const moveLocationsToTestOverrides = (
   config: RunTestsCommandConfig,
@@ -70,48 +69,6 @@ export const replaceGlobalWithDefaultTestOverrides = (
   return config
 }
 
-export const replacePollingTimeoutWithBatchTimeout = (
-  config: RunTestsCommandConfig,
-  reporter: MainReporter,
-  warnDeprecatedPollingTimeout = false,
-  batchTimeoutCliParam?: number,
-  pollingTimeoutCliParam?: number
-): RunTestsCommandConfig => {
-  // At this point, `global` should already have been moved to `defaultTestOverrides`
-  const pollingTimeout = pollingTimeoutCliParam ?? config.defaultTestOverrides?.pollingTimeout ?? config.pollingTimeout
-  const isPollingTimeoutUsed = pollingTimeout !== undefined && pollingTimeout !== DEFAULT_POLLING_TIMEOUT
-
-  if (isPollingTimeoutUsed && warnDeprecatedPollingTimeout) {
-    reporter.error(
-      "The 'pollingTimeout' property is deprecated. Please use 'batchTimeout' instead.\nIf both 'pollingTimeout' and 'batchTimeout' properties exist, 'batchTimeout' is used!\n"
-    )
-  }
-
-  const batchTimeout = batchTimeoutCliParam ?? config.batchTimeout
-  const isBatchTimeoutUsed = batchTimeout !== DEFAULT_BATCH_TIMEOUT
-
-  // If the user hasn't migrated and is still using `pollingTimeout`, use `pollingTimeout`
-  if (!isBatchTimeoutUsed && isPollingTimeoutUsed) {
-    return {
-      ...config,
-      pollingTimeout,
-      batchTimeout: pollingTimeout,
-    }
-  }
-
-  // If the current call comes from the CLI, keep using both to make the future call by the command show a warning.
-  const calledByCli = !warnDeprecatedPollingTimeout
-  if (calledByCli && isBatchTimeoutUsed && isPollingTimeoutUsed) {
-    return {
-      ...config,
-      batchTimeout,
-      pollingTimeout: batchTimeout,
-    }
-  }
-
-  return config
-}
-
 export const warnIfDeprecatedConfigUsed = (suites: Suite[], reporter: MainReporter): void => {
   // TODO SYNTH-12989: Clean up deprecated `config` in favor of `testOverrides`
   const isUsingConfig = suites.some((suite) =>
@@ -120,20 +77,6 @@ export const warnIfDeprecatedConfigUsed = (suites: Suite[], reporter: MainReport
   if (isUsingConfig) {
     reporter.error(
       "The 'config' property is deprecated. Please use 'testOverrides' instead.\nIf both 'config' and 'testOverrides' properties exist, 'testOverrides' is used!\n"
-    )
-  }
-}
-
-export const warnIfDeprecatedPollingTimeoutUsed = (suites: Suite[], reporter: MainReporter): void => {
-  // TODO SYNTH-12989: Clean up deprecated `pollingTimeout` in favor of `batchTimeout`
-  const isUsingPollingTimeout = suites.some((suite) =>
-    suite.content.tests.some(
-      (test) => test.config?.pollingTimeout !== undefined || test.testOverrides?.pollingTimeout !== undefined
-    )
-  )
-  if (isUsingPollingTimeout) {
-    reporter.error(
-      "The 'pollingTimeout' property is deprecated. Please use 'batchTimeout' in the global configuration file or '--batchTimeout' instead.\nIf both 'pollingTimeout' and 'batchTimeout' properties exist, 'batchTimeout' is used!\n"
     )
   }
 }

--- a/src/commands/synthetics/interfaces.ts
+++ b/src/commands/synthetics/interfaces.ts
@@ -401,9 +401,6 @@ export interface BaseConfigOverride {
   followRedirects?: boolean
   headers?: {[key: string]: string}
   locations?: string[]
-  // TODO SYNTH-12989: Clean up deprecated `pollingTimeout` in favor of `batchTimeout`
-  /** @deprecated This property is deprecated, please use `batchTimeout` in the global configuration file or `--batchTimeout` instead. */
-  pollingTimeout?: number
   resourceUrlSubstitutionRegexes?: string[]
   retry?: RetryConfig
   startUrl?: string
@@ -560,9 +557,6 @@ export interface RunTestsCommandConfig extends SyntheticsCIConfig {
   /** @deprecated This property should only be used inside of `defaultTestOverrides` or `testOverrides`. */
   locations?: string[]
   mobileApplicationVersionFilePath?: string
-  // TODO SYNTH-12989: Clean up deprecated `pollingTimeout` in favor of `batchTimeout`
-  /** @deprecated This property is deprecated, please use `batchTimeout` in the global configuration file or `--batchTimeout` instead. */
-  pollingTimeout?: number
   publicIds: string[]
   /** Whether to only run the tests which failed in the previous test batches. By default, the organization default setting is used. */
   selectiveRerun?: boolean

--- a/src/commands/synthetics/interfaces.ts
+++ b/src/commands/synthetics/interfaces.ts
@@ -553,9 +553,6 @@ export interface RunTestsCommandConfig extends SyntheticsCIConfig {
   /** @deprecated This property is deprecated, please use `defaultTestOverrides` instead. */
   global?: UserConfigOverride
   jUnitReport?: string
-  // TODO SYNTH-12989: Clean up `locations` that should only be part of test overrides
-  /** @deprecated This property should only be used inside of `defaultTestOverrides` or `testOverrides`. */
-  locations?: string[]
   mobileApplicationVersionFilePath?: string
   publicIds: string[]
   /** Whether to only run the tests which failed in the previous test batches. By default, the organization default setting is used. */

--- a/src/commands/synthetics/interfaces.ts
+++ b/src/commands/synthetics/interfaces.ts
@@ -561,9 +561,6 @@ export interface RunTestsCommandConfig extends SyntheticsCIConfig {
   subdomain: string
   testSearchQuery?: string
   tunnel: boolean
-  // TODO SYNTH-12989: Clean up deprecated `variableStrings` in favor of `variables` in `defaultTestOverrides`.
-  /** @deprecated This property is deprecated, please use `variables` inside of `defaultTestOverrides`. */
-  variableStrings: string[]
 }
 
 export type WrapperConfig = Partial<RunTestsCommandConfig>

--- a/src/commands/synthetics/reporters/junit.ts
+++ b/src/commands/synthetics/reporters/junit.ts
@@ -97,7 +97,6 @@ export interface XMLJSON {
       // https://github.com/windyroad/JUnit-Schema/blob/master/JUnit.xsd
       batch_id: string
       batch_url: string
-      // TODO SYNTH-12989: Clean up deprecated `--runName`
       name: string
       tests_critical_error: number
       tests_failed: number
@@ -119,8 +118,6 @@ interface XMLError {
 export interface Args {
   context: CommandContext
   jUnitReport?: string
-  // TODO SYNTH-12989: Clean up deprecated `--runName`
-  /** @deprecated This CLI parameter is deprecated */
   runName?: string
 }
 
@@ -203,7 +200,6 @@ export class JUnitReporter implements Reporter {
         $: {
           batch_id: '',
           batch_url: '',
-          // TODO SYNTH-12989: Clean up deprecated `--runName`
           name: runName || 'Undefined run',
           tests_critical_error: 0,
           tests_failed: 0,

--- a/src/commands/synthetics/run-tests-command.ts
+++ b/src/commands/synthetics/run-tests-command.ts
@@ -102,12 +102,6 @@ export class RunTestsCommand extends Command {
     validator: validation.isInteger(),
   })
   private datadogSite = Option.String('--datadogSite', {description: 'The Datadog instance to which request is sent.'})
-  // TODO SYNTH-12989: Clean up deprecated `--deviceIds` in favor of `--override deviceIds="dev1;dev2;..."`
-  /** @deprecated This CLI parameter is deprecated, please use `--override deviceIds="dev1;dev2;..."` instead. */
-  private deviceIds = Option.Array('--deviceIds', {
-    description:
-      '**DEPRECATED** Override the mobile device(s) to run your mobile test. Please use `--override deviceIds="dev1;dev2;..."` instead.',
-  })
   private failOnCriticalErrors = Option.Boolean('--failOnCriticalErrors', {
     description:
       'A boolean flag that fails the CI job if no tests were triggered, or results could not be fetched from Datadog.',
@@ -386,8 +380,7 @@ export class RunTestsCommand extends Command {
         cookies: Object.keys(cliOverrideCookies).length > 0 ? cliOverrideCookies : undefined,
         setCookies: Object.keys(cliOverrideSetCookies).length > 0 ? cliOverrideSetCookies : undefined,
         defaultStepTimeout: validatedOverrides.defaultStepTimeout,
-        // TODO SYNTH-12989: Clean up deprecated `--deviceIds` in favor of `--override deviceIds="dev1;dev2;..."`
-        deviceIds: validatedOverrides.deviceIds ?? this.deviceIds,
+        deviceIds: validatedOverrides.deviceIds,
         executionRule: validatedOverrides.executionRule,
         followRedirects: validatedOverrides.followRedirects,
         locations: validatedOverrides.locations,

--- a/src/commands/synthetics/run-tests-command.ts
+++ b/src/commands/synthetics/run-tests-command.ts
@@ -9,7 +9,7 @@ import {removeUndefinedValues, resolveConfigFromFile} from '../../helpers/utils'
 import * as validation from '../../helpers/validation'
 import {isValidDatadogSite} from '../../helpers/validation'
 
-import {moveLocationsToTestOverrides, replaceGlobalWithDefaultTestOverrides} from './compatibility'
+import {replaceGlobalWithDefaultTestOverrides} from './compatibility'
 import {CiError} from './errors'
 import {MainReporter, Reporter, Result, RunTestsCommandConfig, Summary} from './interfaces'
 import {DefaultReporter} from './reporters/default'
@@ -47,8 +47,6 @@ export const DEFAULT_COMMAND_CONFIG: RunTestsCommandConfig = {
   // TODO SYNTH-12989: Clean up deprecated `global` in favor of `defaultTestOverrides`
   global: {},
   jUnitReport: '',
-  // TODO SYNTH-12989: Clean up `locations` that should only be part of test overrides
-  locations: [],
   proxy: {protocol: 'http'},
   publicIds: [],
   subdomain: 'app',
@@ -258,9 +256,6 @@ export class RunTestsCommand extends Command {
     // TODO SYNTH-12989: Clean up deprecated `global` in favor of `defaultTestOverrides`
     this.config = replaceGlobalWithDefaultTestOverrides(this.config, this.reporter)
 
-    // TODO SYNTH-12989: Clean up `locations` that should only be part of test overrides
-    this.config = moveLocationsToTestOverrides(this.config, this.reporter)
-
     // Override with ENV variables
     this.config = deepExtend(
       this.config,
@@ -319,10 +314,7 @@ export class RunTestsCommand extends Command {
         deviceIds: process.env.DATADOG_SYNTHETICS_OVERRIDE_DEVICE_IDS?.split(';'),
         executionRule: toExecutionRule(process.env.DATADOG_SYNTHETICS_OVERRIDE_EXECUTION_RULE),
         followRedirects: toBoolean(process.env.DATADOG_SYNTHETICS_OVERRIDE_FOLLOW_REDIRECTS),
-        // TODO SYNTH-12989: Clean up `locations` that should only be part of test overrides
-        locations:
-          process.env.DATADOG_SYNTHETICS_OVERRIDE_LOCATIONS?.split(';') ??
-          process.env.DATADOG_SYNTHETICS_LOCATIONS?.split(';'),
+        locations: process.env.DATADOG_SYNTHETICS_OVERRIDE_LOCATIONS?.split(';'),
         mobileApplicationVersion: process.env.DATADOG_SYNTHETICS_OVERRIDE_MOBILE_APPLICATION_VERSION,
         resourceUrlSubstitutionRegexes: process.env.DATADOG_SYNTHETICS_OVERRIDE_RESOURCE_URL_SUBSTITUTION_REGEXES?.split(
           ';'

--- a/src/commands/synthetics/run-tests-command.ts
+++ b/src/commands/synthetics/run-tests-command.ts
@@ -9,11 +9,7 @@ import {removeUndefinedValues, resolveConfigFromFile} from '../../helpers/utils'
 import * as validation from '../../helpers/validation'
 import {isValidDatadogSite} from '../../helpers/validation'
 
-import {
-  moveLocationsToTestOverrides,
-  replaceGlobalWithDefaultTestOverrides,
-  replacePollingTimeoutWithBatchTimeout,
-} from './compatibility'
+import {moveLocationsToTestOverrides, replaceGlobalWithDefaultTestOverrides} from './compatibility'
 import {CiError} from './errors'
 import {MainReporter, Reporter, Result, RunTestsCommandConfig, Summary} from './interfaces'
 import {DefaultReporter} from './reporters/default'
@@ -34,8 +30,6 @@ import {
 export const MAX_TESTS_TO_TRIGGER = 1000
 
 export const DEFAULT_BATCH_TIMEOUT = 30 * 60 * 1000
-/** @deprecated Please use `DEFAULT_BATCH_TIMEOUT` instead. */
-export const DEFAULT_POLLING_TIMEOUT = DEFAULT_BATCH_TIMEOUT
 
 export const DEFAULT_TEST_CONFIG_FILES_GLOB = '{,!(node_modules)/**/}*.synthetics.json'
 
@@ -55,8 +49,6 @@ export const DEFAULT_COMMAND_CONFIG: RunTestsCommandConfig = {
   jUnitReport: '',
   // TODO SYNTH-12989: Clean up `locations` that should only be part of test overrides
   locations: [],
-  // TODO SYNTH-12989: Clean up deprecated `pollingTimeout` in favor of `batchTimeout`
-  pollingTimeout: DEFAULT_POLLING_TIMEOUT,
   proxy: {protocol: 'http'},
   publicIds: [],
   subdomain: 'app',
@@ -144,13 +136,6 @@ export class RunTestsCommand extends Command {
   })
   private overrides = Option.Array('--override', {
     description: 'Override specific test properties.',
-  })
-  // TODO SYNTH-12989: Clean up deprecated `--pollingTimeout` in favor of `--batchTimeout`
-  /** @deprecated This CLI parameter is deprecated, please use `--batchTimeout` instead. */
-  private pollingTimeout = Option.String('--pollingTimeout', {
-    description:
-      '**DEPRECATED** The duration (in milliseconds) after which `datadog-ci` stops polling for test results. Please use `--batchTimeout` instead.',
-    validator: validation.isInteger(),
   })
   private publicIds = Option.Array('-p,--public-id', {description: 'Specify a test to run.'})
   private selectiveRerun = Option.Boolean('--selectiveRerun', {
@@ -376,14 +361,6 @@ export class RunTestsCommand extends Command {
         testSearchQuery: this.testSearchQuery,
         tunnel: this.tunnel,
       })
-    )
-    // TODO SYNTH-12989: Clean up deprecated `pollingTimeout` in favor of `batchTimeout`
-    this.config = replacePollingTimeoutWithBatchTimeout(
-      this.config,
-      this.reporter,
-      false,
-      this.batchTimeout,
-      this.pollingTimeout
     )
 
     // Override defaultTestOverrides with CLI parameters

--- a/src/commands/synthetics/run-tests-command.ts
+++ b/src/commands/synthetics/run-tests-command.ts
@@ -87,9 +87,9 @@ export class RunTestsCommand extends Command {
   })
 
   public configPath = Option.String('--config', {description: `Pass a path to a ${$1('global configuration file')}.`})
+
+  // JUnit options
   public jUnitReport = Option.String('-j,--jUnitReport', {description: 'Pass a path to a JUnit report file.'})
-  // TODO SYNTH-12989: Clean up deprecated `--runName`
-  /** @deprecated This CLI parameter is deprecated */
   public runName = Option.String('-n,--runName', {
     description: 'A name for this run, which will be included in the JUnit report file.',
   })

--- a/src/commands/synthetics/run-tests-lib.ts
+++ b/src/commands/synthetics/run-tests-lib.ts
@@ -2,11 +2,7 @@ import {getProxyAgent} from '../../helpers/utils'
 
 import {APIHelper, getApiHelper, isForbiddenError} from './api'
 import {runTests, waitForResults} from './batch'
-import {
-  moveLocationsToTestOverrides,
-  replaceGlobalWithDefaultTestOverrides,
-  replacePollingTimeoutWithBatchTimeout,
-} from './compatibility'
+import {moveLocationsToTestOverrides, replaceGlobalWithDefaultTestOverrides} from './compatibility'
 import {CiError, CriticalError, BatchTimeoutRunawayError} from './errors'
 import {
   MainReporter,
@@ -69,9 +65,6 @@ export const executeTests = async (
 
   // TODO SYNTH-12989: Clean up `locations` that should only be part of test overrides
   config = moveLocationsToTestOverrides(config, reporter, true)
-
-  // TODO SYNTH-12989: Clean up deprecated `pollingTimeout` in favor of `batchTimeout`
-  config = replacePollingTimeoutWithBatchTimeout(config, reporter, true)
 
   try {
     triggerConfigs = await getTriggerConfigs(api, config, reporter, suites)
@@ -153,19 +146,14 @@ export const executeTests = async (
   }
 
   try {
-    // TODO SYNTH-12989: Remove the `maxPollingTimeout` calculation when `pollingTimeout` is removed
-    const maxPollingTimeout = Math.max(
-      ...triggerConfigs.map(
-        (t) => config.batchTimeout || t.testOverrides?.pollingTimeout || config.pollingTimeout || DEFAULT_BATCH_TIMEOUT
-      )
-    )
     const {datadogSite, failOnCriticalErrors, failOnTimeout, subdomain} = config
+    const batchTimeout = config.batchTimeout || DEFAULT_BATCH_TIMEOUT
 
     const results = await waitForResults(
       api,
       trigger,
       tests,
-      {datadogSite, failOnCriticalErrors, failOnTimeout, subdomain, batchTimeout: maxPollingTimeout},
+      {datadogSite, failOnCriticalErrors, failOnTimeout, subdomain, batchTimeout},
       reporter,
       tunnel
     )

--- a/src/commands/synthetics/run-tests-lib.ts
+++ b/src/commands/synthetics/run-tests-lib.ts
@@ -2,7 +2,7 @@ import {getProxyAgent} from '../../helpers/utils'
 
 import {APIHelper, getApiHelper, isForbiddenError} from './api'
 import {runTests, waitForResults} from './batch'
-import {moveLocationsToTestOverrides, replaceGlobalWithDefaultTestOverrides} from './compatibility'
+import {replaceGlobalWithDefaultTestOverrides} from './compatibility'
 import {CiError, CriticalError, BatchTimeoutRunawayError} from './errors'
 import {
   MainReporter,
@@ -62,9 +62,6 @@ export const executeTests = async (
 
   // TODO SYNTH-12989: Clean up deprecated `global` in favor of `defaultTestOverrides`
   config = replaceGlobalWithDefaultTestOverrides(config, reporter, true)
-
-  // TODO SYNTH-12989: Clean up `locations` that should only be part of test overrides
-  config = moveLocationsToTestOverrides(config, reporter, true)
 
   try {
     triggerConfigs = await getTriggerConfigs(api, config, reporter, suites)

--- a/src/commands/synthetics/test.ts
+++ b/src/commands/synthetics/test.ts
@@ -1,11 +1,7 @@
 import chalk from 'chalk'
 
 import {APIHelper, EndpointError, formatBackendErrors, isNotFoundError} from './api'
-import {
-  replaceConfigWithTestOverrides,
-  warnIfDeprecatedConfigUsed,
-  warnIfDeprecatedPollingTimeoutUsed,
-} from './compatibility'
+import {replaceConfigWithTestOverrides, warnIfDeprecatedConfigUsed} from './compatibility'
 import {CiError, CriticalError} from './errors'
 import {
   RemoteTriggerConfig,
@@ -60,7 +56,6 @@ export const getTestConfigs = async (
   suites.push(...suitesFromFiles)
 
   warnIfDeprecatedConfigUsed(suites, reporter)
-  warnIfDeprecatedPollingTimeoutUsed(suites, reporter)
 
   const testConfigs = suites
     .map((suite) =>

--- a/src/commands/synthetics/utils/internal.ts
+++ b/src/commands/synthetics/utils/internal.ts
@@ -177,7 +177,6 @@ const allOverrideKeys: AccumulatorBaseConfigOverrideKey[] = [
   'followRedirects',
   'headers',
   'locations',
-  'pollingTimeout',
   'resourceUrlSubstitutionRegexes',
   'startUrl',
   'startUrlSubstitutionRegex',
@@ -232,8 +231,6 @@ export const validateAndParseOverrides = (overrides: string[] | undefined): Accu
       switch (key) {
         // Convert to number
         case 'defaultStepTimeout':
-        // TODO SYNTH-12989: Clean up `pollingTimeout` in favor of `batchTimeout`
-        case 'pollingTimeout':
         case 'testTimeout':
           acc[key] = parseOverrideValue(value, 'number') as number
           break
@@ -367,8 +364,6 @@ export const getBasePayload = (test: Test, testOverrides?: UserConfigOverride): 
       'followRedirects',
       'headers',
       'locations',
-      // TODO SYNTH-12989: Clean up deprecated `pollingTimeout`
-      'pollingTimeout',
       'resourceUrlSubstitutionRegexes',
       'retry',
       'startUrlSubstitutionRegex',

--- a/src/commands/synthetics/utils/public.ts
+++ b/src/commands/synthetics/utils/public.ts
@@ -31,7 +31,6 @@ import {
   TriggerConfig,
   UserConfigOverride,
 } from '../interfaces'
-import {DEFAULT_POLLING_TIMEOUT} from '../run-tests-command'
 
 import {
   LOCAL_TEST_DEFINITION_PUBLIC_ID_PLACEHOLDER,
@@ -77,16 +76,7 @@ export const makeTestPayload = (test: Test, triggerConfig: TriggerConfig, public
 }
 
 export const getTestOverridesCount = (testOverrides: UserConfigOverride) => {
-  return Object.keys(testOverrides).reduce((count, configKey) => {
-    // TODO SYNTH-12989: Clean up deprecated `pollingTimeout`
-    // We always send a value for `pollingTimeout` to the backend, even when the user doesn't override it.
-    // In that case, it shouldn't be counted.
-    if (configKey === 'pollingTimeout' && testOverrides[configKey] === DEFAULT_POLLING_TIMEOUT) {
-      return count
-    }
-
-    return count + 1
-  }, 0)
+  return Object.keys(testOverrides).reduce((count) => count + 1, 0)
 }
 
 export const setCiTriggerApp = (source: string): void => {

--- a/src/commands/synthetics/utils/public.ts
+++ b/src/commands/synthetics/utils/public.ts
@@ -335,35 +335,6 @@ export const retry = async <T, E extends Error>(
   return trier()
 }
 
-// TODO SYNTH-12989: Clean up deprecated `variableStrings` in favor of `variables` in `defaultTestOverrides`.
-export const parseVariablesFromCli = (
-  variableArguments: string[] = [],
-  logFunction: (log: string) => void
-): {[key: string]: string} | undefined => {
-  const variables: {[key: string]: string} = {}
-
-  for (const variableArgument of variableArguments) {
-    const separatorIndex = variableArgument.indexOf('=')
-
-    if (separatorIndex === -1) {
-      logFunction(`Ignoring variable "${variableArgument}" as separator "=" was not found`)
-      continue
-    }
-
-    if (separatorIndex === 0) {
-      logFunction(`Ignoring variable "${variableArgument}" as variable name is empty`)
-      continue
-    }
-
-    const key = variableArgument.substring(0, separatorIndex)
-    const value = variableArgument.substring(separatorIndex + 1)
-
-    variables[key] = value
-  }
-
-  return Object.keys(variables).length > 0 ? variables : undefined
-}
-
 export const getAppBaseURL = ({datadogSite, subdomain}: {datadogSite: string; subdomain: string}) => {
   return getCommonAppBaseURL(datadogSite, subdomain)
 }


### PR DESCRIPTION
### What and why?

- https://github.com/DataDog/datadog-ci/pull/1542
- https://github.com/DataDog/datadog-ci/pull/1543
- https://github.com/DataDog/datadog-ci/pull/1544 (← **you are here**)
- https://github.com/DataDog/datadog-ci/pull/1545
- https://github.com/DataDog/datadog-ci/pull/1546
- https://github.com/DataDog/datadog-ci/pull/1548

> [!NOTE]  
> This PR was created to prepare for the **next major release of datadog-ci**: `v3.0.0`
> A migration guide ([like such](https://github.com/DataDog/dd-trace-js/blob/master/MIGRATING.md)) will be created in a follow-up PR.

This PR removes 4 deprecated CLI parameters:
- `--pollingTimeout`
- `--locations`
- `--variable`
- `--deviceIds`

### How?

Remove the CLI parameters.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
