### PR TITLE
v3.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci",
-  "version": "3.0.2",
+  "version": "3.1.0",
   "description": "Run datadog actions from the CI.",
   "repository": "https://github.com/DataDog/datadog-ci",
   "license": "Apache-2.0",


### PR DESCRIPTION
<!-- Release notes generated using configuration in .github/release.yml at v3.1.0 -->

## What's Changed
### Serverless
* [lambda] support `ruby3.3` and `provided.al2023` by @duncanista in https://github.com/DataDog/datadog-ci/pull/1574
* [lambda] [bugfix] Ensure ARM layers are used for python3.13 ARM functions by @TalUsvyatsky in https://github.com/DataDog/datadog-ci/pull/1575
### Static Analysis
* bump file size for SARIF file by @juli1 in https://github.com/DataDog/datadog-ci/pull/1576
* Bump SARIF limit to 20MB by @juli1 in https://github.com/DataDog/datadog-ci/pull/1578


**Full Changelog**: https://github.com/DataDog/datadog-ci/compare/v3.0.2...v3.1.0