### PR TITLE
Fix `git` logic in `coverage upload` command

### DIFF
--- a/src/commands/coverage/upload.ts
+++ b/src/commands/coverage/upload.ts
@@ -146,9 +146,14 @@ export class UploadCodeCoverageReportCommand extends Command {
       return 1
     }
 
+    const isGitRepository = await isGitRepo()
+
+    if (isGitRepository) {
+      this.git = await newSimpleGit()
+    }
+
     if (!this.skipGitMetadataUpload) {
-      if (await isGitRepo()) {
-        this.git = await newSimpleGit()
+      if (isGitRepository) {
         const traceId = id()
 
         const requestBuilder = getRequestBuilder({


### PR DESCRIPTION
### What and why?

We want `this.git` even if `this.skipGitMetadataUpload` is true

### How?

Move `this.git` initialization outside of the `this.skipGitMetadataUpload` `if`

### Review checklist

Make sure the tests we have today work
