### PR TITLE
[dep] Downgrade @azure/identity from to `4.10.2` to `4.10.1`

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "@aws-sdk/credential-providers": "^3.709.0",
     "@azure/arm-appservice": "^16.0.0",
     "@azure/arm-resources": "^6.1.0",
-    "@azure/identity": "^4.10.2",
+    "@azure/identity": "^4.10.1",
     "@google-cloud/logging": "^11.2.0",
     "@google-cloud/run": "^2.3.0",
     "@smithy/property-provider": "^2.0.12",

--- a/yarn.lock
+++ b/yarn.lock
@@ -855,9 +855,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@azure/identity@npm:^4.10.2":
-  version: 4.10.2
-  resolution: "@azure/identity@npm:4.10.2"
+"@azure/identity@npm:^4.10.1":
+  version: 4.10.1
+  resolution: "@azure/identity@npm:4.10.1"
   dependencies:
     "@azure/abort-controller": ^2.0.0
     "@azure/core-auth": ^1.9.0
@@ -870,7 +870,7 @@ __metadata:
     "@azure/msal-node": ^3.5.0
     open: ^10.1.0
     tslib: ^2.2.0
-  checksum: 6b9459dbea35545a643c9df569f19ad2d455ca8a777074fc8f46b50cf53808132433da47cf05b884ddf85af54b46ae6f4fed8aa99d6ff4a36d032848994e21bd
+  checksum: 9ec058bd1f3aa21eab3d6d60611b665fa73879e044b1ae2c91af305fd3c8a36bd5d093e60fa2cc18a34281eac39ee28076942c7446f4733c3ccd23286138be31
   languageName: node
   linkType: hard
 
@@ -2051,7 +2051,7 @@ __metadata:
     "@aws-sdk/types": ^3.709.0
     "@azure/arm-appservice": ^16.0.0
     "@azure/arm-resources": ^6.1.0
-    "@azure/identity": ^4.10.2
+    "@azure/identity": ^4.10.1
     "@babel/core": 7.8.0
     "@babel/preset-env": 7.4.5
     "@babel/preset-typescript": 7.3.3


### PR DESCRIPTION
### What and why?

The `4.10.2` patch version of `@azure/identity` dropped support for Node 18, which datadog-ci still supports.

See https://github.com/Azure/azure-sdk-for-js/pull/34773#issuecomment-3175073616.

### How?

Downgrade to the last version that supports Node 18.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
