### PR TITLE
[chore] Bump `@google-cloud/run` to v2

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "@azure/arm-appservice": "^16.0.0",
     "@azure/identity": "^4.10.0",
     "@google-cloud/logging": "^11.1.0",
-    "@google-cloud/run": "^1.4.0",
+    "@google-cloud/run": "^2.1.0",
     "@smithy/property-provider": "^2.0.12",
     "@smithy/util-retry": "^2.0.4",
     "@types/datadog-metrics": "0.6.1",

--- a/src/commands/cloud-run/__tests__/instrument.test.ts
+++ b/src/commands/cloud-run/__tests__/instrument.test.ts
@@ -1,7 +1,5 @@
-import IContainer = google.cloud.run.v2.IContainer
-import IVolumeMount = google.cloud.run.v2.IVolumeMount
-
-import {google} from '@google-cloud/run/build/protos/protos'
+// XXX temporary workaround for @google-cloud/run ESM/CJS module issues
+import type {IContainer, IVolumeMount} from '../types'
 
 import {SERVICE_ENV_VAR} from '../../../constants'
 import {makeRunCLI} from '../../../helpers/__tests__/testing-tools'
@@ -160,7 +158,7 @@ describe('InstrumentCommand', () => {
       expect(result.template?.containers?.map((c: IContainer) => c.name)).toEqual(['main', 'datadog-sidecar'])
 
       // main container should get the shared volume mount
-      const main = result.template?.containers?.find((c) => c.name === 'main')
+      const main = result.template?.containers?.find((c: IContainer) => c.name === 'main')
       expect(main?.volumeMounts?.some((vm: IVolumeMount) => vm.mountPath === '/shared-volume')).toBe(true)
 
       // should add the shared-volume

--- a/src/commands/cloud-run/flare.ts
+++ b/src/commands/cloud-run/flare.ts
@@ -1,12 +1,10 @@
-import IService = google.cloud.run.v2.IService
-import IContainer = google.cloud.run.v2.IContainer
 import fs from 'fs'
 import process from 'process'
 import util from 'util'
 
+import type {IService, IContainer, ServicesClient as IServicesClient} from './types'
+
 import {Logging} from '@google-cloud/logging'
-import {RevisionsClient, ServicesClient} from '@google-cloud/run'
-import {google} from '@google-cloud/run/build/protos/protos'
 import chalk from 'chalk'
 import {Command, Option} from 'clipanion'
 import upath from 'upath'
@@ -39,6 +37,9 @@ import {SKIP_MASKING_CLOUDRUN_ENV_VARS} from './constants'
 import {CloudRunLog, LogConfig} from './interfaces'
 import {renderAuthenticationInstructions} from './renderer'
 import {checkAuthentication} from './utils'
+
+// XXX temporary workaround for @google-cloud/run ESM/CJS module issues
+const {RevisionsClient, ServicesClient} = require('@google-cloud/run')
 
 const SERVICE_CONFIG_FILE_NAME = 'service_config.json'
 const FLARE_ZIP_FILE_NAME = 'cloud-run-flare-output.zip'
@@ -168,7 +169,7 @@ export class CloudRunFlareCommand extends Command {
 
     // Get and print service configuration
     this.context.stdout.write(chalk.bold('\n🔍 Fetching service configuration...\n'))
-    const runClient = new ServicesClient()
+    const runClient: IServicesClient = new ServicesClient()
     let config: IService
     try {
       config = await getCloudRunServiceConfig(runClient, this.service!, this.project!, this.region!)
@@ -408,7 +409,7 @@ export class CloudRunFlareCommand extends Command {
  * @returns the configuration for the given service
  */
 export const getCloudRunServiceConfig = async (
-  runClient: ServicesClient,
+  runClient: IServicesClient,
   serviceName: string,
   projectName: string,
   region: string
@@ -468,7 +469,7 @@ export const summarizeConfig = (config: IService) => {
   if (template) {
     const summarizedContainers: IContainer[] = []
     const containers = template.containers ?? []
-    containers.forEach((container) => {
+    containers.forEach((container: IContainer) => {
       const summarizedContainer: any = {}
       summarizedContainer.env = container.env
       summarizedContainer.image = container.image

--- a/src/commands/cloud-run/types.ts
+++ b/src/commands/cloud-run/types.ts
@@ -1,0 +1,53 @@
+// XXX temporary type definitions for @google-cloud/run
+// TODO remove this when google-auth-library ESM/CJS issues are fixed
+
+export interface IEnvVar {
+  name?: string
+  value?: string
+}
+
+export interface IVolumeMount {
+  name?: string
+  mountPath?: string
+}
+
+export interface IContainer {
+  name?: string
+  image?: string
+  env?: IEnvVar[]
+  volumeMounts?: IVolumeMount[]
+  startupProbe?: any
+  resources?: any
+}
+
+export interface IVolume {
+  name?: string
+  emptyDir?: {
+    medium?: number
+  }
+}
+
+export interface IServiceTemplate {
+  containers?: IContainer[]
+  volumes?: IVolume[]
+}
+
+export interface IService {
+  name?: string
+  uid?: string
+  uri?: string
+  description?: string
+  template?: IServiceTemplate
+  labels?: Record<string, string>
+}
+
+export interface ServicesClient {
+  servicePath: (project: string, region: string, service: string) => string
+  getService: (request: {name: string}) => Promise<[IService]>
+  updateService: (request: {service: IService}) => Promise<[any]>
+}
+
+export interface RevisionsClient {
+  servicePath: (project: string, region: string, service: string) => string
+  listRevisions: (request: {parent: string}) => Promise<[any[]]>
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2040,7 +2040,7 @@ __metadata:
     "@babel/preset-env": 7.4.5
     "@babel/preset-typescript": 7.3.3
     "@google-cloud/logging": ^11.1.0
-    "@google-cloud/run": ^1.4.0
+    "@google-cloud/run": ^2.1.0
     "@microsoft/eslint-formatter-sarif": ^3.0.0
     "@smithy/property-provider": ^2.0.12
     "@smithy/util-retry": ^2.0.4
@@ -2319,12 +2319,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@google-cloud/run@npm:^1.4.0":
-  version: 1.4.0
-  resolution: "@google-cloud/run@npm:1.4.0"
+"@google-cloud/run@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "@google-cloud/run@npm:2.1.0"
   dependencies:
-    google-gax: ^4.0.3
-  checksum: 72dc1682f791c0cfc598b35a76aa0cb7fe8662aecb638ee6ea68149dcade2ee30804ce6b8a5efb423a430553e29bd6ebfa68eeb61c2d277dbe2bbe22d74a7625
+    google-gax: ^5.0.1-rc.0
+  checksum: 2eaa3bc2081ddfb3f7026bf54b6ae32e202622c5fe645c0e40f1de687b98da3352d92026875203590278303899ce4b25606fdde58b3819ede8e0972915040824
   languageName: node
   linkType: hard
 
@@ -2335,6 +2335,16 @@ __metadata:
     "@grpc/proto-loader": ^0.7.13
     "@js-sdsl/ordered-map": ^4.4.2
   checksum: 906894851a13b09f5a95052e1bec572b1b5760cc53635e80b50155c7546591cc8b8768d2723e2ec2ff5d7b086f65a27809db345fd3038fd50e3fc5e827ee88c6
+  languageName: node
+  linkType: hard
+
+"@grpc/grpc-js@npm:^1.12.6":
+  version: 1.13.4
+  resolution: "@grpc/grpc-js@npm:1.13.4"
+  dependencies:
+    "@grpc/proto-loader": ^0.7.13
+    "@js-sdsl/ordered-map": ^4.4.2
+  checksum: fe5db84bbbcd07cc1b68d1683b7fbe9cfcc5c3a60655ecc17fb3e1cd2adc4c1ce891b15e6e9a9c2140f6891def6f93b509a60d2bce253d13b317f9136e968451
   languageName: node
   linkType: hard
 
@@ -3734,6 +3744,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/long@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "@types/long@npm:5.0.0"
+  dependencies:
+    long: "*"
+  checksum: 1483b703bd6257cff1c9921cdc80e36f83985bed1f7bf9a64919e29df0038c3eb5acc82b70cd0cf15e4fdd639f79976eed5f7f9053e8db152b21b9e5d202845c
+  languageName: node
+  linkType: hard
+
 "@types/minimatch@npm:*":
   version: 5.1.2
   resolution: "@types/minimatch@npm:5.1.2"
@@ -3759,7 +3778,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/request@npm:^2.48.8":
+"@types/request@npm:^2.48.12, @types/request@npm:^2.48.8":
   version: 2.48.12
   resolution: "@types/request@npm:2.48.12"
   dependencies:
@@ -5192,6 +5211,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"data-uri-to-buffer@npm:^4.0.0":
+  version: 4.0.1
+  resolution: "data-uri-to-buffer@npm:4.0.1"
+  checksum: 0d0790b67ffec5302f204c2ccca4494f70b4e2d940fea3d36b09f0bb2b8539c2e86690429eb1f1dc4bcc9e4df0644193073e63d9ee48ac9fce79ec1506e4aa4c
+  languageName: node
+  linkType: hard
+
 "data-uri-to-buffer@npm:^6.0.2":
   version: 6.0.2
   resolution: "data-uri-to-buffer@npm:6.0.2"
@@ -5552,7 +5578,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"duplexify@npm:^4.0.0, duplexify@npm:^4.1.1":
+"duplexify@npm:^4.0.0, duplexify@npm:^4.1.1, duplexify@npm:^4.1.3":
   version: 4.1.3
   resolution: "duplexify@npm:4.1.3"
   dependencies:
@@ -6366,6 +6392,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fetch-blob@npm:^3.1.2, fetch-blob@npm:^3.1.4":
+  version: 3.2.0
+  resolution: "fetch-blob@npm:3.2.0"
+  dependencies:
+    node-domexception: ^1.0.0
+    web-streams-polyfill: ^3.0.3
+  checksum: f19bc28a2a0b9626e69fd7cf3a05798706db7f6c7548da657cbf5026a570945f5eeaedff52007ea35c8bcd3d237c58a20bf1543bc568ab2422411d762dd3d5bf
+  languageName: node
+  linkType: hard
+
 "figures@npm:^3.0.0":
   version: 3.2.0
   resolution: "figures@npm:3.2.0"
@@ -6483,6 +6519,15 @@ __metadata:
     hasown: ^2.0.2
     mime-types: ^2.1.12
   checksum: b8e2568c0853ce167b2b9c9c4b81fe563f9ade647178baf6b6381cf8a11e3c01dd2b78a63ba367e6f5eab59afab8284a9438bb5ae768133f9d9fce6567fbc26a
+  languageName: node
+  linkType: hard
+
+"formdata-polyfill@npm:^4.0.10":
+  version: 4.0.10
+  resolution: "formdata-polyfill@npm:4.0.10"
+  dependencies:
+    fetch-blob: ^3.1.2
+  checksum: 82a34df292afadd82b43d4a740ce387bc08541e0a534358425193017bf9fb3567875dc5f69564984b1da979979b70703aa73dee715a17b6c229752ae736dd9db
   languageName: node
   linkType: hard
 
@@ -6615,6 +6660,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"gaxios@npm:^7.0.0":
+  version: 7.1.0
+  resolution: "gaxios@npm:7.1.0"
+  dependencies:
+    extend: ^3.0.2
+    https-proxy-agent: ^7.0.1
+    node-fetch: ^3.3.2
+  checksum: 144c74ec6243cd71fc079c4f3d66494edfef09bfd371e493ec9a77f393ccee2459e311deadaa6015e29c0cff62539ac273b0098151b7c244b4c76c5a00b9ff40
+  languageName: node
+  linkType: hard
+
 "gcp-metadata@npm:^6.0.0, gcp-metadata@npm:^6.1.0":
   version: 6.1.0
   resolution: "gcp-metadata@npm:6.1.0"
@@ -6622,6 +6678,17 @@ __metadata:
     gaxios: ^6.0.0
     json-bigint: ^1.0.0
   checksum: 55de8ae4a6b7664379a093abf7e758ae06e82f244d41bd58d881a470bf34db94c4067ce9e1b425d9455b7705636d5f8baad844e49bb73879c338753ba7785b2b
+  languageName: node
+  linkType: hard
+
+"gcp-metadata@npm:^7.0.0":
+  version: 7.0.0
+  resolution: "gcp-metadata@npm:7.0.0"
+  dependencies:
+    gaxios: ^7.0.0
+    google-logging-utils: ^1.0.0
+    json-bigint: ^1.0.0
+  checksum: 057115e9ff1d99d11624fee7229674dfb325655cbb71181a15f397027444610eafc121c91fae4a32701a9f097418f049c8b1364818dfa266b72b07efb1f3868e
   languageName: node
   linkType: hard
 
@@ -6828,6 +6895,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"google-auth-library@npm:^10.0.0-rc.1":
+  version: 10.1.0
+  resolution: "google-auth-library@npm:10.1.0"
+  dependencies:
+    base64-js: ^1.3.0
+    ecdsa-sig-formatter: ^1.0.11
+    gaxios: ^7.0.0
+    gcp-metadata: ^7.0.0
+    google-logging-utils: ^1.0.0
+    gtoken: ^8.0.0
+    jws: ^4.0.0
+  checksum: b453dc5595b54aecd9ad92189a67dab9f5fd644637189577aeedbc50a750946f21e9b4999c2e0a30904b6606ca4dbca8e800bbcebb194a41b2704935968d4172
+  languageName: node
+  linkType: hard
+
 "google-auth-library@npm:^9.0.0, google-auth-library@npm:^9.3.0":
   version: 9.7.0
   resolution: "google-auth-library@npm:9.7.0"
@@ -6876,6 +6958,33 @@ __metadata:
   languageName: node
   linkType: hard
 
+"google-gax@npm:^5.0.1-rc.0":
+  version: 5.0.1-rc.1
+  resolution: "google-gax@npm:5.0.1-rc.1"
+  dependencies:
+    "@grpc/grpc-js": ^1.12.6
+    "@grpc/proto-loader": ^0.7.13
+    "@types/long": ^5.0.0
+    abort-controller: ^3.0.0
+    duplexify: ^4.1.3
+    google-auth-library: ^10.0.0-rc.1
+    google-logging-utils: ^1.1.1
+    node-fetch: ^3.3.2
+    object-hash: ^3.0.0
+    proto3-json-serializer: ^3.0.0
+    protobufjs: ^7.5.0
+    retry-request: ^8.0.0
+  checksum: 4eb1da7aa40895c95d45438e5acfb04990473638755efbdd27dde5ede55e1bedc25b406ffdf1ea240cb3375d9d562d61d10b6a80da388fa0796d7cba4e1125ae
+  languageName: node
+  linkType: hard
+
+"google-logging-utils@npm:^1.0.0, google-logging-utils@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "google-logging-utils@npm:1.1.1"
+  checksum: a1739b445963e82f5894d98fe0b0c3ef393670c6ae8b47810dee69d1d10697cad61b05cd94faf4d963c8207edc0694dc2b3b168c9cca984764801ca47b68333f
+  languageName: node
+  linkType: hard
+
 "gopd@npm:^1.0.1":
   version: 1.0.1
   resolution: "gopd@npm:1.0.1"
@@ -6913,6 +7022,16 @@ __metadata:
     gaxios: ^6.0.0
     jws: ^4.0.0
   checksum: 1f338dced78f9d895ea03cd507454eb5a7b77e841ecd1d45e44483b08c1e64d16a9b0342358d37586d87462ffc2d5f5bff5dfe77ed8d4f0aafc3b5b0347d5d16
+  languageName: node
+  linkType: hard
+
+"gtoken@npm:^8.0.0":
+  version: 8.0.0
+  resolution: "gtoken@npm:8.0.0"
+  dependencies:
+    gaxios: ^7.0.0
+    jws: ^4.0.0
+  checksum: 6825476d404fc6d1577799e222f44824787da96865a5929ec44d18ef5fbe22f3053433c79dfef3c9d944c8a87e78b85b48c31cae7fe7e3cc02f1aed35d160b10
   languageName: node
   linkType: hard
 
@@ -8526,7 +8645,7 @@ jschardet@latest:
   languageName: node
   linkType: hard
 
-"long@npm:^5.0.0":
+"long@npm:*, long@npm:^5.0.0":
   version: 5.3.2
   resolution: "long@npm:5.3.2"
   checksum: be215816b563f4ca27ad3677678b53415bc489f9e3466414e54d2d85f5f8e86768547fa58493bacfb363ffc57a664debc83403ccc2178aef0c40aca28bad47c9
@@ -8932,6 +9051,13 @@ jschardet@latest:
   languageName: node
   linkType: hard
 
+"node-domexception@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "node-domexception@npm:1.0.0"
+  checksum: ee1d37dd2a4eb26a8a92cd6b64dfc29caec72bff5e1ed9aba80c294f57a31ba4895a60fd48347cf17dd6e766da0ae87d75657dfd1f384ebfa60462c2283f5c7f
+  languageName: node
+  linkType: hard
+
 "node-fetch@npm:^2.6.1, node-fetch@npm:^2.6.6, node-fetch@npm:^2.6.9":
   version: 2.7.0
   resolution: "node-fetch@npm:2.7.0"
@@ -8943,6 +9069,17 @@ jschardet@latest:
     encoding:
       optional: true
   checksum: d76d2f5edb451a3f05b15115ec89fc6be39de37c6089f1b6368df03b91e1633fd379a7e01b7ab05089a25034b2023d959b47e59759cb38d88341b2459e89d6e5
+  languageName: node
+  linkType: hard
+
+"node-fetch@npm:^3.3.2":
+  version: 3.3.2
+  resolution: "node-fetch@npm:3.3.2"
+  dependencies:
+    data-uri-to-buffer: ^4.0.0
+    fetch-blob: ^3.1.4
+    formdata-polyfill: ^4.0.10
+  checksum: 06a04095a2ddf05b0830a0d5302699704d59bda3102894ea64c7b9d4c865ecdff2d90fd042df7f5bc40337266961cb6183dcc808ea4f3000d024f422b462da92
   languageName: node
   linkType: hard
 
@@ -9572,6 +9709,15 @@ jschardet@latest:
   languageName: node
   linkType: hard
 
+"proto3-json-serializer@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "proto3-json-serializer@npm:3.0.0"
+  dependencies:
+    protobufjs: ^7.4.0
+  checksum: e66e29c68412ea2125389925502bfa85cbc17caf279082e4b9ebda270d61cefdb60b743b75bf60127b857a55a832d1b64ed623c03ae1e8fcbf55b33b590df155
+  languageName: node
+  linkType: hard
+
 "protobufjs@npm:^7.2.5, protobufjs@npm:^7.3.2":
   version: 7.3.2
   resolution: "protobufjs@npm:7.3.2"
@@ -9589,6 +9735,26 @@ jschardet@latest:
     "@types/node": ">=13.7.0"
     long: ^5.0.0
   checksum: cfb2a744787f26ee7c82f3e7c4b72cfc000e9bb4c07828ed78eb414db0ea97a340c0cc3264d0e88606592f847b12c0351411f10e9af255b7ba864eec44d7705f
+  languageName: node
+  linkType: hard
+
+"protobufjs@npm:^7.4.0, protobufjs@npm:^7.5.0":
+  version: 7.5.3
+  resolution: "protobufjs@npm:7.5.3"
+  dependencies:
+    "@protobufjs/aspromise": ^1.1.2
+    "@protobufjs/base64": ^1.1.2
+    "@protobufjs/codegen": ^2.0.4
+    "@protobufjs/eventemitter": ^1.1.0
+    "@protobufjs/fetch": ^1.1.0
+    "@protobufjs/float": ^1.0.2
+    "@protobufjs/inquire": ^1.1.0
+    "@protobufjs/path": ^1.1.2
+    "@protobufjs/pool": ^1.1.0
+    "@protobufjs/utf8": ^1.1.0
+    "@types/node": ">=13.7.0"
+    long: ^5.0.0
+  checksum: 8a8842338c9bf586f11e1c179fc01f0b65adc22114bb2626daf62d66439c7b4227c182ef375184d24d2a16378716bab8dc5000940287610c8b8742972e4b0a2f
   languageName: node
   linkType: hard
 
@@ -9874,6 +10040,17 @@ jschardet@latest:
     extend: ^3.0.2
     teeny-request: ^9.0.0
   checksum: 2d7307422333f548e5f40524978a344b62193714f6209c4f6a41057ae279804eb9bc8e0a277791e7b6f2d5d76068bdaca8590662a909cf1e6cfc3ab789e4c6b6
+  languageName: node
+  linkType: hard
+
+"retry-request@npm:^8.0.0":
+  version: 8.0.0
+  resolution: "retry-request@npm:8.0.0"
+  dependencies:
+    "@types/request": ^2.48.12
+    extend: ^3.0.2
+    teeny-request: ^10.0.0
+  checksum: 29cf787917802a80d1f8ce802520927106e084413c63f6bc133620c9380fda17ac4bd3c4365d119f176ca9d1defe373f3353c2e3dd8aab6056b9c05b4ba78bdf
   languageName: node
   linkType: hard
 
@@ -10627,6 +10804,18 @@ jschardet@latest:
   languageName: node
   linkType: hard
 
+"teeny-request@npm:^10.0.0":
+  version: 10.1.0
+  resolution: "teeny-request@npm:10.1.0"
+  dependencies:
+    http-proxy-agent: ^5.0.0
+    https-proxy-agent: ^5.0.0
+    node-fetch: ^3.3.2
+    stream-events: ^1.0.5
+  checksum: d966f1bd8b3a348d391d981533cf3aa54ac733b02905103a570f66108b86b99fed4d1bb8d4ec6ac20fc13335ea750611826ff4da61d53e676d1d4d35d2c5266a
+  languageName: node
+  linkType: hard
+
 "teeny-request@npm:^9.0.0":
   version: 9.0.0
   resolution: "teeny-request@npm:9.0.0"
@@ -11152,6 +11341,13 @@ jschardet@latest:
   dependencies:
     defaults: ^1.0.3
   checksum: 814e9d1ddcc9798f7377ffa448a5a3892232b9275ebb30a41b529607691c0491de47cba426e917a4d08ded3ee7e9ba2f3fe32e62ee3cd9c7d3bafb7754bd553c
+  languageName: node
+  linkType: hard
+
+"web-streams-polyfill@npm:^3.0.3":
+  version: 3.3.3
+  resolution: "web-streams-polyfill@npm:3.3.3"
+  checksum: 21ab5ea08a730a2ef8023736afe16713b4f2023ec1c7085c16c8e293ee17ed085dff63a0ad8722da30c99c4ccbd4ccd1b2e79c861829f7ef2963d7de7004c2cb
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### What and why?

Needed to get `instrument` working with Cloud Run functions.

I was getting Typescript build errors:
```
node_modules/@google-cloud/run/node_modules/google-auth-library/build/src/auth/jwtclient.d.ts:1:29 - error TS1479:
The current file is a CommonJS module whose imports will produce 'require' calls; however, the referenced file is an ECMAScript module and cannot be imported with 'require'.
Consider writing a dynamic 'import("gtoken")' call instead.
```

Since `gtoken` is [dual-shipped in ESM and CJS](https://github.com/googleapis/node-gtoken/blob/2c21cb7a8e9d4c8511000916af5a12cb268d83c0/package.json#L37-L44), but google-auth-library [is not](https://github.com/googleapis/google-auth-library-nodejs/blob/082c171cae021e184d68bf3c794fdf8f2eddbd94/package.json#L9-L10).
The workaround now is to temporarily use `require()` and lose all type annotations, until Google fixes this
(thanks for the help @Drarig29)

[More info here](https://dd.slack.com/archives/C0136D22VUZ/p1750439989678209)

### How?



### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
