### PR TITLE
[SYNTH-20482] Mark `/w` as safe in docker image entrypoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ This example demonstrates how to run a command using the container and passing i
 ```shell
 export DD_API_KEY=$(cat /secret/dd_api_key)
 export DD_APP_KEY=$(cat /secret/dd_app_key)
-docker run --rm -it -v $(pwd):/w -e DD_API_KEY -e DD_APP_KEY datadog/ci synthetics run-tests -p pub-lic-id1
+docker run --rm -it -v $(pwd):/w -e DD_API_KEY -e DD_APP_KEY datadog/ci <command> [<subcommand>] [options]
 ```
 
 #### Building your own container image
@@ -209,7 +209,7 @@ docker build --tag datadog-ci .
 Optionally, you can use the `VERSION` build argument to build an image for a specific version:
 
 ```sh
-docker build --build-arg "VERSION=v1.14" --t datadog-ci .
+docker build --build-arg "VERSION=v3.9.0" --t datadog-ci .
 ```
 
 ## Migration guide

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -7,4 +7,7 @@ ARG VERSION
 RUN npm install -g "@datadog/datadog-ci@${VERSION}" \
     && echo "Installed datadog-ci version: $(npm list -g | grep datadog-ci | grep -o '[^@]*$')"
 
-ENTRYPOINT ["datadog-ci"]
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/container/entrypoint.sh
+++ b/container/entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+# Fix "detected dubious ownership in repository at '/w'" error
+git config --global --add safe.directory /w
+
+datadog-ci "$@"

--- a/container/entrypoint.sh
+++ b/container/entrypoint.sh
@@ -3,4 +3,4 @@
 # Fix "detected dubious ownership in repository at '/w'" error
 git config --global --add safe.directory /w
 
-datadog-ci "$@"
+exec datadog-ci "$@"


### PR DESCRIPTION
### What and why?

Closes #1658 

Same as https://github.com/DataDog/datadog-sca-github-action/blob/e373cb84ac57d35fbefd4c7c7ee5b4592e976fbc/entrypoint.sh#L71

### How?

Git fails when the current user inside the `docker/ci` container is not the user owning the files:

```sh
fatal: detected dubious ownership in repository at '/w'
```

And `/w` is the directory where we expect users to mount their host's repository folder: [see docs](https://github.com/DataDog/datadog-ci/blob/42ce08a40d1905ffb9846c1d292db09a916edec2/README.md?plain=1#L197).

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
