### PR TITLE
Add fallback `DD_API_KEY`, `DD_APP_KEY` and `DD_SITE` to all commands

### DIFF
--- a/src/commands/cloud-run/__tests__/__snapshots__/flare.test.ts.snap
+++ b/src/commands/cloud-run/__tests__/__snapshots__/flare.test.ts.snap
@@ -333,6 +333,7 @@ exports[`cloud-run flare prints correct headers prints dry-run header 1`] = `
 [Error] No service specified. [-s,--service]
 [Error] No project specified. [-p,--project]
 [Error] No region specified. [-r,--region]
+[Error] No Datadog API key specified. Set an API key with the DD_API_KEY environment variable.
 [Error] No case ID specified. [-c,--case-id]
 [Error] No email specified. [-e,--email]
 "
@@ -344,6 +345,7 @@ exports[`cloud-run flare prints correct headers prints non-dry-run header 1`] = 
 [Error] No service specified. [-s,--service]
 [Error] No project specified. [-p,--project]
 [Error] No region specified. [-r,--region]
+[Error] No Datadog API key specified. Set an API key with the DD_API_KEY environment variable.
 [Error] No case ID specified. [-c,--case-id]
 [Error] No email specified. [-e,--email]
 "
@@ -480,7 +482,7 @@ exports[`cloud-run flare summarizeConfig 1`] = `
 exports[`cloud-run flare validates required flags prints error when no API key in env variables 1`] = `
 "
 🐶 Generating Cloud Run flare to send your configuration to Datadog...
-[Error] No Datadog API key specified. Set an API key with the DATADOG_API_KEY environment variable.
+[Error] No Datadog API key specified. Set an API key with the DD_API_KEY environment variable.
 "
 `;
 

--- a/src/commands/cloud-run/__tests__/__snapshots__/flare.test.ts.snap
+++ b/src/commands/cloud-run/__tests__/__snapshots__/flare.test.ts.snap
@@ -333,7 +333,6 @@ exports[`cloud-run flare prints correct headers prints dry-run header 1`] = `
 [Error] No service specified. [-s,--service]
 [Error] No project specified. [-p,--project]
 [Error] No region specified. [-r,--region]
-[Error] No Datadog API key specified. Set an API key with the DD_API_KEY environment variable.
 [Error] No case ID specified. [-c,--case-id]
 [Error] No email specified. [-e,--email]
 "
@@ -345,7 +344,6 @@ exports[`cloud-run flare prints correct headers prints non-dry-run header 1`] = 
 [Error] No service specified. [-s,--service]
 [Error] No project specified. [-p,--project]
 [Error] No region specified. [-r,--region]
-[Error] No Datadog API key specified. Set an API key with the DD_API_KEY environment variable.
 [Error] No case ID specified. [-c,--case-id]
 [Error] No email specified. [-e,--email]
 "

--- a/src/commands/cloud-run/__tests__/flare.test.ts
+++ b/src/commands/cloud-run/__tests__/flare.test.ts
@@ -170,6 +170,10 @@ describe('cloud-run flare', () => {
   })
 
   describe('prints correct headers', () => {
+    beforeEach(() => {
+      process.env = { [CI_API_KEY_ENV_VAR]: MOCK_DATADOG_API_KEY }
+    })
+
     it('prints non-dry-run header', async () => {
       const {code, context} = await runCLI([])
       const output = context.stdout.toString()

--- a/src/commands/cloud-run/__tests__/flare.test.ts
+++ b/src/commands/cloud-run/__tests__/flare.test.ts
@@ -171,7 +171,7 @@ describe('cloud-run flare', () => {
 
   describe('prints correct headers', () => {
     beforeEach(() => {
-      process.env = { [CI_API_KEY_ENV_VAR]: MOCK_DATADOG_API_KEY }
+      process.env = {[CI_API_KEY_ENV_VAR]: MOCK_DATADOG_API_KEY}
     })
 
     it('prints non-dry-run header', async () => {

--- a/src/commands/cloud-run/flare.ts
+++ b/src/commands/cloud-run/flare.ts
@@ -128,7 +128,7 @@ export class CloudRunFlareCommand extends Command {
     if (this.apiKey === undefined) {
       errorMessages.push(
         helpersRenderer.renderError(
-          'No Datadog API key specified. Set an API key with the DATADOG_API_KEY environment variable.'
+          'No Datadog API key specified. Set an API key with the DD_API_KEY environment variable.'
         )
       )
     }

--- a/src/commands/dsyms/README.md
+++ b/src/commands/dsyms/README.md
@@ -8,18 +8,18 @@ Upload dSYM files to Datadog to symbolicate your crash reports.
 
 ### Setup
 
-You need to have `DATADOG_API_KEY` in your environment.
+You need to have `DD_API_KEY` in your environment.
 
 ```bash
 # Environment setup
-export DATADOG_API_KEY="<API KEY>"
+export DD_API_KEY="<API KEY>"
 ```
 
-By default, requests are sent to Datadog US1. It is possible to configure the tool to use a different site by setting the `DATADOG_SITE` environment variable to the corresponding [site parameter][2].
+By default, requests are sent to Datadog US1. It is possible to configure the tool to use a different site by setting the `DD_SITE` environment variable to the corresponding [site parameter][2].
 
 ```bash
 # Example environment setup for US5
-export DATADOG_SITE="us5.datadoghq.com"
+export DD_SITE="us5.datadoghq.com"
 ```
 
 It is also possible to override the full URL for the intake endpoint by defining the `DATADOG_DSYM_INTAKE_URL` environment variable.
@@ -56,7 +56,7 @@ datadog-ci dsyms upload ~/Downloads/appDsyms.zip
 To verify this command works as expected, you can trigger a test run and verify it returns 0:
 
 ```bash
-export DATADOG_API_KEY='<API key>'
+export DD_API_KEY='<API key>'
 
 // at this point, build any project in Xcode so that it produces dSYM files in Derived Data path
 // assuming your Derived Data path is ~/Library/Developer/Xcode/DerivedData/

--- a/src/commands/dsyms/__tests__/upload.test.ts
+++ b/src/commands/dsyms/__tests__/upload.test.ts
@@ -298,6 +298,8 @@ describe('execute', () => {
   afterEach(() => {
     delete process.env.DATADOG_API_KEY
     delete process.env.DATADOG_SITE
+    delete process.env.DD_API_KEY
+    delete process.env.DD_SITE
   })
 
   test('Should succeed with folder input', async () => {

--- a/src/commands/dsyms/__tests__/upload.test.ts
+++ b/src/commands/dsyms/__tests__/upload.test.ts
@@ -295,13 +295,6 @@ describe('execute', () => {
     mockDwarfdumpAndLipoIfNotMacOS()
   })
 
-  afterEach(() => {
-    delete process.env.DATADOG_API_KEY
-    delete process.env.DATADOG_SITE
-    delete process.env.DD_API_KEY
-    delete process.env.DD_SITE
-  })
-
   test('Should succeed with folder input', async () => {
     const {context, code} = await runCLI('src/commands/dsyms/__tests__/fixtures/')
     const outputString = context.stdout.toString()

--- a/src/commands/dsyms/upload.ts
+++ b/src/commands/dsyms/upload.ts
@@ -325,7 +325,7 @@ export class UploadCommand extends Command {
 
   private createRequestBuilder(): RequestBuilder {
     if (!this.config.apiKey) {
-      throw new InvalidConfigurationError(`Missing ${chalk.bold('DATADOG_API_KEY')} in your environment.`)
+      throw new InvalidConfigurationError(`Missing ${chalk.bold('DATADOG_API_KEY')} or ${chalk.bold('DD_API_KEY')} in your environment.`)
     }
 
     return getRequestBuilder({

--- a/src/commands/dsyms/upload.ts
+++ b/src/commands/dsyms/upload.ts
@@ -134,7 +134,7 @@ export class UploadCommand extends Command {
           checkAPIKeyOverride(
             process.env.DATADOG_API_KEY || process.env.DD_API_KEY,
             configFromFile.apiKey,
-            this.context.stdout,
+            this.context.stdout
           )
         },
       }
@@ -325,7 +325,9 @@ export class UploadCommand extends Command {
 
   private createRequestBuilder(): RequestBuilder {
     if (!this.config.apiKey) {
-      throw new InvalidConfigurationError(`Missing ${chalk.bold('DATADOG_API_KEY')} or ${chalk.bold('DD_API_KEY')} in your environment.`)
+      throw new InvalidConfigurationError(
+        `Missing ${chalk.bold('DATADOG_API_KEY')} or ${chalk.bold('DD_API_KEY')} in your environment.`
+      )
     }
 
     return getRequestBuilder({

--- a/src/commands/dsyms/upload.ts
+++ b/src/commands/dsyms/upload.ts
@@ -124,14 +124,18 @@ export class UploadCommand extends Command {
     this.config = await resolveConfigFromFileAndEnvironment(
       this.config,
       {
-        apiKey: process.env.DATADOG_API_KEY,
-        datadogSite: process.env.DATADOG_SITE,
+        apiKey: process.env.DATADOG_API_KEY || process.env.DD_API_KEY,
+        datadogSite: process.env.DATADOG_SITE || process.env.DD_SITE,
       },
       {
         configPath: this.configPath,
         defaultConfigPaths: ['datadog-ci.json', '../datadog-ci.json'],
         configFromFileCallback: (configFromFile: any) => {
-          checkAPIKeyOverride(process.env.DATADOG_API_KEY, configFromFile.apiKey, this.context.stdout)
+          checkAPIKeyOverride(
+            process.env.DATADOG_API_KEY || process.env.DD_API_KEY,
+            configFromFile.apiKey,
+            this.context.stdout,
+          )
         },
       }
     )

--- a/src/commands/elf-symbols/README.md
+++ b/src/commands/elf-symbols/README.md
@@ -6,21 +6,21 @@ Upload Elf debug info files to Datadog to symbolicate your profiles.
 
 ## Setup
 
-You need to have `DATADOG_API_KEY` in your environment.
+You need to have `DD_API_KEY` in your environment.
 
 ```bash
 # Environment setup
-export DATADOG_API_KEY="<API KEY>"
+export DD_API_KEY="<API KEY>"
 ```
 
-You can configure the tool to use Datadog EU by defining the `DATADOG_SITE` environment variable as `datadoghq.eu`. By default, the requests are sent to Datadog US.
+You can configure the tool to use Datadog EU by defining the `DD_SITE` environment variable as `datadoghq.eu`. By default, the requests are sent to Datadog US.
 
 To make these variables available, Datadog recommends setting them in an encrypted `datadog-ci.json` file at the root of your project:
 
 ```json
 {
-  "apiKey": "<DATADOG_API_KEY>",
-  "datadogSite": "<DATADOG_SITE>"
+  "apiKey": "<DD_API_KEY>",
+  "datadogSite": "<DD_SITE>"
 }
 ```
 

--- a/src/commands/elf-symbols/README.md
+++ b/src/commands/elf-symbols/README.md
@@ -19,8 +19,8 @@ To make these variables available, Datadog recommends setting them in an encrypt
 
 ```json
 {
-  "apiKey": "<DD_API_KEY>",
-  "datadogSite": "<DD_SITE>"
+  "apiKey": "<API_KEY>",
+  "datadogSite": "<SITE>"
 }
 ```
 

--- a/src/commands/elf-symbols/upload.ts
+++ b/src/commands/elf-symbols/upload.ts
@@ -92,8 +92,8 @@ export class UploadCommand extends Command {
     this.config = await resolveConfigFromFileAndEnvironment(
       this.config,
       {
-        apiKey: process.env.DATADOG_API_KEY,
-        datadogSite: process.env.DATADOG_SITE,
+        apiKey: process.env.DATADOG_API_KEY || process.env.DD_API_KEY,
+        datadogSite: process.env.DATADOG_SITE || process.env.DD_SITE,
       },
       {
         configPath: this.configPath,

--- a/src/commands/elf-symbols/upload.ts
+++ b/src/commands/elf-symbols/upload.ts
@@ -99,7 +99,11 @@ export class UploadCommand extends Command {
         configPath: this.configPath,
         defaultConfigPaths: DEFAULT_CONFIG_PATHS,
         configFromFileCallback: (configFromFile: any) => {
-          checkAPIKeyOverride(process.env.DATADOG_API_KEY, configFromFile.apiKey, this.context.stdout)
+          checkAPIKeyOverride(
+            process.env.DATADOG_API_KEY || process.env.DD_API_KEY,
+            configFromFile.apiKey,
+            this.context.stdout,
+          )
         },
       }
     )

--- a/src/commands/elf-symbols/upload.ts
+++ b/src/commands/elf-symbols/upload.ts
@@ -102,7 +102,7 @@ export class UploadCommand extends Command {
           checkAPIKeyOverride(
             process.env.DATADOG_API_KEY || process.env.DD_API_KEY,
             configFromFile.apiKey,
-            this.context.stdout,
+            this.context.stdout
           )
         },
       }

--- a/src/commands/flutter-symbols/README.md
+++ b/src/commands/flutter-symbols/README.md
@@ -4,26 +4,26 @@ To deobfuscate and symbolicate errors and crashes, upload your Flutter Symbols, 
 
 ## Setup
 
-You need to have `DATADOG_API_KEY` in your environment.
+You need to have `DD_API_KEY` in your environment.
 
 ```bash
 # Environment setup
-export DATADOG_API_KEY="<API KEY>"
+export DD_API_KEY="<API KEY>"
 ```
 
-By default, requests are sent to Datadog US1. It is possible to configure the tool to use a different site by setting the `DATADOG_SITE` environment variable to the corresponding [site parameter][2].
+By default, requests are sent to Datadog US1. It is possible to configure the tool to use a different site by setting the `DD_SITE` environment variable to the corresponding [site parameter][2].
 
 ```bash
 # Example environment setup for US5
-export DATADOG_SITE="us5.datadoghq.com"
+export DD_SITE="us5.datadoghq.com"
 ```
 
 To make these variables available, Datadog recommends setting them in an encrypted `datadog-ci.json` file at the root of your project:
 
 ```json
 {
-  "apiKey": "<DATADOG_API_KEY>",
-  "datadogSite": "<DATADOG_SITE>"
+  "apiKey": "<DD_API_KEY>",
+  "datadogSite": "<DD_SITE>"
 }
 ```
 

--- a/src/commands/flutter-symbols/README.md
+++ b/src/commands/flutter-symbols/README.md
@@ -22,8 +22,8 @@ To make these variables available, Datadog recommends setting them in an encrypt
 
 ```json
 {
-  "apiKey": "<DD_API_KEY>",
-  "datadogSite": "<DD_SITE>"
+  "apiKey": "<API_KEY>",
+  "datadogSite": "<SITE>"
 }
 ```
 

--- a/src/commands/flutter-symbols/upload.ts
+++ b/src/commands/flutter-symbols/upload.ts
@@ -160,7 +160,7 @@ export class UploadCommand extends Command {
           checkAPIKeyOverride(
             process.env.DATADOG_API_KEY || process.env.DD_API_KEY,
             configFromFile.apiKey,
-            this.context.stdout,
+            this.context.stdout
           )
         },
       }

--- a/src/commands/flutter-symbols/upload.ts
+++ b/src/commands/flutter-symbols/upload.ts
@@ -150,14 +150,18 @@ export class UploadCommand extends Command {
     this.config = await resolveConfigFromFileAndEnvironment(
       this.config,
       {
-        apiKey: process.env.DATADOG_API_KEY,
-        datadogSite: process.env.DATADOG_SITE,
+        apiKey: process.env.DATADOG_API_KEY || process.env.DD_API_KEY,
+        datadogSite: process.env.DATADOG_SITE || process.env.DD_SITE,
       },
       {
         configPath: this.configPath,
         defaultConfigPaths: DEFAULT_CONFIG_PATHS,
         configFromFileCallback: (configFromFile: any) => {
-          checkAPIKeyOverride(process.env.DATADOG_API_KEY, configFromFile.apiKey, this.context.stdout)
+          checkAPIKeyOverride(
+            process.env.DATADOG_API_KEY || process.env.DD_API_KEY,
+            configFromFile.apiKey,
+            this.context.stdout,
+          )
         },
       }
     )

--- a/src/commands/git-metadata/README.md
+++ b/src/commands/git-metadata/README.md
@@ -6,14 +6,14 @@ Upload the git commit details to Datadog.
 
 ### Setup
 
-You need to have `DATADOG_API_KEY` in your environment.
+You need to have `DD_API_KEY` in your environment.
 
 ```bash
 # Environment setup
-export DATADOG_API_KEY="<API KEY>"
+export DD_API_KEY="<API KEY>"
 ```
 
-It is possible to configure the tool to use Datadog EU by defining the `DATADOG_SITE` environment variable to `datadoghq.eu`. By default the requests are sent to Datadog US.
+It is possible to configure the tool to use Datadog EU by defining the `DD_SITE` environment variable to `datadoghq.eu`. By default the requests are sent to Datadog US.
 
 It is also possible to override the full URL for the intake endpoint by defining the `DATADOG_SOURCEMAP_INTAKE_URL` environment variable.
 
@@ -51,7 +51,7 @@ The only repository URLs supported are the ones whose host contains: `github`, `
 To verify this command works as expected, you can trigger a test run and verify it returns 0:
 
 ```bash
-export DATADOG_API_KEY='<API key>'
+export DD_API_KEY='<API key>'
 
 yarn launch git-metadata upload
 ```

--- a/src/commands/git-metadata/__tests__/upload.test.ts
+++ b/src/commands/git-metadata/__tests__/upload.test.ts
@@ -17,7 +17,7 @@ describe('execute', () => {
     const {code, context} = await runCLI([], {DATADOG_API_KEY: ''})
     const output = context.stdout.toString().split('\n')
     output.reverse()
-    expect(output[1]).toContain('Missing DATADOG_API_KEY in your environment')
+    expect(output[1]).toContain('Missing DD_API_KEY in your environment')
     expect(code).toBe(1)
   })
 })

--- a/src/commands/git-metadata/upload.ts
+++ b/src/commands/git-metadata/upload.ts
@@ -84,7 +84,7 @@ export class UploadCommand extends Command {
     if (!this.config.apiKey) {
       this.logger.error(
         renderConfigurationError(
-          new InvalidConfigurationError(`Missing ${chalk.bold('DATADOG_API_KEY')} in your environment`)
+          new InvalidConfigurationError(`Missing ${chalk.bold('DD_API_KEY')} in your environment`)
         )
       )
 

--- a/src/commands/lambda/__tests__/__snapshots__/flare.test.ts.snap
+++ b/src/commands/lambda/__tests__/__snapshots__/flare.test.ts.snap
@@ -838,7 +838,7 @@ exports[`lambda flare validates required flags prints error when end time is spe
 exports[`lambda flare validates required flags prints error when no API key in env variables 1`] = `
 "
 🐶 Generating Lambda flare to send your configuration to Datadog...
-[Error] No Datadog API key specified. Set an API key with the DATADOG_API_KEY environment variable.
+[Error] No Datadog API key specified. Set an API key with the DD_API_KEY environment variable.
 "
 `;
 

--- a/src/commands/lambda/flare.ts
+++ b/src/commands/lambda/flare.ts
@@ -124,7 +124,7 @@ export class LambdaFlareCommand extends Command {
     if (this.apiKey === undefined) {
       errorMessages.push(
         helpersRenderer.renderError(
-          'No Datadog API key specified. Set an API key with the DATADOG_API_KEY environment variable.'
+          'No Datadog API key specified. Set an API key with the DD_API_KEY environment variable.'
         )
       )
     }

--- a/src/commands/lambda/renderers/instrument-uninstrument-renderer.ts
+++ b/src/commands/lambda/renderers/instrument-uninstrument-renderer.ts
@@ -62,15 +62,6 @@ export const renderExtensionAndForwarderOptionsBothSetError = () =>
   renderError('"extensionVersion" and "forwarder" should not be used at the same time.')
 
 /**
- * @returns a message indicating that the environment variable `DATADOG_API_KEY` is missing.
- *
- * ```txt
- * [Error] Missing DATADOG_API_KEY in your environment.
- * ```
- */
-export const renderMissingDatadogApiKeyError = () => renderError('Missing DATADOG_API_KEY in your environment.')
-
-/**
  * @param functionsCommandUsed a boolean indicating which command was used for the specified functions.
  * @returns a message indicating that option `--functions-regex`
  * is being used along with either `--functions` or the parameter

--- a/src/commands/pe-symbols/README.md
+++ b/src/commands/pe-symbols/README.md
@@ -5,21 +5,21 @@ Upload Windows PE debug info files to Datadog to symbolicate your profiles.
 
 ## Setup
 
-You need to have `DATADOG_API_KEY` in your environment.
+You need to have `DD_API_KEY` in your environment.
 
 ```bash
 # Environment setup
-export DATADOG_API_KEY="<API KEY>"
+export DD_API_KEY="<API KEY>"
 ```
 
-You can configure the tool to use Datadog EU by defining the `DATADOG_SITE` environment variable as `datadoghq.eu`. By default, the requests are sent to Datadog US.
+You can configure the tool to use Datadog EU by defining the `DD_SITE` environment variable as `datadoghq.eu`. By default, the requests are sent to Datadog US.
 
 To make these variables available, Datadog recommends setting them in an encrypted `datadog-ci.json` file at the root of your project:
 
 ```json
 {
-  "apiKey": "<DATADOG_API_KEY>",
-  "datadogSite": "<DATADOG_SITE>"
+  "apiKey": "<DD_API_KEY>",
+  "datadogSite": "<DD_SITE>"
 }
 ```
 

--- a/src/commands/pe-symbols/README.md
+++ b/src/commands/pe-symbols/README.md
@@ -18,8 +18,8 @@ To make these variables available, Datadog recommends setting them in an encrypt
 
 ```json
 {
-  "apiKey": "<DD_API_KEY>",
-  "datadogSite": "<DD_SITE>"
+  "apiKey": "<API_KEY>",
+  "datadogSite": "<SITE>"
 }
 ```
 

--- a/src/commands/pe-symbols/upload.ts
+++ b/src/commands/pe-symbols/upload.ts
@@ -83,14 +83,18 @@ export class UploadCommand extends Command {
     this.config = await resolveConfigFromFileAndEnvironment(
       this.config,
       {
-        apiKey: process.env.DATADOG_API_KEY,
-        datadogSite: process.env.DATADOG_SITE,
+        apiKey: process.env.DATADOG_API_KEY || process.env.DD_API_KEY,
+        datadogSite: process.env.DATADOG_SITE || process.env.DD_SITE,
       },
       {
         configPath: this.configPath,
         defaultConfigPaths: DEFAULT_CONFIG_PATHS,
         configFromFileCallback: (configFromFile: any) => {
-          checkAPIKeyOverride(process.env.DATADOG_API_KEY, configFromFile.apiKey, this.context.stdout)
+          checkAPIKeyOverride(
+            process.env.DATADOG_API_KEY || process.env.DD_API_KEY,
+            configFromFile.apiKey,
+            this.context.stdout,
+          )
         },
       }
     )

--- a/src/commands/pe-symbols/upload.ts
+++ b/src/commands/pe-symbols/upload.ts
@@ -93,7 +93,7 @@ export class UploadCommand extends Command {
           checkAPIKeyOverride(
             process.env.DATADOG_API_KEY || process.env.DD_API_KEY,
             configFromFile.apiKey,
-            this.context.stdout,
+            this.context.stdout
           )
         },
       }

--- a/src/commands/react-native/README.md
+++ b/src/commands/react-native/README.md
@@ -4,21 +4,21 @@ To un-minify errors, upload your React Native source maps to Datadog.
 
 ## Setup
 
-You need to have `DATADOG_API_KEY` in your environment.
+You need to have `DD_API_KEY` in your environment.
 
 ```bash
 # Environment setup
-export DATADOG_API_KEY="<API KEY>"
+export DD_API_KEY="<API KEY>"
 ```
 
-You can configure the tool to use Datadog EU by defining the `DATADOG_SITE` environment variable as `datadoghq.eu`. By default, the requests are sent to Datadog US.
+You can configure the tool to use Datadog EU by defining the `DD_SITE` environment variable as `datadoghq.eu`. By default, the requests are sent to Datadog US.
 
 To make these variables available, Datadog recommends setting them in an encrypted `datadog-ci.json` file at the root of your project:
 
 ```json
 {
-  "apiKey": "<DATADOG_API_KEY>",
-  "datadogSite": "<DATADOG_SITE>"
+  "apiKey": "<DD_API_KEY>",
+  "datadogSite": "<DD_SITE>"
 }
 ```
 
@@ -144,8 +144,8 @@ You can use the same environment variables as the `upload` command:
 
 | Environment Variable           | Description                                                                                                                                                     |
 | ------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `DATADOG_API_KEY`              | Your Datadog API key. (REQUIRED)
-| `DATADOG_SITE`                 | Optional Datadog site (datadoghq.com, [us3, us5].datadoghq.com, datadoghq.eu, ddog-gov.com, ap1.datadoghq.com, ap2.datadoghq.com). By default, the requests are sent to Datadog US.
+| `DD_API_KEY`                   | Your Datadog API key. (REQUIRED)
+| `DD_SITE`                      | Optional Datadog site (datadoghq.com, [us3, us5].datadoghq.com, datadoghq.eu, ddog-gov.com, ap1.datadoghq.com, ap2.datadoghq.com). By default, the requests are sent to Datadog US.
 | `DATADOG_SOURCEMAP_INTAKE_URL` | Optional variable to override the full URL for the intake endpoint.
 | `DATADOG_RELEASE_VERSION`      | Optional variable to override the version name for sourcemaps upload
 
@@ -227,7 +227,7 @@ The `--dry-run` optional parameter is also available, to run the command without
 To verify this command works as expected, you can trigger a test run and verify that it returns 0:
 
 ```bash
-export DATADOG_API_KEY='<API key>'
+export DD_API_KEY='<API key>'
 
 TEMP_DIR=$(mktemp -d)
 echo '{}' > $TEMP_DIR/fake.js

--- a/src/commands/react-native/README.md
+++ b/src/commands/react-native/README.md
@@ -17,8 +17,8 @@ To make these variables available, Datadog recommends setting them in an encrypt
 
 ```json
 {
-  "apiKey": "<DD_API_KEY>",
-  "datadogSite": "<DD_SITE>"
+  "apiKey": "<API_KEY>",
+  "datadogSite": "<SITE>"
 }
 ```
 

--- a/src/commands/react-native/__tests__/upload.test.ts
+++ b/src/commands/react-native/__tests__/upload.test.ts
@@ -117,6 +117,7 @@ describe('execute', () => {
     if (options?.configPath) {
       command.push('--config', options.configPath)
       delete process.env.DATADOG_API_KEY
+      delete process.env.DD_API_KEY
     }
     if (options?.env) {
       process.env = {

--- a/src/commands/react-native/__tests__/upload.test.ts
+++ b/src/commands/react-native/__tests__/upload.test.ts
@@ -95,7 +95,6 @@ describe('execute', () => {
     cli.register(UploadCommand)
 
     const context = createMockContext()
-    process.env = getEnvVarPlaceholders()
     const command = [
       'react-native',
       'upload',
@@ -111,13 +110,14 @@ describe('execute', () => {
       'android',
       '--dry-run',
     ]
-    if (options?.uploadBundle !== false) {
-      command.push('--bundle', bundle)
-    }
     if (options?.configPath) {
       command.push('--config', options.configPath)
-      delete process.env.DATADOG_API_KEY
-      delete process.env.DD_API_KEY
+      process.env = {}
+    } else {
+      process.env = getEnvVarPlaceholders()
+    }
+    if (options?.uploadBundle !== false) {
+      command.push('--bundle', bundle)
     }
     if (options?.env) {
       process.env = {

--- a/src/commands/react-native/__tests__/upload.test.ts
+++ b/src/commands/react-native/__tests__/upload.test.ts
@@ -15,7 +15,7 @@ describe('upload', () => {
       const command = new UploadCommand()
 
       expect(command['getRequestBuilder'].bind(command)).toThrow(
-        `Missing ${chalk.bold('DATADOG_API_KEY')} in your environment.`
+        `Missing ${chalk.bold('DATADOG_API_KEY')} or ${chalk.bold('DD_API_KEY')} in your environment.`
       )
     })
   })

--- a/src/commands/react-native/__tests__/xcode.test.ts
+++ b/src/commands/react-native/__tests__/xcode.test.ts
@@ -13,6 +13,7 @@ beforeEach(() => {
   delete process.env.CONFIGURATION_BUILD_DIR
   delete process.env.CURRENT_PROJECT_VERSION
   delete process.env.DATADOG_API_KEY
+  delete process.env.DD_API_KEY
   delete process.env.EXTRA_PACKAGER_ARGS
   delete process.env.INFOPLIST_FILE
   delete process.env.MARKETING_VERSION

--- a/src/commands/react-native/__tests__/xcode.test.ts
+++ b/src/commands/react-native/__tests__/xcode.test.ts
@@ -12,8 +12,6 @@ beforeEach(() => {
   delete process.env.CONFIGURATION
   delete process.env.CONFIGURATION_BUILD_DIR
   delete process.env.CURRENT_PROJECT_VERSION
-  delete process.env.DATADOG_API_KEY
-  delete process.env.DD_API_KEY
   delete process.env.EXTRA_PACKAGER_ARGS
   delete process.env.INFOPLIST_FILE
   delete process.env.MARKETING_VERSION

--- a/src/commands/react-native/upload.ts
+++ b/src/commands/react-native/upload.ts
@@ -152,7 +152,7 @@ export class UploadCommand extends Command {
           checkAPIKeyOverride(
             process.env.DATADOG_API_KEY || process.env.DD_API_KEY,
             configFromFile.apiKey,
-            this.context.stdout,
+            this.context.stdout
           )
         },
       }
@@ -273,7 +273,9 @@ export class UploadCommand extends Command {
 
   private getRequestBuilder(): RequestBuilder {
     if (!this.config.apiKey) {
-      throw new InvalidConfigurationError(`Missing ${chalk.bold('DATADOG_API_KEY')} or ${chalk.bold('DD_API_KEY')} in your environment.`)
+      throw new InvalidConfigurationError(
+        `Missing ${chalk.bold('DATADOG_API_KEY')} or ${chalk.bold('DD_API_KEY')} in your environment.`
+      )
     }
 
     return getRequestBuilder({

--- a/src/commands/react-native/upload.ts
+++ b/src/commands/react-native/upload.ts
@@ -142,14 +142,18 @@ export class UploadCommand extends Command {
     this.config = await resolveConfigFromFileAndEnvironment(
       this.config,
       {
-        apiKey: process.env.DATADOG_API_KEY,
-        datadogSite: process.env.DATADOG_SITE,
+        apiKey: process.env.DATADOG_API_KEY || process.env.DD_API_KEY,
+        datadogSite: process.env.DATADOG_SITE || process.env.DD_SITE,
       },
       {
         configPath: this.configPath,
         defaultConfigPaths: ['datadog-ci.json', '../datadog-ci.json'],
         configFromFileCallback: (configFromFile: any) => {
-          checkAPIKeyOverride(process.env.DATADOG_API_KEY, configFromFile.apiKey, this.context.stdout)
+          checkAPIKeyOverride(
+            process.env.DATADOG_API_KEY || process.env.DD_API_KEY,
+            configFromFile.apiKey,
+            this.context.stdout,
+          )
         },
       }
     )

--- a/src/commands/react-native/upload.ts
+++ b/src/commands/react-native/upload.ts
@@ -273,7 +273,7 @@ export class UploadCommand extends Command {
 
   private getRequestBuilder(): RequestBuilder {
     if (!this.config.apiKey) {
-      throw new InvalidConfigurationError(`Missing ${chalk.bold('DATADOG_API_KEY')} in your environment.`)
+      throw new InvalidConfigurationError(`Missing ${chalk.bold('DATADOG_API_KEY')} or ${chalk.bold('DD_API_KEY')} in your environment.`)
     }
 
     return getRequestBuilder({

--- a/src/commands/sarif/README.md
+++ b/src/commands/sarif/README.md
@@ -32,9 +32,9 @@ The positional arguments are the directories or file paths in which the SARIF re
 
 Additionally, you may configure the `sarif` command with environment variables:
 
-- `DATADOG_API_KEY` or `DD_API_KEY` (**required**): API key used to authenticate the requests.
+- `DD_API_KEY` (**required**): API key used to authenticate the requests.
 - `DD_TAGS`: Set global tags applied to all spans. The format must be `key1:value1,key2:value2`. The upload process merges the tags passed on the command line with the tags in the `--tags` parameter. If a key appears in both `--tags` and `DD_TAGS`, the value in `DD_TAGS` takes precedence.
-- `DATADOG_SITE` or `DD_SITE`: choose your Datadog site, for example, datadoghq.com or datadoghq.eu.
+- `DD_SITE`: choose your Datadog site, for example, datadoghq.com or datadoghq.eu.
 
 ### Git context resolution
 

--- a/src/commands/sourcemaps/README.md
+++ b/src/commands/sourcemaps/README.md
@@ -4,14 +4,14 @@ Upload JavaScript sourcemaps to Datadog to un-minify your errors.
 
 ## Setup
 
-You need to have `DATADOG_API_KEY` in your environment.
+You need to have `DD_API_KEY` in your environment.
 
 ```bash
 # Environment setup
-export DATADOG_API_KEY="<API KEY>"
+export DD_API_KEY="<API KEY>"
 ```
 
-It is possible to configure the tool to use Datadog EU by defining the `DATADOG_SITE` environment variable to `datadoghq.eu`. By default the requests are sent to Datadog US.
+It is possible to configure the tool to use Datadog EU by defining the `DD_SITE` environment variable to `datadoghq.eu`. By default the requests are sent to Datadog US.
 
 It is also possible to override the full URL for the intake endpoint by defining the `DATADOG_SOURCEMAP_INTAKE_URL` environment variable.
 
@@ -93,7 +93,7 @@ The only repository URLs supported are the ones whose host contains: `github`, `
 To verify this command works as expected, you can trigger a test run and verify it returns 0:
 
 ```bash
-export DATADOG_API_KEY='<API key>'
+export DD_API_KEY='<API key>'
 export DATADOG_APP_KEY='<application key>'
 
 TEMP_DIR=$(mktemp -d)

--- a/src/commands/sourcemaps/__tests__/upload.test.ts
+++ b/src/commands/sourcemaps/__tests__/upload.test.ts
@@ -97,7 +97,7 @@ describe('upload', () => {
       const command = createCommand(UploadCommand)
 
       expect(command['getRequestBuilder'].bind(command)).toThrow(
-        `Missing ${chalk.bold('DATADOG_API_KEY')} in your environment.`
+        `Missing ${chalk.bold('DD_API_KEY')} in your environment.`
       )
     })
   })

--- a/src/commands/sourcemaps/__tests__/upload.test.ts
+++ b/src/commands/sourcemaps/__tests__/upload.test.ts
@@ -97,7 +97,7 @@ describe('upload', () => {
       const command = createCommand(UploadCommand)
 
       expect(command['getRequestBuilder'].bind(command)).toThrow(
-        `Missing ${chalk.bold('DD_API_KEY')} in your environment.`
+        `Missing ${chalk.bold('DATADOG_API_KEY')} or ${chalk.bold('DD_API_KEY')} in your environment.`
       )
     })
   })

--- a/src/commands/sourcemaps/upload.ts
+++ b/src/commands/sourcemaps/upload.ts
@@ -75,8 +75,8 @@ export class UploadCommand extends Command {
   private fipsIgnoreError = Option.Boolean('--fips-ignore-error', false)
 
   private config = {
-    apiKey: process.env.DATADOG_API_KEY,
-    datadogSite: process.env.DATADOG_SITE || 'datadoghq.com',
+    apiKey: process.env.DATADOG_API_KEY || process.env.DD_API_KEY,
+    datadogSite: process.env.DATADOG_SITE || process.env.DD_SITE || 'datadoghq.com',
     fips: toBoolean(process.env[FIPS_ENV_VAR]) ?? false,
     fipsIgnoreError: toBoolean(process.env[FIPS_IGNORE_ERROR_ENV_VAR]) ?? false,
   }
@@ -245,7 +245,7 @@ export class UploadCommand extends Command {
 
   private getRequestBuilder(): RequestBuilder {
     if (!this.config.apiKey) {
-      throw new InvalidConfigurationError(`Missing ${chalk.bold('DATADOG_API_KEY')} in your environment.`)
+      throw new InvalidConfigurationError(`Missing ${chalk.bold('DD_API_KEY')} in your environment.`)
     }
 
     return getRequestBuilder({

--- a/src/commands/sourcemaps/upload.ts
+++ b/src/commands/sourcemaps/upload.ts
@@ -122,7 +122,7 @@ export class UploadCommand extends Command {
       )
     )
     const metricsLogger = getMetricsLogger({
-      datadogSite: process.env.DATADOG_SITE,
+      datadogSite: process.env.DATADOG_SITE || process.env.DD_SITE,
       defaultTags: [`version:${this.releaseVersion}`, `service:${this.service}`, `cli_version:${this.cliVersion}`],
       prefix: 'datadog.ci.sourcemaps.',
     })
@@ -245,7 +245,7 @@ export class UploadCommand extends Command {
 
   private getRequestBuilder(): RequestBuilder {
     if (!this.config.apiKey) {
-      throw new InvalidConfigurationError(`Missing ${chalk.bold('DD_API_KEY')} in your environment.`)
+      throw new InvalidConfigurationError(`Missing ${chalk.bold('DATADOG_API_KEY')} or ${chalk.bold('DD_API_KEY')} in your environment.`)
     }
 
     return getRequestBuilder({

--- a/src/commands/sourcemaps/upload.ts
+++ b/src/commands/sourcemaps/upload.ts
@@ -245,7 +245,9 @@ export class UploadCommand extends Command {
 
   private getRequestBuilder(): RequestBuilder {
     if (!this.config.apiKey) {
-      throw new InvalidConfigurationError(`Missing ${chalk.bold('DATADOG_API_KEY')} or ${chalk.bold('DD_API_KEY')} in your environment.`)
+      throw new InvalidConfigurationError(
+        `Missing ${chalk.bold('DATADOG_API_KEY')} or ${chalk.bold('DD_API_KEY')} in your environment.`
+      )
     }
 
     return getRequestBuilder({

--- a/src/commands/synthetics/README.md
+++ b/src/commands/synthetics/README.md
@@ -45,8 +45,8 @@ To setup the client, your Datadog API and application keys need to be configured
 2. Defined as environment variables:
 
     ```bash
-    export DATADOG_API_KEY="<API_KEY>"
-    export DATADOG_APP_KEY="<APPLICATION_KEY>"
+    export DD_API_KEY="<API_KEY>"
+    export DD_APP_KEY="<APPLICATION_KEY>"
     ```
 
 3. Passed to the CLI when running your tests:
@@ -65,7 +65,7 @@ Example:
 
 ```jsonc
 {
-  "apiKey": "<DATADOG_API_KEY>",
+  "apiKey": "<DD_API_KEY>",
   "appKey": "<DATADOG_APPLICATION_KEY>",
   "batchTimeout": 1800000,
   "datadogSite": "datadoghq.com",
@@ -265,7 +265,7 @@ Your Datadog API key. This key is [created in your Datadog organization][15] and
 **Configuration options**
 
 * Global Config: `"apiKey": "<API_KEY>"`
-* ENV variable: `DATADOG_API_KEY="<API_KEY>"`
+* ENV variable: `DD_API_KEY="<API_KEY>"`
 * CLI param: `--apiKey "<API_KEY>"`
 
 #### `appKey` (Required)
@@ -275,7 +275,7 @@ Your Datadog application key. This key is [created in your Datadog organization]
 **Configuration options**
 
 * Global Config: `"appKey": "<APPLICATION_KEY>"`
-* ENV variable: `DATADOG_APP_KEY="<APPLICATION_KEY>"`
+* ENV variable: `DD_APP_KEY="<APPLICATION_KEY>"`
 * CLI param: `--appKey "<APPLICATION_KEY>"`
 
 #### `batchTimeout`
@@ -849,7 +849,7 @@ Your Datadog API key. This key is [created in your Datadog organization][15] and
 **Configuration options**
 
 * Global Config: `"apiKey": "<API_KEY>"`
-* ENV variable: `DATADOG_API_KEY="<API_KEY>"`
+* ENV variable: `DD_API_KEY="<API_KEY>"`
 * CLI param: `--apiKey "<API_KEY>"`
 
 #### `appKey` (Required)
@@ -859,7 +859,7 @@ Your Datadog application key. This key is [created in your Datadog organization]
 **Configuration options**
 
 * Global Config: `"appKey": "<APPLICATION_KEY>"`
-* ENV variable: `DATADOG_APP_KEY="<APPLICATION_KEY>"`
+* ENV variable: `DD_APP_KEY="<APPLICATION_KEY>"`
 * CLI param: `--appKey "<APPLICATION_KEY>"`
 
 #### `configPath`
@@ -953,7 +953,7 @@ You can also pass these options in a configuration file:
 
 ```json
 {
-  "apiKey": "<DATADOG_API_KEY>",
+  "apiKey": "<DD_API_KEY>",
   "appKey": "<DATADOG_APPLICATION_KEY>",
   "mobileApplicationVersionFilePath": "example_path/example_app.apk",
   "mobileApplicationId": "example-abc",
@@ -983,8 +983,8 @@ This allows you to run tests with end-to-end encryption at every stage of your s
 To verify the Synthetics command works as expected, trigger a test run and verify it returns 0:
 
 ```bash
-export DATADOG_API_KEY='<API_KEY>'
-export DATADOG_APP_KEY='<APPLICATION_KEY>'
+export DD_API_KEY='<API_KEY>'
+export DD_APP_KEY='<APPLICATION_KEY>'
 
 yarn datadog-ci synthetics run-tests --public-id abc-def-ghi
 ```

--- a/src/commands/synthetics/README.md
+++ b/src/commands/synthetics/README.md
@@ -65,8 +65,8 @@ Example:
 
 ```jsonc
 {
-  "apiKey": "<DD_API_KEY>",
-  "appKey": "<DATADOG_APPLICATION_KEY>",
+  "apiKey": "<API_KEY>",
+  "appKey": "<APPLICATION_KEY>",
   "batchTimeout": 1800000,
   "datadogSite": "datadoghq.com",
   "defaultTestOverrides": {
@@ -953,8 +953,8 @@ You can also pass these options in a configuration file:
 
 ```json
 {
-  "apiKey": "<DD_API_KEY>",
-  "appKey": "<DATADOG_APPLICATION_KEY>",
+  "apiKey": "<API_KEY>",
+  "appKey": "<APPLICATION_KEY>",
   "mobileApplicationVersionFilePath": "example_path/example_app.apk",
   "mobileApplicationId": "example-abc",
   "versionName": "example",

--- a/src/commands/synthetics/__tests__/utils/__snapshots__/public.test.ts.snap
+++ b/src/commands/synthetics/__tests__/utils/__snapshots__/public.test.ts.snap
@@ -44,7 +44,7 @@ exports[`utils reportCiError should report MISSING_API_KEY error 1`] = `
 [MockFunction] {
   "calls": [
     [
-      "Missing [31m[1mDATADOG_API_KEY[22m[39m in your environment.
+      "Missing [31m[1mDATADOG_API_KEY[22m[39m or [31m[1mDD_API_KEY[22m[39m in your environment.
 ",
     ],
   ],
@@ -61,7 +61,7 @@ exports[`utils reportCiError should report MISSING_APP_KEY error 1`] = `
 [MockFunction] {
   "calls": [
     [
-      "Missing [31m[1mDATADOG_APP_KEY[22m[39m in your environment.
+      "Missing [31m[1mDATADOG_APP_KEY[22m[39m or [31m[1mDD_APP_KEY[22m[39m in your environment.
 ",
     ],
   ],

--- a/src/commands/synthetics/base-command.ts
+++ b/src/commands/synthetics/base-command.ts
@@ -105,10 +105,10 @@ export abstract class BaseCommand extends Command {
   /** This method can be overloaded by the child class. Use `super.resolveConfigFromEnv()` to add more config. */
   protected resolveConfigFromEnv(): RecursivePartial<DatadogCIConfig> {
     return {
-      apiKey: process.env.DATADOG_API_KEY,
-      appKey: process.env.DATADOG_APP_KEY,
+      apiKey: process.env.DATADOG_API_KEY || process.env.DD_API_KEY,
+      appKey: process.env.DATADOG_APP_KEY || process.env.DD_APP_KEY,
       configPath: process.env.DATADOG_SYNTHETICS_CONFIG_PATH, // Only used for debugging
-      datadogSite: process.env.DATADOG_SITE,
+      datadogSite: process.env.DATADOG_SITE || process.env.DD_SITE,
     }
   }
 

--- a/src/commands/synthetics/examples/global-config-complete-example.json
+++ b/src/commands/synthetics/examples/global-config-complete-example.json
@@ -1,6 +1,6 @@
 {
-  "apiKey": "<DD_API_KEY>",
-  "appKey": "<DD_APPLICATION_KEY>",
+  "apiKey": "<API_KEY>",
+  "appKey": "<APPLICATION_KEY>",
   "batchTimeout": 1800000,
   "datadogSite": "datadoghq.com",
   "defaultTestOverrides": {

--- a/src/commands/synthetics/examples/global-config-complete-example.json
+++ b/src/commands/synthetics/examples/global-config-complete-example.json
@@ -1,6 +1,6 @@
 {
-  "apiKey": "<DATADOG_API_KEY>",
-  "appKey": "<DATADOG_APPLICATION_KEY>",
+  "apiKey": "<DD_API_KEY>",
+  "appKey": "<DD_APPLICATION_KEY>",
   "batchTimeout": 1800000,
   "datadogSite": "datadoghq.com",
   "defaultTestOverrides": {

--- a/src/commands/synthetics/utils/public.ts
+++ b/src/commands/synthetics/utils/public.ts
@@ -547,10 +547,10 @@ export const reportCiError = (error: CiError, reporter: MainReporter) => {
       reporter.error(`\n${chalk.bgRed.bold(' ERROR: invalid config ')}\n${error.message}\n\n`)
       break
     case 'MISSING_APP_KEY':
-      reporter.error(`Missing ${chalk.red.bold('DATADOG_APP_KEY')} in your environment.\n`)
+      reporter.error(`Missing ${chalk.red.bold('DATADOG_APP_KEY')} or ${chalk.red.bold('DD_APP_KEY')} in your environment.\n`)
       break
     case 'MISSING_API_KEY':
-      reporter.error(`Missing ${chalk.red.bold('DATADOG_API_KEY')} in your environment.\n`)
+      reporter.error(`Missing ${chalk.red.bold('DATADOG_API_KEY')} or ${chalk.red.bold('DD_API_KEY')} in your environment.\n`)
       break
     case 'POLL_RESULTS_FAILED':
       reporter.error(`\n${chalk.bgRed.bold(' ERROR: unable to poll test results ')}\n${error.message}\n\n`)

--- a/src/commands/synthetics/utils/public.ts
+++ b/src/commands/synthetics/utils/public.ts
@@ -547,10 +547,14 @@ export const reportCiError = (error: CiError, reporter: MainReporter) => {
       reporter.error(`\n${chalk.bgRed.bold(' ERROR: invalid config ')}\n${error.message}\n\n`)
       break
     case 'MISSING_APP_KEY':
-      reporter.error(`Missing ${chalk.red.bold('DATADOG_APP_KEY')} or ${chalk.red.bold('DD_APP_KEY')} in your environment.\n`)
+      reporter.error(
+        `Missing ${chalk.red.bold('DATADOG_APP_KEY')} or ${chalk.red.bold('DD_APP_KEY')} in your environment.\n`
+      )
       break
     case 'MISSING_API_KEY':
-      reporter.error(`Missing ${chalk.red.bold('DATADOG_API_KEY')} or ${chalk.red.bold('DD_API_KEY')} in your environment.\n`)
+      reporter.error(
+        `Missing ${chalk.red.bold('DATADOG_API_KEY')} or ${chalk.red.bold('DD_API_KEY')} in your environment.\n`
+      )
       break
     case 'POLL_RESULTS_FAILED':
       reporter.error(`\n${chalk.bgRed.bold(' ERROR: unable to poll test results ')}\n${error.message}\n\n`)

--- a/src/commands/unity-symbols/README.md
+++ b/src/commands/unity-symbols/README.md
@@ -4,21 +4,21 @@ To deobfuscate and symbolicate errors and crashes, upload IL2CPP mappings and iO
 
 ## Setup
 
-You need to have `DATADOG_API_KEY` in your environment.
+You need to have `DD_API_KEY` in your environment.
 
 ```bash
 # Environment setup
-export DATADOG_API_KEY="<API KEY>"
+export DD_API_KEY="<API KEY>"
 ```
 
-You can configure the tool to use Datadog EU by defining the `DATADOG_SITE` environment variable as `datadoghq.eu`. By default, the requests are sent to Datadog US.
+You can configure the tool to use Datadog EU by defining the `DD_SITE` environment variable as `datadoghq.eu`. By default, the requests are sent to Datadog US.
 
 To make these variables available, Datadog recommends setting them in an encrypted `datadog-ci.json` file at the root of your project:
 
 ```json
 {
-  "apiKey": "<DATADOG_API_KEY>",
-  "datadogSite": "<DATADOG_SITE>"
+  "apiKey": "<DD_API_KEY>",
+  "datadogSite": "<DD_SITE>"
 }
 ```
 

--- a/src/commands/unity-symbols/README.md
+++ b/src/commands/unity-symbols/README.md
@@ -17,8 +17,8 @@ To make these variables available, Datadog recommends setting them in an encrypt
 
 ```json
 {
-  "apiKey": "<DD_API_KEY>",
-  "datadogSite": "<DD_SITE>"
+  "apiKey": "<API_KEY>",
+  "datadogSite": "<SITE>"
 }
 ```
 

--- a/src/commands/unity-symbols/upload.ts
+++ b/src/commands/unity-symbols/upload.ts
@@ -102,14 +102,18 @@ export class UploadCommand extends Command {
     this.config = await resolveConfigFromFileAndEnvironment(
       this.config,
       {
-        apiKey: process.env.DATADOG_API_KEY,
+        apiKey: process.env.DATADOG_API_KEY || process.env.DD_API_KEY,
         datadogSite: process.env.DATADOG_SITE,
       },
       {
         configPath: this.configPath,
         defaultConfigPaths: DEFAULT_CONFIG_PATHS,
         configFromFileCallback: (configFromFile: any) => {
-          checkAPIKeyOverride(process.env.DATADOG_API_KEY, configFromFile.apiKey, this.context.stdout)
+          checkAPIKeyOverride(
+            process.env.DATADOG_API_KEY || process.env.DD_API_KEY,
+            configFromFile.apiKey,
+            this.context.stdout,
+          )
         },
       }
     )

--- a/src/commands/unity-symbols/upload.ts
+++ b/src/commands/unity-symbols/upload.ts
@@ -112,7 +112,7 @@ export class UploadCommand extends Command {
           checkAPIKeyOverride(
             process.env.DATADOG_API_KEY || process.env.DD_API_KEY,
             configFromFile.apiKey,
-            this.context.stdout,
+            this.context.stdout
           )
         },
       }

--- a/src/commands/unity-symbols/upload.ts
+++ b/src/commands/unity-symbols/upload.ts
@@ -103,7 +103,7 @@ export class UploadCommand extends Command {
       this.config,
       {
         apiKey: process.env.DATADOG_API_KEY || process.env.DD_API_KEY,
-        datadogSite: process.env.DATADOG_SITE,
+        datadogSite: process.env.DATADOG_SITE || process.env.DD_SITE,
       },
       {
         configPath: this.configPath,

--- a/src/helpers/apikey.ts
+++ b/src/helpers/apikey.ts
@@ -51,7 +51,9 @@ class ApiKeyValidatorImplem {
         this.metricsLogger.increment('invalid_auth', 1)
       }
       throw new InvalidConfigurationError(
-        `Neither ${chalk.red.bold('DATADOG_API_KEY')} nor ${chalk.red.bold('DD_API_KEY')} contains a valid API key for Datadog site ${this.datadogSite}`
+        `Neither ${chalk.red.bold('DATADOG_API_KEY')} nor ${chalk.red.bold(
+          'DD_API_KEY'
+        )} contains a valid API key for Datadog site ${this.datadogSite}`
       )
     }
   }

--- a/src/helpers/apikey.ts
+++ b/src/helpers/apikey.ts
@@ -51,7 +51,7 @@ class ApiKeyValidatorImplem {
         this.metricsLogger.increment('invalid_auth', 1)
       }
       throw new InvalidConfigurationError(
-        `${chalk.red.bold('DATADOG_API_KEY')} does not contain a valid API key for Datadog site ${this.datadogSite}`
+        `Neither ${chalk.red.bold('DATADOG_API_KEY')} nor ${chalk.red.bold('DD_API_KEY')} contains a valid API key for Datadog site ${this.datadogSite}`
       )
     }
   }


### PR DESCRIPTION
### What and why?

According to https://github.com/DataDog/datadog-ci/issues/823 and https://github.com/DataDog/datadog-ci/pull/944, users are recommended to use the env vars with the prefix `DD_*`, but some commands don't support them.

### How?

I add them as a fallback and update the documents.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
