### PR TITLE
[synthetics] Fix output of mobile app upload command

### DIFF
--- a/src/commands/synthetics/__tests__/cli.test.ts
+++ b/src/commands/synthetics/__tests__/cli.test.ts
@@ -13,6 +13,7 @@ import {
   DeployTestsCommandConfig,
   ExecutionRule,
   ImportTestsCommandConfig,
+  MobileAppUploadResult,
   RunTestsCommandConfig,
   ServerTest,
   UploadApplicationCommandConfig,
@@ -1431,6 +1432,36 @@ describe('upload-application', () => {
         versionName: 'new',
         latest: true,
       })
+    })
+  })
+
+  describe('reporting version UUID', () => {
+    test('UUID is reported when present', async () => {
+      jest.spyOn(mobile, 'uploadMobileApplicationVersion').mockResolvedValue({
+        valid_app_result: {
+          app_version_uuid: 'fake-uuid',
+        },
+      } as MobileAppUploadResult)
+
+      const writeMock = jest.fn()
+      const command = createCommand(UploadApplicationCommand, {stdout: {write: writeMock}})
+
+      expect(await command['execute']()).toBe(0)
+      expect(writeMock).toHaveBeenCalledWith(expect.stringContaining('The new version has version ID: fake-uuid'))
+    })
+
+    test('the command fails when no UUID is present', async () => {
+      jest.spyOn(mobile, 'uploadMobileApplicationVersion').mockResolvedValue({
+        valid_app_result: undefined,
+      } as MobileAppUploadResult)
+
+      const writeMock = jest.fn()
+      const command = createCommand(UploadApplicationCommand, {stdout: {write: writeMock}})
+
+      expect(await command['execute']()).toBe(1)
+      expect(writeMock).toHaveBeenCalledWith(
+        expect.stringContaining('The upload was successful, but the version ID is missing.')
+      )
     })
   })
 

--- a/src/commands/synthetics/upload-application-command.ts
+++ b/src/commands/synthetics/upload-application-command.ts
@@ -85,6 +85,8 @@ export class UploadApplicationCommand extends BaseCommand {
 
       return 1
     }
+
+    return 0
   }
 
   protected resolveConfigFromEnv(): RecursivePartial<UploadApplicationCommandConfig> {

--- a/src/commands/synthetics/upload-application-command.ts
+++ b/src/commands/synthetics/upload-application-command.ts
@@ -1,3 +1,4 @@
+import chalk from 'chalk'
 import {Command, Option} from 'clipanion'
 
 import {toBoolean} from '../../helpers/env'
@@ -58,7 +59,20 @@ export class UploadApplicationCommand extends BaseCommand {
 
     const appUploadReporter = new AppUploadReporter(this.context)
     try {
-      await uploadMobileApplicationVersion(this.config, appUploadReporter)
+      const result = await uploadMobileApplicationVersion(this.config, appUploadReporter)
+      const versionUuid = result.valid_app_result?.app_version_uuid
+
+      if (!versionUuid) {
+        this.logger.error('The upload was successful, but the version ID is missing.')
+
+        return 1
+      }
+
+      this.logger.info(
+        `\nThe new version has version ID: ${chalk.green(
+          versionUuid
+        )}\nPass it when triggering Synthetic tests to run tests against that version.`
+      )
     } catch (error) {
       if (error instanceof CiError) {
         this.logger.error(`A CI error occurred: [${error.code}] ${error.message}`)


### PR DESCRIPTION
### What and why?

This PR adds back the version UUID in the output, so that it can be [extracted from the logs](https://github.com/DataDog/synthetics-test-automation-bitrise-step-upload-application/blob/2eacc2b79ad4aeb5166d3d9a1e75a1fc6b6d4104/upload-application.sh#L52) in the https://github.com/DataDog/synthetics-test-automation-bitrise-step-upload-application CI integration.

<img width="1294" alt="image" src="https://github.com/user-attachments/assets/248506b3-885a-4088-873f-b8b14c7005a5" />

### How?

The log was removed in a previous PR, so we are reintroducing it (slightly rephrased with a hint on how to use that version ID/UUID). See https://github.com/DataDog/datadog-ci/pull/1240#discussion_r2100010499.

Without this log, the Bitrise upload-application step won't be able to produce its expected `DATADOG_UPLOADED_APPLICATION_VERSION_ID` output.

<img width="1372" alt="image" src="https://github.com/user-attachments/assets/40ba111a-9e19-4fd1-aab8-5a21d6806f0e" />

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
