### PR TITLE
[Cloud Run Instrument] Dry run and interactive mode

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -94,3 +94,4 @@ jszip,import,MIT,Copyright (c) 2009-2016 Stuart Knightley and other contributors
 @google-cloud/run,import,Apache-2.0,Copyright (c) 2023 Google LLC and other contributors
 google-auth-library,import,Apache-2.0,Copyright (c) 2023 Google LLC and other contributors
 @google-cloud/logging,import,Apache-2.0,Copyright (c) 2023 Google LLC and other contributors
+jest-diff,import,MIT,"Copyright (c) Meta Platforms, Inc. and other contributors"

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "google-auth-library": "^9.12.0",
     "inquirer": "^8.2.5",
     "inquirer-checkbox-plus-prompt": "^1.4.2",
+    "jest-diff": "^30.0.4",
     "js-yaml": "3.13.1",
     "jszip": "^3.10.1",
     "ora": "5.4.1",

--- a/src/commands/cloud-run/__tests__/__snapshots__/instrument.test.ts.snap
+++ b/src/commands/cloud-run/__tests__/__snapshots__/instrument.test.ts.snap
@@ -16,6 +16,9 @@ exports[`InstrumentCommand snapshot tests interactive mode 1`] = `
 ⬇️ Fetching existing service configurations from Cloud Run...
 
 🚀 Instrumenting Cloud Run services with sidecar...
+- Expected
++ Received
+
   {
     "name": "projects/interactive-project/locations/us-west1/services/interactive-service",
     "template": {
@@ -117,7 +120,6 @@ exports[`InstrumentCommand snapshot tests interactive mode 1`] = `
 +     ]
     }
   }
-
 ✅ Cloud Run instrumentation completed successfully!
 "
 `;
@@ -138,6 +140,9 @@ exports[`InstrumentCommand snapshot tests prints dry run data with basic flags 1
 [Dry Run] ⬇️ Fetching existing service configurations from Cloud Run...
 
 [Dry Run] 🚀 Instrumenting Cloud Run services with sidecar...
+- Expected
++ Received
+
   {
     "name": "projects/test-project/locations/us-central1/services/test-service",
     "template": {

--- a/src/commands/cloud-run/__tests__/__snapshots__/instrument.test.ts.snap
+++ b/src/commands/cloud-run/__tests__/__snapshots__/instrument.test.ts.snap
@@ -1,0 +1,257 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`InstrumentCommand snapshot tests interactive mode 1`] = `
+"
+🐶 Instrumenting Cloud Run service(s)
+
+
+🔍 Verifying command flags...
+[!] No DD_SERVICE env var found. Will default to the service name.
+✔ Required flags verified
+
+🔑 Verifying GCP credentials...
+✔ GCP credentials verified!
+
+
+⬇️ Fetching existing service configurations from Cloud Run...
+
+🚀 Instrumenting Cloud Run services with sidecar...
+  {
+    "name": "projects/interactive-project/locations/us-west1/services/interactive-service",
+    "template": {
+      "containers": [
+        {
+          "env": [
+            {
+              "name": "NODE_ENV",
+              "value": "production"
++           },
++           {
++             "name": "DD_LOGS_INJECTION",
++             "value": "true"
++           },
++           {
++             "name": "DD_SERVICE",
++             "value": "interactive-service"
++           },
++           {
++             "name": "DD_API_KEY",
++             "value": "PLACEHOLDER"
+            }
+          ],
+          "image": "gcr.io/test-project/test-app:latest",
+          "name": "main-app",
+-         "volumeMounts": []
++         "volumeMounts": [
++           {
++             "mountPath": "/shared-volume",
++             "name": "shared-volume"
++           }
++         ]
++       },
++       {
++         "env": [
++           {
++             "name": "DD_SITE",
++             "value": "datadoghq.com"
++           },
++           {
++             "name": "DD_SERVERLESS_LOG_PATH",
++             "value": "/shared-volume/logs/*.log"
++           },
++           {
++             "name": "DD_LOGS_INJECTION",
++             "value": "true"
++           },
++           {
++             "name": "DD_TRACE_ENABLED",
++             "value": "true"
++           },
++           {
++             "name": "DD_HEALTH_PORT",
++             "value": "5555"
++           },
++           {
++             "name": "DD_API_KEY",
++             "value": "PLACEHOLDER"
++           },
++           {
++             "name": "DD_SERVICE",
++             "value": "interactive-service"
++           }
++         ],
++         "image": "gcr.io/datadoghq/serverless-init:latest",
++         "name": "datadog-sidecar",
++         "resources": {
++           "limits": {
++             "cpu": "1",
++             "memory": "512Mi"
++           }
++         },
++         "startupProbe": {
++           "failureThreshold": 3,
++           "initialDelaySeconds": 0,
++           "periodSeconds": 10,
++           "tcpSocket": {
++             "port": "5555"
++           },
++           "timeoutSeconds": 1
++         },
++         "volumeMounts": [
++           {
++             "mountPath": "/shared-volume",
++             "name": "shared-volume"
++           }
++         ]
+        }
+      ],
+-     "revision": "test-service-v1",
+-     "volumes": []
++     "volumes": [
++       {
++         "emptyDir": {
++           "medium": 1
++         },
++         "name": "shared-volume"
++       }
++     ]
+    }
+  }
+
+✅ Cloud Run instrumentation completed successfully!
+"
+`;
+
+exports[`InstrumentCommand snapshot tests prints dry run data with basic flags 1`] = `
+"
+[Dry Run] 🐶 Instrumenting Cloud Run service(s)
+
+
+🔍 Verifying command flags...
+[!] No DD_SERVICE env var found. Will default to the service name.
+✔ Required flags verified
+
+🔑 Verifying GCP credentials...
+✔ GCP credentials verified!
+
+
+[Dry Run] ⬇️ Fetching existing service configurations from Cloud Run...
+
+[Dry Run] 🚀 Instrumenting Cloud Run services with sidecar...
+  {
+    "name": "projects/test-project/locations/us-central1/services/test-service",
+    "template": {
+      "containers": [
+        {
+          "env": [
+            {
+              "name": "NODE_ENV",
+              "value": "production"
++           },
++           {
++             "name": "DD_LOGS_INJECTION",
++             "value": "true"
++           },
++           {
++             "name": "DD_SERVICE",
++             "value": "test-service"
++           },
++           {
++             "name": "DD_API_KEY",
++             "value": "PLACEHOLDER"
+            }
+          ],
+          "image": "gcr.io/test-project/test-app:latest",
+          "name": "main-app",
+-         "volumeMounts": []
++         "volumeMounts": [
++           {
++             "mountPath": "/shared-volume",
++             "name": "shared-volume"
++           }
++         ]
++       },
++       {
++         "env": [
++           {
++             "name": "DD_SITE",
++             "value": "datadoghq.com"
++           },
++           {
++             "name": "DD_SERVERLESS_LOG_PATH",
++             "value": "/shared-volume/logs/*.log"
++           },
++           {
++             "name": "DD_LOGS_INJECTION",
++             "value": "true"
++           },
++           {
++             "name": "DD_TRACE_ENABLED",
++             "value": "true"
++           },
++           {
++             "name": "DD_HEALTH_PORT",
++             "value": "5555"
++           },
++           {
++             "name": "DD_API_KEY",
++             "value": "PLACEHOLDER"
++           },
++           {
++             "name": "DD_SERVICE",
++             "value": "test-service"
++           },
++           {
++             "name": "DD_ENV",
++             "value": "staging"
++           },
++           {
++             "name": "DD_VERSION",
++             "value": "1.0.0"
++           },
++           {
++             "name": "DD_TAGS",
++             "value": "team:backend,service:api"
++           }
++         ],
++         "image": "gcr.io/datadoghq/serverless-init:latest",
++         "name": "datadog-sidecar",
++         "resources": {
++           "limits": {
++             "cpu": "1",
++             "memory": "512Mi"
++           }
++         },
++         "startupProbe": {
++           "failureThreshold": 3,
++           "initialDelaySeconds": 0,
++           "periodSeconds": 10,
++           "tcpSocket": {
++             "port": "5555"
++           },
++           "timeoutSeconds": 1
++         },
++         "volumeMounts": [
++           {
++             "mountPath": "/shared-volume",
++             "name": "shared-volume"
++           }
++         ]
+        }
+      ],
+-     "revision": "test-service-v1",
+-     "volumes": []
++     "volumes": [
++       {
++         "emptyDir": {
++           "medium": 1
++         },
++         "name": "shared-volume"
++       }
++     ]
+    }
+  }
+
+[Dry Run] Would have updated service test-service with the above changes.
+"
+`;

--- a/src/commands/cloud-run/__tests__/instrument.test.ts
+++ b/src/commands/cloud-run/__tests__/instrument.test.ts
@@ -41,19 +41,19 @@ describe('InstrumentCommand', () => {
     test('should fail if project is missing', async () => {
       const {code, context} = await runCLI(['--services', 'test-service', '--region', 'us-central1'])
       expect(code).toBe(1)
-      expect(context.stdout.toString()).toContain('No project specified')
+      expect(context.stdout.toString()).toContain('missing project')
     })
 
     test('should fail if services are missing', async () => {
       const {code, context} = await runCLI(['--project', 'test-project', '--region', 'us-central1'])
       expect(code).toBe(1)
-      expect(context.stdout.toString()).toContain('No services specified')
+      expect(context.stdout.toString()).toContain('missing service(s)')
     })
 
     test('should fail if region is missing', async () => {
       const {code, context} = await runCLI(['--project', 'test-project', '--services', 'test-service'])
       expect(code).toBe(1)
-      expect(context.stdout.toString()).toContain('No region specified')
+      expect(context.stdout.toString()).toContain('missing region')
     })
   })
 

--- a/src/commands/cloud-run/__tests__/instrument.test.ts
+++ b/src/commands/cloud-run/__tests__/instrument.test.ts
@@ -19,10 +19,24 @@ import {makeRunCLI} from '../../../helpers/__tests__/testing-tools'
 import * as apikey from '../../../helpers/apikey'
 
 import {InstrumentCommand} from '../instrument'
+import * as cloudRunPromptModule from '../prompt'
 import * as utils from '../utils'
 
 jest.mock('../../../helpers/apikey')
-jest.mock('../utils')
+jest.mock('../utils', () => ({
+  ...jest.requireActual('../utils'),
+  checkAuthentication: jest.fn(),
+}))
+
+const mockServicesClient = {
+  servicePath: jest.fn(),
+  getService: jest.fn(),
+  updateService: jest.fn(),
+}
+
+jest.mock('@google-cloud/run', () => ({
+  ServicesClient: jest.fn(() => mockServicesClient),
+}))
 
 describe('InstrumentCommand', () => {
   const runCLI = makeRunCLI(InstrumentCommand, ['cloud-run', 'instrument'])
@@ -35,6 +49,11 @@ describe('InstrumentCommand', () => {
     }
     ;(apikey.newApiKeyValidator as jest.Mock).mockReturnValue(mockValidator)
     ;(utils.checkAuthentication as jest.Mock).mockResolvedValue(true)
+
+    // Reset mock client
+    mockServicesClient.servicePath.mockImplementation(
+      (project, region, service) => `projects/${project}/locations/${region}/services/${service}`
+    )
   })
 
   describe('validates required variables', () => {
@@ -101,6 +120,87 @@ describe('InstrumentCommand', () => {
       ])
       expect(code).toBe(0)
       expect(mockInstrumentSidecar).toHaveBeenCalledWith('test-project', ['test-service'], 'us-central1', undefined)
+    })
+  })
+
+  describe('snapshot tests', () => {
+    const mockService = {
+      name: 'projects/test-project/locations/us-central1/services/test-service',
+      template: {
+        containers: [
+          {
+            name: 'main-app',
+            image: 'gcr.io/test-project/test-app:latest',
+            env: [{name: 'NODE_ENV', value: 'production'}],
+            volumeMounts: [],
+          },
+        ],
+        volumes: [],
+        revision: 'test-service-v1',
+      },
+    }
+
+    beforeEach(() => {
+      process.env[API_KEY_ENV_VAR] = 'test-api-key'
+      process.env[SERVICE_ENV_VAR] = 'test-service'
+
+      mockServicesClient.getService.mockResolvedValue([mockService])
+
+      const mockOperation = {
+        promise: jest.fn().mockResolvedValue([]),
+      }
+      mockServicesClient.updateService.mockResolvedValue([mockOperation])
+
+      jest.restoreAllMocks()
+
+      const mockValidator = {
+        validateApiKey: jest.fn().mockResolvedValue(true),
+        verifyApiKey: jest.fn().mockResolvedValue(undefined),
+      }
+      ;(apikey.newApiKeyValidator as jest.Mock).mockReturnValue(mockValidator)
+      ;(utils.checkAuthentication as jest.Mock).mockResolvedValue(true)
+    })
+
+    test('prints dry run data with basic flags', async () => {
+      const {code, context} = await runCLI([
+        '--project',
+        'test-project',
+        '--services',
+        'test-service',
+        '--region',
+        'us-central1',
+        '--dry-run',
+        '--env',
+        'staging',
+        '--version',
+        '1.0.0',
+        '--extra-tags',
+        'team:backend,service:api',
+      ])
+
+      expect(code).toBe(0)
+      expect(context.stdout.toString()).toMatchSnapshot()
+    })
+
+    test('interactive mode', async () => {
+      // Mock the prompts to return values
+      jest.spyOn(cloudRunPromptModule, 'requestGCPProject').mockResolvedValue('interactive-project')
+      jest.spyOn(cloudRunPromptModule, 'requestGCPRegion').mockResolvedValue('us-west1')
+      jest.spyOn(cloudRunPromptModule, 'requestServiceName').mockResolvedValue('interactive-service')
+      jest.spyOn(cloudRunPromptModule, 'requestSite').mockResolvedValue('datadoghq.com')
+      jest.spyOn(cloudRunPromptModule, 'requestConfirmation').mockResolvedValue(true)
+
+      // Mock the service for interactive mode
+      const interactiveService = {
+        ...mockService,
+        name: 'projects/interactive-project/locations/us-west1/services/interactive-service',
+      }
+      mockServicesClient.getService.mockResolvedValue([interactiveService])
+
+      const {code, context} = await runCLI(['--interactive'])
+
+      expect(code).toBe(0)
+      expect(context.stdout.toString()).toMatchSnapshot()
     })
   })
 

--- a/src/commands/cloud-run/__tests__/utils.test.ts
+++ b/src/commands/cloud-run/__tests__/utils.test.ts
@@ -1,0 +1,54 @@
+import {generateConfigDiff} from '../utils'
+
+describe('generateConfigDiff', () => {
+  test('should generate correct diffs for various config changes', () => {
+    const original = {volumes: [], port: 8080}
+    const updated = {
+      volumes: [
+        {
+          name: 'shared-volume',
+          emptyDir: {
+            medium: 1,
+          },
+        },
+      ],
+      port: 8080,
+    }
+
+    const expected = `  {
+    \"port\": 8080,
+-   \"volumes\": []
++   \"volumes\": [
++     {
++       \"emptyDir\": {
++         \"medium\": 1
++       },
++       \"name\": \"shared-volume\"
++     }
++   ]
+  }`
+    const result = generateConfigDiff(original, updated)
+    expect(result).toContain(expected)
+  })
+
+  test('should return "No changes detected" for identical objects', () => {
+    const config = {name: 'test', port: 8080}
+    const result = generateConfigDiff(config, config)
+    expect(result).toContain('No changes detected.')
+  })
+
+  test('should handle objects with different key ordering', () => {
+    const original = {b: 2, a: 1}
+    const updated = {a: 1, b: 2}
+    const result = generateConfigDiff(original, updated)
+    expect(result).toContain('No changes detected.')
+  })
+
+  test('should obfuscate sensitive values', () => {
+    const original = {api_key: 'abc123'}
+    const updated = {api_key: '1234567890abcdef1234567890abcdef'}
+    const result = generateConfigDiff(original, updated)
+    expect(result).toContain('***')
+    expect(result).not.toContain('1234567890abcdef1234567890abcdef')
+  })
+})

--- a/src/commands/cloud-run/instrument.ts
+++ b/src/commands/cloud-run/instrument.ts
@@ -235,7 +235,7 @@ export class InstrumentCommand extends Command {
     this.context.stdout.write(generateConfigDiff(existingService, updatedService))
     if (this.dryRun) {
       this.context.stdout.write(
-        `\n${dryRunPrefix(this.dryRun)}Would have updated service ${chalk.bold(serviceName)} with the above changes.\n`
+        `\n\n${dryRunPrefix(this.dryRun)}Would have updated service ${chalk.bold(serviceName)} with the above changes.\n`
       )
 
       return

--- a/src/commands/cloud-run/instrument.ts
+++ b/src/commands/cloud-run/instrument.ts
@@ -235,7 +235,9 @@ export class InstrumentCommand extends Command {
     this.context.stdout.write(generateConfigDiff(existingService, updatedService))
     if (this.dryRun) {
       this.context.stdout.write(
-        `\n\n${dryRunPrefix(this.dryRun)}Would have updated service ${chalk.bold(serviceName)} with the above changes.\n`
+        `\n\n${dryRunPrefix(this.dryRun)}Would have updated service ${chalk.bold(
+          serviceName
+        )} with the above changes.\n`
       )
 
       return

--- a/src/commands/cloud-run/instrument.ts
+++ b/src/commands/cloud-run/instrument.ts
@@ -27,7 +27,7 @@ import {maskString} from '../../helpers/utils'
 
 import {CloudRunConfigOptions} from './interfaces'
 import {renderAuthenticationInstructions, renderCloudRunInstrumentUninstrumentHeader, withSpinner} from './renderer'
-import {checkAuthentication} from './utils'
+import {checkAuthentication, generateConfigDiff} from './utils'
 
 // XXX temporary workaround for @google-cloud/run ESM/CJS module issues
 const {ServicesClient} = require('@google-cloud/run')
@@ -217,6 +217,7 @@ export class InstrumentCommand extends Command {
     ddService: string
   ) {
     const updatedService = this.createInstrumentedServiceConfig(existingService, ddService)
+    this.context.stdout.write(generateConfigDiff(existingService, updatedService))
 
     await withSpinner(
       `Instrumenting service ${chalk.bold(serviceName)}...`,

--- a/src/commands/cloud-run/interfaces.ts
+++ b/src/commands/cloud-run/interfaces.ts
@@ -28,26 +28,6 @@ export interface LogConfig {
 }
 
 /**
- * Configuration options provided by the user through
- * the CLI in order to instrument properly.
- */
-export interface CloudRunConfigOptions {
-  project?: string
-  environment?: string
-  extraTags?: string
-  services: string[]
-  interactive?: boolean
-  logging?: string
-  logLevel?: string
-  profile?: string
-  region?: string
-  service?: string
-  tracing?: string
-  version?: string
-  llmobs?: string
-}
-
-/**
  * Interface for Unified Service Tagging.
  *
  * See more at: https://docs.datadoghq.com/getting_started/tagging/unified_service_tagging/?tab=kubernetes#overview

--- a/src/commands/cloud-run/prompt.ts
+++ b/src/commands/cloud-run/prompt.ts
@@ -1,0 +1,80 @@
+import inquirer from 'inquirer'
+
+import {DATADOG_SITES} from '../../constants'
+
+const checkboxPlusPrompt = require('inquirer-checkbox-plus-prompt')
+inquirer.registerPrompt('checkbox-plus', checkboxPlusPrompt)
+
+export const requestGCPProject = async (): Promise<string> => {
+  const answer = await inquirer.prompt({
+    message: 'Enter GCP Project ID:',
+    name: 'project',
+    type: 'input',
+    validate: (value: string) => {
+      if (!value || value.trim().length === 0) {
+        return 'Project ID is required.'
+      }
+
+      return true
+    },
+  })
+
+  return answer.project
+}
+
+export const requestGCPRegion = async (defaultRegion?: string): Promise<string> => {
+  const answer = await inquirer.prompt({
+    default: defaultRegion || 'us-central1',
+    message: 'Enter GCP Region:',
+    name: 'region',
+    type: 'input',
+    validate: (value: string) => {
+      if (!value || value.trim().length === 0) {
+        return 'Region is required.'
+      }
+
+      return true
+    },
+  })
+
+  return answer.region
+}
+
+export const requestServiceName = async (): Promise<string> => {
+  const answer = await inquirer.prompt({
+    message: 'Enter Cloud Run service name:',
+    name: 'serviceName',
+    type: 'input',
+    validate: (value: string) => {
+      if (!value || value.trim().length === 0) {
+        return 'Service name is required.'
+      }
+
+      return true
+    },
+  })
+
+  return answer.serviceName
+}
+
+export const requestSite = async (): Promise<string> => {
+  const answer = await inquirer.prompt({
+    choices: DATADOG_SITES,
+    message: 'Select a Datadog Site:',
+    name: 'site',
+    type: 'list',
+  })
+
+  return answer.site
+}
+
+export const requestConfirmation = async (message: string, defaultValue = true) => {
+  const confirmationAnswer = await inquirer.prompt({
+    message,
+    name: 'confirmation',
+    type: 'confirm',
+    default: defaultValue,
+  })
+
+  return confirmationAnswer.confirmation !== false
+}

--- a/src/commands/cloud-run/renderer.ts
+++ b/src/commands/cloud-run/renderer.ts
@@ -20,17 +20,7 @@ export const renderAuthenticationInstructions = () => {
   return AUTHENTICATION_INSTRUCTIONS.join('\n')
 }
 
-export const renderCloudRunInstrumentUninstrumentHeader = (commandType: InstrumentCommand, isDryRun: boolean) => {
-  const prefix = isDryRun ? `${dryRunTag} ` : ''
-
-  const commandVerb = 'Instrumenting'
-  // TODO
-  // if (commandType === UninstrumentCommand.prototype) {
-  //   commandVerb = 'Uninstrumenting'
-  // }
-
-  return `\n${prefix}🐶 ${commandVerb} Cloud Run service\n`
-}
+export const dryRunPrefix = (isDryRun: boolean) => (isDryRun ? `${dryRunTag} ` : '')
 
 /**
  * Executes an async operation with a spinner

--- a/src/commands/cloud-run/renderer.ts
+++ b/src/commands/cloud-run/renderer.ts
@@ -4,8 +4,6 @@ import ora from 'ora'
 import * as helpersRenderer from '../../helpers/renderer'
 import {dryRunTag} from '../../helpers/renderer'
 
-import {InstrumentCommand} from './instrument'
-
 const AUTHENTICATION_INSTRUCTIONS = [
   '\n' + helpersRenderer.renderError('Unable to authenticate with GCP.'),
   'To authenticate with GCP, please follow these steps:',

--- a/src/commands/cloud-run/utils.ts
+++ b/src/commands/cloud-run/utils.ts
@@ -1,5 +1,6 @@
 import chalk from 'chalk'
 import {GoogleAuth} from 'google-auth-library'
+import {diff} from 'jest-diff'
 
 /**
  * Check if the user is authenticated with GCP.
@@ -43,29 +44,6 @@ const sortObjectKeys = (obj: any): any => {
 }
 
 /**
- * Compute LCS (Longest Common Subsequence) for Git-like diff matching
- */
-const computeLCS = (a: string[], b: string[]): number[][] => {
-  const m = a.length
-  const n = b.length
-  const dp: number[][] = Array(m + 1)
-    .fill(undefined)
-    .map(() => Array(n + 1).fill(0))
-
-  for (let i = 1; i <= m; i++) {
-    for (let j = 1; j <= n; j++) {
-      if (a[i - 1].trimEnd() === b[j - 1].trimEnd()) {
-        dp[i][j] = dp[i - 1][j - 1] + 1
-      } else {
-        dp[i][j] = Math.max(dp[i - 1][j], dp[i][j - 1])
-      }
-    }
-  }
-
-  return dp
-}
-
-/**
  * Obfuscate sensitive values in a line if it contains a key with "_KEY"
  */
 const obfuscateSensitiveValues = (line: string): string => {
@@ -73,36 +51,6 @@ const obfuscateSensitiveValues = (line: string): string => {
   return line
     .replace(/("[0-9a-fA-F]{16}"|"[0-9a-fA-F]{32}"|"[0-9a-fA-F]{64}")/g, '"***"')
     .replace(/('[0-9a-fA-F]{16}'|'[0-9a-fA-F]{32}'|'[0-9a-fA-F]{64}')/g, "'***'")
-}
-
-/**
- * Generate diff operations from the LCS table
- */
-const computeDiff = (
-  originalLines: string[],
-  updatedLines: string[]
-): {type: 'add' | 'remove' | 'context'; line: string}[] => {
-  const result: {type: 'add' | 'remove' | 'context'; line: string}[] = []
-  const lcs = computeLCS(originalLines, updatedLines)
-
-  let i = originalLines.length
-  let j = updatedLines.length
-
-  while (i > 0 || j > 0) {
-    if (i > 0 && j > 0 && originalLines[i - 1].trimEnd() === updatedLines[j - 1].trimEnd()) {
-      result.unshift({type: 'context', line: originalLines[i - 1]})
-      i--
-      j--
-    } else if (j > 0 && (i === 0 || lcs[i][j - 1] >= lcs[i - 1][j])) {
-      result.unshift({type: 'add', line: updatedLines[j - 1]})
-      j--
-    } else if (i > 0 && (j === 0 || lcs[i][j - 1] < lcs[i - 1][j])) {
-      result.unshift({type: 'remove', line: originalLines[i - 1]})
-      i--
-    }
-  }
-
-  return result
 }
 
 /**
@@ -120,45 +68,13 @@ export const generateConfigDiff = (original: any, updated: any): string => {
   const originalJson = JSON.stringify(sortedOriginal, undefined, 2)
   const updatedJson = JSON.stringify(sortedUpdated, undefined, 2)
 
-  // If they're identical after sorting, no changes
-  if (originalJson === updatedJson) {
-    return chalk.gray('No changes detected.\n')
-  }
+  const obfuscatedOriginal = originalJson.split('\n').map(obfuscateSensitiveValues).join('\n')
+  const obfuscatedUpdated = updatedJson.split('\n').map(obfuscateSensitiveValues).join('\n')
 
-  const originalLines = originalJson.split('\n')
-  const updatedLines = updatedJson.split('\n')
-
-  const diff = computeDiff(originalLines, updatedLines)
-
-  // Group consecutive changes into hunks
-  const result: string[] = []
-  let i = 0
-
-  while (i < diff.length) {
-    const current = diff[i]
-
-    if (current.type === 'context') {
-      result.push(`  ${obfuscateSensitiveValues(current.line)}`)
-      i++
-    } else {
-      // Collect all consecutive changes
-      const removals: string[] = []
-      const additions: string[] = []
-
-      while (i < diff.length && diff[i].type !== 'context') {
-        if (diff[i].type === 'remove') {
-          removals.push(diff[i].line)
-        } else if (diff[i].type === 'add') {
-          additions.push(diff[i].line)
-        }
-        i++
-      }
-
-      // Output all removals first, then all additions (with sensitive value obfuscation)
-      removals.forEach((line) => result.push(chalk.red(`- ${obfuscateSensitiveValues(line)}`)))
-      additions.forEach((line) => result.push(chalk.green(`+ ${obfuscateSensitiveValues(line)}`)))
-    }
-  }
-
-  return result.join('\n') + '\n'
+  return (
+    diff(obfuscatedOriginal, obfuscatedUpdated, {
+      aColor: chalk.red,
+      bColor: chalk.green,
+    }) || chalk.gray('No changes detected.')
+  )
 }

--- a/src/commands/cloud-run/utils.ts
+++ b/src/commands/cloud-run/utils.ts
@@ -1,3 +1,4 @@
+import chalk from 'chalk'
 import {GoogleAuth} from 'google-auth-library'
 
 /**
@@ -13,4 +14,151 @@ export const checkAuthentication = async () => {
   } catch (_) {
     return false
   }
+}
+
+/**
+ * Recursively sort object keys to ensure consistent ordering
+ */
+const sortObjectKeys = (obj: any): any => {
+  if (!obj) {
+    return obj
+  }
+
+  if (Array.isArray(obj)) {
+    return obj.map(sortObjectKeys)
+  }
+
+  if (typeof obj === 'object') {
+    const sorted: any = {}
+    Object.keys(obj)
+      .sort()
+      .forEach((key) => {
+        sorted[key] = sortObjectKeys(obj[key])
+      })
+
+    return sorted
+  }
+
+  return obj
+}
+
+/**
+ * Compute LCS (Longest Common Subsequence) for Git-like diff matching
+ */
+const computeLCS = (a: string[], b: string[]): number[][] => {
+  const m = a.length
+  const n = b.length
+  const dp: number[][] = Array(m + 1)
+    .fill(undefined)
+    .map(() => Array(n + 1).fill(0))
+
+  for (let i = 1; i <= m; i++) {
+    for (let j = 1; j <= n; j++) {
+      if (a[i - 1].trimEnd() === b[j - 1].trimEnd()) {
+        dp[i][j] = dp[i - 1][j - 1] + 1
+      } else {
+        dp[i][j] = Math.max(dp[i - 1][j], dp[i][j - 1])
+      }
+    }
+  }
+
+  return dp
+}
+
+/**
+ * Obfuscate sensitive values in a line if it contains a key with "_KEY"
+ */
+const obfuscateSensitiveValues = (line: string): string => {
+  // Match hex strings of 16, 32, or 64 characters (common API key/token lengths)
+  return line
+    .replace(/("[0-9a-fA-F]{16}"|"[0-9a-fA-F]{32}"|"[0-9a-fA-F]{64}")/g, '"***"')
+    .replace(/('[0-9a-fA-F]{16}'|'[0-9a-fA-F]{32}'|'[0-9a-fA-F]{64}')/g, "'***'")
+}
+
+/**
+ * Generate diff operations from the LCS table
+ */
+const computeDiff = (
+  originalLines: string[],
+  updatedLines: string[]
+): {type: 'add' | 'remove' | 'context'; line: string}[] => {
+  const result: {type: 'add' | 'remove' | 'context'; line: string}[] = []
+  const lcs = computeLCS(originalLines, updatedLines)
+
+  let i = originalLines.length
+  let j = updatedLines.length
+
+  while (i > 0 || j > 0) {
+    if (i > 0 && j > 0 && originalLines[i - 1].trimEnd() === updatedLines[j - 1].trimEnd()) {
+      result.unshift({type: 'context', line: originalLines[i - 1]})
+      i--
+      j--
+    } else if (j > 0 && (i === 0 || lcs[i][j - 1] >= lcs[i - 1][j])) {
+      result.unshift({type: 'add', line: updatedLines[j - 1]})
+      j--
+    } else if (i > 0 && (j === 0 || lcs[i][j - 1] < lcs[i - 1][j])) {
+      result.unshift({type: 'remove', line: originalLines[i - 1]})
+      i--
+    }
+  }
+
+  return result
+}
+
+/**
+ * Generate a git diff-style comparison between two configurations
+ * TODO(@nhulston): update Lambda and AAS instrument to show this diff
+ * @param original The original configuration object
+ * @param updated The updated configuration object
+ * @returns A formatted diff string with colors
+ */
+export const generateConfigDiff = (original: any, updated: any): string => {
+  // Sort keys consistently before comparison
+  const sortedOriginal = sortObjectKeys(original)
+  const sortedUpdated = sortObjectKeys(updated)
+
+  const originalJson = JSON.stringify(sortedOriginal, undefined, 2)
+  const updatedJson = JSON.stringify(sortedUpdated, undefined, 2)
+
+  // If they're identical after sorting, no changes
+  if (originalJson === updatedJson) {
+    return chalk.gray('No changes detected.\n')
+  }
+
+  const originalLines = originalJson.split('\n')
+  const updatedLines = updatedJson.split('\n')
+
+  const diff = computeDiff(originalLines, updatedLines)
+
+  // Group consecutive changes into hunks
+  const result: string[] = []
+  let i = 0
+
+  while (i < diff.length) {
+    const current = diff[i]
+
+    if (current.type === 'context') {
+      result.push(`  ${obfuscateSensitiveValues(current.line)}`)
+      i++
+    } else {
+      // Collect all consecutive changes
+      const removals: string[] = []
+      const additions: string[] = []
+
+      while (i < diff.length && diff[i].type !== 'context') {
+        if (diff[i].type === 'remove') {
+          removals.push(diff[i].line)
+        } else if (diff[i].type === 'add') {
+          additions.push(diff[i].line)
+        }
+        i++
+      }
+
+      // Output all removals first, then all additions (with sensitive value obfuscation)
+      removals.forEach((line) => result.push(chalk.red(`- ${obfuscateSensitiveValues(line)}`)))
+      additions.forEach((line) => result.push(chalk.green(`+ ${obfuscateSensitiveValues(line)}`)))
+    }
+  }
+
+  return result.join('\n') + '\n'
 }

--- a/src/commands/cloud-run/utils.ts
+++ b/src/commands/cloud-run/utils.ts
@@ -71,10 +71,13 @@ export const generateConfigDiff = (original: any, updated: any): string => {
   const obfuscatedOriginal = originalJson.split('\n').map(obfuscateSensitiveValues).join('\n')
   const obfuscatedUpdated = updatedJson.split('\n').map(obfuscateSensitiveValues).join('\n')
 
-  return (
-    diff(obfuscatedOriginal, obfuscatedUpdated, {
-      aColor: chalk.red,
-      bColor: chalk.green,
-    }) || chalk.gray('No changes detected.')
-  )
+  const configDiff = diff(obfuscatedOriginal, obfuscatedUpdated, {
+    aColor: chalk.red,
+    bColor: chalk.green,
+  })
+  if (!configDiff || configDiff.includes('no visual difference')) {
+    return chalk.gray('No changes detected.')
+  }
+
+  return configDiff
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2095,6 +2095,7 @@ __metadata:
     inquirer: ^8.2.5
     inquirer-checkbox-plus-prompt: ^1.4.2
     jest: 29.6.2
+    jest-diff: ^30.0.4
     js-yaml: 3.13.1
     jszip: ^3.10.1
     ora: 5.4.1
@@ -2494,6 +2495,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jest/diff-sequences@npm:30.0.1":
+  version: 30.0.1
+  resolution: "@jest/diff-sequences@npm:30.0.1"
+  checksum: e5f931ca69c15a9b3a9b23b723f51ffc97f031b2f3ca37f901333dab99bd4dfa1ad4192a5cd893cd1272f7602eb09b9cfb5fc6bb62a0232c96fb8b5e96094970
+  languageName: node
+  linkType: hard
+
 "@jest/environment@npm:^29.7.0":
   version: 29.7.0
   resolution: "@jest/environment@npm:29.7.0"
@@ -2536,6 +2544,13 @@ __metadata:
     jest-mock: ^29.7.0
     jest-util: ^29.7.0
   checksum: caf2bbd11f71c9241b458d1b5a66cbe95debc5a15d96442444b5d5c7ba774f523c76627c6931cca5e10e76f0d08761f6f1f01a608898f4751a0eee54fc3d8d00
+  languageName: node
+  linkType: hard
+
+"@jest/get-type@npm:30.0.1":
+  version: 30.0.1
+  resolution: "@jest/get-type@npm:30.0.1"
+  checksum: bd6cb2fe1661b652f06e5c6f7ef5aa37247a5b4bf04aad8ce6a8a8ba659efaf983bab9d52755be8cf92478f8d894c024de2fbddf4c3f6be804b808a20dfc347b
   languageName: node
   linkType: hard
 
@@ -2585,6 +2600,15 @@ __metadata:
     node-notifier:
       optional: true
   checksum: 7eadabd62cc344f629024b8a268ecc8367dba756152b761bdcb7b7e570a3864fc51b2a9810cd310d85e0a0173ef002ba4528d5ea0329fbf66ee2a3ada9c40455
+  languageName: node
+  linkType: hard
+
+"@jest/schemas@npm:30.0.1":
+  version: 30.0.1
+  resolution: "@jest/schemas@npm:30.0.1"
+  dependencies:
+    "@sinclair/typebox": ^0.34.0
+  checksum: 766936b48d65586c0e118ea010221822b5256098ea930b3feada5111fe1dcd0636ee6eca27a24ab7e69143c56721bb8074a6ead83fd5e31327da2abd4da982a7
   languageName: node
   linkType: hard
 
@@ -2904,6 +2928,13 @@ __metadata:
   version: 0.27.8
   resolution: "@sinclair/typebox@npm:0.27.8"
   checksum: 00bd7362a3439021aa1ea51b0e0d0a0e8ca1351a3d54c606b115fdcc49b51b16db6e5f43b4fe7a28c38688523e22a94d49dd31168868b655f0d4d50f032d07a1
+  languageName: node
+  linkType: hard
+
+"@sinclair/typebox@npm:^0.34.0":
+  version: 0.34.37
+  resolution: "@sinclair/typebox@npm:0.34.37"
+  checksum: dbfef02bb40b286a40a140a94a3ce5b1f176df7ca1109849748a02533d1163bf0b2663cc098578af8f4e183af0c98add180c3e5e0d17c7ebc2a5b2265b4a8ad8
   languageName: node
   linkType: hard
 
@@ -4331,7 +4362,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ansi-styles@npm:^5.0.0":
+"ansi-styles@npm:^5.0.0, ansi-styles@npm:^5.2.0":
   version: 5.2.0
   resolution: "ansi-styles@npm:5.2.0"
   checksum: d7f4e97ce0623aea6bc0d90dcd28881ee04cba06c570b97fd3391bd7a268eedfd9d5e2dd4fdcbdd82b8105df5faf6f24aaedc08eaf3da898e702db5948f63469
@@ -7888,6 +7919,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jest-diff@npm:^30.0.4":
+  version: 30.0.4
+  resolution: "jest-diff@npm:30.0.4"
+  dependencies:
+    "@jest/diff-sequences": 30.0.1
+    "@jest/get-type": 30.0.1
+    chalk: ^4.1.2
+    pretty-format: 30.0.2
+  checksum: bd4769b9c2695ac201e5dc29385ba9dfdf8860151a8e9cc38cc96405a7ca97595ff7812752dca63304e6a9f2880b6567428e76476bf601305e653e9606e9037a
+  languageName: node
+  linkType: hard
+
 "jest-docblock@npm:^29.7.0":
   version: 29.7.0
   resolution: "jest-docblock@npm:29.7.0"
@@ -9648,6 +9691,17 @@ jschardet@latest:
   languageName: node
   linkType: hard
 
+"pretty-format@npm:30.0.2":
+  version: 30.0.2
+  resolution: "pretty-format@npm:30.0.2"
+  dependencies:
+    "@jest/schemas": 30.0.1
+    ansi-styles: ^5.2.0
+    react-is: ^18.3.1
+  checksum: 28888a4ccd13d85f6b6738c2678b5bcff95ff46ebdb4a02098d0a390adbdfac9e70020f9425d8e58d0c5f39181532c0cd323a19bf9492d44b33d4cc987515b6a
+  languageName: node
+  linkType: hard
+
 "pretty-format@npm:^29.0.0, pretty-format@npm:^29.7.0":
   version: 29.7.0
   resolution: "pretty-format@npm:29.7.0"
@@ -9850,7 +9904,7 @@ jschardet@latest:
   languageName: node
   linkType: hard
 
-"react-is@npm:^18.0.0":
+"react-is@npm:^18.0.0, react-is@npm:^18.3.1":
   version: 18.3.1
   resolution: "react-is@npm:18.3.1"
   checksum: e20fe84c86ff172fc8d898251b7cc2c43645d108bf96d0b8edf39b98f9a2cae97b40520ee7ed8ee0085ccc94736c4886294456033304151c3f94978cec03df21


### PR DESCRIPTION

### What and why?

In the Cloud Run instrument command:
- Implement `--dry` flag
- Implement `--interactive` flag
- And finally, display a git-style diff of the service configuration when running the instrument command:

<img width="300" alt="Screenshot 2025-07-02 at 5 34 02 PM" src="https://github.com/user-attachments/assets/73ef4cba-dc3e-4737-8023-6039c8836d7f" />
<br/>
<img width="300" alt="Screenshot 2025-07-02 at 5 33 54 PM" src="https://github.com/user-attachments/assets/63a21709-3fd4-4636-a19c-9395388456f1" />
<br/>
<img width="300" alt="Screenshot 2025-07-02 at 5 33 46 PM" src="https://github.com/user-attachments/assets/df027ea5-9062-4aad-8711-086d4225edbf" />


### How?

A brief description of implementation details of this PR.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
