### PR TITLE
fix: relative path to datadog-ci-base package

### DIFF
--- a/packages/datadog-ci/src/index.ts
+++ b/packages/datadog-ci/src/index.ts
@@ -1,4 +1,4 @@
-export * as gitMetadata from '../../base/src/commands/git-metadata'
+export * as gitMetadata from '@datadog/datadog-ci-base/commands/git-metadata'
 export * as synthetics from '@datadog/datadog-ci-plugin-synthetics'
 export * as utils from '@datadog/datadog-ci-base/helpers/utils'
 export {cliVersion as version} from '@datadog/datadog-ci-base/version'


### PR DESCRIPTION
This aims to fix an issue [#1871](https://github.com/DataDog/datadog-ci/issues/1871) with git-metadata module is not found.

### What and why?

Error thrown  "Error: Cannot find module '../../base/src/commands/git-metadata'"

### How?

Relative path outside the packge breaks after bundling, use the package name instead

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
