### PR TITLE
Cloud Run Instrument Language Flag

### DIFF
--- a/packages/datadog-ci/src/commands/cloud-run/README.md
+++ b/packages/datadog-ci/src/commands/cloud-run/README.md
@@ -86,7 +86,7 @@ You can pass the following arguments to `instrument` to specify its behavior.
 | `--logs-path` | | (Not recommended) Specify a custom log file path. Must begin with the shared volume path. | `/shared-volume/logs/*.log` |
 | `--sidecar-cpus` | | The number of CPUs to allocate to the sidecar container. | `1` |
 | `--sidecar-memory` | | The amount of memory to allocate to the sidecar container. | `512Mi` |
-| `--language` | | Set the language used in your container or function for advanced log parsing. Sets the DD_SOURCE env var. Possible values: "nodejs", "python", "go", "java", "csharp", "ruby", or "php". | |
+| `--language` | | Set the language used in your container or function for advanced log parsing. Sets the `DD_SOURCE` env var. Possible values: `nodejs`, `python`, `go`, `java`, `csharp`, `ruby`, or `php`. | |
 
 #### `uninstrument`
 You can pass the following arguments to `uninstrument` to specify its behavior.

--- a/packages/datadog-ci/src/commands/cloud-run/README.md
+++ b/packages/datadog-ci/src/commands/cloud-run/README.md
@@ -86,6 +86,7 @@ You can pass the following arguments to `instrument` to specify its behavior.
 | `--logs-path` | | (Not recommended) Specify a custom log file path. Must begin with the shared volume path. | `/shared-volume/logs/*.log` |
 | `--sidecar-cpus` | | The number of CPUs to allocate to the sidecar container. | `1` |
 | `--sidecar-memory` | | The amount of memory to allocate to the sidecar container. | `512Mi` |
+| `--language` | | Set the language used in your container or function for advanced log parsing. Sets the DD_SOURCE env var. Possible values: "nodejs", "python", "go", "java", "csharp", "ruby", or "php". | |
 
 #### `uninstrument`
 You can pass the following arguments to `uninstrument` to specify its behavior.

--- a/packages/datadog-ci/src/commands/cloud-run/__tests__/instrument.test.ts
+++ b/packages/datadog-ci/src/commands/cloud-run/__tests__/instrument.test.ts
@@ -14,6 +14,7 @@ import {
   SITE_ENV_VAR,
   DD_TRACE_ENABLED_ENV_VAR,
   VERSION_ENV_VAR,
+  DD_SOURCE_ENV_VAR,
 } from '../../../constants'
 import {makeRunCLI} from '../../../helpers/__tests__/testing-tools'
 import * as apikey from '../../../helpers/apikey'
@@ -345,6 +346,7 @@ describe('InstrumentCommand', () => {
       ;(command as any).logLevel = 'debug'
       ;(command as any).llmobs = 'my-llm-app'
       ;(command as any).extraTags = 'foo:bar,abc:def'
+      ;(command as any).language = 'nodejs'
 
       const newSidecarContainer = command.buildSidecarContainer(undefined, 'my-service')
       const expected: IEnvVar[] = [
@@ -359,6 +361,7 @@ describe('InstrumentCommand', () => {
         {name: DD_TRACE_ENABLED_ENV_VAR, value: 'true'},
         {name: DD_LOG_LEVEL_ENV_VAR, value: 'debug'},
         {name: DD_TAGS_ENV_VAR, value: 'foo:bar,abc:def'},
+        {name: DD_SOURCE_ENV_VAR, value: 'nodejs'},
       ]
       expect(newSidecarContainer.env).toEqual(expect.arrayContaining(expected))
       expect(newSidecarContainer.env).toHaveLength(expected.length)

--- a/packages/datadog-ci/src/commands/cloud-run/instrument.ts
+++ b/packages/datadog-ci/src/commands/cloud-run/instrument.ts
@@ -23,6 +23,7 @@ import {
   CI_SITE_ENV_VAR,
   FIPS_ENV_VAR,
   FIPS_IGNORE_ERROR_ENV_VAR,
+  DD_SOURCE_ENV_VAR,
 } from '../../constants'
 import {newApiKeyValidator} from '../../helpers/apikey'
 import {toBoolean} from '../../helpers/env'
@@ -111,6 +112,9 @@ export class InstrumentCommand extends Command {
   })
   private sidecarMemory = Option.String('--sidecar-memory', '512Mi', {
     description: `The amount of memory to allocate to the sidecar container. Defaults to '512Mi'.`,
+  })
+  private language = Option.String('--language', {
+    description: `Set the language used in your container or function for advanced log parsing. Sets the DD_SOURCE env var. Possible values: "nodejs", "python", "go", "java", "csharp", "ruby", or "php".`,
   })
   private fips = Option.Boolean('--fips', false)
   private fipsIgnoreError = Option.Boolean('--fips-ignore-error', false)
@@ -370,6 +374,9 @@ export class InstrumentCommand extends Command {
     }
     if (this.extraTags) {
       newEnvVars[DD_TAGS_ENV_VAR] = this.extraTags
+    }
+    if (this.language) {
+      newEnvVars[DD_SOURCE_ENV_VAR] = this.language
     }
     newEnvVars[LOGS_PATH_ENV_VAR] = this.logsPath
 

--- a/packages/datadog-ci/src/constants.ts
+++ b/packages/datadog-ci/src/constants.ts
@@ -45,6 +45,7 @@ export const DD_LLMOBS_ENABLED_ENV_VAR = 'DD_LLMOBS_ENABLED'
 export const DD_LLMOBS_ML_APP_ENV_VAR = 'DD_LLMOBS_ML_APP'
 export const DD_LLMOBS_AGENTLESS_ENABLED_ENV_VAR = 'DD_LLMOBS_AGENTLESS_ENABLED'
 export const DD_TAGS_ENV_VAR = 'DD_TAGS'
+export const DD_SOURCE_ENV_VAR = 'DD_SOURCE'
 /*
  * DD_TAGS Regular Expression
  * This RegExp ensures that the --extra-tags string


### PR DESCRIPTION
### What and why?

Add a `--language` flag, which sets the `DD_SOURCE` flag in the sidecar container, allowing for Log Pipeline Parsing.

The goal here is to just make it easier for people to setup log/trace correlation and other log parsing features.

### How?

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
