### PR TITLE
[SYNTH-18694] Do not prompt ML update confirmation in CI environments

### DIFF
--- a/src/commands/synthetics/__tests__/multilocator.test.ts
+++ b/src/commands/synthetics/__tests__/multilocator.test.ts
@@ -1,8 +1,10 @@
 jest.mock('fs/promises')
 import * as fsPromises from 'fs/promises'
 
+import * as ci from '../../../helpers/ci'
+import * as prompt from '../../../helpers/prompt'
+
 import {ImportTestsCommandConfig, Result, LocalTestDefinition} from '../interfaces'
-import * as multilocator from '../multilocator'
 import {updateLTDMultiLocators} from '../multilocator'
 import * as tests from '../test'
 
@@ -44,7 +46,8 @@ describe('multilocator', () => {
     }
 
     jest.spyOn(tests, 'getTestConfigs').mockResolvedValue(mockTestConfig.tests)
-    jest.spyOn(multilocator, 'promptUser').mockResolvedValue(true)
+    jest.spyOn(prompt, 'requestConfirmation').mockResolvedValue(true)
+    jest.spyOn(ci, 'isInteractive').mockReturnValue(true)
     jest.spyOn(fsPromises, 'writeFile').mockImplementation(async () => Promise.resolve())
   })
 
@@ -77,7 +80,7 @@ describe('multilocator', () => {
     })
 
     test('should not overwrite file if user declines update prompt', async () => {
-      jest.spyOn(multilocator, 'promptUser').mockResolvedValue(false)
+      jest.spyOn(prompt, 'requestConfirmation').mockResolvedValue(false)
 
       await updateLTDMultiLocators(mockReporter, mockConfig, mockResults)
 

--- a/src/commands/synthetics/__tests__/multilocator.test.ts
+++ b/src/commands/synthetics/__tests__/multilocator.test.ts
@@ -122,5 +122,18 @@ describe('multilocator', () => {
 
       expect(fsPromises.writeFile).not.toHaveBeenCalled()
     })
+
+    test('should exit early if not in interactive mode', async () => {
+      jest.spyOn(ci, 'isInteractive').mockReturnValue(false)
+
+      await updateLTDMultiLocators(mockReporter, mockConfig, mockResults)
+
+      expect(prompt.requestConfirmation).not.toHaveBeenCalled()
+      expect(tests.getTestConfigs).not.toHaveBeenCalled()
+      expect(fsPromises.writeFile).not.toHaveBeenCalled()
+      expect(mockReporter.log).toHaveBeenCalledWith(
+        expect.stringContaining('MultiLocator updates found, but cannot apply them in non-interactive mode.')
+      )
+    })
   })
 })

--- a/src/commands/synthetics/multilocator.ts
+++ b/src/commands/synthetics/multilocator.ts
@@ -1,6 +1,7 @@
 import {writeFile} from 'fs/promises'
 
-import inquirer from 'inquirer'
+import {isInteractive} from '../../helpers/ci'
+import {requestConfirmation} from '../../helpers/prompt'
 
 import {Result, MultiLocator, TestConfig, ImportTestsCommandConfig, MainReporter} from './interfaces'
 import {findUniqueLocalTestDefinition} from './local-test-definition'
@@ -24,8 +25,13 @@ export const updateLTDMultiLocators = async (
     return reporter.log('No MultiLocator updates found. No changes will be made.\n')
   }
 
-  const userConfirmed = await promptUser(
-    'MultiLocator updates found. Do you want to apply them to your local test definition?'
+  if (!isInteractive()) {
+    return reporter.log('Cannot apply MultiLocator updates in non-interactive mode.\n')
+  }
+
+  const userConfirmed = await requestConfirmation(
+    'MultiLocator updates found. Do you want to apply them to your local test definition?',
+    false
   )
   if (!userConfirmed) {
     return reporter.log('\nMultiLocator updates aborted by user.\n')
@@ -71,18 +77,6 @@ const getMultiLocatorsFromResults = (results: Result[]): MultiLocatorMap => {
   }
 
   return multiLocatorMap
-}
-
-export const promptUser = async (message: string): Promise<boolean> => {
-  const question: inquirer.ConfirmQuestion<{confirm: boolean}> = {
-    type: 'confirm',
-    name: 'confirm',
-    message,
-    default: false,
-  }
-  const {confirm} = await inquirer.prompt([question])
-
-  return confirm
 }
 
 const overwriteMultiLocatorsInTestConfig = (

--- a/src/commands/synthetics/multilocator.ts
+++ b/src/commands/synthetics/multilocator.ts
@@ -26,7 +26,7 @@ export const updateLTDMultiLocators = async (
   }
 
   if (!isInteractive()) {
-    return reporter.log('Cannot apply MultiLocator updates in non-interactive mode.\n')
+    return reporter.log('MultiLocator updates found, but cannot apply them in non-interactive mode.\n')
   }
 
   const userConfirmed = await requestConfirmation(

--- a/src/helpers/ci.ts
+++ b/src/helpers/ci.ts
@@ -868,3 +868,7 @@ const filterEnv = (values: string[]): Record<string, string> => {
 
   return ciEnvs
 }
+
+export const isInteractive = ({stream = process.stdout}: {stream?: NodeJS.WriteStream} = {}) => {
+  return Boolean(!('CI' in process.env) && process.env.TERM !== 'dumb' && stream && stream.isTTY)
+}

--- a/src/helpers/prompt.ts
+++ b/src/helpers/prompt.ts
@@ -4,7 +4,10 @@
 
 import inquirer from 'inquirer'
 
-export const confirmationQuestion = (message: string, defaultValue = true): inquirer.ConfirmQuestion => ({
+export const confirmationQuestion = (
+  message: string,
+  defaultValue = true
+): inquirer.ConfirmQuestion<{confirmation: boolean}> => ({
   message,
   name: 'confirmation',
   type: 'confirm',
@@ -16,27 +19,28 @@ export const requestConfirmation = async (message: string, defaultValue = true) 
     const confirmationAnswer = await inquirer.prompt(confirmationQuestion(message, defaultValue))
 
     return confirmationAnswer.confirmation
-  } catch (e) {
-    if (e instanceof Error) {
-      throw Error(`Couldn't receive confirmation. ${e.message}`)
+  } catch (err) {
+    if (err instanceof Error) {
+      throw Error(`Couldn't receive confirmation. ${err.message}`)
     }
+    throw err
   }
 }
 
 export const requestFilePath = async () => {
   try {
-    const filePathAnswer = await inquirer.prompt([
-      {
-        type: 'input',
-        name: 'filePath',
-        message: 'Please enter a file path, or press Enter to finish:',
-      },
-    ])
+    const question: inquirer.InputQuestion<{filePath: string}> = {
+      type: 'input',
+      name: 'filePath',
+      message: 'Please enter a file path, or press Enter to finish:',
+    }
+    const filePathAnswer = await inquirer.prompt([question])
 
     return filePathAnswer.filePath
-  } catch (e) {
-    if (e instanceof Error) {
-      throw Error(`Couldn't receive file path. ${e.message}`)
+  } catch (err) {
+    if (err instanceof Error) {
+      throw Error(`Couldn't receive file path. ${err.message}`)
     }
+    throw err
   }
 }

--- a/src/helpers/prompt.ts
+++ b/src/helpers/prompt.ts
@@ -30,9 +30,9 @@ export const requestConfirmation = async (message: string, defaultValue = true) 
 export const requestFilePath = async () => {
   try {
     const question: inquirer.InputQuestion<{filePath: string}> = {
-      type: 'input',
-      name: 'filePath',
       message: 'Please enter a file path, or press Enter to finish:',
+      name: 'filePath',
+      type: 'input',
     }
     const filePathAnswer = await inquirer.prompt([question])
 


### PR DESCRIPTION
### What and why?

Currently, running an LTD can result in pipelines stuck on hold waiting for a prompt from the user, when a ML update is detected. We want to skip this step if we detect that the `run-tests` command was used in a CI environment.

### How?

Only prompt the user for ml updates if in interactive mode.

- Add a new `isInteractive` function
- Reuse preexisting `requestConfirmation` function and improve its typing

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
