### PR TITLE
[docs] Update synthetics upload section + add partial comments

### DIFF
--- a/src/commands/synthetics/README.md
+++ b/src/commands/synthetics/README.md
@@ -873,7 +873,7 @@ The path to the [global configuration file](#global-configuration-file) that con
 
 #### `datadogSite`
 
-Your Datadog site. The possible values are listed [in this table][16].<!-- partial Your Datadog site is {{< region-param key="dd_site" code="true" >}}. partial -->
+Your Datadog site. The possible values are listed [in this table][16].<!-- partial The selected Datadog site is {{< region-param key="dd_site" code="true" >}}. partial -->
 
 **Configuration options**
 

--- a/src/commands/synthetics/README.md
+++ b/src/commands/synthetics/README.md
@@ -1,4 +1,4 @@
-<div class="alert alert-info">This page is about configuring Continuous Testing tests for your Continuous Integration (CI) and Continuous Delivery (CD) pipelines. If you want to bring your CI/CD metrics and data into Datadog dashboards, see the <a href="https://docs.datadoghq.com/continuous_integration/" target="_blank">CI Visibility</a> section.</div>
+<!-- partial <div class="alert alert-info">This page is about configuring Continuous Testing tests for your Continuous Integration (CI) and Continuous Delivery (CD) pipelines. If you want to bring your CI/CD metrics and data into Datadog dashboards, see the <a href="https://docs.datadoghq.com/continuous_integration/" target="_blank">CI Visibility</a> section.</div> partial -->
 
 ## Overview
 

--- a/src/commands/synthetics/README.md
+++ b/src/commands/synthetics/README.md
@@ -302,7 +302,9 @@ The path to the [global configuration file](#global-configuration-file) that con
 
 #### `datadogSite`
 
-Your Datadog site. The possible values are listed [in this table][16].<!-- partial The currently selected site is {{< region-param key="dd_site" code="true" >}}. partial -->
+Your Datadog site. The possible values are listed [in this table][16].
+
+<!-- partial Set it to {{< region-param key="dd_site" code="true" >}} (ensure the correct SITE is selected on the right). partial -->
 
 **Configuration options**
 
@@ -873,7 +875,9 @@ The path to the [global configuration file](#global-configuration-file) that con
 
 #### `datadogSite`
 
-Your Datadog site. The possible values are listed [in this table][16].<!-- partial The currently selected site is {{< region-param key="dd_site" code="true" >}}. partial -->
+Your Datadog site. The possible values are listed [in this table][16].
+
+<!-- partial Set it to {{< region-param key="dd_site" code="true" >}} (ensure the correct SITE is selected on the right). partial -->
 
 **Configuration options**
 

--- a/src/commands/synthetics/README.md
+++ b/src/commands/synthetics/README.md
@@ -302,7 +302,7 @@ The path to the [global configuration file](#global-configuration-file) that con
 
 #### `datadogSite`
 
-Your Datadog site. The possible values are listed [in this table][16].<!-- partial Your Datadog site is {{< region-param key="dd_site" code="true" >}}. partial -->
+Your Datadog site. The possible values are listed [in this table][16].<!-- partial The currently selected site is {{< region-param key="dd_site" code="true" >}}. partial -->
 
 **Configuration options**
 
@@ -873,7 +873,7 @@ The path to the [global configuration file](#global-configuration-file) that con
 
 #### `datadogSite`
 
-Your Datadog site. The possible values are listed [in this table][16].<!-- partial The selected Datadog site is {{< region-param key="dd_site" code="true" >}}. partial -->
+Your Datadog site. The possible values are listed [in this table][16].<!-- partial The currently selected site is {{< region-param key="dd_site" code="true" >}}. partial -->
 
 **Configuration options**
 

--- a/src/commands/synthetics/README.md
+++ b/src/commands/synthetics/README.md
@@ -842,7 +842,7 @@ This command uploads a new version to an **existing** mobile application.
 
 #### `apiKey` (Required)
 
-The API key used to query the Datadog API.
+Your Datadog API key. This key is [created in your Datadog organization][15] and should be stored as a secret.
 
 **Configuration options**
 
@@ -852,7 +852,7 @@ The API key used to query the Datadog API.
 
 #### `appKey` (Required)
 
-The application key used to query the Datadog API.
+Your Datadog application key. This key is [created in your Datadog organization][15] and should be stored as a secret.
 
 **Configuration options**
 
@@ -862,7 +862,7 @@ The application key used to query the Datadog API.
 
 #### `configPath`
 
-A path to the global configuration file. See the [example configuration](#global-configuration-file) for more details.
+The path to the [global configuration file](#global-configuration-file) that configures datadog-ci.
 
 **Configuration options**
 
@@ -873,7 +873,7 @@ A path to the global configuration file. See the [example configuration](#global
 
 #### `datadogSite`
 
-The Datadog instance to which request is sent. The default is `datadoghq.com`.<!-- partial Your Datadog site is {{< region-param key="dd_site" code="true" >}}. partial -->
+Your Datadog site. The possible values are listed [in this table][16].<!-- partial Your Datadog site is {{< region-param key="dd_site" code="true" >}}. partial -->
 
 **Configuration options**
 


### PR DESCRIPTION
### What and why?

I forgot to update the section for the upload-application command.

And this PR also adds partial comments, like in https://github.com/DataDog/synthetics-ci-github-action/pull/323. Here is [the result](https://docs-staging.datadoghq.com/corentin.girard/preview-datadog-ci/continuous_testing/cicd_integrations/configuration?tab=npm&site=us5#datadogsite):

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/22a508ec-e591-4cf6-8276-c57683aede72" />

### How?

Use `<-- partial` comments.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
