### PR TITLE
[SDCD-1090] Add `--version` option to `datadog-ci dora deployment`

### DIFF
--- a/src/commands/dora/__tests__/deployment.test.ts
+++ b/src/commands/dora/__tests__/deployment.test.ts
@@ -56,6 +56,7 @@ describe('execute', () => {
         '--env', 'test',
         '--git-repository-url', 'https://github.com/DataDog/datadog-ci',
         '--git-commit-sha', '2186e1b0ab2a87e312a8c831d5bc947fa081d4f9',
+        '--version', '1.0.0',
       ])
       /* eslint-enable prettier/prettier */
       expect(code).toBe(0)
@@ -68,6 +69,7 @@ describe('execute', () => {
           repoURL: 'https://github.com/DataDog/datadog-ci',
           commitSHA: '2186e1b0ab2a87e312a8c831d5bc947fa081d4f9',
         },
+        version: '1.0.0',
       })
     })
     test('with minimal parameters provided', async () => {

--- a/src/commands/dora/api.ts
+++ b/src/commands/dora/api.ts
@@ -18,6 +18,9 @@ export const sendDeploymentEvent = (request: (args: AxiosRequestConfig) => Axios
   if (deployment.env) {
     attrs.env = deployment.env
   }
+  if (deployment.version) {
+    attrs.version = deployment.version
+  }
   if (deployment.git) {
     attrs.git = {
       repository_url: deployment.git.repoURL,

--- a/src/commands/dora/deployment.ts
+++ b/src/commands/dora/deployment.ts
@@ -40,7 +40,8 @@ export class SendDeploymentEvent extends Command {
         'datadog-ci dora deployment --service my-service --env prod \\\n' +
           '    --started-at 1699960648 --finished-at 1699961048 \\\n' +
           '    --git-repository-url https://github.com/my-organization/my-repository \\\n' +
-          '    --git-commit-sha 102836a25f5477e571c73d489b3f0f183687068e',
+          '    --git-commit-sha 102836a25f5477e571c73d489b3f0f183687068e \\\n' +
+          '    --version 1.0.0',
       ],
       [
         'Send a DORA deployment event with automatically extracted Git info (for deployments triggered from CI in the same repository as the application). The deployment is assumed to target the current HEAD commit',
@@ -73,6 +74,10 @@ export class SendDeploymentEvent extends Command {
   private finishedAt = Option.String('--finished-at', {
     validator: t.isDate(),
     description: 'In Unix seconds or ISO8601 (Examples: 1699961048, 2023-11-14T11:24:08Z)',
+  })
+
+  private version = Option.String('--version', {
+    description: 'The version of the service being deployed',
   })
 
   private gitInfo?: GitInfo
@@ -171,6 +176,9 @@ export class SendDeploymentEvent extends Command {
     }
     if (this.gitInfo) {
       deployment.git = this.gitInfo
+    }
+    if (this.version) {
+      deployment.version = this.version
     }
 
     return deployment

--- a/src/commands/dora/interfaces.ts
+++ b/src/commands/dora/interfaces.ts
@@ -6,6 +6,7 @@ export interface DeploymentEvent {
   startedAt: Date
   finishedAt: Date
   git?: GitInfo
+  version?: string
 }
 
 export interface GitInfo {


### PR DESCRIPTION
### What and why?
- This option is supported through the API but not through `datadog-ci`. We add it.

### How?

A brief description of implementation details of this PR.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
