### PR TITLE
[lambda] [bugfix] Ensure ARM layers are used for python3.13 ARM functions

### DIFF
--- a/src/commands/lambda/__tests__/functions/instrument.part2.test.ts
+++ b/src/commands/lambda/__tests__/functions/instrument.part2.test.ts
@@ -108,25 +108,27 @@ describe('instrument', () => {
       [Runtime.python311, 'Datadog-Python311-ARM'],
       [Runtime.python312, 'Datadog-Python312-ARM'],
       [Runtime.python313, 'Datadog-Python313-ARM'],
-    ])('calculates an update request with just lambda library layers in arm architecture', async (runtime: Runtime, layer: string) => {
-      const config = {
-        Architectures: [Architecture.arm64],
-        FunctionArn: 'arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world',
-        Handler: 'handler.hello',
-        Layers: [],
-        Runtime: runtime,
-      }
-      const settings = {
-        flushMetricsToLogs: false,
-        layerAWSAccount: mockAwsAccount,
-        layerVersion: 11,
-        mergeXrayTraces: false,
-        tracingEnabled: false,
-      }
-      const region = 'sa-east-1'
+    ])(
+      'calculates an update request with just lambda library layers in arm architecture',
+      async (runtime: Runtime, layer: string) => {
+        const config = {
+          Architectures: [Architecture.arm64],
+          FunctionArn: 'arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world',
+          Handler: 'handler.hello',
+          Layers: [],
+          Runtime: runtime,
+        }
+        const settings = {
+          flushMetricsToLogs: false,
+          layerAWSAccount: mockAwsAccount,
+          layerVersion: 11,
+          mergeXrayTraces: false,
+          tracingEnabled: false,
+        }
+        const region = 'sa-east-1'
 
-      const updateRequest = await calculateUpdateRequest(config, settings, region, runtime)
-      expect(updateRequest).toMatchInlineSnapshot(`
+        const updateRequest = await calculateUpdateRequest(config, settings, region, runtime)
+        expect(updateRequest).toMatchInlineSnapshot(`
         {
           "Environment": {
             "Variables": {
@@ -144,7 +146,8 @@ describe('instrument', () => {
           ],
         }
       `)
-    })
+      }
+    )
 
     test('calculates an update request with a lambda library, extension, and DATADOG_API_KEY', async () => {
       process.env[CI_API_KEY_ENV_VAR] = MOCK_DATADOG_API_KEY

--- a/src/commands/lambda/__tests__/functions/instrument.part2.test.ts
+++ b/src/commands/lambda/__tests__/functions/instrument.part2.test.ts
@@ -65,6 +65,7 @@ describe('instrument', () => {
       [Runtime.python310, 'Datadog-Python310'],
       [Runtime.python311, 'Datadog-Python311'],
       [Runtime.python312, 'Datadog-Python312'],
+      [Runtime.python313, 'Datadog-Python313'],
     ])('calculates an update request for %s', async (runtime: Runtime, layer: string) => {
       const config = {
         FunctionArn: 'arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world',
@@ -102,8 +103,12 @@ describe('instrument', () => {
       `)
     })
 
-    test('calculates an update request with just lambda library layers in arm architecture', async () => {
-      const runtime = Runtime.python39
+    test.each([
+      [Runtime.python310, 'Datadog-Python310-ARM'],
+      [Runtime.python311, 'Datadog-Python311-ARM'],
+      [Runtime.python312, 'Datadog-Python312-ARM'],
+      [Runtime.python313, 'Datadog-Python313-ARM'],
+    ])('calculates an update request with just lambda library layers in arm architecture', async (runtime: Runtime, layer: string) => {
       const config = {
         Architectures: [Architecture.arm64],
         FunctionArn: 'arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world',
@@ -135,7 +140,7 @@ describe('instrument', () => {
           "FunctionName": "arn:aws:lambda:us-east-1:123456789012:function:lambda-hello-world",
           "Handler": "datadog_lambda.handler.handler",
           "Layers": [
-            "arn:aws:lambda:sa-east-1:123456789012:layer:Datadog-Python39-ARM:11",
+            "arn:aws:lambda:sa-east-1:123456789012:layer:${layer}:11",
           ],
         }
       `)

--- a/src/commands/lambda/__tests__/functions/instrument.part2.test.ts
+++ b/src/commands/lambda/__tests__/functions/instrument.part2.test.ts
@@ -62,6 +62,7 @@ describe('instrument', () => {
     })
 
     test.each([
+      [Runtime.python39, 'Datadog-Python39'],
       [Runtime.python310, 'Datadog-Python310'],
       [Runtime.python311, 'Datadog-Python311'],
       [Runtime.python312, 'Datadog-Python312'],
@@ -104,6 +105,7 @@ describe('instrument', () => {
     })
 
     test.each([
+      [Runtime.python39, 'Datadog-Python39-ARM'],
       [Runtime.python310, 'Datadog-Python310-ARM'],
       [Runtime.python311, 'Datadog-Python311-ARM'],
       [Runtime.python312, 'Datadog-Python312-ARM'],

--- a/src/commands/lambda/constants.ts
+++ b/src/commands/lambda/constants.ts
@@ -71,6 +71,7 @@ export const ARM_LAYERS = [
   'python3.10',
   'python3.11',
   'python3.12',
+  'python3.13',
   'ruby3.2',
   'ruby3.3',
 ]


### PR DESCRIPTION
### What and why?

In https://github.com/DataDog/datadog-ci/pull/1537, we added support for instrumenting Python3.13 lambdas using `datadog-ci lambda instrument` command. In that PR, we missed adding `python3.13` constant to the `ARM_LAYERS` array, which causes the command to apply non-ARM Python layers to ARM Python 3.13 lambdas.

### How?
This PR adds the constant and a unit test that catches the issue.

### Testing
- Ran yarn prepack to build CLI locally
- Created a Python 3.13 ARM lambda
  - Ran node `./dist/cli.js lambda instrument --function MY_FUNCTION_ARN --extensionVersion 68 --layer-version 105` 
  - Saw it successfully instrument with the `arn:aws:lambda:ca-central-1:464622532012:layer:Datadog-Python313-ARM:105` layer

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
