### PR TITLE
Add monitor variable option to deployment gate command

### DIFF
--- a/src/commands/deployment/__tests__/gate.test.ts
+++ b/src/commands/deployment/__tests__/gate.test.ts
@@ -527,6 +527,20 @@ describe('gate', () => {
       })
     })
 
+    test('should include monitor_variable when provided', () => {
+      const command = createCommand(DeploymentGateCommand)
+      command['service'] = 'test-service'
+      command['env'] = 'prod'
+      command['monitorVariable'] = 'test-monitor-variable'
+
+      const request = command['buildEvaluationRequest']()
+      expect(request).toEqual({
+        service: 'test-service',
+        env: 'prod',
+        monitor_variable: 'test-monitor-variable',
+      })
+    })
+
     test('should include all optional parameters when provided', () => {
       const command = createCommand(DeploymentGateCommand)
       command['service'] = 'test-service'
@@ -534,6 +548,7 @@ describe('gate', () => {
       command['identifier'] = 'default'
       command['version'] = '1.2.3'
       command['apmPrimaryTag'] = 'team:backend'
+      command['monitorVariable'] = 'test-monitor-variable'
 
       const request = command['buildEvaluationRequest']()
       expect(request).toEqual({
@@ -542,6 +557,7 @@ describe('gate', () => {
         identifier: 'default',
         version: '1.2.3',
         apm_primary_tag: 'team:backend',
+        monitor_variable: 'test-monitor-variable',
       })
     })
   })

--- a/src/commands/deployment/api.ts
+++ b/src/commands/deployment/api.ts
@@ -21,6 +21,7 @@ const requestGateEvaluation = (
         identifier: evaluationRequest.identifier,
         ...(evaluationRequest.version && {version: evaluationRequest.version}),
         ...(evaluationRequest.apm_primary_tag && {apm_primary_tag: evaluationRequest.apm_primary_tag}),
+        ...(evaluationRequest.monitor_variable && {monitor_variable: evaluationRequest.monitor_variable}),
       },
     },
   }

--- a/src/commands/deployment/gate.ts
+++ b/src/commands/deployment/gate.ts
@@ -65,12 +65,15 @@ export class DeploymentGateCommand extends Command {
   // Optional parameters
   private identifier = Option.String('--identifier', {
     description: 'The deployment identifier (defaults to "default")',
+    validator: t.isString(),
   })
   private version = Option.String('--version', {
     description: 'The deployment version (required for gates with faulty deployment detection rules)',
+    validator: t.isString(),
   })
   private apmPrimaryTag = Option.String('--apm-primary-tag', {
     description: 'The APM primary tag (only for gates with faulty deployment detection rules)',
+    validator: t.isString(),
   })
   private timeout = Option.String('--timeout', '10800', {
     description: 'Maximum amount of seconds to wait for the script execution in seconds (default: 10800 = 3 hours)',
@@ -79,6 +82,11 @@ export class DeploymentGateCommand extends Command {
   private failOnError = Option.Boolean('--fail-on-error', false, {
     description:
       'When true, the script will consider the gate as failed when timeout is reached or unexpected errors occur calling the Datadog APIs',
+  })
+  // monitorVariable is hidden because it's not available yet
+  private monitorVariable = Option.String('--monitor-variable', '', {
+    validator: t.isString(),
+    hidden: true,
   })
 
   // FIPS options
@@ -207,6 +215,10 @@ export class DeploymentGateCommand extends Command {
 
     if (this.apmPrimaryTag) {
       request.apm_primary_tag = this.apmPrimaryTag
+    }
+
+    if (this.monitorVariable) {
+      request.monitor_variable = this.monitorVariable
     }
 
     return request

--- a/src/commands/deployment/interfaces.ts
+++ b/src/commands/deployment/interfaces.ts
@@ -6,6 +6,7 @@ export interface GateEvaluationRequest {
   identifier?: string
   version?: string
   apm_primary_tag?: string
+  monitor_variable?: string
 }
 
 export interface GateEvaluationRequestResponse {


### PR DESCRIPTION
### What and why?

Adding the `--monitor-variable` option to the `deployment gate` command.

I want to deliberately hide it from the command help and leave it undocumented because this is a trial we are running with a couple of customers and we are not sure if this will be the definitive approach or if this will change radically in the near future

### How?

When the option is present, pass it as-is to the API

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
