### PR TITLE
[SYNTH-20459] Add JSDoc on `BaseResult` and `Summary`

### DIFF
--- a/src/commands/synthetics/interfaces.ts
+++ b/src/commands/synthetics/interfaces.ts
@@ -184,15 +184,15 @@ export interface Summary {
   passed: number
   /** The number of results that already passed in previous CI batches on the same commit. */
   previouslyPassed: number
-  /** The number of tests that were skipped during the CI batch. */
+  /** The number of tests that were skipped when starting the CI batch. */
   skipped: number
   /** The public IDs of tests that could not be found when starting the CI batch. */
   testsNotFound: Set<string>
-  /** The number of results that timed out during the CI batch. */
-  timedOut: number
+  /** The number of results that failed due to the CI batch timing out. */
+  timedOut: number // XXX: When a batch times out, all the results that were in progress are timed out.
 }
 
-// Note: This is exposed in CI integrations as a raw JSON string in the `rawResults` output.
+// Note: This is exposed in CI integrations as a JSON-encoded string in the `rawResults` output.
 export interface BaseResult {
   /** The device used in this test run. */
   device?: Device


### PR DESCRIPTION
### What and why?

- https://github.com/DataDog/datadog-ci/pull/1690 (← **you are here**)
- https://github.com/DataDog/synthetics-ci-github-action/pull/341
- https://github.com/DataDog/datadog-ci-azure-devops/pull/241

This PR adds JSDoc on `BaseResult` because it's exposed in CI integrations ([`raw-results`](https://github.com/DataDog/synthetics-ci-github-action#outputs) and [`rawResults`](https://github.com/DataDog/datadog-ci-azure-devops#outputs)).

It also does it on `Summary` since it's exposed to library users.

### How?

Add JSDoc.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
