### PR TITLE
[CHORE] add pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,3 +15,9 @@ repos:
         language: system
         types: [ts]
         entry: yarn format
+      - id: license-check
+        name: Check 3rd Party Licenses
+        language: system
+        types_or: [json, csv]
+        always_run: true
+        entry: yarn check-licenses

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,17 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v3.2.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-added-large-files
+  - repo: local
+    hooks:
+      - id: format
+        name: format
+        language: system
+        types: [ts]
+        entry: yarn format


### PR DESCRIPTION
### What and why?

I kept forgetting to run `yarn format` and as such, CI would fail. I'd like to remedy this before commits.

### How?

This PR adds an optional pre commit config to run yarn format (as well as some nice others) on commit.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
