### PR TITLE
[Synthetics] Redesign build-and-test command to spawn the dev server

### DIFF
--- a/src/commands/synthetics/__tests__/build-and-test.test.ts
+++ b/src/commands/synthetics/__tests__/build-and-test.test.ts
@@ -58,9 +58,6 @@ describe('build-and-test - buildAssets', () => {
         publicPath: 'prefix/',
       },
     ])
-
-    // Stop the devServer at the end of the test.
-    await stop()
   })
 
   test('rejects malformed builds', async () => {

--- a/src/commands/synthetics/build-and-test.ts
+++ b/src/commands/synthetics/build-and-test.ts
@@ -1,130 +1,235 @@
-import {ChildProcess, spawn} from 'child_process'
+import {spawn} from 'child_process'
 import {once} from 'events'
-
-import axios from 'axios'
+import {promises as fs} from 'fs'
+import * as http from 'http'
+import * as path from 'path'
 
 import {MainReporter} from './interfaces'
-import {poll} from './utils/internal'
 
-interface BuildStatus {
-  status: 'running' | 'fail' | 'success'
-  publicPrefix?: string
+interface ReportedBuild {
+  outputDirectory: string // the path to the assets directory, absolute or relative to the CWD
+  publicPath: string // the public prefix
 }
-
-type BuildCommandReturnValue =
-  | {
-      readiness: 'buildCommandReady'
-      publicPrefix?: string
-    }
-  | {
-      readiness: 'buildCommandExited'
-    }
-  | {
-      readiness: 'buildCommandErrored'
-      error: Error
-    }
-
-export const DEFAULT_BUILD_PLUGIN_PORT = 4000
 
 export const UnconfiguredBuildPluginError = new Error(`
 We couldn't detect the Datadog Build plugins within your build. Did you add it?
 If not, you can learn more about it here: https://github.com/DataDog/build-plugins#readme
 `)
 
-const watchBuildPluginServerReadiness = async (buildPluginServerUrl: string, abortSignal: AbortSignal) => {
-  return poll(async () => {
-    try {
-      const response = await axios.get<BuildStatus>(buildPluginServerUrl, {signal: abortSignal})
-      const {status, publicPrefix = ''} = response.data
+export const MalformedBuildError = new Error(
+  `Invalid payload. Expected payload is {\"outputDirectory\": string, \"publicPath\": string}`
+)
 
-      if (status === 'success') {
-        return {
-          readiness: 'buildCommandReady',
-          publicPrefix,
-        } as const
-      }
-    } catch (error) {
-      // If we got an http error with a response, return buildCommandErrored
-      if (axios.isAxiosError(error) && error.code !== 'ECONNREFUSED' && error.response) {
-        return {
-          readiness: 'buildCommandErrored',
-          error: new Error(`Dev server returned error: ${error.response.status} ${error.response.statusText}`),
-        } as const
-      }
-
-      // Otherwise ignore errors and continue polling in case the dev server is still starting
-    }
-  }, abortSignal)
+const MIME_TYPES = {
+  default: 'application/octet-stream',
+  html: 'text/html; charset=UTF-8',
+  js: 'application/javascript',
+  css: 'text/css',
+  png: 'image/png',
+  jpg: 'image/jpg',
+  gif: 'image/gif',
+  ico: 'image/x-icon',
+  svg: 'image/svg+xml',
+} as const
+type Extension = keyof typeof MIME_TYPES
+const isMIMEType = (mime: string): mime is Extension => {
+  return Object.keys(MIME_TYPES).includes(mime as Extension)
 }
 
-const watchBuildCommandExit = async (buildCommand: ChildProcess) => {
-  await once(buildCommand, 'close')
+type File = {
+  found: boolean
+  ext: string
+  content: string
+}
+
+const routeVerbs = ['get', 'post', 'put', 'patch', 'delete'] as const
+type RouteVerb = typeof routeVerbs[number]
+const isRouteVerb = (verb: string): verb is RouteVerb => {
+  return routeVerbs.includes(verb as RouteVerb)
+}
+
+export type Routes = Record<
+  string,
+  {
+    [key in RouteVerb]?: (req: http.IncomingMessage, res: http.ServerResponse) => Promise<void>
+  }
+>
+
+export type RequestHandlerOptions = {
+  root: string
+  routes?: Routes
+}
+
+const fileExists = async (filePath: string): Promise<boolean> => {
+  try {
+    await fs.access(filePath)
+
+    return true
+  } catch {
+    return false
+  }
+}
+
+const prepareFile = async (root: string, requestUrl: string): Promise<File> => {
+  const staticPath = path.isAbsolute(root) ? root : path.resolve(process.cwd(), root)
+  const url = new URL(requestUrl, 'http://127.0.0.1')
+  // TODO remove the publicPath from the URL
+  const paths = [staticPath, url.pathname]
+  if (url.pathname.endsWith('/')) {
+    paths.push('index.html')
+  }
+
+  const filePath = path.join(...paths)
+  const pathTraversal = filePath.startsWith(staticPath)
+  const found = pathTraversal && (await fileExists(filePath))
 
   return {
-    readiness: 'buildCommandExited',
-  } as const
+    found,
+    ext: path.extname(filePath).substring(1).toLowerCase(),
+    content: found ? await fs.readFile(filePath, {encoding: 'utf-8'}) : '',
+  }
 }
 
-export const spawnBuildPluginDevServer = async (
+const getRequestHandler = ({root, routes}: RequestHandlerOptions) => async (
+  req: http.IncomingMessage,
+  res: http.ServerResponse
+) => {
+  try {
+    // Handle routes.
+    const route = routes?.[req.url || '/']
+    if (route) {
+      const verb = req.method?.toLowerCase() ?? ''
+      if (isRouteVerb(verb)) {
+        const handler = route[verb]
+        if (handler) {
+          await handler(req, res)
+
+          return
+        }
+      }
+    }
+
+    // Fallback to files.
+    const {content, ext, found} = await prepareFile(root, req.url || '/')
+    const mimeType = isMIMEType(ext) ? MIME_TYPES[ext] : MIME_TYPES.default
+    res.writeHead(found ? 200 : 404, {'Content-Type': mimeType})
+    res.end(content)
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error)
+    res.writeHead(500, {'Content-Type': MIME_TYPES.html})
+    res.end(`Internal Server Error: ${errorMessage}`)
+  }
+}
+
+const getRequestBody = async (req: http.IncomingMessage): Promise<string> => {
+  const chunks: string[] = []
+  req.on('data', (chunk: string) => chunks.push(chunk))
+  await once(req, 'end')
+
+  return chunks.join('')
+}
+
+const getReportedBuild = (payload: string): ReportedBuild => {
+  const reportedBuild = JSON.parse(payload)
+  if (
+    'outputDirectory' in reportedBuild &&
+    typeof reportedBuild.outputDirectory === 'string' &&
+    'publicPath' in reportedBuild &&
+    typeof reportedBuild.publicPath === 'string'
+  ) {
+    return reportedBuild
+  }
+  throw MalformedBuildError
+}
+
+const spawnDevServer = async (): Promise<{builds: ReportedBuild[]; server: http.Server; url: string}> => {
+  const builds: ReportedBuild[] = []
+  const requestHandler = getRequestHandler({
+    root: '', // TODO
+    routes: {
+      '/_datadog-ci_/build': {
+        post: async (req, res) => {
+          const body = await getRequestBody(req)
+          const reportedBuild = getReportedBuild(body)
+          builds.push(reportedBuild)
+
+          res.end()
+        },
+      },
+    },
+  })
+
+  // eslint-disable-next-line @typescript-eslint/no-misused-promises
+  const server = http.createServer(requestHandler)
+  server.listen()
+
+  await once(server, 'listening')
+
+  return {builds, server, url: getBuildReportUrl(server)}
+}
+
+export const buildAssets = async (
   buildCommand: string,
   reporter: MainReporter
 ): Promise<{
+  builds: ReportedBuild[]
   devServerUrl: string
-  publicPrefix: string
   stop: () => Promise<void>
 }> => {
-  const buildPluginPort = DEFAULT_BUILD_PLUGIN_PORT
+  const {builds, server, url} = await spawnDevServer()
 
   // Spawn the build command process with the BUILD_PLUGINS_S8S_PORT environment variable.
   const buildCommandProcess = spawn(buildCommand, [], {
-    env: {BUILD_PLUGINS_S8S_PORT: String(buildPluginPort)},
-    shell: true,
+    env: {
+      DATADOG_SYNTHETICS_REPORT_BUILD_URL: url,
+      ...process.env,
+    },
+    shell: process.env.SHELL ?? process.env.ComSpec ?? true,
   })
 
-  // Wait for the build command to either exit, or provide a dev server serving the built assets.
-  const controller = new AbortController() // used to abort the watcher and its http requests
-  const buildCommandExited = watchBuildCommandExit(buildCommandProcess)
-  const buildCommandReady = watchBuildPluginServerReadiness(
-    'http://localhost:' + String(buildPluginPort) + '/_datadog-ci_/build-status',
-    controller.signal
-  )
-  const buildCommandReturnValue: BuildCommandReturnValue | undefined = await Promise.race([
-    buildCommandReady,
-    buildCommandExited,
-  ])
-  controller.abort()
+  buildCommandProcess.stdout?.pipe(process.stdout)
+  buildCommandProcess.stderr?.pipe(process.stderr)
 
-  if (buildCommandReturnValue === undefined) {
-    await killBuildCommand(buildCommandProcess, buildCommandExited)
-    throw new Error('Unexpected state: buildCommandReturnValue is undefined')
-  }
+  // Wait for the build command to finish
+  await once(buildCommandProcess, 'close')
 
-  if (buildCommandReturnValue.readiness === 'buildCommandExited') {
-    reporter.error(UnconfiguredBuildPluginError.message)
-    await killBuildCommand(buildCommandProcess, buildCommandExited)
+  if (builds.length === 0) {
+    await stopDevServer(server)
     throw UnconfiguredBuildPluginError
   }
 
-  if (buildCommandReturnValue.readiness === 'buildCommandErrored') {
-    reporter.error(buildCommandReturnValue.error.message)
-    await killBuildCommand(buildCommandProcess, buildCommandExited)
-    throw buildCommandReturnValue.error
-  }
-
-  const {publicPrefix = ''} = buildCommandReturnValue
-
   // Once the build server is ready, return its URL with the advertised public prefix to run the tests against it.
   return {
-    devServerUrl: 'http://localhost:' + String(buildPluginPort),
-    publicPrefix,
-    stop: async () => killBuildCommand(buildCommandProcess, buildCommandExited),
+    builds,
+    devServerUrl: url,
+    stop: async () => stopDevServer(server),
   }
 }
 
-const killBuildCommand = async (buildCommandProcess: ChildProcess, buildCommandExited: Promise<unknown>) => {
-  buildCommandProcess.kill()
-  buildCommandProcess.stdin?.destroy()
-  buildCommandProcess.stdout?.destroy()
-  buildCommandProcess.stderr?.destroy()
-  await buildCommandExited
+const getBuildReportUrl = (server: http.Server): string => {
+  // net.Server can be listening on a named pipe, in which case the address is a string
+  // or not listening yet, in which case the address is null, which we cast to the 'undefined' string
+  // to meet the same condition as if it was a named pipe, and throw.
+  const serverAddress = server.address() ?? 'undefined'
+  if (typeof serverAddress === 'string') {
+    throw new Error('Server address is not valid')
+  }
+
+  const url = new URL(
+    serverAddress.family === 'IPv6'
+      ? `http://[${serverAddress.address}]:${serverAddress.port}`
+      : `http://${serverAddress.address}:${serverAddress.port}`
+  )
+
+  url.pathname = '/_datadog-ci_/build'
+
+  return url.href
+}
+
+const stopDevServer = async (server: http.Server) => {
+  if (server.listening) {
+    const serverClosed = once(server, 'close')
+    server.close()
+    await serverClosed
+  }
 }

--- a/src/commands/synthetics/utils/internal.ts
+++ b/src/commands/synthetics/utils/internal.ts
@@ -30,29 +30,6 @@ const levenshtein = require('fast-levenshtein')
 
 export const wait = async (duration: number) => new Promise((resolve) => setTimeout(resolve, duration))
 
-export const poll = async <T>(
-  fn: () => Promise<T | undefined>,
-  abortSignal: AbortSignal,
-  interval = 500,
-  timeout = +Infinity,
-  timeoutError = new Error('Polling timed out')
-): Promise<T | undefined> => {
-  const start = Date.now()
-  while (true) {
-    const result = await fn()
-
-    if (result || abortSignal.aborted) {
-      return result
-    }
-
-    if (Date.now() - start >= timeout) {
-      throw timeoutError
-    }
-
-    await wait(interval)
-  }
-}
-
 export const getOverriddenExecutionRule = (
   test?: Test,
   testOverrides?: UserConfigOverride


### PR DESCRIPTION
### What and why?

The build command can trigger several build and neither `datadog-ci` nor the build-plugins have any control or insight over the number of builds triggered. These builds could be run in parallel or in sequence, and the only way to detect that all builds finished is when the build command exited successfully. (we'll handle the case when the build command exit with an error later, in [SYNTH-19418](https://datadoghq.atlassian.net/browse/SYNTH-19418)).

### How?

This PR redesign the `build-and-test` command to host the dev server in `datadog-ci` rather than in the build-plugin.
The build plugins will report the completed builds to the dev server through the `/_datadog-ci_/build` endpoint.

The unit tests for the static serving of the dev server will be implemented later in [SYNTH-19419](https://datadoghq.atlassian.net/browse/SYNTH-19419).

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)


[SYNTH-19418]: https://datadoghq.atlassian.net/browse/SYNTH-19418?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SYNTH-19419]: https://datadoghq.atlassian.net/browse/SYNTH-19419?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ