### PR TITLE
[SVLS-7006] add api key validation

### DIFF
--- a/src/commands/aas/__tests__/instrument.test.ts
+++ b/src/commands/aas/__tests__/instrument.test.ts
@@ -51,6 +51,10 @@ const DEFAULT_CONFIG: AasConfigOptions = {
   logPath: undefined,
 }
 
+const DEFAULT_ARGS = ['-s', '00000000-0000-0000-0000-000000000000', '-g', 'my-resource-group', '-n', 'my-web-app']
+
+const mockResponses: Record<string, unknown> = {}
+
 describe('aas instrument', () => {
   const runCLI = makeRunCLI(InstrumentCommand, ['aas', 'instrument'])
 
@@ -64,17 +68,17 @@ describe('aas instrument', () => {
       webAppsOperations.listApplicationSettings.mockReset().mockResolvedValue({properties: {}})
       webAppsOperations.updateApplicationSettings.mockReset().mockResolvedValue({})
       webAppsOperations.restart.mockReset().mockResolvedValue({})
+      mockResponses['https://api.datadoghq.com/api/v1/validate'] = {valid: true}
+      global.fetch = jest.fn().mockImplementation((url) => {
+        return Promise.resolve({
+          json: () => Promise.resolve(mockResponses[url]),
+          ok: true,
+        })
+      })
     })
 
     test('Adds a sidecar and updates the application settings', async () => {
-      const {code, context} = await runCLI([
-        '-s',
-        '00000000-0000-0000-0000-000000000000',
-        '-g',
-        'my-resource-group',
-        '-n',
-        'my-web-app',
-      ])
+      const {code, context} = await runCLI(DEFAULT_ARGS)
       expect(context.stdout.toString()).toEqual(`🐶 Instrumenting Azure App Service
 Creating sidecar container datadog-sidecar
 Updating Application Settings
@@ -112,15 +116,7 @@ Restarting Azure App Service
     })
 
     test('Performs no actions in dry run mode', async () => {
-      const {code, context} = await runCLI([
-        '-s',
-        '00000000-0000-0000-0000-000000000000',
-        '-g',
-        'my-resource-group',
-        '-n',
-        'my-web-app',
-        '--dry-run',
-      ])
+      const {code, context} = await runCLI([...DEFAULT_ARGS, '--dry-run'])
       expect(context.stdout.toString()).toEqual(`[Dry Run] 🐶 Instrumenting Azure App Service
 [Dry Run] Creating sidecar container datadog-sidecar
 [Dry Run] Updating Application Settings
@@ -138,15 +134,7 @@ Restarting Azure App Service
     })
 
     test('Does not restart when specified', async () => {
-      const {code, context} = await runCLI([
-        '-s',
-        '00000000-0000-0000-0000-000000000000',
-        '-g',
-        'my-resource-group',
-        '-n',
-        'my-web-app',
-        '--no-restart',
-      ])
+      const {code, context} = await runCLI([...DEFAULT_ARGS, '--no-restart'])
       expect(context.stdout.toString()).toEqual(`🐶 Instrumenting Azure App Service
 Creating sidecar container datadog-sidecar
 Updating Application Settings
@@ -185,15 +173,7 @@ Updating Application Settings
     test('Fails if not authenticated with Azure', async () => {
       getToken.mockClear().mockRejectedValue(new Error())
 
-      const {code, context} = await runCLI([
-        '-s',
-        '00000000-0000-0000-0000-000000000000',
-        '-g',
-        'my-resource-group',
-        '-n',
-        'my-web-app',
-        '--dry-run',
-      ])
+      const {code, context} = await runCLI(DEFAULT_ARGS)
       expect(context.stdout.toString()).toEqual(`[!] Failed to authenticate with Azure: Error
 
 Please ensure that you have the Azure CLI installed (https://aka.ms/azure-cli) and have run az login to authenticate.
@@ -209,16 +189,51 @@ Please ensure that you have the Azure CLI installed (https://aka.ms/azure-cli) a
       expect(webAppsOperations.restart).not.toHaveBeenCalled()
     })
 
+    test('Fails if datadog API key is invalid', async () => {
+      mockResponses['https://api.datadoghq.com/api/v1/validate'] = {
+        status: 'error',
+        code: 403,
+        errors: ['Forbidden'],
+      }
+
+      const {code, context} = await runCLI(DEFAULT_ARGS)
+      expect(context.stdout.toString()).toEqual(
+        '[!] Invalid API Key *******LDER, ensure you copied the value and not the Key ID\n'
+      )
+      expect(code).toEqual(1)
+      expect(getToken).not.toHaveBeenCalled()
+      expect(webAppsOperations.getConfiguration).not.toHaveBeenCalled()
+      expect(webAppsOperations.listSiteContainers).not.toHaveBeenCalled()
+      expect(webAppsOperations.createOrUpdateSiteContainer).not.toHaveBeenCalled()
+      expect(webAppsOperations.listApplicationSettings).not.toHaveBeenCalled()
+      expect(webAppsOperations.updateApplicationSettings).not.toHaveBeenCalled()
+      expect(webAppsOperations.restart).not.toHaveBeenCalled()
+    })
+
+    test('Fails if datadog API key is invalid and too short to censor', async () => {
+      mockResponses['https://api.datadoghq.com/api/v1/validate'] = {
+        status: 'error',
+        code: 403,
+        errors: ['Forbidden'],
+      }
+
+      const {code, context} = await runCLI(DEFAULT_ARGS, {DD_API_KEY: 'hi'})
+      expect(context.stdout.toString()).toEqual(
+        '[!] Invalid API Key (too short to display), ensure you copied the value and not the Key ID\n'
+      )
+      expect(code).toEqual(1)
+      expect(getToken).not.toHaveBeenCalled()
+      expect(webAppsOperations.getConfiguration).not.toHaveBeenCalled()
+      expect(webAppsOperations.listSiteContainers).not.toHaveBeenCalled()
+      expect(webAppsOperations.createOrUpdateSiteContainer).not.toHaveBeenCalled()
+      expect(webAppsOperations.listApplicationSettings).not.toHaveBeenCalled()
+      expect(webAppsOperations.updateApplicationSettings).not.toHaveBeenCalled()
+      expect(webAppsOperations.restart).not.toHaveBeenCalled()
+    })
+
     test('Warns and exits if App Service is not Linux', async () => {
       webAppsOperations.getConfiguration.mockClear().mockResolvedValue({kind: 'app,windows'})
-      const {code, context} = await runCLI([
-        '-s',
-        '00000000-0000-0000-0000-000000000000',
-        '-g',
-        'my-resource-group',
-        '-n',
-        'my-web-app',
-      ])
+      const {code, context} = await runCLI(DEFAULT_ARGS)
       expect(context.stdout.toString()).toEqual(`🐶 Instrumenting Azure App Service
 [!] Only Linux-based Azure App Services are currently supported.
 Please see the documentation for information on
@@ -237,14 +252,7 @@ https://docs.datadoghq.com/serverless/azure_app_services/azure_app_services_wind
 
     test('Handles errors during sidecar instrumentation', async () => {
       webAppsOperations.createOrUpdateSiteContainer.mockClear().mockRejectedValue(new Error('sidecar error'))
-      const {code, context} = await runCLI([
-        '-s',
-        '00000000-0000-0000-0000-000000000000',
-        '-g',
-        'my-resource-group',
-        '-n',
-        'my-web-app',
-      ])
+      const {code, context} = await runCLI(DEFAULT_ARGS)
       expect(context.stdout.toString()).toEqual(`🐶 Instrumenting Azure App Service
 Creating sidecar container datadog-sidecar
 [Error] Failed to instrument sidecar: Error: sidecar error

--- a/src/commands/aas/instrument.ts
+++ b/src/commands/aas/instrument.ts
@@ -4,12 +4,12 @@ import chalk from 'chalk'
 import {Command, Option} from 'clipanion'
 import equal from 'fast-deep-equal/es6'
 
+import {newApiKeyValidator} from '../../helpers/apikey'
 import {renderError, renderSoftWarning} from '../../helpers/renderer'
+import {maskString} from '../../helpers/utils'
 
 import {AasCommand, collectAsyncIterator, SIDECAR_CONTAINER_NAME, SIDECAR_IMAGE, SIDECAR_PORT} from './common'
 import {AasConfigOptions} from './interfaces'
-import {newApiKeyValidator} from '../../helpers/apikey'
-import {maskString} from '../../helpers/utils'
 
 export class InstrumentCommand extends AasCommand {
   public static paths = [['aas', 'instrument']]
@@ -45,6 +45,7 @@ export class InstrumentCommand extends AasCommand {
           )}\nEnsure you copied the value and not the Key ID.`
         )
       )
+
       return 1
     }
     const cred = new DefaultAzureCredential()

--- a/src/commands/aas/instrument.ts
+++ b/src/commands/aas/instrument.ts
@@ -124,28 +124,6 @@ https://docs.datadoghq.com/serverless/azure_app_services/azure_app_services_wind
     return envVars
   }
 
-  /**
-   * Validates the Datadog API key in the env by making a request to the Datadog API.
-   * @returns {boolean} - Returns true if the API key is valid, false otherwise.
-   */
-  public async validateAPIKey(): Promise<boolean> {
-    // Validate the Datadog API key
-    const apiKey = process.env.DD_API_KEY!
-    const response = await fetch(`https://api.${process.env.DD_SITE ?? 'datadoghq.com'}/api/v1/validate`, {
-      method: 'GET',
-      headers: {
-        Accept: 'application/json',
-        'DD-API-KEY': apiKey,
-      },
-    })
-    // no-dd-sa:typescript-best-practices/no-explicit-any
-    const data: any = await response.json()
-    if (data?.valid !== true) {
-      return false
-    }
-    return true
-  }
-
   public async instrumentSidecar(
     client: WebSiteManagementClient,
     config: AasConfigOptions,

--- a/src/commands/aas/instrument.ts
+++ b/src/commands/aas/instrument.ts
@@ -43,9 +43,7 @@ export class InstrumentCommand extends AasCommand {
     const data: any = await response.json()
     if (data?.valid !== true) {
       const censoredKey =
-        apiKey.length < 4
-          ? '(too short to display)'
-          : '*'.repeat(apiKey.length - 4) + apiKey.slice(-4)
+        apiKey.length < 4 ? '(too short to display)' : '*'.repeat(apiKey.length - 4) + apiKey.slice(-4)
       this.context.stdout.write(
         renderSoftWarning(`Invalid API Key ${censoredKey}, ensure you copied the value and not the Key ID`)
       )

--- a/src/commands/aas/instrument.ts
+++ b/src/commands/aas/instrument.ts
@@ -4,6 +4,7 @@ import chalk from 'chalk'
 import {Command, Option} from 'clipanion'
 import equal from 'fast-deep-equal/es6'
 
+import {DATADOG_SITE_US1} from '../../constants'
 import {newApiKeyValidator} from '../../helpers/apikey'
 import {renderError, renderSoftWarning} from '../../helpers/renderer'
 import {maskString} from '../../helpers/utils'
@@ -32,12 +33,11 @@ export class InstrumentCommand extends AasCommand {
 
       return 1
     }
-    if (
-      !(await newApiKeyValidator({
-        apiKey: process.env.DD_API_KEY,
-        datadogSite: process.env.DD_SITE ?? 'datadoghq.com',
-      }).validateApiKey())
-    ) {
+    const isApiKeyValid = await newApiKeyValidator({
+      apiKey: process.env.DD_API_KEY,
+      datadogSite: process.env.DD_SITE ?? DATADOG_SITE_US1,
+    }).validateApiKey()
+    if (!isApiKeyValid) {
       this.context.stdout.write(
         renderSoftWarning(
           `Invalid API Key stored in the environment variable ${chalk.bold('DD_API_KEY')}: ${maskString(
@@ -109,7 +109,7 @@ https://docs.datadoghq.com/serverless/azure_app_services/azure_app_services_wind
   public getEnvVars(config: AasConfigOptions): Record<string, string> {
     const envVars: Record<string, string> = {
       DD_API_KEY: process.env.DD_API_KEY!,
-      DD_SITE: process.env.DD_SITE ?? 'datadoghq.com',
+      DD_SITE: process.env.DD_SITE ?? DATADOG_SITE_US1,
       DD_AAS_INSTANCE_LOGGING_ENABLED: config.isInstanceLoggingEnabled.toString(),
     }
     if (config.service) {

--- a/src/helpers/__tests__/upload.test.ts
+++ b/src/helpers/__tests__/upload.test.ts
@@ -187,6 +187,7 @@ describe('upload', () => {
         {
           apiKeyValidator: {
             verifyApiKey: verifyKey,
+            validateApiKey: jest.fn()
           },
           onError: errorCallback,
           onRetry: retryCallback,
@@ -218,6 +219,7 @@ describe('upload', () => {
         {
           apiKeyValidator: {
             verifyApiKey: verifyKey,
+            validateApiKey: jest.fn(),
           },
           onError: errorCallback,
           onRetry: retryCallback,

--- a/src/helpers/__tests__/upload.test.ts
+++ b/src/helpers/__tests__/upload.test.ts
@@ -187,7 +187,7 @@ describe('upload', () => {
         {
           apiKeyValidator: {
             verifyApiKey: verifyKey,
-            validateApiKey: jest.fn()
+            validateApiKey: jest.fn(),
           },
           onError: errorCallback,
           onRetry: retryCallback,

--- a/src/helpers/apikey.ts
+++ b/src/helpers/apikey.ts
@@ -56,18 +56,6 @@ class ApiKeyValidatorImplem {
     }
   }
 
-  private getApiKeyValidationURL(): string {
-    return `https://api.${this.datadogSite}/api/v1/validate`
-  }
-
-  private async isApiKeyValid(): Promise<boolean | undefined> {
-    if (this.isValid === undefined) {
-      this.isValid = await this.validateApiKey()
-    }
-
-    return this.isValid
-  }
-
   /**
    * Check if the API key is valid by making a request to the Datadog validate API.
    * @returns `true` if the API key is valid, `false` otherwise.
@@ -87,5 +75,17 @@ class ApiKeyValidatorImplem {
       }
       throw error
     }
+  }
+
+  private getApiKeyValidationURL(): string {
+    return `https://api.${this.datadogSite}/api/v1/validate`
+  }
+
+  private async isApiKeyValid(): Promise<boolean | undefined> {
+    if (this.isValid === undefined) {
+      this.isValid = await this.validateApiKey()
+    }
+
+    return this.isValid
   }
 }

--- a/src/helpers/apikey.ts
+++ b/src/helpers/apikey.ts
@@ -9,6 +9,7 @@ import {InvalidConfigurationError} from './errors'
  */
 export interface ApiKeyValidator {
   verifyApiKey(error: AxiosError): Promise<void>
+  validateApiKey(): Promise<boolean>
 }
 
 export interface ApiKeyValidatorParams {
@@ -67,7 +68,11 @@ class ApiKeyValidatorImplem {
     return this.isValid
   }
 
-  private async validateApiKey(): Promise<boolean> {
+  /**
+   * Check if the API key is valid by making a request to the Datadog validate API.
+   * @returns `true` if the API key is valid, `false` otherwise.
+   */
+  public async validateApiKey(): Promise<boolean> {
     try {
       const response = await axios.get(this.getApiKeyValidationURL(), {
         headers: {


### PR DESCRIPTION
### What and why?

Adds API key validation to the `aas instrument` CLI to check for a valid API key before adding it to the instrumentation.

### How?

Calls the `/api/v1/validate` endpoint to ensure the key is valid

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
