### PR TITLE
[SYNTH-20802] Fix JUnit reporter not being initialized

### DIFF
--- a/src/commands/synthetics/__tests__/base-command.test.ts
+++ b/src/commands/synthetics/__tests__/base-command.test.ts
@@ -39,10 +39,11 @@ describe('base-command', () => {
 
     // Same as above (bootstrapped reporter)
     expect(write).toHaveBeenCalledTimes(2)
-    expect(write).toHaveBeenCalledWith('Resolving config...')
-    expect(write).toHaveBeenCalledWith('Executing...')
+    expect(write).toHaveBeenNthCalledWith(1, 'Resolving config...')
+    expect(write).toHaveBeenNthCalledWith(2, 'Executing...')
 
     // Mock reporter is also called
-    expect(mockReporter.log).toHaveBeenCalledWith('Executing...')
+    expect(mockReporter.log).toHaveBeenCalledTimes(1)
+    expect(mockReporter.log).toHaveBeenNthCalledWith(1, 'Executing...')
   })
 })

--- a/src/commands/synthetics/__tests__/base-command.test.ts
+++ b/src/commands/synthetics/__tests__/base-command.test.ts
@@ -1,0 +1,48 @@
+import {createCommand} from '../../../helpers/__tests__/testing-tools'
+
+import {BaseCommand} from '../base-command'
+
+import {mockReporter} from './fixtures'
+
+class DummyCommand extends BaseCommand {
+  public async execute() {
+    await this.setup()
+
+    this.reporter.log('Executing...')
+  }
+
+  protected async resolveConfig() {
+    this.reporter.log('Resolving config...')
+  }
+}
+
+describe('base-command', () => {
+  test('reporter is first bootstrapped', async () => {
+    const write = jest.fn()
+    const command = createCommand(DummyCommand, {stdout: {write}})
+
+    await command.execute()
+
+    expect(write).toHaveBeenCalledTimes(2)
+    expect(write).toHaveBeenNthCalledWith(1, 'Resolving config...')
+    expect(write).toHaveBeenNthCalledWith(2, 'Executing...')
+  })
+
+  test('reporter is updated after config resolution', async () => {
+    const write = jest.fn()
+    const command = createCommand(DummyCommand, {stdout: {write}})
+
+    // e.g. mimic JUnit reporter being added after config resolution
+    command['getReporters'] = () => [mockReporter]
+
+    await command.execute()
+
+    // Same as above (bootstrapped reporter)
+    expect(write).toHaveBeenCalledTimes(2)
+    expect(write).toHaveBeenCalledWith('Resolving config...')
+    expect(write).toHaveBeenCalledWith('Executing...')
+
+    // Mock reporter is also called
+    expect(mockReporter.log).toHaveBeenCalledWith('Executing...')
+  })
+})


### PR DESCRIPTION
### What and why?

Closes https://github.com/DataDog/datadog-ci/issues/1712

This PR fixes the JUnit reporter not being initialized by the base command.

### How?

Fix order of calls in `this.setup()`, add unit tests, and add JSDoc + reorganize the file

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
