### PR TITLE
[chores] Set `versioning-strategy: increase` for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: daily
+    commit-message:
+      prefix: 'deps'
+    versioning-strategy: increase


### PR DESCRIPTION
### What and why?

Try setting `versioning-strategy` as advised here: https://github.com/dependabot/dependabot-core/issues/10594

Hopefully this will force dependabot to update `package.json` in addition to `yarn.lock`. (For example, [this PR does not update our version range in `package.json`](https://github.com/DataDog/datadog-ci/pull/1767)).

### How?

Add dependabot configuration file

### Review checklist

- ~~[ ] Feature or bugfix MUST have appropriate tests (unit, integration)~~
