### PR TITLE
Add evaluation summary to 'deployment gate' output

### DIFF
--- a/packages/datadog-ci/src/commands/deployment/__tests__/__snapshots__/gate.test.ts.snap
+++ b/packages/datadog-ci/src/commands/deployment/__tests__/__snapshots__/gate.test.ts.snap
@@ -163,7 +163,16 @@ Gate evaluation started successfully. Evaluation ID: test-evaluation-id
 Waiting for gate evaluation results...
 Unknown gate evaluation status: unexpected
 	Retrying in 15s...
-	✅ Gate evaluation passed
+
+✅ Gate evaluation passed
+   Evaluation mode: Active
+   Evaluation URL: https://app.datadoghq.com/ci/deployment-gates/evaluations?query=evaluation_id%3A123456
+   Rules evaluated:
+    - Rule: Rule 1
+      Evaluation mode: Active
+      Status: PASS
+
+
 "
 `;
 
@@ -182,7 +191,19 @@ Error polling for gate evaluation results: 404 Not Found
 	Retrying in 15s...
 	Gate evaluation in progress (0/2 rules completed)
 	Retrying in 15s...
-	✅ Gate evaluation passed
+
+✅ Gate evaluation passed
+   Evaluation mode: Active
+   Evaluation URL: https://app.datadoghq.com/ci/deployment-gates/evaluations?query=evaluation_id%3A123456
+   Rules evaluated:
+    - Rule: Rule 1
+      Evaluation mode: Active
+      Status: PASS
+    - Rule: Rule 2
+      Evaluation mode: Active
+      Status: PASS
+
+
 "
 `;
 
@@ -197,7 +218,23 @@ Requesting gate evaluation...
 Gate evaluation started successfully. Evaluation ID: test-evaluation-id
 
 Waiting for gate evaluation results...
-	❌ Gate evaluation failed
+
+❌ Gate evaluation failed
+   Evaluation mode: Active
+   Evaluation URL: https://app.datadoghq.com/ci/deployment-gates/evaluations?query=evaluation_id%3A123456
+   Rules evaluated:
+    - Rule: Rule 1
+      Evaluation mode: Active
+      Status: FAIL
+      Reason: Failure reason 1
+    - Rule: Rule 2
+      Evaluation mode: Active
+      Status: IN_PROGRESS
+    - Rule: Rule 3
+      Evaluation mode: Active
+      Status: PASS
+
+
 "
 `;
 
@@ -216,7 +253,19 @@ Waiting for gate evaluation results...
 	Retrying in 15s...
 	Gate evaluation in progress (1/2 rules completed)
 	Retrying in 15s...
-	✅ Gate evaluation passed
+
+✅ Gate evaluation passed
+   Evaluation mode: Active
+   Evaluation URL: https://app.datadoghq.com/ci/deployment-gates/evaluations?query=evaluation_id%3A123456
+   Rules evaluated:
+    - Rule: Rule 1
+      Evaluation mode: Active
+      Status: PASS
+    - Rule: Rule 2
+      Evaluation mode: Active
+      Status: PASS
+
+
 "
 `;
 
@@ -231,7 +280,16 @@ Requesting gate evaluation...
 Gate evaluation started successfully. Evaluation ID: test-evaluation-id
 
 Waiting for gate evaluation results...
-	✅ Gate evaluation passed
+
+✅ Gate evaluation passed
+   Evaluation mode: Active
+   Evaluation URL: https://app.datadoghq.com/ci/deployment-gates/evaluations?query=evaluation_id%3A123456
+   Rules evaluated:
+    - Rule: Rule 1
+      Evaluation mode: Active
+      Status: PASS
+
+
 "
 `;
 
@@ -250,6 +308,15 @@ Gate evaluation started successfully. Evaluation ID: test-evaluation-id
 Waiting for gate evaluation results...
 Error polling for gate evaluation results: 500 Internal Server Error
 	Retrying in 15s...
-	✅ Gate evaluation passed
+
+✅ Gate evaluation passed
+   Evaluation mode: Active
+   Evaluation URL: https://app.datadoghq.com/ci/deployment-gates/evaluations?query=evaluation_id%3A123456
+   Rules evaluated:
+    - Rule: Rule 1
+      Evaluation mode: Active
+      Status: PASS
+
+
 "
 `;

--- a/packages/datadog-ci/src/commands/deployment/__tests__/gate.test.ts
+++ b/packages/datadog-ci/src/commands/deployment/__tests__/gate.test.ts
@@ -14,13 +14,18 @@ const buildEvaluationRequestResponse = (evaluationId: string) => ({
 })
 
 const buildGateEvaluationResultResponse = (status: string, ruleStatuses: string[] | undefined = ['pass']) => {
-  const rules = ruleStatuses.map((ruleStatus) => ({status: ruleStatus}))
+  const rules = ruleStatuses.map((ruleStatus, index) => ({
+    name: `Rule ${index + 1}`,
+    status: ruleStatus,
+    reason: ruleStatus === 'fail' ? `Failure reason ${index + 1}` : '',
+  }))
 
   return {
     data: {
       data: {
         attributes: {
           gate_status: status,
+          evaluation_url: 'https://app.datadoghq.com/ci/deployment-gates/evaluations?query=evaluation_id%3A123456',
           rules,
         },
       },
@@ -143,7 +148,9 @@ describe('gate', () => {
       test('should fail when gate evaluation fails', async () => {
         const mockApi = {
           requestGateEvaluation: jest.fn().mockResolvedValue(buildEvaluationRequestResponse('test-evaluation-id')),
-          getGateEvaluationResult: jest.fn().mockResolvedValue(buildGateEvaluationResultResponse('fail')),
+          getGateEvaluationResult: jest
+            .fn()
+            .mockResolvedValue(buildGateEvaluationResultResponse('fail', ['fail', 'in_progress', 'pass'])),
         }
         const apiConstructorSpy = jest.spyOn(apiModule, 'apiConstructor').mockReturnValue(mockApi)
 


### PR DESCRIPTION
### What and why?

The gate command does not add context on why the gate failed, so this PR adds a summary when the evaluation finishes, with information from the API response detailing the rules that were executed and their result. Example output:

```
Starting deployment gate evaluation with parameters:
        Service: gabi-template-variables-test
        Environment: prod
        Timeout: 10800 seconds
        Fail on error: false

Requesting gate evaluation...
Gate evaluation started successfully. Evaluation ID: 6fa2e611-ea57-4080-b3a5-6509995d15e8

Waiting for gate evaluation results...

❌ Gate evaluation failed
   Evaluation mode: Active
   Evaluation URL: https://app.datadoghq.com/ci/deployment-gates/evaluations?end=1757345212751&index=cdgates&paused=true&query=level%3Agate+%40evaluation_id%3A6fa2e611-ea57-4080-b3a5-6509995d15e8&start=1757343412751
   Rules evaluated:
    - Rule: All hosts are okay
      Evaluation mode: Active
      Status: IN_PROGRESS
    - Rule: Test rule
      Evaluation mode: Active
      Status: FAIL
      Reason: Monitor in ALERT state
```

### How?

Adding a simple helper method and using the response already returned by the API

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
