### PR TITLE
[SCICM-4946] Rollback "Escape Details URL in Quality Gates Response"

### DIFF
--- a/src/commands/gate/renderer.ts
+++ b/src/commands/gate/renderer.ts
@@ -68,7 +68,7 @@ export const renderRuleEvaluation = (ruleEvaluation: RuleEvaluation): string => 
 
   fullStr += `${chalk.yellow('Blocking')}: ${ruleEvaluation.is_blocking}\n`
   if (ruleEvaluation.details_url) {
-    fullStr += `Details: ${encodeURI(ruleEvaluation.details_url)}\n`
+    fullStr += `Details: ${ruleEvaluation.details_url}\n`
   }
 
   fullStr += '\n'


### PR DESCRIPTION
### What and why?

We mistakingly started url-encoding the Details URL on the CLI which is already url-encoded by the API, resulting on double-encoding issues.

The encoding was added as an attempt to fix an edge case with Azure DevOps repositories, but ended up affecting the majority of customers. The edge case will be fixed server-side. 

### How?

Rollback changes from #1639 

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
