### PR TITLE
[SVLS-7098] aas instrument support arbitrary env vars

### DIFF
--- a/src/commands/aas/__tests__/instrument.test.ts
+++ b/src/commands/aas/__tests__/instrument.test.ts
@@ -529,7 +529,7 @@ Restarting Azure App Service my-web-app
       expect(webAppsOperations.restart).toHaveBeenCalled()
     })
 
-    test('Overrides existing environment variables with additional', async () => {
+    test('Overrides default env vars with additional env vars', async () => {
       const {code} = await runCLI([
         ...DEFAULT_ARGS,
         '--env-vars',

--- a/src/commands/aas/common.ts
+++ b/src/commands/aas/common.ts
@@ -28,7 +28,7 @@ const CORECLR_PROFILER = '{846F5F1C-F9AE-4B07-969E-05C26BC060D8}'
 // The profiler binary that the .NET CLR loads into memory, which contains the GUID
 const CORECLR_PROFILER_PATH = '/home/site/wwwroot/datadog/linux-musl-x64/Datadog.Trace.ClrProfiler.Native.so'
 
-const ENV_VAR_REGEX = /^(\w+)=(.*)$/
+const ENV_VAR_REGEX = /^([\w.]+)=(.*)$/
 
 export const AAS_DD_SETTING_NAMES = [
   'DD_API_KEY',

--- a/src/commands/aas/common.ts
+++ b/src/commands/aas/common.ts
@@ -202,11 +202,11 @@ export const parseEnvVars = (envVars: string[] | undefined): Record<string, stri
 
 export const getEnvVars = (config: AasConfigOptions): Record<string, string> => {
   let envVars: Record<string, string> = {
-    ...parseEnvVars(config.envVars),
     DD_API_KEY: process.env.DD_API_KEY!,
     DD_SITE: process.env.DD_SITE ?? DATADOG_SITE_US1,
     DD_AAS_INSTANCE_LOGGING_ENABLED: (config.isInstanceLoggingEnabled ?? false).toString(),
     DD_PROFILING_ENABLED: (config.isProfilingEnabled ?? true).toString(),
+    ...parseEnvVars(config.envVars),
   }
   if (config.service) {
     envVars.DD_SERVICE = config.service

--- a/src/commands/aas/instrument.ts
+++ b/src/commands/aas/instrument.ts
@@ -49,7 +49,10 @@ export class InstrumentCommand extends AasCommand {
   private logPath = Option.String('--log-path', {
     description: 'Where you write your logs. For example, /home/LogFiles/*.log or /home/LogFiles/myapp/*.log',
   })
-
+  private envVars = Option.Array('--env-vars', {
+    description:
+      'Additional environment variables to set for the App Service. Can specify multiple in the form `--env-vars VAR1=VALUE1 --env-vars VAR2=VALUE2`.',
+  })
   private shouldNotRestart = Option.Boolean('--no-restart', false, {
     description: 'Do not restart the App Service after applying instrumentation.',
   })
@@ -67,6 +70,7 @@ export class InstrumentCommand extends AasCommand {
       isInstanceLoggingEnabled: this.isInstanceLoggingEnabled,
       isProfilingEnabled: this.isProfilingEnabled,
       logPath: this.logPath,
+      envVars: this.envVars,
       shouldNotRestart: this.shouldNotRestart,
       isDotnet: this.isDotnet,
     }

--- a/src/commands/aas/interfaces.ts
+++ b/src/commands/aas/interfaces.ts
@@ -16,6 +16,7 @@ export interface AasConfigOptions {
   isInstanceLoggingEnabled?: boolean
   isProfilingEnabled?: boolean
   logPath?: string
+  envVars?: string[]
   isDotnet?: boolean
   // no-dd-sa:typescript-best-practices/boolean-prop-naming
   shouldNotRestart?: boolean

--- a/static-analysis.datadog.yml
+++ b/static-analysis.datadog.yml
@@ -1,3 +1,4 @@
+schema-version: v1
 rulesets:
   - typescript-best-practices
   - typescript-code-style

--- a/static-analysis.datadog.yml
+++ b/static-analysis.datadog.yml
@@ -1,4 +1,3 @@
-schema-version: v1
 rulesets:
   - typescript-best-practices
   - typescript-code-style


### PR DESCRIPTION
### What and why?

Add arbitrary environment variable support, since there are many options that folks may want to use.

### How?

Adds an additional param which takes in a list of `key=value` strings to add to the main container and sidecar.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
