### PR TITLE
[synthetics] Fix poll results for mobile results

### DIFF
--- a/src/commands/synthetics/__tests__/api.test.ts
+++ b/src/commands/synthetics/__tests__/api.test.ts
@@ -72,9 +72,29 @@ describe('dd-api', () => {
             ...API_TEST.config,
             request: {
               ...API_TEST.config.request,
-              dns_server: API_TEST.config.request.dnsServer,
+              dns_server: API_TEST.config.request?.dnsServer,
             },
           },
+        },
+      },
+    ],
+  }
+  const MOBILE_RAW_POLL_RESULTS: RawPollResult = {
+    data: [
+      {
+        ...RAW_POLL_RESULTS.data[0],
+        attributes: {
+          ...POLL_RESULTS[0],
+          test_type: 'mobile',
+        },
+      },
+    ],
+    included: [
+      {
+        ...RAW_POLL_RESULTS.included[0],
+        attributes: {
+          ...RAW_POLL_RESULTS.included[0].attributes,
+          config: {}, // Mobile tests do not have a `request` object.
         },
       },
     ],
@@ -90,6 +110,13 @@ describe('dd-api', () => {
 
   test('should get results from api', async () => {
     jest.spyOn(axios, 'create').mockImplementation((() => () => ({data: RAW_POLL_RESULTS})) as any)
+    const api = apiConstructor(apiConfiguration)
+    const results = await api.pollResults([RESULT_ID])
+    expect(results[0].resultID).toBe(RESULT_ID)
+  })
+
+  test('should get mobile results from api', async () => {
+    jest.spyOn(axios, 'create').mockImplementation((() => () => ({data: MOBILE_RAW_POLL_RESULTS})) as any)
     const api = apiConstructor(apiConfiguration)
     const results = await api.pollResults([RESULT_ID])
     expect(results[0].resultID).toBe(RESULT_ID)

--- a/src/commands/synthetics/__tests__/batch.test.ts
+++ b/src/commands/synthetics/__tests__/batch.test.ts
@@ -840,7 +840,7 @@ describe('waitForResults', () => {
       mockReporter
     )
 
-    expect(results.map(({test}) => test.config.request.url)).toEqual(['http://fake.url', 'https://reddit.com/'])
+    expect(results.map(({test}) => test.config.request?.url)).toEqual(['http://fake.url', 'https://reddit.com/'])
   })
 
   test('results should be timed out if the backend says so', async () => {

--- a/src/commands/synthetics/api.ts
+++ b/src/commands/synthetics/api.ts
@@ -236,7 +236,7 @@ const parseIncludedTest = (test: RawPollResultTest): PollResult['test'] => {
       ...test.config,
       request: {
         ...test.config.request,
-        dnsServer: test.config.request.dns_server,
+        dnsServer: test.config.request?.dns_server,
       },
     },
   }

--- a/src/commands/synthetics/interfaces.ts
+++ b/src/commands/synthetics/interfaces.ts
@@ -107,7 +107,7 @@ export interface RawPollResultTest {
   type: 'browser' | 'api' | 'mobile'
   subtype?: string
   config: {
-    request: {
+    request?: {
       dns_server?: string | undefined
     }
   }
@@ -294,7 +294,7 @@ export interface TestStepWithUnsupportedFields {
 export interface LocalTestDefinition {
   config: {
     assertions: Assertion[]
-    request: {
+    request?: {
       dnsServer?: string
       headers: {[key: string]: string}
       host?: string

--- a/src/commands/synthetics/reporters/default.ts
+++ b/src/commands/synthetics/reporters/default.ts
@@ -163,7 +163,12 @@ const renderResultOutcome = (
 
 const renderApiRequestDescription = (subType: string, config: Test['config']): string => {
   const {request, steps} = config
+
   if (subType === 'dns') {
+    if (!request?.host) {
+      return 'Invalid DNS result'
+    }
+
     const text = `Query for ${request.host}`
     if (request.dnsServer) {
       return `${text} on server ${request.dnsServer}`
@@ -173,6 +178,10 @@ const renderApiRequestDescription = (subType: string, config: Test['config']): s
   }
 
   if (subType === 'ssl' || subType === 'tcp') {
+    if (!request?.host || !request?.port) {
+      return 'Invalid SSL/TCP result'
+    }
+
     return `Host: ${request.host}:${request.port}`
   }
 
@@ -193,6 +202,10 @@ const renderApiRequestDescription = (subType: string, config: Test['config']): s
   }
 
   if (subType === 'http') {
+    if (!request?.method || !request?.url) {
+      return 'Invalid HTTP result'
+    }
+
     return `${chalk.bold(request.method)} - ${request.url}`
   }
 


### PR DESCRIPTION
### What and why?

This PR makes `config.request` optional for mobile tests.

Otherwise, the CLI fails with the following error when polling results:

```js
 ERROR: unable to poll test results 
Failed to poll results: could not query undefinedundefined
Cannot read properties of undefined (reading 'dns_server')
```

### How?

Make this property optional everywhere.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
