### PR TITLE
[K9VULN-4956] Update text when unable to infer default branch

### DIFF
--- a/src/commands/sbom/README.md
+++ b/src/commands/sbom/README.md
@@ -30,6 +30,9 @@ The following environment variables must be defined:
  - `DD_APP_KEY`: the App key to use
  - `DD_API_KEY`: the API key to use
 
+Optional environment variables:
+ - `DD_SUBDOMAIN`: if you have a [custom sub-domain enabled](https://docs.datadoghq.com/account_management/multi_organization/#custom-sub-domains) for your organization, this value should be set with the subdomain so that the link to the Datadog Application that the library logs once the upload finishes is accurate.
+
 ### Git context resolution
 
 The Git context is resolved in the following order of priority:

--- a/src/commands/sbom/README.md
+++ b/src/commands/sbom/README.md
@@ -31,7 +31,7 @@ The following environment variables must be defined:
  - `DD_API_KEY`: the API key to use
 
 Optional environment variables:
- - `DD_SUBDOMAIN`: if you have a [custom sub-domain enabled](https://docs.datadoghq.com/account_management/multi_organization/#custom-sub-domains) for your organization, this value should be set with the subdomain so that the link to the Datadog Application that the library logs once the upload finishes is accurate.
+ - `DD_SUBDOMAIN`: If you have a [custom sub-domain enabled](https://docs.datadoghq.com/account_management/multi_organization/#custom-sub-domains) for your organization, set this variable to your subdomain. This ensures that the link to the Datadog Application, which the library logs after uploading, points to the correct location.
 
 ### Git context resolution
 

--- a/src/commands/sbom/renderer.ts
+++ b/src/commands/sbom/renderer.ts
@@ -44,11 +44,11 @@ export const renderDuplicateUpload = (sha: string, env: string, service: string)
 export const renderNoDefaultBranch = (repositoryUrl: string) => {
   let fullStr = ''
 
-  fullStr += chalk.red(`Default branch not found for repository ${repositoryUrl}\n`)
-  fullStr += chalk.red(`Fix this issue by either:\n`)
-  fullStr += chalk.red(` - define a default branch in the repository settings on Datadog\n`)
-  fullStr += chalk.red(` - push result from your default branch first\n\n`)
-  fullStr += chalk.red(`Run an analysis once the issue is resolved\n`)
+c  fullStr += chalk.red(`${ICONS.WARNING}  Failed to infer the default branch for ${repositoryUrl}\n`)
+  fullStr += chalk.red(`To fix this:\n`)
+  fullStr += chalk.red(` - upload from your default branch first (must be one of master, main, default, stable, source, prod, or develop)\n`)
+  fullStr += chalk.red(` - visit ${getBaseUrl()}source-code/repositories two override your default branch for this repository\n`)
+  fullStr += chalk.red(`Afterwards, you may attempt to re-upload your SBOM on this branch\n`)
 
   return fullStr
 }

--- a/src/commands/sbom/renderer.ts
+++ b/src/commands/sbom/renderer.ts
@@ -44,11 +44,11 @@ export const renderDuplicateUpload = (sha: string, env: string, service: string)
 export const renderNoDefaultBranch = (repositoryUrl: string) => {
   let fullStr = ''
 
-c  fullStr += chalk.red(`${ICONS.WARNING}  Failed to infer the default branch for ${repositoryUrl}\n`)
-  fullStr += chalk.red(`To fix this:\n`)
-  fullStr += chalk.red(` - upload from your default branch first (must be one of master, main, default, stable, source, prod, or develop)\n`)
-  fullStr += chalk.red(` - visit ${getBaseUrl()}source-code/repositories two override your default branch for this repository\n`)
-  fullStr += chalk.red(`Afterwards, you may attempt to re-upload your SBOM on this branch\n`)
+  fullStr += chalk.red(`${ICONS.WARNING}  Failed to infer the default branch for ${repositoryUrl}\n`)
+  fullStr += chalk.red(`To resolve this, do one of the following:\n`)
+  fullStr += chalk.red(` - Upload from your default branch first (must be one of: master, main, default, stable, source, prod, or develop)\n`)
+  fullStr += chalk.red(` - Or visit ${getBaseUrl()}source-code/repositories to manually override the default branch for this repository\n`)
+  fullStr += chalk.red(`After completing either step, you can retry uploading the SBOM from this branch\n`)
 
   return fullStr
 }

--- a/src/commands/sbom/renderer.ts
+++ b/src/commands/sbom/renderer.ts
@@ -46,8 +46,12 @@ export const renderNoDefaultBranch = (repositoryUrl: string) => {
 
   fullStr += chalk.red(`${ICONS.WARNING}  Failed to infer the default branch for ${repositoryUrl}\n`)
   fullStr += chalk.red(`To resolve this, do one of the following:\n`)
-  fullStr += chalk.red(` - Upload from your default branch first (must be one of: master, main, default, stable, source, prod, or develop)\n`)
-  fullStr += chalk.red(` - Or visit ${getBaseUrl()}source-code/repositories to manually override the default branch for this repository\n`)
+  fullStr += chalk.red(
+    ` - Upload from your default branch first (must be one of: master, main, default, stable, source, prod, or develop)\n`
+  )
+  fullStr += chalk.red(
+    ` - Or visit ${getBaseUrl()}source-code/repositories to manually override the default branch for this repository\n`
+  )
   fullStr += chalk.red(`After completing either step, you can retry uploading the SBOM from this branch\n`)
 
   return fullStr


### PR DESCRIPTION
### What and why?

When Datadog is unable to determine or infer a default branch for a repository, we should make it as simple as possible (these are often users that are onboarding) to address the issue.

### New Output

![Screenshot 2025-05-22 at 4 08 25 PM](https://github.com/user-attachments/assets/e11049e8-c156-4b36-b806-d0efa7819a04)
