### PR TITLE
[chores] Update codeowners, docs, issue labeler

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,6 +4,7 @@
 # Commands (grouped by product)
 
 ## CI Visibility (label: ci-visibility)
+src/commands/coverage      @DataDog/datadog-ci @DataDog/ci-app-libraries
 src/commands/deployment    @DataDog/datadog-ci @DataDog/ci-app-libraries
 src/commands/dora          @DataDog/datadog-ci @DataDog/ci-app-libraries
 src/commands/gate          @DataDog/datadog-ci @DataDog/ci-app-libraries

--- a/.github/advanced-issue-labeler.yml
+++ b/.github/advanced-issue-labeler.yml
@@ -6,13 +6,14 @@ policy:
         label:
           - name: ci-visibility
             keys:
-              - junit
+              - coverage
+              - deployment
+              - dora
               - gate
+              - junit
               - metric
               - tag
               - trace
-              - dora
-              - deployment
           - name: static-analysis
             keys:
               - sarif
@@ -23,17 +24,21 @@ policy:
           - name: rum
             keys:
               - dsyms
-              - unity-symbols
+              - flutter-symbols
               - react-native
               - sourcemaps
+              - unity-symbols
           - name: serverless
             keys:
+              - cloud-run
               - lambda
               - stepfunctions
-              - cloud-run
           - name: source-code-integration
             keys:
               - git-metadata
           - name: synthetics
             keys:
               - synthetics
+          - name: profiling
+            keys:
+              - elf-symbols

--- a/README.md
+++ b/README.md
@@ -102,6 +102,9 @@ See each command's linked README for more details, or click on [📚](https://do
 
 The following are **beta** commands, you can enable them with with `DD_BETA_COMMANDS_ENABLED=1`:
 
+#### `coverage`
+- `upload`: Upload code coverage report files to Datadog. (📚: no public documentation page yet)
+
 #### `deployment`
 - `mark`: Mark a CI job as a [deployment](src/commands/deployment). [📚](https://docs.datadoghq.com/continuous_delivery/)
 - `correlate`: [Correlate](src/commands/deployment/) GitOps CD deployments with application repositories CI pipelines. [📚](https://docs.datadoghq.com/continuous_delivery/deployments/argocd#correlate-deployments-with-ci-pipelines)

--- a/src/commands/coverage/README.md
+++ b/src/commands/coverage/README.md
@@ -68,5 +68,5 @@ Will upload ode coverage report file src/commands/coverage/__tests__/fixtures/ja
 
 ## Further reading
 
-- TODO: Add link to the documentation page
-- TODO: Add link to the documentation page in main README beta section
+[//]: <> (TODO: Add link to the documentation page)
+[//]: <> (TODO: Add link to the documentation page in main README beta section)

--- a/src/commands/coverage/README.md
+++ b/src/commands/coverage/README.md
@@ -68,4 +68,5 @@ Will upload ode coverage report file src/commands/coverage/__tests__/fixtures/ja
 
 ## Further reading
 
-[//]: <> (TODO: Add link to the documentation page)
+- TODO: Add link to the documentation page
+- TODO: Add link to the documentation page in main README beta section


### PR DESCRIPTION
### What and why?

This PR adds the `ci-app-libraries` team as codeowners for the `coverage` command, updates the issue labeler and add missing documentation in the beta section of the main readme.

### How?

Update meta files

### Review checklist

- ~~[ ] Feature or bugfix MUST have appropriate tests (unit, integration)~~
