### PR TITLE
[SVLS] add ONE to flare helpers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -25,11 +25,11 @@ src/commands/sourcemaps       @DataDog/datadog-ci-admins @DataDog/rum-browser
 src/commands/unity-symbols    @DataDog/datadog-ci-admins @Datadog/rum-mobile
 
 ## Serverless (label: serverless)
-src/helpers/**/flare*.ts    @DataDog/datadog-ci-admins @DataDog/serverless-onboarding-enablement
 src/commands/aas            @DataDog/datadog-ci-admins @DataDog/serverless-onboarding-enablement
 src/commands/cloud-run      @DataDog/datadog-ci-admins @DataDog/serverless-onboarding-enablement
 src/commands/lambda         @DataDog/datadog-ci-admins @DataDog/serverless-onboarding-enablement
 src/commands/stepfunctions  @DataDog/datadog-ci-admins @DataDog/serverless-onboarding-enablement
+src/helpers/**/flare*.ts    @DataDog/datadog-ci-admins @DataDog/serverless-onboarding-enablement
 
 ## Source Code Integration (label: source-code-integration)
 src/commands/git-metadata  @DataDog/datadog-ci-admins @DataDog/source-code-integration

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -25,6 +25,7 @@ src/commands/sourcemaps       @DataDog/datadog-ci-admins @DataDog/rum-browser
 src/commands/unity-symbols    @DataDog/datadog-ci-admins @Datadog/rum-mobile
 
 ## Serverless (label: serverless)
+src/helpers/**/flare*.ts    @DataDog/datadog-ci-admins @DataDog/serverless-onboarding-enablement
 src/commands/aas            @DataDog/datadog-ci-admins @DataDog/serverless-onboarding-enablement
 src/commands/cloud-run      @DataDog/datadog-ci-admins @DataDog/serverless-onboarding-enablement
 src/commands/lambda         @DataDog/datadog-ci-admins @DataDog/serverless-onboarding-enablement


### PR DESCRIPTION
### What and why?

I noticed https://github.com/DataDog/datadog-ci/pull/1773 didn't require Serverless ONE as codeowners, so this fixes that.

### How?

Updates codeowners

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
