### PR TITLE
[chores] Improve standalone binary e2e tests

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -11,10 +11,10 @@ module.exports = {
     'plugin:prettier/recommended',
     'plugin:jest/recommended',
   ],
-  ignorePatterns: ['.eslintrc.js', 'jest.config.js'],
+  ignorePatterns: ['.eslintrc.js', 'jest.config*.js'],
   parser: '@typescript-eslint/parser',
   parserOptions: {
-    project: 'tsconfig.json',
+    project: true,
     sourceType: 'module',
   },
   plugins: ['@typescript-eslint', 'import', 'jest', 'no-null', 'prefer-arrow'],

--- a/jest.config-standalone.js
+++ b/jest.config-standalone.js
@@ -4,7 +4,7 @@ module.exports = {
     '^.+\\.tsx?$': [
       'ts-jest',
       {
-        tsconfig: 'tsconfig.json',
+        tsconfig: 'standalone-e2e/tsconfig.json',
       },
     ],
   },

--- a/standalone-e2e/tsconfig.json
+++ b/standalone-e2e/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".."
+  },
+  "include": [".", "../package.json"]
+}


### PR DESCRIPTION
### What and why?

This PR fixes a few lint errors, and improves the e2e tests when failing.

Before: 

![image](https://github.com/user-attachments/assets/e7470bf1-340a-4647-8b2e-caf6ad776381)

After:

![image](https://github.com/user-attachments/assets/14defdae-0a4e-4b36-80b6-1fe27d09b081)


### How?

- Add a `tsconfig.json` for that separate folder so that ESLint can lint without errors.
- Replace `promisify(exec)` by custom function that always `resolve` with the exit code, `stdout` and `stderr`

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
