### PR TITLE
Fix base SHA calculation for GitHub actions

### DIFF
--- a/src/commands/coverage/upload.ts
+++ b/src/commands/coverage/upload.ts
@@ -289,12 +289,18 @@ export class UploadCodeCoverageReportCommand extends Command {
       return {}
     }
 
-    const baseSha = spanTags[GIT_PULL_REQUEST_BASE_BRANCH_SHA]
-    if (baseSha) {
-      return {headSha, baseSha}
-    }
     if (!this.git) {
       return {}
+    }
+
+    const baseSha = spanTags[GIT_PULL_REQUEST_BASE_BRANCH_SHA]
+    if (baseSha) {
+      // GitHub incorrectly reports base SHA as the head of the target branch
+      // doing a merge-base allows us to get the real base SHA
+      // (and if the base SHA was reported correctly, merge-base will not alter it)
+      const mergeBase = await getMergeBase(this.git, baseSha, headSha)
+
+      return {headSha, baseSha: mergeBase}
     }
 
     const baseBranch = spanTags[GIT_PULL_REQUEST_BASE_BRANCH]


### PR DESCRIPTION
### What and why?

Fixes calculation of pull-request base SHA in GitHub actions.

### How?

When running a GHA with a `pull_request` trigger, GitHub merges the head of the feature branch into the _head_ of the target branch, and runs the CI checks on the merge commit.
The `head_sha` attribute available in the pull-request event JSON is the head of the feature branch.
The `base_sha` attribute is the _head_ of the target branch (not the real base commit).

Thus, `base_sha` provided by GitHub is not suitable for our PR diff calculation, as it may include more commits than we need.
The solution is to look for a merge-base of the `head_sha` and the `base_sha` to find the real base commit.
In case `base_sha` was correct to begin with (e.g. for another CI provider), doing a merge-base will not alter it.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
