### PR TITLE
[synthetics] Support results without `subtype` in default reporter

### DIFF
--- a/src/commands/synthetics/__tests__/reporters/__snapshots__/default.test.ts.snap
+++ b/src/commands/synthetics/__tests__/reporters/__snapshots__/default.test.ts.snap
@@ -4,11 +4,11 @@ exports[`Default reporter renderApiRequestDescription dns result 1`] = `"Query f
 
 exports[`Default reporter renderApiRequestDescription dns result 2`] = `"Query for example.org on server 1.2.3.4"`;
 
-exports[`Default reporter renderApiRequestDescription dns result 3`] = `"Query for example.org on server 1.2.3.4"`;
+exports[`Default reporter renderApiRequestDescription dns result 3`] = `"Query for example.org on server 1.2.3.4:42"`;
 
 exports[`Default reporter renderApiRequestDescription fallback 1`] = `"[1munknown-subtype[22m test"`;
 
-exports[`Default reporter renderApiRequestDescription host + port, any subtype 1`] = `"[1mundefined[22m test"`;
+exports[`Default reporter renderApiRequestDescription host + port, any subtype 1`] = `"Host: example.org:80"`;
 
 exports[`Default reporter renderApiRequestDescription invalid dns result 1`] = `"Invalid DNS result"`;
 
@@ -18,15 +18,15 @@ exports[`Default reporter renderApiRequestDescription invalid http result 2`] = 
 
 exports[`Default reporter renderApiRequestDescription invalid http result 3`] = `"Invalid HTTP result"`;
 
-exports[`Default reporter renderApiRequestDescription invalid multistep result 1`] = `"[1mmulti[22m test"`;
+exports[`Default reporter renderApiRequestDescription invalid multistep result 1`] = `"Invalid multistep result"`;
 
-exports[`Default reporter renderApiRequestDescription invalid ssl result 1`] = `"Invalid SSL/TCP result"`;
+exports[`Default reporter renderApiRequestDescription invalid ssl result 1`] = `"Invalid SSL result"`;
 
-exports[`Default reporter renderApiRequestDescription invalid ssl result 2`] = `"Invalid SSL/TCP result"`;
+exports[`Default reporter renderApiRequestDescription invalid ssl result 2`] = `"Invalid SSL result"`;
 
-exports[`Default reporter renderApiRequestDescription invalid ssl result 3`] = `"Invalid SSL/TCP result"`;
+exports[`Default reporter renderApiRequestDescription invalid ssl result 3`] = `"Invalid SSL result"`;
 
-exports[`Default reporter renderApiRequestDescription method + url, any subtype 1`] = `"[1mundefined[22m test"`;
+exports[`Default reporter renderApiRequestDescription method + url, any subtype 1`] = `"[1mGET[22m - https://example.org"`;
 
 exports[`Default reporter renderApiRequestDescription multistep result 1`] = `"Multistep test containing 3 HTTP test"`;
 

--- a/src/commands/synthetics/__tests__/reporters/__snapshots__/default.test.ts.snap
+++ b/src/commands/synthetics/__tests__/reporters/__snapshots__/default.test.ts.snap
@@ -1,5 +1,37 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Default reporter renderApiRequestDescription dns result 1`] = `"Query for example.org"`;
+
+exports[`Default reporter renderApiRequestDescription dns result 2`] = `"Query for example.org on server 1.2.3.4"`;
+
+exports[`Default reporter renderApiRequestDescription dns result 3`] = `"Query for example.org on server 1.2.3.4"`;
+
+exports[`Default reporter renderApiRequestDescription fallback 1`] = `"[1munknown-subtype[22m test"`;
+
+exports[`Default reporter renderApiRequestDescription host + port, any subtype 1`] = `"[1mundefined[22m test"`;
+
+exports[`Default reporter renderApiRequestDescription invalid dns result 1`] = `"Invalid DNS result"`;
+
+exports[`Default reporter renderApiRequestDescription invalid http result 1`] = `"Invalid HTTP result"`;
+
+exports[`Default reporter renderApiRequestDescription invalid http result 2`] = `"Invalid HTTP result"`;
+
+exports[`Default reporter renderApiRequestDescription invalid http result 3`] = `"Invalid HTTP result"`;
+
+exports[`Default reporter renderApiRequestDescription invalid multistep result 1`] = `"[1mmulti[22m test"`;
+
+exports[`Default reporter renderApiRequestDescription invalid ssl result 1`] = `"Invalid SSL/TCP result"`;
+
+exports[`Default reporter renderApiRequestDescription invalid ssl result 2`] = `"Invalid SSL/TCP result"`;
+
+exports[`Default reporter renderApiRequestDescription invalid ssl result 3`] = `"Invalid SSL/TCP result"`;
+
+exports[`Default reporter renderApiRequestDescription method + url, any subtype 1`] = `"[1mundefined[22m test"`;
+
+exports[`Default reporter renderApiRequestDescription multistep result 1`] = `"Multistep test containing 3 HTTP test"`;
+
+exports[`Default reporter renderApiRequestDescription multistep result 2`] = `"Multistep test containing 1 HTTP test, 1 SSL test, 1 DNS test"`;
+
 exports[`Default reporter resultEnd 1 API test, 1 location, 1 result: success 1`] = `
 "[1m[32m✓[39m[22m [[1m[2maaa-aaa-aaa[22m[22m] [1mTest name[22m - [1m[32mlocation: [1mFrankfurt (AWS)[22m[1m[39m[22m
   • Total duration: 1000 ms - View test run details:

--- a/src/commands/synthetics/interfaces.ts
+++ b/src/commands/synthetics/interfaces.ts
@@ -338,18 +338,21 @@ export interface TestStepWithUnsupportedFields {
   }
 }
 
+export interface TestRequest {
+  dnsServer?: string
+  dnsServerPort?: number
+  headers: {[key: string]: string}
+  host?: string
+  method: string
+  port?: number
+  timeout: number
+  url: string
+}
+
 export interface LocalTestDefinition {
   config: {
     assertions: Assertion[]
-    request?: {
-      dnsServer?: string
-      headers: {[key: string]: string}
-      host?: string
-      method: string
-      port?: number
-      timeout: number
-      url: string
-    }
+    request?: TestRequest
     steps?: {subtype: string}[] // For multistep API tests
     variables: string[]
   }

--- a/src/commands/synthetics/reporters/default.ts
+++ b/src/commands/synthetics/reporters/default.ts
@@ -21,6 +21,7 @@ import {
   Test,
   UserConfigOverride,
   ResultInBatch,
+  TestRequest,
 } from '../interfaces'
 import {isBaseResult, isTimedOutRetry, getPublicIdOrPlaceholder} from '../utils/internal'
 import {
@@ -128,7 +129,7 @@ const renderResultOutcome = (
     ].join('\n')
   }
 
-  if (test.type === 'api' && test.subtype) {
+  if (test.type === 'api') {
     const requestDescription = renderApiRequestDescription(test.subtype, test.config)
 
     if (result?.failure) {
@@ -164,9 +165,16 @@ const renderResultOutcome = (
   }
 }
 
-const renderApiRequestDescription = (subType: string, config: Test['config']): string => {
-  const {request, steps} = config
-
+export const renderApiRequestDescription = (
+  subType: string | undefined,
+  {
+    request,
+    steps,
+  }: {
+    request?: Partial<Omit<TestRequest, 'headers' | 'timeout'>>
+    steps?: Test['config']['steps']
+  }
+): string => {
   if (subType === 'dns') {
     if (!request?.host) {
       return 'Invalid DNS result'


### PR DESCRIPTION
### What and why?

This PR improves how the default reporter behaves with results without `subtype`.

### How?

Refactor

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
