### PR TITLE
Rename PR ID tag to PR number

### DIFF
--- a/src/helpers/__tests__/ci.test.ts
+++ b/src/helpers/__tests__/ci.test.ts
@@ -10,7 +10,7 @@ import {
   GIT_PULL_REQUEST_BASE_BRANCH,
   GIT_PULL_REQUEST_BASE_BRANCH_SHA,
   GIT_HEAD_SHA,
-  PR_ID,
+  PR_NUMBER,
 } from '../tags'
 import {getUserCISpanTags, getUserGitSpanTags} from '../user-provided-git'
 
@@ -199,19 +199,19 @@ describe('ci spec', () => {
             [GIT_PULL_REQUEST_BASE_BRANCH]: pullRequestBaseBranch,
             [GIT_PULL_REQUEST_BASE_BRANCH_SHA]: pullRequestBaseBranchSha,
             [GIT_HEAD_SHA]: headCommitSha,
-            [PR_ID]: prId,
+            [PR_NUMBER]: prNumber,
           } = getCISpanTags() as SpanTags
 
           expect({
             pullRequestBaseBranch,
             pullRequestBaseBranchSha,
             headCommitSha,
-            prId,
+            prNumber: prNumber,
           }).toEqual({
             pullRequestBaseBranch: 'datadog:main',
             pullRequestBaseBranchSha: '52e0974c74d41160a03d59ddc73bb9f5adab054b',
             headCommitSha: 'df289512a51123083a8e6931dd6f57bb3883d4c4',
-            prId: '1',
+            prNumber: '1',
           })
         })
 

--- a/src/helpers/__tests__/ci.test.ts
+++ b/src/helpers/__tests__/ci.test.ts
@@ -206,7 +206,7 @@ describe('ci spec', () => {
             pullRequestBaseBranch,
             pullRequestBaseBranchSha,
             headCommitSha,
-            prNumber: prNumber,
+            prNumber,
           }).toEqual({
             pullRequestBaseBranch: 'datadog:main',
             pullRequestBaseBranchSha: '52e0974c74d41160a03d59ddc73bb9f5adab054b',

--- a/src/helpers/ci.ts
+++ b/src/helpers/ci.ts
@@ -27,7 +27,7 @@ import {
   GIT_BASE_REF,
   GIT_PULL_REQUEST_BASE_BRANCH,
   GIT_PULL_REQUEST_BASE_BRANCH_SHA,
-  PR_ID,
+  PR_NUMBER,
 } from './tags'
 import {getUserCISpanTags, getUserGitSpanTags} from './user-provided-git'
 import {
@@ -304,7 +304,7 @@ export const getCISpanTags = (): SpanTags | undefined => {
         const eventPayload = getGitHubEventPayload()
         tags[GIT_HEAD_SHA] = eventPayload?.pull_request?.head?.sha
         tags[GIT_PULL_REQUEST_BASE_BRANCH_SHA] = eventPayload?.pull_request?.base?.sha
-        tags[PR_ID] = eventPayload?.pull_request?.number?.toString()
+        tags[PR_NUMBER] = eventPayload?.pull_request?.number?.toString()
       } catch (e) {
         // ignore malformed event content
       }

--- a/src/helpers/interfaces.ts
+++ b/src/helpers/interfaces.ts
@@ -33,7 +33,7 @@ import {
   GIT_PULL_REQUEST_BASE_BRANCH_SHA,
   SBOM_TOOL_GENERATOR_NAME,
   SBOM_TOOL_GENERATOR_VERSION,
-  PR_ID,
+  PR_NUMBER,
 } from './tags'
 
 export interface Metadata {
@@ -108,7 +108,7 @@ export type SpanTag =
   | typeof GIT_PULL_REQUEST_BASE_BRANCH_SHA
   | typeof SBOM_TOOL_GENERATOR_NAME
   | typeof SBOM_TOOL_GENERATOR_VERSION
-  | typeof PR_ID
+  | typeof PR_NUMBER
 
 export type SpanTags = Partial<Record<SpanTag, string>>
 

--- a/src/helpers/tags.ts
+++ b/src/helpers/tags.ts
@@ -43,7 +43,7 @@ export const GIT_PULL_REQUEST_BASE_BRANCH_SHA = 'git.pull_request.base_branch_sh
 export const GIT_PULL_REQUEST_BASE_BRANCH = 'git.pull_request.base_branch'
 
 // PR
-export const PR_ID = 'pr.id'
+export const PR_NUMBER = 'pr.number'
 
 // Sbom
 export const SBOM_TOOL_GENERATOR_NAME = 'tool.generator.name'


### PR DESCRIPTION
### What and why?

Replaces `pr.id` tag with `pr.number` tag in uploaded code coverage events, because the tag really contains the PR number, and not the ID (they are two different things)

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
