### PR TITLE
[Cloud Run Instrument] FIPs, source code integration, and customizable sidecar,shared-volume,logs-path

### DIFF
--- a/src/commands/cloud-run/__tests__/__snapshots__/instrument.test.ts.snap
+++ b/src/commands/cloud-run/__tests__/__snapshots__/instrument.test.ts.snap
@@ -59,10 +59,6 @@ exports[`InstrumentCommand snapshot tests interactive mode 1`] = `
 +             "value": "datadoghq.com"
 +           },
 +           {
-+             "name": "DD_SERVERLESS_LOG_PATH",
-+             "value": "/shared-volume/logs/*.log"
-+           },
-+           {
 +             "name": "DD_LOGS_INJECTION",
 +             "value": "true"
 +           },
@@ -81,6 +77,10 @@ exports[`InstrumentCommand snapshot tests interactive mode 1`] = `
 +           {
 +             "name": "DD_SERVICE",
 +             "value": "interactive-service"
++           },
++           {
++             "name": "DD_SERVERLESS_LOG_PATH",
++             "value": "/shared-volume/logs/*.log"
 +           }
 +         ],
 +         "image": "gcr.io/datadoghq/serverless-init:latest",
@@ -183,10 +183,6 @@ exports[`InstrumentCommand snapshot tests prints dry run data with basic flags 1
 +             "value": "datadoghq.com"
 +           },
 +           {
-+             "name": "DD_SERVERLESS_LOG_PATH",
-+             "value": "/shared-volume/logs/*.log"
-+           },
-+           {
 +             "name": "DD_LOGS_INJECTION",
 +             "value": "true"
 +           },
@@ -217,6 +213,10 @@ exports[`InstrumentCommand snapshot tests prints dry run data with basic flags 1
 +           {
 +             "name": "DD_TAGS",
 +             "value": "team:backend,service:api"
++           },
++           {
++             "name": "DD_SERVERLESS_LOG_PATH",
++             "value": "/shared-volume/logs/*.log"
 +           }
 +         ],
 +         "image": "gcr.io/datadoghq/serverless-init:latest",

--- a/src/commands/cloud-run/__tests__/__snapshots__/instrument.test.ts.snap
+++ b/src/commands/cloud-run/__tests__/__snapshots__/instrument.test.ts.snap
@@ -79,6 +79,10 @@ exports[`InstrumentCommand snapshot tests interactive mode 1`] = `
 +             "value": "interactive-service"
 +           },
 +           {
++             "name": "DD_TAGS",
++             "value": "git.commit.sha:1be168ff837f043bde17c0314341c84271047b31,git.repository_url:git.repository_url:github.com/datadog/test.git"
++           },
++           {
 +             "name": "DD_SERVERLESS_LOG_PATH",
 +             "value": "/shared-volume/logs/*.log"
 +           }
@@ -212,7 +216,7 @@ exports[`InstrumentCommand snapshot tests prints dry run data with basic flags 1
 +           },
 +           {
 +             "name": "DD_TAGS",
-+             "value": "team:backend,service:api"
++             "value": "team:backend,service:api,git.commit.sha:1be168ff837f043bde17c0314341c84271047b31,git.repository_url:git.repository_url:github.com/datadog/test.git"
 +           },
 +           {
 +             "name": "DD_SERVERLESS_LOG_PATH",

--- a/src/commands/cloud-run/__tests__/instrument.test.ts
+++ b/src/commands/cloud-run/__tests__/instrument.test.ts
@@ -291,6 +291,8 @@ describe('InstrumentCommand', () => {
       ;(command as any).sharedVolumeName = 'custom-volume'
       ;(command as any).sharedVolumePath = '/custom/path'
       ;(command as any).logsPath = '/custom/path/logs/*.log'
+      ;(command as any).sidecarCpus = '2'
+      ;(command as any).sidecarMemory = '256Mi'
 
       const service = {
         template: {
@@ -311,6 +313,8 @@ describe('InstrumentCommand', () => {
       expect(sidecarContainer?.env?.find((e: IEnvVar) => e.name === 'DD_SERVERLESS_LOG_PATH')?.value).toBe(
         '/custom/path/logs/*.log'
       )
+      expect(sidecarContainer?.resources?.limits?.cpu).toBe('2')
+      expect(sidecarContainer?.resources?.limits?.memory).toBe('256Mi')
 
       // Check main container has custom volume mount
       const mainContainer = result.template?.containers?.find((c: IContainer) => c.name === 'main')

--- a/src/commands/cloud-run/__tests__/instrument.test.ts
+++ b/src/commands/cloud-run/__tests__/instrument.test.ts
@@ -210,6 +210,11 @@ describe('InstrumentCommand', () => {
     beforeEach(() => {
       command = new InstrumentCommand()
       ;(command as any).tracing = undefined
+      ;(command as any).sidecarImage = 'gcr.io/datadoghq/serverless-init:latest'
+      ;(command as any).sidecarName = 'datadog-sidecar'
+      ;(command as any).sharedVolumeName = 'shared-volume'
+      ;(command as any).sharedVolumePath = '/shared-volume'
+      ;(command as any).logsPath = '/shared-volume/logs/*.log'
     })
 
     test('adds sidecar and shared volume when missing', () => {
@@ -267,6 +272,42 @@ describe('InstrumentCommand', () => {
       expect(result.template?.volumes).toHaveLength(1)
       expect(result.template?.volumes?.[0].name).toBe('shared-volume')
     })
+
+    test('uses custom configuration values', () => {
+      ;(command as any).sidecarImage = 'custom-image:v1.0'
+      ;(command as any).sidecarName = 'custom-sidecar'
+      ;(command as any).sharedVolumeName = 'custom-volume'
+      ;(command as any).sharedVolumePath = '/custom/path'
+      ;(command as any).logsPath = '/custom/path/logs/*.log'
+
+      const service = {
+        template: {
+          containers: [{name: 'main', env: [], volumeMounts: []}],
+          volumes: [],
+        },
+      }
+
+      const result = command.createInstrumentedServiceConfig(service, 'test-service')
+
+      // Check sidecar container has custom values
+      const sidecarContainer = result.template?.containers?.find((c: IContainer) => c.name === 'custom-sidecar')
+      expect(sidecarContainer).toBeDefined()
+      expect(sidecarContainer?.image).toBe('custom-image:v1.0')
+      expect(sidecarContainer?.name).toBe('custom-sidecar')
+      expect(sidecarContainer?.volumeMounts?.[0]?.name).toBe('custom-volume')
+      expect(sidecarContainer?.volumeMounts?.[0]?.mountPath).toBe('/custom/path')
+      expect(sidecarContainer?.env?.find((e: IEnvVar) => e.name === 'DD_SERVERLESS_LOG_PATH')?.value).toBe(
+        '/custom/path/logs/*.log'
+      )
+
+      // Check main container has custom volume mount
+      const mainContainer = result.template?.containers?.find((c: IContainer) => c.name === 'main')
+      expect(mainContainer?.volumeMounts?.[0]?.name).toBe('custom-volume')
+      expect(mainContainer?.volumeMounts?.[0]?.mountPath).toBe('/custom/path')
+
+      // Check custom volume is created
+      expect(result.template?.volumes?.[0]?.name).toBe('custom-volume')
+    })
   })
 
   describe('buildSidecarContainer', () => {
@@ -275,6 +316,11 @@ describe('InstrumentCommand', () => {
     beforeEach(() => {
       command = new InstrumentCommand()
       ;(command as any).tracing = undefined
+      ;(command as any).sidecarImage = 'gcr.io/datadoghq/serverless-init:latest'
+      ;(command as any).sidecarName = 'datadog-sidecar'
+      ;(command as any).sharedVolumeName = 'shared-volume'
+      ;(command as any).sharedVolumePath = '/shared-volume'
+      ;(command as any).logsPath = '/shared-volume/logs/*.log'
     })
 
     test('custom flags set correct env vars', () => {
@@ -290,7 +336,7 @@ describe('InstrumentCommand', () => {
         {name: ENVIRONMENT_ENV_VAR, value: 'dev'},
         {name: VERSION_ENV_VAR, value: 'v123.456'},
         {name: SITE_ENV_VAR, value: 'datadoghq.com'},
-        {name: LOGS_PATH_ENV_VAR, value: '/shared-volume/logs/*.log'},
+        {name: LOGS_PATH_ENV_VAR, value: (command as any).logsPath as string},
         {name: API_KEY_ENV_VAR, value: process.env.DD_API_KEY ?? ''},
         {name: HEALTH_PORT_ENV_VAR, value: '5555'},
         {name: LOGS_INJECTION_ENV_VAR, value: 'true'},
@@ -323,7 +369,7 @@ describe('InstrumentCommand', () => {
       const newSidecarContainer = command.buildSidecarContainer(existingSidecarContainer, 'new-service')
       const expected: IEnvVar[] = [
         {name: SITE_ENV_VAR, value: DATADOG_SITE_EU1},
-        {name: LOGS_PATH_ENV_VAR, value: 'some-log-path'},
+        {name: LOGS_PATH_ENV_VAR, value: '/shared-volume/logs/*.log'},
         {name: LOGS_INJECTION_ENV_VAR, value: 'false'},
         {name: DD_TRACE_ENABLED_ENV_VAR, value: 'false'},
         {name: HEALTH_PORT_ENV_VAR, value: '12345'},

--- a/src/commands/cloud-run/instrument.ts
+++ b/src/commands/cloud-run/instrument.ts
@@ -85,16 +85,16 @@ export class InstrumentCommand extends Command {
     description: `The image to use for the sidecar container. Defaults to '${DEFAULT_SIDECAR_IMAGE}'`,
   })
   private sidecarName = Option.String('--sidecar-name', DEFAULT_SIDECAR_NAME, {
-    description: `The name to use for the sidecar container. Defaults to '${DEFAULT_SIDECAR_NAME}'`,
+    description: `(Not recommended) The name to use for the sidecar container. Defaults to '${DEFAULT_SIDECAR_NAME}'`,
   })
   private sharedVolumeName = Option.String('--shared-volume-name', DEFAULT_VOLUME_NAME, {
-    description: `The name to use for the shared volume. Defaults to '${DEFAULT_VOLUME_NAME}'`,
+    description: `(Not recommended) The name to use for the shared volume. Defaults to '${DEFAULT_VOLUME_NAME}'`,
   })
   private sharedVolumePath = Option.String('--shared-volume-path', DEFAULT_VOLUME_PATH, {
-    description: `The path to use for the shared volume. Defaults to '${DEFAULT_VOLUME_PATH}'`,
+    description: `(Not recommended) The path to use for the shared volume. Defaults to '${DEFAULT_VOLUME_PATH}'`,
   })
   private logsPath = Option.String('--logs-path', DEFAULT_LOGS_PATH, {
-    description: `The path to use for the logs. Defaults to '${DEFAULT_LOGS_PATH}'. Must begin with the shared volume path.`,
+    description: `(Not recommended) The path to use for the logs. Defaults to '${DEFAULT_LOGS_PATH}'. Must begin with the shared volume path.`,
   })
   private sidecarCpus = Option.String('--sidecar-cpus', '1', {
     description: `The number of CPUs to allocate to the sidecar container. Defaults to 1.`,

--- a/src/commands/cloud-run/instrument.ts
+++ b/src/commands/cloud-run/instrument.ts
@@ -96,6 +96,12 @@ export class InstrumentCommand extends Command {
   private logsPath = Option.String('--logs-path', DEFAULT_LOGS_PATH, {
     description: `The path to use for the logs. Defaults to '${DEFAULT_LOGS_PATH}'. Must begin with the shared volume path.`,
   })
+  private sidecarCpus = Option.String('--sidecar-cpus', '1', {
+    description: `The number of CPUs to allocate to the sidecar container. Defaults to 1.`,
+  })
+  private sidecarMemory = Option.String('--sidecar-memory', '512Mi', {
+    description: `The number of CPUs to allocate to the sidecar container. Defaults to '512Mi'.`,
+  })
   private fips = Option.Boolean('--fips', false)
   private fipsIgnoreError = Option.Boolean('--fips-ignore-error', false)
 
@@ -429,8 +435,8 @@ export class InstrumentCommand extends Command {
       },
       resources: {
         limits: {
-          memory: '512Mi',
-          cpu: '1',
+          memory: this.sidecarMemory,
+          cpu: this.sidecarCpus,
         },
       },
     }

--- a/src/commands/cloud-run/instrument.ts
+++ b/src/commands/cloud-run/instrument.ts
@@ -37,14 +37,15 @@ const {ServicesClient} = require('@google-cloud/run')
 // equivalent to google.cloud.run.v2.EmptyDirVolumeSource.Medium.MEMORY
 const EMPTY_DIR_VOLUME_SOURCE_MEMORY = 1
 
-const SIDECAR_NAME = 'datadog-sidecar'
-const VOLUME_NAME = 'shared-volume'
-const VOLUME_MOUNT_PATH = '/shared-volume'
+const DEFAULT_SIDECAR_NAME = 'datadog-sidecar'
+const DEFAULT_VOLUME_NAME = 'shared-volume'
+const DEFAULT_VOLUME_PATH = '/shared-volume'
+const DEFAULT_LOGS_PATH = '/shared-volume/logs/*.log'
 const DEFAULT_HEALTH_CHECK_PORT = 5555
+const DEFAULT_SIDECAR_IMAGE = 'gcr.io/datadoghq/serverless-init:latest'
 
 const DEFAULT_ENV_VARS: IEnvVar[] = [
   {name: SITE_ENV_VAR, value: DATADOG_SITE_US1},
-  {name: LOGS_PATH_ENV_VAR, value: `${VOLUME_MOUNT_PATH}/logs/*.log`}, // TODO make configurable
   {name: LOGS_INJECTION_ENV_VAR, value: 'true'},
   {name: DD_TRACE_ENABLED_ENV_VAR, value: 'true'},
   {name: HEALTH_PORT_ENV_VAR, value: DEFAULT_HEALTH_CHECK_PORT.toString()},
@@ -75,6 +76,21 @@ export class InstrumentCommand extends Command {
   private version = Option.String('--version')
   private llmobs = Option.String('--llmobs')
   private healthCheckPort = Option.String('--port,--health-check-port,--healthCheckPort')
+  private sidecarImage = Option.String('--image,--sidecar-image', DEFAULT_SIDECAR_IMAGE, {
+    description: `The image to use for the sidecar container. Defaults to '${DEFAULT_SIDECAR_IMAGE}'`,
+  })
+  private sidecarName = Option.String('--sidecar-name', DEFAULT_SIDECAR_NAME, {
+    description: `The name to use for the sidecar container. Defaults to '${DEFAULT_SIDECAR_NAME}'`,
+  })
+  private sharedVolumeName = Option.String('--shared-volume-name', DEFAULT_VOLUME_NAME, {
+    description: `The name to use for the shared volume. Defaults to '${DEFAULT_VOLUME_NAME}'`,
+  })
+  private sharedVolumePath = Option.String('--shared-volume-path', DEFAULT_VOLUME_PATH, {
+    description: `The path to use for the shared volume. Defaults to '${DEFAULT_VOLUME_PATH}'`,
+  })
+  private logsPath = Option.String('--logs-path', DEFAULT_LOGS_PATH, {
+    description: `The path to use for the logs. Defaults to '${DEFAULT_LOGS_PATH}'. Must begin with the shared volume path.`,
+  })
 
   public async execute(): Promise<0 | 1> {
     // TODO FIPS
@@ -265,12 +281,12 @@ export class InstrumentCommand extends Command {
     const containers: IContainer[] = template.containers || []
     const volumes: IVolume[] = template.volumes || []
 
-    const existingSidecarContainer = containers.find((c) => c.name === SIDECAR_NAME)
+    const existingSidecarContainer = containers.find((c) => c.name === this.sidecarName)
     const newSidecarContainer = this.buildSidecarContainer(existingSidecarContainer, ddService)
 
     // Update all app containers to add volume mounts and env vars if they don't have them
     const updatedContainers = containers.map((container) => {
-      if (container.name === SIDECAR_NAME) {
+      if (container.name === this.sidecarName) {
         return newSidecarContainer
       }
 
@@ -283,13 +299,13 @@ export class InstrumentCommand extends Command {
     }
 
     // Add shared volume if it doesn't exist
-    const hasSharedVolume = volumes.some((volume) => volume.name === VOLUME_NAME)
+    const hasSharedVolume = volumes.some((volume) => volume.name === this.sharedVolumeName)
     const updatedVolumes = hasSharedVolume
       ? volumes
       : [
           ...volumes,
           {
-            name: VOLUME_NAME,
+            name: this.sharedVolumeName,
             emptyDir: {
               medium: EMPTY_DIR_VOLUME_SOURCE_MEMORY,
             },
@@ -344,6 +360,7 @@ export class InstrumentCommand extends Command {
     if (this.extraTags) {
       newEnvVars[DD_TAGS_ENV_VAR] = this.extraTags
     }
+    newEnvVars[LOGS_PATH_ENV_VAR] = this.logsPath
 
     // If port is specified, overwrite any existing value
     // If port is not specified but already exists, leave the existing value unchanged
@@ -361,12 +378,12 @@ export class InstrumentCommand extends Command {
 
     // Create sidecar container with volume mount and environment variables
     return {
-      name: SIDECAR_NAME,
-      image: 'gcr.io/datadoghq/serverless-init:latest', // TODO make configurable
+      name: this.sidecarName,
+      image: this.sidecarImage,
       volumeMounts: [
         {
-          name: VOLUME_NAME,
-          mountPath: VOLUME_MOUNT_PATH,
+          name: this.sharedVolumeName,
+          mountPath: this.sharedVolumePath,
         },
       ],
       env: newEnv,
@@ -391,7 +408,9 @@ export class InstrumentCommand extends Command {
   // Add volume mount and update required env vars
   private updateAppContainer(appContainer: IContainer, ddService: string) {
     const existingVolumeMounts = appContainer.volumeMounts || []
-    const hasSharedVolumeMount = existingVolumeMounts.some((mount: IVolumeMount) => mount.name === VOLUME_NAME)
+    const hasSharedVolumeMount = existingVolumeMounts.some(
+      (mount: IVolumeMount) => mount.name === this.sharedVolumeName
+    )
     const existingEnvVars = appContainer.env || []
 
     const updatedContainer = {...appContainer}
@@ -399,8 +418,8 @@ export class InstrumentCommand extends Command {
       updatedContainer.volumeMounts = [
         ...existingVolumeMounts,
         {
-          name: VOLUME_NAME,
-          mountPath: VOLUME_MOUNT_PATH,
+          name: this.sharedVolumeName,
+          mountPath: this.sharedVolumePath,
         },
       ]
     }

--- a/src/commands/cloud-run/instrument.ts
+++ b/src/commands/cloud-run/instrument.ts
@@ -21,8 +21,12 @@ import {
   DD_TRACE_ENABLED_ENV_VAR,
   VERSION_ENV_VAR,
   CI_SITE_ENV_VAR,
+  FIPS_ENV_VAR,
+  FIPS_IGNORE_ERROR_ENV_VAR,
 } from '../../constants'
 import {newApiKeyValidator} from '../../helpers/apikey'
+import {toBoolean} from '../../helpers/env'
+import {enableFips} from '../../helpers/fips'
 import {renderError, renderSoftWarning} from '../../helpers/renderer'
 import {maskString} from '../../helpers/utils'
 import {isValidDatadogSite} from '../../helpers/validation'
@@ -91,9 +95,16 @@ export class InstrumentCommand extends Command {
   private logsPath = Option.String('--logs-path', DEFAULT_LOGS_PATH, {
     description: `The path to use for the logs. Defaults to '${DEFAULT_LOGS_PATH}'. Must begin with the shared volume path.`,
   })
+  private fips = Option.Boolean('--fips', false)
+  private fipsIgnoreError = Option.Boolean('--fips-ignore-error', false)
+
+  private fipsConfig = {
+    fips: toBoolean(process.env[FIPS_ENV_VAR]) ?? false,
+    fipsIgnoreError: toBoolean(process.env[FIPS_IGNORE_ERROR_ENV_VAR]) ?? false,
+  }
 
   public async execute(): Promise<0 | 1> {
-    // TODO FIPS
+    enableFips(this.fips || this.fipsConfig.fips, this.fipsIgnoreError || this.fipsConfig.fipsIgnoreError)
 
     this.context.stdout.write(
       `\n${dryRunPrefix(this.dryRun)}🐶 ${chalk.bold('Instrumenting Cloud Run service(s)')}\n\n`

--- a/src/commands/lambda/__tests__/instrument.test.ts
+++ b/src/commands/lambda/__tests__/instrument.test.ts
@@ -24,6 +24,7 @@ import {
   VERSION_ENV_VAR,
 } from '../../../constants'
 import {createCommand, makeRunCLI, MOCK_DATADOG_API_KEY} from '../../../helpers/__tests__/testing-tools'
+import * as instrumentHelpers from '../../../helpers/git/instrument-helpers'
 import {requestConfirmation} from '../../../helpers/prompt'
 
 import {
@@ -257,7 +258,7 @@ describe('lambda', () => {
         })
         process.env.DATADOG_API_KEY = MOCK_DATADOG_API_KEY
         const instrumentCommand = InstrumentCommand
-        const mockGitStatus = jest.spyOn(instrumentCommand.prototype as any, 'getCurrentGitStatus')
+        const mockGitStatus = jest.spyOn(instrumentHelpers as any, 'getCurrentGitStatus')
         mockGitStatus.mockImplementation(() => ({
           ahead: 0,
           isClean: false,
@@ -295,14 +296,15 @@ describe('lambda', () => {
         })
         process.env.DATADOG_API_KEY = MOCK_DATADOG_API_KEY
         const instrumentCommand = InstrumentCommand
-        const mockGitStatus = jest.spyOn(instrumentCommand.prototype as any, 'getCurrentGitStatus')
-        mockGitStatus.mockImplementation(() => ({
+        const mockGitStatus = jest.spyOn(instrumentHelpers, 'getCurrentGitStatus')
+        mockGitStatus.mockImplementation(async () => ({
           ahead: 0,
           hash: '1be168ff837f043bde17c0314341c84271047b31',
           remote: 'git.repository_url:git@github.com:datadog/test.git',
           isClean: true,
+          files: [],
         }))
-        const mockUploadFunction = jest.spyOn(instrumentCommand.prototype as any, 'uploadGitData')
+        const mockUploadFunction = jest.spyOn(instrumentHelpers as any, 'uploadGitData')
         mockUploadFunction.mockImplementation(() => {
           return
         })
@@ -340,15 +342,16 @@ describe('lambda', () => {
         })
         process.env.DATADOG_API_KEY = MOCK_DATADOG_API_KEY
         const instrumentCommand = InstrumentCommand
-        const mockGitStatus = jest.spyOn(instrumentCommand.prototype as any, 'getCurrentGitStatus')
+        const mockGitStatus = jest.spyOn(instrumentHelpers as any, 'getCurrentGitStatus')
         mockGitStatus.mockImplementation(() => ({
           ahead: 0,
           hash: '1be168ff837f043bde17c0314341c84271047b31',
           remote: 'git.repository_url:git@github.com:datadog/test.git',
           isClean: true,
+          files: [],
         }))
-        const mockUploadFunction = jest.spyOn(instrumentCommand.prototype as any, 'uploadGitData')
-        mockUploadFunction.mockImplementation(() => {
+        const mockUploadFunction = jest.spyOn(instrumentHelpers as any, 'uploadGitData')
+        mockUploadFunction.mockImplementation(async () => {
           return
         })
 
@@ -385,10 +388,13 @@ describe('lambda', () => {
         })
         process.env.DATADOG_API_KEY = MOCK_DATADOG_API_KEY
         const instrumentCommand = InstrumentCommand
-        const mockGitStatus = jest.spyOn(instrumentCommand.prototype as any, 'getCurrentGitStatus')
+        const mockGitStatus = jest.spyOn(instrumentHelpers as any, 'getCurrentGitStatus')
         mockGitStatus.mockImplementation(() => ({
           ahead: 1,
           isClean: true,
+          files: [],
+          hash: '',
+          remote: '',
         }))
 
         const cli = new Cli()

--- a/src/helpers/git/instrument-helpers.ts
+++ b/src/helpers/git/instrument-helpers.ts
@@ -1,0 +1,55 @@
+import {BaseContext, Cli} from 'clipanion'
+
+import {getCommitInfo, newSimpleGit} from '../../commands/git-metadata/git'
+import {UploadCommand} from '../../commands/git-metadata/upload'
+
+import {filterAndFormatGithubRemote} from '../utils'
+
+export const getGitData = async () => {
+  let currentStatus
+
+  try {
+    currentStatus = await getCurrentGitStatus()
+  } catch (err) {
+    throw Error("Couldn't get local git status")
+  }
+
+  if (!currentStatus.isClean) {
+    throw Error('Local git repository is dirty')
+  }
+
+  if (currentStatus.ahead > 0) {
+    throw Error('Local changes have not been pushed remotely. Aborting git data tagging.')
+  }
+
+  const gitRemote = filterAndFormatGithubRemote(currentStatus.remote)
+
+  return {commitSha: currentStatus.hash, gitRemote}
+}
+
+export const getCurrentGitStatus = async () => {
+  const simpleGit = await newSimpleGit()
+  const gitCommitInfo = await getCommitInfo(simpleGit)
+  if (gitCommitInfo === undefined) {
+    throw new Error('Git commit info is not defined')
+  }
+  const status = await simpleGit.status()
+
+  return {
+    isClean: status.isClean(),
+    ahead: status.ahead,
+    files: status.files,
+    hash: gitCommitInfo?.hash,
+    remote: gitCommitInfo?.remote,
+  }
+}
+
+export const uploadGitData = async (context: BaseContext) => {
+  const cli = new Cli()
+  cli.register(UploadCommand)
+  if ((await cli.run(['git-metadata', 'upload'], context)) !== 0) {
+    throw Error("Couldn't upload git metadata")
+  }
+
+  return
+}


### PR DESCRIPTION
### What and why?
- Allow user to optionally customize sidecar image, sidecar name, log volume name, log volume path, and logs file path
- Implement `--fips` flag
- Implement source code integration in Cloud Run tags
- Implement `--sidecar-cpus` and `--sidecar-memory` flags to let users customize their sidecar allocation

This is the last PR required before we can release and document the `datadog-ci cloud-run instrument` command

If they pass invalid values for cpu/memory, the cloud-run API has a nice error message, so we don't need to validate anything:
<img width="600" alt="Screenshot 2025-07-07 at 3 04 01 PM" src="https://github.com/user-attachments/assets/00fbb550-65e1-4d1c-8eb2-60e6105deb5b" />

There are cases where customizing the sidecar name, log volume name, log volume path, and logs file path might be useful. However, it's only recommended for users that know what they're doing. 

For example, if the user instruments their app with `--sidecar-name custom-name` and instruments it again without the `--sidecar-name` flag, they'll end up adding 2 sidecar containers. So we're marking them as "Not recommended"

### How?

Source code integration required some refactoring from `lambda/instrument.ts` to /helpers/git/instrument-helpers.ts`

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
