### PR TITLE
Update coverage upload command to include git diff data

### DIFF
--- a/src/commands/coverage/README.md
+++ b/src/commands/coverage/README.md
@@ -29,6 +29,7 @@ datadog-ci coverage upload --tags key1:value1 --tags key2:value2 unit-tests/cove
   - The resulting dictionary will be merged with whatever is in the `DD_MEASURES` environment variable. If a `key` appears both in `--measures` and `DD_MEASURES`, whatever value is in `DD_MEASURES` will take precedence.
 - `--dry-run` (default: `false`): it will run the command without the final upload step. All other checks are performed.
 - `--verbose` (default: `false`): it will add extra verbosity to the output of the command.
+- `--upload-git-diff` (default: `true`): if the command is run in a PR context, it will try to upload the PR git diff along with the coverage data.
 
 #### Environment variables
 

--- a/src/commands/coverage/api.ts
+++ b/src/commands/coverage/api.ts
@@ -1,5 +1,5 @@
 import fs from 'fs'
-import {createGzip} from 'zlib'
+import {createGzip, gzipSync} from 'zlib'
 
 import type {AxiosPromise, AxiosRequestConfig, AxiosResponse} from 'axios'
 
@@ -33,6 +33,18 @@ export const uploadCodeCoverageReport = (request: (args: AxiosRequestConfig) => 
   }
 
   form.append('event', JSON.stringify(event), {filename: 'event.json'})
+
+  if (payload.prDiff) {
+    form.append('pr_diff', gzipSync(Buffer.from(JSON.stringify(payload.prDiff), 'utf8')), {
+      filename: 'pr_diff.json',
+    })
+  }
+
+  if (payload.commitDiff) {
+    form.append('commit_diff', gzipSync(Buffer.from(JSON.stringify(payload.commitDiff), 'utf8')), {
+      filename: 'commit_diff.json',
+    })
+  }
 
   await doWithMaxConcurrency(20, payload.paths, async (path) => {
     const filename = path.split('/').pop() || path

--- a/src/commands/coverage/interfaces.ts
+++ b/src/commands/coverage/interfaces.ts
@@ -2,6 +2,8 @@ import type {AxiosPromise, AxiosResponse} from 'axios'
 
 import {SpanTags} from '../../helpers/interfaces'
 
+import {DiffNode} from '../git-metadata/git'
+
 export interface Payload {
   hostname: string
   spanTags: SpanTags
@@ -9,6 +11,8 @@ export interface Payload {
   customMeasures: Record<string, number>
   paths: string[]
   format: string
+  commitDiff: Record<string, DiffNode> | undefined
+  prDiff: Record<string, DiffNode> | undefined
 }
 
 export interface APIHelper {

--- a/src/commands/git-metadata/__tests__/fixtures/add_delete.diff
+++ b/src/commands/git-metadata/__tests__/fixtures/add_delete.diff
@@ -1,0 +1,19 @@
+diff --git a/src/Utils.java b/src/Utils.java
+new file mode 100644
+index 0000000..b7e23ce
+\--- /dev/null
++++ b/src/Utils.java
+@@ -0,0 +1,4 @@
++package com.example;
+\+
++public class Utils {
++}
+
+diff --git a/README.md b/README.md
+deleted file mode 100644
+index f18dd09..0000000
+\--- a/README.md
++++ /dev/null
+@@ -1,2 +0,0 @@
+-# My Project
+-Initial version

--- a/src/commands/git-metadata/__tests__/fixtures/modify_single_file.diff
+++ b/src/commands/git-metadata/__tests__/fixtures/modify_single_file.diff
@@ -1,0 +1,15 @@
+diff --git a/src/Calculator.java b/src/Calculator.java
+index 34e8512..a6ceb76 100644
+\--- a/src/Calculator.java
++++ b/src/Calculator.java
+@@ -10,2 +10,2 @@
+
+* public int divide(int a, int b) {
+* ```
+     return a / b;
+  ```
+
+- public int mod(int a, int b) {
+- ```
+     return a % b;
+  ```

--- a/src/commands/git-metadata/__tests__/git.test.ts
+++ b/src/commands/git-metadata/__tests__/git.test.ts
@@ -3,7 +3,7 @@ import fs from 'fs'
 import * as simpleGit from 'simple-git'
 import path from 'upath'
 
-import { getCommitInfo, newSimpleGit, stripCredentials, parseGitDiff, DiffNode } from "../git";
+import {getCommitInfo, newSimpleGit, stripCredentials, parseGitDiff} from '../git'
 
 interface MockConfig {
   hash?: string

--- a/src/commands/git-metadata/git.ts
+++ b/src/commands/git-metadata/git.ts
@@ -48,7 +48,7 @@ export const gitTrackedFiles = async (git: simpleGit.SimpleGit): Promise<string[
 // Returns the current hash, remote URL and tracked files paths.
 export const getCommitInfo = async (git: simpleGit.SimpleGit, repositoryURL?: string): Promise<CommitInfo> => {
   // Invoke git commands to retrieve the remote, hash and tracked files.
-  // We're using Promise.all instead of Promive.allSettled since we want to fail early if
+  // We're using Promise.all instead of Promise.allSettled since we want to fail early if
   // any of the promises fails.
   let remote: string
   let hash: string
@@ -61,4 +61,100 @@ export const getCommitInfo = async (git: simpleGit.SimpleGit, repositoryURL?: st
   }
 
   return new CommitInfo(hash, remote, trackedFiles)
+}
+
+export const getGitDiff = async (
+  git: simpleGit.SimpleGit,
+  from: string,
+  to: string
+): Promise<Record<string, DiffNode>> => {
+  const rawDiff = await git.diff([
+    '--unified=0',
+    '--no-color',
+    '--no-ext-diff',
+    '--no-renames',
+    '--diff-algorithm=minimal',
+    `${from}..${to}`,
+  ])
+
+  return parseGitDiff(rawDiff)
+}
+
+export interface DiffNode {
+  addedLines: string // base-64 bit-vector
+  removedLines: string // base-64 bit-vector
+}
+
+const diffHeaderRegex = /^diff --git a\/.+ b\/(.+)$/
+const hunkHeaderRegex = /^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@/
+
+export const parseGitDiff = (diff: string): Record<string, DiffNode> => {
+  const root: Record<string, DiffNode> = {}
+
+  interface Buffer {
+    addedLines: Set<number>
+    removedLines: Set<number>
+  }
+  let currentPath: string | undefined
+  let currentLines: Buffer | undefined
+
+  for (const line of diff.split(/\r?\n/)) {
+    const diffHeader = diffHeaderRegex.exec(line)
+    if (diffHeader) {
+      if (currentPath && currentLines) {
+        root[currentPath] = {
+          addedLines: base64Encode(currentLines.addedLines),
+          removedLines: base64Encode(currentLines.removedLines),
+        }
+      }
+
+      currentPath = diffHeader[1]
+      currentLines = {addedLines: new Set(), removedLines: new Set()}
+      continue
+    }
+
+    if (!currentLines) {
+      // still before first diff-header
+      continue
+    }
+
+    const hunkHeader = hunkHeaderRegex.exec(line)
+    if (hunkHeader) {
+      const oldStart = Number(hunkHeader[1])
+      const oldLen = Number(hunkHeader[2] ?? 1)
+      const newStart = Number(hunkHeader[3])
+      const newLen = Number(hunkHeader[4] ?? 1)
+
+      for (let i = 0; i < oldLen; i++) {
+        currentLines.removedLines.add(oldStart + i)
+      }
+      for (let i = 0; i < newLen; i++) {
+        currentLines.addedLines.add(newStart + i)
+      }
+    }
+  }
+
+  if (currentPath && currentLines) {
+    root[currentPath] = {
+      addedLines: base64Encode(currentLines.addedLines),
+      removedLines: base64Encode(currentLines.removedLines),
+    }
+  }
+
+  return root
+}
+
+const base64Encode = (set: Set<number>): string => {
+  const maxBit = set.size ? Math.max(...set) : 0
+  if (maxBit === 0) {
+    return ''
+  }
+  const bytes = new Uint8Array(Math.ceil(maxBit / 8))
+  for (const n of set) {
+    const idx = n - 1
+    // eslint-disable-next-line no-bitwise
+    bytes[idx >> 3] |= 1 << (idx & 7)
+  }
+
+  return Buffer.from(bytes).toString('base64')
 }

--- a/src/helpers/__tests__/ci.test.ts
+++ b/src/helpers/__tests__/ci.test.ts
@@ -10,6 +10,7 @@ import {
   GIT_PULL_REQUEST_BASE_BRANCH,
   GIT_PULL_REQUEST_BASE_BRANCH_SHA,
   GIT_HEAD_SHA,
+  PR_ID,
 } from '../tags'
 import {getUserCISpanTags, getUserGitSpanTags} from '../user-provided-git'
 
@@ -198,16 +199,19 @@ describe('ci spec', () => {
             [GIT_PULL_REQUEST_BASE_BRANCH]: pullRequestBaseBranch,
             [GIT_PULL_REQUEST_BASE_BRANCH_SHA]: pullRequestBaseBranchSha,
             [GIT_HEAD_SHA]: headCommitSha,
+            [PR_ID]: prId,
           } = getCISpanTags() as SpanTags
 
           expect({
             pullRequestBaseBranch,
             pullRequestBaseBranchSha,
             headCommitSha,
+            prId,
           }).toEqual({
             pullRequestBaseBranch: 'datadog:main',
             pullRequestBaseBranchSha: '52e0974c74d41160a03d59ddc73bb9f5adab054b',
             headCommitSha: 'df289512a51123083a8e6931dd6f57bb3883d4c4',
+            pdId: 1,
           })
         })
 

--- a/src/helpers/__tests__/ci.test.ts
+++ b/src/helpers/__tests__/ci.test.ts
@@ -211,7 +211,7 @@ describe('ci spec', () => {
             pullRequestBaseBranch: 'datadog:main',
             pullRequestBaseBranchSha: '52e0974c74d41160a03d59ddc73bb9f5adab054b',
             headCommitSha: 'df289512a51123083a8e6931dd6f57bb3883d4c4',
-            prId: 1,
+            prId: '1',
           })
         })
 

--- a/src/helpers/__tests__/ci.test.ts
+++ b/src/helpers/__tests__/ci.test.ts
@@ -211,7 +211,7 @@ describe('ci spec', () => {
             pullRequestBaseBranch: 'datadog:main',
             pullRequestBaseBranchSha: '52e0974c74d41160a03d59ddc73bb9f5adab054b',
             headCommitSha: 'df289512a51123083a8e6931dd6f57bb3883d4c4',
-            pdId: 1,
+            prId: 1,
           })
         })
 

--- a/src/helpers/ci.ts
+++ b/src/helpers/ci.ts
@@ -27,6 +27,7 @@ import {
   GIT_BASE_REF,
   GIT_PULL_REQUEST_BASE_BRANCH,
   GIT_PULL_REQUEST_BASE_BRANCH_SHA,
+  PR_ID,
 } from './tags'
 import {getUserCISpanTags, getUserGitSpanTags} from './user-provided-git'
 import {
@@ -303,6 +304,7 @@ export const getCISpanTags = (): SpanTags | undefined => {
         const eventPayload = getGitHubEventPayload()
         tags[GIT_HEAD_SHA] = eventPayload?.pull_request?.head?.sha
         tags[GIT_PULL_REQUEST_BASE_BRANCH_SHA] = eventPayload?.pull_request?.base?.sha
+        tags[PR_ID] = eventPayload?.pull_request?.number?.toString()
       } catch (e) {
         // ignore malformed event content
       }

--- a/src/helpers/interfaces.ts
+++ b/src/helpers/interfaces.ts
@@ -33,6 +33,7 @@ import {
   GIT_PULL_REQUEST_BASE_BRANCH_SHA,
   SBOM_TOOL_GENERATOR_NAME,
   SBOM_TOOL_GENERATOR_VERSION,
+  PR_ID,
 } from './tags'
 
 export interface Metadata {
@@ -107,6 +108,7 @@ export type SpanTag =
   | typeof GIT_PULL_REQUEST_BASE_BRANCH_SHA
   | typeof SBOM_TOOL_GENERATOR_NAME
   | typeof SBOM_TOOL_GENERATOR_VERSION
+  | typeof PR_ID
 
 export type SpanTags = Partial<Record<SpanTag, string>>
 

--- a/src/helpers/tags.ts
+++ b/src/helpers/tags.ts
@@ -42,6 +42,9 @@ export const GIT_BASE_REF = 'git.commit.base_ref'
 export const GIT_PULL_REQUEST_BASE_BRANCH_SHA = 'git.pull_request.base_branch_sha'
 export const GIT_PULL_REQUEST_BASE_BRANCH = 'git.pull_request.base_branch'
 
+// PR
+export const PR_ID = 'pr.id'
+
 // Sbom
 export const SBOM_TOOL_GENERATOR_NAME = 'tool.generator.name'
 export const SBOM_TOOL_GENERATOR_VERSION = 'tool.generator.version'

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -412,6 +412,7 @@ type GitHubWebhookPayload = {
     base?: {
       sha: string
     }
+    number?: number
   }
 }
 


### PR DESCRIPTION
### What and why?

Updates `coverage upload` command to include git diff data for current commit and current PR (if detected).

### How?

Git diff data is obtained using `simpleGit` and is attached to the uploaded events.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
