### PR TITLE
v3.21.1

### DIFF
--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-base",
-  "version": "3.21.0",
+  "version": "3.21.1",
   "description": "Base package for Datadog CI",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/datadog-ci/package.json
+++ b/packages/datadog-ci/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci",
-  "version": "3.21.0",
+  "version": "3.21.1",
   "description": "Use Datadog from your CI.",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-aas/package.json
+++ b/packages/plugin-aas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-aas",
-  "version": "3.21.0",
+  "version": "3.21.1",
   "license": "Apache-2.0",
   "description": "Datadog CI plugin for `aas` commands",
   "keywords": [

--- a/packages/plugin-cloud-run/package.json
+++ b/packages/plugin-cloud-run/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-cloud-run",
-  "version": "3.21.0",
+  "version": "3.21.1",
   "license": "Apache-2.0",
   "description": "Datadog CI plugin for `cloud-run` commands",
   "keywords": [

--- a/packages/plugin-deployment/package.json
+++ b/packages/plugin-deployment/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-deployment",
-  "version": "3.20.0",
+  "version": "3.20.1",
   "license": "Apache-2.0",
   "description": "Datadog CI plugin for `deployment` commands",
   "keywords": [

--- a/packages/plugin-dora/package.json
+++ b/packages/plugin-dora/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-dora",
-  "version": "3.21.0",
+  "version": "3.21.1",
   "license": "Apache-2.0",
   "description": "Datadog CI plugin for `dora` commands",
   "keywords": [

--- a/packages/plugin-gate/package.json
+++ b/packages/plugin-gate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-gate",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "license": "Apache-2.0",
   "description": "Datadog CI plugin for `gate` commands",
   "keywords": [

--- a/packages/plugin-lambda/package.json
+++ b/packages/plugin-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-lambda",
-  "version": "3.21.0",
+  "version": "3.21.1",
   "license": "Apache-2.0",
   "description": "Datadog CI plugin for `lambda` commands",
   "keywords": [

--- a/packages/plugin-sarif/package.json
+++ b/packages/plugin-sarif/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-sarif",
-  "version": "3.21.0",
+  "version": "3.21.1",
   "license": "Apache-2.0",
   "description": "Datadog CI plugin for `sarif` commands",
   "keywords": [

--- a/packages/plugin-sbom/package.json
+++ b/packages/plugin-sbom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-sbom",
-  "version": "3.21.0",
+  "version": "3.21.1",
   "license": "Apache-2.0",
   "description": "Datadog CI plugin for `sbom` commands",
   "keywords": [

--- a/packages/plugin-stepfunctions/package.json
+++ b/packages/plugin-stepfunctions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-stepfunctions",
-  "version": "3.21.0",
+  "version": "3.21.1",
   "license": "Apache-2.0",
   "description": "Datadog CI plugin for `stepfunctions` commands",
   "keywords": [

--- a/packages/plugin-synthetics/package.json
+++ b/packages/plugin-synthetics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-synthetics",
-  "version": "3.21.0",
+  "version": "3.21.1",
   "license": "Apache-2.0",
   "description": "Datadog CI plugin for `synthetics` commands",
   "keywords": [


### PR DESCRIPTION
<!-- Release notes generated using configuration in .github/release.yml at v3.21.1 -->

## What's Changed
### datadog-ci
* [packages-migration] Move root package to packages dir by @Drarig29 in https://github.com/DataDog/datadog-ci/pull/1815
* [packages-migration] Create `@datadog/datadog-ci-base` package by @Drarig29 in https://github.com/DataDog/datadog-ci/pull/1804
* [chore] Use Node.js SEA for standalone binary by @Drarig29 in https://github.com/DataDog/datadog-ci/pull/1835
* [chore] Decrease standalone binary size by @Drarig29 in https://github.com/DataDog/datadog-ci/pull/1858
* [chore] Symlink README and duplicate LICENSE files by @Drarig29 in https://github.com/DataDog/datadog-ci/pull/1859
### Dependencies
* [dep] Bump axios to `1.12.1` by @Drarig29 in https://github.com/DataDog/datadog-ci/pull/1839
### Software Delivery
* Update Software Delivery ownership by @GabrielAnca in https://github.com/DataDog/datadog-ci/pull/1818
* Fix isFile utility method to handle symlinks by @nikita-tkachenko-datadog in https://github.com/DataDog/datadog-ci/pull/1823
* Add evaluation summary to 'deployment gate' output by @GabrielAnca in https://github.com/DataDog/datadog-ci/pull/1826
* [PACKAGES-MIGRATION] Migrate tag command to base package by @GabrielAnca in https://github.com/DataDog/datadog-ci/pull/1852
* [PACKAGES-MIGRATION] Migrate dora scope into a plugin by @GabrielAnca in https://github.com/DataDog/datadog-ci/pull/1854
* [PACKAGES-MIGRATION] Migrate deployment scope into a plugin by @GabrielAnca in https://github.com/DataDog/datadog-ci/pull/1860
### Serverless
* Cloud Run Instrument Language Flag by @nhulston in https://github.com/DataDog/datadog-ci/pull/1819
* packages-migration: migrate aas package by @ava-silver in https://github.com/DataDog/datadog-ci/pull/1837
* [PACKAGES-MIGRATION] migrate cloud-run by @ava-silver in https://github.com/DataDog/datadog-ci/pull/1844
* [PACKAGES-MIGRATION] migrate lambda by @ava-silver in https://github.com/DataDog/datadog-ci/pull/1847
* [PACKAGES-MIGRATION] migrate stepfunctions by @ava-silver in https://github.com/DataDog/datadog-ci/pull/1849
### Source Code Integration
* packages-migration: move git-metadata to base by @ava-silver in https://github.com/DataDog/datadog-ci/pull/1833
* Fix failed Windows tests and timeout by @GabrielAnca in https://github.com/DataDog/datadog-ci/pull/1855
* [PACKAGES-MIGRATION] Move 'gate' commands to packages/gate by @vbarbaresi in https://github.com/DataDog/datadog-ci/pull/1828
### Static Analysis
* Inspect sarif aggregate error by @Drarig29 in https://github.com/DataDog/datadog-ci/pull/1830
* [SYNTH-21715] Create sbom package by @dastrong in https://github.com/DataDog/datadog-ci/pull/1840
* [SYNTH-21714] Create sarif package by @dastrong in https://github.com/DataDog/datadog-ci/pull/1841
### Synthetics
* [packages-migration] Create `@datadog/datadog-ci-plugin-synthetics` package by @Drarig29 in https://github.com/DataDog/datadog-ci/pull/1817
### Profiling
* style: fix eslint warnings by @nsavoire in https://github.com/DataDog/datadog-ci/pull/1846
### Chores
* [chore] Use `knip` to remove leftover dependencies by @Drarig29 in https://github.com/DataDog/datadog-ci/pull/1820
* [chore] Migrate to ESLint 9 by @Drarig29 in https://github.com/DataDog/datadog-ci/pull/1822
* [chore] Use source files during development for better DevX by @Drarig29 in https://github.com/DataDog/datadog-ci/pull/1821
* [chore] Upgrade prettier to support latest TS syntax by @Drarig29 in https://github.com/DataDog/datadog-ci/pull/1834
* [packages-migration] create migration script by @ava-silver in https://github.com/DataDog/datadog-ci/pull/1827
* Run yarn to fix broken pipelines by @dastrong in https://github.com/DataDog/datadog-ci/pull/1843
* Cleanup unused deps by @dastrong in https://github.com/DataDog/datadog-ci/pull/1845
* [SVLS] fix aas path mappings by @ava-silver in https://github.com/DataDog/datadog-ci/pull/1848
* [chore] Mark `peerDependencies` in base package as optional by @Drarig29 in https://github.com/DataDog/datadog-ci/pull/1857
* [chore] Add `publishConfig` to all packages by @Drarig29 in https://github.com/DataDog/datadog-ci/pull/1862
* [chore] Fix release `3.21.0` by @Drarig29 in https://github.com/DataDog/datadog-ci/pull/1863

## New Contributors
* @vbarbaresi made their first contribution in https://github.com/DataDog/datadog-ci/pull/1828

**Full Changelog**: https://github.com/DataDog/datadog-ci/compare/v3.20.0...v3.21.1

[SYNTH-21715]: https://datadoghq.atlassian.net/browse/SYNTH-21715?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ