### PR TITLE
Improve Clover coverage reports auto-detection logic

### DIFF
--- a/src/commands/coverage/__tests__/fixtures/clover-php.xml
+++ b/src/commands/coverage/__tests__/fixtures/clover-php.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<coverage generated="1754507264">
+  <project timestamp="1754507264">
+    <file name="/home/runner/work/MyFile.php">
+      <class name="MyClass" namespace="global">
+        <metrics complexity="3" methods="2" coveredmethods="0" conditionals="0" coveredconditionals="0" statements="6" coveredstatements="0" elements="8" coveredelements="0"/>
+      </class>
+      <line num="11" type="method" name="__construct" visibility="public" complexity="1" crap="2" count="0"/>
+      <line num="12" type="stmt" count="0"/>
+      <line num="42" type="stmt" count="0"/>
+      <metrics loc="36" ncloc="28" classes="1" methods="2" coveredmethods="0" conditionals="0" coveredconditionals="0" statements="6" coveredstatements="0" elements="8" coveredelements="0"/>
+    </file>
+    <metrics files="1234" loc="5678" ncloc="123" classes="456" methods="123" coveredmethods="690" conditionals="0" coveredconditionals="0" statements="223344" coveredstatements="567" elements="5645" coveredelements="1124"/>
+  </project>
+</coverage>

--- a/src/commands/coverage/__tests__/utils.test.ts
+++ b/src/commands/coverage/__tests__/utils.test.ts
@@ -97,6 +97,11 @@ describe('utils', () => {
       expect(validateCoverageReport(filePath, cloverFormat)).toBeUndefined()
     })
 
+    test('Returns undefined for a valid clover PHP report', async () => {
+      const filePath = './src/commands/coverage/__tests__/fixtures/clover-php.xml'
+      expect(validateCoverageReport(filePath, cloverFormat)).toBeUndefined()
+    })
+
     test('Returns error message for an invalid clover report', async () => {
       const filePath = './src/commands/coverage/__tests__/fixtures/clover-invalid.xml'
       expect(validateCoverageReport(filePath, cloverFormat)).toMatch(/.+/)
@@ -136,6 +141,11 @@ describe('utils', () => {
 
     test('Detects clover format for a valid clover report', async () => {
       const filePath = './src/commands/coverage/__tests__/fixtures/clover.xml'
+      expect(detectFormat(filePath)).toEqual(cloverFormat)
+    })
+
+    test('Detects clover format for a PHP clover report', async () => {
+      const filePath = './src/commands/coverage/__tests__/fixtures/clover-php.xml'
       expect(detectFormat(filePath)).toEqual(cloverFormat)
     })
 

--- a/src/commands/coverage/utils.ts
+++ b/src/commands/coverage/utils.ts
@@ -73,7 +73,7 @@ export const detectFormat = (filePath: string): CoverageFormat | undefined => {
         data.includes('<report')
       ) {
         return jacocoFormat
-      } else if (data.includes('<coverage') && data.includes('clover=')) {
+      } else if (data.includes('<coverage') && data.includes('<project')) {
         return cloverFormat
       }
     })


### PR DESCRIPTION
### What and why?

Improves coverage reports auto-detection logic to better handle Clover reports.

### How?

Previous logic was too strict and only found reports that contained a `clover` attribute in their root `<coverage>` tag.
However there are valid Clover reports that do not contain this tag (such as reports generated by some PHP tools).
The logic was updated to rely on less strict heuristics.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
