### PR TITLE
[Azure App Services Instrument] Implement source code integration

### DIFF
--- a/src/commands/aas/common.ts
+++ b/src/commands/aas/common.ts
@@ -44,6 +44,7 @@ export const AAS_DD_SETTING_NAMES = [
   'CORECLR_ENABLE_PROFILING',
   'CORECLR_PROFILER',
   'CORECLR_PROFILER_PATH',
+  'DD_TAGS',
 ] as const
 
 /**
@@ -219,6 +220,9 @@ export const getEnvVars = (config: AasConfigOptions): Record<string, string> => 
   }
   if (config.logPath) {
     envVars.DD_SERVERLESS_LOG_PATH = config.logPath
+  }
+  if (config.extraTags) {
+    envVars.DD_TAGS = config.extraTags
   }
   if (config.isDotnet) {
     envVars = {

--- a/src/commands/aas/interfaces.ts
+++ b/src/commands/aas/interfaces.ts
@@ -20,4 +20,7 @@ export interface AasConfigOptions {
   isDotnet?: boolean
   // no-dd-sa:typescript-best-practices/boolean-prop-naming
   shouldNotRestart?: boolean
+  sourceCodeIntegration?: boolean
+  uploadGitMetadata?: boolean
+  extraTags?: string
 }


### PR DESCRIPTION
### What and why?

Implements source code integration, which just adds some tags under `DD_TAGS` specifying the Git repo URL and the Git commit hash. These tags are then applied to each span.

_Env var added by the instrument command:_
<img width="400" alt="Screenshot 2025-07-09 at 4 35 06 PM" src="https://github.com/user-attachments/assets/043b88e3-1d97-4576-9bbc-a4da9804fbe0" />

_Instrument command in action:_
<img width="400" alt="Screenshot 2025-07-09 at 4 32 44 PM" src="https://github.com/user-attachments/assets/14d869c0-f14e-41b3-97ce-2b19117b9512" />


### How?

Use the existing `getGitData` and `uploadGitData` functions from `/src/heleprs/git/instrument-helpers`

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
