### PR TITLE
Add fips options to code coverage command

### DIFF
--- a/src/__tests__/cli.test.ts
+++ b/src/__tests__/cli.test.ts
@@ -1,5 +1,3 @@
-// import crypto from 'crypto'
-
 import {Builtins, CommandClass} from 'clipanion'
 
 // Test all commands, including beta ones.
@@ -59,6 +57,7 @@ describe('cli', () => {
 
     // Without the required options, the commands are not executed at all
     const requiredOptions: Record<string, string[]> = {
+      'coverage upload': ['.', '--dry-run'],
       'dora deployment': ['--started-at', '0', '--dry-run'],
       'dsyms upload': ['.', '--dry-run'],
       'elf-symbols upload': ['non-existing-file', '--dry-run'],


### PR DESCRIPTION
### What and why?

The PR to add this command (#1520) was old and didn't include the FIPS options added in #1501.

### How?

Add `--fips` and `--fips-ignore-error` to `datadog-ci coverage upload` command.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
