### PR TITLE
Fix coverage upload dir scan to handle symlinks

### DIFF
--- a/src/commands/coverage/__tests__/fixtures/random-file-symlink.xml
+++ b/src/commands/coverage/__tests__/fixtures/random-file-symlink.xml
@@ -1,0 +1,1 @@
+random-file.xml

--- a/src/commands/coverage/__tests__/upload.test.ts
+++ b/src/commands/coverage/__tests__/upload.test.ts
@@ -74,6 +74,23 @@ describe('upload', () => {
       expect(fileNames).toContain('src/commands/coverage/__tests__/fixtures/clover.xml')
     })
 
+    test('should read all coverage report files excluding ignored paths specified partially', () => {
+      const command = createCommand(UploadCodeCoverageReportCommand)
+      command['ignoredPaths'] = 'subfolder.xml'
+      command['basePaths'] = ['src/commands/coverage/__tests__/fixtures']
+
+      const result = command['getMatchingCoverageReportFilesByFormat']()
+      const fileNames = Object.values(result).flatMap((paths) => paths)
+
+      expect(fileNames.length).toEqual(6)
+      expect(fileNames).toContain('src/commands/coverage/__tests__/fixtures/other-Jacoco-report.xml')
+      expect(fileNames).toContain('src/commands/coverage/__tests__/fixtures/jacoco-report.xml')
+      expect(fileNames).toContain('src/commands/coverage/__tests__/fixtures/lcov.info')
+      expect(fileNames).toContain('src/commands/coverage/__tests__/fixtures/coverage.json')
+      expect(fileNames).toContain('src/commands/coverage/__tests__/fixtures/.resultset.json')
+      expect(fileNames).toContain('src/commands/coverage/__tests__/fixtures/clover.xml')
+    })
+
     test('should allow specifying files directly', () => {
       const command = createCommand(UploadCodeCoverageReportCommand)
       command['basePaths'] = [

--- a/src/commands/coverage/upload.ts
+++ b/src/commands/coverage/upload.ts
@@ -138,7 +138,7 @@ export class UploadCodeCoverageReportCommand extends Command {
       return 1
     }
 
-    this.context.stderr.write(`Ignored paths: ${parsePathsList(this.ignoredPaths)}\n')
+    this.context.stderr.write(`Ignored paths: ${parsePathsList(this.ignoredPaths)}\n`)
 
     if (this.format && !isCoverageFormat(this.format)) {
       this.context.stderr.write(

--- a/src/commands/coverage/upload.ts
+++ b/src/commands/coverage/upload.ts
@@ -138,6 +138,9 @@ export class UploadCodeCoverageReportCommand extends Command {
       return 1
     }
 
+    // eslint-disable-next-line @typescript-eslint/restrict-plus-operands
+    this.context.stderr.write('Ignored paths: ' + parsePathsList(this.ignoredPaths) + '\n')
+
     if (this.format && !isCoverageFormat(this.format)) {
       this.context.stderr.write(
         `Unsupported format: ${this.format}, supported values are [${coverageFormats.join(', ')}]\n`

--- a/src/commands/coverage/upload.ts
+++ b/src/commands/coverage/upload.ts
@@ -138,8 +138,7 @@ export class UploadCodeCoverageReportCommand extends Command {
       return 1
     }
 
-    // eslint-disable-next-line @typescript-eslint/restrict-plus-operands
-    this.context.stderr.write('Ignored paths: ' + parsePathsList(this.ignoredPaths) + '\n')
+    this.context.stderr.write(`Ignored paths: ${parsePathsList(this.ignoredPaths)}\n')
 
     if (this.format && !isCoverageFormat(this.format)) {
       this.context.stderr.write(

--- a/src/helpers/file-finder.ts
+++ b/src/helpers/file-finder.ts
@@ -83,7 +83,7 @@ const partitionFilesRecursive = (
   let stats: Stats
   try {
     stats = statSync(path)
-  } catch (e) {
+  } catch {
     return
   }
 

--- a/src/helpers/file-finder.ts
+++ b/src/helpers/file-finder.ts
@@ -1,9 +1,8 @@
 import * as fs from 'fs'
+import {Stats, statSync} from 'fs'
 
 import {globSync, hasMagic} from './glob'
 import {buildPath, isFile} from './utils'
-import { lstatSync } from "fs";
-import { Stats } from "node:fs";
 
 const DEFAULT_IGNORED_FOLDERS = [
   '.circleci',
@@ -83,7 +82,7 @@ const partitionFilesRecursive = (
 
   let stats: Stats
   try {
-    stats = lstatSync(path)
+    stats = statSync(path)
   } catch (e) {
     return
   }
@@ -103,12 +102,22 @@ const partitionFilesRecursive = (
     const entries = fs.readdirSync(path, {withFileTypes: true})
     for (const entry of entries) {
       const fullPath = buildPath(path, entry.name)
-      if (ignoredPaths.includes(fullPath) || DEFAULT_IGNORED_FOLDERS.includes(entry.name)) {
+      if (ignore(fullPath, ignoredPaths) || DEFAULT_IGNORED_FOLDERS.includes(entry.name)) {
         continue
       }
       partitionFilesRecursive(fullPath, ignoredPaths, partition, results, false)
     }
   }
+}
+
+const ignore = (path: string, ignoredPaths: string[]): boolean => {
+  for (const ignoredPath of ignoredPaths) {
+    if (path.includes(ignoredPath)) {
+      return true
+    }
+  }
+
+  return false
 }
 
 /**


### PR DESCRIPTION
### What and why?

Fixes the code that does directory scanning for code coverage reports upload.
The code mistakenly assumed that anything that is not `isFile()` is a directory, and this check failed for symlinks.

### How?

The fixed code uses `statSync` instead of `lstatSync` to follow symlinks. It also does not assume that anything that isn't a file is a directory, and does an explicit check as well.

There's a minor improvement to the `--ignored-paths` param handling as well: now it's possible to specify an ignored paths partially (no need to specify the full path relative to what the scan directory is).

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
