### PR TITLE
[Cloud Run] Add DD_SERVERLESS_LOG_PATH to app containers

### DIFF
--- a/src/commands/cloud-run/__tests__/__snapshots__/instrument.test.ts.snap
+++ b/src/commands/cloud-run/__tests__/__snapshots__/instrument.test.ts.snap
@@ -35,6 +35,10 @@ exports[`InstrumentCommand snapshot tests interactive mode 1`] = `
 +           {
 +             "name": "DD_API_KEY",
 +             "value": "PLACEHOLDER"
++           },
++           {
++             "name": "DD_SERVERLESS_LOG_PATH",
++             "value": "/shared-volume/logs/*.log"
             }
           ],
           "image": "gcr.io/test-project/test-app:latest",
@@ -158,6 +162,10 @@ exports[`InstrumentCommand snapshot tests prints dry run data with basic flags 1
 +           {
 +             "name": "DD_API_KEY",
 +             "value": "PLACEHOLDER"
++           },
++           {
++             "name": "DD_SERVERLESS_LOG_PATH",
++             "value": "/shared-volume/logs/*.log"
             }
           ],
           "image": "gcr.io/test-project/test-app:latest",

--- a/src/commands/cloud-run/instrument.ts
+++ b/src/commands/cloud-run/instrument.ts
@@ -445,6 +445,7 @@ export class InstrumentCommand extends Command {
     // Replace or add other env vars
     newEnvVars[SERVICE_ENV_VAR] = ddService
     newEnvVars[API_KEY_ENV_VAR] = process.env[API_KEY_ENV_VAR] ?? ''
+    newEnvVars[LOGS_PATH_ENV_VAR] = this.logsPath
     if (this.llmobs) {
       newEnvVars[DD_LLMOBS_ENABLED_ENV_VAR] = 'true'
       newEnvVars[DD_LLMOBS_ML_APP_ENV_VAR] = this.llmobs


### PR DESCRIPTION
### What and why?

- Add `DD_SERVERLESS_LOG_PATH` to app containers. Before, we were only adding it to the sidecar container
- Although it's not required, it's useful for the user to have in the main app. Because if they have a mismatch between the log path they try to write to and the log path defined in the sidecar env var, they will have dropped logs.
- In https://github.com/DataDog/serverless-gcp-sample-apps, we want to use best practices and have the sample logging libraries write to the file defined in `DD_SERVERLESS_LOG_PATH` to prevent customers from having mismatched log path values and losing logs

### How?

A brief description of implementation details of this PR.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
