### PR TITLE
[dep] Upgrade axios to `1.8.4`

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "ajv": "^8.12.0",
     "ajv-formats": "^2.1.1",
     "async-retry": "1.3.1",
-    "axios": "^1.7.4",
+    "axios": "^1.8.4",
     "chalk": "3.0.0",
     "clipanion": "^3.2.1",
     "datadog-metrics": "0.9.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1912,7 +1912,7 @@ __metadata:
     async-retry: 1.3.1
     aws-sdk-client-mock: ^4.1.0
     aws-sdk-client-mock-jest: ^4.1.0
-    axios: ^1.7.4
+    axios: ^1.8.4
     chalk: 3.0.0
     clipanion: ^3.2.1
     datadog-metrics: 0.9.3
@@ -4331,14 +4331,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios@npm:^1.7.4":
-  version: 1.7.4
-  resolution: "axios@npm:1.7.4"
+"axios@npm:^1.8.4":
+  version: 1.8.4
+  resolution: "axios@npm:1.8.4"
   dependencies:
     follow-redirects: ^1.15.6
     form-data: ^4.0.0
     proxy-from-env: ^1.1.0
-  checksum: 0c17039a9acfe6a566fca8431ba5c1b455c83d30ea6157fec68a6722878fcd30f3bd32d172f6bee0c51fe75ca98e6414ddcd968a87b5606b573731629440bfaf
+  checksum: e901dc1730bdcd769839b3d93ae6d6457a53d79b19a0eb623ebfea333441259ab51e63ca118baa47a5156567401466ac739f31087b4ee5e6770ab2e227484538
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### What and why?

Closes https://github.com/DataDog/datadog-ci/issues/1594

This PR fixes the following security vulnerability: https://github.com/DataDog/datadog-ci/security/dependabot/52 

### How?

Bump the dependency.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
