### PR TITLE
[SYNTH-18686] Hotfix: only prompt ml updates if config contains ltds

### DIFF
--- a/src/commands/synthetics/run-tests-lib.ts
+++ b/src/commands/synthetics/run-tests-lib.ts
@@ -65,6 +65,14 @@ export const executeTests = async (
     throw new CriticalError(isForbiddenError(error) ? 'AUTHORIZATION_ERROR' : 'UNAVAILABLE_TEST_CONFIG', error.message)
   }
 
+  let hasLTD = false
+  for (const triggerConfig of triggerConfigs) {
+    if (isLocalTriggerConfig(triggerConfig)) {
+      hasLTD = true
+      break
+    }
+  }
+
   if (triggerConfigs.length === 0) {
     throw new CiError('NO_TESTS_TO_RUN')
   }
@@ -151,10 +159,12 @@ export const executeTests = async (
       tunnel
     )
 
-    try {
-      await updateLTDMultiLocators(reporter, config, results)
-    } catch (error) {
-      throw new CriticalError('LTD_MULTILOCATORS_UPDATE_FAILED', error.message)
+    if (hasLTD) {
+      try {
+        await updateLTDMultiLocators(reporter, config, results)
+      } catch (error) {
+        throw new CriticalError('LTD_MULTILOCATORS_UPDATE_FAILED', error.message)
+      }
     }
 
     return {


### PR DESCRIPTION
### What and why?

This PR fixes an [issue](https://github.com/DataDog/datadog-ci/issues/1565) where pipelines hang indefinetly because of a new prompt.

### How?

Only prompt ML update if local test definitions are present in the payload.  

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
