### PR TITLE
[chore] Remove unused `--compress` flag for `pkg`

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "compare-binary-size": "FORCE_COLOR=1 node bin/compare-binary-size.js",
     "clean": "rimraf --glob .eslintcache .jest-cache 'packages/*/{dist,tsconfig.tsbuildinfo}'",
     "dev": "yarn tsc:build --watch",
-    "dist-standalone": "FORCE_COLOR=1 yarn workspace @datadog/datadog-ci bundle && pkg --sea --compress GZip packages/datadog-ci/dist/bundle.js",
+    "dist-standalone": "FORCE_COLOR=1 yarn workspace @datadog/datadog-ci bundle && pkg --sea packages/datadog-ci/dist/bundle.js",
     "dist-standalone:test": "jest --config ./jest.config-standalone.mjs --colors",
     "format": "yarn lint:all --fix",
     "generate-json-schemas:synthetics": "ts-json-schema-generator --markdown-description --no-type-check --no-top-ref --additional-properties --path packages/plugin-synthetics/src/interfaces.ts --type TestConfig > packages/plugin-synthetics/src/test-config.schema.json && prettier --write packages/plugin-synthetics/src/test-config.schema.json",


### PR DESCRIPTION
### What and why?

This flag is a leftover from before we used `--sea` (introduced in #1835).

The `--compress` flag is used to [compress files in `pkg`'s **virtual filesystem**](https://github.com/vercel/pkg/pull/1115), and `--sea` does not use the virtual filesystem.

Removing this flag is a no-op and won't affect our binaries' size.

### How?

Remove `--compress GZip` flag.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
