### PR TITLE
add missing unit tests for resourceUrlSubstitutionRegexes

### DIFF
--- a/src/commands/synthetics/__tests__/cli.test.ts
+++ b/src/commands/synthetics/__tests__/cli.test.ts
@@ -216,6 +216,10 @@ describe('run-test', () => {
           mobileApplicationVersion: '00000000-0000-0000-0000-000000000000',
           mobileApplicationVersionFilePath: './path/to/application.apk',
           pollingTimeout: 3,
+          resourceUrlSubstitutionRegexes: [
+            's/(https://www.)(.*)/$1extra-$2',
+            'https://example.com(.*)|http://subdomain.example.com$1',
+          ],
           retry: {count: 2, interval: 300},
           startUrl: '{{URL}}?static_hash={{STATIC_HASH}}',
           startUrlSubstitutionRegex: 's/(https://www.)(.*)/$1extra-$2/',
@@ -249,6 +253,10 @@ describe('run-test', () => {
           mobileApplicationVersion: '00000000-0000-0000-0000-000000000000',
           mobileApplicationVersionFilePath: './path/to/application.apk',
           pollingTimeout: 2, // not overridden (backwards compatibility not supported)
+          resourceUrlSubstitutionRegexes: [
+            's/(https://www.)(.*)/$1extra-$2',
+            'https://example.com(.*)|http://subdomain.example.com$1',
+          ],
           retry: {count: 2, interval: 300},
           startUrl: '{{URL}}?static_hash={{STATIC_HASH}}',
           startUrlSubstitutionRegex: 's/(https://www.)(.*)/$1extra-$2/',

--- a/src/commands/synthetics/__tests__/config-fixtures/config-with-all-keys.json
+++ b/src/commands/synthetics/__tests__/config-fixtures/config-with-all-keys.json
@@ -31,6 +31,10 @@
     "mobileApplicationVersion": "00000000-0000-0000-0000-000000000000",
     "mobileApplicationVersionFilePath": "./path/to/application.apk",
     "pollingTimeout": 2,
+    "resourceUrlSubstitutionRegexes": [
+      "s/(https://www.)(.*)/$1extra-$2",
+      "https://example.com(.*)|http://subdomain.example.com$1"
+    ],
     "retry": {"count": 2, "interval": 300},
     "startUrl": "{{URL}}?static_hash={{STATIC_HASH}}",
     "startUrlSubstitutionRegex": "s/(https://www.)(.*)/$1extra-$2/",
@@ -59,6 +63,10 @@
     "mobileApplicationVersion": "00000000-0000-0000-0000-000000000000",
     "mobileApplicationVersionFilePath": "./path/to/application.apk",
     "pollingTimeout": 3,
+    "resourceUrlSubstitutionRegexes": [
+      "s/(https://www.)(.*)/$1extra-$2",
+      "https://example.com(.*)|http://subdomain.example.com$1"
+    ],
     "retry": {"count": 2, "interval": 300},
     "startUrl": "{{URL}}?static_hash={{STATIC_HASH}}",
     "startUrlSubstitutionRegex": "s/(https://www.)(.*)/$1extra-$2/",


### PR DESCRIPTION
### What and why?

Add the missing unit test cases for `resourceUrlSubstitutionRegexes`.
