### PR TITLE
[SVLS-7005] aas instrument dotnet settings support

### DIFF
--- a/src/commands/aas/__tests__/common.test.ts
+++ b/src/commands/aas/__tests__/common.test.ts
@@ -1,4 +1,5 @@
 import {Site} from '@azure/arm-appservice'
+
 import {getEnvVars, isDotnet, isWindows} from '../common'
 import {AasConfigOptions} from '../interfaces'
 
@@ -99,6 +100,7 @@ describe('aas common', () => {
         DD_AAS_INSTANCE_LOGGING_ENABLED: 'true',
       })
     })
+
     describe('isWindows', () => {
       test('returns true if site.kind includes "windows"', () => {
         const site: Site = {
@@ -147,6 +149,7 @@ describe('aas common', () => {
         expect(isWindows(site)).toBe(false)
       })
     })
+
     test('includes .NET specific env vars when isDotnet is true', () => {
       const envVars = getEnvVars({...DEFAULT_CONFIG, isDotnet: true})
       expect(envVars).toMatchObject({

--- a/src/commands/aas/__tests__/common.test.ts
+++ b/src/commands/aas/__tests__/common.test.ts
@@ -1,0 +1,239 @@
+import {Site} from '@azure/arm-appservice'
+import {getEnvVars, isDotnet, isWindows} from '../common'
+import {AasConfigOptions} from '../interfaces'
+
+const DEFAULT_CONFIG: AasConfigOptions = {
+  subscriptionId: '00000000-0000-0000-0000-000000000000',
+  resourceGroup: 'my-resource-group',
+  aasName: 'my-web-app',
+  service: undefined,
+  environment: undefined,
+  isInstanceLoggingEnabled: false,
+  logPath: undefined,
+  isDotnet: false,
+}
+
+describe('aas common', () => {
+  describe('getEnvVars', () => {
+    let originalEnv: NodeJS.ProcessEnv
+    beforeAll(() => {
+      originalEnv = {...process.env}
+    })
+
+    beforeEach(() => {
+      process.env.DD_API_KEY = 'test-api-key'
+      delete process.env.DD_SITE
+    })
+
+    afterEach(() => {
+      delete process.env.DD_API_KEY
+      delete process.env.DD_SITE
+    })
+
+    afterAll(() => {
+      process.env = originalEnv
+    })
+
+    test('returns required env vars with default DD_SITE', () => {
+      const envVars = getEnvVars(DEFAULT_CONFIG)
+      expect(envVars).toEqual({
+        DD_API_KEY: 'test-api-key',
+        DD_SITE: 'datadoghq.com',
+        DD_AAS_INSTANCE_LOGGING_ENABLED: 'false',
+      })
+    })
+
+    test('uses DD_SITE from environment if set', () => {
+      process.env.DD_SITE = 'datadoghq.eu'
+      const config: AasConfigOptions = {
+        ...DEFAULT_CONFIG,
+        isInstanceLoggingEnabled: true,
+      }
+      const envVars = getEnvVars(config)
+      expect(envVars.DD_SITE).toEqual('datadoghq.eu')
+      expect(envVars.DD_AAS_INSTANCE_LOGGING_ENABLED).toEqual('true')
+    })
+
+    test('includes DD_SERVICE if provided in config', () => {
+      const config: AasConfigOptions = {
+        ...DEFAULT_CONFIG,
+        service: 'my-service',
+      }
+      const envVars = getEnvVars(config)
+      expect(envVars.DD_SERVICE).toEqual('my-service')
+    })
+
+    test('includes DD_ENV if provided in config', () => {
+      const config: AasConfigOptions = {
+        ...DEFAULT_CONFIG,
+        isInstanceLoggingEnabled: false,
+        environment: 'prod',
+      }
+      const envVars = getEnvVars(config)
+      expect(envVars.DD_ENV).toEqual('prod')
+    })
+
+    test('includes DD_SERVERLESS_LOG_PATH if provided in config', () => {
+      const config: AasConfigOptions = {
+        ...DEFAULT_CONFIG,
+        isInstanceLoggingEnabled: false,
+        logPath: '/tmp/logs',
+      }
+      const envVars = getEnvVars(config)
+      expect(envVars.DD_SERVERLESS_LOG_PATH).toEqual('/tmp/logs')
+    })
+
+    test('includes all optional vars if provided', () => {
+      const config: AasConfigOptions = {
+        ...DEFAULT_CONFIG,
+        isInstanceLoggingEnabled: true,
+        service: 'svc',
+        environment: 'dev',
+        logPath: '/var/log',
+      }
+      const envVars = getEnvVars(config)
+      expect(envVars).toMatchObject({
+        DD_SERVICE: 'svc',
+        DD_ENV: 'dev',
+        DD_SERVERLESS_LOG_PATH: '/var/log',
+        DD_AAS_INSTANCE_LOGGING_ENABLED: 'true',
+      })
+    })
+    describe('isWindows', () => {
+      test('returns true if site.kind includes "windows"', () => {
+        const site: Site = {
+          kind: 'app,windows',
+          location: 'East US',
+          siteConfig: {},
+        }
+        expect(isWindows(site)).toBe(true)
+      })
+
+      test('returns false if site.kind does not include "windows"', () => {
+        const site: Site = {
+          kind: 'app,linux',
+          location: 'East US',
+          siteConfig: {},
+        }
+        expect(isWindows(site)).toBe(false)
+      })
+
+      test('returns true if site.kind is undefined but siteConfig.windowsFxVersion is set', () => {
+        const site: Site = {
+          kind: undefined,
+          location: 'East US',
+          siteConfig: {
+            windowsFxVersion: 'DOTNET|6.0',
+          },
+        }
+        expect(isWindows(site)).toBe(true)
+      })
+
+      test('returns false if site.kind is undefined and siteConfig.windowsFxVersion is not set', () => {
+        const site: Site = {
+          kind: undefined,
+          location: 'East US',
+          siteConfig: {},
+        }
+        expect(isWindows(site)).toBe(false)
+      })
+
+      test('returns false if site.kind is undefined and siteConfig is undefined', () => {
+        const site: Site = {
+          kind: undefined,
+          location: 'East US',
+          siteConfig: undefined,
+        }
+        expect(isWindows(site)).toBe(false)
+      })
+    })
+    test('includes .NET specific env vars when isDotnet is true', () => {
+      const envVars = getEnvVars({...DEFAULT_CONFIG, isDotnet: true})
+      expect(envVars).toMatchObject({
+        DD_DOTNET_TRACER_HOME: '/home/site/wwwroot/datadog',
+        DD_TRACE_LOG_DIRECTORY: '/home/LogFiles/dotnet',
+        CORECLR_ENABLE_PROFILING: '1',
+        CORECLR_PROFILER: '{846F5F1C-F9AE-4B07-969E-05C26BC060D8}',
+        CORECLR_PROFILER_PATH: '/home/site/wwwroot/datadog/linux-musl-x64/Datadog.Trace.ClrProfiler.Native.so',
+      })
+    })
+
+    test('includes all .NET and optional env vars', () => {
+      const config: AasConfigOptions = {
+        ...DEFAULT_CONFIG,
+        isDotnet: true,
+        service: 'svc',
+        environment: 'qa',
+        logPath: '/dotnet/logs',
+        isInstanceLoggingEnabled: true,
+      }
+      const envVars = getEnvVars(config)
+      expect(envVars).toMatchObject({
+        DD_SERVICE: 'svc',
+        DD_ENV: 'qa',
+        DD_SERVERLESS_LOG_PATH: '/dotnet/logs',
+        DD_AAS_INSTANCE_LOGGING_ENABLED: 'true',
+        DD_DOTNET_TRACER_HOME: '/home/site/wwwroot/datadog',
+        DD_TRACE_LOG_DIRECTORY: '/home/LogFiles/dotnet',
+        CORECLR_ENABLE_PROFILING: '1',
+        CORECLR_PROFILER: '{846F5F1C-F9AE-4B07-969E-05C26BC060D8}',
+        CORECLR_PROFILER_PATH: '/home/site/wwwroot/datadog/linux-musl-x64/Datadog.Trace.ClrProfiler.Native.so',
+      })
+    })
+  })
+
+  describe('isDotnet', () => {
+    test('returns true if linuxFxVersion starts with "dotnet"', () => {
+      const site: Site = {
+        kind: 'app,linux',
+        location: 'East US',
+        siteConfig: {
+          linuxFxVersion: 'dotnet|6.0',
+        },
+      }
+      expect(isDotnet(site)).toBe(true)
+    })
+
+    test('returns true if windowsFxVersion starts with "dotnet"', () => {
+      const site: Site = {
+        kind: 'app,windows',
+        location: 'East US',
+        siteConfig: {
+          windowsFxVersion: 'dotnet|7.0',
+        },
+      }
+      expect(isDotnet(site)).toBe(true)
+    })
+
+    test('returns false if linuxFxVersion does not start with "dotnet"', () => {
+      const site: Site = {
+        kind: 'app,linux',
+        location: 'East US',
+        siteConfig: {
+          linuxFxVersion: 'node|18-lts',
+        },
+      }
+      expect(isDotnet(site)).toBe(false)
+    })
+
+    test('returns false if windowsFxVersion does not start with "dotnet"', () => {
+      const site: Site = {
+        kind: 'app,windows',
+        location: 'East US',
+        siteConfig: {
+          windowsFxVersion: 'node|18-lts',
+        },
+      }
+      expect(isDotnet(site)).toBe(false)
+    })
+
+    test('returns false if siteConfig is undefined', () => {
+      const site: Site = {
+        kind: 'app,windows',
+        location: 'East US',
+        siteConfig: undefined,
+      }
+      expect(isDotnet(site)).toBe(false)
+    })
+  })
+})

--- a/src/commands/aas/__tests__/instrument.test.ts
+++ b/src/commands/aas/__tests__/instrument.test.ts
@@ -352,6 +352,7 @@ Creating sidecar container datadog-sidecar
         },
       })
     })
+
     test('adds .NET settings when the config option is specified', async () => {
       await command.instrumentSidecar(client, {...DEFAULT_CONFIG, isDotnet: true}, 'rg', 'app')
 

--- a/src/commands/aas/common.ts
+++ b/src/commands/aas/common.ts
@@ -15,6 +15,18 @@ export const SIDECAR_CONTAINER_NAME = 'datadog-sidecar'
 export const SIDECAR_IMAGE = 'index.docker.io/datadog/serverless-init:latest'
 export const SIDECAR_PORT = '8126'
 
+
+// Path to tracing libraries, copied within the Docker file
+const DD_DOTNET_TRACER_HOME = '/home/site/wwwroot/datadog'
+// Where tracer logs are stored
+const DD_TRACE_LOG_DIRECTORY = '/home/LogFiles/dotnet'
+// Instructs the .NET CLR that profiling should be enabled
+const CORECLR_ENABLE_PROFILING = '1'
+// Profiler GUID
+const CORECLR_PROFILER = '{846F5F1C-F9AE-4B07-969E-05C26BC060D8}'
+// The profiler binary that the .NET CLR loads into memory, which contains the GUID
+const CORECLR_PROFILER_PATH = '/home/site/wwwroot/datadog/linux-musl-x64/Datadog.Trace.ClrProfiler.Native.so'
+
 export abstract class AasCommand extends Command {
   public dryRun = Option.Boolean('-d,--dry-run', false, {
     description: 'Run the command in dry-run mode, without making any changes',
@@ -46,7 +58,7 @@ export abstract class AasCommand extends Command {
   })
 
   private isDotnet = Option.Boolean('--dotnet', false, {
-    description: 'Add in required .NET-specific configuration options, is automatically inferred for code runtimes',
+    description: 'Add in required .NET-specific configuration options, is automatically inferred for code runtimes. This should be specified if you are using a containerized .NET app.',
   })
 
   private fips = Option.Boolean('--fips', false)
@@ -122,11 +134,11 @@ export const getEnvVars = (config: AasConfigOptions): Record<string, string> => 
     envVars = {
       ...envVars,
 
-      DD_DOTNET_TRACER_HOME: '/home/site/wwwroot/datadog',
-      DD_TRACE_LOG_DIRECTORY: '/home/LogFiles/dotnet',
-      CORECLR_ENABLE_PROFILING: '1',
-      CORECLR_PROFILER: '{846F5F1C-F9AE-4B07-969E-05C26BC060D8}',
-      CORECLR_PROFILER_PATH: '/home/site/wwwroot/datadog/linux-musl-x64/Datadog.Trace.ClrProfiler.Native.so',
+      DD_DOTNET_TRACER_HOME,
+      DD_TRACE_LOG_DIRECTORY,
+      CORECLR_ENABLE_PROFILING,
+      CORECLR_PROFILER,
+      CORECLR_PROFILER_PATH,
     }
   }
 

--- a/src/commands/aas/common.ts
+++ b/src/commands/aas/common.ts
@@ -15,7 +15,6 @@ export const SIDECAR_CONTAINER_NAME = 'datadog-sidecar'
 export const SIDECAR_IMAGE = 'index.docker.io/datadog/serverless-init:latest'
 export const SIDECAR_PORT = '8126'
 
-
 // Path to tracing libraries, copied within the Docker file
 const DD_DOTNET_TRACER_HOME = '/home/site/wwwroot/datadog'
 // Where tracer logs are stored
@@ -58,7 +57,8 @@ export abstract class AasCommand extends Command {
   })
 
   private isDotnet = Option.Boolean('--dotnet', false, {
-    description: 'Add in required .NET-specific configuration options, is automatically inferred for code runtimes. This should be specified if you are using a containerized .NET app.',
+    description:
+      'Add in required .NET-specific configuration options, is automatically inferred for code runtimes. This should be specified if you are using a containerized .NET app.',
   })
 
   private fips = Option.Boolean('--fips', false)
@@ -133,7 +133,6 @@ export const getEnvVars = (config: AasConfigOptions): Record<string, string> => 
   if (config.isDotnet) {
     envVars = {
       ...envVars,
-
       DD_DOTNET_TRACER_HOME,
       DD_TRACE_LOG_DIRECTORY,
       CORECLR_ENABLE_PROFILING,

--- a/src/commands/aas/interfaces.ts
+++ b/src/commands/aas/interfaces.ts
@@ -10,6 +10,7 @@ export interface AasConfigOptions {
   environment: string | undefined
   isInstanceLoggingEnabled: boolean
   logPath: string | undefined
+  isDotnet: boolean
 }
 
 export type ValueOptional<T> = {


### PR DESCRIPTION
### What and why?

Adds the additional required dotnet settings as specified by the docs. This allows us to fully support instrumenting dotnet applications running on linux code or container runtimes

### How?

Adds an additional flag `--dotnet` to force the settings, and for code runtimes we can auto-detect the runtime and add it in after the fact.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
