### PR TITLE
[synthetics] Modify the datadog-ci deploy command to exclude certain fields from being updated

### DIFF
--- a/src/commands/synthetics/__tests__/cli.test.ts
+++ b/src/commands/synthetics/__tests__/cli.test.ts
@@ -1628,6 +1628,7 @@ describe('deploy-tests', () => {
         proxy: {protocol: 'http'},
         publicIds: ['ran-dom-id1'],
         subdomain: 'ppa',
+        exclude_fields: ['config'],
       }
 
       const command = createCommand(DeployTestsCommand)

--- a/src/commands/synthetics/__tests__/deploy-tests-lib.test.ts
+++ b/src/commands/synthetics/__tests__/deploy-tests-lib.test.ts
@@ -79,5 +79,124 @@ describe('deploy-tests', () => {
       const {public_id, monitor_id, ...expectedUpdate} = getApiTest('123-456-789')
       expect(apiHelper.editTest).toHaveBeenNthCalledWith(1, '123-456-789', expectedUpdate)
     })
+
+    it('excludes specified fields from the payload', async () => {
+      const config = DeployTestsCommand.getDefaultConfig()
+      config['exclude_fields'] = ['config', 'locations']
+
+      const localTest = getApiLocalTestDefinition('123-456-789', {
+        config: {
+          assertions: [],
+          request: {
+            headers: {},
+            method: 'POST',
+            timeout: 60000,
+            url: 'http://new.url',
+          },
+          variables: [],
+        },
+        locations: ['new-location'],
+      })
+
+      jest
+        .spyOn(tests, 'getTestConfigs')
+        .mockImplementation(async () => [{localTestDefinition: localTest}])
+
+      const existingRemoteTest = getApiTest('123-456-789', {
+        config: {
+          assertions: [],
+          request: {
+            headers: {},
+            method: 'GET',
+            timeout: 60000,
+            url: 'http://old.url',
+          },
+          variables: [],
+        },
+        locations: ['old-location'],
+      })
+
+      const apiHelper = mockApi({
+        getTest: jest.fn(async () => existingRemoteTest),
+        editTest: jest.fn(),
+      })
+      jest.spyOn(api, 'getApiHelper').mockImplementation(() => apiHelper as any)
+
+      await deployTests(mockReporter, config)
+
+      expect(tests.getTestConfigs).toHaveBeenCalledTimes(1)
+      expect(apiHelper.getTest).toHaveBeenCalledTimes(1)
+      expect(apiHelper.editTest).toHaveBeenCalledTimes(1)
+
+      const expectedTest = {
+        ...localTest,
+        config: existingRemoteTest.config,
+        locations: existingRemoteTest.locations,
+        message: '',
+        status: 'live',
+        tags: [],
+      }
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      const {public_id, ...expectedUpdate} = expectedTest
+      expect(apiHelper.editTest).toHaveBeenCalledWith('123-456-789', expectedUpdate)
+    })
+
+    it('excludes config field by default', async () => {
+      const config = DeployTestsCommand.getDefaultConfig()
+
+      const localTest = getApiLocalTestDefinition('123-456-789', {
+        config: {
+          assertions: [],
+          request: {
+            headers: {},
+            method: 'POST',
+            timeout: 60000,
+            url: 'http://new.url',
+          },
+          variables: [],
+        },
+      })
+
+      jest
+        .spyOn(tests, 'getTestConfigs')
+        .mockImplementation(async () => [{localTestDefinition: localTest}])
+
+      const existingRemoteTest = getApiTest('123-456-789', {
+        config: {
+          assertions: [],
+          request: {
+            headers: {},
+            method: 'GET',
+            timeout: 60000,
+            url: 'http://old.url',
+          },
+          variables: [],
+        },
+      })
+
+      const apiHelper = mockApi({
+        getTest: jest.fn(async () => existingRemoteTest),
+        editTest: jest.fn(),
+      })
+      jest.spyOn(api, 'getApiHelper').mockImplementation(() => apiHelper as any)
+
+      await deployTests(mockReporter, config)
+
+      expect(tests.getTestConfigs).toHaveBeenCalledTimes(1)
+      expect(apiHelper.getTest).toHaveBeenCalledTimes(1)
+      expect(apiHelper.editTest).toHaveBeenCalledTimes(1)
+
+      // The final test should have the config from the remote test
+      const expectedTest = {
+        ...localTest,
+        config: existingRemoteTest.config,
+        message: '',
+        status: 'live',
+        tags: [],
+      }
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      const {public_id, ...expectedUpdate} = expectedTest
+      expect(apiHelper.editTest).toHaveBeenCalledWith('123-456-789', expectedUpdate)
+    })
   })
 })

--- a/src/commands/synthetics/__tests__/deploy-tests-lib.test.ts
+++ b/src/commands/synthetics/__tests__/deploy-tests-lib.test.ts
@@ -98,9 +98,7 @@ describe('deploy-tests', () => {
         locations: ['new-location'],
       })
 
-      jest
-        .spyOn(tests, 'getTestConfigs')
-        .mockImplementation(async () => [{localTestDefinition: localTest}])
+      jest.spyOn(tests, 'getTestConfigs').mockImplementation(async () => [{localTestDefinition: localTest}])
 
       const existingRemoteTest = getApiTest('123-456-789', {
         config: {
@@ -157,9 +155,7 @@ describe('deploy-tests', () => {
         },
       })
 
-      jest
-        .spyOn(tests, 'getTestConfigs')
-        .mockImplementation(async () => [{localTestDefinition: localTest}])
+      jest.spyOn(tests, 'getTestConfigs').mockImplementation(async () => [{localTestDefinition: localTest}])
 
       const existingRemoteTest = getApiTest('123-456-789', {
         config: {

--- a/src/commands/synthetics/deploy-tests-command.ts
+++ b/src/commands/synthetics/deploy-tests-command.ts
@@ -41,6 +41,9 @@ export class DeployTestsCommand extends BaseCommand {
     description:
       'The custom subdomain to access your Datadog organization. If your URL is `myorg.datadoghq.com`, the custom subdomain is `myorg`.',
   })
+  private excludeFields = Option.Array('--exclude-fields', {
+    description: 'Fields to exclude from the payload when calling the API. The "config" attribute is excluded by default.',
+  })
 
   public static getDefaultConfig(): DeployTestsCommandConfig {
     return {
@@ -48,6 +51,7 @@ export class DeployTestsCommand extends BaseCommand {
       files: [],
       publicIds: [],
       subdomain: 'app',
+      exclude_fields: ['config'],
     }
   }
 
@@ -72,6 +76,7 @@ export class DeployTestsCommand extends BaseCommand {
       files: process.env.DATADOG_SYNTHETICS_FILES?.split(';'),
       publicIds: process.env.DATADOG_SYNTHETICS_PUBLIC_IDS?.split(';'),
       subdomain: process.env.DATADOG_SUBDOMAIN,
+      exclude_fields: process.env.DATADOG_SYNTHETICS_EXCLUDE_FIELDS?.split(';'),
     }
   }
 
@@ -81,6 +86,7 @@ export class DeployTestsCommand extends BaseCommand {
       files: this.files,
       publicIds: this.publicIds,
       subdomain: this.subdomain,
+      exclude_fields: this.excludeFields,
     }
   }
 }

--- a/src/commands/synthetics/deploy-tests-command.ts
+++ b/src/commands/synthetics/deploy-tests-command.ts
@@ -42,7 +42,8 @@ export class DeployTestsCommand extends BaseCommand {
       'The custom subdomain to access your Datadog organization. If your URL is `myorg.datadoghq.com`, the custom subdomain is `myorg`.',
   })
   private excludeFields = Option.Array('--exclude-fields', {
-    description: 'Fields to exclude from the payload when calling the API. The "config" attribute is excluded by default.',
+    description:
+      'Fields to exclude from the payload when calling the API. The "config" attribute is excluded by default.',
   })
 
   public static getDefaultConfig(): DeployTestsCommandConfig {

--- a/src/commands/synthetics/deploy-tests-lib.ts
+++ b/src/commands/synthetics/deploy-tests-lib.ts
@@ -5,7 +5,11 @@ import {DeployTestsCommandConfig, LocalTriggerConfig, MainReporter, ServerTest} 
 import {getTestConfigs} from './test'
 import {isLocalTriggerConfig} from './utils/internal'
 
-const removeExcludedFields = (existingRemoteTest: ServerTest, excludeFields: string[], test: ServerTest): ServerTest => {
+const removeExcludedFields = (
+  existingRemoteTest: ServerTest,
+  excludeFields: string[],
+  test: ServerTest
+): ServerTest => {
   if (!excludeFields || excludeFields.length === 0) {
     return test
   }
@@ -14,7 +18,7 @@ const removeExcludedFields = (existingRemoteTest: ServerTest, excludeFields: str
   for (const field of excludeFields as (keyof ServerTest)[]) {
     const value = existingRemoteTest[field] as unknown
     if (value !== undefined) {
-      (newTest as Record<keyof ServerTest, unknown>)[field] = value
+      ;(newTest as Record<keyof ServerTest, unknown>)[field] = value
     }
   }
 

--- a/src/commands/synthetics/interfaces.ts
+++ b/src/commands/synthetics/interfaces.ts
@@ -696,4 +696,5 @@ export interface DeployTestsCommandConfig extends SyntheticsCIConfig {
   files: string[]
   publicIds: string[]
   subdomain: string
+  exclude_fields?: string[]
 }


### PR DESCRIPTION
### What and why?
This PR adds support for excluding specified fields from the payload when updating Synthetics tests via the datadog-ci synthetics deploy-tests command. This enables more flexible control over which fields are updated in remote tests, and, by default, ensures that certain fields (such as `config`) are preserved from the existing remote test.

Previously, when deploying Synthetics tests via deploy-tests, the entire local test definition was sent to the API, potentially overwriting remote fields unintentionally. In some cases (e.g., `config`), we want to preserve the current remote values. This change allows users to specify which fields should be excluded from the update payload, defaulting to exclude config.

### How?
Added a new option --exclude-fields to the deploy-tests command.
By default, the config field is excluded from updates, preserving the remote test’s config.


### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
