### PR TITLE
[K9VULN-3872] Add --git-repository option to sbom/sarif upload

### DIFF
--- a/src/commands/sarif/README.md
+++ b/src/commands/sarif/README.md
@@ -41,7 +41,7 @@ Additionally, you may configure the `sarif` command with environment variables:
 The Git context is resolved in the following order of priority:
 1. Current process location
 2. CI environment variables (can be disabled with: `--no-ci-tags` option)
-3. Explicitely provided Git repository (through `--git-repository` option)
+3. Explicitly provided Git repository (through `--git-repository` option)
 4. Override environment variables (`DD_GIT_*` variables)
 
 ### End-to-end testing process

--- a/src/commands/sarif/README.md
+++ b/src/commands/sarif/README.md
@@ -25,8 +25,8 @@ The positional arguments are the directories or file paths in which the SARIF re
 - `--max-concurrency` (default: `20`): number of concurrent uploads to the API.
 - `--dry-run` (default: `false`): runs the command without the final upload step. All other checks are performed.
 - `--no-verify` (default: `false`): runs the command without performing report validation on the CLI.
-- `--no-ci-tags` (default: `false`): ignore automatic detection of continuous integration environment variables.
-- `--git-repository` (default: `current working directory`): reports git environment context from specified repository.
+- `--no-ci-tags` (default: `false`): ignore the automatic detection of continuous integration environment variables.
+- `--git-repository` (default: `current working directory`): reports git environment context from the specified repository.
 
 ### Environment variables
 

--- a/src/commands/sarif/README.md
+++ b/src/commands/sarif/README.md
@@ -25,6 +25,7 @@ The positional arguments are the directories or file paths in which the SARIF re
 - `--max-concurrency` (default: `20`): number of concurrent uploads to the API.
 - `--dry-run` (default: `false`): runs the command without the final upload step. All other checks are performed.
 - `--no-verify` (default: `false`): runs the command without performing report validation on the CLI.
+- `--no-ci-tags` (default: `false`): ignore automatic detection of continuous integration environment variables.
 - `--git-repository` (default: `current working directory`): reports git environment context from specified repository.
 
 ### Environment variables
@@ -35,9 +36,13 @@ Additionally, you may configure the `sarif` command with environment variables:
 - `DD_TAGS`: Set global tags applied to all spans. The format must be `key1:value1,key2:value2`. The upload process merges the tags passed on the command line with the tags in the `--tags` parameter. If a key appears in both `--tags` and `DD_TAGS`, the value in `DD_TAGS` takes precedence.
 - `DATADOG_SITE` or `DD_SITE`: choose your Datadog site, for example, datadoghq.com or datadoghq.eu.
 
-### Optional dependencies
+### Git context resolution
 
-- [`git`](https://git-scm.com/downloads) is used for extracting repository metadata.
+The Git context is resolved in the following order of priority:
+1. Current process location
+2. CI environment variables (can be disabled with: `--no-ci-tags` option)
+3. Explicitely provided Git repository (through `--git-repository` option)
+4. Override environment variables (`DD_GIT_*` variables)
 
 ### End-to-end testing process
 

--- a/src/commands/sarif/README.md
+++ b/src/commands/sarif/README.md
@@ -25,6 +25,7 @@ The positional arguments are the directories or file paths in which the SARIF re
 - `--max-concurrency` (default: `20`): number of concurrent uploads to the API.
 - `--dry-run` (default: `false`): runs the command without the final upload step. All other checks are performed.
 - `--no-verify` (default: `false`): runs the command without performing report validation on the CLI.
+- `--git-repository` (default: `current working directory`): reports git environment context from specified repository.
 
 ### Environment variables
 

--- a/src/commands/sarif/__tests__/fixtures/gitconfig
+++ b/src/commands/sarif/__tests__/fixtures/gitconfig
@@ -1,0 +1,26 @@
+[core]
+    repositoryformatversion = 1 
+    filemode = false
+    bare = false
+    logallrefupdates = false
+    ignorecase = true
+
+[init]
+  defaultBranch = mock-branch
+
+[user]
+    name = MockUser123
+    email = mock@fake.local
+
+[remote "mock-origin"]
+    url = https://mock-repo.local/fake.git
+    fetch = +refs/mocks/*:refs/remotes/mock-origin/*
+
+[branch "mock-branch"]
+    remote = mock-origin
+    merge = refs/heads/mock-branch
+    rebase = never  # Unusual setting
+
+[hooks]
+    pre-commit = echo 'Mock pre-commit hook executed'
+    pre-push = echo 'Mock pre-push hook executed'

--- a/src/commands/sarif/__tests__/upload.test.ts
+++ b/src/commands/sarif/__tests__/upload.test.ts
@@ -225,13 +225,18 @@ describe('execute', () => {
       // Configure local git repository
       const git = simpleGit(tmpdir)
       setupLocalGitConfig(tmpdir)
+
       await git.init()
+
       // eslint-disable-next-line no-null/no-null
       await git.commit('Initial commit', [], {'--allow-empty': null})
+      const repositoryParam = `--git-repository=${tmpdir}`
+
       const {context, code} = await runCLI([
-        `--git-repository=${tmpdir}`,
+        repositoryParam,
         process.cwd() + '/src/commands/sarif/__tests__/fixtures/subfolder',
       ])
+
       const output = context.stdout.toString().split(os.EOL)
       expect(code).toBe(0)
 
@@ -258,22 +263,21 @@ describe('execute', () => {
 
   test('absolute path when passing git repository which does not exist', async () => {
     const nonExistingGitRepository = '/you/cannot/find/me'
-    // Pass a git repository which do not exist, command should fail
-    const {code} = await runCLI([
-      `--git-repository=${nonExistingGitRepository}`,
-      process.cwd() + '/src/commands/sarif/__tests__/fixtures/subfolder',
-    ])
+    const repositoryParam = `--git-repository=${nonExistingGitRepository}`
+
+    // Pass a git repository which does not exist, command should fail
+    const {code} = await runCLI([repositoryParam, process.cwd() + '/src/commands/sarif/__tests__/fixtures/subfolder'])
     expect(code).toBe(1)
   })
 
   test('single file', async () => {
     const {context, code} = await runCLI([process.cwd() + '/src/commands/sarif/__tests__/fixtures/valid-results.sarif'])
     const output = context.stdout.toString().split(os.EOL)
-    const path1 = `${process.cwd()}/src/commands/sarif/__tests__/fixtures/valid-results.sarif`
+    const location = `${process.cwd()}/src/commands/sarif/__tests__/fixtures/valid-results.sarif`
     expect(code).toBe(0)
     expect(output[0]).toContain('DRY-RUN MODE ENABLED. WILL NOT UPLOAD SARIF REPORT')
     expect(output[1]).toContain('Starting upload with concurrency 20.')
-    expect(output[2]).toContain(`Will upload SARIF report file ${path1}`)
+    expect(output[2]).toContain(`Will upload SARIF report file ${location}`)
     expect(output[3]).toContain('Only one upload per commit, env and tool')
     expect(output[4]).toContain(`Preparing upload for`)
     expect(output[4]).toContain(`env:ci`)
@@ -282,9 +286,9 @@ describe('execute', () => {
   test('not found file', async () => {
     const {context, code} = await runCLI([process.cwd() + '/src/commands/sarif/__tests__/fixtures/not-found.sarif'])
     const output = context.stdout.toString().split(os.EOL)
-    const path2 = `${process.cwd()}/src/commands/sarif/__tests__/fixtures/not-found.sarif`
+    const location = `${process.cwd()}/src/commands/sarif/__tests__/fixtures/not-found.sarif`
     expect(code).toBe(1)
-    expect(output[0]).toContain(`Cannot find valid SARIF report files to upload in ${path2}`)
+    expect(output[0]).toContain(`Cannot find valid SARIF report files to upload in ${location}`)
     expect(output[1]).toContain('Check the files exist and are valid.')
   })
 })

--- a/src/commands/sarif/__tests__/upload.test.ts
+++ b/src/commands/sarif/__tests__/upload.test.ts
@@ -1,12 +1,12 @@
-import os from 'os'
 import fs from 'fs'
-import simpleGit from 'simple-git';
-import path from 'path';
+import os from 'os'
+import path from 'path'
 
-import { Cli } from 'clipanion/lib/advanced'
+import {Cli} from 'clipanion/lib/advanced'
+import simpleGit from 'simple-git'
 
-import { renderInvalidFile } from '../renderer'
-import { UploadSarifReportCommand } from '../upload'
+import {renderInvalidFile} from '../renderer'
+import {UploadSarifReportCommand} from '../upload'
 
 const makeCli = () => {
   const cli = new Cli()
@@ -40,7 +40,7 @@ describe('upload', () => {
       process.env = {}
       const write = jest.fn()
       const command = new UploadSarifReportCommand()
-      command.context = { stdout: { write } } as any
+      command.context = {stdout: {write}} as any
 
       expect(command['getApiHelper'].bind(command)).toThrow('API key is missing')
       expect(write.mock.calls[0][0]).toContain('DATADOG_API_KEY')
@@ -172,13 +172,13 @@ describe('execute', () => {
   const runCLI = async (args: string[]) => {
     const cli = makeCli()
     const context = createMockContext() as any
-    process.env = { DATADOG_API_KEY: 'PLACEHOLDER' }
+    process.env = {DATADOG_API_KEY: 'PLACEHOLDER'}
     const code = await cli.run(['sarif', 'upload', '--env', 'ci', '--dry-run', ...args], context)
 
-    return { context, code }
+    return {context, code}
   }
   test('relative path with double dots', async () => {
-    const { context, code } = await runCLI(['./src/commands/sarif/__tests__/doesnotexist/../fixtures/subfolder'])
+    const {context, code} = await runCLI(['./src/commands/sarif/__tests__/doesnotexist/../fixtures/subfolder'])
     const output = context.stdout.toString().split(os.EOL)
     expect(code).toBe(0)
     checkConsoleOutput(output, {
@@ -188,7 +188,7 @@ describe('execute', () => {
     })
   })
   test('multiple paths', async () => {
-    const { context, code } = await runCLI([
+    const {context, code} = await runCLI([
       './src/commands/sarif/__tests__/fixtures/subfolder/',
       './src/commands/sarif/__tests__/fixtures/another_subfolder/',
     ])
@@ -205,7 +205,7 @@ describe('execute', () => {
   })
 
   test('absolute path', async () => {
-    const { context, code } = await runCLI([process.cwd() + '/src/commands/sarif/__tests__/fixtures/subfolder'])
+    const {context, code} = await runCLI([process.cwd() + '/src/commands/sarif/__tests__/fixtures/subfolder'])
     const output = context.stdout.toString().split(os.EOL)
     expect(code).toBe(0)
     checkConsoleOutput(output, {
@@ -213,21 +213,24 @@ describe('execute', () => {
       concurrency: 20,
       env: 'ci',
       spanTags: {
-        "git.repository_url": "git@github.com:DataDog/datadog-ci.git",
-        "env": "ci"
-      }
+        'git.repository_url': 'git@github.com:DataDog/datadog-ci.git',
+        env: 'ci',
+      },
     })
   })
 
   test('absolute path when passing git repository', async () => {
-    const tmpdir = fs.mkdtempSync(path.join(os.tmpdir(), 'gitPath-'));
+    const tmpdir = fs.mkdtempSync(path.join(os.tmpdir(), 'gitPath-'))
     try {
       // Configure local git repository
-      const git = simpleGit(tmpdir);
-      await git.init(['--initial-branch=test-branch']).addRemote('origin', 'https://github.com/TeSt-FaKe-RePo/repo.git');
-      await git.commit('Initial commit', [], { '--allow-empty': null, '--author': '"John Doe <john.doe@example.com>"', });
+      const git = simpleGit(tmpdir)
+      await git.init(['--initial-branch=test-branch']).addRemote('origin', 'https://github.com/TeSt-FaKe-RePo/repo.git')
+      await git.commit('Initial commit', [], {'--author': '"John Doe <john.doe@example.com>"'})
 
-      const { context, code } = await runCLI([`--git-repository=${tmpdir}`, process.cwd() + '/src/commands/sarif/__tests__/fixtures/subfolder'])
+      const {context, code} = await runCLI([
+        `--git-repository=${tmpdir}`,
+        process.cwd() + '/src/commands/sarif/__tests__/fixtures/subfolder',
+      ])
       const output = context.stdout.toString().split(os.EOL)
       expect(code).toBe(0)
       checkConsoleOutput(output, {
@@ -235,45 +238,48 @@ describe('execute', () => {
         concurrency: 20,
         env: 'ci',
         spanTags: {
-          "git.repository_url": "git@github.com:TeSt-FaKe-RePo/repo.git",
-          "git.branch": "test-branch",
-          "git.commit.author.email": "john.doe@example.com",
-          "git.commit.author.name": "John Doe",
-          "env": "ci"
-        }
+          'git.repository_url': 'git@github.com:TeSt-FaKe-RePo/repo.git',
+          'git.branch': 'test-branch',
+          'git.commit.author.email': 'john.doe@example.com',
+          'git.commit.author.name': 'John Doe',
+          env: 'ci',
+        },
       })
     } finally {
       // Removed temporary git file
-      fs.rmSync(tmpdir, { recursive: true, force: true });
+      fs.rmSync(tmpdir, {recursive: true, force: true})
     }
   })
 
   test('absolute path when passing git repository which do not exist', async () => {
-    const nonExistingGitRepository = "/you/cannot/find/me"
+    const nonExistingGitRepository = '/you/cannot/find/me'
     // Pass a git repository which do not exist, command should fail
-    const { context, code } = await runCLI([`--git-repository=${nonExistingGitRepository}`, process.cwd() + '/src/commands/sarif/__tests__/fixtures/subfolder'])
+    const {code} = await runCLI([
+      `--git-repository=${nonExistingGitRepository}`,
+      process.cwd() + '/src/commands/sarif/__tests__/fixtures/subfolder',
+    ])
     expect(code).toBe(1)
   })
 
   test('single file', async () => {
-    const { context, code } = await runCLI([process.cwd() + '/src/commands/sarif/__tests__/fixtures/valid-results.sarif'])
+    const {context, code} = await runCLI([process.cwd() + '/src/commands/sarif/__tests__/fixtures/valid-results.sarif'])
     const output = context.stdout.toString().split(os.EOL)
-    const path = `${process.cwd()}/src/commands/sarif/__tests__/fixtures/valid-results.sarif`
+    const path1 = `${process.cwd()}/src/commands/sarif/__tests__/fixtures/valid-results.sarif`
     expect(code).toBe(0)
     expect(output[0]).toContain('DRY-RUN MODE ENABLED. WILL NOT UPLOAD SARIF REPORT')
     expect(output[1]).toContain('Starting upload with concurrency 20.')
-    expect(output[2]).toContain(`Will upload SARIF report file ${path}`)
+    expect(output[2]).toContain(`Will upload SARIF report file ${path1}`)
     expect(output[3]).toContain('Only one upload per commit, env and tool')
     expect(output[4]).toContain(`Preparing upload for`)
     expect(output[4]).toContain(`env:ci`)
   })
 
   test('not found file', async () => {
-    const { context, code } = await runCLI([process.cwd() + '/src/commands/sarif/__tests__/fixtures/not-found.sarif'])
+    const {context, code} = await runCLI([process.cwd() + '/src/commands/sarif/__tests__/fixtures/not-found.sarif'])
     const output = context.stdout.toString().split(os.EOL)
-    const path = `${process.cwd()}/src/commands/sarif/__tests__/fixtures/not-found.sarif`
+    const path2 = `${process.cwd()}/src/commands/sarif/__tests__/fixtures/not-found.sarif`
     expect(code).toBe(1)
-    expect(output[0]).toContain(`Cannot find valid SARIF report files to upload in ${path}`)
+    expect(output[0]).toContain(`Cannot find valid SARIF report files to upload in ${path2}`)
     expect(output[1]).toContain('Check the files exist and are valid.')
   })
 })

--- a/src/commands/sarif/__tests__/upload.test.ts
+++ b/src/commands/sarif/__tests__/upload.test.ts
@@ -251,7 +251,7 @@ describe('execute', () => {
     }
   })
 
-  test('absolute path when passing git repository which do not exist', async () => {
+  test('absolute path when passing git repository which does not exist', async () => {
     const nonExistingGitRepository = '/you/cannot/find/me'
     // Pass a git repository which do not exist, command should fail
     const {code} = await runCLI([

--- a/src/commands/sarif/renderer.ts
+++ b/src/commands/sarif/renderer.ts
@@ -2,9 +2,9 @@ import path from 'path'
 
 import chalk from 'chalk'
 
-import {getBaseUrl} from '../junit/utils'
+import { getBaseUrl } from '../junit/utils'
 
-import {Payload} from './interfaces'
+import { Payload } from './interfaces'
 
 const ICONS = {
   FAILED: '❌',
@@ -72,9 +72,10 @@ export const renderSuccessfulCommand = (fileCount: number, duration: number) => 
   return fullStr
 }
 
-export const renderDryRunUpload = (payload: Payload): string => `[DRYRUN] ${renderUpload(payload)}`
+export const renderDryRunUpload = (payload: Payload): string => `[DRYRUN] ${renderUploadWithSpan(payload)}`
 
 export const renderUpload = (payload: Payload): string => `Uploading SARIF report in ${payload.reportPath}\n`
+export const renderUploadWithSpan = (payload: Payload): string => `Uploading SARIF report to ${payload.reportPath} with tags ${JSON.stringify(payload.spanTags)}\n`
 
 export const renderCommandInfo = (
   basePaths: string[],

--- a/src/commands/sarif/renderer.ts
+++ b/src/commands/sarif/renderer.ts
@@ -2,9 +2,9 @@ import path from 'path'
 
 import chalk from 'chalk'
 
-import { getBaseUrl } from '../junit/utils'
+import {getBaseUrl} from '../junit/utils'
 
-import { Payload } from './interfaces'
+import {Payload} from './interfaces'
 
 const ICONS = {
   FAILED: '❌',
@@ -75,7 +75,8 @@ export const renderSuccessfulCommand = (fileCount: number, duration: number) => 
 export const renderDryRunUpload = (payload: Payload): string => `[DRYRUN] ${renderUploadWithSpan(payload)}`
 
 export const renderUpload = (payload: Payload): string => `Uploading SARIF report in ${payload.reportPath}\n`
-export const renderUploadWithSpan = (payload: Payload): string => `Uploading SARIF report to ${payload.reportPath} with tags ${JSON.stringify(payload.spanTags)}\n`
+export const renderUploadWithSpan = (payload: Payload): string =>
+  `Uploading SARIF report to ${payload.reportPath} with tags ${JSON.stringify(payload.spanTags)}\n`
 
 export const renderCommandInfo = (
   basePaths: string[],

--- a/src/commands/sarif/upload.ts
+++ b/src/commands/sarif/upload.ts
@@ -64,6 +64,7 @@ export class UploadSarifReportCommand extends Command {
   private maxConcurrency = Option.String('--max-concurrency', '20', {validator: validation.isInteger()})
   private serviceFromCli = Option.String('--service')
   private tags = Option.Array('--tags')
+  private gitPath = Option.String('--git-repository')
   private noVerify = Option.Boolean('--no-verify', false)
   private noCiTags = Option.Boolean('--no-ci-tags', false)
 
@@ -110,7 +111,7 @@ export class UploadSarifReportCommand extends Command {
     // Always using the posix version to avoid \ on Windows.
     this.basePaths = this.basePaths.map((basePath) => path.posix.normalize(basePath))
 
-    const spanTags = await getSpanTags(this.config, this.tags, !this.noCiTags)
+    const spanTags = await getSpanTags(this.config, this.tags, !this.noCiTags, this.gitPath)
 
     // Gather any missing mandatory git fields to display to the user
     const missingGitFields = getMissingRequiredGitTags(spanTags)
@@ -121,7 +122,7 @@ export class UploadSarifReportCommand extends Command {
     }
 
     const payloads = await this.getMatchingSarifReports(spanTags)
-
+      
     if (payloads.length === 0) {
       this.context.stdout.write(renderFilesNotFound(this.basePaths))
 
@@ -133,7 +134,7 @@ export class UploadSarifReportCommand extends Command {
     this.context.stdout.write(
       renderCommandInfo(this.basePaths, env, sha, this.maxConcurrency, this.dryRun, this.noVerify)
     )
-    const upload = (p: Payload) => this.uploadSarifReport(api, p)
+    const upload = (payload: Payload) => this.uploadSarifReport(api, payload)
 
     const initialTime = new Date().getTime()
 

--- a/src/commands/sarif/upload.ts
+++ b/src/commands/sarif/upload.ts
@@ -122,7 +122,7 @@ export class UploadSarifReportCommand extends Command {
     }
 
     const payloads = await this.getMatchingSarifReports(spanTags)
-      
+
     if (payloads.length === 0) {
       this.context.stdout.write(renderFilesNotFound(this.basePaths))
 

--- a/src/commands/sbom/README.md
+++ b/src/commands/sbom/README.md
@@ -17,6 +17,7 @@ datadog-ci sbom upload <path/to/sbom.json>
 ### Optional arguments
 
 - `--env` is a string that represents the environment in which you want your tests to appear.
+- `--git-repository` (default: `current working directory`): reports git environment context from specified repository.
 
 ### Environment variables
 

--- a/src/commands/sbom/README.md
+++ b/src/commands/sbom/README.md
@@ -18,7 +18,7 @@ datadog-ci sbom upload [--env] [--no-ci-tags] [--git-repository] [--debug] <path
 ### Optional arguments
 
 - `--env` (default: `ci`): represents the environment in which you want your sbom to appear.
-- `--no-ci-tags` (default: `false`): ignore continuous integration automatic detection of environment variables.
+- `--no-ci-tags` (default: `false`): ignore automatic detection of continuous integration environment variables.
 - `--git-repository` (default: `current working directory`): reports git environment context from specified repository.
 - `--debug` (default: `false`): output debug logs.
 
@@ -29,6 +29,14 @@ The following environment variables must be defined:
  - `DD_SITE`: the [Datadog site](https://docs.datadoghq.com/getting_started/site/#access-the-datadog-site)
  - `DD_APP_KEY`: the App key to use
  - `DD_API_KEY`: the API key to use
+
+### Git context resolution
+
+The Git context is resolved in the following order of priority:
+1. Current process location
+2. CI environment variables (can be disabled with: `--no-ci-tags` option)
+3. Explicitely provided Git repository (through `--git-repository` option)
+4. Override environment variables (`DD_GIT_*` variables)
 
 ## Development
 

--- a/src/commands/sbom/README.md
+++ b/src/commands/sbom/README.md
@@ -7,17 +7,20 @@ This command lets you upload SBOM files to the Datadog intake endpoint.
 
  - CycloneDX 1.4
  - CycloneDX 1.5
+ - CycloneDX 1.6
 
 ## Usage
 
 ```bash
-datadog-ci sbom upload <path/to/sbom.json>
+datadog-ci sbom upload [--env] [--no-ci-tags] [--git-repository] [--debug] <path/to/sbom.json>
 ```
 
 ### Optional arguments
 
-- `--env` is a string that represents the environment in which you want your tests to appear.
+- `--env` (default: `ci`): represents the environment in which you want your sbom to appear.
+- `--no-ci-tags` (default: `false`): ignore continuous integration automatic detection of environment variables.
 - `--git-repository` (default: `current working directory`): reports git environment context from specified repository.
+- `--debug` (default: `false`): output debug logs.
 
 ### Environment variables
 

--- a/src/commands/sbom/README.md
+++ b/src/commands/sbom/README.md
@@ -35,7 +35,7 @@ The following environment variables must be defined:
 The Git context is resolved in the following order of priority:
 1. Current process location
 2. CI environment variables (can be disabled with: `--no-ci-tags` option)
-3. Explicitely provided Git repository (through `--git-repository` option)
+3. Explicitly provided Git repository (through --git-repository option)
 4. Override environment variables (`DD_GIT_*` variables)
 
 ## Development

--- a/src/commands/sbom/README.md
+++ b/src/commands/sbom/README.md
@@ -18,8 +18,8 @@ datadog-ci sbom upload [--env] [--no-ci-tags] [--git-repository] [--debug] <path
 ### Optional arguments
 
 - `--env` (default: `ci`): represents the environment in which you want your sbom to appear.
-- `--no-ci-tags` (default: `false`): ignore automatic detection of continuous integration environment variables.
-- `--git-repository` (default: `current working directory`): reports git environment context from specified repository.
+- `--no-ci-tags` (default: `false`): ignore the automatic detection of continuous integration environment variables.
+- `--git-repository` (default: `current working directory`): reports git environment context from the specified repository.
 - `--debug` (default: `false`): output debug logs.
 
 ### Environment variables

--- a/src/commands/sbom/__tests__/fixtures/gitconfig
+++ b/src/commands/sbom/__tests__/fixtures/gitconfig
@@ -1,0 +1,26 @@
+[core]
+    repositoryformatversion = 1 
+    filemode = false
+    bare = false
+    logallrefupdates = false
+    ignorecase = true
+
+[init]
+  defaultBranch = mock-branch
+
+[user]
+    name = MockUser123
+    email = mock@fake.local
+
+[remote "mock-origin"]
+    url = https://mock-repo.local/fake.git
+    fetch = +refs/mocks/*:refs/remotes/mock-origin/*
+
+[branch "mock-branch"]
+    remote = mock-origin
+    merge = refs/heads/mock-branch
+    rebase = never  # Unusual setting
+
+[hooks]
+    pre-commit = echo 'Mock pre-commit hook executed'
+    pre-push = echo 'Mock pre-push hook executed'

--- a/src/commands/sbom/__tests__/payload.test.ts
+++ b/src/commands/sbom/__tests__/payload.test.ts
@@ -24,7 +24,7 @@ describe('generation of payload', () => {
       env: undefined,
       envVarTags: undefined,
     }
-    const tags = await getSpanTags(config, [], true, undefined)
+    const tags = await getSpanTags(config, [], true)
 
     const payload = generatePayload(sbomContent, tags, 'service', 'env')
     expect(payload).not.toBeNull()
@@ -53,7 +53,7 @@ describe('generation of payload', () => {
       env: undefined,
       envVarTags: undefined,
     }
-    const tags = await getSpanTags(config, [], true, undefined)
+    const tags = await getSpanTags(config, [], true)
 
     const payload = generatePayload(sbomContent, tags, 'service', 'env')
     expect(payload).not.toBeNull()
@@ -86,7 +86,7 @@ describe('generation of payload', () => {
       env: undefined,
       envVarTags: undefined,
     }
-    const tags = await getSpanTags(config, [], true, undefined)
+    const tags = await getSpanTags(config, [], true)
 
     const payload = generatePayload(sbomContent, tags, 'service', 'env')
     expect(payload).not.toBeNull()
@@ -128,7 +128,7 @@ describe('generation of payload', () => {
       env: undefined,
       envVarTags: undefined,
     }
-    const tags = await getSpanTags(config, [], true, undefined)
+    const tags = await getSpanTags(config, [], true)
 
     const payload = generatePayload(sbomContent, tags, 'service', 'env')
 
@@ -149,7 +149,7 @@ describe('generation of payload', () => {
       env: undefined,
       envVarTags: undefined,
     }
-    const tags = await getSpanTags(config, [], true, undefined)
+    const tags = await getSpanTags(config, [], true)
 
     const payload = generatePayload(sbomContent, tags, 'service', 'env')
 
@@ -170,7 +170,7 @@ describe('generation of payload', () => {
       env: undefined,
       envVarTags: undefined,
     }
-    const tags = await getSpanTags(config, [], true, undefined)
+    const tags = await getSpanTags(config, [], true)
 
     const payload = generatePayload(sbomContent, tags, 'service', 'env')
 
@@ -195,7 +195,7 @@ describe('generation of payload', () => {
       env: undefined,
       envVarTags: undefined,
     }
-    const tags = await getSpanTags(config, [], true, undefined)
+    const tags = await getSpanTags(config, [], true)
 
     const payload = generatePayload(sbomContent, tags, 'service', 'env')
 
@@ -218,7 +218,7 @@ describe('generation of payload', () => {
       env: undefined,
       envVarTags: undefined,
     }
-    const tags = await getSpanTags(config, [], true, undefined)
+    const tags = await getSpanTags(config, [], true)
 
     const payload = generatePayload(sbomContent, tags, 'service', 'env')
 
@@ -244,7 +244,7 @@ describe('generation of payload', () => {
       env: undefined,
       envVarTags: undefined,
     }
-    const tags = await getSpanTags(config, [], true, undefined)
+    const tags = await getSpanTags(config, [], true)
 
     const payload = generatePayload(sbomContent, tags, 'service', 'env')
 
@@ -268,7 +268,7 @@ describe('generation of payload', () => {
       env: undefined,
       envVarTags: undefined,
     }
-    const tags = await getSpanTags(config, [], true, undefined)
+    const tags = await getSpanTags(config, [], true)
 
     const payload = generatePayload(sbomContent, tags, 'service', 'env')
 
@@ -334,7 +334,7 @@ describe('generation of payload', () => {
       env: undefined,
       envVarTags: undefined,
     }
-    const tags = await getSpanTags(config, [], true, undefined)
+    const tags = await getSpanTags(config, [], true)
 
     const payload = generatePayload(sbomContent, tags, 'service', 'env')
 

--- a/src/commands/sbom/__tests__/payload.test.ts
+++ b/src/commands/sbom/__tests__/payload.test.ts
@@ -404,7 +404,7 @@ describe('generation of payload', () => {
     // Pass non existing git directory to load git context
     // It is missing all git tags.
     const tags = await getSpanTags(config, [], true, nonExistingGitRepository)
-    expect(getMissingRequiredGitTags(tags)).toHaveLength(7)
+    expect(getMissingRequiredGitTags(tags).length).toBeGreaterThanOrEqual(1)
   })
 })
 

--- a/src/commands/sbom/__tests__/payload.test.ts
+++ b/src/commands/sbom/__tests__/payload.test.ts
@@ -1,13 +1,14 @@
 import fs from 'fs'
-import simpleGit from 'simple-git';
-import os from 'os';
-import path from 'path';
+import os from 'os'
+import path from 'path'
 
-import { DatadogCiConfig } from '../../../helpers/config'
-import { getSpanTags, getMissingRequiredGitTags } from '../../../helpers/tags'
+import simpleGit from 'simple-git'
 
-import { generatePayload } from '../payload'
-import { DependencyLanguage, Location } from '../types'
+import {DatadogCiConfig} from '../../../helpers/config'
+import {getSpanTags, getMissingRequiredGitTags} from '../../../helpers/tags'
+
+import {generatePayload} from '../payload'
+import {DependencyLanguage, Location} from '../types'
 
 describe('generation of payload', () => {
   beforeEach(() => {
@@ -348,12 +349,12 @@ describe('generation of payload', () => {
   })
 
   test('should correctly work with a CycloneDX 1.4 file and passing git repository', async () => {
-    const tmpdir = fs.mkdtempSync(path.join(os.tmpdir(), 'gitPath-'));
+    const tmpdir = fs.mkdtempSync(path.join(os.tmpdir(), 'gitPath-'))
     try {
       // Configure local git repository
-      const git = simpleGit(tmpdir);
-      await git.init(['--initial-branch=test-branch']).addRemote('origin', 'https://github.com/TeSt-FaKe-RePo/repo.git');
-      await git.commit('Initial commit', [], { '--allow-empty': null, '--author': '"John Doe <john.doe@example.com>"', });
+      const git = simpleGit(tmpdir)
+      await git.init(['--initial-branch=test-branch']).addRemote('origin', 'https://github.com/TeSt-FaKe-RePo/repo.git')
+      await git.commit('Initial commit', [], {'--author': '"John Doe <john.doe@example.com>"'})
 
       const sbomFile = './src/commands/sbom/__tests__/fixtures/sbom.1.4.ok.json'
       const sbomContent = JSON.parse(fs.readFileSync(sbomFile).toString('utf8'))
@@ -373,11 +374,11 @@ describe('generation of payload', () => {
 
       // Local git repository should be reported
       expect(payload?.commit.sha).toStrictEqual(expect.any(String))
-      expect(payload?.commit.author_name).toStrictEqual("John Doe")
-      expect(payload?.commit.author_email).toStrictEqual("john.doe@example.com")
+      expect(payload?.commit.author_name).toStrictEqual('John Doe')
+      expect(payload?.commit.author_email).toStrictEqual('john.doe@example.com')
       expect(payload?.commit.committer_name).toStrictEqual(expect.any(String))
       expect(payload?.commit.committer_email).toStrictEqual(expect.any(String))
-      expect(payload?.commit.branch).toStrictEqual("test-branch")
+      expect(payload?.commit.branch).toStrictEqual('test-branch')
       expect(payload?.repository.url).toContain('github.com')
       expect(payload?.repository.url).toContain('git@github.com:TeSt-FaKe-RePo/repo.git')
       expect(payload?.dependencies.length).toBe(62)
@@ -387,12 +388,12 @@ describe('generation of payload', () => {
       expect(payload?.dependencies[0].language).toBe(DependencyLanguage.PHP)
     } finally {
       // Removed temporary git file
-      fs.rmSync(tmpdir, { recursive: true, force: true });
+      fs.rmSync(tmpdir, {recursive: true, force: true})
     }
   })
 
   test('should fail to read git information', async () => {
-    const nonExistingGitRepository = "/you/cannot/find/me"
+    const nonExistingGitRepository = '/you/cannot/find/me'
     const config: DatadogCiConfig = {
       apiKey: undefined,
       env: undefined,
@@ -404,5 +405,4 @@ describe('generation of payload', () => {
     const tags = await getSpanTags(config, [], true, nonExistingGitRepository)
     expect(getMissingRequiredGitTags(tags)).toHaveLength(7)
   })
-
 })

--- a/src/commands/sbom/__tests__/validation.test.ts
+++ b/src/commands/sbom/__tests__/validation.test.ts
@@ -149,7 +149,7 @@ describe('validation of sbom file', () => {
       env: undefined,
       envVarTags: undefined,
     }
-    const tags = await getSpanTags(config, [], true)
+    const tags = await getSpanTags(config, [], true, undefined)
 
     const payload = generatePayload(sbomContent, tags, 'service', 'env')
     expect(payload).not.toBeNull()
@@ -166,7 +166,7 @@ describe('validation of sbom file', () => {
       env: undefined,
       envVarTags: undefined,
     }
-    const tags = await getSpanTags(config, [], true)
+    const tags = await getSpanTags(config, [], true, undefined)
 
     const payload = generatePayload(sbomContent, tags, 'service', 'env')
     expect(payload).not.toBeNull()

--- a/src/commands/sbom/__tests__/validation.test.ts
+++ b/src/commands/sbom/__tests__/validation.test.ts
@@ -149,7 +149,7 @@ describe('validation of sbom file', () => {
       env: undefined,
       envVarTags: undefined,
     }
-    const tags = await getSpanTags(config, [], true, undefined)
+    const tags = await getSpanTags(config, [], true)
 
     const payload = generatePayload(sbomContent, tags, 'service', 'env')
     expect(payload).not.toBeNull()
@@ -166,7 +166,7 @@ describe('validation of sbom file', () => {
       env: undefined,
       envVarTags: undefined,
     }
-    const tags = await getSpanTags(config, [], true, undefined)
+    const tags = await getSpanTags(config, [], true)
 
     const payload = generatePayload(sbomContent, tags, 'service', 'env')
     expect(payload).not.toBeNull()

--- a/src/commands/sbom/upload.ts
+++ b/src/commands/sbom/upload.ts
@@ -48,6 +48,7 @@ export class UploadSbomCommand extends Command {
   private serviceFromCli = Option.String('--service')
   private env = Option.String('--env', 'ci')
   private tags = Option.Array('--tags')
+  private gitPath = Option.String('--git-repository')
   private debug = Option.Boolean('--debug')
   private noCiTags = Option.Boolean('--no-ci-tags', false)
 
@@ -114,7 +115,7 @@ export class UploadSbomCommand extends Command {
       this.config.appKey
     )
 
-    const tags = await getSpanTags(this.config, this.tags, !this.noCiTags)
+    const tags = await getSpanTags(this.config, this.tags, !this.noCiTags, this.gitPath)
 
     // Gather any missing mandatory git fields to display to the user
     const missingGitFields = getMissingRequiredGitTags(tags)

--- a/src/commands/sbom/upload.ts
+++ b/src/commands/sbom/upload.ts
@@ -136,7 +136,7 @@ export class UploadSbomCommand extends Command {
 
     if (!validateSbomFileAgainstSchema(basePath, validator, !!this.debug)) {
       this.context.stdout.write(
-        'SBOM file not fully compliant against CycloneDX 1.4 or 1.5 specifications (use --debug to get validation error)\n'
+        'SBOM file not fully compliant against CycloneDX 1.4, 1.5 or 1.6 specifications (use --debug to get validation error)\n'
       )
     }
     if (!validateFileAgainstToolRequirements(basePath, !!this.debug)) {

--- a/src/helpers/__tests__/tags.test.ts
+++ b/src/helpers/__tests__/tags.test.ts
@@ -1,6 +1,7 @@
 import {BaseContext} from 'clipanion'
 import simpleGit from 'simple-git'
 
+import {DatadogCiConfig} from '../config'
 import {SpanTags} from '../interfaces'
 import {
   parseTags,
@@ -188,7 +189,7 @@ describe('getSpanTags', () => {
     })
   })
   test('should prioritized git context corrently', async () => {
-    const config = {
+    const config: DatadogCiConfig = {
       apiKey: undefined,
       env: undefined,
       envVarTags: undefined,

--- a/src/helpers/git/format-git-span-data.ts
+++ b/src/helpers/git/format-git-span-data.ts
@@ -18,7 +18,7 @@ import {filterSensitiveInfoFromRepository} from '../utils'
 
 import {gitAuthorAndCommitter, gitBranch, gitHash, gitMessage, gitRepositoryURL} from './get-git-data'
 
-export const getGitMetadata = async (path: string | undefined): Promise<SpanTags> => {
+export const getGitMetadata = async (path?: string): Promise<SpanTags> => {
   try {
     const git = simpleGit({
       baseDir: path || process.cwd(),

--- a/src/helpers/git/format-git-span-data.ts
+++ b/src/helpers/git/format-git-span-data.ts
@@ -1,4 +1,4 @@
-import type {SpanTags} from '../interfaces'
+import type { SpanTags } from '../interfaces'
 
 import simpleGit from 'simple-git'
 
@@ -14,14 +14,14 @@ import {
   GIT_REPOSITORY_URL,
   GIT_SHA,
 } from '../tags'
-import {filterSensitiveInfoFromRepository} from '../utils'
+import { filterSensitiveInfoFromRepository } from '../utils'
 
-import {gitAuthorAndCommitter, gitBranch, gitHash, gitMessage, gitRepositoryURL} from './get-git-data'
+import { gitAuthorAndCommitter, gitBranch, gitHash, gitMessage, gitRepositoryURL } from './get-git-data'
 
-export const getGitMetadata = async (): Promise<SpanTags> => {
+export const getGitMetadata = async (path: string | undefined): Promise<SpanTags> => {
   try {
     const git = simpleGit({
-      baseDir: process.cwd(),
+      baseDir: path || process.cwd(),
       binary: 'git',
       // We are invoking at most 5 git commands at the same time.
       maxConcurrentProcesses: 5,

--- a/src/helpers/git/format-git-span-data.ts
+++ b/src/helpers/git/format-git-span-data.ts
@@ -18,10 +18,10 @@ import {filterSensitiveInfoFromRepository} from '../utils'
 
 import {gitAuthorAndCommitter, gitBranch, gitHash, gitMessage, gitRepositoryURL} from './get-git-data'
 
-export const getGitMetadata = async (path?: string): Promise<SpanTags> => {
+export const getGitMetadata = async (repositoryPath?: string): Promise<SpanTags> => {
   try {
     const git = simpleGit({
-      baseDir: path || process.cwd(),
+      baseDir: repositoryPath || process.cwd(),
       binary: 'git',
       // We are invoking at most 5 git commands at the same time.
       maxConcurrentProcesses: 5,

--- a/src/helpers/git/format-git-span-data.ts
+++ b/src/helpers/git/format-git-span-data.ts
@@ -1,4 +1,4 @@
-import type { SpanTags } from '../interfaces'
+import type {SpanTags} from '../interfaces'
 
 import simpleGit from 'simple-git'
 
@@ -14,9 +14,9 @@ import {
   GIT_REPOSITORY_URL,
   GIT_SHA,
 } from '../tags'
-import { filterSensitiveInfoFromRepository } from '../utils'
+import {filterSensitiveInfoFromRepository} from '../utils'
 
-import { gitAuthorAndCommitter, gitBranch, gitHash, gitMessage, gitRepositoryURL } from './get-git-data'
+import {gitAuthorAndCommitter, gitBranch, gitHash, gitMessage, gitRepositoryURL} from './get-git-data'
 
 export const getGitMetadata = async (path: string | undefined): Promise<SpanTags> => {
   try {

--- a/src/helpers/tags.ts
+++ b/src/helpers/tags.ts
@@ -236,10 +236,11 @@ export const getMissingRequiredGitTags = (tags: SpanTags): string[] => {
 export const getSpanTags = async (
   config: DatadogCiConfig,
   additionalTags: string[] | undefined,
-  includeCiTags: boolean
+  includeCiTags: boolean,
+  gitPath: string | undefined
 ): Promise<SpanTags> => {
   const ciSpanTags = includeCiTags ? getCISpanTags() : []
-  const gitSpanTags = await getGitMetadata()
+  const gitSpanTags = await getGitMetadata(gitPath)
   const userGitSpanTags = getUserGitSpanTags()
 
   const envVarTags = config.envVarTags ? parseTags(config.envVarTags.split(',')) : {}

--- a/src/helpers/tags.ts
+++ b/src/helpers/tags.ts
@@ -237,7 +237,7 @@ export const getSpanTags = async (
   config: DatadogCiConfig,
   additionalTags: string[] | undefined,
   includeCiTags: boolean,
-  gitPath: string | undefined
+  gitPath?: string
 ): Promise<SpanTags> => {
   const ciSpanTags = includeCiTags ? getCISpanTags() : []
   const gitSpanTags = await getGitMetadata(gitPath)
@@ -247,8 +247,8 @@ export const getSpanTags = async (
   const cliTags = additionalTags ? parseTags(additionalTags) : {}
 
   return {
-    ...gitSpanTags,
-    ...ciSpanTags,
+    // if users specify a git path to read from, we prefer git env variables over the CI context one
+    ...(gitPath ? {...ciSpanTags, ...gitSpanTags} : {...gitSpanTags, ...ciSpanTags}),
     ...userGitSpanTags, // User-provided git tags have precedence over the ones we get from the git command
     ...cliTags,
     ...envVarTags,


### PR DESCRIPTION
### TL;DR
Adding `--git-repository` option support to `datadog-ci sbom upload` and `datadog-ci sarif upload`.

### What 
We have users complaining about **CI** integration of `datadog-ci` to generate SBOM for repository which do not report the correct git information. 

### And why?
Currently, it is not clear how the `datadog-ci sbom upload` command gets Git context. It currently does:
1. Current process location
2. CI environment variables (can be disabled with: `--no-ci-tags` option)
3. Override environment variables (`DD_GIT_*` variables)

Currently users have two options to have the correct Git values when running the `upload` command from CI:
1. disable ci automatic detection of env vars with`--no-ci-tags`
2. use override `DD_` variables.

The current workaround is to override `DD_` variables
```typescript
export DD_GIT_REPOSITORY_URL=$(git config --get remote.origin.url)
export DD_GIT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
export DD_GIT_COMMIT_SHA=$COMMIT_SHA
...
```

it would be better if we could specify a repository while still read CI variables (not related to GIT info). New priority would be:
1. Current process location
2. CI environment variables (can be disabled with: `--no-ci-tags` option)
3. Explicitly provided Git repository (through `--git-repository` option)
4. Override environment variables (`DD_GIT_*` variables)

### How?

We give user the ability to pass an extra parameter `--git-repository` which we will use to initialize the directory from which we read the git environment variables.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
