### PR TITLE
v3.21.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "lint:ci": "yarn lint:all -f @microsoft/sarif -o 'sarif-datadog-ci.sarif'",
     "lint:all": "eslint --cache --quiet '**/*.ts'",
     "loop-packages": "yarn workspaces foreach --all --no-private",
-    "publish:all": "yarn loop-packages --topological --verbose npm publish --tolerate-republish",
+    "publish:all": "yarn loop-packages --topological --verbose npm publish",
     "version:all": "yarn loop-packages version ${0} --immediate",
     "package:build": "yarn tsc:build $INIT_CWD",
     "package:clean": "cd $INIT_CWD && rimraf dist tsconfig.tsbuildinfo",

--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-base",
-  "version": "3.21.1",
+  "version": "3.21.2",
   "description": "Base package for Datadog CI",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/datadog-ci/package.json
+++ b/packages/datadog-ci/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci",
-  "version": "3.21.1",
+  "version": "3.21.2",
   "description": "Use Datadog from your CI.",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-aas/package.json
+++ b/packages/plugin-aas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-aas",
-  "version": "3.21.1",
+  "version": "3.21.2",
   "license": "Apache-2.0",
   "description": "Datadog CI plugin for `aas` commands",
   "keywords": [

--- a/packages/plugin-cloud-run/package.json
+++ b/packages/plugin-cloud-run/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-cloud-run",
-  "version": "3.21.1",
+  "version": "3.21.2",
   "license": "Apache-2.0",
   "description": "Datadog CI plugin for `cloud-run` commands",
   "keywords": [

--- a/packages/plugin-deployment/package.json
+++ b/packages/plugin-deployment/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-deployment",
-  "version": "3.21.1",
+  "version": "3.21.2",
   "license": "Apache-2.0",
   "description": "Datadog CI plugin for `deployment` commands",
   "keywords": [

--- a/packages/plugin-dora/package.json
+++ b/packages/plugin-dora/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-dora",
-  "version": "3.21.1",
+  "version": "3.21.2",
   "license": "Apache-2.0",
   "description": "Datadog CI plugin for `dora` commands",
   "keywords": [

--- a/packages/plugin-gate/package.json
+++ b/packages/plugin-gate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-gate",
-  "version": "0.1.1",
+  "version": "3.21.1",
   "license": "Apache-2.0",
   "description": "Datadog CI plugin for `gate` commands",
   "keywords": [

--- a/packages/plugin-gate/package.json
+++ b/packages/plugin-gate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-gate",
-  "version": "3.21.1",
+  "version": "3.21.2",
   "license": "Apache-2.0",
   "description": "Datadog CI plugin for `gate` commands",
   "keywords": [

--- a/packages/plugin-lambda/package.json
+++ b/packages/plugin-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-lambda",
-  "version": "3.21.1",
+  "version": "3.21.2",
   "license": "Apache-2.0",
   "description": "Datadog CI plugin for `lambda` commands",
   "keywords": [

--- a/packages/plugin-sarif/package.json
+++ b/packages/plugin-sarif/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-sarif",
-  "version": "3.21.1",
+  "version": "3.21.2",
   "license": "Apache-2.0",
   "description": "Datadog CI plugin for `sarif` commands",
   "keywords": [

--- a/packages/plugin-sbom/package.json
+++ b/packages/plugin-sbom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-sbom",
-  "version": "3.21.1",
+  "version": "3.21.2",
   "license": "Apache-2.0",
   "description": "Datadog CI plugin for `sbom` commands",
   "keywords": [

--- a/packages/plugin-stepfunctions/package.json
+++ b/packages/plugin-stepfunctions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-stepfunctions",
-  "version": "3.21.1",
+  "version": "3.21.2",
   "license": "Apache-2.0",
   "description": "Datadog CI plugin for `stepfunctions` commands",
   "keywords": [

--- a/packages/plugin-synthetics/package.json
+++ b/packages/plugin-synthetics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-synthetics",
-  "version": "3.21.1",
+  "version": "3.21.2",
   "license": "Apache-2.0",
   "description": "Datadog CI plugin for `synthetics` commands",
   "keywords": [


### PR DESCRIPTION
Closes #1866 

Fix #1864 and #1865.

The `--tolerate-republish` option didn't republish the base package, so peer dependency versions were outdated.

We also didn't sync the gate plugin version properly.

The static analyzer jobs are failing because of this very issue, so we'll skip them.