### PR TITLE
[K9VULN-5872] Send exclusion properties as a dependency field

### DIFF
--- a/src/commands/sbom/__tests__/fixtures/sbom-with-exclusion.json
+++ b/src/commands/sbom/__tests__/fixtures/sbom-with-exclusion.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.5",
+  "version": 1,
+  "components": [
+    {
+      "bom-ref": "pkg:maven/com.datastax.cassandra/cassandra-driver-core@3.11.5",
+      "type": "library",
+      "name": "com.datastax.cassandra:cassandra-driver-core",
+      "version": "3.11.5",
+      "purl": "pkg:maven/com.datastax.cassandra/cassandra-driver-core@3.11.5",
+      "properties": [
+        {"name": "datadog-sbom-generator:exclusion", "value": "com.github.jnr:jnr-ffi"},
+        {"name": "datadog-sbom-generator:exclusion", "value": "com.github.jnr:jnr-posix"},
+        {"name": "datadog-sbom-generator:exclusion", "value": "io.dropwizard.metrics:metrics-core"},
+        {"name": "datadog-sbom-generator:exclusion", "value": "io.netty:netty-handler"},
+        {"name": "osv-scanner:is-direct", "value": "true"},
+        {"name": "osv-scanner:package-manager", "value": "Maven"}
+      ]
+    },
+    {
+      "bom-ref": "pkg:maven/org.apache.curator/curator-client@2.7.1",
+      "type": "library",
+      "name": "org.apache.curator:curator-client",
+      "version": "2.7.1",
+      "purl": "pkg:maven/org.apache.curator/curator-client@2.7.1",
+      "properties": [
+        {"name": "datadog-sbom-generator:exclusion", "value": "org.apache.zookeeper:zookeeper"},
+        {"name": "osv-scanner:is-direct", "value": "true"},
+        {"name": "osv-scanner:package-manager", "value": "Maven"}
+      ]
+    },
+    {
+      "bom-ref": "pom.xml",
+      "type": "file",
+      "name": "pom.xml",
+      "properties": [
+        {"name": "osv-scanner:package", "value": "pkg:maven/com.example/secure-deserialization@1.0-SNAPSHOT"}
+      ]
+    }
+  ],
+  "vulnerabilities": []
+}

--- a/src/commands/sbom/__tests__/validation.test.ts
+++ b/src/commands/sbom/__tests__/validation.test.ts
@@ -106,6 +106,7 @@ describe('validation of sbom file', () => {
         package_manager: 'pypi',
         is_dev: undefined,
         reachable_symbol_properties: undefined,
+        exclusions: undefined,
       })
     ).toBeFalsy()
     expect(
@@ -121,6 +122,7 @@ describe('validation of sbom file', () => {
         package_manager: 'pypi',
         is_dev: undefined,
         reachable_symbol_properties: undefined,
+        exclusions: undefined,
       })
     ).toBeTruthy()
     expect(
@@ -136,6 +138,7 @@ describe('validation of sbom file', () => {
         package_manager: 'pypi',
         is_dev: undefined,
         reachable_symbol_properties: undefined,
+        exclusions: undefined,
       })
     ).toBeTruthy()
     expect(
@@ -151,6 +154,7 @@ describe('validation of sbom file', () => {
         package_manager: 'pypi',
         is_dev: undefined,
         reachable_symbol_properties: undefined,
+        exclusions: undefined,
       })
     ).toBeTruthy()
   })

--- a/src/commands/sbom/constants.ts
+++ b/src/commands/sbom/constants.ts
@@ -4,5 +4,6 @@ export const PACKAGE_MANAGER_PROPERTY_KEY = 'osv-scanner:package-manager'
 export const IS_DEPENDENCY_DIRECT_PROPERTY_KEY = 'osv-scanner:is-direct'
 export const IS_DEPENDENCY_DEV_ENVIRONMENT_PROPERTY_KEY = 'osv-scanner:is-dev'
 export const FILE_PACKAGE_PROPERTY_KEY = 'osv-scanner:package'
+export const EXCLUSION_KEY = 'datadog-sbom-generator:exclusion'
 
 export const REACHABLE_SYMBOL_LOCATION_KEY_PREFIX = 'datadog-sbom-generator:reachable-symbol-location'

--- a/src/commands/sbom/payload.ts
+++ b/src/commands/sbom/payload.ts
@@ -15,6 +15,7 @@ import {
 } from '../../helpers/tags'
 
 import {
+  EXCLUSION_KEY,
   FILE_PACKAGE_PROPERTY_KEY,
   IS_DEPENDENCY_DEV_ENVIRONMENT_PROPERTY_KEY,
   IS_DEPENDENCY_DIRECT_PROPERTY_KEY,
@@ -246,6 +247,7 @@ const extractingDependency = (component: any): Dependency | undefined => {
   let packageManager = ''
   let isDirect
   let isDev
+  const exclusions: string[] = []
   const reachableSymbolProperties: Property[] = []
   for (const property of component['properties'] ?? []) {
     if (property['name'] === PACKAGE_MANAGER_PROPERTY_KEY) {
@@ -254,6 +256,8 @@ const extractingDependency = (component: any): Dependency | undefined => {
       isDirect = property['value'].toLowerCase() === 'true' ? true : undefined
     } else if (property['name'] === IS_DEPENDENCY_DEV_ENVIRONMENT_PROPERTY_KEY) {
       isDev = property['value'].toLowerCase() === 'true' ? true : undefined
+    } else if (property['name'] === EXCLUSION_KEY) {
+      exclusions.push(property['value'])
     } else if (property['name'].startsWith(REACHABLE_SYMBOL_LOCATION_KEY_PREFIX)) {
       const missingKeys = validateReachableSymbolLocationValue(property['value'])
       if (missingKeys.length > 0) {
@@ -282,6 +286,7 @@ const extractingDependency = (component: any): Dependency | undefined => {
     is_dev: isDev,
     package_manager: packageManager,
     reachable_symbol_properties: reachableSymbolProperties,
+    exclusions,
   }
 
   return dependency

--- a/src/commands/sbom/types.ts
+++ b/src/commands/sbom/types.ts
@@ -97,6 +97,7 @@ export interface Dependency {
   is_dev: undefined | boolean
   package_manager: string
   reachable_symbol_properties: undefined | Property[]
+  exclusions: undefined | string[]
 }
 
 export interface ReachableSymbolLocationValue extends LocationFromFile {


### PR DESCRIPTION
### What and why?

Our current scans of Maven projects do it by analyzing `pom.xml` files and resolving transitive dependencies down the road. However, it does not currently support the Maven `<exclusions>` mechanism ([doc](https://maven.apache.org/guides/introduction/introduction-to-optional-and-excludes-dependencies.html)), which allows projects to intentionally omit specific transitive dependencies.
As a result, our SCA scanning includes dependencies that are explicitly excluded by the project, leading to inaccurate or misleading outputs. 

### How?

We now set as a property the detected exclusions for a given package, we should send it to the API as a property. 

We are reading:
```json
{
    "properties": [
        { "name": "datadog-sbom-generator:exclusion", "value": "com.github.jnr:jnr-ffi"}, // this
        { "name": "datadog-sbom-generator:exclusion", "value": "com.github.jnr:jnr-posix"}, // this
        { "name": "datadog-sbom-generator:exclusion", "value": "io.dropwizard.metrics:metrics-core"}, // this
        { "name": "datadog-sbom-generator:exclusion", "value": "io.netty:netty-handler"}, // this
        { "name": "osv-scanner:is-direct", "value": "true"},
        { "name": "osv-scanner:package-manager", "value": "Maven" }
    ]
}
```
and converting it to:
```json
{
    "exclusions": [
        "com.github.jnr:jnr-ffi",
        "com.github.jnr:jnr-posix",
        "io.dropwizard.metrics:metrics-core",
        "io.netty:netty-handler"
    ]
}
```
### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
