### PR TITLE
Refactor the common config and setup into a base command

### DIFF
--- a/src/commands/synthetics/deploy-tests-command.ts
+++ b/src/commands/synthetics/deploy-tests-command.ts
@@ -9,18 +9,26 @@ import {Logger, LogLevel} from '../../helpers/logger'
 import {removeUndefinedValues, resolveConfigFromFile} from '../../helpers/utils'
 
 import {deployTests} from './deploy-tests-lib'
-import {CiError} from './errors'
-import {DeployTestsCommandConfig, MainReporter, Reporter, RunTestsCommandConfig} from './interfaces'
+import {DeployTestsCommandConfig, DatadogCIConfig, MainReporter, Reporter} from './interfaces'
 import {DefaultReporter} from './reporters/default'
-import {getReporter, reportCiError} from './utils/public'
+import {getReporter} from './utils/public'
 
-export const DEFAULT_DEPLOY_TESTS_COMMAND_CONFIG: DeployTestsCommandConfig = {
+const DEFAULT_DATADOG_CI_COMMAND_CONFIG: DatadogCIConfig = {
   apiKey: '',
   appKey: '',
   configPath: 'datadog-ci.json',
   datadogSite: 'datadoghq.com',
-  files: [],
   proxy: {protocol: 'http'},
+}
+
+export const getDefaultDatadogCiConfig = () => {
+  // Deep copy to avoid mutation
+  return JSON.parse(JSON.stringify(DEFAULT_DATADOG_CI_COMMAND_CONFIG)) as DatadogCIConfig
+}
+
+export const DEFAULT_DEPLOY_TESTS_COMMAND_CONFIG: DeployTestsCommandConfig = {
+  ...getDefaultDatadogCiConfig(),
+  files: [],
   publicIds: [],
   subdomain: 'app',
 }
@@ -30,7 +38,88 @@ const configurationLink = 'https://docs.datadoghq.com/continuous_testing/cicd_in
 const $1 = (text: string) => terminalLink(text, `${configurationLink}#global-configuration-file-options`)
 const $2 = (text: string) => terminalLink(text, `${configurationLink}#test-files`)
 
-export class DeployTestsCommand extends Command {
+export abstract class BaseCommand extends Command {
+  protected config: DatadogCIConfig = this.getDefaultConfig()
+  protected reporter!: MainReporter
+
+  protected configPath = Option.String('--config', {
+    description: `Pass a path to a ${$1('global configuration file')}.`,
+  })
+  protected apiKey = Option.String('--apiKey', {description: 'The API key used to query the Datadog API.'})
+  protected appKey = Option.String('--appKey', {description: 'The application key used to query the Datadog API.'})
+  protected datadogSite = Option.String('--datadogSite', {
+    description: 'The Datadog instance to which request is sent.',
+  })
+
+  protected fips = Option.Boolean('--fips', false)
+  protected fipsIgnoreError = Option.Boolean('--fips-ignore-error', false)
+  protected fipsConfig = {
+    fips: toBoolean(process.env[FIPS_ENV_VAR]) ?? false,
+    fipsIgnoreError: toBoolean(process.env[FIPS_IGNORE_ERROR_ENV_VAR]) ?? false,
+  }
+
+  protected logger: Logger = new Logger((s: string) => {
+    this.context.stdout.write(s)
+  }, LogLevel.INFO)
+
+  protected async setup() {
+    enableFips(this.fips || this.fipsConfig.fips, this.fipsIgnoreError || this.fipsConfig.fipsIgnoreError)
+
+    await this.resolveConfig()
+
+    const reporters: Reporter[] = [new DefaultReporter(this)]
+    this.reporter = getReporter(reporters)
+  }
+
+  // These methods should be overloaded by the child class, and called as super.<method> in the child class, to add more config.
+  protected getDefaultConfig(): DatadogCIConfig {
+    return getDefaultDatadogCiConfig()
+  }
+
+  protected resolveConfigFromEnv(): Partial<DatadogCIConfig> {
+    return {
+      apiKey: process.env.DATADOG_API_KEY,
+      appKey: process.env.DATADOG_APP_KEY,
+      configPath: process.env.DATADOG_SYNTHETICS_CONFIG_PATH, // Only used for debugging
+      datadogSite: process.env.DATADOG_SITE,
+    }
+  }
+
+  protected resolveConfigFromCli(): Partial<DatadogCIConfig> {
+    return {
+      apiKey: this.apiKey,
+      appKey: this.appKey,
+      configPath: this.configPath,
+      datadogSite: this.datadogSite,
+    }
+  }
+
+  protected async resolveConfig() {
+    // Defaults < file < ENV < CLI
+
+    // Override with config file variables (e.g. datadog-ci.json)
+    try {
+      // Override Config Path with ENV variables
+      const overrideConfigPath = this.configPath ?? process.env.DATADOG_SYNTHETICS_CONFIG_PATH ?? 'datadog-ci.json'
+      this.config = await resolveConfigFromFile(this.config, {
+        configPath: overrideConfigPath,
+        defaultConfigPaths: [this.config.configPath],
+      })
+    } catch (error) {
+      if (this.configPath) {
+        throw error
+      }
+    }
+
+    // Override with ENV variables
+    this.config = deepExtend(this.config, removeUndefinedValues(this.resolveConfigFromEnv()))
+
+    // Override with CLI parameters
+    this.config = deepExtend(this.config, removeUndefinedValues(this.resolveConfigFromCli()))
+  }
+}
+
+export class DeployTestsCommand extends BaseCommand {
   public static paths = [['synthetics', 'deploy-tests']]
 
   public static usage = Command.Usage({
@@ -51,49 +140,21 @@ export class DeployTestsCommand extends Command {
     ],
   })
 
-  public configPath = Option.String('--config', {description: `Pass a path to a ${$1('global configuration file')}.`})
-
-  private apiKey = Option.String('--apiKey', {description: 'The API key used to query the Datadog API.'})
-  private appKey = Option.String('--appKey', {description: 'The application key used to query the Datadog API.'})
-  private datadogSite = Option.String('--datadogSite', {description: 'The Datadog instance to which request is sent.'})
-  private files = Option.Array('-f,--files', {
-    description: `Glob pattern to detect Synthetic test ${$2('configuration files')}}.`,
-  })
-  private publicIds = Option.Array('-p,--public-id', {description: 'Specify a test to run.'})
-  private subdomain = Option.String('--subdomain', {
+  protected subdomain = Option.String('--subdomain', {
     description:
       'The name of the custom subdomain set to access your Datadog application. If the URL used to access Datadog is `myorg.datadoghq.com`, the `subdomain` value needs to be set to `myorg`.',
   })
 
-  private reporter!: MainReporter
-  private config: RunTestsCommandConfig = JSON.parse(JSON.stringify(DEFAULT_DEPLOY_TESTS_COMMAND_CONFIG)) // Deep copy to avoid mutation
+  protected config: DeployTestsCommandConfig = this.getDefaultConfig()
 
-  private logger: Logger = new Logger((s: string) => {
-    this.context.stdout.write(s)
-  }, LogLevel.INFO)
-
-  private fips = Option.Boolean('--fips', false)
-  private fipsIgnoreError = Option.Boolean('--fips-ignore-error', false)
-  private fipsConfig = {
-    fips: toBoolean(process.env[FIPS_ENV_VAR]) ?? false,
-    fipsIgnoreError: toBoolean(process.env[FIPS_IGNORE_ERROR_ENV_VAR]) ?? false,
-  }
+  private files = Option.Array('-f,--files', {
+    description: `Glob pattern to detect Synthetic test ${$2('configuration files')}}.`,
+  })
+  private publicIds = Option.Array('-p,--public-id', {description: 'Specify a test to run.'})
 
   public async execute() {
-    enableFips(this.fips || this.fipsConfig.fips, this.fipsIgnoreError || this.fipsConfig.fipsIgnoreError)
-
-    const reporters: Reporter[] = [new DefaultReporter(this)]
-    this.reporter = getReporter(reporters)
-
-    try {
-      await this.resolveConfig()
-    } catch (error) {
-      if (error instanceof CiError) {
-        reportCiError(error, this.reporter)
-      }
-
-      return 1
-    }
+    // populate the config
+    await this.setup()
 
     try {
       await deployTests(this.reporter, this.config)
@@ -102,51 +163,32 @@ export class DeployTestsCommand extends Command {
 
       return 1
     }
+
+    return 0
   }
 
-  private async resolveConfig() {
-    // Defaults < file < ENV < CLI
-
-    // Override with config file variables (e.g. datadog-ci.json)
-    try {
-      // Override Config Path with ENV variables
-      const overrideConfigPath = this.configPath ?? process.env.DATADOG_SYNTHETICS_CONFIG_PATH ?? 'datadog-ci.json'
-      this.config = await resolveConfigFromFile(this.config, {
-        configPath: overrideConfigPath,
-        defaultConfigPaths: [this.config.configPath],
-      })
-    } catch (error) {
-      if (this.configPath) {
-        throw error
-      }
+  protected getDefaultConfig(): DeployTestsCommandConfig {
+    return {
+      ...super.getDefaultConfig(),
+      ...DEFAULT_DEPLOY_TESTS_COMMAND_CONFIG,
     }
+  }
 
-    // Override with ENV variables
-    this.config = deepExtend(
-      this.config,
-      removeUndefinedValues({
-        apiKey: process.env.DATADOG_API_KEY,
-        appKey: process.env.DATADOG_APP_KEY,
-        configPath: process.env.DATADOG_SYNTHETICS_CONFIG_PATH, // Only used for debugging
-        datadogSite: process.env.DATADOG_SITE,
-        files: process.env.DATADOG_SYNTHETICS_FILES?.split(';'),
-        publicIds: process.env.DATADOG_SYNTHETICS_PUBLIC_IDS?.split(';'),
-        subdomain: process.env.DATADOG_SUBDOMAIN,
-      })
-    )
+  protected resolveConfigFromEnv(): Partial<DeployTestsCommandConfig> {
+    return {
+      ...super.resolveConfigFromEnv(),
+      files: process.env.DATADOG_SYNTHETICS_FILES?.split(';'),
+      publicIds: process.env.DATADOG_SYNTHETICS_PUBLIC_IDS?.split(';'),
+      subdomain: process.env.DATADOG_SUBDOMAIN,
+    }
+  }
 
-    // Override with CLI parameters
-    this.config = deepExtend(
-      this.config,
-      removeUndefinedValues({
-        apiKey: this.apiKey,
-        appKey: this.appKey,
-        configPath: this.configPath,
-        datadogSite: this.datadogSite,
-        files: this.files,
-        publicIds: this.publicIds,
-        subdomain: this.subdomain,
-      })
-    )
+  protected resolveConfigFromCli(): Partial<DeployTestsCommandConfig> {
+    return {
+      ...super.resolveConfigFromCli(),
+      files: this.files,
+      publicIds: this.publicIds,
+      subdomain: this.subdomain,
+    }
   }
 }

--- a/src/commands/synthetics/interfaces.ts
+++ b/src/commands/synthetics/interfaces.ts
@@ -536,12 +536,15 @@ export interface APIHelperConfig {
   proxy: ProxyConfiguration
 }
 
+export interface DatadogCIConfig extends APIHelperConfig {
+  configPath: string
+}
+
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
-export interface SyntheticsCIConfig extends APIHelperConfig {}
+export interface SyntheticsCIConfig extends DatadogCIConfig {}
 
 export interface RunTestsCommandConfig extends SyntheticsCIConfig {
   batchTimeout?: number
-  configPath: string
   defaultTestOverrides?: UserConfigOverride
   failOnCriticalErrors: boolean
   failOnMissingTests: boolean


### PR DESCRIPTION
### What and why?

This PR introduces a new `BaseCommand` that currently lives in the same file as `DeployTestCommand`, but is expected to be moved to a new file, and be extended from all of the Synthetics commands. Moving to a new file appears to fail in the CI (but not locally), and might be related to circular dependencies.

### How?

`abstract` and moving code around 📦 

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
