### PR TITLE
[SVLS-7166] [AAS .NET] use glibc by default for the profiler path, with the option for musl

### DIFF
--- a/src/commands/aas/__tests__/common.test.ts
+++ b/src/commands/aas/__tests__/common.test.ts
@@ -157,7 +157,7 @@ describe('aas common', () => {
         DD_TRACE_LOG_DIRECTORY: '/home/LogFiles/dotnet',
         CORECLR_ENABLE_PROFILING: '1',
         CORECLR_PROFILER: '{846F5F1C-F9AE-4B07-969E-05C26BC060D8}',
-        CORECLR_PROFILER_PATH: '/home/site/wwwroot/datadog/linux-musl-x64/Datadog.Trace.ClrProfiler.Native.so',
+        CORECLR_PROFILER_PATH: '/home/site/wwwroot/datadog/linux-x64/Datadog.Trace.ClrProfiler.Native.so',
       })
     })
 
@@ -165,6 +165,30 @@ describe('aas common', () => {
       const config: AasConfigOptions = {
         ...DEFAULT_CONFIG,
         isDotnet: true,
+        service: 'svc',
+        environment: 'qa',
+        logPath: '/dotnet/logs',
+        isInstanceLoggingEnabled: true,
+      }
+      const envVars = getEnvVars(config)
+      expect(envVars).toMatchObject({
+        DD_SERVICE: 'svc',
+        DD_ENV: 'qa',
+        DD_SERVERLESS_LOG_PATH: '/dotnet/logs',
+        DD_AAS_INSTANCE_LOGGING_ENABLED: 'true',
+        DD_DOTNET_TRACER_HOME: '/home/site/wwwroot/datadog',
+        DD_TRACE_LOG_DIRECTORY: '/home/LogFiles/dotnet',
+        CORECLR_ENABLE_PROFILING: '1',
+        CORECLR_PROFILER: '{846F5F1C-F9AE-4B07-969E-05C26BC060D8}',
+        CORECLR_PROFILER_PATH: '/home/site/wwwroot/datadog/linux-x64/Datadog.Trace.ClrProfiler.Native.so',
+      })
+    })
+
+    test('.NET options sets musl path when specified', () => {
+      const config: AasConfigOptions = {
+        ...DEFAULT_CONFIG,
+        isDotnet: true,
+        isMusl: true,
         service: 'svc',
         environment: 'qa',
         logPath: '/dotnet/logs',

--- a/src/commands/aas/__tests__/instrument.test.ts
+++ b/src/commands/aas/__tests__/instrument.test.ts
@@ -639,6 +639,38 @@ Restarting Azure App Service my-web-app
           DD_AAS_INSTANCE_LOGGING_ENABLED: 'false',
           CORECLR_ENABLE_PROFILING: '1',
           CORECLR_PROFILER: '{846F5F1C-F9AE-4B07-969E-05C26BC060D8}',
+          CORECLR_PROFILER_PATH: '/home/site/wwwroot/datadog/linux-x64/Datadog.Trace.ClrProfiler.Native.so',
+          DD_DOTNET_TRACER_HOME: '/home/site/wwwroot/datadog',
+          DD_TRACE_LOG_DIRECTORY: '/home/LogFiles/dotnet',
+        },
+      })
+    })
+
+    test('adds musl .NET settings when the config options are specified', async () => {
+      await command.instrumentSidecar(client, {...DEFAULT_CONFIG, isDotnet: true, isMusl: true}, 'rg', 'app')
+
+      expect(webAppsOperations.createOrUpdateSiteContainer).toHaveBeenCalledWith('rg', 'app', 'datadog-sidecar', {
+        image: 'index.docker.io/datadog/serverless-init:latest',
+        targetPort: '8126',
+        isMain: false,
+        environmentVariables: expect.arrayContaining([
+          {name: 'DD_API_KEY', value: 'DD_API_KEY'},
+          {name: 'DD_SITE', value: 'DD_SITE'},
+          {name: 'DD_AAS_INSTANCE_LOGGING_ENABLED', value: 'DD_AAS_INSTANCE_LOGGING_ENABLED'},
+          {name: 'DD_DOTNET_TRACER_HOME', value: 'DD_DOTNET_TRACER_HOME'},
+          {name: 'DD_TRACE_LOG_DIRECTORY', value: 'DD_TRACE_LOG_DIRECTORY'},
+          {name: 'CORECLR_ENABLE_PROFILING', value: 'CORECLR_ENABLE_PROFILING'},
+          {name: 'CORECLR_PROFILER', value: 'CORECLR_PROFILER'},
+          {name: 'CORECLR_PROFILER_PATH', value: 'CORECLR_PROFILER_PATH'},
+        ]),
+      })
+      expect(webAppsOperations.updateApplicationSettings).toHaveBeenCalledWith('rg', 'app', {
+        properties: {
+          DD_API_KEY: process.env.DD_API_KEY,
+          DD_SITE: 'datadoghq.com',
+          DD_AAS_INSTANCE_LOGGING_ENABLED: 'false',
+          CORECLR_ENABLE_PROFILING: '1',
+          CORECLR_PROFILER: '{846F5F1C-F9AE-4B07-969E-05C26BC060D8}',
           CORECLR_PROFILER_PATH: '/home/site/wwwroot/datadog/linux-musl-x64/Datadog.Trace.ClrProfiler.Native.so',
           DD_DOTNET_TRACER_HOME: '/home/site/wwwroot/datadog',
           DD_TRACE_LOG_DIRECTORY: '/home/LogFiles/dotnet',

--- a/src/commands/aas/__tests__/instrument.test.ts
+++ b/src/commands/aas/__tests__/instrument.test.ts
@@ -567,6 +567,25 @@ Restarting Azure App Service my-web-app
       expect(code).toEqual(1)
       expect(context.stdout.toString()).toContain('[Error] Extra tags do not comply with the <key>:<value> array.\n')
     })
+
+    test('Ignores --musl flag and warns on non-containerized dotnet apps', async () => {
+      webAppsOperations.get.mockClear().mockResolvedValue({
+        ...CONTAINER_WEB_APP,
+        siteConfig: {
+          linuxFxVersion: 'DOTNETCORE|9.0',
+        },
+      })
+      const {code, context} = await runCLI([...DEFAULT_INSTRUMENT_ARGS, '--musl', '--dotnet'])
+      expect(code).toEqual(0)
+      expect(context.stdout.toString()).toEqual(`🐶 Beginning instrumentation of Azure App Service(s)
+[!] The --musl flag is set, but the App Service my-web-app is not a containerized app. \
+This flag is only applicable for containerized .NET apps (on musl-based distributions like Alpine Linux), and will be ignored.
+Creating sidecar container datadog-sidecar on my-web-app
+Updating Application Settings for my-web-app
+Restarting Azure App Service my-web-app
+🐶 Instrumentation completed successfully!
+`)
+    })
   })
 
   describe('instrumentSidecar', () => {

--- a/src/commands/aas/common.ts
+++ b/src/commands/aas/common.ts
@@ -25,8 +25,10 @@ const DD_TRACE_LOG_DIRECTORY = '/home/LogFiles/dotnet'
 const CORECLR_ENABLE_PROFILING = '1'
 // Profiler GUID
 const CORECLR_PROFILER = '{846F5F1C-F9AE-4B07-969E-05C26BC060D8}'
+
 // The profiler binary that the .NET CLR loads into memory, which contains the GUID
-const CORECLR_PROFILER_PATH = '/home/site/wwwroot/datadog/linux-musl-x64/Datadog.Trace.ClrProfiler.Native.so'
+const CORECLR_PROFILER_PATH = '/home/site/wwwroot/datadog/linux-x64/Datadog.Trace.ClrProfiler.Native.so'
+const CORECLR_PROFILER_PATH_MUSL = '/home/site/wwwroot/datadog/linux-musl-x64/Datadog.Trace.ClrProfiler.Native.so'
 
 const ENV_VAR_REGEX = /^([\w.]+)=(.*)$/
 
@@ -238,7 +240,7 @@ export const getEnvVars = (config: AasConfigOptions): Record<string, string> => 
       DD_TRACE_LOG_DIRECTORY,
       CORECLR_ENABLE_PROFILING,
       CORECLR_PROFILER,
-      CORECLR_PROFILER_PATH,
+      CORECLR_PROFILER_PATH: config.isMusl ? CORECLR_PROFILER_PATH_MUSL : CORECLR_PROFILER_PATH,
     }
   }
 
@@ -261,6 +263,9 @@ export const isDotnet = (site: Site): boolean => {
   )
 }
 
+export const isLinuxContainer = (site: Site): boolean => {
+  return !!site.siteConfig?.linuxFxVersion && site.siteConfig.linuxFxVersion.toLowerCase() === 'sitecontainers'
+}
 export const collectAsyncIterator = async <T>(it: PagedAsyncIterableIterator<T>): Promise<T[]> => {
   const arr = []
   for await (const x of it) {

--- a/src/commands/aas/common.ts
+++ b/src/commands/aas/common.ts
@@ -129,6 +129,12 @@ export abstract class AasCommand extends Command {
     if (config.extraTags && !config.extraTags.match(EXTRA_TAGS_REG_EXP)) {
       errors.push('Extra tags do not comply with the <key>:<value> array.')
     }
+    // Validate musl setting
+    if (config.isMusl && !config.isDotnet) {
+      errors.push(
+        '--musl can only be set if --dotnet is also set, as it is only relevant for containerized .NET applications.'
+      )
+    }
     const specifiedSiteArgs = [config.subscriptionId, config.resourceGroup, config.aasName]
     // all or none of the site args should be specified
     if (!(specifiedSiteArgs.every((arg) => arg) || specifiedSiteArgs.every((arg) => !arg))) {

--- a/src/commands/aas/instrument.ts
+++ b/src/commands/aas/instrument.ts
@@ -176,9 +176,18 @@ export class InstrumentCommand extends AasCommand {
         return false
       }
 
+      const isContainer = isLinuxContainer(site)
+      if (config.isMusl && !isContainer) {
+        this.context.stdout.write(
+          renderSoftWarning(
+            `The --musl flag is set, but the App Service ${chalk.bold(aasName)} is not a containerized app. \
+This flag is only applicable for containerized .NET apps (on musl-based distributions like Alpine Linux), and will be ignored.`
+          )
+        )
+      }
       await this.instrumentSidecar(
         aasClient,
-        {...config, isDotnet: config.isDotnet || isDotnet(site), isMusl: config.isMusl && isLinuxContainer(site)},
+        {...config, isDotnet: config.isDotnet || isDotnet(site), isMusl: config.isMusl && isContainer},
         resourceGroup,
         aasName
       )

--- a/src/commands/aas/instrument.ts
+++ b/src/commands/aas/instrument.ts
@@ -17,6 +17,7 @@ import {
   formatError,
   getEnvVars,
   isDotnet,
+  isLinuxContainer,
   SIDECAR_CONTAINER_NAME,
   SIDECAR_IMAGE,
   SIDECAR_PORT,
@@ -54,6 +55,10 @@ export class InstrumentCommand extends AasCommand {
     description:
       'Add in required .NET-specific configuration options, is automatically inferred for code runtimes. This should be specified if you are using a containerized .NET app.',
   })
+  private isMusl = Option.Boolean('--musl', false, {
+    description:
+      'Add in required .NET-specific configuration options for musl-based .NET apps. This should be specified if you are using a containerized .NET app on a musl-based distribution like Alpine Linux.',
+  })
 
   private sourceCodeIntegration = Option.Boolean('--source-code-integration,--sourceCodeIntegration', true, {
     description:
@@ -77,6 +82,7 @@ export class InstrumentCommand extends AasCommand {
       logPath: this.logPath,
       shouldNotRestart: this.shouldNotRestart,
       isDotnet: this.isDotnet,
+      isMusl: this.isMusl,
       sourceCodeIntegration: this.sourceCodeIntegration,
       uploadGitMetadata: this.uploadGitMetadata,
       extraTags: this.extraTags,
@@ -172,7 +178,7 @@ export class InstrumentCommand extends AasCommand {
 
       await this.instrumentSidecar(
         aasClient,
-        {...config, isDotnet: config.isDotnet || isDotnet(site)},
+        {...config, isDotnet: config.isDotnet || isDotnet(site), isMusl: config.isMusl && isLinuxContainer(site)},
         resourceGroup,
         aasName
       )

--- a/src/commands/aas/instrument.ts
+++ b/src/commands/aas/instrument.ts
@@ -187,7 +187,11 @@ This flag is only applicable for containerized .NET apps (on musl-based distribu
       }
       await this.instrumentSidecar(
         aasClient,
-        {...config, isDotnet: config.isDotnet || isDotnet(site), isMusl: config.isMusl && isContainer},
+        {
+          ...config,
+          isDotnet: config.isDotnet || isDotnet(site),
+          isMusl: config.isMusl && config.isDotnet && isContainer,
+        },
         resourceGroup,
         aasName
       )

--- a/src/commands/aas/interfaces.ts
+++ b/src/commands/aas/interfaces.ts
@@ -2,24 +2,27 @@
  * Configuration options provided by the user through
  * the CLI in order to instrument properly.
  */
-export interface AasConfigOptions {
+export type AasConfigOptions = Partial<{
   // AAS Targeting options
-  subscriptionId?: string
-  resourceGroup?: string
-  aasName?: string
-  resourceIds?: string[]
+  subscriptionId: string
+  resourceGroup: string
+  aasName: string
+  resourceIds: string[]
 
   // Configuration options
-  service?: string
-  environment?: string
-  version?: string
-  isInstanceLoggingEnabled?: boolean
-  logPath?: string
-  envVars?: string[]
-  isDotnet?: boolean
+  service: string
+  environment: string
+  version: string
+  isInstanceLoggingEnabled: boolean
+  logPath: string
+  envVars: string[]
+  isDotnet: boolean
+  isMusl: boolean
   // no-dd-sa:typescript-best-practices/boolean-prop-naming
-  shouldNotRestart?: boolean
-  sourceCodeIntegration?: boolean
-  uploadGitMetadata?: boolean
-  extraTags?: string
-}
+  shouldNotRestart: boolean
+  // no-dd-sa:typescript-best-practices/boolean-prop-naming
+  sourceCodeIntegration: boolean
+  // no-dd-sa:typescript-best-practices/boolean-prop-naming
+  uploadGitMetadata: boolean
+  extraTags: string
+}>


### PR DESCRIPTION
### What and why?

Previously, `musl` was the default backend for the profiler path, which should be glibc, since Azure is now using only ubuntu for dotnet code deployments. if customers are instrumenting a musl-based containerized web app running dotnet, they can now specify the `--musl` flag to specify, since we would have no way of knowing otherwise.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
