### PR TITLE
[dep] Bump `@types/node`

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "@types/inquirer": "8.2.6",
     "@types/jest": "29.5.3",
     "@types/js-yaml": "^4.0.5",
-    "@types/node": "14.18.34",
+    "@types/node": "^18.19.76",
     "@types/rimraf": "^3.0.2",
     "@types/semver": "^7.3.12",
     "@types/ssh2": "1.11.6",

--- a/src/commands/synthetics/tunnel/tunnel.ts
+++ b/src/commands/synthetics/tunnel/tunnel.ts
@@ -270,12 +270,12 @@ export class Tunnel {
     this.multiplexer.on('error', (error) => this.reporter?.warn(`Multiplexer error: ${error.message}`))
     duplex.on('error', (error) => this.reporter?.warn(`Websocket error: ${error.message}`))
 
-    pipeline([duplex, this.multiplexer], (err) => {
+    pipeline(duplex, this.multiplexer, (err) => {
       if (err) {
         this.reporter?.warn(`Error on duplex connection close: ${err}`)
       }
     })
-    pipeline([this.multiplexer, duplex], (err) => {
+    pipeline(this.multiplexer, duplex, (err) => {
       if (err) {
         this.reporter?.warn(`Error on Multiplexer connection close: ${err}`)
       }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1936,7 +1936,7 @@ __metadata:
     "@types/inquirer": 8.2.6
     "@types/jest": 29.5.3
     "@types/js-yaml": ^4.0.5
-    "@types/node": 14.18.34
+    "@types/node": ^18.19.76
     "@types/rimraf": ^3.0.2
     "@types/semver": ^7.3.12
     "@types/ssh2": 1.11.6
@@ -3692,10 +3692,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:14.18.34":
-  version: 14.18.34
-  resolution: "@types/node@npm:14.18.34"
-  checksum: 25ac3b456a0b7b82c76b37276ec86845849e8276fc81d1470a87227c105c619e299aa7165b6148aa11a4ea156b1452f6d3327935f3e7dc0067ff54dde0e3d4e0
+"@types/node@npm:^18.19.76":
+  version: 18.19.76
+  resolution: "@types/node@npm:18.19.76"
+  dependencies:
+    undici-types: ~5.26.4
+  checksum: 33b477bfff9ebc15721d0d94beacbedbc3c66892587cce758289682a07a2a77e69b536cc68bddf240b82ddcb426700b4e04fc6f1db6fcfb174a98c5ec6d9bbf5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### What and why?

This PR bumps `@types/node` to be in sync with the new minimum supported version of Node.js: v18.

### How?

Update `stream.pipeline` to new way [callback function signature](https://nodejs.org/api/stream.html#streampipelinestreams-options).

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
