### PR TITLE
Print link to Datadog UI when uploading coverage data

### DIFF
--- a/src/commands/coverage/renderer.ts
+++ b/src/commands/coverage/renderer.ts
@@ -1,7 +1,10 @@
 import chalk from 'chalk'
 import upath from 'upath'
 
+import {SpanTags} from '../../helpers/interfaces'
+
 import {Payload} from './interfaces'
+import {getCoverageDetailsUrl} from './utils'
 
 const ICONS = {
   FAILED: '❌',
@@ -37,18 +40,25 @@ export const renderSuccessfulUpload = (dryRun: boolean, fileCount: number, durat
   return chalk.green(`${dryRun ? '[DRYRUN] ' : ''}${ICONS.SUCCESS} Uploaded ${fileCount} files in ${duration} seconds.`)
 }
 
-// TODO add some Datadog links to the output
-export const renderSuccessfulUploadCommand = () => {
-  let fullStr = ''
-  fullStr += chalk.green(
-    '=================================================================================================\n'
-  )
-  fullStr += chalk.green('* Code coverage report(s) upload successful\n')
-  fullStr += chalk.green(
-    '=================================================================================================\n'
-  )
+export const renderSuccessfulUploadCommand = (spanTags: SpanTags) => {
+  const coverageDetailsUrl = getCoverageDetailsUrl(spanTags)
+  if (coverageDetailsUrl) {
+    let fullStr = ''
+    fullStr += chalk.green(
+      '=================================================================================================\n'
+    )
+    fullStr += chalk.green(
+      '* View detailed coverage report in Datadog (it can take a few minutes to become available)\n'
+    )
+    fullStr += chalk.green(`* ${coverageDetailsUrl}\n`)
+    fullStr += chalk.green(
+      '=================================================================================================\n'
+    )
 
-  return fullStr
+    return fullStr
+  }
+
+  return ''
 }
 
 export const renderDryRunUpload = (payload: Payload): string => `[DRYRUN] ${renderUpload(payload)}`

--- a/src/commands/coverage/upload.ts
+++ b/src/commands/coverage/upload.ts
@@ -146,10 +146,6 @@ export class UploadCodeCoverageReportCommand extends Command {
     }
 
     await this.uploadCodeCoverageReports()
-
-    if (!this.dryRun) {
-      this.context.stdout.write(renderSuccessfulUploadCommand())
-    }
   }
 
   private async uploadCodeCoverageReports() {
@@ -158,8 +154,9 @@ export class UploadCodeCoverageReportCommand extends Command {
 
     this.logger.info(renderCommandInfo(this.basePaths, this.dryRun))
 
+    const spanTags = await this.getSpanTags()
     const api = this.getApiHelper()
-    const payloads = await this.generatePayloads()
+    const payloads = await this.generatePayloads(spanTags)
 
     let fileCount = 0
 
@@ -171,6 +168,10 @@ export class UploadCodeCoverageReportCommand extends Command {
     const totalTimeSeconds = (Date.now() - initialTime) / 1000
 
     this.logger.info(renderSuccessfulUpload(this.dryRun, fileCount, totalTimeSeconds))
+
+    if (!this.dryRun) {
+      this.context.stdout.write(renderSuccessfulUploadCommand(spanTags))
+    }
   }
 
   private getApiHelper(): APIHelper {
@@ -184,8 +185,7 @@ export class UploadCodeCoverageReportCommand extends Command {
     return apiConstructor(intakeUrl, this.config.apiKey)
   }
 
-  private async generatePayloads(): Promise<Payload[]> {
-    const spanTags = await this.getSpanTags()
+  private async generatePayloads(spanTags: SpanTags): Promise<Payload[]> {
     const customTags = this.getCustomTags()
     const customMeasures = this.getCustomMeasures()
 

--- a/src/commands/coverage/utils.ts
+++ b/src/commands/coverage/utils.ts
@@ -75,5 +75,5 @@ export const getCoverageDetailsUrl = (spanTags: SpanTags): string => {
   const escapedPrNumber = encodeURIComponent(prNumber)
   const escapedRepoUrl = encodeURIComponent(repoUrl)
 
-  return `${getBaseUrl()}api/ui/code-coverage-api/redirect/pull-requests/${escapedPrNumber}?repository_url=${escapedRepoUrl}`
+  return `${getBaseUrl()}api/ui/code-coverage/redirect/pull-requests/${escapedPrNumber}?repository_url=${escapedRepoUrl}`
 }

--- a/src/commands/coverage/utils.ts
+++ b/src/commands/coverage/utils.ts
@@ -3,6 +3,10 @@ import fs from 'fs'
 import {XMLValidator} from 'fast-xml-parser'
 import upath from 'upath'
 
+import {getBaseUrl} from '../../helpers/app'
+import {SpanTags} from '../../helpers/interfaces'
+import {CI_JOB_URL, CI_PIPELINE_URL, GIT_REPOSITORY_URL, PR_NUMBER} from '../../helpers/tags'
+
 import {renderFileReadError} from './renderer'
 
 const ROOT_TAG_REGEX = /<([^?!\s/>]+)/
@@ -55,4 +59,21 @@ export const detectFormat = (filePath: string): 'jacoco' | undefined => {
   }
 
   return undefined
+}
+
+export const getCoverageDetailsUrl = (spanTags: SpanTags): string => {
+  const repoUrl = spanTags[GIT_REPOSITORY_URL]
+  if (!repoUrl) {
+    return ''
+  }
+
+  const prNumber = spanTags[PR_NUMBER]
+  if (!prNumber) {
+    return ''
+  }
+
+  const escapedPrNumber = encodeURIComponent(prNumber)
+  const escapedRepoUrl = encodeURIComponent(repoUrl)
+
+  return `${getBaseUrl()}api/ui/code-coverage-api/redirect/pull-requests/${escapedPrNumber}?repositoryUrl=${escapedRepoUrl}`
 }

--- a/src/commands/coverage/utils.ts
+++ b/src/commands/coverage/utils.ts
@@ -75,5 +75,5 @@ export const getCoverageDetailsUrl = (spanTags: SpanTags): string => {
   const escapedPrNumber = encodeURIComponent(prNumber)
   const escapedRepoUrl = encodeURIComponent(repoUrl)
 
-  return `${getBaseUrl()}api/ui/code-coverage-api/redirect/pull-requests/${escapedPrNumber}?repositoryUrl=${escapedRepoUrl}`
+  return `${getBaseUrl()}api/ui/code-coverage-api/redirect/pull-requests/${escapedPrNumber}?repository_url=${escapedRepoUrl}`
 }

--- a/src/commands/junit/utils.ts
+++ b/src/commands/junit/utils.ts
@@ -1,13 +1,6 @@
-import {getCommonAppBaseURL} from '../../helpers/app'
+import {getBaseUrl} from '../../helpers/app'
 import {SpanTags} from '../../helpers/interfaces'
 import {CI_JOB_URL, CI_PIPELINE_URL, GIT_BRANCH, GIT_REPOSITORY_URL, GIT_SHA} from '../../helpers/tags'
-
-export const getBaseUrl = () => {
-  const site = process.env.DATADOG_SITE || process.env.DD_SITE || 'datadoghq.com'
-  const subdomain = process.env.DD_SUBDOMAIN || ''
-
-  return getCommonAppBaseURL(site, subdomain)
-}
 
 export const getTestRunsUrl = (spanTags: SpanTags): string => {
   if (!spanTags[CI_PIPELINE_URL] && !spanTags[CI_JOB_URL]) {

--- a/src/commands/sarif/renderer.ts
+++ b/src/commands/sarif/renderer.ts
@@ -1,7 +1,7 @@
 import chalk from 'chalk'
 import upath from 'upath'
 
-import {getBaseUrl} from '../junit/utils'
+import {getBaseUrl} from '../../helpers/app'
 
 import {Payload} from './interfaces'
 

--- a/src/commands/sbom/api.ts
+++ b/src/commands/sbom/api.ts
@@ -1,9 +1,8 @@
 import type {AxiosPromise, AxiosRequestConfig, AxiosResponse} from 'axios'
 
 import {CONTENT_TYPE_HEADER, CONTENT_TYPE_VALUE_JSON, METHOD_POST} from '../../constants'
+import {getBaseUrl} from '../../helpers/app'
 import {getRequestBuilder} from '../../helpers/utils'
-
-import {getBaseUrl} from '../junit/utils'
 
 import {API_ENDPOINT} from './constants'
 import {ScaRequest} from './types'

--- a/src/commands/sbom/renderer.ts
+++ b/src/commands/sbom/renderer.ts
@@ -1,6 +1,6 @@
 import chalk from 'chalk'
 
-import {getBaseUrl} from '../junit/utils'
+import {getBaseUrl} from '../../helpers/app'
 
 import {Dependency, ScaRequest} from './types'
 import {validateDependencyName} from './validation'

--- a/src/helpers/app.ts
+++ b/src/helpers/app.ts
@@ -1,5 +1,12 @@
 export const DEFAULT_DATADOG_SUBDOMAIN = 'app'
 
+export const getBaseUrl = () => {
+  const site = process.env.DATADOG_SITE || process.env.DD_SITE || 'datadoghq.com'
+  const subdomain = process.env.DD_SUBDOMAIN || ''
+
+  return getCommonAppBaseURL(site, subdomain)
+}
+
 export const getCommonAppBaseURL = (datadogSite: string, subdomain: string) => {
   const validSubdomain = subdomain || DEFAULT_DATADOG_SUBDOMAIN
   const datadogSiteParts = datadogSite.split('.')


### PR DESCRIPTION
### What and why?

When running the `coverage upload` command, prints a link to code coverage details screen in Datadog 

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
