### PR TITLE
[SYNTH-18941] Use v1 results

### DIFF
--- a/src/commands/synthetics/__tests__/api.test.ts
+++ b/src/commands/synthetics/__tests__/api.test.ts
@@ -46,6 +46,7 @@ describe('dd-api', () => {
         id: RESULT_ID,
         finished_at: 0,
       } as unknown) as ServerResult,
+      resultID: RESULT_ID,
     },
   ]
   const RAW_POLL_RESULTS: RawPollResult = {
@@ -91,7 +92,7 @@ describe('dd-api', () => {
     jest.spyOn(axios, 'create').mockImplementation((() => () => ({data: RAW_POLL_RESULTS})) as any)
     const api = apiConstructor(apiConfiguration)
     const results = await api.pollResults([RESULT_ID])
-    expect(results[0].result.id).toBe(RESULT_ID)
+    expect(results[0].resultID).toBe(RESULT_ID)
   })
 
   test('should trigger tests using api', async () => {

--- a/src/commands/synthetics/__tests__/deploy-tests-lib.test.ts
+++ b/src/commands/synthetics/__tests__/deploy-tests-lib.test.ts
@@ -3,7 +3,14 @@ import {DeployTestsCommand} from '../deploy-tests-command'
 import {deployTests} from '../deploy-tests-lib'
 import * as tests from '../test'
 
-import {getApiLocalTestDefinition, getApiTest, mockApi, mockReporter} from './fixtures'
+import {
+  getApiTest,
+  mockApi,
+  mockReporter,
+  getApiLocalTestDefinition,
+  getBrowserLocalTestDefinition,
+  getBrowserTest,
+} from './fixtures'
 
 describe('deploy-tests', () => {
   describe('deployTests', () => {
@@ -14,7 +21,7 @@ describe('deploy-tests', () => {
         .spyOn(tests, 'getTestConfigs')
         .mockImplementation(async () => [
           {localTestDefinition: getApiLocalTestDefinition('123-456-789')},
-          {localTestDefinition: getApiLocalTestDefinition('987-654-321')},
+          {localTestDefinition: getBrowserLocalTestDefinition('987-654-321')},
         ])
 
       const apiHelper = mockApi({
@@ -37,9 +44,7 @@ describe('deploy-tests', () => {
       // eslint-disable-next-line @typescript-eslint/naming-convention, prefer-const
       let {public_id, monitor_id, ...expectedUpdate} = getApiTest('123-456-789')
       expect(apiHelper.editTest).toHaveBeenNthCalledWith(1, '123-456-789', expectedUpdate)
-
-      // eslint-disable-next-line @typescript-eslint/naming-convention
-      ;({public_id, monitor_id, ...expectedUpdate} = getApiTest('987-654-321'))
+      ;({public_id, monitor_id, ...expectedUpdate} = getBrowserTest('987-654-321'))
       expect(apiHelper.editTest).toHaveBeenNthCalledWith(2, '987-654-321', expectedUpdate)
     })
 
@@ -51,7 +56,7 @@ describe('deploy-tests', () => {
         .spyOn(tests, 'getTestConfigs')
         .mockImplementation(async () => [
           {localTestDefinition: getApiLocalTestDefinition('123-456-789')},
-          {localTestDefinition: getApiLocalTestDefinition('987-654-321')},
+          {localTestDefinition: getBrowserLocalTestDefinition('987-654-321')},
         ])
 
       const apiHelper = mockApi({

--- a/src/commands/synthetics/__tests__/fixtures.ts
+++ b/src/commands/synthetics/__tests__/fixtures.ts
@@ -212,7 +212,7 @@ export const getApiResult = (
 })
 
 export const getIncompleteServerResult = (): ServerResult => {
-  return ({test_type: 'api'} as unknown) as ServerResult
+  return {id: 'my_result_id'} as ServerResult
 }
 
 export const getBrowserServerResult = (opts: Partial<BrowserServerResult> = {}): BrowserServerResult => ({

--- a/src/commands/synthetics/__tests__/fixtures.ts
+++ b/src/commands/synthetics/__tests__/fixtures.ts
@@ -82,6 +82,8 @@ export const getApiLocalTestDefinition = (
   publicId = 'abc-def-ghi',
   opts: Partial<LocalTestDefinition> = {}
 ): LocalTestDefinition & {public_id: string} => ({
+  type: 'api',
+  subtype: 'http',
   config: {
     assertions: [],
     request: {
@@ -98,8 +100,6 @@ export const getApiLocalTestDefinition = (
     device_ids: [],
   },
   public_id: publicId,
-  subtype: 'http',
-  type: 'api',
   ...opts,
 })
 
@@ -111,28 +111,40 @@ export const getApiTest = (publicId = 'abc-def-ghi', opts: Partial<LocalTestDefi
   tags: [],
 })
 
+export const getBrowserLocalTestDefinition = (
+  publicId = 'abc-def-ghi',
+  deviceIds = ['chrome.laptop_large'],
+  opts: Partial<LocalTestDefinition> = {}
+): LocalTestDefinition & {public_id: string} => ({
+  ...getApiLocalTestDefinition(publicId, opts),
+  options: {device_ids: deviceIds},
+  type: 'browser',
+  subtype: undefined,
+})
+
 export const getBrowserTest = (
   publicId = 'abc-def-ghi',
   deviceIds = ['chrome.laptop_large'],
-  opts: Partial<ServerTest> = {}
+  opts: Partial<LocalTestDefinition> = {}
 ): ServerTest => ({
-  ...getApiTest(publicId),
-  options: {device_ids: deviceIds},
-  type: 'browser',
-  ...opts,
+  ...getBrowserLocalTestDefinition(publicId, deviceIds, opts),
+  message: '',
+  monitor_id: 0,
+  status: 'live',
+  tags: [],
 })
 
 export const getStep = (): Step => ({
-  allowFailure: false,
-  browserErrors: [],
+  allow_failure: false,
+  browser_errors: [],
   description: 'description',
   duration: 1000,
-  skipped: false,
-  stepId: -1,
+  step_id: -1,
   type: 'type',
+  status: 'passed',
   url: 'about:blank',
   value: 'value',
-  vitalsMetrics: [
+  vitals_metrics: [
     {
       cls: 1,
       lcp: 1,
@@ -143,11 +155,10 @@ export const getStep = (): Step => ({
 })
 
 export const getMultiStep = (): MultiStep => ({
-  allowFailure: false,
-  assertionResults: [],
+  allow_failure: false,
+  assertion_results: [],
   name: 'name',
-  passed: true,
-  skipped: false,
+  status: 'passed',
   subtype: 'subtype',
   timings: {
     total: 123,
@@ -182,6 +193,13 @@ export const getBrowserResult = (
 ): BaseResult & {result: ServerResult} => ({
   ...getBaseResult(resultId, test),
   result: getBrowserServerResult(resultOpts),
+  device: {
+    id: 'chrome.laptop_large',
+    resolution: {
+      height: 1100,
+      width: 1440,
+    },
+  },
 })
 
 export const getApiResult = (
@@ -193,16 +211,13 @@ export const getApiResult = (
   result: getApiServerResult(resultOpts),
 })
 
-export const getIncompleteServerResult = (): ServerResult => {
-  return ({eventType: 'created'} as unknown) as ServerResult
-}
-
 export const getBrowserServerResult = (opts: Partial<BrowserServerResult> = {}): BrowserServerResult => ({
-  device: {height: 1100, id: 'chrome.laptop_large', width: 1440},
+  id: 'my_result_id',
+  finished_at: 1,
   duration: 1000,
-  passed: true,
-  startUrl: '',
-  stepDetails: [],
+  status: 'passed',
+  start_url: '',
+  steps: [],
   ...opts,
 })
 
@@ -212,9 +227,11 @@ export const getTimedOutBrowserResult = (): Result => ({
   location: 'Location name',
   passed: false,
   result: {
+    id: 'ghjsdghc',
     duration: 0,
+    finished_at: 1,
     failure: {code: 'TIMEOUT', message: 'The batch timed out before receiving the result.'},
-    passed: false,
+    status: 'failed',
     steps: [],
   },
   resultId: '1',
@@ -231,52 +248,60 @@ export const getFailedBrowserResult = (): Result => ({
   location: 'Location name',
   passed: false,
   result: {
-    device: {height: 1100, id: 'chrome.laptop_large', width: 1440},
+    id: 'my_result_id',
+    finished_at: 1,
     duration: 22000,
     failure: {code: 'STEP_TIMEOUT', message: 'Step failed because it took more than 20 seconds.'},
-    passed: false,
-    startUrl: 'https://example.org/',
-    stepDetails: [
+    status: 'failed',
+    start_url: 'https://example.org/',
+    steps: [
       {
         ...getStep(),
-        browserErrors: [{description: 'Error', name: 'Console error', type: 'js'}],
+        browser_errors: [{description: 'Error', name: 'Console error', type: 'js'}],
         description: 'Navigate to start URL',
         duration: 1000,
-        skipped: false,
-        stepId: -1,
+        status: 'passed',
+        step_id: -1,
         type: 'goToUrlAndMeasureTti',
         url: 'https://example.org/',
         value: 'https://example.org/',
-        vitalsMetrics: [{url: 'https://example.com', lcp: 100, cls: 0}],
+        vitals_metrics: [{url: 'https://example.com', lcp: 100, cls: 0}],
       },
       {
         ...getStep(),
-        allowFailure: true,
+        allow_failure: true,
         description: 'Navigate again',
         duration: 1000,
-        error: 'Navigation failure',
-        skipped: true,
-        stepId: 2,
+        failure: {message: 'Navigation failure'},
+        status: 'skipped',
+        step_id: 2,
         type: 'goToUrl',
         url: 'https://example.org/',
         value: 'https://example.org/',
-        vitalsMetrics: [],
+        vitals_metrics: [],
       },
       {
         ...getStep(),
         description: 'Assert',
         duration: 20000,
-        error: 'Step timeout',
-        publicId: 'abc-def-hij',
-        stepId: 3,
+        failure: {message: 'Step timeout'},
+        public_id: 'abc-def-hij',
+        step_id: 3,
         type: 'assertElementContent',
         url: 'https://example.org/',
-        vitalsMetrics: [],
+        vitals_metrics: [],
       },
-      {...getStep(), skipped: true},
-      {...getStep(), skipped: true},
-      {...getStep(), skipped: true},
+      {...getStep(), status: 'skipped'},
+      {...getStep(), status: 'skipped'},
+      {...getStep(), status: 'skipped'},
     ],
+  },
+  device: {
+    id: 'chrome.laptop_large',
+    resolution: {
+      height: 1100,
+      width: 1440,
+    },
   },
   resultId: '1',
   retries: 0,
@@ -287,13 +312,15 @@ export const getFailedBrowserResult = (): Result => ({
 })
 
 export const getApiServerResult = (opts: Partial<ApiServerResult> = {}): ApiServerResult => ({
-  assertionResults: [
+  id: 'my_api_result_id',
+  finished_at: 1,
+  assertions: [
     {
       actual: 'actual',
       valid: true,
     },
   ],
-  passed: true,
+  status: 'passed',
   timings: {
     total: 1000,
   },
@@ -301,57 +328,63 @@ export const getApiServerResult = (opts: Partial<ApiServerResult> = {}): ApiServ
 })
 
 export const getMultiStepsServerResult = (): MultiStepsServerResult => ({
+  id: 'my_multi_steps_result_id',
   duration: 1000,
-  passed: true,
+  finished_at: 1,
+  status: 'passed',
   steps: [],
 })
 
 export const getFailedMultiStepsTestLevelServerResult = (): MultiStepsServerResult => ({
+  id: 'my_multi_steps_result_id',
+  finished_at: 1,
   duration: 2000,
   failure: {code: 'TEST_TIMEOUT', message: 'Error: Maximum test execution time reached: 2 seconds.'},
-  passed: false,
+  status: 'failed',
   steps: [
     {
       ...getMultiStep(),
-      passed: true,
+      status: 'passed',
     },
     {
       ...getMultiStep(),
-      skipped: true,
+      status: 'skipped',
     },
   ],
 })
 
 export const getFailedMultiStepsServerResult = (): MultiStepsServerResult => ({
+  id: 'my_multi_steps_result_id',
+  finished_at: 1,
   duration: 123,
   failure: {code: 'INCORRECT_ASSERTION', message: 'incorrect assertion'},
-  passed: false,
+  status: 'failed',
   steps: [
     {
       ...getMultiStep(),
-      passed: true,
+      status: 'passed',
     },
     {
       ...getMultiStep(),
-      skipped: true,
+      status: 'skipped',
     },
     {
       ...getMultiStep(),
-      allowFailure: true,
+      allow_failure: true,
       failure: {
         code: 'INCORRECT_ASSERTION',
         message: 'incorrect assertion',
       },
-      passed: false,
+      status: 'failed',
     },
     {
       ...getMultiStep(),
-      allowFailure: false,
+      allow_failure: false,
       failure: {
         code: 'INCORRECT_ASSERTION',
         message: 'incorrect assertion',
       },
-      passed: false,
+      status: 'failed',
     },
   ],
 })
@@ -480,7 +513,7 @@ export const getResults = (resultsFixtures: ResultFixtures[]): Result[] => {
     const result = getApiResult(index.toString(), test)
     result.executionRule = testExecutionRule || executionRule || ExecutionRule.BLOCKING
     result.passed = !!passed
-    result.result = {...result.result, passed: !!passed, unhealthy}
+    result.result = {...result.result, status: !!passed ? 'passed' : 'failed', unhealthy}
 
     if (timedOut) {
       result.timedOut = true
@@ -586,7 +619,6 @@ export const getMobileTest = (
   },
   public_id: publicId,
   status: 'live',
-  subtype: '',
   tags: [],
   type: 'mobile',
 })
@@ -596,7 +628,8 @@ export const getMockApiConfiguration = (): APIConfiguration => ({
   appKey: '123',
   baseIntakeUrl: 'http://baseIntake',
   baseUnstableUrl: 'http://baseUnstable',
-  baseUrl: 'http://base',
+  baseV1Url: 'http://baseV1',
+  baseV2Url: 'http://baseV2',
   proxyOpts: {protocol: 'http'} as ProxyConfiguration,
 })
 

--- a/src/commands/synthetics/__tests__/fixtures.ts
+++ b/src/commands/synthetics/__tests__/fixtures.ts
@@ -211,6 +211,10 @@ export const getApiResult = (
   result: getApiServerResult(resultOpts),
 })
 
+export const getIncompleteServerResult = (): ServerResult => {
+  return ({test_type: 'api'} as unknown) as ServerResult
+}
+
 export const getBrowserServerResult = (opts: Partial<BrowserServerResult> = {}): BrowserServerResult => ({
   id: 'my_result_id',
   finished_at: 1,

--- a/src/commands/synthetics/__tests__/multilocator.test.ts
+++ b/src/commands/synthetics/__tests__/multilocator.test.ts
@@ -26,10 +26,10 @@ describe('multilocator', () => {
     mockConfig = {files: ['test.json']} as ImportTestsCommandConfig
     mockResults = [
       getBrowserResult('result-1', browserTest, {
-        stepDetails: [
+        steps: [
           getStep(), // Step 0 (ignored)
           getStep(),
-          {...getStep(), stepElementUpdates: {multiLocator: {ab: 'xpath-1'}}},
+          {...getStep(), step_element_updates: {multi_locator: {ab: 'xpath-1'}}},
         ],
       }),
     ]
@@ -66,7 +66,7 @@ describe('multilocator', () => {
     test('should not modify tests when no MultiLocators exist', async () => {
       mockResults = [
         getBrowserResult('result-1', getBrowserTest('test-1'), {
-          stepDetails: [getStep(), {...getStep(), stepElementUpdates: {}}], // No ML updates
+          steps: [getStep(), {...getStep(), step_element_updates: {}}], // No ML updates
         }),
       ]
 

--- a/src/commands/synthetics/__tests__/reporters/__snapshots__/default.test.ts.snap
+++ b/src/commands/synthetics/__tests__/reporters/__snapshots__/default.test.ts.snap
@@ -83,17 +83,20 @@ exports[`Default reporter resultEnd Incomplete API and Browser tests - passed an
   • Total duration: 1000 ms - View test run details:
     ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=1&batch_id=123&from_ci=true[39m[22m
   [1m[31m✖[39m[22m [1m[31m[1mGET[22m[1m - http://fake.url[39m[22m
+[1m[31m  - Assertion failed:[39m[22m
+[1m[31m    ▶ responseTime should be less than [4m1000[24m. Actual: [4m1234[24m[39m[22m
 
 [1m[32m✓[39m[22m [[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m - [1m[32mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m
   • Total duration: 1000 ms - View test run details:
     ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=2&batch_id=123&from_ci=true[39m[22m
   [1m[32m✓[39m[22m [1m[32m[1mGET[22m[1m - http://fake.url[39m[22m
 
-[1m[31m✖[39m[22m [[1m[31mblocking[39m[22m] [[1m[2mbbb-bbb-bbb[22m[22m] [1mTest name[22m - [1m[31mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m
+[1m[31m✖[39m[22m [[1m[31mblocking[39m[22m] [[1m[2mbbb-bbb-bbb[22m[22m] [1mTest name[22m - [1m[31mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m - [1m[31mdevice: [1mchrome.laptop_large[22m[1m[39m[22m
   • Total duration: 1000 ms - View test run details:
     ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/bbb-bbb-bbb/result/3?batch_id=123&from_ci=true[39m[22m
+[31m    [[1mINCORRECT_ASSERTION[22m] - [2m[{"actual":1234,"operator":"lessThan","target":1000,"type":"responseTime"}][22m[39m
 
-[1m[32m✓[39m[22m [[1m[2mbbb-bbb-bbb[22m[22m] [1mTest name[22m - [1m[32mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m
+[1m[32m✓[39m[22m [[1m[2mbbb-bbb-bbb[22m[22m] [1mTest name[22m - [1m[32mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m - [1m[32mdevice: [1mchrome.laptop_large[22m[1m[39m[22m
   • Total duration: 1000 ms - View test run details:
     ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/bbb-bbb-bbb/result/4?batch_id=123&from_ci=true[39m[22m
 

--- a/src/commands/synthetics/__tests__/reporters/__snapshots__/default.test.ts.snap
+++ b/src/commands/synthetics/__tests__/reporters/__snapshots__/default.test.ts.snap
@@ -83,8 +83,6 @@ exports[`Default reporter resultEnd Incomplete API and Browser tests - passed an
   • Total duration: 1000 ms - View test run details:
     ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/aaa-aaa-aaa?resultId=1&batch_id=123&from_ci=true[39m[22m
   [1m[31m✖[39m[22m [1m[31m[1mGET[22m[1m - http://fake.url[39m[22m
-[1m[31m  - Assertion failed:[39m[22m
-[1m[31m    ▶ responseTime should be less than [4m1000[24m. Actual: [4m1234[24m[39m[22m
 
 [1m[32m✓[39m[22m [[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m - [1m[32mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m
   • Total duration: 1000 ms - View test run details:
@@ -94,7 +92,6 @@ exports[`Default reporter resultEnd Incomplete API and Browser tests - passed an
 [1m[31m✖[39m[22m [[1m[31mblocking[39m[22m] [[1m[2mbbb-bbb-bbb[22m[22m] [1mTest name[22m - [1m[31mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m - [1m[31mdevice: [1mchrome.laptop_large[22m[1m[39m[22m
   • Total duration: 1000 ms - View test run details:
     ⎋ [2m[36mhttps://app.datadoghq.com/synthetics/details/bbb-bbb-bbb/result/3?batch_id=123&from_ci=true[39m[22m
-[31m    [[1mINCORRECT_ASSERTION[22m] - [2m[{"actual":1234,"operator":"lessThan","target":1000,"type":"responseTime"}][22m[39m
 
 [1m[32m✓[39m[22m [[1m[2mbbb-bbb-bbb[22m[22m] [1mTest name[22m - [1m[32mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m - [1m[32mdevice: [1mchrome.laptop_large[22m[1m[39m[22m
   • Total duration: 1000 ms - View test run details:

--- a/src/commands/synthetics/__tests__/reporters/default.test.ts
+++ b/src/commands/synthetics/__tests__/reporters/default.test.ts
@@ -22,7 +22,6 @@ import {
   getBrowserResult,
   getBrowserTest,
   getFailedBrowserResult,
-  getIncompleteServerResult,
   getSummary,
   getTimedOutBrowserResult,
 } from '../fixtures'
@@ -256,7 +255,7 @@ describe('Default reporter', () => {
       ])
       const failure = {code: 'INCORRECT_ASSERTION', message: errorMessage}
 
-      const {executionRule, incomplete, passed, retries, maxRetries, selectiveRerun, timedOut} = opts
+      const {executionRule, passed, retries, maxRetries, selectiveRerun, timedOut} = opts
 
       const result = test.type === 'api' ? getApiResult(resultId, test) : getBrowserResult(resultId, test)
 
@@ -265,7 +264,7 @@ describe('Default reporter', () => {
         result.result = {
           ...result.result,
           ...(passed ? {} : {failure}),
-          passed,
+          status: passed ? 'passed' : 'failed',
         }
       } else if (executionRule === ExecutionRule.SKIPPED) {
         delete (result as {result?: unknown}).result
@@ -291,10 +290,6 @@ describe('Default reporter', () => {
 
       if (selectiveRerun) {
         result.selectiveRerun = selectiveRerun
-      }
-
-      if (incomplete) {
-        result.result = getIncompleteServerResult()
       }
 
       return result
@@ -332,14 +327,17 @@ describe('Default reporter', () => {
             {
               ...getTimedOutBrowserResult(),
               result: {
+                id: 'rid',
+                finished_at: 0,
                 duration: 0,
                 failure: {code: 'FAILURE_CODE', message: 'Failure message'},
-                passed: false,
+                status: 'failed',
+                start_url: 'https://example.com',
                 steps: [],
               },
               timedOut: false,
             },
-          ],
+          ] as Result[],
         },
       },
       {

--- a/src/commands/synthetics/__tests__/reporters/default.test.ts
+++ b/src/commands/synthetics/__tests__/reporters/default.test.ts
@@ -22,6 +22,7 @@ import {
   getBrowserResult,
   getBrowserTest,
   getFailedBrowserResult,
+  getIncompleteServerResult,
   getSummary,
   getTimedOutBrowserResult,
 } from '../fixtures'
@@ -255,7 +256,7 @@ describe('Default reporter', () => {
       ])
       const failure = {code: 'INCORRECT_ASSERTION', message: errorMessage}
 
-      const {executionRule, passed, retries, maxRetries, selectiveRerun, timedOut} = opts
+      const {executionRule, incomplete, passed, retries, maxRetries, selectiveRerun, timedOut} = opts
 
       const result = test.type === 'api' ? getApiResult(resultId, test) : getBrowserResult(resultId, test)
 
@@ -290,6 +291,10 @@ describe('Default reporter', () => {
 
       if (selectiveRerun) {
         result.selectiveRerun = selectiveRerun
+      }
+
+      if (incomplete) {
+        result.result = getIncompleteServerResult()
       }
 
       return result

--- a/src/commands/synthetics/__tests__/test.test.ts
+++ b/src/commands/synthetics/__tests__/test.test.ts
@@ -42,7 +42,8 @@ describe('getTestsToTrigger', () => {
     appKey: '123',
     baseIntakeUrl: 'baseintake',
     baseUnstableUrl: 'baseUnstable',
-    baseUrl: 'base',
+    baseV1Url: 'basev1',
+    baseV2Url: 'basev2',
     proxyOpts: {protocol: 'http'} as ProxyConfiguration,
   }
   const api = apiConstructor(apiConfiguration)
@@ -174,7 +175,8 @@ describe('getTestAndOverrideConfig', () => {
     appKey: '123',
     baseIntakeUrl: 'baseintake',
     baseUnstableUrl: 'baseUnstable',
-    baseUrl: 'base',
+    baseV1Url: 'basev1',
+    baseV2Url: 'basev2',
     proxyOpts: {protocol: 'http'} as ProxyConfiguration,
   }
   const api = apiConstructor(apiConfiguration)

--- a/src/commands/synthetics/api.ts
+++ b/src/commands/synthetics/api.ts
@@ -11,19 +11,22 @@ import {
   APIConfiguration,
   APIHelperConfig,
   Batch,
+  LocalTestDefinition,
+  MobileAppUploadResult,
+  MobileApplicationNewVersionParams,
   MobileApplicationUploadPart,
   MobileApplicationUploadPartResponse,
+  MultipartPresignedUrlsResponse,
   Payload,
   PollResult,
-  MultipartPresignedUrlsResponse,
+  RawPollResultTest,
+  RawPollResult,
   ServerBatch,
   ServerTest,
   SyntheticsOrgSettings,
   TestSearchResult,
   Trigger,
-  MobileAppUploadResult,
-  MobileApplicationNewVersionParams,
-  LocalTestDefinition,
+  PollResultTest,
 } from './interfaces'
 import {MAX_TESTS_TO_TRIGGER} from './test'
 import {ciTriggerApp, getDatadogHost, retry} from './utils/public'
@@ -181,7 +184,7 @@ const getBatch = (request: (args: AxiosRequestConfig) => AxiosPromise<{data: Ser
   }
 }
 
-const pollResults = (request: (args: AxiosRequestConfig) => AxiosPromise<{results: PollResult[]}>) => async (
+const pollResults = (request: (args: AxiosRequestConfig) => AxiosPromise<RawPollResult>) => async (
   resultIds: string[]
 ) => {
   const resp = await retryRequest(
@@ -195,7 +198,40 @@ const pollResults = (request: (args: AxiosRequestConfig) => AxiosPromise<{result
     {retryOn404: true, retryOn429: true}
   )
 
-  return resp.data.results
+  const includedTestsByID = new Map<string, RawPollResultTest>()
+  resp.data.included?.forEach((r) => {
+    if (r.type === 'test') {
+      const test = {
+        id: r.id,
+        ...r.attributes,
+      }
+      includedTestsByID.set(r.id, test)
+    }
+  })
+
+  const rawPollResults = resp.data.data
+  const parsedPollResults = []
+  for (const r of rawPollResults) {
+    const test = includedTestsByID.get(r.relationships.test.data.id)
+    if (!test) {
+      continue
+    }
+    const pollResult: PollResult = {
+      ...r.attributes,
+      test: parseIncludedTest(test),
+    }
+
+    parsedPollResults.push(pollResult)
+  }
+
+  return parsedPollResults
+}
+
+const parseIncludedTest = (test: RawPollResultTest): PollResultTest => {
+  return {
+    id: test.id,
+    type: test.type,
+  }
 }
 
 const getTunnelPresignedURL = (request: (args: AxiosRequestConfig) => AxiosPromise<{url: string}>) => async (
@@ -382,24 +418,25 @@ const retryRequest = <T>(
   )
 
 export const apiConstructor = (configuration: APIConfiguration) => {
-  const {baseUrl, baseIntakeUrl, baseUnstableUrl, apiKey, appKey, proxyOpts} = configuration
+  const {baseV1Url, baseV2Url, baseIntakeUrl, baseUnstableUrl, apiKey, appKey, proxyOpts} = configuration
   const baseOptions = {apiKey, appKey, proxyOpts}
-  const request = getRequestBuilder({...baseOptions, baseUrl})
+  const requestV1 = getRequestBuilder({...baseOptions, baseUrl: baseV1Url})
+  const requestV2 = getRequestBuilder({...baseOptions, baseUrl: baseV2Url})
   const requestUnstable = getRequestBuilder({...baseOptions, baseUrl: baseUnstableUrl})
   const requestIntake = getRequestBuilder({...baseOptions, baseUrl: baseIntakeUrl})
 
   return {
-    getBatch: getBatch(request),
+    getBatch: getBatch(requestV1),
     getMobileApplicationPresignedURLs: getMobileApplicationPresignedURLs(requestUnstable),
-    getTest: getTest(request),
-    getLocalTestDefinition: getLocalTestDefinition(request),
-    editTest: editTest(request),
-    getSyntheticsOrgSettings: getSyntheticsOrgSettings(request),
+    getTest: getTest(requestV1),
+    getLocalTestDefinition: getLocalTestDefinition(requestV1),
+    editTest: editTest(requestV1),
+    getSyntheticsOrgSettings: getSyntheticsOrgSettings(requestV1),
     getTunnelPresignedURL: getTunnelPresignedURL(requestIntake),
-    pollResults: pollResults(request),
-    searchTests: searchTests(request),
+    pollResults: pollResults(requestV2),
+    searchTests: searchTests(requestV1),
     triggerTests: triggerTests(requestIntake),
-    uploadMobileApplicationPart: uploadMobileApplicationPart(request),
+    uploadMobileApplicationPart: uploadMobileApplicationPart(requestV1),
     completeMultipartMobileApplicationUpload: completeMultipartMobileApplicationUpload(requestUnstable),
     pollMobileApplicationUploadResponse: pollMobileApplicationUploadResponse(requestUnstable),
   }
@@ -420,7 +457,8 @@ export const getApiHelper = (config: APIHelperConfig): APIHelper => {
     appKey: config.appKey,
     baseIntakeUrl: getDatadogHost({useIntake: true, apiVersion: 'v1', config}),
     baseUnstableUrl: getDatadogHost({useIntake: false, apiVersion: 'unstable', config}),
-    baseUrl: getDatadogHost({useIntake: false, apiVersion: 'v1', config}),
+    baseV1Url: getDatadogHost({useIntake: false, apiVersion: 'v1', config}),
+    baseV2Url: getDatadogHost({useIntake: false, apiVersion: 'v2', config}),
     proxyOpts: config.proxy,
   })
 }

--- a/src/commands/synthetics/api.ts
+++ b/src/commands/synthetics/api.ts
@@ -218,6 +218,7 @@ const pollResults = (request: (args: AxiosRequestConfig) => AxiosPromise<RawPoll
     const pollResult: PollResult = {
       ...r.attributes,
       test: parseIncludedTest(test),
+      resultID: r.id,
     }
 
     parsedPollResults.push(pollResult)

--- a/src/commands/synthetics/api.ts
+++ b/src/commands/synthetics/api.ts
@@ -26,7 +26,6 @@ import {
   SyntheticsOrgSettings,
   TestSearchResult,
   Trigger,
-  PollResultTest,
 } from './interfaces'
 import {MAX_TESTS_TO_TRIGGER} from './test'
 import {ciTriggerApp, getDatadogHost, retry} from './utils/public'
@@ -227,10 +226,18 @@ const pollResults = (request: (args: AxiosRequestConfig) => AxiosPromise<RawPoll
   return parsedPollResults
 }
 
-const parseIncludedTest = (test: RawPollResultTest): PollResultTest => {
+const parseIncludedTest = (test: RawPollResultTest): PollResult['test'] => {
   return {
-    id: test.id,
+    public_id: test.id,
     type: test.type,
+    subtype: test.subtype,
+    config: {
+      ...test.config,
+      request: {
+        ...test.config.request,
+        dnsServer: test.config.request.dns_server,
+      },
+    },
   }
 }
 

--- a/src/commands/synthetics/batch.ts
+++ b/src/commands/synthetics/batch.ts
@@ -396,9 +396,8 @@ const getPollResultMap = async (api: APIHelper, resultIds: string[], backupPollR
 
     pollResults.forEach((r) => {
       // Server results can take some time to arrive. During this time,
-      // the endpoint returns a partial result with only `id` and `test_type` set.
-      // We keep the `PollResult` information (e.g. `timestamp`)
-      // but remove the server result to avoid reporting an unexpected object shape.
+      // the endpoint returns a partial result with only `test_type` and `result.id` set.
+      // We keep the `PollResult` but remove the `ServerResult` to avoid reporting incomplete data.
       if (r.result && !('finished_at' in (r.result as Partial<ServerResult>))) {
         incompleteResultIds.add(r.resultID)
         delete r.result

--- a/src/commands/synthetics/batch.ts
+++ b/src/commands/synthetics/batch.ts
@@ -367,7 +367,7 @@ const createResult = (
     retries: resultInBatch.retries || 0,
     maxRetries: resultInBatch.max_retries || 0,
     selectiveRerun: resultInBatch.selective_rerun,
-    test: deepExtend({}, test, pollResult?.test), // TODO: Find solution as test and pollResult.test are not the same type. Check camelCase properties.
+    test: deepExtend({}, test, pollResult?.test),
     timedOut: hasTimedOut,
     timestamp: pollResult?.result.finished_at ?? Date.now(),
   }

--- a/src/commands/synthetics/interfaces.ts
+++ b/src/commands/synthetics/interfaces.ts
@@ -115,8 +115,9 @@ export interface RawPollResultTest {
 
 export type PollResult = {
   test_type: 'api' | 'browser' | 'mobile'
-  result: ServerResult
   test: RecursivePartial<Test>
+  result?: ServerResult
+  resultID: string
   device?: Device
 }
 

--- a/src/commands/synthetics/interfaces.ts
+++ b/src/commands/synthetics/interfaces.ts
@@ -1,6 +1,7 @@
 import {Metadata} from '../../helpers/interfaces'
 import {ProxyConfiguration} from '../../helpers/utils'
 
+import {RecursivePartial} from './base-command'
 import {TunnelInfo} from './tunnel'
 
 export type SupportedReporter = 'junit' | 'default'
@@ -97,26 +98,27 @@ export interface RawPollResult {
   included: {
     type: string
     id: string
-    attributes: Pick<RawPollResultTest, 'type'>
+    attributes: Pick<RawPollResultTest, 'type' | 'subtype' | 'config'>
   }[]
 }
 
 export interface RawPollResultTest {
   id: string
   type: 'browser' | 'api' | 'mobile'
+  subtype?: string
+  config: {
+    request: {
+      dns_server?: string | undefined
+    }
+  }
 }
 
 export type PollResult = {
   test_type: 'api' | 'browser' | 'mobile'
   result: ServerResult
-  test: Partial<Test>
+  test: RecursivePartial<Test>
   device?: Device
 }
-
-export type PollResultTest = {
-  id: string
-  type: 'browser' | 'api' | 'mobile'
-} & Partial<Test>
 
 /**
  * Information required to convert a `PollResult` to a `Result`.

--- a/src/commands/synthetics/multilocator.ts
+++ b/src/commands/synthetics/multilocator.ts
@@ -3,7 +3,7 @@ import {writeFile} from 'fs/promises'
 import {isInteractive} from '../../helpers/ci'
 import {requestConfirmation} from '../../helpers/prompt'
 
-import {Result, MultiLocator, TestConfig, ImportTestsCommandConfig, MainReporter} from './interfaces'
+import {Result, MultiLocator, TestConfig, ImportTestsCommandConfig, MainReporter, Step} from './interfaces'
 import {findUniqueLocalTestDefinition} from './local-test-definition'
 import {ICONS} from './reporters/constants'
 import {getTestConfigs} from './test'
@@ -64,9 +64,9 @@ const getMultiLocatorsFromResults = (results: Result[]): MultiLocatorMap => {
     const stepMLUpdates: (MultiLocator | undefined)[] = []
 
     if (hasDefinedResult(result) && result.result && isBrowserServerResult(result.result)) {
-      const steps = result.result.stepDetails.slice(1) // Skip first step (navigation)
+      const steps = result.result.steps.slice(1) as Step[] // Skip first step (navigation)
       for (const step of steps) {
-        const multiLocator = step.stepElementUpdates?.multiLocator
+        const multiLocator = step.step_element_updates?.multi_locator
         stepMLUpdates.push(multiLocator)
       }
     }

--- a/src/commands/synthetics/reporters/default.ts
+++ b/src/commands/synthetics/reporters/default.ts
@@ -54,10 +54,10 @@ const renderStepDuration = (duration: number) => {
 }
 
 const renderStepIcon = (step: Step) => {
-  if (step.error) {
+  if (step.failure) {
     return ICONS.FAILED
   }
-  if (step.skipped) {
+  if (step.status === 'skipped') {
     return ICONS.SKIPPED
   }
 
@@ -69,7 +69,7 @@ const renderStep = (step: Step) => {
   const icon = renderStepIcon(step)
 
   const value = step.value ? `\n    ${chalk.dim(step.value)}` : ''
-  const error = step.error ? `\n    ${chalk.red.dim(step.error)}` : ''
+  const error = step.failure ? `\n    ${chalk.red.dim(step.failure.message)}` : ''
 
   return `    ${icon} | ${duration} - ${step.description}${value}${error}`
 }
@@ -125,7 +125,7 @@ const renderResultOutcome = (
     ].join('\n')
   }
 
-  if (test.type === 'api') {
+  if (test.type === 'api' && test.subtype) {
     const requestDescription = renderApiRequestDescription(test.subtype, test.config)
 
     if (result?.failure) {
@@ -146,11 +146,12 @@ const renderResultOutcome = (
     }
 
     // We render the step only if the test hasn't passed to avoid cluttering the output.
-    if (result && !result.passed && 'stepDetails' in result) {
-      const criticalFailedStepIndex = result.stepDetails.findIndex((s) => s.error && !s.allowFailure) + 1
-      lines.push(...result.stepDetails.slice(0, criticalFailedStepIndex).map(renderStep))
+    if (result && result.status !== 'passed' && 'steps' in result) {
+      const steps = result.steps as Step[]
+      const criticalFailedStepIndex = result.steps.findIndex((s) => s.failure && !s.allow_failure) + 1
+      lines.push(...steps.slice(0, criticalFailedStepIndex).map(renderStep))
 
-      const skippedStepDisplay = renderSkippedSteps(result.stepDetails.slice(criticalFailedStepIndex))
+      const skippedStepDisplay = renderSkippedSteps(steps.slice(criticalFailedStepIndex))
       if (skippedStepDisplay) {
         lines.push(skippedStepDisplay)
       }
@@ -251,7 +252,7 @@ const getResultIdentificationSuffix = (execution: Result, setColor: chalk.Chalk)
   if (isBaseResult(execution)) {
     const {result, passed, retries, maxRetries, timedOut} = execution
     const location = execution.location ? setColor(`location: ${chalk.bold(execution.location)}`) : ''
-    const device = result && isDeviceIdSet(result) ? ` - ${setColor(`device: ${chalk.bold(result.device.id)}`)}` : ''
+    const device = result && isDeviceIdSet(execution) ? ` - ${setColor(`device: ${chalk.bold(execution.device.id)}`)}` : ''
     const attempt = getAttemptSuffix(passed, retries, maxRetries, timedOut)
 
     return ` - ${location}${device}${attempt}`

--- a/src/commands/synthetics/reporters/default.ts
+++ b/src/commands/synthetics/reporters/default.ts
@@ -252,7 +252,8 @@ const getResultIdentificationSuffix = (execution: Result, setColor: chalk.Chalk)
   if (isBaseResult(execution)) {
     const {result, passed, retries, maxRetries, timedOut} = execution
     const location = execution.location ? setColor(`location: ${chalk.bold(execution.location)}`) : ''
-    const device = result && isDeviceIdSet(execution) ? ` - ${setColor(`device: ${chalk.bold(execution.device.id)}`)}` : ''
+    const device =
+      result && isDeviceIdSet(execution) ? ` - ${setColor(`device: ${chalk.bold(execution.device.id)}`)}` : ''
     const attempt = getAttemptSuffix(passed, retries, maxRetries, timedOut)
 
     return ` - ${location}${device}${attempt}`

--- a/src/commands/synthetics/reporters/junit.ts
+++ b/src/commands/synthetics/reporters/junit.ts
@@ -411,7 +411,7 @@ export class JUnitReporter implements Reporter {
         _: step.failure.message,
       }
 
-      if (step.failure) {
+      if (step.allow_failure) {
         allowedErrors.push(xmlError)
       } else {
         errors.push(xmlError)

--- a/src/commands/synthetics/reporters/junit.ts
+++ b/src/commands/synthetics/reporters/junit.ts
@@ -235,21 +235,25 @@ export class JUnitReporter implements Reporter {
         ? testCase.error // ❗️
         : testCase.failure // ❌
 
-    if (hasDefinedResult(result) && 'stepDetails' in result.result) {
-      // It's a browser test.
-      for (const stepDetail of result.result.stepDetails) {
-        const {allowedErrors, browserErrors, errors, warnings} = this.getBrowserTestErrors(stepDetail)
-        testCase.allowed_error.push(...allowedErrors)
-        testCase.browser_error.push(...browserErrors)
-        errorOrFailure.push(...errors)
-        testCase.warning.push(...warnings)
-      }
-    } else if (hasDefinedResult(result) && 'steps' in result.result) {
-      // It's a multistep test.
-      for (const step of result.result.steps) {
-        const {allowedErrors, errors} = this.getMultiStepTestErrors(step)
-        testCase.allowed_error.push(...allowedErrors)
-        errorOrFailure.push(...errors)
+    if (hasDefinedResult(result) && 'steps' in result.result) {
+      if (result.test.type === 'browser') {
+        // It's a browser test.
+        const steps = result.result.steps as Step[]
+        for (const step of steps) {
+          const {allowedErrors, browserErrors, errors, warnings} = this.getBrowserTestErrors(step)
+          testCase.allowed_error.push(...allowedErrors)
+          testCase.browser_error.push(...browserErrors)
+          errorOrFailure.push(...errors)
+          testCase.warning.push(...warnings)
+        }
+      } else if (result.test.type === 'api') {
+        // It's a multistep test.
+        const steps = result.result.steps as MultiStep[]
+        for (const step of steps) {
+          const {allowedErrors, errors} = this.getMultiStepTestErrors(step)
+          testCase.allowed_error.push(...allowedErrors)
+          errorOrFailure.push(...errors)
+        }
       }
     } else {
       // It's an api test.
@@ -334,18 +338,18 @@ export class JUnitReporter implements Reporter {
     // TODO use more granular result based on step.assertionResults
     let allowfailures = 0
     let skipped = 0
-    if ('allowFailure' in step) {
-      allowfailures += step.allowFailure ? 1 : 0
+    if ('allow_failure' in step) {
+      allowfailures += step.allow_failure ? 1 : 0
     }
-    if ('skipped' in step) {
-      skipped += step.skipped ? 1 : 0
+    if ('status' in step) {
+      skipped += step.status === 'skipped' ? 1 : 0
     }
 
     return {
       steps_allowfailures: allowfailures,
       steps_count: 1,
-      steps_errors: step.passed ? 0 : 1,
-      steps_failures: step.passed ? 0 : 1,
+      steps_errors: step.status === 'failed' ? 1 : 0,
+      steps_failures: step.status === 'failed' ? 1 : 0,
       steps_skipped: skipped,
       steps_warnings: 0,
     }
@@ -367,20 +371,20 @@ export class JUnitReporter implements Reporter {
   }
 
   private getBrowserStepStats(step: Step): TestCaseStats {
-    const errors = step.browserErrors ? step.browserErrors.length : 0
+    const errors = step.browser_errors ? step.browser_errors.length : 0
 
     return {
-      steps_allowfailures: step.allowFailure ? 1 : 0,
-      steps_count: step.subTestStepDetails ? step.subTestStepDetails.length : 1,
-      steps_errors: errors + (step.error ? 1 : 0),
-      steps_failures: step.error ? 1 : 0,
-      steps_skipped: step.skipped ? 1 : 0,
+      steps_allowfailures: step.allow_failure ? 1 : 0,
+      steps_count: step.sub_test_step_details ? step.sub_test_step_details.length : 1,
+      steps_errors: errors + (step.failure ? 1 : 0),
+      steps_failures: step.failure ? 1 : 0,
+      steps_skipped: step.status === 'skipped' ? 1 : 0,
       steps_warnings: step.warnings ? step.warnings.length : 0,
     }
   }
 
   private getBrowserTestErrors(
-    stepDetail: Step
+    step: Step
   ): {
     allowedErrors: XMLError[]
     browserErrors: XMLError[]
@@ -392,32 +396,32 @@ export class JUnitReporter implements Reporter {
     const errors = []
     const warnings = []
 
-    if (stepDetail.browserErrors?.length) {
+    if (step.browser_errors?.length) {
       browserErrors.push(
-        ...stepDetail.browserErrors.map((e) => ({
-          $: {type: e.type, name: e.name, step: stepDetail.description},
+        ...step.browser_errors.map((e) => ({
+          $: {type: e.type, name: e.name, step: step.description},
           _: e.description,
         }))
       )
     }
 
-    if (stepDetail.error) {
+    if (step.failure) {
       const xmlError = {
-        $: {type: 'assertion', step: stepDetail.description, allowFailure: `${stepDetail.allowFailure}`},
-        _: stepDetail.error,
+        $: {type: 'assertion', step: step.description, allowFailure: `${step.allow_failure}`},
+        _: step.failure.message,
       }
 
-      if (stepDetail.allowFailure) {
+      if (step.failure) {
         allowedErrors.push(xmlError)
       } else {
         errors.push(xmlError)
       }
     }
 
-    if (stepDetail.warnings?.length) {
+    if (step.warnings?.length) {
       warnings.push(
-        ...stepDetail.warnings.map((w) => ({
-          $: {type: w.type, step: stepDetail.description},
+        ...step.warnings.map((w) => ({
+          $: {type: w.type, step: step.description},
           _: w.message,
         }))
       )
@@ -432,11 +436,11 @@ export class JUnitReporter implements Reporter {
 
     if (step.failure) {
       const xmlError = {
-        $: {type: step.failure.code, step: step.name, allowFailure: `${step.allowFailure}`},
+        $: {type: step.failure.code, step: step.name, allowFailure: `${step.allow_failure}`},
         _: renderApiError(step.failure.code, step.failure.message),
       }
 
-      if (step.allowFailure) {
+      if (step.allow_failure) {
         allowedErrors.push(xmlError)
       } else {
         errors.push(xmlError)
@@ -508,8 +512,7 @@ export class JUnitReporter implements Reporter {
     const publicId = getPublicIdOrPlaceholder(test)
     const id = `id: ${publicId}`
     const location = isBaseResult(result) ? `location: ${result.location}` : ''
-    const device =
-      hasDefinedResult(result) && isDeviceIdSet(result.result) ? ` - device: ${result.result.device.id}` : ''
+    const device = hasDefinedResult(result) && isDeviceIdSet(result) ? ` - device: ${result.device.id}` : ''
     const resultTimedOut = result.timedOut ? ` - result id: ${result.resultId} (not yet received)` : ''
 
     // This has to identify results, otherwise GitLab will only show the last result with the same name.
@@ -521,7 +524,9 @@ export class JUnitReporter implements Reporter {
         file: test.suite,
         name: resultIdentification,
         time: isBaseResult(result) ? result.duration / 1000 : 0,
-        timestamp: isBaseResult(result) ? new Date(result.timestamp).toISOString() : new Date().toISOString(),
+        timestamp: hasDefinedResult(result)
+          ? new Date(result.result.finished_at).toISOString()
+          : new Date().toISOString(),
         ...this.getTestCaseStats(result),
       },
       allowed_error: [],
@@ -531,11 +536,11 @@ export class JUnitReporter implements Reporter {
       properties: {
         property: [
           {$: {name: 'check_id', value: publicId}},
-          ...(hasDefinedResult(result) && isDeviceIdSet(result.result)
+          ...(hasDefinedResult(result) && isDeviceIdSet(result)
             ? [
-                {$: {name: 'device', value: result.result.device.id}},
-                {$: {name: 'width', value: result.result.device.width}},
-                {$: {name: 'height', value: result.result.device.height}},
+                {$: {name: 'device', value: result.device.id}},
+                {$: {name: 'width', value: result.device.resolution.width}},
+                {$: {name: 'height', value: result.device.resolution.height}},
               ]
             : []),
           {$: {name: 'execution_rule', value: test.options.ci?.executionRule}},
@@ -573,22 +578,27 @@ export class JUnitReporter implements Reporter {
     }
 
     let stepsStats: TestCaseStats[] = []
-    if ('stepDetails' in result.result) {
-      // It's a browser test.
-      stepsStats = result.result.stepDetails
-        .map((step) => {
-          if (!step.subTestStepDetails) {
-            return [step]
-          }
+    if ('steps' in result.result) {
+      if (result.test.type === 'browser') {
+        // It's a browser test.
+        const steps = result.result.steps as Step[]
+        stepsStats = steps
+          .map((step) => {
+            if (!step.sub_test_step_details) {
+              return [step]
+            }
 
-          return [step, ...step.subTestStepDetails]
-        })
-        .reduce((acc, val) => acc.concat(val), [])
-        .map(this.getBrowserStepStats)
-    } else if ('steps' in result.result) {
-      // It's an multistep API test
-      stepsStats = result.result.steps.map(this.getApiStepStats)
+            return [step, ...step.sub_test_step_details]
+          })
+          .reduce((acc, val) => acc.concat(val), [])
+          .map(this.getBrowserStepStats)
+      } else if (result.test.type === 'api') {
+        // It's an multistep API test
+        const steps = result.result.steps as MultiStep[]
+        stepsStats = steps.map(this.getApiStepStats)
+      }
     } else {
+      // It's an api test
       stepsStats = [this.getApiStepStats(result.result)]
     }
 

--- a/src/commands/synthetics/utils/internal.ts
+++ b/src/commands/synthetics/utils/internal.ts
@@ -99,7 +99,7 @@ export const isLocalTriggerConfig = (triggerConfig?: TriggerConfig): triggerConf
 }
 
 export const isBrowserServerResult = (serverResult: ServerResult): serverResult is BrowserServerResult => {
-  return (serverResult as BrowserServerResult).stepDetails !== undefined
+  return (serverResult as BrowserServerResult).steps !== undefined
 }
 
 export const getTriggerConfigPublicId = (triggerConfig: TriggerConfig): string | undefined => {

--- a/src/commands/synthetics/utils/public.ts
+++ b/src/commands/synthetics/utils/public.ts
@@ -13,7 +13,6 @@ import {formatBackendErrors, getApiHelper} from '../api'
 import {CiError, CriticalError} from '../errors'
 import {
   APIHelperConfig,
-  BrowserServerResult,
   ExecutionRule,
   MainReporter,
   Operator,
@@ -21,7 +20,6 @@ import {
   Result,
   ResultSkippedBySelectiveRerun,
   RunTestsCommandConfig,
-  ServerResult,
   Suite,
   Summary,
   SyntheticsCIConfig,
@@ -305,7 +303,7 @@ export const getReporter = (reporters: Reporter[]): MainReporter => ({
   },
 })
 
-export const isDeviceIdSet = (result: ServerResult): result is Required<BrowserServerResult> =>
+export const isDeviceIdSet = (result: Result): result is Required<Result> =>
   'device' in result && result.device !== undefined
 
 export const fetchTest = async (publicId: string, config: SyntheticsCIConfig): Promise<Test> => {
@@ -488,13 +486,25 @@ export const toExitCode = (reason: ExitReason) => {
 }
 
 export const getDatadogHost = (hostConfig: {
-  apiVersion: 'v1' | 'unstable'
+  apiVersion: 'v1' | 'v2' | 'unstable'
   config: APIHelperConfig
   useIntake: boolean
 }) => {
   const {useIntake, apiVersion, config} = hostConfig
 
-  const apiPath = apiVersion === 'v1' ? 'api/v1' : 'api/unstable'
+  const apiPath = (() => {
+    switch (apiVersion) {
+      case 'v1':
+        return 'api/v1'
+      case 'v2':
+        return 'api/v2'
+      case 'unstable':
+        return 'api/unstable'
+      default:
+        return 'api/unstable'
+    }
+  })()
+
   let host = `https://api.${config.datadogSite}`
   const hostOverride = process.env.DD_API_HOST_OVERRIDE
 


### PR DESCRIPTION
### What and why?

This PR updates the Synthetics component to use the new v2 `poll_result` endpoint that sends v1 results.

### How?

- Refactored the API configuration to use separate `baseV1Url` and `baseV2Url` instead of a single `baseUrl`
- Added `RawPollResult` interface to handle the new nested JSON structure
- Updated `pollResults` to properly extract test result and data from the api response
- Updated test fixtures to match the new V2 API response format with proper test relationships
- Fixed all tests to match the new result format and relationship structure

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)