### PR TITLE
[K9VULN-3897] Filter large SARIF files

### DIFF
--- a/src/commands/sarif/renderer.ts
+++ b/src/commands/sarif/renderer.ts
@@ -18,7 +18,9 @@ export const renderInvalidFile = (sarifReport: string, errorMessages: string[]) 
   const reportPath = `[${chalk.bold.dim(sarifReport)}]`
 
   fullStr += chalk.red(`${ICONS.FAILED} Invalid SARIF report file ${reportPath}.\n`)
-  fullStr += chalk.red(`The report is not a valid JSON or is not compliant with the SARIF json schema v2.1.0.\n`)
+  fullStr += chalk.red(
+    `The report is too large, not a valid JSON or is not compliant with the SARIF json schema v2.1.0.\n`
+  )
 
   fullStr += chalk.red(`Error(s) found:\n`)
   for (const errorMessage of errorMessages) {

--- a/src/commands/sarif/validation.ts
+++ b/src/commands/sarif/validation.ts
@@ -7,12 +7,26 @@ import addFormats from 'ajv-formats'
 
 import sarifJsonSchema from './json-schema/sarif-schema-2.1.0.json'
 
+const maxSarifFileSize = 5 * 1024 * 1024 // 5MB in bytes
+
 /**
- * Validate the SARIF file against the SARIF schema.
+ * Validate the SARIF file and check if the file is too large or not valid
+ * against the SARIF schema.
  *
  * @param sarifReportPath - the path of the SARIF file
  */
 export const validateSarif = (sarifReportPath: string) => {
+  try {
+    const stats = fs.statSync(sarifReportPath) // Synchronously get file stats
+    const fileSize = stats.size
+
+    if (fileSize > maxSarifFileSize) {
+      return `file size too large (size: ${fileSize}, max size: ${maxSarifFileSize})`
+    }
+  } catch (err) {
+    return err.message
+  }
+
   const ajv = new Ajv({allErrors: true})
   addFormats(ajv)
   const sarifJsonSchemaValidate = ajv.compile(sarifJsonSchema)

--- a/src/commands/sarif/validation.ts
+++ b/src/commands/sarif/validation.ts
@@ -21,7 +21,7 @@ export const validateSarif = (sarifReportPath: string) => {
     const fileSize = stats.size
 
     if (fileSize > maxSarifFileSize) {
-      return `file size too large (size: ${fileSize}, max size: ${maxSarifFileSize})`
+      return `file size too large (size: ${fileSize / 1024 / 1024} MB, max size: ${maxSarifFileSize / 1024 / 1024} MB)`
     }
   } catch (err) {
     return err.message


### PR DESCRIPTION
### What and why?

We want to prevent large SARIF files from being uploaded. This leads to operational issues.

### How?

Add a check in the validation and do an early exit if validation fails.

## Testing

Tested by setting the max size to 1. There is the output below.


![Screenshot 2025-02-27 at 2 39 57 PM](https://github.com/user-attachments/assets/a08e2598-e0d4-4b43-a3f6-72220565ab9f)
