### PR TITLE
[SYNTH-12989] Remove deprecated `files` usage

### DIFF
--- a/src/commands/synthetics/run-tests-command.ts
+++ b/src/commands/synthetics/run-tests-command.ts
@@ -396,11 +396,6 @@ export class RunTestsCommand extends Command {
       this.config.defaultTestOverrides.variables = validatedOverrides.variables
     }
 
-    if (typeof this.config.files === 'string') {
-      this.reporter.log('[DEPRECATED] "files" should be an array of string instead of a string.\n')
-      this.config.files = [this.config.files]
-    }
-
     if (!isValidDatadogSite(this.config.datadogSite)) {
       throw new CiError(
         'INVALID_CONFIG',


### PR DESCRIPTION
### What and why?

- https://github.com/DataDog/datadog-ci/pull/1542
- https://github.com/DataDog/datadog-ci/pull/1543
- https://github.com/DataDog/datadog-ci/pull/1544
- https://github.com/DataDog/datadog-ci/pull/1545
- https://github.com/DataDog/datadog-ci/pull/1546
- https://github.com/DataDog/datadog-ci/pull/1548 (← **you are here**)

> [!NOTE]  
> This PR was created to prepare for the **next major release of datadog-ci**: `v3.0.0`
> A migration guide ([like such](https://github.com/DataDog/dd-trace-js/blob/master/MIGRATING.md)) will be created in a follow-up PR.

This PR removes the backwards compatibility for `"files"` being a glob string in the global configuration file. It now needs to be an array of strings.

### How?

Remove backwards compatibility and deprecation log.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
