### PR TITLE
v3.16.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci",
-  "version": "3.15.0",
+  "version": "3.16.0",
   "description": "Run datadog actions from the CI.",
   "repository": "https://github.com/DataDog/datadog-ci",
   "license": "Apache-2.0",


### PR DESCRIPTION
<!-- Release notes generated using configuration in .github/release.yml at v3.16.0 -->

## What's Changed
### Documentation
* [SVLS-7166][AAS] update readme by @ava-silver in https://github.com/DataDog/datadog-ci/pull/1754
### CI Visibility
* Remove redundant log from coverage upload command by @nikita-tkachenko-datadog in https://github.com/DataDog/datadog-ci/pull/1750
* Remove leading dots from uploaded coverage report filenames by @nikita-tkachenko-datadog in https://github.com/DataDog/datadog-ci/pull/1761
* Add 'deployment gate' command by @GabrielAnca in https://github.com/DataDog/datadog-ci/pull/1751
### Serverless
* [SVLS-7166][AAS] remove explicit profiling option by @ava-silver in https://github.com/DataDog/datadog-ci/pull/1752
* [SVLS-7166] [AAS .NET] use glibc by default for the profiler path, with the option for musl by @ava-silver in https://github.com/DataDog/datadog-ci/pull/1753
* [SVLS-6823] Support FIPS-compatible lambda functions by @alexgallotta in https://github.com/DataDog/datadog-ci/pull/1709
### Synthetics
* [SYNTH-3437] Generate JSON schema for `*.synthetics.json` files by @Drarig29 in https://github.com/DataDog/datadog-ci/pull/1736
* [synthetics] Downgrade some tunnel warn logs to debug by @Drarig29 in https://github.com/DataDog/datadog-ci/pull/1757
* [SYNTH-16186] Intercept Ctrl+C to close tunnel and wait by @Drarig29 in https://github.com/DataDog/datadog-ci/pull/1756
### Chores
* Add `datadog-ci-admins` group to codeowners by @AntoineDona in https://github.com/DataDog/datadog-ci/pull/1759
* [chores] Add `datadog-ci` label for repo-wide changes by @Drarig29 in https://github.com/DataDog/datadog-ci/pull/1758
* Remove the `@DataDog/datadog-ci` from CODEOWNERS by @AntoineDona in https://github.com/DataDog/datadog-ci/pull/1760

## New Contributors
* @GabrielAnca made their first contribution in https://github.com/DataDog/datadog-ci/pull/1751
* @alexgallotta made their first contribution in https://github.com/DataDog/datadog-ci/pull/1709

**Full Changelog**: https://github.com/DataDog/datadog-ci/compare/v3.15.0...v3.16.0

[SVLS-7166]: https://datadoghq.atlassian.net/browse/SVLS-7166?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SVLS-7166]: https://datadoghq.atlassian.net/browse/SVLS-7166?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SVLS-7166]: https://datadoghq.atlassian.net/browse/SVLS-7166?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SVLS-6823]: https://datadoghq.atlassian.net/browse/SVLS-6823?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SYNTH-3437]: https://datadoghq.atlassian.net/browse/SYNTH-3437?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ