### PR TITLE
Add --base-path parameter to coverage upload command

### DIFF
--- a/src/commands/coverage/README.md
+++ b/src/commands/coverage/README.md
@@ -21,11 +21,8 @@ datadog-ci coverage upload --tags key1:value1 --tags key2:value2 unit-tests/cove
 ```
 
 - The positional arguments are directories, files, or glob patterns that will be used when looking for coverage report files. If you pass a folder, the CLI will do a recursive search looking for supported coverage reports.
-- `--ignored-paths` a comma-separated list of paths that should be excluded from automatic reports discovery (only applicable when `--auto-discovery` is set). Glob patterns are supported
-- `--tags` is an array of key value pairs of the shape `key:value`. This will set global tags applied to all coverage reports.
-  - The resulting dictionary will be merged with whatever is in the `DD_TAGS` environment variable. If a `key` appears both in `--tags` and `DD_TAGS`, whatever value is in `DD_TAGS` will take precedence.
-- `--measures` is an array of key numerical value pairs of the shape `key:123`. This will set global measures applied to all coverage reports.
-  - The resulting dictionary will be merged with whatever is in the `DD_MEASURES` environment variable. If a `key` appears both in `--measures` and `DD_MEASURES`, whatever value is in `DD_MEASURES` will take precedence.
+- `--ignored-paths` a comma-separated list of paths that should be excluded from automatic reports discovery (only applicable when `--auto-discovery` is set). Glob patterns are supported.
+- `--base-path` a string specifying the base (relative to repository root) for the file paths inside the coverage reports. If not specified, the paths inside the reports are considered relative to repository root.
 - `--dry-run` (default: `false`): it will run the command without the final upload step. All other checks are performed.
 - `--verbose` (default: `false`): it will add extra verbosity to the output of the command.
 - `--upload-git-diff` (default: `true`): if the command is run in a PR context, it will try to upload the PR git diff along with the coverage data.

--- a/src/commands/coverage/__tests__/upload.test.ts
+++ b/src/commands/coverage/__tests__/upload.test.ts
@@ -26,7 +26,7 @@ describe('upload', () => {
   describe('getMatchingCoverageReportFilesByFormat', () => {
     test('should read all coverage report files and reject invalid ones', () => {
       const command = createCommand(UploadCodeCoverageReportCommand)
-      command['basePaths'] = ['src/commands/coverage/__tests__/fixtures']
+      command['reportPaths'] = ['src/commands/coverage/__tests__/fixtures']
 
       const result = command['getMatchingCoverageReportFilesByFormat']()
       const fileNames = Object.values(result).flatMap((paths) => paths)
@@ -47,7 +47,7 @@ describe('upload', () => {
     test('should filter by format', () => {
       const command = createCommand(UploadCodeCoverageReportCommand)
       command['format'] = jacocoFormat
-      command['basePaths'] = ['src/commands/coverage/__tests__/fixtures']
+      command['reportPaths'] = ['src/commands/coverage/__tests__/fixtures']
 
       const result = command['getMatchingCoverageReportFilesByFormat']()
       const fileNames = Object.values(result).flatMap((paths) => paths)
@@ -61,7 +61,7 @@ describe('upload', () => {
     test('should read all coverage report files excluding ignored paths', () => {
       const command = createCommand(UploadCodeCoverageReportCommand)
       command['ignoredPaths'] = 'src/commands/coverage/__tests__/fixtures/subfolder.xml'
-      command['basePaths'] = ['src/commands/coverage/__tests__/fixtures']
+      command['reportPaths'] = ['src/commands/coverage/__tests__/fixtures']
 
       const result = command['getMatchingCoverageReportFilesByFormat']()
       const fileNames = Object.values(result).flatMap((paths) => paths)
@@ -79,7 +79,7 @@ describe('upload', () => {
     test('should read all coverage report files excluding ignored paths specified partially', () => {
       const command = createCommand(UploadCodeCoverageReportCommand)
       command['ignoredPaths'] = 'subfolder.xml'
-      command['basePaths'] = ['src/commands/coverage/__tests__/fixtures']
+      command['reportPaths'] = ['src/commands/coverage/__tests__/fixtures']
 
       const result = command['getMatchingCoverageReportFilesByFormat']()
       const fileNames = Object.values(result).flatMap((paths) => paths)
@@ -96,7 +96,7 @@ describe('upload', () => {
 
     test('should allow specifying files directly', () => {
       const command = createCommand(UploadCodeCoverageReportCommand)
-      command['basePaths'] = [
+      command['reportPaths'] = [
         'src/commands/coverage/__tests__/fixtures/jacoco-report.xml',
         'src/commands/coverage/__tests__/fixtures/lcov.info',
       ]
@@ -113,7 +113,7 @@ describe('upload', () => {
     test('should filter files by format if format is provided', () => {
       const command = createCommand(UploadCodeCoverageReportCommand)
       command['format'] = 'lcov'
-      command['basePaths'] = [
+      command['reportPaths'] = [
         'src/commands/coverage/__tests__/fixtures/jacoco-report.xml',
         'src/commands/coverage/__tests__/fixtures/lcov.info',
       ]
@@ -128,7 +128,7 @@ describe('upload', () => {
 
     test('should not fail for invalid single files', () => {
       const command = createCommand(UploadCodeCoverageReportCommand)
-      command['basePaths'] = ['src/commands/coverage/__tests__/fixtures/does-not-exist.xml']
+      command['reportPaths'] = ['src/commands/coverage/__tests__/fixtures/does-not-exist.xml']
 
       const result = command['getMatchingCoverageReportFilesByFormat']()
 
@@ -140,7 +140,7 @@ describe('upload', () => {
     test('should allow folder and single unit paths', () => {
       const command = createCommand(UploadCodeCoverageReportCommand)
       command['format'] = jacocoFormat
-      command['basePaths'] = [
+      command['reportPaths'] = [
         'src/commands/coverage/__tests__/fixtures',
         'src/commands/coverage/__tests__/fixtures/subfolder.xml/nested-Jacoco-report.xml',
       ]
@@ -157,7 +157,7 @@ describe('upload', () => {
     test('should not have repeated files', () => {
       const command = createCommand(UploadCodeCoverageReportCommand)
       command['format'] = jacocoFormat
-      command['basePaths'] = [
+      command['reportPaths'] = [
         'src/commands/coverage/__tests__/fixtures',
         'src/commands/coverage/__tests__/fixtures/jacoco-report.xml',
       ]
@@ -174,7 +174,7 @@ describe('upload', () => {
 
     test('should fetch nested folders when using glob patterns', () => {
       const command = createCommand(UploadCodeCoverageReportCommand)
-      command['basePaths'] = ['**/coverage/**/*.xml']
+      command['reportPaths'] = ['**/coverage/**/*.xml']
 
       const result = command['getMatchingCoverageReportFilesByFormat']()
 
@@ -193,7 +193,7 @@ describe('upload', () => {
     test('should filter by format when using glob patterns', () => {
       const command = createCommand(UploadCodeCoverageReportCommand)
       command['format'] = 'lcov'
-      command['basePaths'] = ['**/coverage/**']
+      command['reportPaths'] = ['**/coverage/**']
 
       const result = command['getMatchingCoverageReportFilesByFormat']()
 
@@ -206,7 +206,7 @@ describe('upload', () => {
     test('should fetch nested folders and ignore files that are not coverage reports', () => {
       const command = createCommand(UploadCodeCoverageReportCommand)
       command['format'] = jacocoFormat
-      command['basePaths'] = ['**/coverage/**']
+      command['reportPaths'] = ['**/coverage/**']
 
       const result = command['getMatchingCoverageReportFilesByFormat']()
 
@@ -326,7 +326,7 @@ describe('execute', () => {
     const output = context.stdout.toString().split('\n')
     expect(code).toBe(0)
     checkConsoleOutput(output, {
-      basePaths: ['src/commands/coverage/__tests__/fixtures'],
+      reportPaths: ['src/commands/coverage/__tests__/fixtures'],
     })
   })
 
@@ -335,7 +335,7 @@ describe('execute', () => {
     const output = context.stdout.toString().split('\n')
     expect(code).toBe(0)
     checkConsoleOutput(output, {
-      basePaths: ['src/commands/coverage/first/', 'src/commands/coverage/second/'],
+      reportPaths: ['src/commands/coverage/first/', 'src/commands/coverage/second/'],
     })
   })
 
@@ -344,7 +344,7 @@ describe('execute', () => {
     const output = context.stdout.toString().split('\n')
     expect(code).toBe(0)
     checkConsoleOutput(output, {
-      basePaths: [`${CWD}/src/commands/coverage/__tests__/fixtures`],
+      reportPaths: [`${CWD}/src/commands/coverage/__tests__/fixtures`],
     })
   })
 
@@ -362,7 +362,7 @@ describe('execute', () => {
 })
 
 interface ExpectedOutput {
-  basePaths: string[]
+  reportPaths: string[]
 }
 
 const checkConsoleOutput = (output: string[], expected: ExpectedOutput) => {
@@ -370,5 +370,5 @@ const checkConsoleOutput = (output: string[], expected: ExpectedOutput) => {
   // output[1] is "Synced git metadata in XXX seconds"
   expect(output[2]).toContain('DRY-RUN MODE ENABLED. WILL NOT UPLOAD COVERAGE REPORT')
   expect(output[3]).toContain(`Starting upload`)
-  expect(output[4]).toContain(`Will look for code coverage report files in ${expected.basePaths.join(', ')}`)
+  expect(output[4]).toContain(`Will look for code coverage report files in ${expected.reportPaths.join(', ')}`)
 }

--- a/src/commands/coverage/api.ts
+++ b/src/commands/coverage/api.ts
@@ -27,6 +27,7 @@ export const uploadCodeCoverageReport = (request: (args: AxiosRequestConfig) => 
     type: 'coverage_report',
     '_dd.hostname': payload.hostname,
     format: payload.format,
+    basepath: payload.basePath,
     ...payload.spanTags,
     ...payload.customTags,
     ...payload.customMeasures,

--- a/src/commands/coverage/interfaces.ts
+++ b/src/commands/coverage/interfaces.ts
@@ -11,6 +11,7 @@ export interface Payload {
   customMeasures: Record<string, number>
   paths: string[]
   format: string
+  basePath: string | undefined
   commitDiff: DiffData | undefined
   prDiff: DiffData | undefined
 }

--- a/src/commands/coverage/renderer.ts
+++ b/src/commands/coverage/renderer.ts
@@ -71,17 +71,17 @@ export const renderUpload = (payload: Payload): string => {
   }
 }
 
-export const renderCommandInfo = (basePaths: string[], dryRun: boolean) => {
+export const renderCommandInfo = (reportPaths: string[], dryRun: boolean) => {
   let fullStr = ''
   if (dryRun) {
     fullStr += chalk.yellow(`${ICONS.WARNING} DRY-RUN MODE ENABLED. WILL NOT UPLOAD COVERAGE REPORTS\n`)
   }
   fullStr += chalk.green(`${new Date().toLocaleString()} - Starting upload. \n`)
-  if (!!basePaths.length) {
-    if (basePaths.length === 1 && !!upath.extname(basePaths[0])) {
-      fullStr += chalk.green(`Will upload code coverage report file ${basePaths[0]}`)
+  if (!!reportPaths.length) {
+    if (reportPaths.length === 1 && !!upath.extname(reportPaths[0])) {
+      fullStr += chalk.green(`Will upload code coverage report file ${reportPaths[0]}`)
     } else {
-      fullStr += chalk.green(`Will look for code coverage report files in ${basePaths.join(', ')}`)
+      fullStr += chalk.green(`Will look for code coverage report files in ${reportPaths.join(', ')}`)
     }
   }
 


### PR DESCRIPTION
### What and why?

This PR adds `--base-path` parameter to `coverage upload` command.

### How?

A brief description of implementation details of this PR.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
