### PR TITLE
[chore] Upgrade prettier to support latest TS syntax

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "eslint-plugin-prefer-arrow": "^1.2.3",
     "eslint-plugin-prettier": "^5.5.4",
     "jest": "29.6.2",
-    "prettier": "2.0.5",
+    "prettier": "^3.6.2",
     "rimraf": "^5.0.0",
     "ts-jest": "29.1.1",
     "ts-json-schema-generator": "^2.4.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "build": "yarn tsc:build",
     "check-licenses": "node bin/check-licenses.js",
     "check-junit-upload": "node bin/check-junit-upload.js",
-    "clean": "rimraf --glob 'packages/*/{dist,tsconfig.tsbuildinfo}'",
+    "clean": "rimraf --glob .eslintcache .jest-cache 'packages/*/{dist,tsconfig.tsbuildinfo}'",
     "dev": "yarn tsc:build --watch",
     "dist-standalone": "yarn workspace @datadog/datadog-ci dist-standalone",
     "dist-standalone:test": "jest --config ./jest.config-standalone.mjs --colors",

--- a/packages/base/src/helpers/__tests__/ci.test.ts
+++ b/packages/base/src/helpers/__tests__/ci.test.ts
@@ -87,7 +87,7 @@ describe('getCIMetadata', () => {
   describe.each(CI_PROVIDERS)('%s', (ciProvider) => {
     const assertions = require(upath.join(__dirname, 'ci-env', ciProvider)) as [
       {[key: string]: string},
-      {[tag: string]: string}
+      {[tag: string]: string},
     ][]
 
     for (const assertion of assertions) {
@@ -138,7 +138,7 @@ describe('getCIMetadata', () => {
 
     const assertions = require(upath.join(__dirname, 'ci-env', ciProvider)) as [
       {[key: string]: string},
-      {[tag: string]: string}
+      {[tag: string]: string},
     ][]
 
     it.each(assertions)('spec %#', (env, tags: SpanTags) => {
@@ -170,7 +170,7 @@ describe('ci spec', () => {
   CI_PROVIDERS.forEach((ciProvider) => {
     const assertions = require(upath.join(__dirname, 'ci-env', ciProvider)) as [
       {[key: string]: string},
-      {[key: string]: string}
+      {[key: string]: string},
     ][]
 
     if (ciProvider === 'github.json') {

--- a/packages/base/src/helpers/__tests__/testing-tools.ts
+++ b/packages/base/src/helpers/__tests__/testing-tools.ts
@@ -63,28 +63,27 @@ export const getEnvVarPlaceholders = () => ({
   DATADOG_APP_KEY: 'PLACEHOLDER',
 })
 
-export const makeRunCLI = (commandClass: CommandClass, baseArgs: string[], opts?: MakeRunCLIOptions) => async (
-  extraArgs: string[],
-  extraEnv?: Record<string, string>
-) => {
-  const cli = new Cli()
-  cli.register(commandClass)
+export const makeRunCLI =
+  (commandClass: CommandClass, baseArgs: string[], opts?: MakeRunCLIOptions) =>
+  async (extraArgs: string[], extraEnv?: Record<string, string>) => {
+    const cli = new Cli()
+    cli.register(commandClass)
 
-  if (!opts?.skipResetEnv) {
-    process.env = getEnvVarPlaceholders()
+    if (!opts?.skipResetEnv) {
+      process.env = getEnvVarPlaceholders()
+    }
+
+    process.env = {
+      ...process.env,
+      ...opts?.env,
+      ...extraEnv,
+    }
+
+    const context = createMockContext({...opts, env: process.env})
+    const code = await cli.run([...baseArgs, ...extraArgs], context)
+
+    return {context, code}
   }
-
-  process.env = {
-    ...process.env,
-    ...opts?.env,
-    ...extraEnv,
-  }
-
-  const context = createMockContext({...opts, env: process.env})
-  const code = await cli.run([...baseArgs, ...extraArgs], context)
-
-  return {context, code}
-}
 
 const isCommandOption = <T = unknown>(value: unknown): value is CommandOption<T> => {
   // eslint-disable-next-line no-null/no-null

--- a/packages/base/src/helpers/id.ts
+++ b/packages/base/src/helpers/id.ts
@@ -42,7 +42,7 @@ const pseudoRandom = () => {
   const offset = batch * 8
 
   return [
-    data[offset] & 0x7F, // only positive int64,
+    data[offset] & 0x7f, // only positive int64,
     data[offset + 1],
     data[offset + 2],
     data[offset + 3],
@@ -55,10 +55,7 @@ const pseudoRandom = () => {
 
 // Read a buffer to unsigned integer bytes.
 const readInt32 = (buffer: number[], offset: number) => {
-  return (buffer[offset + 0] * 16777216) +
-    (buffer[offset + 1] << 16) +
-    (buffer[offset + 2] << 8) +
-    buffer[offset + 3]
+  return buffer[offset + 0] * 16777216 + (buffer[offset + 1] << 16) + (buffer[offset + 2] << 8) + buffer[offset + 3]
 }
 
 export default () => toNumberString(pseudoRandom())

--- a/packages/base/src/helpers/upload.ts
+++ b/packages/base/src/helpers/upload.ts
@@ -65,34 +65,33 @@ export enum UploadStatus {
  * This handles retries as well as logging information about upload if a logger is provided in
  * the options
  */
-export const upload = (requestBuilder: RequestBuilder) => async (
-  payload: MultipartPayload,
-  opts: UploadOptions
-): Promise<UploadStatus> => {
-  opts.onUpload()
-  try {
-    await retryRequest(() => uploadMultipart(requestBuilder, payload, opts.useGzip ?? false), {
-      onRetry: opts.onRetry,
-      retries: opts.retries,
-    })
+export const upload =
+  (requestBuilder: RequestBuilder) =>
+  async (payload: MultipartPayload, opts: UploadOptions): Promise<UploadStatus> => {
+    opts.onUpload()
+    try {
+      await retryRequest(() => uploadMultipart(requestBuilder, payload, opts.useGzip ?? false), {
+        onRetry: opts.onRetry,
+        retries: opts.retries,
+      })
 
-    return UploadStatus.Success
-  } catch (error) {
-    if (opts.apiKeyValidator) {
-      // Raise an exception in case of invalid API key
-      await opts.apiKeyValidator.verifyApiKey(error)
-    }
-    if (error.response && error.response.statusText) {
-      // Rewrite error to have formatted error string
-      opts.onError(new Error(`${error.message} (${error.response.statusText})`))
-    } else {
-      // Default error handling
-      opts.onError(error)
-    }
+      return UploadStatus.Success
+    } catch (error) {
+      if (opts.apiKeyValidator) {
+        // Raise an exception in case of invalid API key
+        await opts.apiKeyValidator.verifyApiKey(error)
+      }
+      if (error.response && error.response.statusText) {
+        // Rewrite error to have formatted error string
+        opts.onError(new Error(`${error.message} (${error.response.statusText})`))
+      } else {
+        // Default error handling
+        opts.onError(error)
+      }
 
-    return UploadStatus.Failure
+      return UploadStatus.Failure
+    }
   }
-}
 
 // Dependency follows-redirects sets a default maxBodyLength of 10 MB https://github.com/follow-redirects/follow-redirects/blob/b774a77e582b97174813b3eaeb86931becba69db/index.js#L391
 // We don't want any hard limit enforced by the CLI, the backend will enforce a max size by returning 413 errors.

--- a/packages/base/src/helpers/utils.ts
+++ b/packages/base/src/helpers/utils.ts
@@ -74,7 +74,7 @@ const resolveConfigPath = ({
  */
 export const resolveConfigFromFileAndEnvironment = async <
   T extends Record<string, unknown>,
-  U extends Record<string, unknown>
+  U extends Record<string, unknown>,
 >(
   baseConfig: T,
   environment: U,

--- a/packages/datadog-ci/src/commands/coverage/__tests__/api.test.ts
+++ b/packages/datadog-ci/src/commands/coverage/__tests__/api.test.ts
@@ -24,8 +24,8 @@ describe('uploadCodeCoverageReport', () => {
     const zlibMock = jest.mocked(zlib)
 
     const mockStream = new PassThrough()
-    fsMock.createReadStream.mockReturnValueOnce((mockStream as unknown) as fs.ReadStream)
-    zlibMock.createGzip.mockReturnValueOnce((mockStream as unknown) as zlib.Gzip)
+    fsMock.createReadStream.mockReturnValueOnce(mockStream as unknown as fs.ReadStream)
+    zlibMock.createGzip.mockReturnValueOnce(mockStream as unknown as zlib.Gzip)
 
     const appendMock = jest.fn()
     const getHeadersMock = jest.fn().mockReturnValue({'Content-Type': 'multipart/form-data'})
@@ -73,8 +73,8 @@ describe('uploadCodeCoverageReport', () => {
     const zlibMock = jest.mocked(zlib)
 
     const mockStream = new PassThrough()
-    fsMock.createReadStream.mockReturnValueOnce((mockStream as unknown) as fs.ReadStream)
-    zlibMock.createGzip.mockReturnValueOnce((mockStream as unknown) as zlib.Gzip)
+    fsMock.createReadStream.mockReturnValueOnce(mockStream as unknown as fs.ReadStream)
+    zlibMock.createGzip.mockReturnValueOnce(mockStream as unknown as zlib.Gzip)
 
     const appendMock = jest.fn()
     const getHeadersMock = jest.fn().mockReturnValue({'Content-Type': 'multipart/form-data'})

--- a/packages/datadog-ci/src/commands/coverage/utils.ts
+++ b/packages/datadog-ci/src/commands/coverage/utils.ts
@@ -27,7 +27,7 @@ export const coverageFormats = [
   simplecovInternalFormat,
   cloverFormat,
 ] as const
-export type CoverageFormat = typeof coverageFormats[number]
+export type CoverageFormat = (typeof coverageFormats)[number]
 
 export const isCoverageFormat = (value: string): value is CoverageFormat => {
   return (coverageFormats as readonly string[]).includes(value)

--- a/packages/datadog-ci/src/commands/deployment/api.ts
+++ b/packages/datadog-ci/src/commands/deployment/api.ts
@@ -9,43 +9,43 @@ import {
   GateEvaluationStatusResponse,
 } from './interfaces'
 
-const requestGateEvaluation = (
-  request: (args: AxiosRequestConfig) => AxiosPromise<GateEvaluationRequestResponse>
-) => async (evaluationRequest: GateEvaluationRequest) => {
-  const payload = {
-    data: {
-      type: 'deployment_gates_evaluation_request',
-      attributes: {
-        service: evaluationRequest.service,
-        env: evaluationRequest.env,
-        identifier: evaluationRequest.identifier,
-        ...(evaluationRequest.version && {version: evaluationRequest.version}),
-        ...(evaluationRequest.apm_primary_tag && {apm_primary_tag: evaluationRequest.apm_primary_tag}),
-        ...(evaluationRequest.monitors_query_variable && {
-          monitors_query_variable: evaluationRequest.monitors_query_variable,
-        }),
+const requestGateEvaluation =
+  (request: (args: AxiosRequestConfig) => AxiosPromise<GateEvaluationRequestResponse>) =>
+  async (evaluationRequest: GateEvaluationRequest) => {
+    const payload = {
+      data: {
+        type: 'deployment_gates_evaluation_request',
+        attributes: {
+          service: evaluationRequest.service,
+          env: evaluationRequest.env,
+          identifier: evaluationRequest.identifier,
+          ...(evaluationRequest.version && {version: evaluationRequest.version}),
+          ...(evaluationRequest.apm_primary_tag && {apm_primary_tag: evaluationRequest.apm_primary_tag}),
+          ...(evaluationRequest.monitors_query_variable && {
+            monitors_query_variable: evaluationRequest.monitors_query_variable,
+          }),
+        },
       },
-    },
+    }
+
+    return request({
+      data: JSON.stringify(payload),
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      method: 'POST',
+      url: '/api/unstable/deployments/gates/evaluation',
+    })
   }
 
-  return request({
-    data: JSON.stringify(payload),
-    headers: {
-      'Content-Type': 'application/json',
-    },
-    method: 'POST',
-    url: '/api/unstable/deployments/gates/evaluation',
-  })
-}
-
-const getGateEvaluationResult = (
-  request: (args: AxiosRequestConfig) => AxiosPromise<GateEvaluationStatusResponse>
-) => async (evaluationId: string) => {
-  return request({
-    method: 'GET',
-    url: `/api/unstable/deployments/gates/evaluation/${evaluationId}`,
-  })
-}
+const getGateEvaluationResult =
+  (request: (args: AxiosRequestConfig) => AxiosPromise<GateEvaluationStatusResponse>) =>
+  async (evaluationId: string) => {
+    return request({
+      method: 'GET',
+      url: `/api/unstable/deployments/gates/evaluation/${evaluationId}`,
+    })
+  }
 
 export const apiConstructor = (baseUrl: string, apiKey: string, appKey: string): APIHelper => {
   const requestBuilder = getRequestBuilder({baseUrl, apiKey, appKey})

--- a/packages/datadog-ci/src/commands/deployment/interfaces.ts
+++ b/packages/datadog-ci/src/commands/deployment/interfaces.ts
@@ -35,7 +35,7 @@ export interface GateEvaluationStatusResponse {
           status: 'pass' | 'fail' | 'in_progress'
           reason: string
           dry_run: boolean
-        }
+        },
       ]
     }
   }

--- a/packages/datadog-ci/src/commands/dora/api.ts
+++ b/packages/datadog-ci/src/commands/dora/api.ts
@@ -7,43 +7,42 @@ import {DeploymentEvent} from './interfaces'
 export const datadogSite = process.env.DD_SITE || 'datadoghq.com'
 export const apiUrl = `https://api.${datadogSite}`
 
-export const sendDeploymentEvent = (request: (args: AxiosRequestConfig) => AxiosPromise<AxiosResponse>) => async (
-  deployment: DeploymentEvent
-) => {
-  const attrs: Record<string, any> = {
-    service: deployment.service,
-    started_at: deployment.startedAt.getTime() * 1e6, // ms to ns
-    finished_at: deployment.finishedAt.getTime() * 1e6, // ms to ns
-  }
-  if (deployment.env) {
-    attrs.env = deployment.env
-  }
-  if (deployment.version) {
-    attrs.version = deployment.version
-  }
-  if (deployment.git) {
-    attrs.git = {
-      repository_url: deployment.git.repoURL,
-      commit_sha: deployment.git.commitSHA,
+export const sendDeploymentEvent =
+  (request: (args: AxiosRequestConfig) => AxiosPromise<AxiosResponse>) => async (deployment: DeploymentEvent) => {
+    const attrs: Record<string, any> = {
+      service: deployment.service,
+      started_at: deployment.startedAt.getTime() * 1e6, // ms to ns
+      finished_at: deployment.finishedAt.getTime() * 1e6, // ms to ns
     }
-  }
-  if (deployment.team) {
-    attrs.team = deployment.team
-  }
-  if (deployment.customTags) {
-    attrs.custom_tags = deployment.customTags
-  }
+    if (deployment.env) {
+      attrs.env = deployment.env
+    }
+    if (deployment.version) {
+      attrs.version = deployment.version
+    }
+    if (deployment.git) {
+      attrs.git = {
+        repository_url: deployment.git.repoURL,
+        commit_sha: deployment.git.commitSHA,
+      }
+    }
+    if (deployment.team) {
+      attrs.team = deployment.team
+    }
+    if (deployment.customTags) {
+      attrs.custom_tags = deployment.customTags
+    }
 
-  return request({
-    method: 'POST',
-    url: 'api/v2/dora/deployment',
-    data: {
+    return request({
+      method: 'POST',
+      url: 'api/v2/dora/deployment',
       data: {
-        attributes: attrs,
+        data: {
+          attributes: attrs,
+        },
       },
-    },
-  })
-}
+    })
+  }
 
 export const apiConstructor = (apiKey: string) => {
   const requestAPI = getRequestBuilder({baseUrl: apiUrl, apiKey})

--- a/packages/datadog-ci/src/commands/gate/api.ts
+++ b/packages/datadog-ci/src/commands/gate/api.ts
@@ -6,36 +6,36 @@ import {getRequestBuilder} from '@datadog/datadog-ci-base/helpers/utils'
 
 import {EvaluationResponsePayload, Payload} from './interfaces'
 
-export const evaluateGateRules = (
-  request: (args: AxiosRequestConfig) => AxiosPromise<EvaluationResponsePayload>
-) => async (evaluateRequest: Payload, write: Writable['write']) => {
-  const payload = JSON.stringify({
-    data: {
-      id: evaluateRequest.requestId,
-      type: 'gate_evaluation',
-      attributes: {
-        tags: evaluateRequest.spanTags,
-        user_scope: evaluateRequest.userScope,
-        start_time_ms: evaluateRequest.startTimeMs,
-        options: {
-          no_wait: evaluateRequest.options.noWait,
-          dry_run: evaluateRequest.options.dryRun,
-          is_last_retry: evaluateRequest.options.isLastRetry,
-          pull_request_sha: evaluateRequest.options.pull_request_sha,
+export const evaluateGateRules =
+  (request: (args: AxiosRequestConfig) => AxiosPromise<EvaluationResponsePayload>) =>
+  async (evaluateRequest: Payload, write: Writable['write']) => {
+    const payload = JSON.stringify({
+      data: {
+        id: evaluateRequest.requestId,
+        type: 'gate_evaluation',
+        attributes: {
+          tags: evaluateRequest.spanTags,
+          user_scope: evaluateRequest.userScope,
+          start_time_ms: evaluateRequest.startTimeMs,
+          options: {
+            no_wait: evaluateRequest.options.noWait,
+            dry_run: evaluateRequest.options.dryRun,
+            is_last_retry: evaluateRequest.options.isLastRetry,
+            pull_request_sha: evaluateRequest.options.pull_request_sha,
+          },
         },
       },
-    },
-  })
+    })
 
-  return request({
-    data: payload,
-    headers: {
-      'Content-Type': 'application/json',
-    },
-    method: 'POST',
-    url: '/api/v2/quality-gates/evaluate',
-  })
-}
+    return request({
+      data: payload,
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      method: 'POST',
+      url: '/api/v2/quality-gates/evaluate',
+    })
+  }
 
 export const apiConstructor = (baseIntakeUrl: string, apiKey: string, appKey: string) => {
   const serviceRequest = getRequestBuilder({baseUrl: baseIntakeUrl, apiKey, appKey})

--- a/packages/datadog-ci/src/commands/gate/evaluate.ts
+++ b/packages/datadog-ci/src/commands/gate/evaluate.ts
@@ -221,9 +221,12 @@ export class GateEvaluateCommand extends Command {
           if (response.data.data.attributes.status === 'wait') {
             this.context.stdout.write(renderWaiting())
             const waitTime = response.data.data.attributes.metadata?.wait_time_ms ?? 0
-            setTimeout(() => {
-              reject(new Error('wait'))
-            }, Math.min(remainingWait, waitTime))
+            setTimeout(
+              () => {
+                reject(new Error('wait'))
+              },
+              Math.min(remainingWait, waitTime)
+            )
           } else {
             resolve(response)
           }
@@ -234,9 +237,12 @@ export class GateEvaluateCommand extends Command {
 
             return
           }
-          setTimeout(() => {
-            reject(err)
-          }, Math.min(remainingWait, this.getDelay(attempt ?? 1)))
+          setTimeout(
+            () => {
+              reject(err)
+            },
+            Math.min(remainingWait, this.getDelay(attempt ?? 1))
+          )
         })
     })
   }

--- a/packages/datadog-ci/src/commands/git-metadata/library.ts
+++ b/packages/datadog-ci/src/commands/git-metadata/library.ts
@@ -101,14 +101,13 @@ const uploadToSrcmapTrack = async (apiKey: string, datadogSite: string, payload:
   }
 }
 
-export const uploadRepository = (
-  requestBuilder: RequestBuilder,
-  libraryVersion: string
-): ((commitInfo: CommitInfo, opts: UploadOptions) => Promise<UploadStatus>) => async (
-  commitInfo: CommitInfo,
-  opts: UploadOptions
-) => {
-  const payload = commitInfo.asMultipartPayload(libraryVersion)
+export const uploadRepository =
+  (
+    requestBuilder: RequestBuilder,
+    libraryVersion: string
+  ): ((commitInfo: CommitInfo, opts: UploadOptions) => Promise<UploadStatus>) =>
+  async (commitInfo: CommitInfo, opts: UploadOptions) => {
+    const payload = commitInfo.asMultipartPayload(libraryVersion)
 
-  return upload(requestBuilder)(payload, opts)
-}
+    return upload(requestBuilder)(payload, opts)
+  }

--- a/packages/datadog-ci/src/commands/lambda/__tests__/flare.test.ts
+++ b/packages/datadog-ci/src/commands/lambda/__tests__/flare.test.ts
@@ -268,7 +268,7 @@ describe('lambda flare', () => {
       cloudWatchLogsClientMock.on(DescribeLogStreamsCommand).rejects('Cannot retrieve log streams')
 
       await expect(
-        getLogStreamNames((cloudWatchLogsClientMock as unknown) as CloudWatchLogsClient, MOCK_LOG_GROUP)
+        getLogStreamNames(cloudWatchLogsClientMock as unknown as CloudWatchLogsClient, MOCK_LOG_GROUP)
       ).rejects.toThrow('Cannot retrieve log streams')
     })
 
@@ -308,7 +308,7 @@ describe('lambda flare', () => {
       ]
 
       const logEvents = await getLogEvents(
-        (cloudWatchLogsClientMock as unknown) as CloudWatchLogsClient,
+        cloudWatchLogsClientMock as unknown as CloudWatchLogsClient,
         MOCK_LOG_GROUP,
         MOCK_LOG_STREAM
       )
@@ -320,7 +320,7 @@ describe('lambda flare', () => {
       mockCloudWatchLogEvents(cloudWatchLogsClientMock, [])
 
       const logEvents = await getLogEvents(
-        (cloudWatchLogsClientMock as unknown) as CloudWatchLogsClient,
+        cloudWatchLogsClientMock as unknown as CloudWatchLogsClient,
         MOCK_LOG_GROUP,
         MOCK_LOG_STREAM
       )
@@ -331,7 +331,7 @@ describe('lambda flare', () => {
     it('throws error when log events cannot be retrieved', async () => {
       cloudWatchLogsClientMock.on(GetLogEventsCommand).rejects('Cannot retrieve log events')
       await expect(
-        getLogEvents((cloudWatchLogsClientMock as unknown) as CloudWatchLogsClient, MOCK_LOG_GROUP, MOCK_LOG_STREAM)
+        getLogEvents(cloudWatchLogsClientMock as unknown as CloudWatchLogsClient, MOCK_LOG_GROUP, MOCK_LOG_STREAM)
       ).rejects.toThrow('Cannot retrieve log events')
     })
 
@@ -349,7 +349,7 @@ describe('lambda flare', () => {
       cloudWatchLogsClientMock.send = sendMock
 
       const logEventsResult = await getLogEvents(
-        (cloudWatchLogsClientMock as unknown) as CloudWatchLogsClient,
+        cloudWatchLogsClientMock as unknown as CloudWatchLogsClient,
         MOCK_LOG_GROUP,
         MOCK_LOG_STREAM,
         mockStartTime,

--- a/packages/datadog-ci/src/commands/lambda/__tests__/functions/commons.test.ts
+++ b/packages/datadog-ci/src/commands/lambda/__tests__/functions/commons.test.ts
@@ -320,11 +320,12 @@ describe('commons', () => {
     ;(fs.readFile as any).mockImplementation((a: any, b: any, callback: any) => callback({code: 'ENOENT'}))
 
     test('returns credentials when `fromNodeProviderChain` returns a succesful promise', async () => {
-      ;(fromNodeProviderChain as any).mockImplementation(() => () =>
-        Promise.resolve({
-          accessKeyId: mockAwsAccessKeyId,
-          secretAccessKey: mockAwsSecretAccessKey,
-        })
+      ;(fromNodeProviderChain as any).mockImplementation(
+        () => () =>
+          Promise.resolve({
+            accessKeyId: mockAwsAccessKeyId,
+            secretAccessKey: mockAwsSecretAccessKey,
+          })
       )
 
       const credentials = await getAWSCredentials()

--- a/packages/datadog-ci/src/commands/react-native/interfaces.ts
+++ b/packages/datadog-ci/src/commands/react-native/interfaces.ts
@@ -131,4 +131,4 @@ export interface GitData {
 
 export const RN_SUPPORTED_PLATFORMS = ['ios', 'android'] as const
 // Notice that the array and type can have the same name if you want
-export type RNPlatform = typeof RN_SUPPORTED_PLATFORMS[number]
+export type RNPlatform = (typeof RN_SUPPORTED_PLATFORMS)[number]

--- a/packages/datadog-ci/src/commands/sbom/api.ts
+++ b/packages/datadog-ci/src/commands/sbom/api.ts
@@ -21,29 +21,28 @@ export const getApiHelper = (
    * function used to marshall and send the data
    * @param request - the AXIOS element used to send the request
    */
-  const uploadSBomPayload = (request: (args: AxiosRequestConfig) => AxiosPromise<AxiosResponse>) => async (
-    scaPayload: ScaRequest
-  ) => {
-    // Make sure we follow the API signature
-    const payload = {
-      data: {
-        type: 'scarequests',
-        attributes: scaPayload,
-      },
-    }
+  const uploadSBomPayload =
+    (request: (args: AxiosRequestConfig) => AxiosPromise<AxiosResponse>) => async (scaPayload: ScaRequest) => {
+      // Make sure we follow the API signature
+      const payload = {
+        data: {
+          type: 'scarequests',
+          attributes: scaPayload,
+        },
+      }
 
-    return request({
-      data: JSON.stringify(payload),
-      headers: {
-        [CONTENT_TYPE_HEADER]: CONTENT_TYPE_VALUE_JSON,
-        'DD-EVP-ORIGIN': 'datadog-ci',
-        'DD-EVP-ORIGIN-VERSION': '0.0.1',
-      },
-      maxBodyLength,
-      method: METHOD_POST,
-      url: API_ENDPOINT,
-    })
-  }
+      return request({
+        data: JSON.stringify(payload),
+        headers: {
+          [CONTENT_TYPE_HEADER]: CONTENT_TYPE_VALUE_JSON,
+          'DD-EVP-ORIGIN': 'datadog-ci',
+          'DD-EVP-ORIGIN-VERSION': '0.0.1',
+        },
+        maxBodyLength,
+        method: METHOD_POST,
+        url: API_ENDPOINT,
+      })
+    }
 
   // Get the intake name
   const url = getBaseUrl()

--- a/packages/datadog-ci/src/commands/trace/api.ts
+++ b/packages/datadog-ci/src/commands/trace/api.ts
@@ -8,21 +8,20 @@ import {Payload} from './interfaces'
 // We don't want any hard limit enforced by the CLI, the backend will enforce a max size by returning 413 errors.
 const maxBodyLength = Infinity
 
-export const reportCustomSpan = (request: (args: AxiosRequestConfig) => AxiosPromise<AxiosResponse>) => async (
-  customSpan: Payload
-) => {
-  return request({
-    data: {
+export const reportCustomSpan =
+  (request: (args: AxiosRequestConfig) => AxiosPromise<AxiosResponse>) => async (customSpan: Payload) => {
+    return request({
       data: {
-        type: 'ci_app_custom_span',
-        attributes: customSpan,
+        data: {
+          type: 'ci_app_custom_span',
+          attributes: customSpan,
+        },
       },
-    },
-    maxBodyLength,
-    method: 'POST',
-    url: '/api/intake/ci/custom_spans',
-  })
-}
+      maxBodyLength,
+      method: 'POST',
+      url: '/api/intake/ci/custom_spans',
+    })
+  }
 
 export const apiConstructor = (baseUrl: string, apiKey: string) => {
   const requestIntake = getRequestBuilder({baseUrl, apiKey})

--- a/packages/datadog-ci/src/commands/trace/interfaces.ts
+++ b/packages/datadog-ci/src/commands/trace/interfaces.ts
@@ -11,7 +11,7 @@ export const SUPPORTED_PROVIDERS = [
   CI_ENGINES.AZURE,
   CI_ENGINES.BUILDKITE,
 ] as const
-export type Provider = typeof SUPPORTED_PROVIDERS[number]
+export type Provider = (typeof SUPPORTED_PROVIDERS)[number]
 
 export interface Payload {
   ci_provider: string

--- a/packages/plugin-synthetics/src/__tests__/api.test.ts
+++ b/packages/plugin-synthetics/src/__tests__/api.test.ts
@@ -41,10 +41,10 @@ describe('dd-api', () => {
     {
       test_type: 'api',
       test: API_TEST as RecursivePartial<Test>,
-      result: ({
+      result: {
         id: RESULT_ID,
         finished_at: 0,
-      } as unknown) as ServerResult,
+      } as unknown as ServerResult,
       resultID: RESULT_ID,
     },
   ]

--- a/packages/plugin-synthetics/src/__tests__/reporters/default.test.ts
+++ b/packages/plugin-synthetics/src/__tests__/reporters/default.test.ts
@@ -223,7 +223,7 @@ describe('Default reporter', () => {
         },
       }
 
-      const ttyReporter = new DefaultReporter((ttyContext as unknown) as {context: CommandContext})
+      const ttyReporter = new DefaultReporter(ttyContext as unknown as {context: CommandContext})
 
       clearLine.mockClear()
       ttyReporter.testsWait([getApiTest('aaa-aaa-aaa'), getApiTest('bbb-bbb-bbb')], MOCK_BASE_URL, '123')

--- a/packages/plugin-synthetics/src/__tests__/reporters/junit.test.ts
+++ b/packages/plugin-synthetics/src/__tests__/reporters/junit.test.ts
@@ -36,7 +36,7 @@ const globalSummaryMock = getSummary()
 describe('Junit reporter', () => {
   const writeMock: Writable['write'] = jest.fn()
   const commandMock: Args = {
-    context: ({stdout: {write: writeMock}} as unknown) as CommandContext,
+    context: {stdout: {write: writeMock}} as unknown as CommandContext,
     jUnitReport: 'junit',
     runName: 'Custom run name',
   }
@@ -390,7 +390,7 @@ describe('Junit reporter', () => {
 describe('GitLab test report compatibility', () => {
   const writeMock: Writable['write'] = jest.fn()
   const commandMock: Args = {
-    context: ({stdout: {write: writeMock}} as unknown) as CommandContext,
+    context: {stdout: {write: writeMock}} as unknown as CommandContext,
     jUnitReport: 'junit',
     runName: 'Custom run name',
   }
@@ -547,9 +547,8 @@ describe('GitLab test report compatibility', () => {
       ''
     )
 
-    const [testCaseSkipped, testCaseBlocking, testCaseNonBlocking, testCasePassed] = reporter[
-      'json'
-    ].testsuites.testsuite[0].testcase
+    const [testCaseSkipped, testCaseBlocking, testCaseNonBlocking, testCasePassed] =
+      reporter['json'].testsuites.testsuite[0].testcase
 
     expect(getStatusIcon(testCaseSkipped)).toBe('⏩')
     expect(getStatusIcon(testCaseBlocking)).toBe('❌')

--- a/packages/plugin-synthetics/src/__tests__/run-tests-lib.test.ts
+++ b/packages/plugin-synthetics/src/__tests__/run-tests-lib.test.ts
@@ -52,7 +52,7 @@ describe('run-test', () => {
 
       const apiHelper = {}
 
-      jest.spyOn(api, 'getApiHelper').mockImplementation(() => ({} as any))
+      jest.spyOn(api, 'getApiHelper').mockImplementation(() => ({}) as any)
 
       await expect(
         runTests.executeTests(mockReporter, {
@@ -85,7 +85,7 @@ describe('run-test', () => {
 
       const apiHelper = {}
 
-      jest.spyOn(api, 'getApiHelper').mockImplementation(() => ({} as any))
+      jest.spyOn(api, 'getApiHelper').mockImplementation(() => ({}) as any)
       await expect(
         runTests.executeTests(mockReporter, {
           ...ciConfig,
@@ -118,7 +118,7 @@ describe('run-test', () => {
       const apiHelper = {}
       const configOverride = {executionRule: ExecutionRule.SKIPPED}
 
-      jest.spyOn(api, 'getApiHelper').mockImplementation(() => ({} as any))
+      jest.spyOn(api, 'getApiHelper').mockImplementation(() => ({}) as any)
       await expect(
         runTests.executeTests(mockReporter, {
           ...ciConfig,
@@ -531,7 +531,7 @@ describe('run-test', () => {
             getSyntheticsOrgSettings: () => ({
               onDemandConcurrencyCap: 1,
             }),
-          } as any)
+          }) as any
       )
       jest.spyOn(runTests, 'executeTests').mockReturnValue(Promise.resolve({results: [], summary: {} as Summary}))
       jest.spyOn(utils, 'renderResults').mockImplementation(jest.fn())

--- a/packages/plugin-synthetics/src/__tests__/tunnel/tunnel.test.ts
+++ b/packages/plugin-synthetics/src/__tests__/tunnel/tunnel.test.ts
@@ -53,7 +53,7 @@ describe('Tunnel', () => {
         ({
           close: mockClose,
           connect: mockConnect,
-        } as any)
+        }) as any
     )
 
     const websocketConnectError = new Error('Error when connecting over WebSocket!')

--- a/packages/plugin-synthetics/src/api.ts
+++ b/packages/plugin-synthetics/src/api.ts
@@ -40,7 +40,10 @@ interface BackendError {
 }
 
 export class EndpointError extends Error {
-  constructor(public message: string, public status: number) {
+  constructor(
+    public message: string,
+    public status: number
+  ) {
     super(message)
     Object.setPrototypeOf(this, EndpointError.prototype)
   }
@@ -107,157 +110,147 @@ const triggerTests = (request: (args: AxiosRequestConfig) => AxiosPromise<Server
   return resp.data
 }
 
-const getTest = (request: (args: AxiosRequestConfig) => AxiosPromise<ServerTest>) => async (
-  testId: string,
-  testType?: string
-) => {
-  const resp = await retryRequest(
-    {
-      url: !!testType ? `/synthetics/tests/${testType}/${testId}` : `/synthetics/tests/${testId}`,
-    },
-    request,
-    {retryOn429: true}
-  )
-
-  return resp.data
-}
-
-const getTestVersion = (request: (args: AxiosRequestConfig) => AxiosPromise<void>) => async (
-  testId: string,
-  version: number
-) => {
-  await retryRequest(
-    {
-      url: `/synthetics/tests/${testId}/version_history/${version}?only_check_existence=true`,
-    },
-    request,
-    {retryOn429: true}
-  )
-}
-
-const getLocalTestDefinition = (request: (args: AxiosRequestConfig) => AxiosPromise<LocalTestDefinition>) => async (
-  testId: string,
-  testType?: string
-) => {
-  const resp = await retryRequest(
-    {
-      params: {
-        format: 'ltd',
+const getTest =
+  (request: (args: AxiosRequestConfig) => AxiosPromise<ServerTest>) => async (testId: string, testType?: string) => {
+    const resp = await retryRequest(
+      {
+        url: !!testType ? `/synthetics/tests/${testType}/${testId}` : `/synthetics/tests/${testId}`,
       },
-      url: !!testType ? `/synthetics/tests/${testType}/${testId}` : `/synthetics/tests/${testId}`,
-    },
-    request,
-    {retryOn429: true}
-  )
+      request,
+      {retryOn429: true}
+    )
 
-  return resp.data
-}
-
-const editTest = (request: (args: AxiosRequestConfig) => AxiosPromise<void>) => async (
-  testId: string,
-  data: ServerTest
-) => {
-  await retryRequest(
-    {
-      data,
-      method: 'PUT',
-      url: `/synthetics/tests/${testId}`,
-    },
-    request,
-    {retryOn429: true}
-  )
-}
-
-const searchTests = (request: (args: AxiosRequestConfig) => AxiosPromise<TestSearchResult>) => async (
-  query: string
-) => {
-  const resp = await retryRequest(
-    {
-      params: {
-        // Search for one more test than limit to detect if too many tests are returned
-        count: MAX_TESTS_TO_TRIGGER + 1,
-        text: query,
-      },
-      url: '/synthetics/tests/search',
-    },
-    request
-  )
-
-  return resp.data
-}
-
-const getSyntheticsOrgSettings = (
-  request: (args: AxiosRequestConfig) => AxiosPromise<SyntheticsOrgSettings>
-) => async () => {
-  const resp = await retryRequest(
-    {
-      url: '/synthetics/settings',
-    },
-    request
-  )
-
-  return resp.data
-}
-
-const getBatch = (request: (args: AxiosRequestConfig) => AxiosPromise<{data: ServerBatch}>) => async (
-  batchId: string
-): Promise<Batch> => {
-  const resp = await retryRequest({url: `/synthetics/ci/batch/${batchId}`}, request, {
-    retryOn404: true,
-    retryOn429: true,
-  })
-
-  const serverBatch = resp.data.data
-
-  return {
-    results: serverBatch.results.filter((r) => r.status !== 'skipped' || r.selective_rerun) as Batch['results'],
-    status: serverBatch.status,
+    return resp.data
   }
-}
 
-const pollResults = (request: (args: AxiosRequestConfig) => AxiosPromise<RawPollResult>) => async (
-  resultIds: string[]
-) => {
-  const resp = await retryRequest(
-    {
-      params: {
-        result_ids: JSON.stringify(resultIds),
+const getTestVersion =
+  (request: (args: AxiosRequestConfig) => AxiosPromise<void>) => async (testId: string, version: number) => {
+    await retryRequest(
+      {
+        url: `/synthetics/tests/${testId}/version_history/${version}?only_check_existence=true`,
       },
-      url: '/synthetics/tests/poll_results',
-    },
-    request,
-    {retryOn404: true, retryOn429: true}
-  )
+      request,
+      {retryOn429: true}
+    )
+  }
 
-  const includedTestsByID = new Map<string, RawPollResultTest>()
-  resp.data.included?.forEach((r) => {
-    if (r.type === 'test') {
-      const test = {
-        id: r.id,
-        ...r.attributes,
+const getLocalTestDefinition =
+  (request: (args: AxiosRequestConfig) => AxiosPromise<LocalTestDefinition>) =>
+  async (testId: string, testType?: string) => {
+    const resp = await retryRequest(
+      {
+        params: {
+          format: 'ltd',
+        },
+        url: !!testType ? `/synthetics/tests/${testType}/${testId}` : `/synthetics/tests/${testId}`,
+      },
+      request,
+      {retryOn429: true}
+    )
+
+    return resp.data
+  }
+
+const editTest =
+  (request: (args: AxiosRequestConfig) => AxiosPromise<void>) => async (testId: string, data: ServerTest) => {
+    await retryRequest(
+      {
+        data,
+        method: 'PUT',
+        url: `/synthetics/tests/${testId}`,
+      },
+      request,
+      {retryOn429: true}
+    )
+  }
+
+const searchTests =
+  (request: (args: AxiosRequestConfig) => AxiosPromise<TestSearchResult>) => async (query: string) => {
+    const resp = await retryRequest(
+      {
+        params: {
+          // Search for one more test than limit to detect if too many tests are returned
+          count: MAX_TESTS_TO_TRIGGER + 1,
+          text: query,
+        },
+        url: '/synthetics/tests/search',
+      },
+      request
+    )
+
+    return resp.data
+  }
+
+const getSyntheticsOrgSettings =
+  (request: (args: AxiosRequestConfig) => AxiosPromise<SyntheticsOrgSettings>) => async () => {
+    const resp = await retryRequest(
+      {
+        url: '/synthetics/settings',
+      },
+      request
+    )
+
+    return resp.data
+  }
+
+const getBatch =
+  (request: (args: AxiosRequestConfig) => AxiosPromise<{data: ServerBatch}>) =>
+  async (batchId: string): Promise<Batch> => {
+    const resp = await retryRequest({url: `/synthetics/ci/batch/${batchId}`}, request, {
+      retryOn404: true,
+      retryOn429: true,
+    })
+
+    const serverBatch = resp.data.data
+
+    return {
+      results: serverBatch.results.filter((r) => r.status !== 'skipped' || r.selective_rerun) as Batch['results'],
+      status: serverBatch.status,
+    }
+  }
+
+const pollResults =
+  (request: (args: AxiosRequestConfig) => AxiosPromise<RawPollResult>) => async (resultIds: string[]) => {
+    const resp = await retryRequest(
+      {
+        params: {
+          result_ids: JSON.stringify(resultIds),
+        },
+        url: '/synthetics/tests/poll_results',
+      },
+      request,
+      {retryOn404: true, retryOn429: true}
+    )
+
+    const includedTestsByID = new Map<string, RawPollResultTest>()
+    resp.data.included?.forEach((r) => {
+      if (r.type === 'test') {
+        const test = {
+          id: r.id,
+          ...r.attributes,
+        }
+        includedTestsByID.set(r.id, test)
       }
-      includedTestsByID.set(r.id, test)
-    }
-  })
+    })
 
-  const rawPollResults = resp.data.data
-  const parsedPollResults = []
-  for (const r of rawPollResults) {
-    const test = includedTestsByID.get(r.relationships.test.data.id)
-    if (!test) {
-      continue
-    }
-    const pollResult: PollResult = {
-      ...r.attributes,
-      test: parseIncludedTest(test),
-      resultID: r.id,
+    const rawPollResults = resp.data.data
+    const parsedPollResults = []
+    for (const r of rawPollResults) {
+      const test = includedTestsByID.get(r.relationships.test.data.id)
+      if (!test) {
+        continue
+      }
+      const pollResult: PollResult = {
+        ...r.attributes,
+        test: parseIncludedTest(test),
+        resultID: r.id,
+      }
+
+      parsedPollResults.push(pollResult)
     }
 
-    parsedPollResults.push(pollResult)
+    return parsedPollResults
   }
-
-  return parsedPollResults
-}
 
 const parseIncludedTest = (test: RawPollResultTest): PollResult['test'] => {
   return {
@@ -274,126 +267,127 @@ const parseIncludedTest = (test: RawPollResultTest): PollResult['test'] => {
   }
 }
 
-const getTunnelPresignedURL = (request: (args: AxiosRequestConfig) => AxiosPromise<{url: string}>) => async (
-  testIds: string[]
-) => {
-  const resp = await retryRequest(
-    {
-      params: {
-        test_id: testIds,
-      },
-      paramsSerializer: (params) => stringify(params),
-      url: '/synthetics/ci/tunnel',
-    },
-    request
-  )
-
-  return resp.data
-}
-
-const getMobileApplicationPresignedURLs = (
-  request: (args: AxiosRequestConfig) => AxiosPromise<MultipartPresignedUrlsResponse>
-) => async (
-  applicationId: string,
-  appSize: number,
-  parts: MobileApplicationUploadPart[]
-): Promise<MultipartPresignedUrlsResponse> => {
-  const partForRequest = (part: MobileApplicationUploadPart) => ({
-    md5: part.md5,
-    partNumber: part.partNumber,
-  })
-
-  const resp = await retryRequest(
-    {
-      data: {
-        appSize,
-        parts: parts.map(partForRequest),
-      },
-      method: 'POST',
-      url: `/synthetics/mobile/applications/${applicationId}/multipart-presigned-urls`,
-    },
-    request
-  )
-
-  return resp.data
-}
-
-const uploadMobileApplicationPart = (request: (args: AxiosRequestConfig) => AxiosPromise<void>) => async (
-  parts: MobileApplicationUploadPart[],
-  multipartPresignedUrlsParams: MultipartPresignedUrlsResponse['multipart_presigned_urls_params']
-): Promise<MobileApplicationUploadPartResponse[]> => {
-  const promises = Object.entries(multipartPresignedUrlsParams.urls).map(async ([partNumber, presignedUrl]) => {
+const getTunnelPresignedURL =
+  (request: (args: AxiosRequestConfig) => AxiosPromise<{url: string}>) => async (testIds: string[]) => {
     const resp = await retryRequest(
       {
-        data: parts[Number(partNumber) - 1].blob,
-        headers: {
-          'Content-MD5': parts[Number(partNumber) - 1].md5,
-          // Presigned URL *requires* unset content-type since it's used for signature
-          // We can clear axios default by setting to null
-          // https://github.com/axios/axios/pull/1845
-          // eslint-disable-next-line no-null/no-null
-          'Content-Type': null,
+        params: {
+          test_id: testIds,
         },
-        maxBodyLength: Infinity,
-        maxContentLength: Infinity,
-        method: 'PUT',
-        url: presignedUrl,
+        paramsSerializer: (params) => stringify(params),
+        url: '/synthetics/ci/tunnel',
       },
       request
     )
 
-    // Azure part-upload does not return ETag headers, so our backend ignores it for Azure
-    const quotedEtag = isAzureUrl(presignedUrl) ? '' : (resp.headers.etag as string)
+    return resp.data
+  }
 
-    return {
-      ETag: quotedEtag.replace(/"/g, ''),
-      PartNumber: Number(partNumber),
-    }
-  })
+const getMobileApplicationPresignedURLs =
+  (request: (args: AxiosRequestConfig) => AxiosPromise<MultipartPresignedUrlsResponse>) =>
+  async (
+    applicationId: string,
+    appSize: number,
+    parts: MobileApplicationUploadPart[]
+  ): Promise<MultipartPresignedUrlsResponse> => {
+    const partForRequest = (part: MobileApplicationUploadPart) => ({
+      md5: part.md5,
+      partNumber: part.partNumber,
+    })
 
-  return Promise.all(promises)
-}
-
-export const completeMultipartMobileApplicationUpload = (
-  request: (args: AxiosRequestConfig) => AxiosPromise<{job_id: string}>
-) => async (
-  applicationId: string,
-  uploadId: string,
-  key: string,
-  uploadPartResponses: MobileApplicationUploadPartResponse[],
-  newVersionParams?: MobileApplicationNewVersionParams
-): Promise<string> => {
-  const resp = await retryRequest(
-    {
-      data: {
-        key,
-        newVersionParams,
-        parts: uploadPartResponses,
-        uploadId,
-        validateMode: newVersionParams ? 'validate-and-persist' : 'validate-only',
+    const resp = await retryRequest(
+      {
+        data: {
+          appSize,
+          parts: parts.map(partForRequest),
+        },
+        method: 'POST',
+        url: `/synthetics/mobile/applications/${applicationId}/multipart-presigned-urls`,
       },
-      method: 'POST',
-      url: `/synthetics/mobile/applications/${applicationId}/multipart-upload-complete`,
-    },
-    request
-  )
+      request
+    )
 
-  return resp.data.job_id
-}
+    return resp.data
+  }
 
-export const pollMobileApplicationUploadResponse = (
-  request: (args: AxiosRequestConfig) => AxiosPromise<MobileAppUploadResult>
-) => async (jobId: string): Promise<MobileAppUploadResult> => {
-  const response = await retryRequest(
-    {
-      method: 'GET',
-      url: `/synthetics/mobile/applications/validation-job-status/${jobId}`,
-    },
-    request
-  )
+const uploadMobileApplicationPart =
+  (request: (args: AxiosRequestConfig) => AxiosPromise<void>) =>
+  async (
+    parts: MobileApplicationUploadPart[],
+    multipartPresignedUrlsParams: MultipartPresignedUrlsResponse['multipart_presigned_urls_params']
+  ): Promise<MobileApplicationUploadPartResponse[]> => {
+    const promises = Object.entries(multipartPresignedUrlsParams.urls).map(async ([partNumber, presignedUrl]) => {
+      const resp = await retryRequest(
+        {
+          data: parts[Number(partNumber) - 1].blob,
+          headers: {
+            'Content-MD5': parts[Number(partNumber) - 1].md5,
+            // Presigned URL *requires* unset content-type since it's used for signature
+            // We can clear axios default by setting to null
+            // https://github.com/axios/axios/pull/1845
+            // eslint-disable-next-line no-null/no-null
+            'Content-Type': null,
+          },
+          maxBodyLength: Infinity,
+          maxContentLength: Infinity,
+          method: 'PUT',
+          url: presignedUrl,
+        },
+        request
+      )
 
-  return response.data
-}
+      // Azure part-upload does not return ETag headers, so our backend ignores it for Azure
+      const quotedEtag = isAzureUrl(presignedUrl) ? '' : (resp.headers.etag as string)
+
+      return {
+        ETag: quotedEtag.replace(/"/g, ''),
+        PartNumber: Number(partNumber),
+      }
+    })
+
+    return Promise.all(promises)
+  }
+
+export const completeMultipartMobileApplicationUpload =
+  (request: (args: AxiosRequestConfig) => AxiosPromise<{job_id: string}>) =>
+  async (
+    applicationId: string,
+    uploadId: string,
+    key: string,
+    uploadPartResponses: MobileApplicationUploadPartResponse[],
+    newVersionParams?: MobileApplicationNewVersionParams
+  ): Promise<string> => {
+    const resp = await retryRequest(
+      {
+        data: {
+          key,
+          newVersionParams,
+          parts: uploadPartResponses,
+          uploadId,
+          validateMode: newVersionParams ? 'validate-and-persist' : 'validate-only',
+        },
+        method: 'POST',
+        url: `/synthetics/mobile/applications/${applicationId}/multipart-upload-complete`,
+      },
+      request
+    )
+
+    return resp.data.job_id
+  }
+
+export const pollMobileApplicationUploadResponse =
+  (request: (args: AxiosRequestConfig) => AxiosPromise<MobileAppUploadResult>) =>
+  async (jobId: string): Promise<MobileAppUploadResult> => {
+    const response = await retryRequest(
+      {
+        method: 'GET',
+        url: `/synthetics/mobile/applications/validation-job-status/${jobId}`,
+      },
+      request
+    )
+
+    return response.data
+  }
 
 const retryWithJitter = (delay: number = DELAY_BETWEEN_429_RETRIES) => delay + Math.floor(Math.random() * delay)
 

--- a/packages/plugin-synthetics/src/build-and-test.ts
+++ b/packages/plugin-synthetics/src/build-and-test.ts
@@ -50,7 +50,7 @@ type File =
     }
 
 const routeVerbs = ['get', 'post', 'put', 'patch', 'delete'] as const
-type RouteVerb = typeof routeVerbs[number]
+type RouteVerb = (typeof routeVerbs)[number]
 const isRouteVerb = (verb: string): verb is RouteVerb => {
   return routeVerbs.includes(verb as RouteVerb)
 }
@@ -110,43 +110,42 @@ const prepareFile = async (root = process.cwd(), builds: ReportedBuild[], reques
   }
 }
 
-const getRequestHandler = ({builds, root, routes}: RequestHandlerOptions) => async (
-  req: http.IncomingMessage,
-  res: http.ServerResponse
-) => {
-  try {
-    // Handle routes.
-    const route = routes?.[req.url || '/']
-    if (route) {
-      const verb = req.method?.toLowerCase() ?? ''
-      if (isRouteVerb(verb)) {
-        const handler = route[verb]
-        if (handler) {
-          await handler(req, res)
+const getRequestHandler =
+  ({builds, root, routes}: RequestHandlerOptions) =>
+  async (req: http.IncomingMessage, res: http.ServerResponse) => {
+    try {
+      // Handle routes.
+      const route = routes?.[req.url || '/']
+      if (route) {
+        const verb = req.method?.toLowerCase() ?? ''
+        if (isRouteVerb(verb)) {
+          const handler = route[verb]
+          if (handler) {
+            await handler(req, res)
 
-          return
+            return
+          }
         }
       }
+
+      // Fallback to files.
+      const file = await prepareFile(root, builds, req.url || '/')
+      if (file.found) {
+        const mimeType = isMIMEType(file.ext) ? MIME_TYPES[file.ext] : MIME_TYPES.default
+        res.writeHead(200, {'Content-Type': mimeType})
+        res.end(file.content)
+
+        return
+      }
+
+      res.writeHead(404)
+      res.end()
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error)
+      res.writeHead(500, {'Content-Type': MIME_TYPES.html})
+      res.end(`Internal Server Error: ${errorMessage}`)
     }
-
-    // Fallback to files.
-    const file = await prepareFile(root, builds, req.url || '/')
-    if (file.found) {
-      const mimeType = isMIMEType(file.ext) ? MIME_TYPES[file.ext] : MIME_TYPES.default
-      res.writeHead(200, {'Content-Type': mimeType})
-      res.end(file.content)
-
-      return
-    }
-
-    res.writeHead(404)
-    res.end()
-  } catch (error) {
-    const errorMessage = error instanceof Error ? error.message : String(error)
-    res.writeHead(500, {'Content-Type': MIME_TYPES.html})
-    res.end(`Internal Server Error: ${errorMessage}`)
   }
-}
 
 const getRequestBody = async (req: http.IncomingMessage): Promise<string> => {
   const chunks: string[] = []

--- a/packages/plugin-synthetics/src/commands/__tests__/run-tests.test.ts
+++ b/packages/plugin-synthetics/src/commands/__tests__/run-tests.test.ts
@@ -101,9 +101,8 @@ describe('run-tests', () => {
           headers: toStringMap(overrideEnv.DATADOG_SYNTHETICS_OVERRIDE_HEADERS),
           locations: overrideEnv.DATADOG_SYNTHETICS_OVERRIDE_LOCATIONS.split(';'),
           mobileApplicationVersion: overrideEnv.DATADOG_SYNTHETICS_OVERRIDE_MOBILE_APPLICATION_VERSION,
-          resourceUrlSubstitutionRegexes: overrideEnv.DATADOG_SYNTHETICS_OVERRIDE_RESOURCE_URL_SUBSTITUTION_REGEXES?.split(
-            ';'
-          ),
+          resourceUrlSubstitutionRegexes:
+            overrideEnv.DATADOG_SYNTHETICS_OVERRIDE_RESOURCE_URL_SUBSTITUTION_REGEXES?.split(';'),
           retry: {
             count: toNumber(overrideEnv.DATADOG_SYNTHETICS_OVERRIDE_RETRY_COUNT)!,
             interval: toNumber(overrideEnv.DATADOG_SYNTHETICS_OVERRIDE_RETRY_INTERVAL)!,
@@ -502,9 +501,8 @@ describe('run-tests', () => {
             },
             locations: overrideEnv.DATADOG_SYNTHETICS_OVERRIDE_LOCATIONS.split(';'),
             mobileApplicationVersion: overrideEnv.DATADOG_SYNTHETICS_OVERRIDE_MOBILE_APPLICATION_VERSION,
-            resourceUrlSubstitutionRegexes: overrideEnv.DATADOG_SYNTHETICS_OVERRIDE_RESOURCE_URL_SUBSTITUTION_REGEXES?.split(
-              ';'
-            ),
+            resourceUrlSubstitutionRegexes:
+              overrideEnv.DATADOG_SYNTHETICS_OVERRIDE_RESOURCE_URL_SUBSTITUTION_REGEXES?.split(';'),
             retry: {
               count: toNumber(overrideEnv.DATADOG_SYNTHETICS_OVERRIDE_RETRY_COUNT),
               interval: toNumber(overrideEnv.DATADOG_SYNTHETICS_OVERRIDE_RETRY_INTERVAL),
@@ -898,10 +896,10 @@ describe('run-tests', () => {
       })
       const getExpectedTestsToTriggerArguments = (
         testOverrides: Partial<UserConfigOverride>
-      ): Parameters<typeof testUtils['getTestsToTrigger']> => {
+      ): Parameters<(typeof testUtils)['getTestsToTrigger']> => {
         return [
           // Parameters we care about.
-          (apiHelper as unknown) as api.APIHelper,
+          apiHelper as unknown as api.APIHelper,
           [{suite: 'Suite 1', id: 'aaa-bbb-ccc', testOverrides}],
 
           // Ignore the rest of the parameters.

--- a/packages/plugin-synthetics/src/commands/run-tests.ts
+++ b/packages/plugin-synthetics/src/commands/run-tests.ts
@@ -188,9 +188,8 @@ export class PluginCommand extends RunTestsCommand {
         headers: toStringMap(process.env.DATADOG_SYNTHETICS_OVERRIDE_HEADERS),
         locations: process.env.DATADOG_SYNTHETICS_OVERRIDE_LOCATIONS?.split(';'),
         mobileApplicationVersion: process.env.DATADOG_SYNTHETICS_OVERRIDE_MOBILE_APPLICATION_VERSION,
-        resourceUrlSubstitutionRegexes: process.env.DATADOG_SYNTHETICS_OVERRIDE_RESOURCE_URL_SUBSTITUTION_REGEXES?.split(
-          ';'
-        ),
+        resourceUrlSubstitutionRegexes:
+          process.env.DATADOG_SYNTHETICS_OVERRIDE_RESOURCE_URL_SUBSTITUTION_REGEXES?.split(';'),
         retry: Object.keys(envOverrideRetryConfig).length > 0 ? envOverrideRetryConfig : undefined,
         startUrl: process.env.DATADOG_SYNTHETICS_OVERRIDE_START_URL,
         startUrlSubstitutionRegex: process.env.DATADOG_SYNTHETICS_OVERRIDE_START_URL_SUBSTITUTION_REGEX,

--- a/packages/plugin-synthetics/src/errors.ts
+++ b/packages/plugin-synthetics/src/errors.ts
@@ -26,7 +26,10 @@ export type CriticalCiErrorCode =
 export type CiErrorCode = NonCriticalCiErrorCode | CriticalCiErrorCode
 
 export class CiError extends Error {
-  constructor(public code: CiErrorCode, message?: string) {
+  constructor(
+    public code: CiErrorCode,
+    message?: string
+  ) {
     super(message)
   }
 
@@ -39,7 +42,10 @@ export class CiError extends Error {
 }
 
 export class CriticalError extends CiError {
-  constructor(public code: CriticalCiErrorCode, message?: string) {
+  constructor(
+    public code: CriticalCiErrorCode,
+    message?: string
+  ) {
     super(code, message)
   }
 }

--- a/packages/plugin-synthetics/src/reporters/default.ts
+++ b/packages/plugin-synthetics/src/reporters/default.ts
@@ -198,11 +198,14 @@ export const renderApiRequestDescription = (
     const stepsDescription = Object.entries(
       steps
         .map((step) => step.subtype)
-        .reduce((counts, type) => {
-          counts[type] = (counts[type] || 0) + 1
+        .reduce(
+          (counts, type) => {
+            counts[type] = (counts[type] || 0) + 1
 
-          return counts
-        }, {} as {[key: string]: number})
+            return counts
+          },
+          {} as {[key: string]: number}
+        )
     )
       .map(([type, count]) => `${count} ${type.toUpperCase()} test`)
       .join(', ')

--- a/packages/plugin-synthetics/src/reporters/junit.ts
+++ b/packages/plugin-synthetics/src/reporters/junit.ts
@@ -385,9 +385,7 @@ export class JUnitReporter implements Reporter {
     }
   }
 
-  private getBrowserTestErrors(
-    step: Step
-  ): {
+  private getBrowserTestErrors(step: Step): {
     allowedErrors: XMLError[]
     browserErrors: XMLError[]
     errors: XMLError[]

--- a/packages/plugin-synthetics/src/tunnel/websocket.ts
+++ b/packages/plugin-synthetics/src/tunnel/websocket.ts
@@ -9,7 +9,10 @@ export class WebSocket extends EventEmitter {
   private keepAliveWebsocket?: Promise<void> // Artificial promise that resolves when closing and will reject in case of error
   private websocket?: WebSocketModule
 
-  constructor(private url: string, private proxyAgent: ProxyAgent | undefined) {
+  constructor(
+    private url: string,
+    private proxyAgent: ProxyAgent | undefined
+  ) {
     super()
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4934,7 +4934,7 @@ __metadata:
     eslint-plugin-prefer-arrow: "npm:^1.2.3"
     eslint-plugin-prettier: "npm:^5.5.4"
     jest: "npm:29.6.2"
-    prettier: "npm:2.0.5"
+    prettier: "npm:^3.6.2"
     rimraf: "npm:^5.0.0"
     ts-jest: "npm:29.1.1"
     ts-json-schema-generator: "npm:^2.4.0"
@@ -9100,12 +9100,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prettier@npm:2.0.5":
-  version: 2.0.5
-  resolution: "prettier@npm:2.0.5"
+"prettier@npm:^3.6.2":
+  version: 3.6.2
+  resolution: "prettier@npm:3.6.2"
   bin:
-    prettier: bin-prettier.js
-  checksum: 10/62e58e8b7a5ec8d3cb4e7576e788d6c7a81afd25845a91fef270e24ce4952212d6493b92f1ab9340ad705febc868db1f797578fcac896ee8cffb7c12b9dce36d
+    prettier: bin/prettier.cjs
+  checksum: 10/1213691706bcef1371d16ef72773c8111106c3533b660b1cc8ec158bd109cdf1462804125f87f981f23c4a3dba053b6efafda30ab0114cc5b4a725606bb9ff26
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### What and why?

This PR upgrades prettier to support the `satisfies` keyword and the `{ [K in ... as ...`}: ... }` syntax.

### How?

Upgrade `prettier` and run `prettier --write`

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
