### PR TITLE
Get author and committer info using json formatter

### DIFF
--- a/src/helpers/git/__tests__/format-git-span-data.test.ts
+++ b/src/helpers/git/__tests__/format-git-span-data.test.ts
@@ -28,7 +28,7 @@ describe('getGitMetadata', () => {
           return 'commit message'
         }
 
-        return 'authorName,authorEmail,authorDate,committerName,committerEmail,committerDate'
+        return '{"authorName":"authorName","authorEmail":"authorEmail","authorDate":"authorDate","committerName":"committerName","committerEmail":"committerEmail","committerDate":"committerDate"}'
       },
     }))
     const result = await getGitMetadata()
@@ -76,7 +76,7 @@ describe('getGitMetadata', () => {
           return 'commit message'
         }
 
-        return 'authorName,authorEmail,authorDate,committerName,committerEmail,committerDate'
+        return '{"authorName":"authorName","authorEmail":"authorEmail","authorDate":"authorDate","committerName":"committerName","committerEmail":"committerEmail","committerDate":"committerDate"}'
       },
     }))
     const result = await getGitMetadata()
@@ -104,7 +104,7 @@ describe('getGitMetadata', () => {
           return 'commit message'
         }
 
-        return 'authorName,authorEmail,authorDate,committerName,committerEmail,committerDate'
+        return '{"authorName":"authorName","authorEmail":"authorEmail","authorDate":"authorDate","committerName":"committerName","committerEmail":"committerEmail","committerDate":"committerDate"}'
       },
     }))
     const result = await getGitMetadata()

--- a/src/helpers/git/format-git-span-data.ts
+++ b/src/helpers/git/format-git-span-data.ts
@@ -1,4 +1,4 @@
-import type {SpanTags} from '../interfaces'
+import type {SpanTags, GitAuthorAndCommitterMetadata} from '../interfaces'
 
 import simpleGit from 'simple-git'
 
@@ -27,7 +27,7 @@ export const getGitMetadata = async (repositoryPath?: string): Promise<SpanTags>
       maxConcurrentProcesses: 5,
     })
 
-    const [commitSHA, branch, repositoryUrl, message, authorAndCommitter] = await Promise.all([
+    const [commitSHA, branch, repositoryUrl, message, authorAndCommitterJson] = await Promise.all([
       gitHash(git),
       gitBranch(git),
       gitRepositoryURL(git),
@@ -35,14 +35,9 @@ export const getGitMetadata = async (repositoryPath?: string): Promise<SpanTags>
       gitAuthorAndCommitter(git),
     ])
 
-    const [
-      authorName,
-      authorEmail,
-      authorDate,
-      committerName,
-      committerEmail,
-      committerDate,
-    ] = authorAndCommitter.split(',')
+    const {authorName, authorEmail, authorDate, committerName, committerEmail, committerDate} = JSON.parse(
+      authorAndCommitterJson
+    ) as GitAuthorAndCommitterMetadata
 
     return {
       [GIT_REPOSITORY_URL]: filterSensitiveInfoFromRepository(repositoryUrl.trim()),

--- a/src/helpers/git/get-git-data.ts
+++ b/src/helpers/git/get-git-data.ts
@@ -62,8 +62,9 @@ export const gitCurrentBranch = async (git: simpleGit.SimpleGit): Promise<string
 
 export const gitMessage = async (git: simpleGit.SimpleGit): Promise<string> => git.show(['-s', '--format=%s'])
 
+// Returns the author and committer information of the current commit in JSON format to avoid parsing issues with values that contain commas.
 export const gitAuthorAndCommitter = async (git: simpleGit.SimpleGit): Promise<string> =>
-  git.show(['-s', '--format=%an,%ae,%aI,%cn,%ce,%cI'])
+  git.show(['-s', `--format='{"authorName":"%an","authorEmail":"%ae","authorDate":"%aI","committerName":"%cn","committerEmail":"%ce","committerDate":"%cI"}'`])
 
 export const gitRepositoryURL = async (git: simpleGit.SimpleGit): Promise<string> =>
   git.listRemote(['--get-url']).then((url) => url.trim())

--- a/src/helpers/interfaces.ts
+++ b/src/helpers/interfaces.ts
@@ -77,6 +77,15 @@ export interface Metadata {
   }
 }
 
+export interface GitAuthorAndCommitterMetadata {
+  authorName: string;
+  authorEmail: string;
+  authorDate: string;
+  committerName: string;
+  committerEmail: string;
+  committerDate: string;
+}
+
 export type SpanTag =
   | typeof CI_JOB_NAME
   | typeof CI_JOB_URL

--- a/src/helpers/interfaces.ts
+++ b/src/helpers/interfaces.ts
@@ -78,12 +78,12 @@ export interface Metadata {
 }
 
 export interface GitAuthorAndCommitterMetadata {
-  authorName: string;
-  authorEmail: string;
-  authorDate: string;
-  committerName: string;
-  committerEmail: string;
-  committerDate: string;
+  authorName: string
+  authorEmail: string
+  authorDate: string
+  committerName: string
+  committerEmail: string
+  committerDate: string
 }
 
 export type SpanTag =


### PR DESCRIPTION
### What and why?

The Datadog SCA product introduced the `git.commit.author.date` field to our internal model and our validators are failing due to the given authorDate now being a valid data string. This is due to us return a comma-separated string and then splitting the string by said comma's. This doesn't work as expected when an author name includes a comma (ex. `Strong, Daniel`). Consequently this has caused uploads for customers to begin failing, so fixing this is an urgent issue.

### How?

When collecting these details we format the response as JSON to avoid issues when splitting the string.

I've updated the test accordingly, but you can run the following locally to see the output in your shell:
```
git show -s --format='{"authorName":"%an","authorEmail":"%ae","authorDate":"%aI","committerName":"%cn","committerEmail":"%ce","committerDate":"%cI"}'
```

### Review checklist

- [X] Feature or bugfix MUST have appropriate tests (unit, integration)
