### PR TITLE
[SYNTH-17738] Fix ERR_STREAM_PREMATURE_CLOSE tunnel error

### DIFF
--- a/src/commands/synthetics/tunnel/tunnel.ts
+++ b/src/commands/synthetics/tunnel/tunnel.ts
@@ -120,10 +120,6 @@ export class Tunnel {
       }
     })
 
-    if (this.multiplexer) {
-      this.multiplexer.close()
-    }
-
     await this.ws.close()
   }
 
@@ -209,7 +205,9 @@ export class Tunnel {
         })
         dest.on('error', (error: NodeJS.ErrnoException) => {
           if (src) {
-            this.reporter?.warn(`Error on opened connection (${destIP}): ${error.code}`)
+            if (error.code !== 'ERR_STREAM_PREMATURE_CLOSE') {
+              this.reporter?.warn(`Error on opened connection (${destIP}): ${error.code}`)
+            }
             src.close()
           } else {
             if ('code' in error && error.code === 'ENOTFOUND') {


### PR DESCRIPTION
### What and why?

This PR fixes errors that we had with the synthetics tunnel, mainly `ERR_STREAM_PREMATURE_CLOSE`, which turned out to be harmless.

### How?

- Hide `ERR_STREAM_PREMATURE_CLOSE` logs during tunnel execution
- Fix errors during Tunnel shutdown. 

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
