### PR TITLE
[K9VULN-5794] Guard against vulnerabilities without affects being defined

### DIFF
--- a/src/commands/sbom/__tests__/fixtures/sbom-with-reachability.json
+++ b/src/commands/sbom/__tests__/fixtures/sbom-with-reachability.json
@@ -80,6 +80,10 @@
       "bom-ref": "GHSA-4wrc-f8pq-fpqp",
       "id": "GHSA-4wrc-f8pq-fpqp",
       "affects": [{ "ref": "pkg:maven/org.springframework/spring-web@5.3.30" }]
+    },
+    {
+      "bom-ref": "GHSA-4jrv-ppp4-jm57",
+      "id": "GHSA-4jrv-ppp4-jm57"
     }
   ]
 }

--- a/src/commands/sbom/__tests__/payload.test.ts
+++ b/src/commands/sbom/__tests__/payload.test.ts
@@ -500,12 +500,15 @@ describe('generation of payload', () => {
       '[{"file_name":"src/main/java/com/example/InsecureDeserializationExample.java","line_start":41,"line_end":41,"column_start":58,"column_end":88,"symbol":"CodebaseAwareObjectInputStream"}]'
     )
 
-    expect(payload?.vulnerabilities.length).toStrictEqual(1)
+    expect(payload?.vulnerabilities.length).toStrictEqual(2)
     const vulnerabilities = payload!.vulnerabilities
     expect(vulnerabilities[0].id).toEqual('GHSA-4wrc-f8pq-fpqp')
     expect(vulnerabilities[0].bom_ref).toEqual('GHSA-4wrc-f8pq-fpqp')
     expect(vulnerabilities[0].affects).toHaveLength(1)
     expect(vulnerabilities[0].affects[0].ref).toEqual('pkg:maven/org.springframework/spring-web@5.3.30')
+    expect(vulnerabilities[1].id).toEqual('GHSA-4jrv-ppp4-jm57')
+    expect(vulnerabilities[1].bom_ref).toEqual('GHSA-4jrv-ppp4-jm57')
+    expect(vulnerabilities[1].affects).toHaveLength(0)
   })
 
   test('should fail to read git information', async () => {

--- a/src/commands/sbom/payload.ts
+++ b/src/commands/sbom/payload.ts
@@ -160,13 +160,16 @@ export const generatePayload = (
           continue
         }
         const affects: Affect[] = []
-        for (const affected of vulnerability['affects']) {
-          if (!affected['ref']) {
-            continue
+        // Iterate over the affects of the vulnerability when it exists
+        if (vulnerability['affects']) {
+          for (const affected of vulnerability['affects']) {
+            if (!affected['ref']) {
+              continue
+            }
+            affects.push({
+              ref: affected['ref'],
+            })
           }
-          affects.push({
-            ref: affected['ref'],
-          })
         }
         vulnerabilities.push({
           id: vulnerability['id'],


### PR DESCRIPTION
### What and why?

This adds a check before iterating over a field (`vulnerabilities[].affects[]`) that may be omitted.

### How?

In our tests, we only include an affected vulnerability (reachable), so this situation went unnoticed. 

I've updated the test case to include both (un)reachable vulnerabilities.

### Review checklist

- [X] Feature or bugfix MUST have appropriate tests (unit, integration)
