### PR TITLE
implement the build-and-test command

### DIFF
--- a/src/commands/synthetics/__tests__/build-and-test.test.ts
+++ b/src/commands/synthetics/__tests__/build-and-test.test.ts
@@ -1,0 +1,55 @@
+import {once} from 'events'
+import * as http from 'http'
+
+import {spawnBuildPluginDevServer} from '../build-and-test'
+
+import {mockReporter} from './fixtures'
+
+// if BUILD_PLUGINS_S8S_PORT is defined, this command does nothing forever, otherwise, it exits immediately
+const MOCKED_BUILD_COMMAND = (port: number) => `[ "$BUILD_PLUGINS_S8S_PORT" = "${port}" ] && tail -f /dev/null`
+// this command simulates a build command without the build plugin configured
+const MOCKED_BUILD_COMMAND_NOT_CONFIGURED = 'echo "build successful"'
+
+describe('build-and-test - spawnBuildPluginDevServer', () => {
+  test('wait for the dev server and return expected readiness and status', async () => {
+    // Given a dev server which listen on port 4000
+    const port = 4000
+    const requests: string[] = []
+    const server = http
+      .createServer((req, res) => {
+        requests.push(String(req.url))
+        res.writeHead(200, {'Content-Type': 'application/json'})
+        res.end(
+          JSON.stringify({
+            status: 'success',
+            publicPrefix: 'prefix/',
+          })
+        )
+      })
+      .listen(port)
+
+    // When calling spawnBuildPluginDevServer
+    const command = await spawnBuildPluginDevServer(MOCKED_BUILD_COMMAND(port), port, mockReporter)
+
+    // Then it should send requests to the dev server until it's ready to serve,
+    // and return the devServerUrl and the path prefix.
+    expect(command.devServerUrl).toBe('http://localhost:4000')
+    expect(command.publicPrefix).toBe('prefix/')
+    expect(requests.pop()).toBe('/_datadog-ci_/build-status')
+
+    // Close the server and the command at the end of the test.
+    server.close()
+    await Promise.all([command.stop(), once(server, 'close')])
+  })
+
+  test('alert when the build-plugin is not configured', async () => {
+    // Given a build command without the build plugin configured
+    // When calling spawnBuildPluginDevServer
+    const commandPromise = spawnBuildPluginDevServer(MOCKED_BUILD_COMMAND_NOT_CONFIGURED, 4000, mockReporter)
+
+    // Then it should throw when the command exits.
+    await expect(commandPromise).rejects.toThrow(
+      'Build command exited before the build plugin could be started. Is the build plugin configured?'
+    )
+  })
+})

--- a/src/commands/synthetics/__tests__/build-and-test.test.ts
+++ b/src/commands/synthetics/__tests__/build-and-test.test.ts
@@ -7,6 +7,17 @@ import {mockReporter} from './fixtures'
 const NODE_COMMAND = process.execPath
 
 describe('build-and-test - spawnBuildPluginDevServer', () => {
+  test('alert when the build-plugin is not configured', async () => {
+    // Given a build command without the build plugin configured
+    const MOCKED_BUILD_COMMAND_NOT_CONFIGURED = `${NODE_COMMAND} -e "console.log('build successful')"`
+
+    // When calling spawnBuildPluginDevServer
+    const commandPromise = spawnBuildPluginDevServer(MOCKED_BUILD_COMMAND_NOT_CONFIGURED, mockReporter)
+
+    // Then it should throw when the command exits.
+    await expect(commandPromise).rejects.toThrow(UnconfiguredBuildPluginError)
+  })
+
   test('wait for the dev server and return expected readiness and status', async () => {
     // Given a dev server which listen on the port provided in the environment variable BUILD_PLUGINS_S8S_PORT.
     // The implementation of this server is written as a function, and stringified into a single line,
@@ -33,16 +44,5 @@ describe('build-and-test - spawnBuildPluginDevServer', () => {
 
     // Stop the command at the end of the test.
     await command.stop()
-  })
-
-  test('alert when the build-plugin is not configured', async () => {
-    // Given a build command without the build plugin configured
-    const MOCKED_BUILD_COMMAND_NOT_CONFIGURED = `${NODE_COMMAND} -e "console.log('build successful')"`
-
-    // When calling spawnBuildPluginDevServer
-    const commandPromise = spawnBuildPluginDevServer(MOCKED_BUILD_COMMAND_NOT_CONFIGURED, mockReporter)
-
-    // Then it should throw when the command exits.
-    await expect(commandPromise).rejects.toThrow(UnconfiguredBuildPluginError)
   })
 })

--- a/src/commands/synthetics/__tests__/build-and-test.test.ts
+++ b/src/commands/synthetics/__tests__/build-and-test.test.ts
@@ -1,7 +1,7 @@
 import {once} from 'events'
 import * as http from 'http'
 
-import {spawnBuildPluginDevServer} from '../build-and-test'
+import {UnconfiguredBuildPluginError, spawnBuildPluginDevServer} from '../build-and-test'
 
 import {mockReporter} from './fixtures'
 
@@ -48,8 +48,6 @@ describe('build-and-test - spawnBuildPluginDevServer', () => {
     const commandPromise = spawnBuildPluginDevServer(MOCKED_BUILD_COMMAND_NOT_CONFIGURED, 4000, mockReporter)
 
     // Then it should throw when the command exits.
-    await expect(commandPromise).rejects.toThrow(
-      'Build command exited before the build plugin could be started. Is the build plugin configured?'
-    )
+    await expect(commandPromise).rejects.toThrow(UnconfiguredBuildPluginError)
   })
 })

--- a/src/commands/synthetics/__tests__/build-and-test.test.ts
+++ b/src/commands/synthetics/__tests__/build-and-test.test.ts
@@ -4,6 +4,8 @@ import {UnconfiguredBuildPluginError, spawnBuildPluginDevServer} from '../build-
 
 import {mockReporter} from './fixtures'
 
+const NODE_COMMAND = process.execPath
+
 describe('build-and-test - spawnBuildPluginDevServer', () => {
   test('wait for the dev server and return expected readiness and status', async () => {
     // Given a dev server which listen on the port provided in the environment variable BUILD_PLUGINS_S8S_PORT.
@@ -19,7 +21,6 @@ describe('build-and-test - spawnBuildPluginDevServer', () => {
         .listen(process.env.BUILD_PLUGINS_S8S_PORT)
     }
     const SERVER_IMPLEMENTATION = httpDevServer.toString().replace(/\n\s+/g, '')
-    const NODE_COMMAND = process.execPath
     const MOCKED_BUILD_COMMAND = `${NODE_COMMAND} -e "(${SERVER_IMPLEMENTATION})()"`
 
     // When calling spawnBuildPluginDevServer
@@ -36,7 +37,7 @@ describe('build-and-test - spawnBuildPluginDevServer', () => {
 
   test('alert when the build-plugin is not configured', async () => {
     // Given a build command without the build plugin configured
-    const MOCKED_BUILD_COMMAND_NOT_CONFIGURED = 'echo "build successful"'
+    const MOCKED_BUILD_COMMAND_NOT_CONFIGURED = `${NODE_COMMAND} -e "console.log('build successful')"`
 
     // When calling spawnBuildPluginDevServer
     const commandPromise = spawnBuildPluginDevServer(MOCKED_BUILD_COMMAND_NOT_CONFIGURED, mockReporter)

--- a/src/commands/synthetics/__tests__/cli.test.ts
+++ b/src/commands/synthetics/__tests__/cli.test.ts
@@ -70,7 +70,6 @@ describe('run-tests', () => {
         DATADOG_SUBDOMAIN: 'custom',
         DATADOG_SYNTHETICS_BATCH_TIMEOUT: '1',
         DATADOG_SYNTHETICS_BUILD_COMMAND: 'build-command',
-        DATADOG_SYNTHETICS_BUILD_PLUGIN_PORT: '3000',
         DATADOG_SYNTHETICS_CONFIG_PATH: 'path/to/config.json',
         DATADOG_SYNTHETICS_FAIL_ON_CRITICAL_ERRORS: 'false',
         DATADOG_SYNTHETICS_FAIL_ON_MISSING_TESTS: 'false',
@@ -117,7 +116,6 @@ describe('run-tests', () => {
         appKey: overrideEnv.DATADOG_APP_KEY,
         batchTimeout: 1,
         buildCommand: overrideEnv.DATADOG_SYNTHETICS_BUILD_COMMAND,
-        buildPluginPort: toNumber(overrideEnv.DATADOG_SYNTHETICS_BUILD_PLUGIN_PORT),
         configPath: overrideEnv.DATADOG_SYNTHETICS_CONFIG_PATH,
         datadogSite: overrideEnv.DATADOG_SITE,
         defaultTestOverrides: {
@@ -196,7 +194,6 @@ describe('run-tests', () => {
         appKey: 'fake_app_key',
         batchTimeout: 1,
         buildCommand: 'build-command',
-        buildPluginPort: 3000,
         configPath: 'src/commands/synthetics/__tests__/config-fixtures/config-with-all-keys.json',
         datadogSite: 'datadoghq.eu',
         defaultTestOverrides: {
@@ -422,7 +419,6 @@ describe('run-tests', () => {
         apiKey: 'config_file_api_key',
         appKey: 'config_file_app_key',
         buildCommand: 'build-command',
-        buildPluginPort: 3000,
         datadogSite: 'us3.datadoghq.com',
         defaultTestOverrides: {
           allowInsecureCertificates: true,
@@ -476,7 +472,6 @@ describe('run-tests', () => {
           DATADOG_SUBDOMAIN: 'subdomain_from_env',
           DATADOG_SYNTHETICS_BATCH_TIMEOUT: '1',
           DATADOG_SYNTHETICS_BUILD_COMMAND: 'build-command',
-          DATADOG_SYNTHETICS_BUILD_PLUGIN_PORT: '3000',
           DATADOG_SYNTHETICS_CONFIG_PATH: 'path/to/config_from_env.json',
           DATADOG_SYNTHETICS_FAIL_ON_CRITICAL_ERRORS: 'true',
           DATADOG_SYNTHETICS_FAIL_ON_MISSING_TESTS: 'true',
@@ -519,7 +514,6 @@ describe('run-tests', () => {
           appKey: overrideEnv.DATADOG_APP_KEY,
           batchTimeout: toNumber(overrideEnv.DATADOG_SYNTHETICS_BATCH_TIMEOUT),
           buildCommand: overrideEnv.DATADOG_SYNTHETICS_BUILD_COMMAND,
-          buildPluginPort: toNumber(overrideEnv.DATADOG_SYNTHETICS_BUILD_PLUGIN_PORT),
           configPath: overrideEnv.DATADOG_SYNTHETICS_CONFIG_PATH,
           datadogSite: overrideEnv.DATADOG_SITE,
           defaultTestOverrides: {
@@ -593,7 +587,6 @@ describe('run-tests', () => {
           appKey: 'cli_app_key',
           batchTimeout: 1,
           buildCommand: 'build-command',
-          buildPluginPort: 3000,
           configPath: 'src/commands/synthetics/__tests__/config-fixtures/empty-config-file-from-cli.json',
           datadogSite: 'datadoghq.eu',
           failOnCriticalErrors: true,
@@ -651,7 +644,6 @@ describe('run-tests', () => {
         command['appKey'] = overrideCLI.appKey
         command['batchTimeout'] = overrideCLI.batchTimeout
         command['buildCommand'] = overrideCLI.buildCommand
-        command['buildPluginPort'] = overrideCLI.buildPluginPort
         command['configPath'] = overrideCLI.configPath
         command['datadogSite'] = overrideCLI.datadogSite
         command['failOnCriticalErrors'] = overrideCLI.failOnCriticalErrors
@@ -718,7 +710,6 @@ describe('run-tests', () => {
           DATADOG_SYNTHETICS_CONFIG_PATH: 'path/to/config_from_env.json',
           DATADOG_SUBDOMAIN: 'subdomain_from_env',
           DATADOG_SYNTHETICS_BUILD_COMMAND: 'default-build-command',
-          DATADOG_SYNTHETICS_BUILD_PLUGIN_PORT: '4000',
           DATADOG_SYNTHETICS_FAIL_ON_CRITICAL_ERRORS: 'true',
           DATADOG_SYNTHETICS_FAIL_ON_MISSING_TESTS: 'true',
           DATADOG_SYNTHETICS_FAIL_ON_TIMEOUT: 'true',
@@ -760,7 +751,6 @@ describe('run-tests', () => {
           appKey: 'cli_app_key',
           batchTimeout: 1,
           buildCommand: 'build-command',
-          buildPluginPort: 3000,
           configPath: 'path/to/config_from_cli.json',
           datadogSite: 'datadoghq.eu',
           failOnCriticalErrors: false,
@@ -820,7 +810,6 @@ describe('run-tests', () => {
         command['appKey'] = overrideCLI.appKey
         command['batchTimeout'] = overrideCLI.batchTimeout
         command['buildCommand'] = overrideCLI.buildCommand
-        command['buildPluginPort'] = overrideCLI.buildPluginPort
         command['configPath'] = overrideCLI.configPath
         command['datadogSite'] = overrideCLI.datadogSite
         command['failOnCriticalErrors'] = overrideCLI.failOnCriticalErrors

--- a/src/commands/synthetics/__tests__/cli.test.ts
+++ b/src/commands/synthetics/__tests__/cli.test.ts
@@ -69,6 +69,8 @@ describe('run-tests', () => {
         DATADOG_SITE: 'datadoghq.eu',
         DATADOG_SUBDOMAIN: 'custom',
         DATADOG_SYNTHETICS_BATCH_TIMEOUT: '1',
+        DATADOG_SYNTHETICS_BUILD_COMMAND: 'build-command',
+        DATADOG_SYNTHETICS_BUILD_PLUGIN_PORT: '3000',
         DATADOG_SYNTHETICS_CONFIG_PATH: 'path/to/config.json',
         DATADOG_SYNTHETICS_FAIL_ON_CRITICAL_ERRORS: 'false',
         DATADOG_SYNTHETICS_FAIL_ON_MISSING_TESTS: 'false',
@@ -114,6 +116,8 @@ describe('run-tests', () => {
         apiKey: overrideEnv.DATADOG_API_KEY,
         appKey: overrideEnv.DATADOG_APP_KEY,
         batchTimeout: 1,
+        buildCommand: overrideEnv.DATADOG_SYNTHETICS_BUILD_COMMAND,
+        buildPluginPort: toNumber(overrideEnv.DATADOG_SYNTHETICS_BUILD_PLUGIN_PORT),
         configPath: overrideEnv.DATADOG_SYNTHETICS_CONFIG_PATH,
         datadogSite: overrideEnv.DATADOG_SITE,
         defaultTestOverrides: {
@@ -191,6 +195,8 @@ describe('run-tests', () => {
         apiKey: 'fake_api_key',
         appKey: 'fake_app_key',
         batchTimeout: 1,
+        buildCommand: 'build-command',
+        buildPluginPort: 3000,
         configPath: 'src/commands/synthetics/__tests__/config-fixtures/config-with-all-keys.json',
         datadogSite: 'datadoghq.eu',
         defaultTestOverrides: {
@@ -415,6 +421,8 @@ describe('run-tests', () => {
       const configFile = {
         apiKey: 'config_file_api_key',
         appKey: 'config_file_app_key',
+        buildCommand: 'build-command',
+        buildPluginPort: 3000,
         datadogSite: 'us3.datadoghq.com',
         defaultTestOverrides: {
           allowInsecureCertificates: true,
@@ -467,6 +475,8 @@ describe('run-tests', () => {
           DATADOG_SITE: 'us5.datadoghq.com',
           DATADOG_SUBDOMAIN: 'subdomain_from_env',
           DATADOG_SYNTHETICS_BATCH_TIMEOUT: '1',
+          DATADOG_SYNTHETICS_BUILD_COMMAND: 'build-command',
+          DATADOG_SYNTHETICS_BUILD_PLUGIN_PORT: '3000',
           DATADOG_SYNTHETICS_CONFIG_PATH: 'path/to/config_from_env.json',
           DATADOG_SYNTHETICS_FAIL_ON_CRITICAL_ERRORS: 'true',
           DATADOG_SYNTHETICS_FAIL_ON_MISSING_TESTS: 'true',
@@ -508,6 +518,8 @@ describe('run-tests', () => {
           apiKey: overrideEnv.DATADOG_API_KEY,
           appKey: overrideEnv.DATADOG_APP_KEY,
           batchTimeout: toNumber(overrideEnv.DATADOG_SYNTHETICS_BATCH_TIMEOUT),
+          buildCommand: overrideEnv.DATADOG_SYNTHETICS_BUILD_COMMAND,
+          buildPluginPort: toNumber(overrideEnv.DATADOG_SYNTHETICS_BUILD_PLUGIN_PORT),
           configPath: overrideEnv.DATADOG_SYNTHETICS_CONFIG_PATH,
           datadogSite: overrideEnv.DATADOG_SITE,
           defaultTestOverrides: {
@@ -580,6 +592,8 @@ describe('run-tests', () => {
           apiKey: 'cli_api_key',
           appKey: 'cli_app_key',
           batchTimeout: 1,
+          buildCommand: 'build-command',
+          buildPluginPort: 3000,
           configPath: 'src/commands/synthetics/__tests__/config-fixtures/empty-config-file-from-cli.json',
           datadogSite: 'datadoghq.eu',
           failOnCriticalErrors: true,
@@ -636,6 +650,8 @@ describe('run-tests', () => {
         command['apiKey'] = overrideCLI.apiKey
         command['appKey'] = overrideCLI.appKey
         command['batchTimeout'] = overrideCLI.batchTimeout
+        command['buildCommand'] = overrideCLI.buildCommand
+        command['buildPluginPort'] = overrideCLI.buildPluginPort
         command['configPath'] = overrideCLI.configPath
         command['datadogSite'] = overrideCLI.datadogSite
         command['failOnCriticalErrors'] = overrideCLI.failOnCriticalErrors
@@ -701,6 +717,8 @@ describe('run-tests', () => {
           DATADOG_SITE: 'us5.datadoghq.com',
           DATADOG_SYNTHETICS_CONFIG_PATH: 'path/to/config_from_env.json',
           DATADOG_SUBDOMAIN: 'subdomain_from_env',
+          DATADOG_SYNTHETICS_BUILD_COMMAND: 'default-build-command',
+          DATADOG_SYNTHETICS_BUILD_PLUGIN_PORT: '4000',
           DATADOG_SYNTHETICS_FAIL_ON_CRITICAL_ERRORS: 'true',
           DATADOG_SYNTHETICS_FAIL_ON_MISSING_TESTS: 'true',
           DATADOG_SYNTHETICS_FAIL_ON_TIMEOUT: 'true',
@@ -741,6 +759,8 @@ describe('run-tests', () => {
           apiKey: 'cli_api_key',
           appKey: 'cli_app_key',
           batchTimeout: 1,
+          buildCommand: 'build-command',
+          buildPluginPort: 3000,
           configPath: 'path/to/config_from_cli.json',
           datadogSite: 'datadoghq.eu',
           failOnCriticalErrors: false,
@@ -799,6 +819,8 @@ describe('run-tests', () => {
         command['apiKey'] = overrideCLI.apiKey
         command['appKey'] = overrideCLI.appKey
         command['batchTimeout'] = overrideCLI.batchTimeout
+        command['buildCommand'] = overrideCLI.buildCommand
+        command['buildPluginPort'] = overrideCLI.buildPluginPort
         command['configPath'] = overrideCLI.configPath
         command['datadogSite'] = overrideCLI.datadogSite
         command['failOnCriticalErrors'] = overrideCLI.failOnCriticalErrors

--- a/src/commands/synthetics/__tests__/config-fixtures/config-with-all-keys.json
+++ b/src/commands/synthetics/__tests__/config-fixtures/config-with-all-keys.json
@@ -3,7 +3,6 @@
   "appKey": "fake_app_key",
   "batchTimeout": 1,
   "buildCommand": "build-command",
-  "buildPluginPort": 3000,
   "configPath": "fake-datadog-ci.json",
   "datadogSite": "datadoghq.eu",
   "failOnCriticalErrors": true,

--- a/src/commands/synthetics/__tests__/config-fixtures/config-with-all-keys.json
+++ b/src/commands/synthetics/__tests__/config-fixtures/config-with-all-keys.json
@@ -2,6 +2,8 @@
   "apiKey": "fake_api_key",
   "appKey": "fake_app_key",
   "batchTimeout": 1,
+  "buildCommand": "build-command",
+  "buildPluginPort": 3000,
   "configPath": "fake-datadog-ci.json",
   "datadogSite": "datadoghq.eu",
   "failOnCriticalErrors": true,

--- a/src/commands/synthetics/build-and-test.ts
+++ b/src/commands/synthetics/build-and-test.ts
@@ -1,0 +1,101 @@
+import {ChildProcess, spawn} from 'child_process'
+import {once} from 'events'
+
+import axios from 'axios'
+
+import {MainReporter} from './interfaces'
+import {poll} from './utils/internal'
+
+interface BuildStatus {
+  status: 'running' | 'fail' | 'success'
+  publicPrefix?: string
+}
+
+type BuildCommandReturnValue =
+  | {
+      readiness: 'buildCommandReady'
+      publicPrefix?: string
+    }
+  | {
+      readiness: 'buildCommandExited'
+    }
+
+const watchBuildPluginServerReadiness = async (buildPluginServerUrl: string, abortSignal: AbortSignal) => {
+  return poll(async () => {
+    try {
+      const response = await axios.get<BuildStatus>(buildPluginServerUrl, {signal: abortSignal})
+      const {status, publicPrefix = ''} = response.data
+
+      if (status === 'success') {
+        return {
+          readiness: 'buildCommandReady',
+          publicPrefix,
+        } as const
+      }
+    } catch (error) {
+      // ignore errors and continue polling in case the dev server is still starting
+    }
+  }, abortSignal)
+}
+
+const watchBuildCommandExit = async (buildCommand: ChildProcess) => {
+  await once(buildCommand, 'close')
+
+  return {
+    readiness: 'buildCommandExited',
+  } as const
+}
+
+export const spawnBuildPluginDevServer = async (
+  buildCommand: string,
+  buildPluginPort: number,
+  reporter: MainReporter
+): Promise<{
+  devServerUrl: string
+  publicPrefix: string
+  stop: () => Promise<void>
+}> => {
+  // Spawn the build command process with the BUILD_PLUGINS_S8S_PORT environment variable.
+  const buildCommandProcess = spawn(buildCommand, [], {
+    env: {BUILD_PLUGINS_S8S_PORT: String(buildPluginPort)},
+    shell: true,
+  })
+
+  // Wait for the build command to either exit, or provide a dev server serving the built assets.
+  const controller = new AbortController() // used to abort the watcher and its http requests
+  const buildCommandExited = watchBuildCommandExit(buildCommandProcess)
+  const buildCommandReady = watchBuildPluginServerReadiness(
+    'http://localhost:' + String(buildPluginPort) + '/_datadog-ci_/build-status',
+    controller.signal
+  )
+  const buildCommandReturnValue: BuildCommandReturnValue | undefined = await Promise.race([
+    buildCommandReady,
+    buildCommandExited,
+  ])
+  controller.abort()
+
+  if (buildCommandReturnValue === undefined) {
+    throw new Error('Unexpected state: buildCommandReturnValue is undefined')
+  }
+
+  if (buildCommandReturnValue.readiness === 'buildCommandExited') {
+    const errorMessage = `Build command exited before the build plugin could be started. Is the build plugin configured?`
+    reporter.error(errorMessage)
+    throw new Error(errorMessage)
+  }
+
+  const {publicPrefix = ''} = buildCommandReturnValue
+
+  // Once the build server is ready, return its URL with the advertised public prefix to run the tests against it.
+  return {
+    devServerUrl: 'http://localhost:' + String(buildPluginPort),
+    publicPrefix,
+    stop: async () => {
+      buildCommandProcess.kill()
+      buildCommandProcess.stdin?.destroy()
+      buildCommandProcess.stdout?.destroy()
+      buildCommandProcess.stderr?.destroy()
+      await buildCommandExited
+    },
+  }
+}

--- a/src/commands/synthetics/interfaces.ts
+++ b/src/commands/synthetics/interfaces.ts
@@ -543,7 +543,6 @@ export interface RunTestsCommandConfig extends SyntheticsCIConfig {
   batchTimeout?: number
   configPath: string
   buildCommand?: string
-  buildPluginPort?: number
   defaultTestOverrides?: UserConfigOverride
   failOnCriticalErrors: boolean
   failOnMissingTests: boolean

--- a/src/commands/synthetics/interfaces.ts
+++ b/src/commands/synthetics/interfaces.ts
@@ -542,6 +542,8 @@ export interface SyntheticsCIConfig extends APIHelperConfig {}
 export interface RunTestsCommandConfig extends SyntheticsCIConfig {
   batchTimeout?: number
   configPath: string
+  buildCommand?: string
+  buildPluginPort?: number
   defaultTestOverrides?: UserConfigOverride
   failOnCriticalErrors: boolean
   failOnMissingTests: boolean

--- a/src/commands/synthetics/interfaces.ts
+++ b/src/commands/synthetics/interfaces.ts
@@ -541,8 +541,8 @@ export interface SyntheticsCIConfig extends APIHelperConfig {}
 
 export interface RunTestsCommandConfig extends SyntheticsCIConfig {
   batchTimeout?: number
-  configPath: string
   buildCommand?: string
+  configPath: string
   defaultTestOverrides?: UserConfigOverride
   failOnCriticalErrors: boolean
   failOnMissingTests: boolean

--- a/src/commands/synthetics/run-tests-command.ts
+++ b/src/commands/synthetics/run-tests-command.ts
@@ -9,6 +9,7 @@ import {removeUndefinedValues, resolveConfigFromFile} from '../../helpers/utils'
 import * as validation from '../../helpers/validation'
 import {isValidDatadogSite} from '../../helpers/validation'
 
+import {spawnBuildPluginDevServer} from './build-and-test'
 import {CiError} from './errors'
 import {MainReporter, Reporter, Result, RunTestsCommandConfig, Summary} from './interfaces'
 import {DefaultReporter} from './reporters/default'
@@ -35,6 +36,8 @@ export const DEFAULT_COMMAND_CONFIG: RunTestsCommandConfig = {
   apiKey: '',
   appKey: '',
   batchTimeout: DEFAULT_BATCH_TIMEOUT,
+  buildCommand: '',
+  buildPluginPort: 4000,
   configPath: 'datadog-ci.json',
   datadogSite: 'datadoghq.com',
   defaultTestOverrides: {},
@@ -57,7 +60,10 @@ const $2 = (text: string) => terminalLink(text, `${configurationLink}#test-files
 const $3 = (text: string) => terminalLink(text, `${configurationLink}#use-the-testing-tunnel`)
 
 export class RunTestsCommand extends Command {
-  public static paths = [['synthetics', 'run-tests']]
+  public static paths = [
+    ['synthetics', 'run-tests'],
+    ['synthetics', 'build-and-test'],
+  ]
 
   public static usage = Command.Usage({
     category: 'Synthetics',
@@ -139,6 +145,15 @@ export class RunTestsCommand extends Command {
     description: `Use the ${$3('Continuous Testing Tunnel')} to execute your test batch.`,
   })
 
+  private buildCommand = Option.String('--buildCommand', {
+    description: 'The build command to generate the assets to run the tests against.',
+  })
+
+  private buildPluginPort = Option.String('--buildPluginPort', {
+    description: 'The port on which to listen for the build plugin. Default is 4000',
+    validator: validation.isInteger(),
+  })
+
   private reporter!: MainReporter
   private config: RunTestsCommandConfig = JSON.parse(JSON.stringify(DEFAULT_COMMAND_CONFIG)) // Deep copy to avoid mutation
 
@@ -148,6 +163,8 @@ export class RunTestsCommand extends Command {
     fips: toBoolean(process.env[FIPS_ENV_VAR]) ?? false,
     fipsIgnoreError: toBoolean(process.env[FIPS_IGNORE_ERROR_ENV_VAR]) ?? false,
   }
+
+  private tearDowns: (() => Promise<void>)[] = []
 
   public async execute() {
     enableFips(this.fips || this.fipsConfig.fips, this.fipsIgnoreError || this.fipsConfig.fipsIgnoreError)
@@ -185,12 +202,42 @@ export class RunTestsCommand extends Command {
     let results: Result[]
     let summary: Summary
 
+    const [_, command] = this.path ?? []
+    if (command === 'build-and-test') {
+      if (!this.config.buildCommand) {
+        this.reporter.error('The `buildCommand` option is required for the `build-and-test` command.')
+
+        return 1
+      }
+      if (!this.config.buildPluginPort) {
+        this.reporter.error('The `buildPluginPort` option is required for the `build-and-test` command.')
+
+        return 1
+      }
+
+      const {devServerUrl, publicPrefix, stop} = await spawnBuildPluginDevServer(
+        this.config.buildCommand,
+        this.config.buildPluginPort,
+        this.reporter
+      )
+      this.tearDowns.push(stop)
+
+      this.config = deepExtend(this.config, {
+        tunnel: true,
+        defaultTestOverrides: {
+          resourceUrlSubstitutionRegexes: [`.*${publicPrefix}|${devServerUrl}`],
+        },
+      })
+    }
+
     try {
       ;({results, summary} = await executeTests(this.reporter, this.config))
     } catch (error) {
       reportExitLogs(this.reporter, this.config, {error})
 
       return toExitCode(getExitReason(this.config, {error}))
+    } finally {
+      await this.tearDown()
     }
 
     const orgSettings = await getOrgSettings(this.reporter, this.config)
@@ -243,6 +290,8 @@ export class RunTestsCommand extends Command {
         apiKey: process.env.DATADOG_API_KEY,
         appKey: process.env.DATADOG_APP_KEY,
         batchTimeout: toNumber(process.env.DATADOG_SYNTHETICS_BATCH_TIMEOUT),
+        buildCommand: process.env.DATADOG_SYNTHETICS_BUILD_COMMAND,
+        buildPluginPort: toNumber(process.env.DATADOG_SYNTHETICS_BUILD_PLUGIN_PORT),
         configPath: process.env.DATADOG_SYNTHETICS_CONFIG_PATH, // Only used for debugging
         datadogSite: process.env.DATADOG_SITE,
         failOnCriticalErrors: toBoolean(process.env.DATADOG_SYNTHETICS_FAIL_ON_CRITICAL_ERRORS),
@@ -320,6 +369,8 @@ export class RunTestsCommand extends Command {
         apiKey: this.apiKey,
         appKey: this.appKey,
         batchTimeout: this.batchTimeout,
+        buildCommand: this.buildCommand,
+        buildPluginPort: this.buildPluginPort,
         configPath: this.configPath,
         datadogSite: this.datadogSite,
         failOnCriticalErrors: this.failOnCriticalErrors,
@@ -417,6 +468,12 @@ export class RunTestsCommand extends Command {
       !this.config.defaultTestOverrides.setCookies.value
     ) {
       throw new CiError('INVALID_CONFIG', 'SetCookies value cannot be empty.')
+    }
+  }
+
+  private tearDown = async () => {
+    for (const tearDown of this.tearDowns) {
+      await tearDown()
     }
   }
 }

--- a/src/commands/synthetics/run-tests-command.ts
+++ b/src/commands/synthetics/run-tests-command.ts
@@ -37,7 +37,6 @@ export const DEFAULT_COMMAND_CONFIG: RunTestsCommandConfig = {
   appKey: '',
   batchTimeout: DEFAULT_BATCH_TIMEOUT,
   buildCommand: '',
-  buildPluginPort: 4000,
   configPath: 'datadog-ci.json',
   datadogSite: 'datadoghq.com',
   defaultTestOverrides: {},
@@ -149,11 +148,6 @@ export class RunTestsCommand extends Command {
     description: 'The build command to generate the assets to run the tests against.',
   })
 
-  private buildPluginPort = Option.String('--buildPluginPort', {
-    description: 'The port on which to listen for the build plugin. Default is 4000',
-    validator: validation.isInteger(),
-  })
-
   private reporter!: MainReporter
   private config: RunTestsCommandConfig = JSON.parse(JSON.stringify(DEFAULT_COMMAND_CONFIG)) // Deep copy to avoid mutation
 
@@ -209,15 +203,9 @@ export class RunTestsCommand extends Command {
 
         return 1
       }
-      if (!this.config.buildPluginPort) {
-        this.reporter.error('The `buildPluginPort` option is required for the `build-and-test` command.')
-
-        return 1
-      }
 
       const {devServerUrl, publicPrefix, stop} = await spawnBuildPluginDevServer(
         this.config.buildCommand,
-        this.config.buildPluginPort,
         this.reporter
       )
       this.tearDowns.push(stop)
@@ -291,7 +279,6 @@ export class RunTestsCommand extends Command {
         appKey: process.env.DATADOG_APP_KEY,
         batchTimeout: toNumber(process.env.DATADOG_SYNTHETICS_BATCH_TIMEOUT),
         buildCommand: process.env.DATADOG_SYNTHETICS_BUILD_COMMAND,
-        buildPluginPort: toNumber(process.env.DATADOG_SYNTHETICS_BUILD_PLUGIN_PORT),
         configPath: process.env.DATADOG_SYNTHETICS_CONFIG_PATH, // Only used for debugging
         datadogSite: process.env.DATADOG_SITE,
         failOnCriticalErrors: toBoolean(process.env.DATADOG_SYNTHETICS_FAIL_ON_CRITICAL_ERRORS),
@@ -370,7 +357,6 @@ export class RunTestsCommand extends Command {
         appKey: this.appKey,
         batchTimeout: this.batchTimeout,
         buildCommand: this.buildCommand,
-        buildPluginPort: this.buildPluginPort,
         configPath: this.configPath,
         datadogSite: this.datadogSite,
         failOnCriticalErrors: this.failOnCriticalErrors,

--- a/src/commands/synthetics/utils/internal.ts
+++ b/src/commands/synthetics/utils/internal.ts
@@ -30,6 +30,29 @@ const levenshtein = require('fast-levenshtein')
 
 export const wait = async (duration: number) => new Promise((resolve) => setTimeout(resolve, duration))
 
+export const poll = async <T>(
+  fn: () => Promise<T | undefined>,
+  abortSignal: AbortSignal,
+  interval = 500,
+  timeout = +Infinity,
+  timeoutError = new Error('Polling timed out')
+): Promise<T | undefined> => {
+  const start = Date.now()
+  while (true) {
+    const result = await fn()
+
+    if (result || abortSignal.aborted) {
+      return result
+    }
+
+    if (Date.now() - start >= timeout) {
+      throw timeoutError
+    }
+
+    await wait(interval)
+  }
+}
+
 export const getOverriddenExecutionRule = (
   test?: Test,
   testOverrides?: UserConfigOverride


### PR DESCRIPTION
### What and why?

This PR implements the `synthetics build-and-test` command.
Provided with a `buildCommand`, and an optional `buildPluginPort` (defaults to 4000) options, this command runs the build command, wait for a successful build, and a dev server spawned by the [Datadog build-plugin](https://github.com/DataDog/build-plugins/pull/153), to run Synthetics tests against this dev server using the tunnel.

Except the unit tests, this command hasn't been tested properly yet. It'll be done later.

### How?

The `build-and-test` command spawns the build command, and regularly request the expected dev server (e.g. `https://localhost:4000`) until the build is advertised as successful. Then it runs the tests.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
