### PR TITLE
[SYNTH-20724] Enable support for running specific versions of synthetic tests

### DIFF
--- a/src/commands/synthetics/README.md
+++ b/src/commands/synthetics/README.md
@@ -229,13 +229,13 @@ Run tests by executing the CLI through **Yarn**:
 The `run-tests` sub-command accepts the `--public-id` (or shorthand `-p`) argument to trigger only the specified test. It can be set multiple times to run multiple tests:
 
 ```bash
-yarn datadog-ci synthetics run-tests --public-id pub-lic-id1 --public-id pub-lic-id2
+yarn datadog-ci synthetics run-tests --public-id aaa-aaa-aaa --public-id bbb-bbb-bbb
 ```
 
-You can also specify a specific version of a test using the format `<public_id>@<version>`:
+You can also specify a specific version of a test using the format `<public-id>@<version>`:
 
 ```bash
-yarn datadog-ci synthetics run-tests --public-id pub-lic-id1@2 --public-id pub-lic-id1@4
+yarn datadog-ci synthetics run-tests --public-id aaa-aaa-aaa@2 --public-id bbb-bbb-bbb@4
 ```
 
 It is also possible to trigger tests corresponding to a search query by using the `--search` (or shorthand `-s`) argument. With this option, the overrides defined in your [global configuration file](#global-configuration-file) apply to all tests discovered with the search query.
@@ -408,7 +408,7 @@ The proxy to be used for outgoing connections to Datadog. `host` and `port` keys
 
 Public IDs of Synthetic tests to run. If no value is provided, tests are discovered in Synthetic [test configuration files](#test-files).
 
-You can specify a specific version of a test using the format `<public_id>@<version>`. For example, `abc-def-ghi@123` will run version 123 of the test with public ID `abc-def-ghi`. If no version is specified, the latest version of the test will be used.
+You can specify a specific version of a test using the format `<public-id>@<version>`. For example, `abc-def-ghi@123` runs version 123 of the test with public ID `abc-def-ghi`. If no version is specified, the latest version of the test is used.
 
 **Configuration options**
 

--- a/src/commands/synthetics/README.md
+++ b/src/commands/synthetics/README.md
@@ -232,6 +232,12 @@ The `run-tests` sub-command accepts the `--public-id` (or shorthand `-p`) argume
 yarn datadog-ci synthetics run-tests --public-id pub-lic-id1 --public-id pub-lic-id2
 ```
 
+You can also specify a specific version of a test using the format `<public_id>@<version>`:
+
+```bash
+yarn datadog-ci synthetics run-tests --public-id pub-lic-id1@2 --public-id pub-lic-id1@4
+```
+
 It is also possible to trigger tests corresponding to a search query by using the `--search` (or shorthand `-s`) argument. With this option, the overrides defined in your [global configuration file](#global-configuration-file) apply to all tests discovered with the search query.
 
 ```bash
@@ -401,6 +407,8 @@ The proxy to be used for outgoing connections to Datadog. `host` and `port` keys
 #### `publicIds`
 
 Public IDs of Synthetic tests to run. If no value is provided, tests are discovered in Synthetic [test configuration files](#test-files).
+
+You can specify a specific version of a test using the format `<public_id>@<version>`. For example, `abc-def-ghi@123` will run version 123 of the test with public ID `abc-def-ghi`. If no version is specified, the latest version of the test will be used.
 
 **Configuration options**
 

--- a/src/commands/synthetics/__tests__/fixtures.ts
+++ b/src/commands/synthetics/__tests__/fixtures.ts
@@ -660,6 +660,7 @@ export const mockApi = (override?: Partial<APIHelper>): APIHelper => {
     getBatch: jest.fn(),
     getMobileApplicationPresignedURLs: jest.fn(),
     getTest: jest.fn(),
+    getTestVersion: jest.fn(),
     getLocalTestDefinition: jest.fn(),
     editTest: jest.fn(),
     getSyntheticsOrgSettings: jest.fn(),

--- a/src/commands/synthetics/__tests__/test.test.ts
+++ b/src/commands/synthetics/__tests__/test.test.ts
@@ -99,7 +99,10 @@ describe('getTestsToTrigger', () => {
     const {tests, overriddenTestsToTrigger, initialSummary} = await getTestsToTrigger(api, triggerConfigs, mockReporter)
 
     expect(tests).toStrictEqual([fakeTests['123-456-789']])
-    expect(overriddenTestsToTrigger).toStrictEqual([{public_id: '123-456-789', version: undefined}, {public_id: 'ski-ppe-d01', version: undefined}])
+    expect(overriddenTestsToTrigger).toStrictEqual([
+      {public_id: '123-456-789', version: undefined},
+      {public_id: 'ski-ppe-d01', version: undefined},
+    ])
 
     const expectedSummary: InitialSummary = {
       criticalErrors: 0,
@@ -222,12 +225,14 @@ describe('getTestAndOverrideConfig', () => {
       if (e.url?.includes('/synthetics/tests/123-456-789/version_history/50')) {
         throw getAxiosError(404, {errors: ['Version not found']})
       }
+
       return {data: {subtype: 'http', public_id: '123-456-789'}}
     }) as any)
 
     const triggerConfig = {id: '123-456-789', version: 50}
     expect(await getTestAndOverrideConfig(api, triggerConfig, mockReporter, getSummary())).toStrictEqual({
-      errorMessage: '[123-456-789@50] Test version not found: query on https://app.datadoghq.com/example returned: "Version not found"',
+      errorMessage:
+        '[123-456-789@50] Test version not found: query on https://app.datadoghq.com/example returned: "Version not found"',
     })
   })
 
@@ -237,6 +242,7 @@ describe('getTestAndOverrideConfig', () => {
       if (e.url?.includes('/synthetics/tests/123-456-789/version_history/50')) {
         return {data: {}}
       }
+
       return {data: {subtype: 'http', public_id: '123-456-789'}}
     }) as any)
 

--- a/src/commands/synthetics/__tests__/utils/public.test.ts
+++ b/src/commands/synthetics/__tests__/utils/public.test.ts
@@ -189,6 +189,85 @@ describe('utils', () => {
     })
   })
 
+  describe('parsePublicIdWithVersion', () => {
+    test('should parse public ID without version', () => {
+      expect(utils.parsePublicIdWithVersion('abc-def-ghi')).toEqual({
+        publicId: 'abc-def-ghi',
+        version: undefined,
+      })
+    })
+
+    test('should parse public ID with version', () => {
+      expect(utils.parsePublicIdWithVersion('abc-def-ghi@123')).toEqual({
+        publicId: 'abc-def-ghi',
+        version: 123,
+      })
+    })
+
+    test('should parse public ID with version 0', () => {
+      expect(utils.parsePublicIdWithVersion('abc-def-ghi@0')).toEqual({
+        publicId: 'abc-def-ghi',
+        version: 0,
+      })
+    })
+
+    test('should handle local test placeholder', () => {
+      expect(utils.parsePublicIdWithVersion('local')).toEqual({
+        publicId: 'local',
+        version: undefined,
+      })
+    })
+
+    test('should return undefined for invalid format', () => {
+      expect(utils.parsePublicIdWithVersion('invalid-id@123')).toBe(undefined)
+      expect(utils.parsePublicIdWithVersion('@123')).toBe(undefined)
+      expect(utils.parsePublicIdWithVersion('not-a-valid-id')).toBe(undefined)
+      expect(utils.parsePublicIdWithVersion('')).toBe(undefined)
+    })
+
+    test('should handle public ID with multiple @ symbols', () => {
+      expect(utils.parsePublicIdWithVersion('abc-def-ghi@123@456')).toEqual({
+        publicId: 'abc-def-ghi',
+        version: undefined,
+      })
+    })
+
+    test('should parse public ID with large version numbers', () => {
+      expect(utils.parsePublicIdWithVersion('abc-def-ghi@999999')).toEqual({
+        publicId: 'abc-def-ghi',
+        version: 999999,
+      })
+    })
+
+    test('should parse public ID with version from URL', () => {
+      expect(utils.parsePublicIdWithVersion('abc-def-ghi@123')).toEqual({
+        publicId: 'abc-def-ghi',
+        version: 123,
+      })
+    })
+
+    test('should parse public ID with single digit version', () => {
+      expect(utils.parsePublicIdWithVersion('abc-def-ghi@1')).toEqual({
+        publicId: 'abc-def-ghi',
+        version: 1,
+      })
+    })
+
+    test('should parse public ID with large version number', () => {
+      expect(utils.parsePublicIdWithVersion('abc-def-ghi@9999')).toEqual({
+        publicId: 'abc-def-ghi',
+        version: 9999,
+      })
+    })
+
+    test('should handle edge cases', () => {
+      expect(utils.parsePublicIdWithVersion('abc-def-ghi@0')).toEqual({
+        publicId: 'abc-def-ghi',
+        version: 0,
+      })
+    })
+  })
+
   describe('makeTestPayload', () => {
     test('empty config returns simple payload', () => {
       const publicId = 'abc-def-ghi'
@@ -305,6 +384,50 @@ describe('utils', () => {
         ...testOverrides,
         public_id: publicId,
       })
+    })
+
+    test('version is included when specified in trigger config', () => {
+      const publicId = 'abc-def-ghi'
+      const version = 123
+      const fakeTest = {
+        config: {request: {url: 'http://example.org/path'}},
+        public_id: publicId,
+        type: 'api',
+      } as Test
+
+      const overriddenConfig = utils.makeTestPayload(fakeTest, {id: publicId, version}, publicId) as RemoteTestPayload
+
+      expect(overriddenConfig.public_id).toBe(publicId)
+      expect(overriddenConfig.version).toBe(version)
+    })
+
+    test('version is undefined when not specified in trigger config', () => {
+      const publicId = 'abc-def-ghi'
+      const fakeTest = {
+        config: {request: {url: 'http://example.org/path'}},
+        public_id: publicId,
+        type: 'api',
+      } as Test
+
+      const overriddenConfig = utils.makeTestPayload(fakeTest, {id: publicId}, publicId) as RemoteTestPayload
+
+      expect(overriddenConfig.public_id).toBe(publicId)
+      expect(overriddenConfig.version).toBe(undefined)
+    })
+
+    test('version 0 is included when specified', () => {
+      const publicId = 'abc-def-ghi'
+      const version = 0
+      const fakeTest = {
+        config: {request: {url: 'http://example.org/path'}},
+        public_id: publicId,
+        type: 'api',
+      } as Test
+
+      const overriddenConfig = utils.makeTestPayload(fakeTest, {id: publicId, version}, publicId) as RemoteTestPayload
+
+      expect(overriddenConfig.public_id).toBe(publicId)
+      expect(overriddenConfig.version).toBe(0)
     })
   })
 

--- a/src/commands/synthetics/api.ts
+++ b/src/commands/synthetics/api.ts
@@ -123,6 +123,19 @@ const getTest = (request: (args: AxiosRequestConfig) => AxiosPromise<ServerTest>
   return resp.data
 }
 
+const getTestVersion = (request: (args: AxiosRequestConfig) => AxiosPromise<void>) => async (
+  testId: string,
+  version: number
+) => {
+  await retryRequest(
+    {
+      url: `/synthetics/tests/${testId}/version_history/${version}?check_only=true`,
+    },
+    request,
+    {retryOn429: true}
+  )
+}
+
 const getLocalTestDefinition = (request: (args: AxiosRequestConfig) => AxiosPromise<LocalTestDefinition>) => async (
   testId: string,
   testType?: string
@@ -457,6 +470,7 @@ export const apiConstructor = (configuration: APIConfiguration) => {
     getBatch: getBatch(requestV1),
     getMobileApplicationPresignedURLs: getMobileApplicationPresignedURLs(requestUnstable),
     getTest: getTest(requestV1),
+    getTestVersion: getTestVersion(requestV2),
     getLocalTestDefinition: getLocalTestDefinition(requestV1),
     editTest: editTest(requestV1),
     getSyntheticsOrgSettings: getSyntheticsOrgSettings(requestV1),

--- a/src/commands/synthetics/api.ts
+++ b/src/commands/synthetics/api.ts
@@ -129,7 +129,7 @@ const getTestVersion = (request: (args: AxiosRequestConfig) => AxiosPromise<void
 ) => {
   await retryRequest(
     {
-      url: `/synthetics/tests/${testId}/version_history/${version}?check_only=true`,
+      url: `/synthetics/tests/${testId}/version_history/${version}?only_check_existence=true`,
     },
     request,
     {retryOn429: true}

--- a/src/commands/synthetics/interfaces.ts
+++ b/src/commands/synthetics/interfaces.ts
@@ -532,6 +532,7 @@ export interface LocalTestPayload extends ServerConfigOverride {
 }
 export interface RemoteTestPayload extends ServerConfigOverride {
   public_id: string
+  version?: number
 }
 export type TestPayload = LocalTestPayload | RemoteTestPayload
 
@@ -569,6 +570,7 @@ interface BaseTriggerConfig {
 }
 export interface RemoteTriggerConfig extends BaseTriggerConfig {
   id: string
+  version?: number
 }
 export interface LocalTriggerConfig extends BaseTriggerConfig {
   localTestDefinition: LocalTestDefinition

--- a/src/commands/synthetics/run-tests-lib.ts
+++ b/src/commands/synthetics/run-tests-lib.ts
@@ -30,6 +30,7 @@ import {
   getReporter,
   getOrgSettings,
   InitialSummary,
+  parsePublicIdWithVersion,
   renderResults,
   getExitReason,
   toExitCode,
@@ -255,20 +256,25 @@ export const getTriggerConfigs = async (
 
   // Create the overrides required for the list of tests to trigger
   const triggerConfigsWithId = testIdsToTrigger.map((id) => {
-    const testIndexFromSearchQuery = testsFromSearchQuery.findIndex((t) => t.id === id)
+    // Parse public ID and version ID from the input
+    const parsedId = parsePublicIdWithVersion(id)
+    const publicId = parsedId?.publicId ?? id
+    const version = parsedId?.version
+
+    const testIndexFromSearchQuery = testsFromSearchQuery.findIndex((t) => t.id === publicId)
     let testFromSearchQuery
     if (testIndexFromSearchQuery >= 0) {
       testFromSearchQuery = testsFromSearchQuery.splice(testIndexFromSearchQuery, 1)[0]
     }
 
-    const testIndexFromTestConfigs = testsFromTestConfigs.findIndex((t) => getTriggerConfigPublicId(t) === id)
+    const testIndexFromTestConfigs = testsFromTestConfigs.findIndex((t) => getTriggerConfigPublicId(t) === publicId)
     let testFromTestConfigs
     if (testIndexFromTestConfigs >= 0) {
       testFromTestConfigs = testsFromTestConfigs.splice(testIndexFromTestConfigs, 1)[0]
     }
 
     return {
-      ...(isLocalTriggerConfig(testFromTestConfigs) ? {} : {id}),
+      ...(isLocalTriggerConfig(testFromTestConfigs) ? {} : {id: publicId, version}),
       ...testFromSearchQuery,
       ...testFromTestConfigs,
       testOverrides: {

--- a/src/commands/synthetics/test.ts
+++ b/src/commands/synthetics/test.ts
@@ -194,7 +194,10 @@ export const getTestAndOverrideConfig = async (
 
   const testResult = await getTest(api, triggerConfig)
   if ('errorMessage' in testResult) {
-    if (testResult.errorMessage.includes('Test not found') || testResult.errorMessage.includes('Test version not found')) {
+    if (
+      testResult.errorMessage.includes('Test not found') ||
+      testResult.errorMessage.includes('Test version not found')
+    ) {
       summary.testsNotFound.add(normalizedId)
     } else if (testResult.errorMessage.includes('Test not authorized')) {
       summary.testsNotAuthorized.add(normalizedId)
@@ -261,14 +264,18 @@ const getTest = async (
     } catch (error) {
       if (isForbiddenError(error)) {
         const errorMessage = formatBackendErrors(error)
-  
+
         return {errorMessage: `[${chalk.bold.dim(publicId)}] ${chalk.red.bold('Test not authorized')}: ${errorMessage}`}
       }
 
       if (isNotFoundError(error)) {
         const errorMessage = formatBackendErrors(error)
-        
-        return {errorMessage: `[${chalk.bold.dim(publicId)}@${version}] ${chalk.yellow.bold('Test version not found')}: ${errorMessage}`}
+
+        return {
+          errorMessage: `[${chalk.bold.dim(publicId)}@${version}] ${chalk.yellow.bold(
+            'Test version not found'
+          )}: ${errorMessage}`,
+        }
       }
     }
   }

--- a/src/commands/synthetics/test.ts
+++ b/src/commands/synthetics/test.ts
@@ -72,7 +72,10 @@ export const getTestConfigs = async (
           suite: suite.name,
           ...(isLocalTriggerConfig(test)
             ? {localTestDefinition: normalizeLocalTestDefinition(test.localTestDefinition)}
-            : {id: normalizePublicId(test.id) ?? ''}),
+            : {
+                id: normalizePublicId(test.id) ?? '',
+                version: test.version,
+              }),
         }
       })
     )

--- a/src/commands/synthetics/utils/public.ts
+++ b/src/commands/synthetics/utils/public.ts
@@ -70,6 +70,7 @@ export const makeTestPayload = (test: Test, triggerConfig: TriggerConfig, public
   return {
     ...getBasePayload(test, triggerConfig.testOverrides),
     public_id: publicId,
+    version: triggerConfig.version,
   }
 }
 
@@ -198,6 +199,29 @@ export const getFilePathRelativeToRepo = async (filePath: string) => {
 
 export const normalizePublicId = (id: string): string | undefined =>
   id === LOCAL_TEST_DEFINITION_PUBLIC_ID_PLACEHOLDER ? id : id.match(PUBLIC_ID_REGEX)?.[0]
+
+export interface ParsedPublicId {
+  publicId: string
+  version?: number
+}
+
+export const parsePublicIdWithVersion = (id: string): ParsedPublicId | undefined => {
+  // Check if the ID contains a version (format: <public-id>@<version-id>)
+  const versionMatch = id.match(/^([a-z0-9]{3}-[a-z0-9]{3}-[a-z0-9]{3})@(\d+)$/)
+  if (versionMatch) {
+    const [, matchedId, versionStr] = versionMatch
+    const version = parseInt(versionStr, 10)
+
+    return {publicId: matchedId, version}
+  }
+
+  const plainId = normalizePublicId(id)
+  if (plainId) {
+    return {publicId: plainId}
+  }
+
+  return undefined
+}
 
 export const getOrgSettings = async (
   reporter: MainReporter,


### PR DESCRIPTION
### What and why?

The goal of this PR is to enable support for running specific versions of synthetic tests using the `<id>@<version>` pattern

```
datadog-ci synthetics run-tests -p abc-123-def@3
```

### How?

- IDs containing @ are parsed to extract both the synthetics test public_id and the version number
- If provided, the specific version number to run is forwarded to the backend system
- The test existence check using failOnMissingTests also supports the new version mechanics

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
