### PR TITLE
[lambda] support `ruby3.3` and `provided.al2023`

### DIFF
--- a/src/commands/lambda/__tests__/__snapshots__/instrument.test.ts.snap
+++ b/src/commands/lambda/__tests__/__snapshots__/instrument.test.ts.snap
@@ -307,13 +307,15 @@ exports[`lambda instrument execute instruments Ruby application properly 1`] = `
 [Warning] Instrument your Lambda functions in a dev or staging environment first. Should the instrumentation result be unsatisfactory, run \`uninstrument\` with the same arguments to revert the changes.
 
 [!] Functions to be updated:
-	- arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world
-	- arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world-2
+	- arn:aws:lambda:us-east-1:123456789012:function:ruby32
+	- arn:aws:lambda:us-east-1:123456789012:function:ruby33
+	- arn:aws:lambda:us-east-1:123456789012:function:ruby32arm
+	- arn:aws:lambda:us-east-1:123456789012:function:ruby33arm
 
 [Dry Run] Will apply the following updates:
-UpdateFunctionConfiguration -> arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world
+UpdateFunctionConfiguration -> arn:aws:lambda:us-east-1:123456789012:function:ruby32
 {
-  "FunctionName": "arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world",
+  "FunctionName": "arn:aws:lambda:us-east-1:123456789012:function:ruby32",
   "Environment": {
     "Variables": {
       "DD_API_KEY": "02**********33bd",
@@ -333,13 +335,39 @@ UpdateFunctionConfiguration -> arn:aws:lambda:us-east-1:123456789012:function:la
     "arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Ruby3-2:19"
   ]
 }
-TagResource -> arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world
+TagResource -> arn:aws:lambda:us-east-1:123456789012:function:ruby32
 {
   "dd_sls_ci": "vXXXX"
 }
-UpdateFunctionConfiguration -> arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world-2
+UpdateFunctionConfiguration -> arn:aws:lambda:us-east-1:123456789012:function:ruby33
 {
-  "FunctionName": "arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world-2",
+  "FunctionName": "arn:aws:lambda:us-east-1:123456789012:function:ruby33",
+  "Environment": {
+    "Variables": {
+      "DD_API_KEY": "02**********33bd",
+      "DD_SITE": "datadoghq.com",
+      "DD_SERVERLESS_APPSEC_ENABLED": "false",
+      "DD_CAPTURE_LAMBDA_PAYLOAD": "false",
+      "DD_ENV": "staging",
+      "DD_TAGS": "layer:api,team:intake",
+      "DD_MERGE_XRAY_TRACES": "false",
+      "DD_SERVICE": "middletier",
+      "DD_TRACE_ENABLED": "true",
+      "DD_VERSION": "0.2"
+    }
+  },
+  "Layers": [
+    "arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Extension:40",
+    "arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Ruby3-3:19"
+  ]
+}
+TagResource -> arn:aws:lambda:us-east-1:123456789012:function:ruby33
+{
+  "dd_sls_ci": "vXXXX"
+}
+UpdateFunctionConfiguration -> arn:aws:lambda:us-east-1:123456789012:function:ruby32arm
+{
+  "FunctionName": "arn:aws:lambda:us-east-1:123456789012:function:ruby32arm",
   "Environment": {
     "Variables": {
       "DD_API_KEY": "02**********33bd",
@@ -359,7 +387,33 @@ UpdateFunctionConfiguration -> arn:aws:lambda:us-east-1:123456789012:function:la
     "arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Ruby3-2-ARM:19"
   ]
 }
-TagResource -> arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world-2
+TagResource -> arn:aws:lambda:us-east-1:123456789012:function:ruby32arm
+{
+  "dd_sls_ci": "vXXXX"
+}
+UpdateFunctionConfiguration -> arn:aws:lambda:us-east-1:123456789012:function:ruby33arm
+{
+  "FunctionName": "arn:aws:lambda:us-east-1:123456789012:function:ruby33arm",
+  "Environment": {
+    "Variables": {
+      "DD_API_KEY": "02**********33bd",
+      "DD_SITE": "datadoghq.com",
+      "DD_SERVERLESS_APPSEC_ENABLED": "false",
+      "DD_CAPTURE_LAMBDA_PAYLOAD": "false",
+      "DD_ENV": "staging",
+      "DD_TAGS": "layer:api,team:intake",
+      "DD_MERGE_XRAY_TRACES": "false",
+      "DD_SERVICE": "middletier",
+      "DD_TRACE_ENABLED": "true",
+      "DD_VERSION": "0.2"
+    }
+  },
+  "Layers": [
+    "arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Extension-ARM:40",
+    "arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Ruby3-3-ARM:19"
+  ]
+}
+TagResource -> arn:aws:lambda:us-east-1:123456789012:function:ruby33arm
 {
   "dd_sls_ci": "vXXXX"
 }

--- a/src/commands/lambda/__tests__/__snapshots__/instrument.test.ts.snap
+++ b/src/commands/lambda/__tests__/__snapshots__/instrument.test.ts.snap
@@ -420,6 +420,70 @@ TagResource -> arn:aws:lambda:us-east-1:123456789012:function:ruby33arm
 "
 `;
 
+exports[`lambda instrument execute instruments image runtimes properly 1`] = `
+"
+[Dry Run] 🐶 Instrumenting Lambda function
+
+[Warning] Instrument your Lambda functions in a dev or staging environment first. Should the instrumentation result be unsatisfactory, run \`uninstrument\` with the same arguments to revert the changes.
+
+[!] Functions to be updated:
+	- arn:aws:lambda:us-east-1:123456789012:function:provided-al2
+	- arn:aws:lambda:us-east-1:123456789012:function:provided-al2023
+
+[Dry Run] Will apply the following updates:
+UpdateFunctionConfiguration -> arn:aws:lambda:us-east-1:123456789012:function:provided-al2
+{
+  "FunctionName": "arn:aws:lambda:us-east-1:123456789012:function:provided-al2",
+  "Environment": {
+    "Variables": {
+      "DD_API_KEY": "02**********33bd",
+      "DD_SITE": "datadoghq.com",
+      "DD_SERVERLESS_APPSEC_ENABLED": "false",
+      "DD_CAPTURE_LAMBDA_PAYLOAD": "false",
+      "DD_ENV": "staging",
+      "DD_TAGS": "layer:api,team:intake",
+      "DD_MERGE_XRAY_TRACES": "false",
+      "DD_SERVICE": "middletier",
+      "DD_TRACE_ENABLED": "true",
+      "DD_VERSION": "0.2"
+    }
+  },
+  "Layers": [
+    "arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Extension:40"
+  ]
+}
+TagResource -> arn:aws:lambda:us-east-1:123456789012:function:provided-al2
+{
+  "dd_sls_ci": "vXXXX"
+}
+UpdateFunctionConfiguration -> arn:aws:lambda:us-east-1:123456789012:function:provided-al2023
+{
+  "FunctionName": "arn:aws:lambda:us-east-1:123456789012:function:provided-al2023",
+  "Environment": {
+    "Variables": {
+      "DD_API_KEY": "02**********33bd",
+      "DD_SITE": "datadoghq.com",
+      "DD_SERVERLESS_APPSEC_ENABLED": "false",
+      "DD_CAPTURE_LAMBDA_PAYLOAD": "false",
+      "DD_ENV": "staging",
+      "DD_TAGS": "layer:api,team:intake",
+      "DD_MERGE_XRAY_TRACES": "false",
+      "DD_SERVICE": "middletier",
+      "DD_TRACE_ENABLED": "true",
+      "DD_VERSION": "0.2"
+    }
+  },
+  "Layers": [
+    "arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Extension-ARM:40"
+  ]
+}
+TagResource -> arn:aws:lambda:us-east-1:123456789012:function:provided-al2023
+{
+  "dd_sls_ci": "vXXXX"
+}
+"
+`;
+
 exports[`lambda instrument execute prints dry run data for lambda .NET layer 1`] = `
 "
 [Dry Run] 🐶 Instrumenting Lambda function

--- a/src/commands/lambda/__tests__/instrument.test.ts
+++ b/src/commands/lambda/__tests__/instrument.test.ts
@@ -1103,16 +1103,29 @@ describe('lambda', () => {
         ;(fs.readFile as any).mockImplementation((a: any, b: any, callback: any) => callback({code: 'ENOENT'}))
 
         mockLambdaConfigurations(lambdaClientMock, {
-          'arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world': {
+          'arn:aws:lambda:us-east-1:123456789012:function:ruby32': {
             config: {
-              FunctionArn: 'arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world',
+              FunctionArn: 'arn:aws:lambda:us-east-1:123456789012:function:ruby32',
               Runtime: 'ruby3.2',
             },
           },
-          'arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world-2': {
+          'arn:aws:lambda:us-east-1:123456789012:function:ruby32arm': {
             config: {
-              FunctionArn: 'arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world-2',
+              FunctionArn: 'arn:aws:lambda:us-east-1:123456789012:function:ruby32arm',
               Runtime: 'ruby3.2',
+              Architectures: ['arm64'],
+            },
+          },
+          'arn:aws:lambda:us-east-1:123456789012:function:ruby33': {
+            config: {
+              FunctionArn: 'arn:aws:lambda:us-east-1:123456789012:function:ruby33',
+              Runtime: 'ruby3.3',
+            },
+          },
+          'arn:aws:lambda:us-east-1:123456789012:function:ruby33arm': {
+            config: {
+              FunctionArn: 'arn:aws:lambda:us-east-1:123456789012:function:ruby33arm',
+              Runtime: 'ruby3.3',
               Architectures: ['arm64'],
             },
           },
@@ -1126,9 +1139,13 @@ describe('lambda', () => {
             'lambda',
             'instrument',
             '-f',
-            'arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world',
+            'arn:aws:lambda:us-east-1:123456789012:function:ruby32',
             '-f',
-            'arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world-2',
+            'arn:aws:lambda:us-east-1:123456789012:function:ruby33',
+            '-f',
+            'arn:aws:lambda:us-east-1:123456789012:function:ruby32arm',
+            '-f',
+            'arn:aws:lambda:us-east-1:123456789012:function:ruby33arm',
             '--dry-run',
             '-e',
             '40',

--- a/src/commands/lambda/constants.ts
+++ b/src/commands/lambda/constants.ts
@@ -25,6 +25,7 @@ export const LAYER_LOOKUP = {
   'python3.12': 'Datadog-Python312',
   'python3.13': 'Datadog-Python313',
   'ruby3.2': 'Datadog-Ruby3-2',
+  'ruby3.3': 'Datadog-Ruby3-3',
 } as const
 
 export enum RuntimeType {
@@ -49,6 +50,7 @@ export const RUNTIME_LOOKUP: Partial<Record<Runtime, RuntimeType>> = {
   'nodejs20.x': RuntimeType.NODE,
   'nodejs22.x': RuntimeType.NODE,
   'provided.al2': RuntimeType.CUSTOM,
+  'provided.al2023': RuntimeType.CUSTOM,
   'python3.8': RuntimeType.PYTHON,
   'python3.9': RuntimeType.PYTHON,
   'python3.10': RuntimeType.PYTHON,
@@ -56,6 +58,7 @@ export const RUNTIME_LOOKUP: Partial<Record<Runtime, RuntimeType>> = {
   'python3.12': RuntimeType.PYTHON,
   'python3.13': RuntimeType.PYTHON,
   'ruby3.2': RuntimeType.RUBY,
+  'ruby3.3': RuntimeType.RUBY,
 }
 
 export type LayerKey = keyof typeof LAYER_LOOKUP
@@ -69,6 +72,7 @@ export const ARM_LAYERS = [
   'python3.11',
   'python3.12',
   'ruby3.2',
+  'ruby3.3',
 ]
 export const ARM64_ARCHITECTURE = 'arm64'
 export const ARM_LAYER_SUFFIX = '-ARM'


### PR DESCRIPTION
### What and why?

Adds support for `ruby3.3` and `provided.al2023` runtimes.

### How?

Adding them to the lookup keys.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
