### PR TITLE
[dep] Bump `google-auth-library` to 10.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "fuzzy": "^0.1.3",
     "get-value": "^4.0.1",
     "glob": "^10.4.5",
-    "google-auth-library": "^9.12.0",
+    "google-auth-library": "^10.2.1",
     "inquirer": "^8.2.5",
     "inquirer-checkbox-plus-prompt": "^1.4.2",
     "jest-diff": "^30.0.4",

--- a/src/commands/cloud-run/__tests__/flare.test.ts
+++ b/src/commands/cloud-run/__tests__/flare.test.ts
@@ -3,7 +3,6 @@ import process from 'process'
 import stream from 'stream'
 
 import {Logging} from '@google-cloud/logging'
-import {GoogleAuth} from 'google-auth-library'
 
 import {API_KEY_ENV_VAR, CI_API_KEY_ENV_VAR} from '../../../constants'
 import {
@@ -29,6 +28,8 @@ import {
   CloudRunFlareCommand,
 } from '../flare'
 import {checkAuthentication} from '../utils'
+
+const {GoogleAuth} = require('google-auth-library')
 
 const MOCK_REGION = 'us-east1'
 const MOCK_SERVICE = 'mock-service'
@@ -273,7 +274,7 @@ describe('cloud-run flare', () => {
 
   describe('checkAuthentication', () => {
     it('should return true when authentication is successful', async () => {
-      ;(GoogleAuth as any).mockImplementationOnce(() => ({
+      GoogleAuth.mockImplementationOnce(() => ({
         getApplicationDefault: () => Promise.resolve(),
       }))
 
@@ -283,7 +284,7 @@ describe('cloud-run flare', () => {
     })
 
     it('should return false when authentication fails', async () => {
-      ;(GoogleAuth as any).mockImplementationOnce(() => ({
+      GoogleAuth.mockImplementationOnce(() => ({
         getApplicationDefault: () => Promise.reject(),
       }))
 
@@ -293,7 +294,7 @@ describe('cloud-run flare', () => {
     })
 
     it('prints instructions on how to authenticate when authentication fails', async () => {
-      ;(GoogleAuth as any).mockImplementationOnce(() => ({
+      GoogleAuth.mockImplementationOnce(() => ({
         getApplicationDefault: () => Promise.reject(),
       }))
 

--- a/src/commands/cloud-run/utils.ts
+++ b/src/commands/cloud-run/utils.ts
@@ -1,7 +1,6 @@
 import type {IService, ServicesClient as IServicesClient} from './types'
 
 import chalk from 'chalk'
-import {GoogleAuth} from 'google-auth-library'
 import {diff} from 'jest-diff'
 
 import {withSpinner} from './renderer'
@@ -11,6 +10,9 @@ import {withSpinner} from './renderer'
  * @returns true if the user is authenticated, false otherwise
  */
 export const checkAuthentication = async () => {
+  // TODO: remove this in favor of `await import()` when google-auth-library ESM/CJS issues are fixed
+  const {GoogleAuth} = require('google-auth-library')
+
   const auth = new GoogleAuth()
   try {
     await auth.getApplicationDefault()

--- a/yarn.lock
+++ b/yarn.lock
@@ -2108,7 +2108,7 @@ __metadata:
     fuzzy: ^0.1.3
     get-value: ^4.0.1
     glob: ^10.4.5
-    google-auth-library: ^9.12.0
+    google-auth-library: ^10.2.1
     inquirer: ^8.2.5
     inquirer-checkbox-plus-prompt: ^1.4.2
     jest: 29.6.2
@@ -7029,6 +7029,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"google-auth-library@npm:^10.2.1":
+  version: 10.2.1
+  resolution: "google-auth-library@npm:10.2.1"
+  dependencies:
+    base64-js: ^1.3.0
+    ecdsa-sig-formatter: ^1.0.11
+    gaxios: ^7.0.0
+    gcp-metadata: ^7.0.0
+    google-logging-utils: ^1.0.0
+    gtoken: ^8.0.0
+    jws: ^4.0.0
+  checksum: 07320917304e9b36f3a6b52b5a28fbebdf8b9619085f65c195f31fa3c54984a62a328905d5fa415d3f0054a63003e818bb84f50cce7e11d7947a61c83c3a40e5
+  languageName: node
+  linkType: hard
+
 "google-auth-library@npm:^9.0.0, google-auth-library@npm:^9.3.0":
   version: 9.7.0
   resolution: "google-auth-library@npm:9.7.0"
@@ -7040,20 +7055,6 @@ __metadata:
     gtoken: ^7.0.0
     jws: ^4.0.0
   checksum: b0f273fa08ac69cf38f037c195c137ef9d1f3d197c31fd57db957bd5c38c4a110e1c029504f09574a59fa6c9c85fc6fb9d7748c2ed75f30ecae0c71daa369c23
-  languageName: node
-  linkType: hard
-
-"google-auth-library@npm:^9.12.0":
-  version: 9.12.0
-  resolution: "google-auth-library@npm:9.12.0"
-  dependencies:
-    base64-js: ^1.3.0
-    ecdsa-sig-formatter: ^1.0.11
-    gaxios: ^6.1.1
-    gcp-metadata: ^6.1.0
-    gtoken: ^7.0.0
-    jws: ^4.0.0
-  checksum: 7b5810eae68b27b1d9dd3afa0e408f4ec50e96363d79fab4eec996205a91e1eb776b1613811e5110a5a51f5afe5ed77fd077f2b37602b5f77310f4d1a5fd50b8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### What and why?

Related to https://github.com/DataDog/datadog-ci/issues/1283

- https://github.com/googleapis/google-auth-library-nodejs/releases/tag/v10.0.0

### How?

Bump the dependency. None of the breaking changes impacted us. And our minimal Node.js version (18) is still supported  by the library.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
