### PR TITLE
Conditionally import `@google-cloud/logging`

### DIFF
--- a/src/commands/cloud-run/flare.ts
+++ b/src/commands/cloud-run/flare.ts
@@ -3,8 +3,8 @@ import process from 'process'
 import util from 'util'
 
 import type {IService, IContainer, ServicesClient as IServicesClient} from './types'
+import type {Logging} from '@google-cloud/logging'
 
-import {Logging} from '@google-cloud/logging'
 import chalk from 'chalk'
 import {Command, Option} from 'clipanion'
 import upath from 'upath'
@@ -263,7 +263,9 @@ export class CloudRunFlareCommand extends Command {
     if (this.withLogs) {
       this.context.stdout.write(chalk.bold('\n📖 Getting logs...\n'))
 
+      const {Logging} = await import('@google-cloud/logging')
       const logClient = new Logging({projectId: this.project})
+
       for (const logConfig of LOG_CONFIGS) {
         try {
           const logs = await getLogs(


### PR DESCRIPTION
### What and why?

After https://github.com/DataDog/datadog-ci/pull/1806 and https://github.com/DataDog/datadog-ci/pull/1807 are merged, `@google-cloud/logging` is our last dependency that depends on `gaxios@<7.0.0`:

```sh
$ yarn why -R gaxios

└─ @datadog/datadog-ci@workspace:.
   ├─ @google-cloud/logging@npm:11.2.0 (via npm:^11.2.0)
   │  ├─ @google-cloud/common@npm:5.0.2 (via npm:^5.0.0)
   │  │  └─ google-auth-library@npm:9.7.0 (via npm:^9.0.0)
   │  │     ├─ gaxios@npm:6.7.0 (via npm:^6.1.1)
   │  │     ├─ gcp-metadata@npm:6.1.0 (via npm:^6.1.0)
   │  │     │  └─ gaxios@npm:6.7.0 (via npm:^6.0.0)
   │  │     └─ gtoken@npm:7.1.0 (via npm:^7.0.0)
   │  │        └─ gaxios@npm:6.7.0 (via npm:^6.0.0)
   │  ├─ gcp-metadata@npm:6.1.0 (via npm:^6.0.0)
   │  ├─ google-auth-library@npm:9.7.0 (via npm:^9.0.0)
   │  └─ google-gax@npm:4.3.8 (via npm:^4.0.3)
   │     └─ google-auth-library@npm:9.7.0 (via npm:^9.3.0)
   ├─ @google-cloud/run@npm:3.0.0 (via npm:^3.0.0)
   │  └─ google-gax@npm:5.0.1 (via npm:^5.0.0)
   │     └─ google-auth-library@npm:10.2.0 (via npm:^10.1.0)
   │        ├─ gaxios@npm:7.1.0 (via npm:^7.0.0)
   │        ├─ gcp-metadata@npm:7.0.0 (via npm:^7.0.0)
   │        │  └─ gaxios@npm:7.1.0 (via npm:^7.0.0)
   │        └─ gtoken@npm:8.0.0 (via npm:^8.0.0)
   │           └─ gaxios@npm:7.1.0 (via npm:^7.0.0)
   └─ google-auth-library@npm:10.2.1 (via npm:^10.2.1)
      ├─ gaxios@npm:7.1.0 (via npm:^7.0.0)
      ├─ gcp-metadata@npm:7.0.0 (via npm:^7.0.0)
      └─ gtoken@npm:8.0.0 (via npm:^8.0.0)
```

Since it had [no commits in the last year](https://github.com/DataDog/datadog-ci/issues/1283#issuecomment-3205236737) we can't upgrade it.

### How?

Let's **conditionally import `@google-cloud/logging`** to make the "_[DEP0040] DeprecationWarning: The punycode module is deprecated. Please use a userland alternative instead._" warning only appear when using `datadog-ci cloud-run flare` with the `--with-logs` option **in Node.js 21+**.

To reproduce:
- `volta pin node@21`
- `yarn launch --help` should not print the warning anymore

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
