### PR TITLE
chore: Document IAM permissions needed for Lambda Flare

### DIFF
--- a/src/commands/lambda/README.md
+++ b/src/commands/lambda/README.md
@@ -179,6 +179,13 @@ datadog-ci lambda flare -f <function-arn> -c <case-id> -e <email-on-case-id> --w
 | `--start` and `--end` |           | Only gather logs within the time range (`--with-logs` must be included.) Both arguments are numbers in milliseconds since Unix Epoch. |         |
 | `--dry-run`           | `-d`      | Preview collected data which would be sent to Datadog support.                                                                        | `false` |
 
+**Permissions**
+
+To run this command, you need to have these IAM permissions:
+- `lambda:GetFunction`
+- `lambda:ListTags`
+- `logs:DescribeLogStreams`, if `--with-logs` is set
+- `logs:GetLogEvents`, if `--with-logs` is set
 
 ## Community
 


### PR DESCRIPTION
### What

Documents what IAM permissions are needed to run `datadog-ci lambda flare`.

### Why

A customer failed to run Lambda Flare due to lacking permissions. It took them some effort to figure out all the permissions needed. We should document this to make it easier for them.

https://datadog.zendesk.com/agent/tickets/2045500

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
