### PR TITLE
[RN CODEPUSH] Sanitize Upload Release Version

### DIFF
--- a/src/commands/react-native/__tests__/fixtures/codepush-deployment-history/valid-deployment-with-invalid-version.txt
+++ b/src/commands/react-native/__tests__/fixtures/codepush-deployment-history/valid-deployment-with-invalid-version.txt
@@ -1,0 +1,18 @@
+[
+  [
+    "v1",
+    "Sep 05, 02:19 PM",
+    "1.0",
+    "No",
+    null,
+    "\u001b[35mNo installs recorded\u001b[39m"
+  ],
+  [
+    "v2",
+    "Sep 05, 02:27 PM",
+    "#??0.0.1",
+    "No",
+    null,
+    "\u001b[35mNo installs recorded\u001b[39m"
+  ]
+]

--- a/src/commands/react-native/__tests__/fixtures/codepush-deployment-history/valid-deployment-with-prefix-symbols.txt
+++ b/src/commands/react-native/__tests__/fixtures/codepush-deployment-history/valid-deployment-with-prefix-symbols.txt
@@ -1,0 +1,26 @@
+[
+  [
+    "v5",
+    "Jun 16, 04:34 PM",
+    "<0.0.1",
+    "No",
+    null,
+    "\u001b[32mActive: \u001b[39m100% (5 of 5)\n\u001b[32mInstalled: \u001b[39m17 (18 pending)"
+  ],
+  [
+    "v6",
+    "Sep 05, 02:19 PM",
+    "1.0",
+    "No",
+    null,
+    "\u001b[35mNo installs recorded\u001b[39m"
+  ],
+  [
+    "v7",
+    "Sep 05, 02:27 PM",
+    ">=2.0",
+    "No",
+    null,
+    "\u001b[35mNo installs recorded\u001b[39m"
+  ]
+]

--- a/src/commands/react-native/__tests__/utils.test.ts
+++ b/src/commands/react-native/__tests__/utils.test.ts
@@ -1,6 +1,6 @@
 import fs from 'fs'
 
-import {getBundleName} from '../utils'
+import {getBundleName, sanitizeReleaseVersion} from '../utils'
 
 describe('react-native utils', () => {
   describe('getBundleName', () => {
@@ -21,6 +21,56 @@ describe('react-native utils', () => {
 
     test('should return the default Android bundle name when no bundle is specified on Android', () => {
       expect(getBundleName(undefined, 'android')).toBe('index.android.bundle')
+    })
+  })
+
+  describe('sanitizeReleaseVersion', () => {
+    test('should remove >= prefix', () => {
+      expect(sanitizeReleaseVersion('>=2.1.0')).toBe('2.1.0')
+      expect(sanitizeReleaseVersion('>=1.0')).toBe('1.0')
+      expect(sanitizeReleaseVersion('>=1.0.1-rc1')).toBe('1.0.1-rc1')
+    })
+
+    test('should remove <= prefix', () => {
+      expect(sanitizeReleaseVersion('<=2.1.0')).toBe('2.1.0')
+      expect(sanitizeReleaseVersion('<=1.0')).toBe('1.0')
+      expect(sanitizeReleaseVersion('<=1.0.1-rc1')).toBe('1.0.1-rc1')
+    })
+
+    test('should remove == prefix', () => {
+      expect(sanitizeReleaseVersion('==2.1.0')).toBe('2.1.0')
+      expect(sanitizeReleaseVersion('==1.0')).toBe('1.0')
+      expect(sanitizeReleaseVersion('==1.0.1-rc1')).toBe('1.0.1-rc1')
+    })
+
+    test('should remove = prefix', () => {
+      expect(sanitizeReleaseVersion('=2.1.0')).toBe('2.1.0')
+      expect(sanitizeReleaseVersion('=1.0')).toBe('1.0')
+      expect(sanitizeReleaseVersion('=1.0.1-rc1')).toBe('1.0.1-rc1')
+    })
+
+    test('should remove ~ prefix', () => {
+      expect(sanitizeReleaseVersion('~2.1.0')).toBe('2.1.0')
+      expect(sanitizeReleaseVersion('~1.0')).toBe('1.0')
+      expect(sanitizeReleaseVersion('~1.0.1-rc1')).toBe('1.0.1-rc1')
+    })
+
+    test('should remove ^ prefix', () => {
+      expect(sanitizeReleaseVersion('^2.1.0')).toBe('2.1.0')
+      expect(sanitizeReleaseVersion('^1.0')).toBe('1.0')
+      expect(sanitizeReleaseVersion('^1.0.1-rc1')).toBe('1.0.1-rc1')
+    })
+
+    test('should remove < prefix', () => {
+      expect(sanitizeReleaseVersion('<2.1.0')).toBe('2.1.0')
+      expect(sanitizeReleaseVersion('<1.0')).toBe('1.0')
+      expect(sanitizeReleaseVersion('<1.0.1-rc1')).toBe('1.0.1-rc1')
+    })
+
+    test('should remove > prefix', () => {
+      expect(sanitizeReleaseVersion('>2.1.0')).toBe('2.1.0')
+      expect(sanitizeReleaseVersion('>1.0')).toBe('1.0')
+      expect(sanitizeReleaseVersion('>1.0.1-rc1')).toBe('1.0.1-rc1')
     })
   })
 })

--- a/src/commands/react-native/utils.ts
+++ b/src/commands/react-native/utils.ts
@@ -30,3 +30,7 @@ export const getBundleName = (bundlePath: string | undefined, platform: RNPlatfo
 
   return DEFAULT_ANDROID_BUNDLE_NAME
 }
+
+export const sanitizeReleaseVersion = (version: string) => {
+  return version.replace(/^(>=|<=|==|=|<|>|\^|~)/, '').trim()
+}


### PR DESCRIPTION
### What and why?

Introduces an extra step to sanitize the release version extracted from codepush deployments history.

In some cases, the version might have a prefix:

```
  [
    "v7",
    "Sep 05, 02:27 PM",
    ">=2.0",                             <---- see here
    "No",
    null,
    "\u001b[35mNo installs recorded\u001b[39m"
  ]
```

This PR removes extra leading symbols from the version, and validates it before proceeding with the upload.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
