### PR TITLE
elf-symbols: fix dynamic symbols extraction (part 2)

### DIFF
--- a/src/commands/elf-symbols/elf.ts
+++ b/src/commands/elf-symbols/elf.ts
@@ -559,7 +559,7 @@ export const copyElfDebugInfo = async (
 
   if (keepDynamicSymbolTable) {
     // If the file has only a dynamic symbol table, preserve the sections needed by symbolic to create a symcache
-    const sectionsToKeep = ['.dynsym', '.dynstr']
+    const sectionsToKeep = ['.dynsym', '.dynstr', '.dynamic', '.hash', '.gnu.hash', '.gnu.version*', '.rel*']
     options += ' ' + sectionsToKeep.map((section) => `--set-section-flags ${section}=alloc,readonly,contents`).join(' ')
   }
 


### PR DESCRIPTION
### What and why?

Ensure that generated elf symbol file is usable by un-patched symbolic library.

### How?

Symbolic library requires dynamic section/segment and some other sections (hash sections, version sections, relocation sections) to be present in the in the debug info file to be able to create a symcache.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)

