### PR TITLE
Make code coverage upload command non-beta

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,7 +5,7 @@ import {CommandClass} from 'clipanion/lib/advanced/Command'
 
 import {version} from './helpers/version'
 
-export const BETA_COMMANDS = ['dora', 'deployment', 'elf-symbols', 'coverage']
+export const BETA_COMMANDS = ['dora', 'deployment', 'elf-symbols']
 
 const onError = (err: any) => {
   console.log(err)


### PR DESCRIPTION
### What and why?

Removes the requirement to set `DD_BETA_COMMANDS_ENABLED=1` end var when doing code coverage upload.

### How?

Removes code coverage upload command from the list of beta commands.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
