### PR TITLE
[chore] Decrease standalone binary size

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,7 +197,7 @@ jobs:
       - name: Install node
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: 20.11.0 # Use newer version to build the standalone binary
+          node-version: 22.19.0
       - run: yarn install --immutable
       - run: yarn build
       - name: Create standalone binary
@@ -206,6 +206,8 @@ jobs:
         run: yarn rimraf --glob 'packages/*/{src,dist}'
       - name: Test generated standalone binary
         run: yarn dist-standalone:test
+      - name: Compare binary sizes
+        run: yarn compare-binary-size datadog-ci_linux-x64
 
   standalone-binary-test-ubuntu-arm:
     name: Test standalone binary in ARM ubuntu
@@ -217,7 +219,7 @@ jobs:
       - name: Install node
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: 20.11.0 # Use newer version to build the standalone binary
+          node-version: 22.19.0
       - run: npm install -g yarn
         name: Install Yarn # Yarn is not installed by default in this runner
       - run: yarn install --immutable
@@ -228,6 +230,8 @@ jobs:
         run: yarn rimraf --glob 'packages/*/{src,dist}'
       - name: Test generated standalone binary
         run: yarn dist-standalone:test
+      - name: Compare binary sizes
+        run: yarn compare-binary-size datadog-ci_linux-arm64
 
   standalone-binary-test-windows:
     name: Test standalone binary in windows
@@ -237,7 +241,7 @@ jobs:
       - name: Install node
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: 20.11.0 # Use newer version to build the standalone binary
+          node-version: 22.19.0
       - run: yarn install --immutable
       - run: yarn build
       - name: Create standalone binary
@@ -246,6 +250,8 @@ jobs:
         run: yarn rimraf --glob 'packages/*/{src,dist}'
       - name: Test generated standalone binary
         run: yarn dist-standalone:test
+      - name: Compare binary sizes
+        run: yarn compare-binary-size datadog-ci_win-x64.exe
 
   standalone-binary-test-macos:
     name: Test standalone binary in macOS
@@ -257,7 +263,7 @@ jobs:
       - name: Install node
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: 20.11.0 # Use newer version to build the standalone binary
+          node-version: 22.19.0
       - run: yarn install --immutable
       - run: yarn build
       - name: Create standalone binary
@@ -266,6 +272,8 @@ jobs:
         run: yarn rimraf --glob 'packages/*/{src,dist}'
       - name: Test generated standalone binary
         run: yarn dist-standalone:test
+      - name: Compare binary sizes
+        run: yarn compare-binary-size datadog-ci_darwin-x64
 
   standalone-binary-test-macos-arm:
     name: Test standalone binary in ARM macOS
@@ -275,7 +283,7 @@ jobs:
       - name: Install node
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: 20.11.0 # Use newer version to build the standalone binary
+          node-version: 22.19.0
       - run: yarn install --immutable
       - run: yarn build
       - name: Create standalone binary
@@ -284,6 +292,8 @@ jobs:
         run: yarn rimraf --glob 'packages/*/{src,dist}'
       - name: Test generated standalone binary
         run: yarn dist-standalone:test
+      - name: Compare binary sizes
+        run: yarn compare-binary-size datadog-ci_darwin-arm64
 
   datadog-static-analyzer:
     runs-on: ubuntu-latest
@@ -324,7 +334,7 @@ jobs:
       - name: Install node
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: 20.11.0
+          node-version: 22.19.0
       # The install step has been added here such that the `.yarn/install-state.gz` file is generated. This file is used
       # by the script `check-licenses` below.
       - run: yarn install --immutable

--- a/.github/workflows/publish-prerelease.yml
+++ b/.github/workflows/publish-prerelease.yml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: 20.11.0
+          node-version: 22.19.0
       - run: |
           # Isolate the tag and exit if none found
           IFS='-' read -ra ARR_TAG <<< $TAG

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Install node
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: 20.11.0 # Use newer version to build the standalone binary
+          node-version: 22.19.0
       - name: Install project dependencies
         run: yarn install --immutable
       - name: Bundle library
@@ -86,7 +86,7 @@ jobs:
       - name: Install node
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: 20.11.0 # Use newer version to build the standalone binary
+          node-version: 22.19.0
       - run: npm install -g yarn
         name: Install Yarn # Yarn is not installed by default in this runner
       - name: Install project dependencies
@@ -122,7 +122,7 @@ jobs:
       - name: Install node
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: 20.11.0 # Use newer version to build the standalone binary
+          node-version: 22.19.0
       - name: Install project dependencies
         run: yarn install --immutable
       - name: Bundle library
@@ -158,7 +158,7 @@ jobs:
       - name: Install node
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: 20.11.0 # Use newer version to build the standalone binary
+          node-version: 22.19.0
       - name: Install project dependencies
         run: yarn install --immutable
       - name: Bundle library
@@ -192,7 +192,7 @@ jobs:
       - name: Install node
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: 20.11.0 # Use newer version to build the standalone binary
+          node-version: 22.19.0
       - name: Install project dependencies
         run: yarn install --immutable
       - name: Bundle library
@@ -227,7 +227,7 @@ jobs:
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: 20.11.0
+          node-version: 22.19.0
       - run: yarn
       - run: yarn publish:all
         env:

--- a/.yarn/patches/@yao-pkg-pkg-fetch-npm-3.5.24-3b96980136.patch
+++ b/.yarn/patches/@yao-pkg-pkg-fetch-npm-3.5.24-3b96980136.patch
@@ -1,0 +1,102 @@
+diff --git a/lib-es5/expected-shas.json b/lib-es5/expected-shas.json
+index 62cc3245a0c3c56580e069de4e40caf330a6d601..309bb600921ddd9c890137ebab621cc670925ea5 100644
+--- a/lib-es5/expected-shas.json
++++ b/lib-es5/expected-shas.json
+@@ -1,57 +1,7 @@
+ {
+-    "node-v14.21.3-alpine-arm64": "651c2b423925c9dab1ca7695acfb1462be13264f0c1fb6c8b472474c7dbacddd",
+-    "node-v14.21.3-alpine-x64": "4f2b5b16428f998302bbcf59ca229998be48e5dc6c2487edb603152651c182cd",
+-    "node-v14.21.3-linux-arm64": "bb20f63ac32c4e6a0545dfcea3833e8a8a968b95e91ce01cab7f4f48f1a56064",
+-    "node-v14.21.3-linux-x64": "4be08d8f62fc05d70d76daf1ad71aec0bdb47317e4f7b74bb0cb5ec13a137179",
+-    "node-v14.21.3-linuxstatic-arm64": "c4812bbb6829e06fa60716a55a044f11b6bf6096ebc4945d5bccf05d860cc7a8",
+-    "node-v14.21.3-linuxstatic-armv7": "7c4e47db71c4c7dbc071fd2be13ba34b324fbec28ccaa0beadc7dab74fec8d23",
+-    "node-v14.21.3-linuxstatic-x64": "22b84e0d92817432cc7e25cdb5e4d984b49415f708fc0aef13110ad194c773f1",
+-    "node-v14.21.3-macos-x64": "4b19a9555807de2119e2fb00f2ba5f04126b35afdb8264d7b2dd8e2e134fa934",
+-    "node-v14.21.3-win-arm64": "1f9d32c4693893ce4e2e8b340648a12d37cb742866b067b85402078e70151ba7",
+-    "node-v14.21.3-win-x64": "cb2a0bf3e063a2bc6b66a4894e6a57d334922c4bb3a337157764fd914d616666",
+-    "node-v14.21.3-macos-arm64": "1cdd2e5aeea38c909aba5d4565082914370d16f32ca90bb1671f3b9687c62e1d",
+-    "node-v16.20.2-alpine-arm64": "a30cc9be5472dc0f66bf859669c742c6a47f66973c82bea0e7605c357079c8d5",
+-    "node-v16.20.2-alpine-x64": "171381ff415321dede24c5883003a1c07301a4d7bf44aeb0ef4e72b7f78c3202",
+-    "node-v16.20.2-linux-arm64": "12c175838b4e76dabf67f0668dbfa0889ce80aca35a5866635a3a42664cbba22",
+-    "node-v16.20.2-linux-x64": "b8ad09f0fccf5341dc459056096aa6d413d278ca3e939e42a29e6fbaa149ca50",
+-    "node-v16.20.2-linuxstatic-arm64": "fa6ecba685dbdd0e1a1e3a9cb7db07dc558f422a0b53baf3834b855c422a2a3a",
+-    "node-v16.20.2-linuxstatic-armv7": "a8c63fb9523ad44fe59329ba02dba2936da4b9adc7d4238e7180f15031cb1cff",
+-    "node-v16.20.2-linuxstatic-x64": "1a136b7c97c56a90e48d51683ca9181e53e750928a439a88da185c0d7917e432",
+-    "node-v16.20.2-macos-x64": "cd60ba35e3305519ce4ce6398897a1c9e9e68a14c170325d9ece8d078775b3f9",
+-    "node-v16.20.2-win-arm64": "7514915e02aedfbdc9f87ede04f1f251b014e312e3e184d5b94b42aeb28c2485",
+-    "node-v16.20.2-win-x64": "272729724993ce07b37d328718a0152e50ec5c9d27aa972975c09b75604c0dca",
+-    "node-v16.20.2-macos-arm64": "3d04eb7ddd8b614b888eeb1caa6e64a068b665ab4a26dd064051973ae5842a85",
+-    "node-v18.20.8-alpine-arm64": "c7f20847fbfd765517612647593c7767331a318d2b229ddac2b4afd7d13b78d0",
+-    "node-v18.20.8-alpine-x64": "3b24c6f571681046a6ed1b42752b21a41e10e8c7ac19416b9571927cc10f4a49",
+-    "node-v18.20.8-linux-arm64": "690ed47821dfbf842a1ba40a7cd2e28344e6ad998a89f5d0eb61da3c86fcd29c",
+-    "node-v18.20.8-linux-x64": "0121b3c810db3f5e47028f0b1e2294a1a52a2aa20923c037247e39c82be0f789",
+-    "node-v18.20.8-linuxstatic-arm64": "ac03e112f9229126e62924f1fefbb44c54f5fbbb4827d5ffa6243d3b8e81dfa4",
+-    "node-v18.20.8-linuxstatic-armv7": "4c96d99319e850887d01cb63500e34f5db3b64944b3644f4ed5c94ae2be5b625",
+-    "node-v18.20.8-linuxstatic-x64": "16e25c30e3a4d03a18e21bcd41b6980c65f837425d485e3f5f68c8362bad0625",
+-    "node-v18.20.8-macos-arm64": "d3f8f8966ceb4cea5447edacda9d2f151e97e06baf21a3fcba9d7a7e8470cee9",
+-    "node-v18.20.8-macos-x64": "f2cf139bfe3501d39d22b48a069f9ceb24942b0cdc001a0bc30ea3a68fbcc6b3",
+-    "node-v18.20.8-win-arm64": "dd56454cfc9292f047413657c8b997006f27ecda8cd7f7dd38acf8d22317e743",
+-    "node-v18.20.8-win-x64": "4d45cdfbcba3de3f6c0ddcd78251179b9d04dd2fcb2dba2fb052940a2821eb39",
+-    "node-v20.19.4-alpine-arm64": "26bdc75d316a8e63f6023d419987f7e87f40899cd6f14bc320531d90cec3a2fd",
+-    "node-v20.19.4-alpine-x64": "ebf147ddef51f42184d7efd37220f4430db8aaeabc3a1420f9e395484d90f456",
+-    "node-v20.19.4-linux-arm64": "f7444ac0fd3a1b5af900e59f31d4ad0b73c5d4f0db66723b01f22ad6a0952b73",
+-    "node-v20.19.4-linux-x64": "41ef9a2b41373d5923984a323dbbe61b6729751096c61989872be6ae63972531",
+-    "node-v20.19.4-linuxstatic-arm64": "ad100cef1de4fecfe3e00aac60220c2276ad5e9feb6f7917bac2af20d633f2e3",
+-    "node-v20.19.4-linuxstatic-armv7": "09e670c1ba93bf531d9ce3ee5f7f069b9a4813732c353d477be72833ca80f6d8",
+-    "node-v20.19.4-linuxstatic-x64": "43ccf1fc68b659c20a633302d7cb7117c3f3a2ec99a73b27b3928590c768ce01",
+-    "node-v20.19.4-macos-arm64": "103917dfe9e4f106ce9c3d8f62f162a3faeb107524938a01c96fdacc182c3420",
+-    "node-v20.19.4-macos-x64": "f26530d2b3af9c7f4cf2b27a60ffbf75522c2ca08a573f6cabf2424b40783587",
+-    "node-v20.19.4-win-arm64": "d146053af54d560d5fb2890ab90595c1f3eb02f025ec491ace830353fc596008",
+-    "node-v20.19.4-win-x64": "4627b65afcd8a0abfbe616c4a7eb4cb7b81dbb52f5ccc54c8103efa34fe9a125",
+-    "node-v22.17.1-alpine-arm64": "e28a2c0cc6529e1a133485b94211602a99ff6f8bd485aea2f5d21dae9f8d30a1",
+-    "node-v22.17.1-alpine-x64": "41b3ede409b27c755e4c24d1bf071cc40f448199d98744f6c40fcebba398beff",
+-    "node-v22.17.1-linux-arm64": "2f356ceacb670010db08189a129e1c250e1d98f37fec60b492797e043a1fc696",
+-    "node-v22.17.1-linux-x64": "9702cb7019c72b2dc31f7de33a0e73fefcddade2364c59a9a22d3edb75d637b1",
+-    "node-v22.17.1-linuxstatic-arm64": "95664f11b6619d6dd905d88776aba80b6218601dde25647b552fe223a3b52484",
+-    "node-v22.17.1-linuxstatic-armv7": "69660e85e5249d6965d8e682b157f35a467730a4f2b80b0242f83e53e6c083e6",
+-    "node-v22.17.1-linuxstatic-x64": "657881fe0f18b0aecda9d63140c6c2b8b8ff7287c81826a93a90100459540b70",
+-    "node-v22.17.1-macos-arm64": "bbb0ce0747474ab4a3fb98ece79b29d7e5dc9ea72d12136a898cedbb6b7638b6",
+-    "node-v22.17.1-macos-x64": "b8ba2debbdbe9cf967f738a450ef3656c55bb13da776a206b673e1bb23437f70",
+-    "node-v22.17.1-win-arm64": "6188cdeb574a9e3de4f664d73bab0068201967245c8eb50b69b2850e1f356f8e",
+-    "node-v22.17.1-win-x64": "6974763a335f33733766805659eb039908bcab3f09a5525d59fbe9ab4ed7926a"
++    "node-v22.19.0-linux-arm64": "bf0b13343f044104e935e8c9581c1c8bbf4f70185fc49ee49a63c83be95e2b93",
++    "node-v22.19.0-linux-x64": "f51476881e6af23347b4e8e0cc56e1aeffe6641e7523f2cac9601287ab3d00b4",
++    "node-v22.19.0-macos-arm64": "83b21eb4f79caa516ac7638fcbbbedd9dd357756549dd61f69ee7d40f2d95e63",
++    "node-v22.19.0-macos-x64": "fb493dbaced86bc65b19e04b5a325c89f470bc318720b0ab505a00cbb80ec039",
++    "node-v22.19.0-win-x64": "8440fe844868085dce1eb363b819c982f56f650e789fd04aa8213ce9968f07c4"
+ }
+\ No newline at end of file
+diff --git a/lib-es5/index.js b/lib-es5/index.js
+index f9b35abdd8c2be426df193885da5cb538b77f4e6..8177990218c4d10e66bcba768cd4af85292212f3 100644
+--- a/lib-es5/index.js
++++ b/lib-es5/index.js
+@@ -84,7 +84,7 @@ function download(_a, local) {
+         return __generator(this, function (_c) {
+             switch (_c.label) {
+                 case 0:
+-                    url = "https://github.com/yao-pkg/pkg-fetch/releases/download/".concat(tag, "/").concat(name);
++                    url = "https://github.com/Drarig29/pkg-fetch/releases/download/".concat(tag, "/").concat(name);
+                     _c.label = 1;
+                 case 1:
+                     _c.trys.push([1, 4, , 5]);
+@@ -123,7 +123,7 @@ function exists(file) {
+     });
+ }
+ function satisfyingNodeVersion(nodeRange) {
+-    var versions = Object.keys(patches_json_1.default)
++    var versions = ['v22.19.0']
+         .filter(function (nv) { return semver_1.default.satisfies(nv, nodeRange) || nodeRange === 'latest'; })
+         .sort(function (nv1, nv2) { return (semver_1.default.gt(nv1, nv2) ? 1 : -1); });
+     var nodeVersion = versions.pop();
+diff --git a/package.json b/package.json
+index af50b3c6c776b8b4ad4365235f567d48a625969e..690a8c9bdf7a6b734d22e83d0f675f4fe1918ccc 100644
+--- a/package.json
++++ b/package.json
+@@ -1,6 +1,6 @@
+ {
+   "name": "@yao-pkg/pkg-fetch",
+-  "version": "3.5.24",
++  "version": "1.0.0",
+   "description": "Compiles and stores base binaries for pkg",
+   "main": "lib-es5/index.js",
+   "license": "MIT",

--- a/.yarn/patches/@yao-pkg-pkg-npm-6.6.0-d4777368b9.patch
+++ b/.yarn/patches/@yao-pkg-pkg-npm-6.6.0-d4777368b9.patch
@@ -1,0 +1,46 @@
+diff --git a/lib-es5/index.js b/lib-es5/index.js
+index 17ad9d3ff875433ff3b813c82106349bbd1fb7cc..ecc0815f56fa1710c1078418b8a8378d8a8a5272 100644
+--- a/lib-es5/index.js
++++ b/lib-es5/index.js
+@@ -398,13 +398,6 @@ async function exec(argv2) {
+             }
+         }
+     }
+-    if (argv.sea) {
+-        await (0, sea_1.default)(inputFin, {
+-            targets,
+-            signature: argv.signature,
+-        });
+-        return;
+-    }
+     // fetch targets
+     const { bytecode } = argv;
+     const nativeBuild = argv['native-build'];
+@@ -447,6 +440,13 @@ async function exec(argv2) {
+             }
+         }
+     }
++    if (argv.sea) {
++        await (0, sea_1.default)(inputFin, {
++            targets,
++            signature: argv.signature,
++        });
++        return;
++    }
+     // marker
+     let marker;
+     if (configJson) {
+diff --git a/lib-es5/sea.js b/lib-es5/sea.js
+index 181835978c61f4ece50cacd50aec0ce2ae544a48..fd02b9440ab3946bcdf02fdb3867c585762bda03 100644
+--- a/lib-es5/sea.js
++++ b/lib-es5/sea.js
+@@ -176,6 +176,9 @@ async function getNodejsExecutable(target, opts) {
+     }
+     const os = getNodeOs(target.platform);
+     const arch = getNodeArch(target.arch);
++    if (target.fabricator) {
++        return target.fabricator.binaryPath;
++    }
+     const nodeVersion = await getNodeVersion(os, arch, target.nodeRange.replace('node', ''));
+     const fileName = `node-${nodeVersion}-${os}-${arch}.${os === 'win' ? 'zip' : 'tar.gz'}`;
+     let url;

--- a/bin/compare-binary-size.js
+++ b/bin/compare-binary-size.js
@@ -1,0 +1,81 @@
+'use strict'
+
+const {execSync} = require('child_process')
+const fs = require('fs')
+const path = require('path')
+const chalk = require('chalk')
+
+const formatFileSize = (bytes) => {
+  const units = ['B', 'KB', 'MB']
+  let size = bytes
+  let unitIndex = 0
+
+  while (size >= 1024 && unitIndex < units.length - 1) {
+    size /= 1024
+    unitIndex++
+  }
+
+  return `${size.toFixed(2)} ${units[unitIndex]}`
+}
+
+const runVersion = (executablePath) => {
+  try {
+    const result = execSync(`"${executablePath}" --version`, {encoding: 'utf8', timeout: 5000})
+
+    return result.trim()
+  } catch (error) {
+    return `Error: ${error.message}`
+  }
+}
+
+console.log(chalk.bold.blue('Node.js Binary Size Comparison'))
+console.log(chalk.gray('===================================\n'))
+
+// Get Node.js binary size
+const nodePath = process.execPath
+const nodeSize = fs.statSync(nodePath).size
+
+console.log(chalk.cyan(`${chalk.bold('Current')} Node.js executable path:`), chalk.white(nodePath))
+console.log(chalk.cyan(`${chalk.bold('Current')} Node.js binary size:`), chalk.bold.magenta(formatFileSize(nodeSize)))
+
+// Run --version on Node.js binary
+console.log(chalk.yellow(`Output of --version:`), runVersion(nodePath))
+
+// Check if a file argument was provided
+const fileArg = process.argv[2]
+
+if (!fileArg) {
+  console.log(chalk.red('\nUsage: yarn compare-binary-size <filename>'))
+  process.exit(1)
+}
+
+// Get the provided file size
+const filePath = path.resolve(fileArg)
+const fileSize = fs.statSync(filePath).size
+
+console.log(chalk.cyan(`\n${chalk.bold('Given')} Node.js binary path:`), chalk.white(filePath))
+console.log(chalk.cyan(`${chalk.bold('Given')} Node.js binary size:`), chalk.bold.magenta(formatFileSize(fileSize)))
+
+// Run --version on the provided file
+console.log(chalk.yellow(`Output of --version:`), runVersion(filePath))
+
+// Compare sizes
+const ratio = fileSize / nodeSize
+console.log(chalk.bold.magenta('\nComparison:'))
+console.log(
+  chalk.white(`  ${chalk.bold('Given')} Node.js binary is ${chalk.bold(ratio.toFixed(2))}x the size of Node.js binary`)
+)
+
+if (fileSize > nodeSize) {
+  console.log(
+    chalk.red(
+      `  ${chalk.bold('Given')} Node.js binary is ${chalk.bold(formatFileSize(fileSize - nodeSize))} larger than Node.js binary`
+    )
+  )
+} else {
+  console.log(
+    chalk.green(
+      `  ${chalk.bold('Given')} Node.js binary is ${chalk.bold(formatFileSize(nodeSize - fileSize))} smaller than Node.js binary`
+    )
+  )
+}

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -104,6 +104,7 @@ export default defineConfig(
     'eslint.config.mjs',
     'packages/*/dist',
     'packages/datadog-ci/shims/injected-plugin-submodules.js',
+    'packages/datadog-ci/shims/intl-collator.js',
     'bin/*.js',
   ]),
   eslint.configs.recommended,

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -100,7 +100,12 @@ const restrictedImports = [
 ]
 
 export default defineConfig(
-  globalIgnores(['eslint.config.mjs', 'packages/*/dist', 'packages/datadog-ci/shims/injected-plugin-submodules.js']),
+  globalIgnores([
+    'eslint.config.mjs',
+    'packages/*/dist',
+    'packages/datadog-ci/shims/injected-plugin-submodules.js',
+    'bin/*.js',
+  ]),
   eslint.configs.recommended,
   tseslint.configs.recommendedTypeChecked,
   importX.flatConfigs.recommended,

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "build": "yarn tsc:build",
     "check-licenses": "node bin/check-licenses.js",
     "check-junit-upload": "node bin/check-junit-upload.js",
+    "compare-binary-size": "FORCE_COLOR=1 node bin/compare-binary-size.js",
     "clean": "rimraf --glob .eslintcache .jest-cache 'packages/*/{dist,tsconfig.tsbuildinfo}'",
     "dev": "yarn tsc:build --watch",
     "dist-standalone": "FORCE_COLOR=1 yarn workspace @datadog/datadog-ci bundle && pkg --sea --compress GZip packages/datadog-ci/dist/bundle.js",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   "devDependencies": {
     "@microsoft/eslint-formatter-sarif": "^3.1.0",
     "@stylistic/eslint-plugin": "^5.3.1",
-    "@yao-pkg/pkg": "^6.6.0",
+    "@yao-pkg/pkg": "patch:@yao-pkg/pkg@npm%3A6.6.0#~/.yarn/patches/@yao-pkg-pkg-npm-6.6.0-d4777368b9.patch",
     "dd-trace": "^5.42.0",
     "eslint": "^9.34.0",
     "eslint-config-prettier": "^10.1.8",
@@ -69,5 +69,8 @@
     "tsx": "^4.20.5",
     "typescript": "5.1.6",
     "typescript-eslint": "^8.42.0"
+  },
+  "resolutions": {
+    "@yao-pkg/pkg-fetch@npm:3.5.24": "patch:@yao-pkg/pkg-fetch@npm%3A3.5.24#~/.yarn/patches/@yao-pkg-pkg-fetch-npm-3.5.24-3b96980136.patch"
   }
 }

--- a/packages/datadog-ci/scripts/esbuild.mjs
+++ b/packages/datadog-ci/scripts/esbuild.mjs
@@ -8,7 +8,7 @@ try {
     entryPoints: ['dist/cli.js'],
     bundle: true,
     platform: 'node',
-    inject: ['shims/injected-plugin-submodules.js'],
+    inject: ['shims/injected-plugin-submodules.js', 'shims/intl-collator.js'],
     target: 'node22',
     format: 'cjs',
     outfile: 'dist/bundle.js',

--- a/packages/datadog-ci/shims/intl-collator.js
+++ b/packages/datadog-ci/shims/intl-collator.js
@@ -1,0 +1,13 @@
+// This file's syntax will look broken and your IDE will complain about it, but it's expected.
+// See: https://esbuild.github.io/api/#inject
+
+// To replace `var { compare: localeCompare } = new Intl.Collator();` in `node_modules/packageurl-js/src/strings.js`
+
+const IntlCollator = function () {
+  return {
+    // See https://nodejs.org/api/intl.html
+    compare: (a, b) => String(a).localeCompare(b),
+  }
+}
+
+export {IntlCollator as 'Intl.Collator'}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4170,7 +4170,24 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@yao-pkg/pkg@npm:^6.6.0":
+"@yao-pkg/pkg-fetch@patch:@yao-pkg/pkg-fetch@npm%3A3.5.24#~/.yarn/patches/@yao-pkg-pkg-fetch-npm-3.5.24-3b96980136.patch":
+  version: 3.5.24
+  resolution: "@yao-pkg/pkg-fetch@patch:@yao-pkg/pkg-fetch@npm%3A3.5.24#~/.yarn/patches/@yao-pkg-pkg-fetch-npm-3.5.24-3b96980136.patch::version=3.5.24&hash=49e69c"
+  dependencies:
+    https-proxy-agent: "npm:^5.0.0"
+    node-fetch: "npm:^2.6.6"
+    picocolors: "npm:^1.1.0"
+    progress: "npm:^2.0.3"
+    semver: "npm:^7.3.5"
+    tar-fs: "npm:^2.1.1"
+    yargs: "npm:^16.2.0"
+  bin:
+    pkg-fetch: lib-es5/bin.js
+  checksum: 10/5e25d31929146c5a0a091cb08f82a82c789dbf9189c9defe94c39a80780543a05b92b6bc1221481e2114478bae3b9a34e5a5c05fe68439f3426ca49415b838ad
+  languageName: node
+  linkType: hard
+
+"@yao-pkg/pkg@npm:6.6.0":
   version: 6.6.0
   resolution: "@yao-pkg/pkg@npm:6.6.0"
   dependencies:
@@ -4192,6 +4209,31 @@ __metadata:
   bin:
     pkg: lib-es5/bin.js
   checksum: 10/71793921f729c9e0d89f6a7c325d132eacd44339145182d87296a11f318fa7ebd3e79ea0c4cafb4439e81e2b4eaa73a5305501c44674075eb8cfedc7cda61bf5
+  languageName: node
+  linkType: hard
+
+"@yao-pkg/pkg@patch:@yao-pkg/pkg@npm%3A6.6.0#~/.yarn/patches/@yao-pkg-pkg-npm-6.6.0-d4777368b9.patch":
+  version: 6.6.0
+  resolution: "@yao-pkg/pkg@patch:@yao-pkg/pkg@npm%3A6.6.0#~/.yarn/patches/@yao-pkg-pkg-npm-6.6.0-d4777368b9.patch::version=6.6.0&hash=013c77"
+  dependencies:
+    "@babel/generator": "npm:^7.23.0"
+    "@babel/parser": "npm:^7.23.0"
+    "@babel/types": "npm:^7.23.0"
+    "@yao-pkg/pkg-fetch": "npm:3.5.24"
+    into-stream: "npm:^6.0.0"
+    minimist: "npm:^1.2.6"
+    multistream: "npm:^4.1.0"
+    picocolors: "npm:^1.1.0"
+    picomatch: "npm:^4.0.2"
+    prebuild-install: "npm:^7.1.1"
+    resolve: "npm:^1.22.10"
+    stream-meter: "npm:^1.0.4"
+    tar: "npm:^7.4.3"
+    tinyglobby: "npm:^0.2.11"
+    unzipper: "npm:^0.12.3"
+  bin:
+    pkg: lib-es5/bin.js
+  checksum: 10/76f5b3a4562631a3b8c9add780b2c28cb787ba8f2f252ad46d261ad927554450b72ea151ce22c52273c94156b84e42b3be8c6b0bd4398a515f8679542e066957
   languageName: node
   linkType: hard
 
@@ -5172,7 +5214,7 @@ __metadata:
   dependencies:
     "@microsoft/eslint-formatter-sarif": "npm:^3.1.0"
     "@stylistic/eslint-plugin": "npm:^5.3.1"
-    "@yao-pkg/pkg": "npm:^6.6.0"
+    "@yao-pkg/pkg": "patch:@yao-pkg/pkg@npm%3A6.6.0#~/.yarn/patches/@yao-pkg-pkg-npm-6.6.0-d4777368b9.patch"
     dd-trace: "npm:^5.42.0"
     eslint: "npm:^9.34.0"
     eslint-config-prettier: "npm:^10.1.8"


### PR DESCRIPTION
### What and why?

This PR patches `@yao-pkg/pkg` and `@yao-pkg/pkg-fetch` to use precompiled binaries without `Intl` support with the `--sea` option.

See https://github.com/Drarig29/pkg-fetch#this-project-is-a-fork-used-by-datadogdatadog-ci-see-1858 for the big picture.

| Before      | After       |
| ----------- | ----------- |
| <img width="735" height="364" alt="image" src="https://github.com/user-attachments/assets/210eea10-9db2-40e4-a151-a2a294676ca2" />         | <img width="725" height="365" alt="image" src="https://github.com/user-attachments/assets/62efe32c-1ec4-4bc8-b8d4-5fa171148252" />         |
| [**Link**](https://github.com/DataDog/datadog-ci/actions/runs/17949601069/job/51045668951?pr=1858#step:9:5) | [**Link**](https://github.com/DataDog/datadog-ci/actions/runs/17949673652/job/51045754438?pr=1858#step:9:5) |

In the last version of datadog-ci we had standalone binaries based on **Node.js 18**, with a size of **~90MB**. By moving to **Node.js 22 without any optimization** we would end up with **~125MB** binaries.

With this PR, we have the best of both worlds: the upgrade to Node.js 22, and **~71MB** binaries! 🎉 

**Assets in [release `v3.20.0`](https://github.com/DataDog/datadog-ci/releases/tag/v3.20.0):**

<img width="504" height="392" alt="image" src="https://github.com/user-attachments/assets/9a8dd313-8e02-4acf-a20c-790ab8678ef5" />


### How?

Fork `@yao-pkg/pkg-fetch`, prebuild Node.js binaries without `Intl` support and add patches in datadog-ci to use those prebuilt binaries.

We could write our own scripts to download the prebuilt binaries and generate the SEA binary without importing `pkg` or `@yao-pkg/pkg` at all, but this is more error-prone than tiny patches in the repo.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
