### PR TITLE
Remove redundant log from coverage upload command

### DIFF
--- a/src/commands/coverage/upload.ts
+++ b/src/commands/coverage/upload.ts
@@ -138,8 +138,6 @@ export class UploadCodeCoverageReportCommand extends Command {
       return 1
     }
 
-    this.context.stderr.write(`Ignored paths: ${parsePathsList(this.ignoredPaths)}\n`)
-
     if (this.format && !isCoverageFormat(this.format)) {
       this.context.stderr.write(
         `Unsupported format: ${this.format}, supported values are [${coverageFormats.join(', ')}]\n`


### PR DESCRIPTION
### What and why?

Removes redundant log message from `coverage upload` command.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
