### PR TITLE
Add base and head SHAs to git diff data uploaded with coverage

### DIFF
--- a/src/commands/coverage/api.ts
+++ b/src/commands/coverage/api.ts
@@ -36,13 +36,13 @@ export const uploadCodeCoverageReport = (request: (args: AxiosRequestConfig) => 
 
   if (payload.prDiff) {
     form.append('pr_diff', gzipSync(Buffer.from(JSON.stringify(payload.prDiff), 'utf8')), {
-      filename: 'pr_diff.json',
+      filename: 'pr_diff.json.gz',
     })
   }
 
   if (payload.commitDiff) {
     form.append('commit_diff', gzipSync(Buffer.from(JSON.stringify(payload.commitDiff), 'utf8')), {
-      filename: 'commit_diff.json',
+      filename: 'commit_diff.json.gz',
     })
   }
 

--- a/src/commands/coverage/interfaces.ts
+++ b/src/commands/coverage/interfaces.ts
@@ -2,7 +2,7 @@ import type {AxiosPromise, AxiosResponse} from 'axios'
 
 import {SpanTags} from '../../helpers/interfaces'
 
-import {DiffNode} from '../git-metadata/git'
+import {DiffData} from '../git-metadata/git'
 
 export interface Payload {
   hostname: string
@@ -11,8 +11,8 @@ export interface Payload {
   customMeasures: Record<string, number>
   paths: string[]
   format: string
-  commitDiff: Record<string, DiffNode> | undefined
-  prDiff: Record<string, DiffNode> | undefined
+  commitDiff: DiffData | undefined
+  prDiff: DiffData | undefined
 }
 
 export interface APIHelper {

--- a/src/commands/coverage/upload.ts
+++ b/src/commands/coverage/upload.ts
@@ -25,7 +25,7 @@ import {
 } from '../../helpers/tags'
 import {getUserGitSpanTags} from '../../helpers/user-provided-git'
 
-import {newSimpleGit, getGitDiff, DiffNode} from '../git-metadata/git'
+import {newSimpleGit, getGitDiff, DiffData} from '../git-metadata/git'
 
 import {apiConstructor, intakeUrl} from './api'
 import {APIHelper, Payload} from './interfaces'
@@ -218,7 +218,7 @@ export class UploadCodeCoverageReportCommand extends Command {
     return payloads
   }
 
-  private async getPrDiff(spanTags: SpanTags): Promise<Record<string, DiffNode> | undefined> {
+  private async getPrDiff(spanTags: SpanTags): Promise<DiffData | undefined> {
     if (!this.uploadGitDiff) {
       return undefined
     }
@@ -240,7 +240,7 @@ export class UploadCodeCoverageReportCommand extends Command {
     }
   }
 
-  private async getCommitDiff(spanTags: SpanTags): Promise<Record<string, DiffNode> | undefined> {
+  private async getCommitDiff(spanTags: SpanTags): Promise<DiffData | undefined> {
     if (!this.uploadGitDiff) {
       return undefined
     }

--- a/src/commands/git-metadata/__tests__/git.test.ts
+++ b/src/commands/git-metadata/__tests__/git.test.ts
@@ -81,12 +81,12 @@ describe('git', () => {
       }) as any
       const gitDiff = await getGitDiff(mock, 'HEAD^', 'HEAD')
 
-      expect(gitDiff.headSha).toEqual('abcd')
-      expect(gitDiff.baseSha).toEqual('abcd')
+      expect(gitDiff.head_sha).toEqual('abcd')
+      expect(gitDiff.base_sha).toEqual('abcd')
 
       const calc = gitDiff.files['src/Calculator.java']
-      expect(decode(calc.addedLines)).toEqual(new Set([10, 11]))
-      expect(decode(calc.removedLines)).toEqual(new Set([10, 11]))
+      expect(decode(calc.added_lines)).toEqual(new Set([10, 11]))
+      expect(decode(calc.removed_lines)).toEqual(new Set([10, 11]))
     })
   })
   describe('getCommitInfo', () => {
@@ -154,8 +154,8 @@ describe('parseGitDiff – tree structure', () => {
     const tree = parseGitDiff(diff)
 
     const calc = tree['src/Calculator.java']
-    expect(decode(calc.addedLines)).toEqual(new Set([10, 11]))
-    expect(decode(calc.removedLines)).toEqual(new Set([10, 11]))
+    expect(decode(calc.added_lines)).toEqual(new Set([10, 11]))
+    expect(decode(calc.removed_lines)).toEqual(new Set([10, 11]))
   })
 
   test('file add & delete in one patch', () => {
@@ -164,13 +164,13 @@ describe('parseGitDiff – tree structure', () => {
 
     // deleted README.md
     const readme = tree['README.md']
-    expect(readme.addedLines).toBe('')
-    expect(decode(readme.removedLines)).toEqual(new Set([1, 2]))
+    expect(readme.added_lines).toBe('')
+    expect(decode(readme.removed_lines)).toEqual(new Set([1, 2]))
 
     // new Utils.java
     const utils = tree['src/Utils.java']
-    expect(decode(utils.addedLines)).toEqual(new Set([1, 2, 3, 4]))
-    expect(utils.removedLines).toBe('')
+    expect(decode(utils.added_lines)).toEqual(new Set([1, 2, 3, 4]))
+    expect(utils.removed_lines).toBe('')
   })
 })
 

--- a/src/commands/git-metadata/git.ts
+++ b/src/commands/git-metadata/git.ts
@@ -67,17 +67,30 @@ export const getGitDiff = async (
   git: simpleGit.SimpleGit,
   from: string,
   to: string
-): Promise<Record<string, DiffNode>> => {
+): Promise<DiffData> => {
+  const fromResolved = await git.revparse(from)
+  const toResolved = await git.revparse(to)
+
   const rawDiff = await git.diff([
     '--unified=0',
     '--no-color',
     '--no-ext-diff',
     '--no-renames',
     '--diff-algorithm=minimal',
-    `${from}..${to}`,
+    `${fromResolved}..${toResolved}`,
   ])
 
-  return parseGitDiff(rawDiff)
+  return {
+    headSha: toResolved,
+    baseSha: fromResolved,
+    files: parseGitDiff(rawDiff),
+  }
+}
+
+export interface DiffData {
+  headSha: string
+  baseSha: string
+  files: Record<string, DiffNode>
 }
 
 export interface DiffNode {

--- a/src/commands/git-metadata/git.ts
+++ b/src/commands/git-metadata/git.ts
@@ -63,11 +63,7 @@ export const getCommitInfo = async (git: simpleGit.SimpleGit, repositoryURL?: st
   return new CommitInfo(hash, remote, trackedFiles)
 }
 
-export const getGitDiff = async (
-  git: simpleGit.SimpleGit,
-  from: string,
-  to: string
-): Promise<DiffData> => {
+export const getGitDiff = async (git: simpleGit.SimpleGit, from: string, to: string): Promise<DiffData> => {
   const fromResolved = await git.revparse(from)
   const toResolved = await git.revparse(to)
 

--- a/src/commands/git-metadata/git.ts
+++ b/src/commands/git-metadata/git.ts
@@ -77,21 +77,21 @@ export const getGitDiff = async (git: simpleGit.SimpleGit, from: string, to: str
   ])
 
   return {
-    headSha: toResolved,
-    baseSha: fromResolved,
+    head_sha: toResolved,
+    base_sha: fromResolved,
     files: parseGitDiff(rawDiff),
   }
 }
 
 export interface DiffData {
-  headSha: string
-  baseSha: string
+  head_sha: string
+  base_sha: string
   files: Record<string, DiffNode>
 }
 
 export interface DiffNode {
-  addedLines: string // base-64 bit-vector
-  removedLines: string // base-64 bit-vector
+  added_lines: string // base-64 bit-vector
+  removed_lines: string // base-64 bit-vector
 }
 
 const diffHeaderRegex = /^diff --git a\/.+ b\/(.+)$/
@@ -112,8 +112,8 @@ export const parseGitDiff = (diff: string): Record<string, DiffNode> => {
     if (diffHeader) {
       if (currentPath && currentLines) {
         root[currentPath] = {
-          addedLines: base64Encode(currentLines.addedLines),
-          removedLines: base64Encode(currentLines.removedLines),
+          added_lines: base64Encode(currentLines.addedLines),
+          removed_lines: base64Encode(currentLines.removedLines),
         }
       }
 
@@ -145,8 +145,8 @@ export const parseGitDiff = (diff: string): Record<string, DiffNode> => {
 
   if (currentPath && currentLines) {
     root[currentPath] = {
-      addedLines: base64Encode(currentLines.addedLines),
-      removedLines: base64Encode(currentLines.removedLines),
+      added_lines: base64Encode(currentLines.addedLines),
+      removed_lines: base64Encode(currentLines.removedLines),
     }
   }
 


### PR DESCRIPTION
### What and why?

Updates the format of git diff data uploaded together with code coverage data.
Apart from the list of files with their added/removed lines, the updated diff contains the SHAs of the head and base commits used to calculate the diff.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
