### PR TITLE
[SVLS-7097] add unified tags as resource tags

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -9,6 +9,7 @@ Component,Origin,Licence,Copyright
 @aws-sdk/credential-provider-ini,import,Apache-2.0,"Copyright 2018-2024 Amazon.com, Inc. or its affiliates."
 @azure/identity,import,MIT,Copyright (c) Microsoft Corporation
 @azure/arm-appservice,import,MIT,Copyright (c) Microsoft Corporation
+@azure/arm-resources,import,MIT,Copyright (c) Microsoft Corporation
 @babel/core,dev,MIT,Copyright (c) 2014-present Sebastian McKenzie and other contributors
 @babel/preset-env,dev,MIT,Copyright (c) 2014-present Sebastian McKenzie and other contributors
 @babel/preset-typescript,dev,MIT,Copyright (c) 2014-present Sebastian McKenzie and other contributors

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "@aws-sdk/credential-provider-ini": "^3.709.0",
     "@aws-sdk/credential-providers": "^3.709.0",
     "@azure/arm-appservice": "^16.0.0",
+    "@azure/arm-resources": "^6.1.0",
     "@azure/identity": "^4.10.0",
     "@google-cloud/logging": "^11.1.0",
     "@google-cloud/run": "^2.1.0",

--- a/src/commands/aas/__tests__/common.ts
+++ b/src/commands/aas/__tests__/common.ts
@@ -14,9 +14,11 @@ export const DEFAULT_CONFIG: AasConfigOptions = {
   shouldNotRestart: false,
 }
 
+export const WEB_APP_ID =
+  '/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/my-resource-group/providers/Microsoft.Web/sites/my-web-app'
+
 export const CONTAINER_WEB_APP: Site = {
-  id:
-    '/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/my-resource-group/providers/Microsoft.Web/sites/my-web-app',
+  id: WEB_APP_ID,
   name: 'my-web-app',
   kind: 'app,linux',
   location: 'East US',

--- a/src/commands/aas/instrument.ts
+++ b/src/commands/aas/instrument.ts
@@ -1,4 +1,5 @@
 import {StringDictionary, WebSiteManagementClient} from '@azure/arm-appservice'
+import {ResourceManagementClient, TagsOperations} from '@azure/arm-resources'
 import {DefaultAzureCredential} from '@azure/identity'
 import chalk from 'chalk'
 import {Command, Option} from 'clipanion'
@@ -20,7 +21,6 @@ import {
   SIDECAR_PORT,
 } from './common'
 import {AasConfigOptions} from './interfaces'
-import {ResourceManagementClient, TagsOperations} from '@azure/arm-resources'
 
 export class InstrumentCommand extends AasCommand {
   public static paths = [['aas', 'instrument']]

--- a/yarn.lock
+++ b/yarn.lock
@@ -758,6 +758,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@azure/arm-resources@npm:^6.1.0":
+  version: 6.1.0
+  resolution: "@azure/arm-resources@npm:6.1.0"
+  dependencies:
+    "@azure/abort-controller": ^2.1.2
+    "@azure/core-auth": ^1.9.0
+    "@azure/core-client": ^1.9.2
+    "@azure/core-lro": ^2.5.4
+    "@azure/core-paging": ^1.6.2
+    "@azure/core-rest-pipeline": ^1.19.0
+    tslib: ^2.8.1
+  checksum: 7799f0c28afab03a299d562b764748b752b3c8f678c0ab314c9381e5eef38f5e5cf2cb891cbdf9fa9db792deab140d1af5fe1dc5a3e75a4a6e478f8384561ba2
+  languageName: node
+  linkType: hard
+
 "@azure/core-auth@npm:^1.4.0, @azure/core-auth@npm:^1.8.0, @azure/core-auth@npm:^1.9.0":
   version: 1.9.0
   resolution: "@azure/core-auth@npm:1.9.0"
@@ -2035,6 +2050,7 @@ __metadata:
     "@aws-sdk/credential-providers": ^3.709.0
     "@aws-sdk/types": ^3.709.0
     "@azure/arm-appservice": ^16.0.0
+    "@azure/arm-resources": ^6.1.0
     "@azure/identity": ^4.10.0
     "@babel/core": 7.8.0
     "@babel/preset-env": 7.4.5


### PR DESCRIPTION
### What and why?

Adds automatic tagging support to the AAS for full  [Unified Service Tagging](https://docs.datadoghq.com/getting_started/tagging/unified_service_tagging/) support, via the Azure Integration.

### How?

Uses the resource management client to add in the additional tags, since this cannot be done with the web apps client

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
