### PR TITLE
[synthetics] Add `ci.job.id` and `DD_CI_JOB_ID` override

### DIFF
--- a/src/helpers/__tests__/ci.test.ts
+++ b/src/helpers/__tests__/ci.test.ts
@@ -108,6 +108,7 @@ describe('getCIMetadata', () => {
 
   describe.each(CI_PROVIDERS)('Ensure DD env variables override %s env variables', (ciProvider) => {
     const DD_METADATA = {
+      DD_CI_JOB_ID: 'DD_CI_JOB_ID',
       DD_CI_JOB_NAME: 'DD_CI_JOB_NAME',
       DD_CI_JOB_URL: 'DD_CI_JOB_URL',
       DD_CI_PIPELINE_ID: 'DD_CI_PIPELINE_ID',
@@ -148,7 +149,6 @@ describe('getCIMetadata', () => {
       delete ciMetadata?.[CI_ENV_VARS]
       delete ciMetadata?.[CI_NODE_LABELS]
       delete ciMetadata?.[CI_NODE_NAME]
-      delete ciMetadata?.[CI_JOB_ID]
       delete ciMetadata?.[PR_NUMBER]
       delete ciMetadata?.[GIT_PULL_REQUEST_BASE_BRANCH_HEAD_SHA]
       expect(ciMetadata).toEqual(expectedMetadata)

--- a/src/helpers/__tests__/user-provided-git.test.ts
+++ b/src/helpers/__tests__/user-provided-git.test.ts
@@ -22,6 +22,7 @@ import {
   GIT_SHA,
   GIT_TAG,
   GIT_HEAD_SHA,
+  CI_JOB_ID,
 } from '../tags'
 import {getUserCISpanTags, getUserGitSpanTags} from '../user-provided-git'
 
@@ -114,6 +115,7 @@ describe('getUserGitSpanTags', () => {
 
 describe('getUserCISpanTags', () => {
   const DD_CI_METADATA = {
+    DD_CI_JOB_ID: 'DD_CI_JOB_ID',
     DD_CI_JOB_NAME: 'DD_CI_JOB_NAME',
     DD_CI_JOB_URL: 'DD_CI_JOB_URL',
     DD_CI_PIPELINE_ID: 'DD_CI_PIPELINE_ID',
@@ -129,6 +131,7 @@ describe('getUserCISpanTags', () => {
     process.env = {...DD_CI_METADATA}
     const result = getUserCISpanTags()
     expect(result).toEqual({
+      [CI_JOB_ID]: 'DD_CI_JOB_ID',
       [CI_JOB_NAME]: 'DD_CI_JOB_NAME',
       [CI_JOB_URL]: 'DD_CI_JOB_URL',
       [CI_PIPELINE_ID]: 'DD_CI_PIPELINE_ID',
@@ -145,6 +148,7 @@ describe('getUserCISpanTags', () => {
     process.env = {...DD_CI_METADATA, DD_CI_PIPELINE_ID: undefined}
     const result = getUserCISpanTags()
     expect(result).toEqual({
+      [CI_JOB_ID]: 'DD_CI_JOB_ID',
       [CI_JOB_NAME]: 'DD_CI_JOB_NAME',
       [CI_JOB_URL]: 'DD_CI_JOB_URL',
       [CI_PIPELINE_NAME]: 'DD_CI_PIPELINE_NAME',

--- a/src/helpers/ci.ts
+++ b/src/helpers/ci.ts
@@ -827,6 +827,7 @@ export const getCIMetadata = (tagSizeLimits?: {[key in keyof SpanTags]?: number}
   const metadata: Metadata = {
     ci: removeUndefinedValues({
       job: removeUndefinedValues({
+        id: tags[CI_JOB_ID],
         name: tags[CI_JOB_NAME],
         url: tags[CI_JOB_URL],
       }),

--- a/src/helpers/interfaces.ts
+++ b/src/helpers/interfaces.ts
@@ -40,6 +40,7 @@ import {
 export interface Metadata {
   ci: {
     job: {
+      id?: string
       name?: string
       url?: string
     }

--- a/src/helpers/user-provided-git.ts
+++ b/src/helpers/user-provided-git.ts
@@ -1,4 +1,5 @@
 import {
+  CI_JOB_ID,
   CI_JOB_NAME,
   CI_JOB_URL,
   CI_PIPELINE_ID,
@@ -74,6 +75,7 @@ export const getUserGitSpanTags = () => {
 
 export const getUserCISpanTags = () => {
   const {
+    DD_CI_JOB_ID,
     DD_CI_JOB_NAME,
     DD_CI_JOB_URL,
     DD_CI_PIPELINE_ID,
@@ -86,6 +88,7 @@ export const getUserCISpanTags = () => {
   } = process.env
 
   return removeEmptyValues({
+    [CI_JOB_ID]: DD_CI_JOB_ID,
     [CI_JOB_NAME]: DD_CI_JOB_NAME,
     [CI_JOB_URL]: DD_CI_JOB_URL,
     [CI_PIPELINE_ID]: DD_CI_PIPELINE_ID,


### PR DESCRIPTION
### What and why?

Follow-up of #1811 

The Synthetics endpoints also support `ci.job.id` in the batch metadata, so we add it to the collected metadata. This PR also adds the `DD_CI_JOB_ID` env var to let the user override their job ID.

### How?

Update `getUserCISpanTags` and `getCIMetadata`

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
