### PR TITLE
Change CODEOWNERS for elf-symbols to @DataDog/profiling-full-host

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -36,7 +36,7 @@ src/commands/git-metadata  @DataDog/datadog-ci @DataDog/source-code-integration
 src/commands/synthetics  @DataDog/datadog-ci @DataDog/synthetics-ct
 
 ## Profiling (label: profiling)
-src/commands/elf-symbols  @DataDog/datadog-ci @DataDog/profiling-native
+src/commands/elf-symbols  @DataDog/datadog-ci @DataDog/profiling-full-host
 
 # Shared utilities
 


### PR DESCRIPTION
### What and why?

Change CODEOWNERS for elf-symbols to @DataDog/profiling-full-host

### How?


### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
