### PR TITLE
Run yarn to fix broken pipelines

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -4338,6 +4338,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"axios@npm:^1.11.0":
+  version: 1.12.2
+  resolution: "axios@npm:1.12.2"
+  dependencies:
+    follow-redirects: "npm:^1.15.6"
+    form-data: "npm:^4.0.4"
+    proxy-from-env: "npm:^1.1.0"
+  checksum: 10/886a79770594eaad76493fecf90344b567bd956240609b5dcd09bd0afe8d3e6f1ad6d3257a93a483b6192b409d4b673d9515a34619e3e3ed1b2c0ec2a83b20ba
+  languageName: node
+  linkType: hard
+
 "axios@npm:^1.12.1":
   version: 1.12.1
   resolution: "axios@npm:1.12.1"


### PR DESCRIPTION
When https://github.com/DataDog/datadog-ci/pull/1841 was merged all pipelines were green, but on `master` [they are failing](https://github.com/DataDog/datadog-ci/actions/runs/17738382739/job/50405889387).

This PR is the result of running `yarn` and committing the updated `yarn.lock` file.
