### PR TITLE
SDCD-1464: adding `--team` and `--custom-tags` as options in the DORA CLI

### DIFF
--- a/src/commands/dora/README.md
+++ b/src/commands/dora/README.md
@@ -21,6 +21,8 @@ $ DD_BETA_COMMANDS_ENABLED=1 datadog-ci dora deployment [--service #0] [--env #0
   --finished-at #0           In Unix seconds or ISO8601. (Examples: 1699961048, 2023-11-14T11:24:08Z)
   --git-repository-url #0    Example: https://github.com/DataDog/datadog-ci.git
   --git-commit-sha #0        Example: 102836a25f5477e571c73d489b3f0f183687068e
+  --team #0                  Example: my-team
+  --custom-tags #0           Example: department:engineering,deployment-type:hotfix
   --skip-git                 Disables sending git URL and SHA. Change Lead Time will not be available
 ```
 
@@ -43,6 +45,8 @@ datadog-ci dora deployment --service my-service --env prod \
 - `--finished-at` (default: current timestamp) is the timestamp in Unix seconds or ISO8601 when the deployment finished.
 - `--git-repository-url` is a string with the repository URL for the deployed service. If this is missing, the URL is retrieved from the local git repository.
 - `--git-commit-sha` is a string with the git commit SHA that has been deployed. If this is missing, the current HEAD is retrieved from the local git repository.
+- `--team` is a string of the team associated with the deployment. If this is missing, the team associated with the service in the Software Catalog will be used.
+- `--custom-tags` is an array of strings of custom tags to add to the deployment event in the form `key:value`. A max of 100 tags can be added to each deployment. 
 - `--skip-git` (default: `false`): Disables sending git URL and SHA. Change Lead Time will not be available
 - `--dry-run` (default: `false`): It runs the command without actually sending the event. All other checks are still performed.
 

--- a/src/commands/dora/__tests__/deployment.test.ts
+++ b/src/commands/dora/__tests__/deployment.test.ts
@@ -42,6 +42,8 @@ describe('execute', () => {
         '--git-repository-url', 'https://github.com/DataDog/datadog-ci',
         '--git-commit-sha', '2186e1b0ab2a87e312a8c831d5bc947fa081d4f9',
         '--version', '1.0.0',
+        '--team', 'test-team',
+        '--custom-tags', 'key1:value1,key2:value2',
       ])
       /* eslint-enable prettier/prettier */
       expect(code).toBe(0)
@@ -55,6 +57,8 @@ describe('execute', () => {
           commitSHA: '2186e1b0ab2a87e312a8c831d5bc947fa081d4f9',
         },
         version: '1.0.0',
+        team: 'test-team',
+        customTags: ['key1:value1', 'key2:value2'],
       })
     })
 

--- a/src/commands/dora/api.ts
+++ b/src/commands/dora/api.ts
@@ -27,6 +27,12 @@ export const sendDeploymentEvent = (request: (args: AxiosRequestConfig) => Axios
       commit_sha: deployment.git.commitSHA,
     }
   }
+  if (deployment.team) {
+    attrs.team = deployment.team
+  }
+  if (deployment.customTags) {
+    attrs.custom_tags = deployment.customTags
+  }
 
   return request({
     method: 'POST',

--- a/src/commands/dora/deployment.ts
+++ b/src/commands/dora/deployment.ts
@@ -80,6 +80,14 @@ export class SendDeploymentEvent extends Command {
     description: 'The version of the service being deployed',
   })
 
+  private team = Option.String('--team', {
+    description: 'The team responsible for the deployment',
+  })
+
+  private customTags = Option.Array('--custom-tags', {
+    description: 'Custom tags to add to the deployment event in the format key:value. Max 100 tags per deployment event.',
+  })
+
   private gitInfo?: GitInfo
   private gitRepoURL = Option.String('--git-repository-url', {
     description: 'Example: https://github.com/DataDog/datadog-ci.git',
@@ -179,6 +187,12 @@ export class SendDeploymentEvent extends Command {
     }
     if (this.version) {
       deployment.version = this.version
+    }
+    if (this.team) {
+      deployment.team = this.team
+    }
+    if (this.customTags) {
+      deployment.customTags = this.customTags
     }
 
     return deployment

--- a/src/commands/dora/interfaces.ts
+++ b/src/commands/dora/interfaces.ts
@@ -7,6 +7,8 @@ export interface DeploymentEvent {
   finishedAt: Date
   git?: GitInfo
   version?: string
+  team?: string
+  customTags?: string[]
 }
 
 export interface GitInfo {


### PR DESCRIPTION
### What and why?

Adding two new options in the dora deployments cli command:
  `--team`: our documentation has stated for a long time that the [cli accepts a `--team` option](https://docs.datadoghq.com/dora_metrics/setup/deployments?tab=apiorcli#requirements) but that has not been this case. It has recently been brought to our attention that this has not, up until now, actually been an available option.
  `--custom-tags`: we have recently added the ability for customers to add custom tags to deployment events via our api, and we want them to be able to add tags in the cli as well. These tags take the form `key:value` (for example, `department:engineering`), and we accept a maximum of 100 tags per deployment event.

### How?

In order to add these optional parameters, we have updated the `DeploymentEvent` interface to include these fields, and we read any values provided for them like we do for the other optional fields (`version`, `git`, `env`). The tests have also been updated to include a test case where we provide these fields.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
