### PR TITLE
[chores] Add `datadog-ci` label for repo-wide changes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -7,6 +7,9 @@ changelog:
     labels:
       - release # Exclude release PRs from changelog
   categories:
+    - title: datadog-ci
+      labels:
+        - datadog-ci # For PRs spanning multiple commands, and repo-wide changes
     - title: Dependencies
       labels:
         - dependencies # Generally about vulnerability fixes

--- a/.github/workflows/pr-required-labels.yml
+++ b/.github/workflows/pr-required-labels.yml
@@ -25,6 +25,7 @@ jobs:
           mode: minimum
           count: 1
           labels: |
+            datadog-ci
             dependencies
             documentation
             chores


### PR DESCRIPTION
### What and why?

Some PRs are spanning across multiple commands, which make them "repo-wide" (like https://github.com/DataDog/datadog-ci/pull/1723).

We want to put those PRs under a `## datadog-ci` section in the release notes (like [`v3.14.0`](https://github.com/DataDog/datadog-ci/releases/tag/v3.14.0).

### How?

Create a `datadog-ci` label and configure it in YML files.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
