### PR TITLE
[ci] Fix slow `getSyntheticsOrgSettings` unit test

### DIFF
--- a/src/commands/synthetics/__tests__/utils/public.test.ts
+++ b/src/commands/synthetics/__tests__/utils/public.test.ts
@@ -47,9 +47,8 @@ import type * as path from 'path'
 import glob from 'glob'
 
 import {getAxiosError} from '../../../../helpers/__tests__/fixtures'
-import * as ciUtils from '../../../../helpers/utils'
 
-import {apiConstructor} from '../../api'
+import * as api from '../../api'
 import {CiError, CiErrorCode, CriticalError} from '../../errors'
 import {
   ExecutionRule,
@@ -69,22 +68,13 @@ import {
   getApiTest,
   getResults,
   getSummary,
+  mockApi,
   MockedReporter,
   mockReporter,
   RenderResultsTestCase,
 } from '../fixtures'
 
 describe('utils', () => {
-  const apiConfiguration = {
-    apiKey: '123',
-    appKey: '123',
-    baseIntakeUrl: 'baseintake',
-    baseUnstableUrl: 'baseUnstable',
-    baseUrl: 'base',
-    proxyOpts: {protocol: 'http'} as ciUtils.ProxyConfiguration,
-  }
-  const api = apiConstructor(apiConfiguration)
-
   describe('getSuites', () => {
     const GLOB = 'testGlob'
     const FILES = ['file1', 'file2']
@@ -632,7 +622,11 @@ describe('utils', () => {
     ]
 
     test.each(cases)('$description', async (testCase) => {
-      jest.spyOn(api, 'getSyntheticsOrgSettings').mockResolvedValue({onDemandConcurrencyCap: 1})
+      jest.spyOn(api, 'getApiHelper').mockReturnValue(
+        mockApi({
+          getSyntheticsOrgSettings: jest.fn().mockResolvedValue({onDemandConcurrencyCap: 1}),
+        })
+      )
 
       const config = {
         ...DEFAULT_COMMAND_CONFIG,
@@ -766,12 +760,15 @@ describe('utils', () => {
     })
 
     test('failing to get org settings is not important enough to throw', async () => {
-      jest.spyOn(api, 'getSyntheticsOrgSettings').mockImplementation(() => {
-        throw getAxiosError(502, {message: 'Server Error'})
-      })
+      jest.spyOn(api, 'getApiHelper').mockReturnValue(
+        mockApi({
+          getSyntheticsOrgSettings: jest.fn().mockImplementation(() => {
+            throw getAxiosError(502, {message: 'Server Error'})
+          }),
+        })
+      )
 
-      const config = (apiConfiguration as unknown) as SyntheticsCIConfig
-      expect(await utils.getOrgSettings(mockReporter, config)).toBeUndefined()
+      expect(await utils.getOrgSettings(mockReporter, {} as SyntheticsCIConfig)).toBeUndefined()
     })
   })
 

--- a/src/commands/synthetics/utils/public.ts
+++ b/src/commands/synthetics/utils/public.ts
@@ -215,10 +215,10 @@ export const getOrgSettings = async (
   reporter: MainReporter,
   config: SyntheticsCIConfig
 ): Promise<SyntheticsOrgSettings | undefined> => {
-  const apiHelper = getApiHelper(config)
+  const api = getApiHelper(config)
 
   try {
-    return await apiHelper.getSyntheticsOrgSettings()
+    return await api.getSyntheticsOrgSettings()
   } catch (e) {
     reporter.error(`Failed to get settings: ${formatBackendErrors(e, 'synthetics_default_settings_read')}`)
   }
@@ -319,9 +319,9 @@ export const isDeviceIdSet = (result: ServerResult): result is Required<BrowserS
   'device' in result && result.device !== undefined
 
 export const fetchTest = async (publicId: string, config: SyntheticsCIConfig): Promise<Test> => {
-  const apiHelper = getApiHelper(config)
+  const api = getApiHelper(config)
 
-  return apiHelper.getTest(publicId)
+  return api.getTest(publicId)
 }
 
 export const retry = async <T, E extends Error>(


### PR DESCRIPTION
### What and why?

The `failing to get org settings is not important enough to throw` unit test wasn't mocked properly, so the `/synthetics/settings` call was failing and retrying 3 times.

This was very noticeable in the train with slow internet 😅 

### How?

Fix mocks in unit tests

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
