### PR TITLE
Update Software Delivery ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,15 +3,14 @@
 
 # Commands (grouped by product)
 
-## CI Visibility (label: ci-visibility)
-src/commands/coverage      @DataDog/datadog-ci-admins @DataDog/ci-app-libraries
-src/commands/deployment    @DataDog/datadog-ci-admins @DataDog/ci-app-libraries
-src/commands/dora          @DataDog/datadog-ci-admins @DataDog/ci-app-libraries
-src/commands/gate          @DataDog/datadog-ci-admins @DataDog/ci-app-libraries
-src/commands/junit         @DataDog/datadog-ci-admins @DataDog/ci-app-libraries
-src/commands/measure       @DataDog/datadog-ci-admins @DataDog/ci-app-libraries
-src/commands/tag           @DataDog/datadog-ci-admins @DataDog/ci-app-libraries
-src/commands/trace         @DataDog/datadog-ci-admins @DataDog/ci-app-libraries
+## Software Delivery (label: software-delivery)
+src/commands/coverage      @DataDog/datadog-ci-admins @DataDog/ci-app-libraries @DataDog/ci-app-backend
+src/commands/deployment    @DataDog/datadog-ci-admins @DataDog/ci-app-libraries @DataDog/ci-app-backend
+src/commands/dora          @DataDog/datadog-ci-admins @DataDog/ci-app-libraries @DataDog/ci-app-backend
+src/commands/junit         @DataDog/datadog-ci-admins @DataDog/ci-app-libraries @DataDog/ci-app-backend
+src/commands/measure       @DataDog/datadog-ci-admins @DataDog/ci-app-libraries @DataDog/ci-app-backend
+src/commands/tag           @DataDog/datadog-ci-admins @DataDog/ci-app-libraries @DataDog/ci-app-backend
+src/commands/trace         @DataDog/datadog-ci-admins @DataDog/ci-app-libraries @DataDog/ci-app-backend
 
 ## Static Analysis (label: static-analysis)
 src/commands/sarif   @DataDog/datadog-ci-admins @DataDog/k9-vm-ast
@@ -33,6 +32,7 @@ src/helpers/**/flare*.ts    @DataDog/datadog-ci-admins @DataDog/serverless-onboa
 
 ## Source Code Integration (label: source-code-integration)
 src/commands/git-metadata  @DataDog/datadog-ci-admins @DataDog/source-code-integration
+src/commands/gate          @DataDog/datadog-ci-admins @DataDog/source-code-integration
 
 ## Synthetics (label: synthetics)
 src/commands/synthetics  @DataDog/datadog-ci-admins @DataDog/synthetics-orchestrating
@@ -46,14 +46,14 @@ src/commands/elf-symbols  @DataDog/datadog-ci-admins @DataDog/profiling-full-hos
 src/helpers/git  @DataDog/datadog-ci-admins @DataDog/ci-app-libraries @DataDog/source-code-integration
 
 ## CI
-src/helpers/file.ts                              @DataDog/datadog-ci-admins @DataDog/ci-app-libraries
-src/helpers/ci.ts                                @DataDog/datadog-ci-admins @DataDog/ci-app-libraries @DataDog/synthetics-orchestrating
-src/helpers/tags.ts                              @DataDog/datadog-ci-admins @DataDog/ci-app-libraries @DataDog/synthetics-orchestrating
-src/helpers/user-provided-git.ts                 @DataDog/datadog-ci-admins @DataDog/ci-app-libraries @DataDog/synthetics-orchestrating
-src/helpers/**tests**/ci-env                     @DataDog/datadog-ci-admins @DataDog/ci-app-libraries @DataDog/synthetics-orchestrating
-src/helpers/**tests**/ci.test.ts                 @DataDog/datadog-ci-admins @DataDog/ci-app-libraries @DataDog/synthetics-orchestrating
-src/helpers/**tests**/tags.test.ts               @DataDog/datadog-ci-admins @DataDog/ci-app-libraries @DataDog/synthetics-orchestrating
-src/helpers/**tests**/user-provided-git.test.ts  @DataDog/datadog-ci-admins @DataDog/ci-app-libraries @DataDog/synthetics-orchestrating
+src/helpers/file.ts                              @DataDog/datadog-ci-admins @DataDog/ci-app-libraries @DataDog/ci-app-backend
+src/helpers/ci.ts                                @DataDog/datadog-ci-admins @DataDog/ci-app-libraries @DataDog/ci-app-backend @DataDog/synthetics-orchestrating
+src/helpers/tags.ts                              @DataDog/datadog-ci-admins @DataDog/ci-app-libraries @DataDog/ci-app-backend @DataDog/synthetics-orchestrating
+src/helpers/user-provided-git.ts                 @DataDog/datadog-ci-admins @DataDog/ci-app-libraries @DataDog/ci-app-backend @DataDog/synthetics-orchestrating
+src/helpers/**tests**/ci-env                     @DataDog/datadog-ci-admins @DataDog/ci-app-libraries @DataDog/ci-app-backend @DataDog/synthetics-orchestrating
+src/helpers/**tests**/ci.test.ts                 @DataDog/datadog-ci-admins @DataDog/ci-app-libraries @DataDog/ci-app-backend @DataDog/synthetics-orchestrating
+src/helpers/**tests**/tags.test.ts               @DataDog/datadog-ci-admins @DataDog/ci-app-libraries @DataDog/ci-app-backend @DataDog/synthetics-orchestrating
+src/helpers/**tests**/user-provided-git.test.ts  @DataDog/datadog-ci-admins @DataDog/ci-app-libraries @DataDog/ci-app-backend @DataDog/synthetics-orchestrating
 
 
 # Documentation

--- a/.github/advanced-issue-labeler.yml
+++ b/.github/advanced-issue-labeler.yml
@@ -4,12 +4,11 @@ policy:
   - section:
       - id: [command]
         label:
-          - name: ci-visibility
+          - name: software-delivery
             keys:
               - coverage
               - deployment
               - dora
-              - gate
               - junit
               - metric
               - tag
@@ -36,6 +35,7 @@ policy:
           - name: source-code-integration
             keys:
               - git-metadata
+              - gate
           - name: synthetics
             keys:
               - synthetics

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -16,9 +16,9 @@ changelog:
     - title: Documentation
       labels:
         - documentation
-    - title: CI Visibility
+    - title: Software Delivery
       labels:
-        - ci-visibility
+        - software-delivery
     - title: RUM
       labels:
         - rum

--- a/.github/workflows/pr-required-labels.yml
+++ b/.github/workflows/pr-required-labels.yml
@@ -30,7 +30,7 @@ jobs:
             documentation
             chores
             release
-            ci-visibility
+            software-delivery
             static-analysis
             rum
             serverless


### PR DESCRIPTION
### What and why?

- What used to be the CI Visibility product is now a broader group of products called Software Delivery.
- The Software Delivery teams have two GitHub teams: Datadog/ci-app-libraries and Datadog/ci-app-backend
- The Gate command is now owned by the Source Code Integration team

### How?

- Renaming the label `ci-visibility` to `software-delivery`
- Adding Datadog/ci-app-backend as code owner for Software Delivery items
- Moving the gate command to source code integration

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
