### PR TITLE
Drop support for Node 14 and 16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -278,7 +278,7 @@ jobs:
       - name: Install node
         uses: actions/setup-node@v4
         with:
-          node-version: 14.18.3
+          node-version: 20.11.0
       # The install step has been added here such that the `.yarn/install-state.gz` file is generated. This file is used
       # by the script `check-licenses` below.
       - run: yarn install --immutable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [14, 16, 18, 20]
+        version: [18, 20, 22]
 
     name: Build and test
     runs-on: ubuntu-latest
@@ -62,7 +62,7 @@ jobs:
   e2e-test:
     strategy:
       matrix:
-        version: [14, 16, 18, 20]
+        version: [18, 20, 22]
 
     name: End-to-end test the package
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-prerelease.yml
+++ b/.github/workflows/publish-prerelease.yml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 14.18.3
+          node-version: 20.11.0
       - run: |
           # Isolate the tag and exit if none found
           IFS='-' read -ra ARR_TAG <<< $TAG

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -237,7 +237,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 14.18.3
+          node-version: 20.11.0
       - run: yarn
       - run: yarn npm publish
         env:

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "Apache-2.0",
   "bin": "dist/cli.js",
   "engines": {
-    "node": ">=14"
+    "node": ">=18"
   },
   "volta": {
     "node": "20.11.0",


### PR DESCRIPTION
### What and why?

This PR drops support for Node 14 and 16. It's a noop in terms of code, but will unblock other issues.

### How?

Update `package.json`, and stop testing on Node 14 and 16.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
