### PR TITLE
Upload git metadata when uploading coverage

### DIFF
--- a/src/commands/coverage/README.md
+++ b/src/commands/coverage/README.md
@@ -30,8 +30,8 @@ datadog-ci coverage upload --tags key1:value1 --tags key2:value2 unit-tests/cove
 - `--dry-run` (default: `false`): it will run the command without the final upload step. All other checks are performed.
 - `--verbose` (default: `false`): it will add extra verbosity to the output of the command.
 - `--upload-git-diff` (default: `true`): if the command is run in a PR context, it will try to upload the PR git diff along with the coverage data.
-- `--skip-git-metadata-upload` (default: `false`): allows to skip the upload of git metadata.
-- `--git-repository-url` is a string with the repository URL to retrieve git metadata from. If this is missing, the URL is retrieved from the local git repository.
+- `--skip-git-metadata-upload` (default: `false`): skip the upload of git metadata.
+- `--git-repository-url` is a string specifying the repository URL to retrieve git metadata from. If this is missing, the URL is retrieved from the local git repository.
 
 #### Environment variables
 

--- a/src/commands/coverage/README.md
+++ b/src/commands/coverage/README.md
@@ -30,6 +30,8 @@ datadog-ci coverage upload --tags key1:value1 --tags key2:value2 unit-tests/cove
 - `--dry-run` (default: `false`): it will run the command without the final upload step. All other checks are performed.
 - `--verbose` (default: `false`): it will add extra verbosity to the output of the command.
 - `--upload-git-diff` (default: `true`): if the command is run in a PR context, it will try to upload the PR git diff along with the coverage data.
+- `--skip-git-metadata-upload` (default: `false`): allows to skip the upload of git metadata.
+- `--git-repository-url` is a string with the repository URL to retrieve git metadata from. If this is missing, the URL is retrieved from the local git repository.
 
 #### Environment variables
 

--- a/src/commands/coverage/__tests__/upload.test.ts
+++ b/src/commands/coverage/__tests__/upload.test.ts
@@ -294,9 +294,11 @@ describe('execute', () => {
     const output = context.stdout.toString().split('\n')
     const path = `${CWD}/src/commands/coverage/__tests__/fixtures/single_file.xml`
     expect(code).toBe(0)
-    expect(output[0]).toContain('DRY-RUN MODE ENABLED. WILL NOT UPLOAD COVERAGE REPORT')
-    expect(output[1]).toContain('Starting upload')
-    expect(output[2]).toContain(`Will upload code coverage report file ${path}`)
+    expect(output[0]).toContain('[DRYRUN] Syncing git metadata...')
+    // output[1] is "Synced git metadata in XXX seconds"
+    expect(output[2]).toContain('DRY-RUN MODE ENABLED. WILL NOT UPLOAD COVERAGE REPORT')
+    expect(output[3]).toContain('Starting upload')
+    expect(output[4]).toContain(`Will upload code coverage report file ${path}`)
   })
 })
 
@@ -305,7 +307,9 @@ interface ExpectedOutput {
 }
 
 const checkConsoleOutput = (output: string[], expected: ExpectedOutput) => {
-  expect(output[0]).toContain('DRY-RUN MODE ENABLED. WILL NOT UPLOAD COVERAGE REPORT')
-  expect(output[1]).toContain(`Starting upload`)
-  expect(output[2]).toContain(`Will look for code coverage report files in ${expected.basePaths.join(', ')}`)
+  expect(output[0]).toContain('[DRYRUN] Syncing git metadata...')
+  // output[1] is "Synced git metadata in XXX seconds"
+  expect(output[2]).toContain('DRY-RUN MODE ENABLED. WILL NOT UPLOAD COVERAGE REPORT')
+  expect(output[3]).toContain(`Starting upload`)
+  expect(output[4]).toContain(`Will look for code coverage report files in ${expected.basePaths.join(', ')}`)
 }

--- a/src/commands/coverage/renderer.ts
+++ b/src/commands/coverage/renderer.ts
@@ -77,3 +77,11 @@ export const renderCommandInfo = (basePaths: string[], dryRun: boolean) => {
 
   return fullStr
 }
+
+export const renderSuccessfulGitDBSync = (dryRun: boolean, elapsed: number) => {
+  return chalk.green(`${dryRun ? '[DRYRUN] ' : ''}${ICONS.SUCCESS} Synced git metadata in ${elapsed} seconds.`)
+}
+
+export const renderFailedGitDBSync = (err: any) => {
+  return chalk.red.bold(`${ICONS.FAILED} Could not sync git metadata: ${err}\n`)
+}

--- a/src/commands/coverage/upload.ts
+++ b/src/commands/coverage/upload.ts
@@ -48,7 +48,6 @@ import {
   renderSuccessfulGitDBSync,
 } from './renderer'
 import {detectFormat, validateCoverageReport} from './utils'
-import { Dsym } from "../dsyms/interfaces";
 
 const TRACE_ID_HTTP_HEADER = 'x-datadog-trace-id'
 const PARENT_ID_HTTP_HEADER = 'x-datadog-parent-id'


### PR DESCRIPTION
### What and why?

Adds git metadata upload to `coverage upload` command.
Coverage upload needs git metadata for the following reasons:
- backend needs commit data in gitdb, and if the user has not enabled Datadog GitHub integration, then the data needs to be uploaded from a library
- calculating and uploading git diffs as part of coverage upload needs repo unshallowing, and git metadata upload does this

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
