### PR TITLE
[SYNTH-19349] bump the batch timeout safety margin to 60s

### DIFF
--- a/src/commands/synthetics/__tests__/batch.test.ts
+++ b/src/commands/synthetics/__tests__/batch.test.ts
@@ -898,8 +898,8 @@ describe('waitForResults', () => {
     expect(mockReporter.resultEnd).toHaveBeenNthCalledWith(1, result, MOCK_BASE_URL, 'bid')
     expect(mockReporter.resultEnd).toHaveBeenNthCalledWith(2, expectedDeadlineResult, MOCK_BASE_URL, 'bid')
 
-    // Initial wait + 3 polling cycles.
-    expect(internalUtils.wait).toHaveBeenCalledTimes(4)
+    // Initial wait + 12 polling cycles.
+    expect(internalUtils.wait).toHaveBeenCalledTimes(13)
   })
 
   test('results failure should be ignored if timed out', async () => {
@@ -986,7 +986,7 @@ describe('waitForResults', () => {
   test('wait between batch polling', async () => {
     const {getBatchMock} = mockApi({
       getBatchImplementation: async () => {
-        return getBatchMock.mock.calls.length === 3 ? batch : {...batch, status: 'in_progress'}
+        return getBatchMock.mock.calls.length === 12 ? batch : {...batch, status: 'in_progress'}
       },
     })
 
@@ -1005,8 +1005,8 @@ describe('waitForResults', () => {
       )
     ).toEqual([result])
 
-    expect(getBatchMock).toHaveBeenCalledTimes(3)
-    expect(internalUtils.wait).toHaveBeenCalledTimes(2)
+    expect(getBatchMock).toHaveBeenCalledTimes(12)
+    expect(internalUtils.wait).toHaveBeenCalledTimes(11)
   })
 
   test('correct number of passed and timed out results', async () => {

--- a/src/commands/synthetics/batch.ts
+++ b/src/commands/synthetics/batch.ts
@@ -119,7 +119,7 @@ const waitForBatchToFinish = async (
   resultDisplayInfo: ResultDisplayInfo,
   reporter: MainReporter
 ): Promise<Result[]> => {
-  const safeDeadline = Date.now() + batchTimeout + 3 * POLLING_INTERVAL
+  const safeDeadline = Date.now() + batchTimeout + 12 * POLLING_INTERVAL
   const emittedResultIds = new Set<string>()
   const backupPollResultMap = new Map<string, PollResult>()
 


### PR DESCRIPTION
Need to deal with some smoke test triggers with the following error:

```
SMOKE TEST ERROR: The batch didn't timeout after the expected timeout period
```
The safety limit margin was set to 15s which is a bit to short of a margin, as any lag > 15s between the batch reducer and datadog-ci can cause this error.

Thus, went from 15s to 60s by having `12*POLLING_INTERVAL` instead of `3*`