### PR TITLE
SYNTH-21051: Update CODEOWNERS -synthetics-ct/+synthetics-orchestrating

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -35,7 +35,7 @@ src/helpers/**/flare*.ts    @DataDog/datadog-ci-admins @DataDog/serverless-onboa
 src/commands/git-metadata  @DataDog/datadog-ci-admins @DataDog/source-code-integration
 
 ## Synthetics (label: synthetics)
-src/commands/synthetics  @DataDog/datadog-ci-admins @DataDog/synthetics-ct
+src/commands/synthetics  @DataDog/datadog-ci-admins @DataDog/synthetics-orchestrating
 
 ## Profiling (label: profiling)
 src/commands/elf-symbols  @DataDog/datadog-ci-admins @DataDog/profiling-full-host
@@ -47,13 +47,13 @@ src/helpers/git  @DataDog/datadog-ci-admins @DataDog/ci-app-libraries @DataDog/s
 
 ## CI
 src/helpers/file.ts                              @DataDog/datadog-ci-admins @DataDog/ci-app-libraries
-src/helpers/ci.ts                                @DataDog/datadog-ci-admins @DataDog/ci-app-libraries @DataDog/synthetics-ct
-src/helpers/tags.ts                              @DataDog/datadog-ci-admins @DataDog/ci-app-libraries @DataDog/synthetics-ct
-src/helpers/user-provided-git.ts                 @DataDog/datadog-ci-admins @DataDog/ci-app-libraries @DataDog/synthetics-ct
-src/helpers/**tests**/ci-env                     @DataDog/datadog-ci-admins @DataDog/ci-app-libraries @DataDog/synthetics-ct
-src/helpers/**tests**/ci.test.ts                 @DataDog/datadog-ci-admins @DataDog/ci-app-libraries @DataDog/synthetics-ct
-src/helpers/**tests**/tags.test.ts               @DataDog/datadog-ci-admins @DataDog/ci-app-libraries @DataDog/synthetics-ct
-src/helpers/**tests**/user-provided-git.test.ts  @DataDog/datadog-ci-admins @DataDog/ci-app-libraries @DataDog/synthetics-ct
+src/helpers/ci.ts                                @DataDog/datadog-ci-admins @DataDog/ci-app-libraries @DataDog/synthetics-orchestrating
+src/helpers/tags.ts                              @DataDog/datadog-ci-admins @DataDog/ci-app-libraries @DataDog/synthetics-orchestrating
+src/helpers/user-provided-git.ts                 @DataDog/datadog-ci-admins @DataDog/ci-app-libraries @DataDog/synthetics-orchestrating
+src/helpers/**tests**/ci-env                     @DataDog/datadog-ci-admins @DataDog/ci-app-libraries @DataDog/synthetics-orchestrating
+src/helpers/**tests**/ci.test.ts                 @DataDog/datadog-ci-admins @DataDog/ci-app-libraries @DataDog/synthetics-orchestrating
+src/helpers/**tests**/tags.test.ts               @DataDog/datadog-ci-admins @DataDog/ci-app-libraries @DataDog/synthetics-orchestrating
+src/helpers/**tests**/user-provided-git.test.ts  @DataDog/datadog-ci-admins @DataDog/ci-app-libraries @DataDog/synthetics-orchestrating
 
 
 # Documentation


### PR DESCRIPTION
### What and why?

@DataDog/synthetics-ct team is deprecated. synthetics-ct scope now falls within @DataDog/synthetics-orchestrating. This PR updates CODEOWNERS accordingly. 

