### PR TITLE
[SVLS] fix aas path mappings

### DIFF
--- a/packages/base/src/cli.ts
+++ b/packages/base/src/cli.ts
@@ -1,5 +1,7 @@
 import {CommandClass} from 'clipanion'
 
+import {InstrumentCommand as AasInstrumentCommand} from './commands/aas/instrument'
+import {UninstrumentCommand as AasUninstrumentCommand} from './commands/aas/uninstrument'
 import {UploadCommand} from './commands/git-metadata/upload'
 import {SarifUploadCommand} from './commands/sarif/upload-command'
 import {SbomUploadCommand} from './commands/sbom/upload-command'
@@ -12,5 +14,6 @@ export const baseCommands: Record<string, CommandClass[]> = {
   sarif: [SarifUploadCommand],
   sbom: [SbomUploadCommand],
   synthetics: [RunTestsCommand, DeployTestsCommand, UploadApplicationCommand, ImportTestsCommand],
+  aas: [AasInstrumentCommand, AasUninstrumentCommand],
   'git-metadata': [UploadCommand],
 }

--- a/packages/plugin-aas/src/__tests__/instrument.test.ts
+++ b/packages/plugin-aas/src/__tests__/instrument.test.ts
@@ -52,7 +52,7 @@ import {WebSiteManagementClient} from '@azure/arm-appservice'
 import {DefaultAzureCredential} from '@azure/identity'
 import {makeRunCLI} from '@datadog/datadog-ci-base/helpers/__tests__/testing-tools'
 
-import {PluginCommand as InstrumentCommand} from '../instrument'
+import {PluginCommand as InstrumentCommand} from '../commands/instrument'
 
 import {CONTAINER_WEB_APP, DEFAULT_INSTRUMENT_ARGS, DEFAULT_CONFIG, WEB_APP_ID} from './common'
 

--- a/packages/plugin-aas/src/__tests__/uninstrument.test.ts
+++ b/packages/plugin-aas/src/__tests__/uninstrument.test.ts
@@ -28,7 +28,7 @@ jest.mock('@azure/arm-appservice', () => ({
 
 import {makeRunCLI} from '@datadog/datadog-ci-base/helpers/__tests__/testing-tools'
 
-import {PluginCommand as UninstrumentCommand} from '../uninstrument'
+import {PluginCommand as UninstrumentCommand} from '../commands/uninstrument'
 
 import {CONTAINER_WEB_APP, DEFAULT_ARGS} from './common'
 

--- a/packages/plugin-aas/src/cli.ts
+++ b/packages/plugin-aas/src/cli.ts
@@ -1,4 +1,4 @@
-import {PluginCommand as InstrumentCommand} from './instrument'
-import {PluginCommand as UninstrumentCommand} from './uninstrument'
+import {PluginCommand as InstrumentCommand} from './commands/instrument'
+import {PluginCommand as UninstrumentCommand} from './commands/uninstrument'
 
 module.exports = [InstrumentCommand, UninstrumentCommand]

--- a/packages/plugin-aas/src/commands/instrument.ts
+++ b/packages/plugin-aas/src/commands/instrument.ts
@@ -22,7 +22,7 @@ import {
   SIDECAR_CONTAINER_NAME,
   SIDECAR_IMAGE,
   SIDECAR_PORT,
-} from './common'
+} from '../common'
 
 export class PluginCommand extends InstrumentCommand {
   public async execute(): Promise<0 | 1> {

--- a/packages/plugin-aas/src/commands/uninstrument.ts
+++ b/packages/plugin-aas/src/commands/uninstrument.ts
@@ -13,7 +13,7 @@ import {
   isDotnet,
   parseEnvVars,
   SIDECAR_CONTAINER_NAME,
-} from './common'
+} from '../common'
 
 export class PluginCommand extends UninstrumentCommand {
   public async execute(): Promise<0 | 1> {


### PR DESCRIPTION
### What and why?

I forgot to add aas to base `cli.ts`, so we need to do that

### How?

To do that we need to fix the path mappings by moving the command logic under the command directory in the plugin.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
