### PR TITLE
Support uploading opencover coverage reports

### DIFF
--- a/src/commands/coverage/__tests__/fixtures/subfolder.xml/opencover-coverage-invalid.xml
+++ b/src/commands/coverage/__tests__/fixtures/subfolder.xml/opencover-coverage-invalid.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Modules>
+    <Module hash="B0-C2-FD-A1-3A-C9-E1-62-0F-2F-6D-EB-74-68-5A-20-27-5F-00-BC">
+        <Summary numSequencePoints="1657" visitedSequencePoints="1577" numBranchPoints="922" visitedBranchPoints="769"
+                 sequenceCoverage="95.17" branchCoverage="83.41" maxCyclomaticComplexity="31"
+                 minCyclomaticComplexity="1"/>
+        <FullName>C:\Projects\opencover.git\working\main\bin\Debug\OpenCover.Framework.dll</FullName>
+        <ModuleName>OpenCover.Framework</ModuleName>
+        <Files>
+            <File uid="1" fullPath="c:\Projects\opencover.git\working\main\OpenCover.Framework\Bootstrapper.cs"/>
+            <File uid="2"
+                  fullPath="c:\Projects\opencover.git\working\main\OpenCover.Framework\CommandLineParserBase.cs"/>
+            <File uid="3" fullPath="c:\Projects\opencover.git\working\main\OpenCover.Framework\CommandLineParser.cs"/>
+            <File uid="5"
+                  fullPath="c:\Projects\opencover.git\working\main\OpenCover.Framework\Communication\MarshalWapper.cs"/>
+        </Files>
+        <Classes>
+            <Class>
+                <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0"
+                         sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="0"
+                         minCyclomaticComplexity="0"/>
+                <FullName>&lt;Module&gt;</FullName>
+                <Methods/>
+            </Class>
+            <Class>
+                <Summary numSequencePoints="22" visitedSequencePoints="22" numBranchPoints="3" visitedBranchPoints="3"
+                         sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1"
+                         minCyclomaticComplexity="1"/>
+                <FullName>OpenCover.Framework.Bootstrapper</FullName>
+                <Methods>
+                    <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="100" branchCoverage="100"
+                            isConstructor="false" isStatic="false" isGetter="true" isSetter="false">
+                        <Summary numSequencePoints="3" visitedSequencePoints="3" numBranchPoints="1"
+                                 visitedBranchPoints="1"
+                                 sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1"
+                                 minCyclomaticComplexity="1"/>
+                        <MetadataToken>100663298</MetadataToken>
+                        <Name>Microsoft.Practices.Unity.IUnityContainer
+                            OpenCover.Framework.Bootstrapper::get_Container()
+                        </Name>
+                        <FileRef uid="1"/>
+                        <SequencePoints>
+                            <SequencePoint vc="2" uspid="1" ordinal="0" offset="0" sl="46" sc="17" el="46" ec="18"/>
+                            <SequencePoint vc="2" uspid="2" ordinal="1" offset="1" sl="46" sc="19" el="46" ec="37"/>
+                            <SequencePoint vc="2" uspid="3" ordinal="2" offset="10" sl="46" sc="38" el="46" ec="39"/>
+                        </SequencePoints>
+                        <BranchPoints/>
+                        <MethodPoint xsi:type="SequencePoint" vc="2" uspid="1" ordinal="0" offset="0" sl="46" sc="17"
+                                     el="46" ec="18"/>
+                    </Method>
+                </Methods>
+            </Class>
+        </Classes>
+    </Module>
+    <Module skippedDueTo="Filter" hash="70-2E-5B-8B-05-0C-3D-E1-31-05-34-A1-87-7E-B0-D3-D3-A6-4D-F9">
+        <FullName>C:\Projects\opencover.git\working\main\bin\Debug\Gendarme.Framework.dll</FullName>
+        <ModuleName>Gendarme.Framework</ModuleName>
+        <Classes/>
+    </Module>
+</Modules>

--- a/src/commands/coverage/__tests__/fixtures/subfolder.xml/opencover-coverage-malformed.xml
+++ b/src/commands/coverage/__tests__/fixtures/subfolder.xml/opencover-coverage-malformed.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<CoverageSession xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <Summary numSequencePoints="1657" visitedSequencePoints="1577" numBranchPoints="922" visitedBranchPoints="769" sequenceCoverage="95.17" branchCoverage="83.41" maxCyclomaticComplexity="31" minCyclomaticComplexity="1" />
+    <Modules>
+        <Module hash="B0-C2-FD-A1-3A-C9-E1-62-0F-2F-6D-EB-74-68-5A-20-27-5F-00-BC">
+            <Summary numSequencePoints="1657" visitedSequencePoints="1577" numBranchPoints="922" visitedBranchPoints="769" sequenceCoverage="95.17" branchCoverage="83.41" maxCyclomaticComplexity="31" minCyclomaticComplexity="1" />
+            <FullName>C:\Projects\opencover.git\working\main\bin\Debug\OpenCover.Framework.dll</FullName>
+            <ModuleName>OpenCover.Framework</ModuleName>
+            <Files>
+                <File uid="1" fullPath="c:\Projects\opencover.git\working\main\OpenCover.Framework\Bootstrapper.cs" />
+                <File uid="2" fullPath="c:\Projects\opencover.git\working\main\OpenCover.Framework\CommandLineParserBase.cs" />
+                <File uid="3" fullPath="c:\Projects\opencover.git\working\main\OpenCover.Framework\CommandLineParser.cs" />
+                <File uid="5" fullPath="c:\Projects\opencover.git\working\main\OpenCover.Framework\Communication\MarshalWapper.cs" />
+            </Files>

--- a/src/commands/coverage/__tests__/fixtures/subfolder.xml/opencover-coverage.xml
+++ b/src/commands/coverage/__tests__/fixtures/subfolder.xml/opencover-coverage.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8"?>
+<CoverageSession xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <Summary numSequencePoints="1657" visitedSequencePoints="1577" numBranchPoints="922" visitedBranchPoints="769" sequenceCoverage="95.17" branchCoverage="83.41" maxCyclomaticComplexity="31" minCyclomaticComplexity="1" />
+  <Modules>
+    <Module hash="B0-C2-FD-A1-3A-C9-E1-62-0F-2F-6D-EB-74-68-5A-20-27-5F-00-BC">
+      <Summary numSequencePoints="1657" visitedSequencePoints="1577" numBranchPoints="922" visitedBranchPoints="769" sequenceCoverage="95.17" branchCoverage="83.41" maxCyclomaticComplexity="31" minCyclomaticComplexity="1" />
+      <FullName>C:\Projects\opencover.git\working\main\bin\Debug\OpenCover.Framework.dll</FullName>
+      <ModuleName>OpenCover.Framework</ModuleName>
+      <Files>
+        <File uid="1" fullPath="c:\Projects\opencover.git\working\main\OpenCover.Framework\Bootstrapper.cs" />
+        <File uid="2" fullPath="c:\Projects\opencover.git\working\main\OpenCover.Framework\CommandLineParserBase.cs" />
+        <File uid="3" fullPath="c:\Projects\opencover.git\working\main\OpenCover.Framework\CommandLineParser.cs" />
+        <File uid="5" fullPath="c:\Projects\opencover.git\working\main\OpenCover.Framework\Communication\MarshalWapper.cs" />
+      </Files>
+      <Classes>
+        <Class>
+          <Summary numSequencePoints="0" visitedSequencePoints="0" numBranchPoints="0" visitedBranchPoints="0" sequenceCoverage="0" branchCoverage="0" maxCyclomaticComplexity="0" minCyclomaticComplexity="0" />
+          <FullName>&lt;Module&gt;</FullName>
+          <Methods />
+        </Class>
+        <Class>
+          <Summary numSequencePoints="22" visitedSequencePoints="22" numBranchPoints="3" visitedBranchPoints="3" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+          <FullName>OpenCover.Framework.Bootstrapper</FullName>
+          <Methods>
+            <Method visited="true" cyclomaticComplexity="1" sequenceCoverage="100" branchCoverage="100" isConstructor="false" isStatic="false" isGetter="true" isSetter="false">
+              <Summary numSequencePoints="3" visitedSequencePoints="3" numBranchPoints="1" visitedBranchPoints="1" sequenceCoverage="100" branchCoverage="100" maxCyclomaticComplexity="1" minCyclomaticComplexity="1" />
+              <MetadataToken>100663298</MetadataToken>
+              <Name>Microsoft.Practices.Unity.IUnityContainer OpenCover.Framework.Bootstrapper::get_Container()</Name>
+              <FileRef uid="1" />
+              <SequencePoints>
+                <SequencePoint vc="2" uspid="1" ordinal="0" offset="0" sl="46" sc="17" el="46" ec="18" />
+                <SequencePoint vc="2" uspid="2" ordinal="1" offset="1" sl="46" sc="19" el="46" ec="37" />
+                <SequencePoint vc="2" uspid="3" ordinal="2" offset="10" sl="46" sc="38" el="46" ec="39" />
+              </SequencePoints>
+              <BranchPoints />
+              <MethodPoint xsi:type="SequencePoint" vc="2" uspid="1" ordinal="0" offset="0" sl="46" sc="17" el="46" ec="18" />
+            </Method>
+          </Methods>
+        </Class>
+      </Classes>
+    </Module>
+    <Module skippedDueTo="Filter" hash="70-2E-5B-8B-05-0C-3D-E1-31-05-34-A1-87-7E-B0-D3-D3-A6-4D-F9">
+      <FullName>C:\Projects\opencover.git\working\main\bin\Debug\Gendarme.Framework.dll</FullName>
+      <ModuleName>Gendarme.Framework</ModuleName>
+      <Classes />
+    </Module>
+  </Modules>
+</CoverageSession>

--- a/src/commands/coverage/__tests__/upload.test.ts
+++ b/src/commands/coverage/__tests__/upload.test.ts
@@ -4,6 +4,7 @@ import {createCommand, createMockContext, makeRunCLI} from '../../../helpers/__t
 import {SpanTags} from '../../../helpers/interfaces'
 
 import {UploadCodeCoverageReportCommand} from '../upload'
+import {jacocoFormat} from '../utils'
 
 jest.mock('../../../helpers/id', () => jest.fn())
 
@@ -30,16 +31,17 @@ describe('upload', () => {
       const result = command['getMatchingCoverageReportFilesByFormat']()
       const fileNames = Object.values(result).flatMap((paths) => paths)
 
-      expect(fileNames.length).toEqual(4)
+      expect(fileNames.length).toEqual(5)
       expect(fileNames).toContain('src/commands/coverage/__tests__/fixtures/other-Jacoco-report.xml')
       expect(fileNames).toContain('src/commands/coverage/__tests__/fixtures/jacoco-report.xml')
       expect(fileNames).toContain('src/commands/coverage/__tests__/fixtures/subfolder.xml/nested-Jacoco-report.xml')
       expect(fileNames).toContain('src/commands/coverage/__tests__/fixtures/lcov.info')
+      expect(fileNames).toContain('src/commands/coverage/__tests__/fixtures/subfolder.xml/opencover-coverage.xml')
     })
 
     test('should filter by format', () => {
       const command = createCommand(UploadCodeCoverageReportCommand)
-      command['format'] = 'jacoco'
+      command['format'] = jacocoFormat
       command['basePaths'] = ['src/commands/coverage/__tests__/fixtures']
 
       const result = command['getMatchingCoverageReportFilesByFormat']()
@@ -110,6 +112,7 @@ describe('upload', () => {
 
     test('should allow folder and single unit paths', () => {
       const command = createCommand(UploadCodeCoverageReportCommand)
+      command['format'] = jacocoFormat
       command['basePaths'] = [
         'src/commands/coverage/__tests__/fixtures',
         'src/commands/coverage/__tests__/fixtures/subfolder.xml/nested-Jacoco-report.xml',
@@ -118,15 +121,15 @@ describe('upload', () => {
       const result = command['getMatchingCoverageReportFilesByFormat']()
 
       const fileNames = Object.values(result).flatMap((paths) => paths)
-      expect(fileNames.length).toEqual(4)
+      expect(fileNames.length).toEqual(3)
       expect(fileNames).toContain('src/commands/coverage/__tests__/fixtures/other-Jacoco-report.xml')
       expect(fileNames).toContain('src/commands/coverage/__tests__/fixtures/jacoco-report.xml')
       expect(fileNames).toContain('src/commands/coverage/__tests__/fixtures/subfolder.xml/nested-Jacoco-report.xml')
-      expect(fileNames).toContain('src/commands/coverage/__tests__/fixtures/lcov.info')
     })
 
     test('should not have repeated files', () => {
       const command = createCommand(UploadCodeCoverageReportCommand)
+      command['format'] = jacocoFormat
       command['basePaths'] = [
         'src/commands/coverage/__tests__/fixtures',
         'src/commands/coverage/__tests__/fixtures/jacoco-report.xml',
@@ -136,11 +139,10 @@ describe('upload', () => {
 
       const fileNames = Object.values(result).flatMap((paths) => paths)
 
-      expect(fileNames.length).toEqual(4)
+      expect(fileNames.length).toEqual(3)
       expect(fileNames).toContain('src/commands/coverage/__tests__/fixtures/other-Jacoco-report.xml')
       expect(fileNames).toContain('src/commands/coverage/__tests__/fixtures/jacoco-report.xml')
       expect(fileNames).toContain('src/commands/coverage/__tests__/fixtures/subfolder.xml/nested-Jacoco-report.xml')
-      expect(fileNames).toContain('src/commands/coverage/__tests__/fixtures/lcov.info')
     })
 
     test('should fetch nested folders when using glob patterns', () => {
@@ -150,10 +152,11 @@ describe('upload', () => {
       const result = command['getMatchingCoverageReportFilesByFormat']()
 
       const fileNames = Object.values(result).flatMap((paths) => paths)
-      expect(fileNames.length).toEqual(3)
+      expect(fileNames.length).toEqual(4)
       expect(fileNames).toContain('./src/commands/coverage/__tests__/fixtures/other-Jacoco-report.xml')
       expect(fileNames).toContain('./src/commands/coverage/__tests__/fixtures/jacoco-report.xml')
       expect(fileNames).toContain('./src/commands/coverage/__tests__/fixtures/subfolder.xml/nested-Jacoco-report.xml')
+      expect(fileNames).toContain('./src/commands/coverage/__tests__/fixtures/subfolder.xml/opencover-coverage.xml')
     })
 
     test('should filter by format when using glob patterns', () => {
@@ -170,16 +173,16 @@ describe('upload', () => {
 
     test('should fetch nested folders and ignore files that are not coverage reports', () => {
       const command = createCommand(UploadCodeCoverageReportCommand)
+      command['format'] = jacocoFormat
       command['basePaths'] = ['**/coverage/**']
 
       const result = command['getMatchingCoverageReportFilesByFormat']()
 
       const fileNames = Object.values(result).flatMap((paths) => paths)
-      expect(fileNames.length).toEqual(4)
+      expect(fileNames.length).toEqual(3)
       expect(fileNames).toContain('./src/commands/coverage/__tests__/fixtures/other-Jacoco-report.xml')
       expect(fileNames).toContain('./src/commands/coverage/__tests__/fixtures/jacoco-report.xml')
       expect(fileNames).toContain('./src/commands/coverage/__tests__/fixtures/subfolder.xml/nested-Jacoco-report.xml')
-      expect(fileNames).toContain('./src/commands/coverage/__tests__/fixtures/lcov.info')
     })
   })
 

--- a/src/commands/coverage/__tests__/utils.test.ts
+++ b/src/commands/coverage/__tests__/utils.test.ts
@@ -1,41 +1,76 @@
-import {detectFormat, validateCoverageReport} from '../utils'
+import {detectFormat, jacocoFormat, lcovFormat, opencoverFormat, validateCoverageReport} from '../utils'
 
 describe('utils', () => {
   describe('validateCoverageReport', () => {
     test('Returns undefined for a valid Jacoco report', async () => {
       const filePath = './src/commands/coverage/__tests__/fixtures/jacoco-report.xml'
-      expect(validateCoverageReport(filePath, 'jacoco')).toBeUndefined()
+      expect(validateCoverageReport(filePath, jacocoFormat)).toBeUndefined()
     })
 
     test('Returns undefined for a valid Jacoco report with user-provided format', async () => {
       const filePath = './src/commands/coverage/__tests__/fixtures/jacoco-report.xml'
-      expect(validateCoverageReport(filePath, 'jacoco')).toBeUndefined()
+      expect(validateCoverageReport(filePath, jacocoFormat)).toBeUndefined()
     })
 
     test('Returns error message for an invalid Jacoco report', async () => {
       const filePath = './src/commands/coverage/__tests__/fixtures/invalid-jacoco-report.xml'
-      expect(validateCoverageReport(filePath, 'jacoco')).toMatch(/.+/)
+      expect(validateCoverageReport(filePath, jacocoFormat)).toMatch(/.+/)
     })
 
     test('Returns error message for a Jacoco report with invalid root tag', async () => {
       const filePath = './src/commands/coverage/__tests__/fixtures/jacoco-report-incorrect-root-tag.xml'
-      expect(validateCoverageReport(filePath, 'jacoco')).toMatch(/.+/)
+      expect(validateCoverageReport(filePath, jacocoFormat)).toMatch(/.+/)
+    })
+
+    test('Returns undefined for a valid lcov report', async () => {
+      const filePath = './src/commands/coverage/__tests__/fixtures/lcov.info'
+      expect(validateCoverageReport(filePath, lcovFormat)).toBeUndefined()
+    })
+
+    test('Returns error message for an invalid lcov report', async () => {
+      const filePath = './src/commands/coverage/__tests__/fixtures/invalid.lcov'
+      expect(validateCoverageReport(filePath, lcovFormat)).toMatch(/.+/)
+    })
+
+    test('Returns undefined for a valid opencover report', async () => {
+      const filePath = './src/commands/coverage/__tests__/fixtures/subfolder.xml/opencover-coverage.xml'
+      expect(validateCoverageReport(filePath, opencoverFormat)).toBeUndefined()
+    })
+
+    test('Returns error message for an invalid opencover report', async () => {
+      const filePath = './src/commands/coverage/__tests__/fixtures/subfolder.xml/opencover-coverage-invalid.xml'
+      expect(validateCoverageReport(filePath, opencoverFormat)).toMatch(/.+/)
+    })
+
+    test('Returns error message for a malformed opencover report', async () => {
+      const filePath = './src/commands/coverage/__tests__/fixtures/subfolder.xml/opencover-coverage-malformed.xml'
+      expect(validateCoverageReport(filePath, opencoverFormat)).toMatch(/.+/)
     })
   })
 
   describe('detectFormat', () => {
     test('Detects Jacoco format for a valid Jacoco report', async () => {
       const filePath = './src/commands/coverage/__tests__/fixtures/jacoco-report.xml'
-      expect(detectFormat(filePath)).toEqual('jacoco')
+      expect(detectFormat(filePath)).toEqual(jacocoFormat)
     })
 
-    test('Returns undefined for a non-XML file', async () => {
-      const filePath = './src/commands/coverage/__tests__/fixtures/non-xml-file.txt'
+    test('Detects lcov format for a valid lcov report', async () => {
+      const filePath = './src/commands/coverage/__tests__/fixtures/lcov.info'
+      expect(detectFormat(filePath)).toEqual(lcovFormat)
+    })
+
+    test('Detects opencover format for a valid opencover report', async () => {
+      const filePath = './src/commands/coverage/__tests__/fixtures/subfolder.xml/opencover-coverage.xml'
+      expect(detectFormat(filePath)).toEqual(opencoverFormat)
+    })
+
+    test('Returns undefined for an XML file that is not a coverage report', async () => {
+      const filePath = './src/commands/coverage/__tests__/fixtures/random-file.xml'
       expect(detectFormat(filePath)).toBeUndefined()
     })
 
-    test('Returns undefined for a non-Jacoco XML file', async () => {
-      const filePath = './src/commands/coverage/__tests__/fixtures/random-file.xml'
+    test('Returns undefined for a text file that is not a coverage report', async () => {
+      const filePath = './src/commands/coverage/__tests__/fixtures/non-xml-file.txt'
       expect(detectFormat(filePath)).toBeUndefined()
     })
   })


### PR DESCRIPTION
### What and why?

Updates `coverage upload` command, adding detection and validation logic specific to Opencover format.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
