### PR TITLE
Remove leading dots from uploaded coverage report filenames

### DIFF
--- a/src/commands/coverage/__tests__/api.test.ts
+++ b/src/commands/coverage/__tests__/api.test.ts
@@ -1,0 +1,67 @@
+import fs from 'fs'
+import {PassThrough} from 'stream'
+import zlib from 'zlib'
+
+import FormData from 'form-data'
+
+import {uploadCodeCoverageReport} from '../api'
+
+jest.mock('fs')
+jest.mock('zlib')
+
+jest.mock('form-data', () => {
+  return jest.fn().mockImplementation(() => ({
+    append: jest.fn(),
+    getHeaders: jest.fn().mockReturnValue({'content-type': 'multipart/form-data'}),
+  }))
+})
+
+describe('uploadCodeCoverageReport', () => {
+  it('removes leading dot from report filenames', async () => {
+    const requestMock = jest.fn().mockResolvedValue({status: 200})
+
+    const fsMock = jest.mocked(fs)
+    const zlibMock = jest.mocked(zlib)
+
+    const mockStream = new PassThrough()
+    fsMock.createReadStream.mockReturnValueOnce((mockStream as unknown) as fs.ReadStream)
+    zlibMock.createGzip.mockReturnValueOnce((mockStream as unknown) as zlib.Gzip)
+
+    const appendMock = jest.fn()
+    const getHeadersMock = jest.fn().mockReturnValue({'Content-Type': 'multipart/form-data'})
+    const formMock = {
+      append: appendMock,
+      getHeaders: getHeadersMock,
+    }
+
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore override constructor
+    FormData.mockImplementation(() => formMock)
+
+    const payload = {
+      hostname: 'test-host',
+      format: 'simplecov-internal',
+      spanTags: {},
+      customTags: {'custom.tag': 'value'},
+      customMeasures: {'custom.measure': 123},
+      prDiff: undefined,
+      commitDiff: undefined,
+      paths: ['/my/path/.resultset.json'],
+    }
+
+    const uploader = uploadCodeCoverageReport(requestMock)
+    await uploader(payload)
+
+    expect(appendMock).toHaveBeenCalledWith('event', expect.stringMatching(/coverage_report/), {filename: 'event.json'})
+    expect(appendMock).toHaveBeenCalledWith('code_coverage_report_file', mockStream, {filename: 'resultset.json.gz'})
+
+    expect(requestMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: 'POST',
+        url: 'api/v2/cicovreprt',
+        data: formMock,
+        headers: formMock.getHeaders(),
+      })
+    )
+  })
+})

--- a/src/commands/coverage/api.ts
+++ b/src/commands/coverage/api.ts
@@ -47,9 +47,8 @@ export const uploadCodeCoverageReport = (request: (args: AxiosRequestConfig) => 
   }
 
   await doWithMaxConcurrency(20, payload.paths, async (path) => {
-    const filename = path.split('/').pop() || path
     const gzip = fs.createReadStream(path).pipe(createGzip())
-    form.append(filename, gzip, {filename: `${filename}.gz`})
+    form.append('code_coverage_report_file', gzip, {filename: `${getReportFilename(path)}.gz`})
   })
 
   return request({
@@ -59,6 +58,13 @@ export const uploadCodeCoverageReport = (request: (args: AxiosRequestConfig) => 
     method: 'POST',
     url: 'api/v2/cicovreprt',
   })
+}
+
+const getReportFilename = (path: string) => {
+  const filename = path.split('/').pop() || path
+
+  // Remove leading dot if it exists, as the backend does not accept filenames starting with a dot
+  return filename.startsWith('.') ? filename.slice(1) : filename
 }
 
 export const apiConstructor = (baseIntakeUrl: string, apiKey: string) => {


### PR DESCRIPTION
### What and why?

Removes leading dot characters from filenames of uploaded code coverage reports.
The backend fails when a report filename in the uploaded form starts with a dot character.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
