### PR TITLE
[chore] Add `publishConfig` to all packages

### DIFF
--- a/bin/migrate.sh
+++ b/bin/migrate.sh
@@ -56,6 +56,9 @@ cat > "$PLUGIN_DIR/package.json" <<EOF
     "README",
     "LICENSE"
   ],
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "yarn package:clean; yarn package:build",
     "lint": "yarn package:lint",

--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -36,6 +36,9 @@
     "README",
     "LICENSE"
   ],
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "yarn package:clean; yarn package:build",
     "lint": "yarn package:lint",

--- a/packages/datadog-ci/package.json
+++ b/packages/datadog-ci/package.json
@@ -9,16 +9,16 @@
     "url": "https://github.com/DataDog/datadog-ci.git",
     "directory": "packages/datadog-ci"
   },
-  "bin": "dist/cli.js",
   "engines": {
     "node": ">=18"
   },
+  "bin": "dist/cli.js",
+  "main": "dist/index.js",
   "files": [
     "dist/**/*",
     "README",
     "LICENSE"
   ],
-  "main": "dist/index.js",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/plugin-aas/package.json
+++ b/packages/plugin-aas/package.json
@@ -20,6 +20,9 @@
     "README",
     "LICENSE"
   ],
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "yarn package:clean; yarn package:build",
     "lint": "yarn package:lint",

--- a/packages/plugin-cloud-run/package.json
+++ b/packages/plugin-cloud-run/package.json
@@ -20,6 +20,9 @@
     "README",
     "LICENSE"
   ],
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "yarn package:clean; yarn package:build",
     "lint": "yarn package:lint",

--- a/packages/plugin-dora/package.json
+++ b/packages/plugin-dora/package.json
@@ -19,6 +19,9 @@
     "README",
     "LICENSE"
   ],
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "yarn package:clean; yarn package:build",
     "lint": "yarn package:lint",

--- a/packages/plugin-gate/package.json
+++ b/packages/plugin-gate/package.json
@@ -19,6 +19,9 @@
     "README",
     "LICENSE"
   ],
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "yarn package:clean; yarn package:build",
     "lint": "yarn package:lint",

--- a/packages/plugin-lambda/package.json
+++ b/packages/plugin-lambda/package.json
@@ -20,6 +20,9 @@
     "README",
     "LICENSE"
   ],
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "yarn package:clean; yarn package:build",
     "lint": "yarn package:lint",

--- a/packages/plugin-sarif/package.json
+++ b/packages/plugin-sarif/package.json
@@ -20,6 +20,9 @@
     "README",
     "LICENSE"
   ],
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "yarn package:clean; yarn package:build",
     "lint": "yarn package:lint",

--- a/packages/plugin-sbom/package.json
+++ b/packages/plugin-sbom/package.json
@@ -20,6 +20,9 @@
     "README",
     "LICENSE"
   ],
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "yarn package:clean; yarn package:build",
     "lint": "yarn package:lint",

--- a/packages/plugin-stepfunctions/package.json
+++ b/packages/plugin-stepfunctions/package.json
@@ -20,6 +20,9 @@
     "README",
     "LICENSE"
   ],
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "yarn package:clean; yarn package:build",
     "lint": "yarn package:lint",

--- a/packages/plugin-synthetics/package.json
+++ b/packages/plugin-synthetics/package.json
@@ -24,6 +24,9 @@
     "README",
     "LICENSE"
   ],
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "yarn package:clean; yarn package:build",
     "lint": "yarn package:lint",


### PR DESCRIPTION
### What and why?

By default, packages are private. So we need to make them public explicitly.

<img width="889" height="308" alt="image" src="https://github.com/user-attachments/assets/d62004bf-6eed-4aaa-9722-30b1cc685ece" />

### How?

Use `publishConfig` with `access: public`

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
