### PR TITLE
[dev] Bump tsx to `4.20.6`

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "rimraf": "^5.0.0",
     "ts-jest": "29.1.1",
     "ts-json-schema-generator": "^2.4.0",
-    "tsx": "^4.20.5",
+    "tsx": "^4.20.6",
     "typescript": "5.1.6",
     "typescript-eslint": "^8.42.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -5267,7 +5267,7 @@ __metadata:
     rimraf: "npm:^5.0.0"
     ts-jest: "npm:29.1.1"
     ts-json-schema-generator: "npm:^2.4.0"
-    tsx: "npm:^4.20.5"
+    tsx: "npm:^4.20.6"
     typescript: "npm:5.1.6"
     typescript-eslint: "npm:^8.42.0"
   languageName: unknown
@@ -10628,9 +10628,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tsx@npm:^4.20.5":
-  version: 4.20.5
-  resolution: "tsx@npm:4.20.5"
+"tsx@npm:^4.20.6":
+  version: 4.20.6
+  resolution: "tsx@npm:4.20.6"
   dependencies:
     esbuild: "npm:~0.25.0"
     fsevents: "npm:~2.3.3"
@@ -10640,7 +10640,7 @@ __metadata:
       optional: true
   bin:
     tsx: dist/cli.mjs
-  checksum: 10/161420678027c43d07b60b7b6b512cc67ff86ae3cca0641a19b0d3e742c5e262bca57034c4bff6d9346f9269e9ada24b6030e1d2bc890df5e1a9754865d3c08a
+  checksum: 10/16396df25c474d7526f7adf9cd0c1f0b71a8c42f70bb93c2399c561eae3998abc015e8fe36a1e149fd289472919fb02816c5b46d72cf9f4335932419ecf2de8b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### What and why?

Bump tsx to fix https://github.com/privatenumber/tsx/issues/742 when using the `yarn launch synthetics run-tests` command.

### How?

Bump the package

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
