### PR TITLE
[SYNTH-19315] Add batch-smoke-tester to bump-ci-integrations list

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -256,6 +256,7 @@ jobs:
           - synthetics-test-automation-circleci-orb
           - synthetics-test-automation-bitrise-step-run-tests
           - synthetics-test-automation-bitrise-step-upload-application
+          - synthetics-batch-smoke-tester
     steps:
       - name: Create bump datadog-ci PR
         uses: actions/github-script@v7


### PR DESCRIPTION
### What and why?

We want to automatically create a PR in the `batch-smoke-tester` repo when there is a new release of `datadog-ci`.

### How?

- Add the repo to the `bump-ci-integrations` job list.

### Review checklist

~~- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)~~
