### PR TITLE
Inspect sarif aggregate error

### DIFF
--- a/packages/datadog-ci/src/commands/sarif/renderer.ts
+++ b/packages/datadog-ci/src/commands/sarif/renderer.ts
@@ -1,3 +1,5 @@
+import {inspect} from 'util'
+
 import {getBaseUrl} from '@datadog/datadog-ci-base/helpers/app'
 import chalk from 'chalk'
 import upath from 'upath'
@@ -48,6 +50,9 @@ export const renderFailedUpload = (sarifReport: Payload, error: any) => {
   fullStr += chalk.red(`${ICONS.FAILED} Failed upload SARIF report file ${reportPath}: ${error.message}\n`)
   if (error?.response?.status) {
     fullStr += chalk.red(`API status code: ${error.response.status}\n`)
+  }
+  if (error.message.includes('Aggregate Error')) {
+    fullStr += chalk.red(`Inspect error: ${inspect(error)}\n`)
   }
 
   return fullStr


### PR DESCRIPTION
### What and why?

A user had the following error intermittently while using the command `datadog-ci sarif upload xxxxx.sarif --service xxx`.

With datadog-ci version `3.20.0`, and Node.js `20.19.4`

```sh
Preparing upload for sha:xxx env:xxx
Uploading SARIF report in xxxxx.sarif
[attempt 1] Retrying SARIF report upload [xxxxx.sarif]: 
Uploading SARIF report in xxxxx.sarif
[attempt 2] Retrying SARIF report upload [xxxxx.sarif]: 
Uploading SARIF report in xxxxx.sarif
[attempt 3] Retrying SARIF report upload [xxxxx.sarif]: 
Uploading SARIF report in xxxxx.sarif
[attempt 4] Retrying SARIF report upload [xxxxx.sarif]: 
Uploading SARIF report in xxxxx.sarif
[attempt 5] Retrying SARIF report upload [xxxxx.sarif]: 
Uploading SARIF report in xxxxx.sarif
❌ Failed upload SARIF report file [xxxxx.sarif]: 
Aggregate Error: 
    at AxiosError.from (node_modules/axios/dist/node/axios.cjs:899:14)
    at RedirectableRequest.handleRequestError (node_modules/axios/dist/node/axios.cjs:3228:25)
    at RedirectableRequest.emit (node:events:524:28)
    at eventHandlers.<computed> (node_modules/follow-redirects/index.js:49:24)
    at ClientRequest.emit (node:events:524:28)
    at emitErrorEvent (node:_http_client:101:11)
    at TLSSocket.socketErrorListener (node:_http_client:504:5)
    at TLSSocket.emit (node:events:524:28)
    at emitErrorNT (node:internal/streams/destroy:169:8)
    at emitErrorCloseNT (node:internal/streams/destroy:128:3)
    at Axios.request (node_modules/axios/dist/node/axios.cjs:4317:41)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
```

We could not reproduce the error, so we are adding more verbosity to the output.

### How?

Use `util.inspect()` to hopefully get more info.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
