### PR TITLE
v3.21.1 (redo)

### DIFF
--- a/packages/plugin-deployment/package.json
+++ b/packages/plugin-deployment/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-deployment",
-  "version": "3.20.1",
+  "version": "3.21.1",
   "license": "Apache-2.0",
   "description": "Datadog CI plugin for `deployment` commands",
   "keywords": [
@@ -26,6 +26,9 @@
     "README",
     "LICENSE"
   ],
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "yarn package:clean; yarn package:build",
     "lint": "yarn package:lint",


### PR DESCRIPTION
<!-- Release notes generated using configuration in .github/release.yml at v3.21.1 -->

## What's Changed
### datadog-ci
* [packages-migration] Move root package to packages dir by @Drarig29 in https://github.com/DataDog/datadog-ci/pull/1815
* [packages-migration] Create `@datadog/datadog-ci-base` package by @Drarig29 in https://github.com/DataDog/datadog-ci/pull/1804
* [chore] Use Node.js SEA for standalone binary by @Drarig29 in https://github.com/DataDog/datadog-ci/pull/1835
* [chore] Decrease standalone binary size by @Drarig29 in https://github.com/DataDog/datadog-ci/pull/1858
* [chore] Symlink README and duplicate LICENSE files by @Drarig29 in https://github.com/DataDog/datadog-ci/pull/1859
### Dependencies
* [dep] Bump axios to `1.12.1` by @Drarig29 in https://github.com/DataDog/datadog-ci/pull/1839
### Software Delivery
* Update Software Delivery ownership by @GabrielAnca in https://github.com/DataDog/datadog-ci/pull/1818
* Fix isFile utility method to handle symlinks by @nikita-tkachenko-datadog in https://github.com/DataDog/datadog-ci/pull/1823
* Add evaluation summary to 'deployment gate' output by @GabrielAnca in https://github.com/DataDog/datadog-ci/pull/1826
* [PACKAGES-MIGRATION] Migrate tag command to base package by @GabrielAnca in https://github.com/DataDog/datadog-ci/pull/1852
* [PACKAGES-MIGRATION] Migrate dora scope into a plugin by @GabrielAnca in https://github.com/DataDog/datadog-ci/pull/1854
* [PACKAGES-MIGRATION] Migrate deployment scope into a plugin by @GabrielAnca in https://github.com/DataDog/datadog-ci/pull/1860
### Serverless
* Cloud Run Instrument Language Flag by @nhulston in https://github.com/DataDog/datadog-ci/pull/1819
* packages-migration: migrate aas package by @ava-silver in https://github.com/DataDog/datadog-ci/pull/1837
* [PACKAGES-MIGRATION] migrate cloud-run by @ava-silver in https://github.com/DataDog/datadog-ci/pull/1844
* [PACKAGES-MIGRATION] migrate lambda by @ava-silver in https://github.com/DataDog/datadog-ci/pull/1847
* [PACKAGES-MIGRATION] migrate stepfunctions by @ava-silver in https://github.com/DataDog/datadog-ci/pull/1849
### Source Code Integration
* packages-migration: move git-metadata to base by @ava-silver in https://github.com/DataDog/datadog-ci/pull/1833
* Fix failed Windows tests and timeout by @GabrielAnca in https://github.com/DataDog/datadog-ci/pull/1855
* [PACKAGES-MIGRATION] Move 'gate' commands to packages/gate by @vbarbaresi in https://github.com/DataDog/datadog-ci/pull/1828
### Static Analysis
* Inspect sarif aggregate error by @Drarig29 in https://github.com/DataDog/datadog-ci/pull/1830
* [SYNTH-21715] Create sbom package by @dastrong in https://github.com/DataDog/datadog-ci/pull/1840
* [SYNTH-21714] Create sarif package by @dastrong in https://github.com/DataDog/datadog-ci/pull/1841
### Synthetics
* [packages-migration] Create `@datadog/datadog-ci-plugin-synthetics` package by @Drarig29 in https://github.com/DataDog/datadog-ci/pull/1817
### Profiling
* style: fix eslint warnings by @nsavoire in https://github.com/DataDog/datadog-ci/pull/1846
### Chores
* [chore] Use `knip` to remove leftover dependencies by @Drarig29 in https://github.com/DataDog/datadog-ci/pull/1820
* [chore] Migrate to ESLint 9 by @Drarig29 in https://github.com/DataDog/datadog-ci/pull/1822
* [chore] Use source files during development for better DevX by @Drarig29 in https://github.com/DataDog/datadog-ci/pull/1821
* [chore] Upgrade prettier to support latest TS syntax by @Drarig29 in https://github.com/DataDog/datadog-ci/pull/1834
* [packages-migration] create migration script by @ava-silver in https://github.com/DataDog/datadog-ci/pull/1827
* Run yarn to fix broken pipelines by @dastrong in https://github.com/DataDog/datadog-ci/pull/1843
* Cleanup unused deps by @dastrong in https://github.com/DataDog/datadog-ci/pull/1845
* [SVLS] fix aas path mappings by @ava-silver in https://github.com/DataDog/datadog-ci/pull/1848
* [chore] Mark `peerDependencies` in base package as optional by @Drarig29 in https://github.com/DataDog/datadog-ci/pull/1857
* [chore] Add `publishConfig` to all packages by @Drarig29 in https://github.com/DataDog/datadog-ci/pull/1862
* [chore] Fix release `3.21.0` by @Drarig29 in https://github.com/DataDog/datadog-ci/pull/1863

## New Contributors
* @vbarbaresi made their first contribution in https://github.com/DataDog/datadog-ci/pull/1828

**Full Changelog**: https://github.com/DataDog/datadog-ci/compare/v3.20.0...v3.21.1

[SYNTH-21715]: https://datadoghq.atlassian.net/browse/SYNTH-21715?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ