### PR TITLE
chore: Improve error message for flare file upload

### DIFF
--- a/src/helpers/__tests__/flare.test.ts
+++ b/src/helpers/__tests__/flare.test.ts
@@ -119,7 +119,8 @@ describe('flare', () => {
 
       const fn = sendToDatadog(MOCK_ZIP_PATH, MOCK_CASE_ID, MOCK_EMAIL, MOCK_API_KEY, MOCK_ROOT_FOLDER_PATH)
       await expect(fn).rejects.toThrow(
-        `Failed to send flare file to Datadog Support: Some error. Another error\nIs your Datadog API key correct?\n`
+        `Failed to send flare file to Datadog Support: Some error. Another error\nIs your Datadog API key correct? Please follow this doc to set your API key: 
+https://docs.datadoghq.com/serverless/libraries_integrations/cli/#environment-variables\n`
       )
     })
   })

--- a/src/helpers/flare.ts
+++ b/src/helpers/flare.ts
@@ -73,7 +73,8 @@ export const sendToDatadog = async (
           break
         case 400:
         case 403:
-          message += 'Is your Datadog API key correct?\n'
+          message += `Is your Datadog API key correct? Please follow this doc to set your API key: 
+https://docs.datadoghq.com/serverless/libraries_integrations/cli/#environment-variables\n`
           break
       }
 


### PR DESCRIPTION
### Problem

According to @SiddhithaBhoopathy , a few customers failed to send Lambda Flare due to potential API key error:
- https://datadog.zendesk.com/agent/tickets/2076284
- https://datadog.zendesk.com/agent/tickets/2077466
- https://datadoghq.atlassian.net/browse/SLES-1893

The current error message customers get is like:
> [Error] Failed to send flare file to Datadog Support: Request failed with status code 400. request does not match with Datadog or Zendesk information: VER_000
Is your Datadog API key correct?

where no clear action item is available, so the customer reached back to support engineers for help.

### What

Adds a doc link in the error message, and suggests the customer to follow it to set API key.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
