### PR TITLE
[chore] Add npm publish provenance

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "lint:ci": "yarn lint:all -f @microsoft/sarif -o 'sarif-datadog-ci.sarif'",
     "lint:all": "eslint --cache --quiet '**/*.ts'",
     "loop-packages": "yarn workspaces foreach --all --no-private",
-    "publish:all": "yarn loop-packages --topological --verbose npm publish",
+    "publish:all": "yarn loop-packages --topological --verbose npm publish --provenance",
     "version:all": "yarn loop-packages version ${0} --immediate",
     "package:build": "yarn tsc:build $INIT_CWD",
     "package:clean": "cd $INIT_CWD && rimraf dist tsconfig.tsbuildinfo",


### PR DESCRIPTION
### What and why?

Similar to https://github.com/DataDog/dd-trace-js/pull/3645

See https://docs.npmjs.com/generating-provenance-statements#publishing-packages-with-provenance-via-github-actions

### How?

Add `--provenance` flag. Yarn supports it since [4.9.0](https://github.com/yarnpkg/berry/releases/tag/%40yarnpkg/cli/4.9.0).

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
