### PR TITLE
[dep] Bump axios to `1.12.1`

### DIFF
--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -44,7 +44,7 @@
   "dependencies": {
     "@types/datadog-metrics": "0.6.1",
     "async-retry": "1.3.1",
-    "axios": "^1.11.0",
+    "axios": "^1.12.1",
     "chalk": "3.0.0",
     "clipanion": "^3.2.1",
     "datadog-metrics": "0.9.3",

--- a/packages/datadog-ci/package.json
+++ b/packages/datadog-ci/package.json
@@ -54,7 +54,7 @@
     "@smithy/util-retry": "^2.0.4",
     "ajv": "^8.12.0",
     "ajv-formats": "^2.1.1",
-    "axios": "^1.11.0",
+    "axios": "^1.12.1",
     "chalk": "3.0.0",
     "clipanion": "^3.2.1",
     "deep-object-diff": "^1.1.9",

--- a/packages/plugin-synthetics/package.json
+++ b/packages/plugin-synthetics/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@datadog/datadog-ci-base": "workspace:*",
-    "axios": "^1.11.0",
+    "axios": "^1.12.1",
     "chalk": "3.0.0",
     "debug": "^4.4.1",
     "deep-extend": "0.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1374,7 +1374,7 @@ __metadata:
     "@types/semver": "npm:^7.7.1"
     "@types/tiny-async-pool": "npm:^2.0.3"
     async-retry: "npm:1.3.1"
-    axios: "npm:^1.11.0"
+    axios: "npm:^1.12.1"
     chalk: "npm:3.0.0"
     clipanion: "npm:^3.2.1"
     datadog-metrics: "npm:0.9.3"
@@ -1408,7 +1408,7 @@ __metadata:
     "@types/sshpk": "npm:1.10.5"
     "@types/ws": "npm:7.2.9"
     "@types/xml2js": "npm:0.4.9"
-    axios: "npm:^1.11.0"
+    axios: "npm:^1.12.1"
     chalk: "npm:3.0.0"
     debug: "npm:^4.4.1"
     deep-extend: "npm:0.6.0"
@@ -1457,7 +1457,7 @@ __metadata:
     ajv-formats: "npm:^2.1.1"
     aws-sdk-client-mock: "npm:^4.1.0"
     aws-sdk-client-mock-jest: "npm:^4.1.0"
-    axios: "npm:^1.11.0"
+    axios: "npm:^1.12.1"
     chalk: "npm:3.0.0"
     clipanion: "npm:^3.2.1"
     deep-object-diff: "npm:^1.1.9"
@@ -4291,14 +4291,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios@npm:^1.11.0":
-  version: 1.11.0
-  resolution: "axios@npm:1.11.0"
+"axios@npm:^1.12.1":
+  version: 1.12.1
+  resolution: "axios@npm:1.12.1"
   dependencies:
     follow-redirects: "npm:^1.15.6"
     form-data: "npm:^4.0.4"
     proxy-from-env: "npm:^1.1.0"
-  checksum: 10/232df4af7a4e4e07baa84621b9cc4b0c518a757b4eacc7f635c0eb3642cb98dff347326739f24b891b3b4481b7b838c79a3a0c4819c9fbc1fc40232431b9c5dc
+  checksum: 10/928e88cba180a48451a7872cfd7e7072f39e3e797c69960a048eae90f456d1de44ef0d7929325939140cd4d03b06fe2ee0d29f3f4d5873b4a7584cbe6d0d3080
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### What and why?

This PR bumps `axios` to fix this vulnerability: https://github.com/DataDog/datadog-ci/security/dependabot/63

And it directly jumps to `1.12.1` to fix a build issue: https://github.com/axios/axios/pull/7020

### How?

Bump `axios`

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
