### PR TITLE
Escape Details URL in Quality Gates Response

### DIFF
--- a/src/commands/gate/renderer.ts
+++ b/src/commands/gate/renderer.ts
@@ -68,7 +68,7 @@ export const renderRuleEvaluation = (ruleEvaluation: RuleEvaluation): string => 
 
   fullStr += `${chalk.yellow('Blocking')}: ${ruleEvaluation.is_blocking}\n`
   if (ruleEvaluation.details_url) {
-    fullStr += `Details: ${ruleEvaluation.details_url}\n`
+    fullStr += `Details: ${encodeURI(ruleEvaluation.details_url)}\n`
   }
 
   fullStr += '\n'


### PR DESCRIPTION
### What and why?

This PR escapes the details URL in our Quality Gates response. Without this URL escape, the URL leads to a 404.

### How?

Simply adds a `URLEncode` to the `details_url` string in the rendering of the quality gate.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
Current tests cover changes
