### PR TITLE
Use `moduleResolution: node16` and remove `baseUrl`

### DIFF
--- a/src/commands/synthetics/__tests__/reporters/mobile/app-upload.test.ts
+++ b/src/commands/synthetics/__tests__/reporters/mobile/app-upload.test.ts
@@ -9,7 +9,7 @@ Object.defineProperty(process, 'platform', {
   writable: true,
 })
 
-import {CommandContext} from 'src/helpers/interfaces'
+import {CommandContext} from '../../../../../helpers/interfaces'
 
 import {AppUploadReporter} from '../../../reporters/mobile/app-upload'
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,6 @@
     "strict": true,
     "noImplicitAny": true,
     "moduleResolution": "node16",
-    "baseUrl": "./",
     "allowSyntheticDefaultImports": true,
     "useUnknownInCatchVariables": false,
     "esModuleInterop": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,19 +1,19 @@
 {
   "compilerOptions": {
+    "lib": ["es2020"],
     "target": "es6",
     "module": "commonjs",
+    "moduleResolution": "node16",
     "declaration": true,
     "sourceMap": true,
-    "outDir": "dist",
     "rootDir": "src",
+    "outDir": "dist",
     "strict": true,
     "noImplicitAny": true,
-    "moduleResolution": "node16",
     "allowSyntheticDefaultImports": true,
     "useUnknownInCatchVariables": false,
-    "esModuleInterop": true,
-    "lib": ["es2020"],
-    "resolveJsonModule": true
+    "esModuleInterop": true, // Allows default imports from modules with no default export
+    "resolveJsonModule": true // Used for SBOM json schemas
   },
   "include": ["src/**/*"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,7 @@
     "rootDir": "src",
     "strict": true,
     "noImplicitAny": true,
-    "moduleResolution": "node",
+    "moduleResolution": "node16",
     "baseUrl": "./",
     "allowSyntheticDefaultImports": true,
     "useUnknownInCatchVariables": false,

--- a/yarn.lock
+++ b/yarn.lock
@@ -8089,9 +8089,9 @@ jschardet@latest:
   linkType: hard
 
 "long@npm:^5.0.0":
-  version: 5.2.3
-  resolution: "long@npm:5.2.3"
-  checksum: 885ede7c3de4facccbd2cacc6168bae3a02c3e836159ea4252c87b6e34d40af819824b2d4edce330bfb5c4d6e8ce3ec5864bdcf9473fa1f53a4f8225860e5897
+  version: 5.3.2
+  resolution: "long@npm:5.3.2"
+  checksum: be215816b563f4ca27ad3677678b53415bc489f9e3466414e54d2d85f5f8e86768547fa58493bacfb363ffc57a664debc83403ccc2178aef0c40aca28bad47c9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### What and why?

This PR changes the `moduleResolution` to be `node16` to unblock https://github.com/DataDog/datadog-ci/pull/1665#discussion_r2138381593.

### How?

Just change `moduleResolution` and `baseUrl`. All other options are kept as is to avoid any breaking changes.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
