### PR TITLE
[Serverless] Better warning when missing API key

### DIFF
--- a/src/commands/aas/instrument.ts
+++ b/src/commands/aas/instrument.ts
@@ -99,11 +99,16 @@ export class InstrumentCommand extends AasCommand {
 
       return 1
     }
-    const isApiKeyValid = await newApiKeyValidator({
-      apiKey: process.env.DD_API_KEY,
-      datadogSite: process.env.DD_SITE ?? DATADOG_SITE_US1,
-    }).validateApiKey()
-    if (!isApiKeyValid) {
+
+    try {
+      const isApiKeyValid = await newApiKeyValidator({
+        apiKey: process.env.DD_API_KEY,
+        datadogSite: process.env.DD_SITE ?? DATADOG_SITE_US1,
+      }).validateApiKey()
+      if (!isApiKeyValid) {
+        throw Error()
+      }
+    } catch (e) {
       this.context.stdout.write(
         renderSoftWarning(
           `Invalid API Key stored in the environment variable ${chalk.bold('DD_API_KEY')}: ${maskString(

--- a/src/commands/cloud-run/instrument.ts
+++ b/src/commands/cloud-run/instrument.ts
@@ -129,11 +129,15 @@ export class InstrumentCommand extends Command {
 
     // Verify DD API Key
     const site = process.env.DD_SITE ?? DATADOG_SITE_US1
-    const isApiKeyValid = await newApiKeyValidator({
-      apiKey: process.env.DD_API_KEY,
-      datadogSite: site,
-    }).validateApiKey()
-    if (!isApiKeyValid) {
+    try {
+      const isApiKeyValid = await newApiKeyValidator({
+        apiKey: process.env.DD_API_KEY,
+        datadogSite: site,
+      }).validateApiKey()
+      if (!isApiKeyValid) {
+        throw Error()
+      }
+    } catch (e) {
       this.context.stdout.write(
         renderSoftWarning(
           `Invalid API Key stored in the environment variable ${chalk.bold('DD_API_KEY')}: ${maskString(


### PR DESCRIPTION
### What and why?

The `validateApiKey()` throws when no API key is set. Before, this was uncaught, so it was not clear what the issue actually was:
```
datadog-ci % datadog-ci cloud-run instrument 

🐶 Instrumenting Cloud Run service(s)

Axios Error: Request failed with status code 401
    at settle (/Users/nicholas.hulston/.nvm/versions/node/v22.11.0/lib/node_modules/@datadog/datadog-ci/node_modules/axios/dist/node/axios.cjs:2090:12)
    at IncomingMessage.handleStreamEnd (/Users/nicholas.hulston/.nvm/versions/node/v22.11.0/lib/node_modules/@datadog/datadog-ci/node_modules/axios/dist/node/axios.cjs:3207:11)
    at IncomingMessage.emit (node:events:530:35)
    at endReadableNT (node:internal/streams/readable:1698:12)
    at process.processTicksAndRejections (node:internal/process/task_queues:90:21)
    at Axios.request (/Users/nicholas.hulston/.nvm/versions/node/v22.11.0/lib/node_modules/@datadog/datadog-ci/node_modules/axios/dist/node/axios.cjs:4317:41)
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
```

Before, it was only clear if the API key was *invalid* but set to some value:
```
 DD_API_KEY=invalid datadog-ci cloud-run instrument

🐶 Instrumenting Cloud Run service(s)

[!] Invalid API Key stored in the environment variable DD_API_KEY: **************** and DD_SITE: datadoghq.com
Ensure you've set both DD_API_KEY and DD_SITE.
```

Now, the issue is much more clear:
```
datadog-ci % yarn launch cloud-run instrument                  

🐶 Instrumenting Cloud Run service(s)

[!] Invalid API Key stored in the environment variable DD_API_KEY:  and DD_SITE: datadoghq.com
```

### How?

A brief description of implementation details of this PR.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
