### PR TITLE
[dep] Bump glob to `10.4.5`

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "fast-xml-parser": "^4.4.1",
     "form-data": "4.0.0",
     "fuzzy": "^0.1.3",
-    "glob": "^7.1.4",
+    "glob": "^10.4.5",
     "google-auth-library": "^9.12.0",
     "inquirer": "^8.2.5",
     "inquirer-checkbox-plus-prompt": "^1.4.2",

--- a/src/commands/coverage/__tests__/upload.test.ts
+++ b/src/commands/coverage/__tests__/upload.test.ts
@@ -35,8 +35,8 @@ describe('upload', () => {
       })
       const fileNames = Object.values(result).flatMap((paths) => paths)
 
-      expect(fileNames[0]).toEqual('./src/commands/coverage/__tests__/fixtures/another-jacoco-report.xml')
-      expect(fileNames[1]).toEqual('./src/commands/coverage/__tests__/fixtures/jacoco-report.xml')
+      expect(fileNames[0]).toEqual('./src/commands/coverage/__tests__/fixtures/jacoco-report.xml')
+      expect(fileNames[1]).toEqual('./src/commands/coverage/__tests__/fixtures/another-jacoco-report.xml')
 
       const output = context.stdout.toString()
       expect(output).toContain(
@@ -96,8 +96,8 @@ describe('upload', () => {
 
       const fileNames = Object.values(result).flatMap((paths) => paths)
 
-      expect(fileNames[0]).toEqual('./src/commands/coverage/__tests__/fixtures/another-jacoco-report.xml')
-      expect(fileNames[1]).toEqual('./src/commands/coverage/__tests__/fixtures/jacoco-report.xml')
+      expect(fileNames[0]).toEqual('./src/commands/coverage/__tests__/fixtures/jacoco-report.xml')
+      expect(fileNames[1]).toEqual('./src/commands/coverage/__tests__/fixtures/another-jacoco-report.xml')
       expect(fileNames[2]).toEqual('./src/commands/coverage/__tests__/fixtures/subfolder/nested-jacoco-report.xml')
     })
 
@@ -130,9 +130,9 @@ describe('upload', () => {
       const fileNames = Object.values(result).flatMap((paths) => paths)
 
       expect(fileNames).toEqual([
-        'src/commands/coverage/__tests__/fixtures/another-jacoco-report.xml',
-        'src/commands/coverage/__tests__/fixtures/jacoco-report.xml',
-        'src/commands/coverage/__tests__/fixtures/subfolder/nested-jacoco-report.xml',
+        './src/commands/coverage/__tests__/fixtures/jacoco-report.xml',
+        './src/commands/coverage/__tests__/fixtures/another-jacoco-report.xml',
+        './src/commands/coverage/__tests__/fixtures/subfolder/nested-jacoco-report.xml',
       ])
     })
 
@@ -148,9 +148,9 @@ describe('upload', () => {
       const fileNames = Object.values(result).flatMap((paths) => paths)
 
       expect(fileNames).toEqual([
-        'src/commands/coverage/__tests__/fixtures/another-jacoco-report.xml',
-        'src/commands/coverage/__tests__/fixtures/jacoco-report.xml',
-        'src/commands/coverage/__tests__/fixtures/subfolder/nested-jacoco-report.xml',
+        './src/commands/coverage/__tests__/fixtures/jacoco-report.xml',
+        './src/commands/coverage/__tests__/fixtures/another-jacoco-report.xml',
+        './src/commands/coverage/__tests__/fixtures/subfolder/nested-jacoco-report.xml',
       ])
     })
   })

--- a/src/commands/coverage/upload.ts
+++ b/src/commands/coverage/upload.ts
@@ -4,7 +4,7 @@ import path from 'path'
 
 import chalk from 'chalk'
 import {Command, Option} from 'clipanion'
-import glob from 'glob'
+import {glob} from 'glob'
 import * as t from 'typanion'
 
 import {FIPS_ENV_VAR, FIPS_IGNORE_ERROR_ENV_VAR} from '../../constants'
@@ -249,7 +249,9 @@ export class UploadCodeCoverageReportCommand extends Command {
           globPattern = buildPath(basePath, '*.xml')
         }
 
-        const filesToUpload = glob.sync(globPattern).filter((file) => path.extname(file) === '.xml')
+        const filesToUpload = glob
+          .sync(globPattern, {dotRelative: true})
+          .filter((file) => path.extname(file) === '.xml')
 
         return acc.concat(filesToUpload)
       }, [])

--- a/src/commands/dsyms/__tests__/upload.test.ts
+++ b/src/commands/dsyms/__tests__/upload.test.ts
@@ -3,7 +3,7 @@ import {EOL, platform} from 'os'
 import path from 'path'
 
 import {Cli} from 'clipanion/lib/advanced'
-import glob from 'glob'
+import {glob} from 'glob'
 
 import * as APIKeyHelpers from '../../../helpers/apikey'
 import {buildPath} from '../../../helpers/utils'
@@ -308,13 +308,13 @@ describe('execute', () => {
     expect(output[4]).toContain('Will use temporary intermediate directory: ')
     expect(output[5]).toContain('Will use temporary upload directory: ')
     expect(output[6]).toContain(
-      'Uploading C8469F85-B060-3085-B69D-E46C645560EA.zip (DDTest, arch: armv7, UUID: C8469F85-B060-3085-B69D-E46C645560EA)'
+      'Uploading 3BC12422-63CC-30E8-B916-E5006CE3286C.zip (DDTest, arch: arm64, UUID: 3BC12422-63CC-30E8-B916-E5006CE3286C)'
     )
     expect(output[7]).toContain(
-      'Uploading 06EE3D68-D605-3E92-B92D-2F48C02A505E.zip (DDTest, arch: arm64, UUID: 06EE3D68-D605-3E92-B92D-2F48C02A505E)'
+      'Uploading C8469F85-B060-3085-B69D-E46C645560EA.zip (DDTest, arch: armv7, UUID: C8469F85-B060-3085-B69D-E46C645560EA)'
     )
     expect(output[8]).toContain(
-      'Uploading 3BC12422-63CC-30E8-B916-E5006CE3286C.zip (DDTest, arch: arm64, UUID: 3BC12422-63CC-30E8-B916-E5006CE3286C)'
+      'Uploading 06EE3D68-D605-3E92-B92D-2F48C02A505E.zip (DDTest, arch: arm64, UUID: 06EE3D68-D605-3E92-B92D-2F48C02A505E)'
     )
     expect(output[11]).toContain('Handled 3 dSYMs with success')
   })
@@ -334,13 +334,13 @@ describe('execute', () => {
     expect(output[4]).toContain('Will use temporary intermediate directory: ')
     expect(output[5]).toContain('Will use temporary upload directory: ')
     expect(output[6]).toContain(
-      'Uploading C8469F85-B060-3085-B69D-E46C645560EA.zip (DDTest, arch: armv7, UUID: C8469F85-B060-3085-B69D-E46C645560EA)'
+      'Uploading 3BC12422-63CC-30E8-B916-E5006CE3286C.zip (DDTest, arch: arm64, UUID: 3BC12422-63CC-30E8-B916-E5006CE3286C)'
     )
     expect(output[7]).toContain(
-      'Uploading 06EE3D68-D605-3E92-B92D-2F48C02A505E.zip (DDTest, arch: arm64, UUID: 06EE3D68-D605-3E92-B92D-2F48C02A505E)'
+      'Uploading C8469F85-B060-3085-B69D-E46C645560EA.zip (DDTest, arch: armv7, UUID: C8469F85-B060-3085-B69D-E46C645560EA)'
     )
     expect(output[8]).toContain(
-      'Uploading 3BC12422-63CC-30E8-B916-E5006CE3286C.zip (DDTest, arch: arm64, UUID: 3BC12422-63CC-30E8-B916-E5006CE3286C)'
+      'Uploading 06EE3D68-D605-3E92-B92D-2F48C02A505E.zip (DDTest, arch: arm64, UUID: 06EE3D68-D605-3E92-B92D-2F48C02A505E)'
     )
     expect(output[11]).toContain('Handled 3 dSYMs with success')
   })
@@ -362,13 +362,13 @@ describe('execute', () => {
     expect(output[4]).toContain('Will use temporary intermediate directory: ')
     expect(output[5]).toContain('Will use temporary upload directory: ')
     expect(output[6]).toContain(
-      'Uploading C8469F85-B060-3085-B69D-E46C645560EA.zip (DDTest, arch: armv7, UUID: C8469F85-B060-3085-B69D-E46C645560EA)'
+      'Uploading 3BC12422-63CC-30E8-B916-E5006CE3286C.zip (DDTest, arch: arm64, UUID: 3BC12422-63CC-30E8-B916-E5006CE3286C)'
     )
     expect(output[7]).toContain(
-      'Uploading 06EE3D68-D605-3E92-B92D-2F48C02A505E.zip (DDTest, arch: arm64, UUID: 06EE3D68-D605-3E92-B92D-2F48C02A505E)'
+      'Uploading C8469F85-B060-3085-B69D-E46C645560EA.zip (DDTest, arch: armv7, UUID: C8469F85-B060-3085-B69D-E46C645560EA)'
     )
     expect(output[8]).toContain(
-      'Uploading 3BC12422-63CC-30E8-B916-E5006CE3286C.zip (DDTest, arch: arm64, UUID: 3BC12422-63CC-30E8-B916-E5006CE3286C)'
+      'Uploading 06EE3D68-D605-3E92-B92D-2F48C02A505E.zip (DDTest, arch: arm64, UUID: 06EE3D68-D605-3E92-B92D-2F48C02A505E)'
     )
     expect(output[11]).toContain('Handled 3 dSYMs with success')
   })

--- a/src/commands/dsyms/__tests__/utils.test.ts
+++ b/src/commands/dsyms/__tests__/utils.test.ts
@@ -1,6 +1,6 @@
 import fs, {promises} from 'fs'
 
-import glob from 'glob'
+import {glob} from 'glob'
 
 import {buildPath} from '../../../helpers/utils'
 

--- a/src/commands/dsyms/upload.ts
+++ b/src/commands/dsyms/upload.ts
@@ -3,7 +3,7 @@ import path from 'path'
 
 import chalk from 'chalk'
 import {Command, Option} from 'clipanion'
-import glob from 'glob'
+import {glob} from 'glob'
 
 import {FIPS_ENV_VAR, FIPS_IGNORE_ERROR_ENV_VAR} from '../../constants'
 import {ApiKeyValidator, newApiKeyValidator} from '../../helpers/apikey'

--- a/src/commands/elf-symbols/upload.ts
+++ b/src/commands/elf-symbols/upload.ts
@@ -2,7 +2,7 @@ import fs from 'fs'
 import path from 'path'
 
 import {Command, Option} from 'clipanion'
-import glob from 'glob'
+import {glob} from 'glob'
 
 import {FIPS_ENV_VAR, FIPS_IGNORE_ERROR_ENV_VAR} from '../../constants'
 import {newApiKeyValidator} from '../../helpers/apikey'
@@ -211,8 +211,7 @@ export class UploadCommand extends Command {
 
     const stat = await fs.promises.stat(symbolsLocation)
     if (stat.isDirectory()) {
-      // strict: false is needed to avoid throwing an error if a directory is not readable
-      paths = glob.sync(buildPath(symbolsLocation, '**'), {dot: true, strict: false, silent: true})
+      paths = await glob(buildPath(symbolsLocation, '**'), {dot: true, dotRelative: true})
       reportFailure = (message: string) => this.context.stdout.write(renderWarning(message))
 
       // throw an error if top-level directory is not readable

--- a/src/commands/flutter-symbols/__tests__/upload.test.ts
+++ b/src/commands/flutter-symbols/__tests__/upload.test.ts
@@ -129,10 +129,10 @@ describe('flutter-symbol upload', () => {
       const files = command['getFlutterSymbolFiles'](searchDir)
 
       expect(files).toEqual([
-        `${searchDir}/app.android-arm.symbols`,
-        `${searchDir}/app.android-arm64.symbols`,
-        `${searchDir}/app.android-x64.symbols`,
         `${searchDir}/app.ios-arm64.symbols`,
+        `${searchDir}/app.android-x64.symbols`,
+        `${searchDir}/app.android-arm64.symbols`,
+        `${searchDir}/app.android-arm.symbols`,
       ])
     })
   })

--- a/src/commands/flutter-symbols/upload.ts
+++ b/src/commands/flutter-symbols/upload.ts
@@ -1,7 +1,7 @@
 import fs from 'fs'
 
 import {Command, Option} from 'clipanion'
-import glob from 'glob'
+import {glob} from 'glob'
 import yaml from 'js-yaml'
 import semver from 'semver'
 
@@ -211,7 +211,7 @@ export class UploadCommand extends Command {
   }
 
   private getFlutterSymbolFiles(dartSymbolLocation: string): string[] {
-    const symbolPaths = glob.sync(buildPath(dartSymbolLocation, '*.symbols'))
+    const symbolPaths = glob.sync(buildPath(dartSymbolLocation, '*.symbols'), {dotRelative: true})
 
     return symbolPaths
   }

--- a/src/commands/junit/__tests__/upload.test.ts
+++ b/src/commands/junit/__tests__/upload.test.ts
@@ -49,10 +49,10 @@ describe('upload', () => {
       )
 
       expect(firstFile).toMatchObject({
-        xmlPath: './src/commands/junit/__tests__/fixtures/go-report.xml',
+        xmlPath: './src/commands/junit/__tests__/fixtures/java-report.xml',
       })
       expect(secondFile).toMatchObject({
-        xmlPath: './src/commands/junit/__tests__/fixtures/java-report.xml',
+        xmlPath: './src/commands/junit/__tests__/fixtures/go-report.xml',
       })
 
       const output = context.stdout.toString()
@@ -128,10 +128,10 @@ describe('upload', () => {
         {}
       )
       expect(firstFile).toMatchObject({
-        xmlPath: './src/commands/junit/__tests__/fixtures/go-report.xml',
+        xmlPath: './src/commands/junit/__tests__/fixtures/java-report.xml',
       })
       expect(secondFile).toMatchObject({
-        xmlPath: './src/commands/junit/__tests__/fixtures/java-report.xml',
+        xmlPath: './src/commands/junit/__tests__/fixtures/go-report.xml',
       })
       expect(thirdFile).toMatchObject({
         xmlPath: './src/commands/junit/__tests__/fixtures/subfolder/js-report.xml',
@@ -154,10 +154,10 @@ describe('upload', () => {
         {}
       )
       expect(firstFile).toMatchObject({
-        xmlPath: './src/commands/junit/__tests__/fixtures/junit.xml/valid-report-2.xml',
+        xmlPath: './src/commands/junit/__tests__/fixtures/junit.xml/valid-report.xml',
       })
       expect(secondFile).toMatchObject({
-        xmlPath: './src/commands/junit/__tests__/fixtures/junit.xml/valid-report.xml',
+        xmlPath: './src/commands/junit/__tests__/fixtures/junit.xml/valid-report-2.xml',
       })
     })
     test('should not have repeated files', async () => {
@@ -268,11 +268,11 @@ describe('upload', () => {
       const fileNames = files.map((file) => file.xmlPath)
 
       expect(fileNames).toEqual([
-        'src/commands/junit/__tests__/fixtures/go-report.xml',
-        'src/commands/junit/__tests__/fixtures/java-report.xml',
-        'src/commands/junit/__tests__/fixtures/junit.xml/valid-report-2.xml',
-        'src/commands/junit/__tests__/fixtures/junit.xml/valid-report.xml',
-        'src/commands/junit/__tests__/fixtures/subfolder/js-report.xml',
+        './src/commands/junit/__tests__/fixtures/java-report.xml',
+        './src/commands/junit/__tests__/fixtures/go-report.xml',
+        './src/commands/junit/__tests__/fixtures/subfolder/js-report.xml',
+        './src/commands/junit/__tests__/fixtures/junit.xml/valid-report.xml',
+        './src/commands/junit/__tests__/fixtures/junit.xml/valid-report-2.xml',
       ])
     })
     test('should fetch nested folders and ignore non xml files', async () => {
@@ -294,11 +294,11 @@ describe('upload', () => {
       const fileNames = files.map((file) => file.xmlPath)
 
       expect(fileNames).toEqual([
-        'src/commands/junit/__tests__/fixtures/go-report.xml',
-        'src/commands/junit/__tests__/fixtures/java-report.xml',
-        'src/commands/junit/__tests__/fixtures/junit.xml/valid-report-2.xml',
-        'src/commands/junit/__tests__/fixtures/junit.xml/valid-report.xml',
-        'src/commands/junit/__tests__/fixtures/subfolder/js-report.xml',
+        './src/commands/junit/__tests__/fixtures/java-report.xml',
+        './src/commands/junit/__tests__/fixtures/go-report.xml',
+        './src/commands/junit/__tests__/fixtures/subfolder/js-report.xml',
+        './src/commands/junit/__tests__/fixtures/junit.xml/valid-report.xml',
+        './src/commands/junit/__tests__/fixtures/junit.xml/valid-report-2.xml',
       ])
     })
   })

--- a/src/commands/junit/upload.ts
+++ b/src/commands/junit/upload.ts
@@ -5,7 +5,7 @@ import path from 'path'
 import chalk from 'chalk'
 import {Command, Option} from 'clipanion'
 import {XMLParser, XMLValidator} from 'fast-xml-parser'
-import glob from 'glob'
+import {glob} from 'glob'
 import * as t from 'typanion'
 
 import {FIPS_ENV_VAR, FIPS_IGNORE_ERROR_ENV_VAR} from '../../constants'
@@ -293,7 +293,9 @@ export class UploadJUnitXMLCommand extends Command {
           globPattern = buildPath(basePath, '*.xml')
         }
 
-        const filesToUpload = glob.sync(globPattern).filter((file) => path.extname(file) === '.xml')
+        const filesToUpload = glob
+          .sync(globPattern, {dotRelative: true})
+          .filter((file) => path.extname(file) === '.xml')
 
         return acc.concat(filesToUpload)
       }, [])

--- a/src/commands/sarif/__tests__/upload.test.ts
+++ b/src/commands/sarif/__tests__/upload.test.ts
@@ -57,10 +57,10 @@ describe('upload', () => {
       )
 
       expect(firstFile).toMatchObject({
-        reportPath: './src/commands/sarif/__tests__/fixtures/valid-no-results.sarif',
+        reportPath: './src/commands/sarif/__tests__/fixtures/valid-results.sarif',
       })
       expect(secondFile).toMatchObject({
-        reportPath: './src/commands/sarif/__tests__/fixtures/valid-results.sarif',
+        reportPath: './src/commands/sarif/__tests__/fixtures/valid-no-results.sarif',
       })
 
       const getInvalidJsonUnexpectedTokenErrorMessage = () => {
@@ -136,10 +136,10 @@ describe('upload', () => {
         {}
       )
       expect(firstFile).toMatchObject({
-        reportPath: './src/commands/sarif/__tests__/fixtures/valid-no-results.sarif',
+        reportPath: './src/commands/sarif/__tests__/fixtures/valid-results.sarif',
       })
       expect(secondFile).toMatchObject({
-        reportPath: './src/commands/sarif/__tests__/fixtures/valid-results.sarif',
+        reportPath: './src/commands/sarif/__tests__/fixtures/valid-no-results.sarif',
       })
       expect(thirdFile).toMatchObject({
         reportPath: './src/commands/sarif/__tests__/fixtures/subfolder/valid-results.sarif',

--- a/src/commands/sarif/upload.ts
+++ b/src/commands/sarif/upload.ts
@@ -3,7 +3,7 @@ import path from 'path'
 
 import chalk from 'chalk'
 import {Command, Option} from 'clipanion'
-import glob from 'glob'
+import {glob} from 'glob'
 
 import {FIPS_ENV_VAR, FIPS_IGNORE_ERROR_ENV_VAR} from '../../constants'
 import {doWithMaxConcurrency} from '../../helpers/concurrency'
@@ -185,7 +185,7 @@ export class UploadSarifReportCommand extends Command {
         return acc.concat(fs.existsSync(basePath) ? [basePath] : [])
       }
 
-      return acc.concat(glob.sync(buildPath(basePath, '*.sarif')))
+      return acc.concat(glob.sync(buildPath(basePath, '*.sarif'), {dotRelative: true}))
     }, [])
 
     const validUniqueFiles = [...new Set(sarifReports)].filter((sarifReport) => {

--- a/src/commands/sourcemaps/upload.ts
+++ b/src/commands/sourcemaps/upload.ts
@@ -3,7 +3,7 @@ import {URL} from 'url'
 
 import chalk from 'chalk'
 import {Command, Option} from 'clipanion'
-import glob from 'glob'
+import {glob} from 'glob'
 
 import {FIPS_ENV_VAR, FIPS_IGNORE_ERROR_ENV_VAR} from '../../constants'
 import {ApiKeyValidator, newApiKeyValidator} from '../../helpers/apikey'

--- a/src/commands/synthetics/__tests__/utils/public.test.ts
+++ b/src/commands/synthetics/__tests__/utils/public.test.ts
@@ -44,7 +44,7 @@ import process from 'process'
 
 import type * as path from 'path'
 
-import glob from 'glob'
+import {glob} from 'glob'
 
 import {getAxiosError} from '../../../../helpers/__tests__/fixtures'
 
@@ -83,10 +83,10 @@ describe('utils', () => {
       file2: '{"tests":"file2"}',
     }
 
+    jest.spyOn(glob, 'glob').mockResolvedValue(FILES)
     ;(fs.readFile as any).mockImplementation((path: 'file1' | 'file2', opts: any, callback: any) =>
       callback(undefined, FILES_CONTENT[path])
     )
-    ;(glob as any).mockImplementation((query: string, callback: (e: any, v: any) => void) => callback(undefined, FILES))
     ;(child_process.exec as any).mockImplementation(
       (command: string, callback: (error: any, stdout: string, stderr: string) => void) => callback(undefined, '.', '')
     )

--- a/src/commands/synthetics/utils/public.ts
+++ b/src/commands/synthetics/utils/public.ts
@@ -5,7 +5,7 @@ import process from 'process'
 import {promisify} from 'util'
 
 import chalk from 'chalk'
-import glob from 'glob'
+import {glob} from 'glob'
 
 import {getCommonAppBaseURL} from '../../../helpers/app'
 
@@ -159,7 +159,7 @@ export const getResultOutcome = (result: Result): ResultOutcome => {
 export const getSuites = async (GLOB: string, reporter: MainReporter): Promise<Suite[]> => {
   reporter.log(`Finding files matching ${path.resolve(process.cwd(), GLOB)}\n`)
 
-  const files: string[] = await promisify(glob)(GLOB)
+  const files: string[] = await glob(GLOB)
   if (files.length) {
     reporter.log(`\nGot test files:\n${files.map((file) => `  - ${file}\n`).join('')}\n`)
   } else {

--- a/src/commands/unity-symbols/upload.ts
+++ b/src/commands/unity-symbols/upload.ts
@@ -2,7 +2,7 @@ import fs from 'fs'
 import path, {basename} from 'path'
 
 import {Command, Option} from 'clipanion'
-import glob from 'glob'
+import {glob} from 'glob'
 
 import {FIPS_ENV_VAR, FIPS_IGNORE_ERROR_ENV_VAR} from '../../constants'
 import {newApiKeyValidator} from '../../helpers/apikey'

--- a/yarn.lock
+++ b/yarn.lock
@@ -1971,7 +1971,7 @@ __metadata:
     fast-xml-parser: ^4.4.1
     form-data: 4.0.0
     fuzzy: ^0.1.3
-    glob: ^7.1.4
+    glob: ^10.4.5
     google-auth-library: ^9.12.0
     inquirer: ^8.2.5
     inquirer-checkbox-plus-prompt: ^1.4.2
@@ -6468,7 +6468,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"glob@npm:^10.2.2, glob@npm:^10.3.10, glob@npm:^10.3.7":
+"glob@npm:^10.2.2, glob@npm:^10.3.10, glob@npm:^10.3.7, glob@npm:^10.4.5":
   version: 10.4.5
   resolution: "glob@npm:10.4.5"
   dependencies:


### PR DESCRIPTION
### What and why?

> [!NOTE]  
> This PR is based on https://github.com/DataDog/datadog-ci/pull/1381, which had to be reverted (https://github.com/DataDog/datadog-ci/pull/1398) because it was bumping `glob` to its latest version (`11.0.0`), which has dropped support for Node 18: https://github.com/isaacs/node-glob/blob/main/changelog.md#110

Related to https://github.com/DataDog/datadog-ci/issues/1378

This PR bumps `glob` to the latest version **that still supports Node 18** (our new minimal version as per #1554).

### How?

Differences with the old version:
- The algorithm was rewritten, and the order of results has changed
- A `dotRelative` option was added to keep `./`: https://github.com/isaacs/node-glob/issues/495
- The `silent` and `strict` options were removed:
  > Any readdir errors are simply treated as "the directory could not be read", and it is treated as a normal file entry instead, like shells do. (see [changelog.md](https://github.com/isaacs/node-glob/blob/main/changelog.md#90))

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
