### PR TITLE
[synthetics] Downgrade some tunnel warn logs to debug

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -41,6 +41,7 @@ chalk,import,MIT,Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (https://s
 clipanion,import,MIT,Copyright (c) 2019 Mael Nison
 datadog-metrics,import,MIT,Copyright (c) 2014 Daniel Bader
 dd-trace,import,Apache-2.0,Copyright 2016-Present Datadog Inc.
+debug,import,MIT,Copyright (c) 2018-2021 Josh Junon
 deep-extend,import,MIT,"Copyright (c) 2013-2018, Viacheslav Lotsmanov"
 deep-object-diff,import,MIT,Copyright (c) 2016-present Matt Phillips
 fast-deep-equal,import,MIT,Copyright (c) 2017 Evgeny Poberezkin

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "chalk": "3.0.0",
     "clipanion": "^3.2.1",
     "datadog-metrics": "0.9.3",
+    "debug": "^4.3.4",
     "deep-extend": "0.6.0",
     "deep-object-diff": "^1.1.9",
     "fast-deep-equal": "^3.1.3",

--- a/src/commands/synthetics/README.md
+++ b/src/commands/synthetics/README.md
@@ -454,7 +454,7 @@ Use the [Continuous Testing tunnel](https://docs.datadoghq.com/continuous_testin
 
 For more information, see [Using Local and Staging Environments](#using-local-and-staging-environments).
 
-To troubleshoot tests failing due to the tunnel, you may enable debug logs with `DEBUG=synthetics:tunnel`.
+To troubleshoot tests failing due to the tunnel, you can enable debug logs with `DEBUG=synthetics:tunnel`.
 
 **Configuration options**
 

--- a/src/commands/synthetics/README.md
+++ b/src/commands/synthetics/README.md
@@ -454,6 +454,8 @@ Use the [Continuous Testing tunnel](https://docs.datadoghq.com/continuous_testin
 
 For more information, see [Using Local and Staging Environments](#using-local-and-staging-environments).
 
+To troubleshoot tests failing due to the tunnel, you may enable debug logs with `DEBUG=synthetics:tunnel`.
+
 **Configuration options**
 
 * Default: `false`

--- a/yarn.lock
+++ b/yarn.lock
@@ -2090,6 +2090,7 @@ __metadata:
     clipanion: ^3.2.1
     datadog-metrics: 0.9.3
     dd-trace: ^5.42.0
+    debug: ^4.3.4
     deep-extend: 0.6.0
     deep-object-diff: ^1.1.9
     eslint: ^8.57.1


### PR DESCRIPTION
### What and why?

Use the `debug` package to support `DEBUG=synthetics:tunnel datadog-ci ...`

### How?

Replace `this.reporter.warn` calls with `debug` calls for some non-actionable warn logs.

All those warn logs were being printed even for successful runs, so they aren't interesting. In case the user suspects something is going wrong because of the tunnel, they can enable debug logs with `DEBUG=synthetics:tunnel`

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
