### PR TITLE
[chore] Also auto-generate base `commands/<scope>/cli.ts` files

### DIFF
--- a/bin/lint-packages.ts
+++ b/bin/lint-packages.ts
@@ -163,7 +163,8 @@ const formatBasePackageScopeCliFile = (plugin: PluginPackage) => {
     importPath: `./${command}`,
   }))
 
-  const newContent = `${imports.map((i) => `import {${i.importName}} from '${i.importPath}'`).join('\n')}
+  const newContent = `/* eslint-disable import-x/order */
+${imports.map((i) => `import {${i.importName}} from '${i.importPath}'`).join('\n')}
 
 // prettier-ignore
 export const commands = [

--- a/bin/lint-packages.ts
+++ b/bin/lint-packages.ts
@@ -163,13 +163,13 @@ const formatBasePackageScopeCliFile = (plugin: PluginPackage) => {
     importPath: `./${command}`,
   }))
 
-  const newContent = `
-${imports.map((i) => `import {${i.importName}} from '${i.importPath}'`).join('\n')}
+  const newContent = `${imports.map((i) => `import {${i.importName}} from '${i.importPath}'`).join('\n')}
 
 // prettier-ignore
 export const commands = [
 ${imports.map((i) => `  ${i.importName},`).join('\n')}
-]`
+]
+`
 
   return makeApplyChanges(file, originalContent, newContent)
 }

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "tsc:build": "tsc --build --verbose"
   },
   "devDependencies": {
-    "@datadog/datadog-ci-base": "workspace:*",
     "@microsoft/eslint-formatter-sarif": "^3.1.0",
     "@stylistic/eslint-plugin": "^5.3.1",
     "@types/node": "^20.19.18",

--- a/packages/base/src/commands/aas/cli.ts
+++ b/packages/base/src/commands/aas/cli.ts
@@ -1,4 +1,8 @@
-import {InstrumentCommand} from './instrument'
-import {UninstrumentCommand} from './uninstrument'
+import {AasInstrumentCommand} from './instrument'
+import {AasUninstrumentCommand} from './uninstrument'
 
-export const commands = [InstrumentCommand, UninstrumentCommand]
+// prettier-ignore
+export const commands = [
+  AasInstrumentCommand,
+  AasUninstrumentCommand,
+]

--- a/packages/base/src/commands/aas/cli.ts
+++ b/packages/base/src/commands/aas/cli.ts
@@ -1,3 +1,4 @@
+/* eslint-disable import-x/order */
 import {AasInstrumentCommand} from './instrument'
 import {AasUninstrumentCommand} from './uninstrument'
 

--- a/packages/base/src/commands/aas/instrument.ts
+++ b/packages/base/src/commands/aas/instrument.ts
@@ -4,7 +4,7 @@ import {executePluginCommand} from '../../helpers/plugin'
 
 import {AasCommand, AasConfigOptions} from './common'
 
-export class InstrumentCommand extends AasCommand {
+export class AasInstrumentCommand extends AasCommand {
   public static paths = [['aas', 'instrument']]
   public static usage = Command.Usage({
     category: 'Serverless',

--- a/packages/base/src/commands/aas/uninstrument.ts
+++ b/packages/base/src/commands/aas/uninstrument.ts
@@ -4,7 +4,7 @@ import {executePluginCommand} from '../../helpers/plugin'
 
 import {AasCommand} from './common'
 
-export class UninstrumentCommand extends AasCommand {
+export class AasUninstrumentCommand extends AasCommand {
   public static paths = [['aas', 'uninstrument']]
   public static usage = Command.Usage({
     category: 'Serverless',

--- a/packages/base/src/commands/cloud-run/cli.ts
+++ b/packages/base/src/commands/cloud-run/cli.ts
@@ -1,5 +1,10 @@
 import {CloudRunFlareCommand} from './flare'
-import {InstrumentCommand} from './instrument'
-import {UninstrumentCommand} from './uninstrument'
+import {CloudRunInstrumentCommand} from './instrument'
+import {CloudRunUninstrumentCommand} from './uninstrument'
 
-export const commands = [InstrumentCommand, UninstrumentCommand, CloudRunFlareCommand]
+// prettier-ignore
+export const commands = [
+  CloudRunFlareCommand,
+  CloudRunInstrumentCommand,
+  CloudRunUninstrumentCommand,
+]

--- a/packages/base/src/commands/cloud-run/cli.ts
+++ b/packages/base/src/commands/cloud-run/cli.ts
@@ -1,3 +1,4 @@
+/* eslint-disable import-x/order */
 import {CloudRunFlareCommand} from './flare'
 import {CloudRunInstrumentCommand} from './instrument'
 import {CloudRunUninstrumentCommand} from './uninstrument'

--- a/packages/base/src/commands/cloud-run/instrument.ts
+++ b/packages/base/src/commands/cloud-run/instrument.ts
@@ -9,7 +9,7 @@ const DEFAULT_LOGS_PATH = '/shared-volume/logs/*.log'
 
 const DEFAULT_SIDECAR_IMAGE = 'gcr.io/datadoghq/serverless-init:latest'
 
-export class InstrumentCommand extends Command {
+export class CloudRunInstrumentCommand extends Command {
   public static paths = [['cloud-run', 'instrument']]
 
   public static usage = Command.Usage({

--- a/packages/base/src/commands/cloud-run/uninstrument.ts
+++ b/packages/base/src/commands/cloud-run/uninstrument.ts
@@ -4,7 +4,7 @@ import {executePluginCommand} from '../../helpers/plugin'
 
 import {DEFAULT_SIDECAR_NAME, DEFAULT_VOLUME_NAME} from './constants'
 
-export class UninstrumentCommand extends Command {
+export class CloudRunUninstrumentCommand extends Command {
   public static paths = [['cloud-run', 'uninstrument']]
 
   public static usage = Command.Usage({

--- a/packages/base/src/commands/deployment/cli.ts
+++ b/packages/base/src/commands/deployment/cli.ts
@@ -1,11 +1,12 @@
-import {DeploymentCorrelateCommand} from './correlate'
 import {DeploymentCorrelateImageCommand} from './correlate-image'
+import {DeploymentCorrelateCommand} from './correlate'
 import {DeploymentGateCommand} from './gate'
 import {DeploymentMarkCommand} from './mark'
 
+// prettier-ignore
 export const commands = [
-  DeploymentCorrelateCommand,
   DeploymentCorrelateImageCommand,
+  DeploymentCorrelateCommand,
   DeploymentGateCommand,
   DeploymentMarkCommand,
 ]

--- a/packages/base/src/commands/deployment/cli.ts
+++ b/packages/base/src/commands/deployment/cli.ts
@@ -1,3 +1,4 @@
+/* eslint-disable import-x/order */
 import {DeploymentCorrelateImageCommand} from './correlate-image'
 import {DeploymentCorrelateCommand} from './correlate'
 import {DeploymentGateCommand} from './gate'

--- a/packages/base/src/commands/dora/cli.ts
+++ b/packages/base/src/commands/dora/cli.ts
@@ -1,3 +1,6 @@
 import {DoraDeploymentCommand} from './deployment'
 
-export const commands = [DoraDeploymentCommand]
+// prettier-ignore
+export const commands = [
+  DoraDeploymentCommand,
+]

--- a/packages/base/src/commands/dora/cli.ts
+++ b/packages/base/src/commands/dora/cli.ts
@@ -1,3 +1,4 @@
+/* eslint-disable import-x/order */
 import {DoraDeploymentCommand} from './deployment'
 
 // prettier-ignore

--- a/packages/base/src/commands/gate/cli.ts
+++ b/packages/base/src/commands/gate/cli.ts
@@ -1,3 +1,4 @@
+/* eslint-disable import-x/order */
 import {GateEvaluateCommand} from './evaluate'
 
 // prettier-ignore

--- a/packages/base/src/commands/gate/cli.ts
+++ b/packages/base/src/commands/gate/cli.ts
@@ -1,3 +1,6 @@
 import {GateEvaluateCommand} from './evaluate'
 
-export const commands = [GateEvaluateCommand]
+// prettier-ignore
+export const commands = [
+  GateEvaluateCommand,
+]

--- a/packages/base/src/commands/git-metadata/__tests__/upload.test.ts
+++ b/packages/base/src/commands/git-metadata/__tests__/upload.test.ts
@@ -3,10 +3,10 @@ import {UploadStatus} from '../../../helpers/upload'
 
 import * as gitdbModule from '../gitdb'
 import * as libraryModule from '../library'
-import {UploadCommand} from '../upload'
+import {GitMetadataUploadCommand} from '../upload'
 
 describe('execute', () => {
-  const runCLI = makeRunCLI(UploadCommand, ['git-metadata', 'upload', '--dry-run'])
+  const runCLI = makeRunCLI(GitMetadataUploadCommand, ['git-metadata', 'upload', '--dry-run'])
   let mockUploadToGitDB: jest.SpyInstance
   let mockUploadRepository: jest.SpyInstance
 

--- a/packages/base/src/commands/git-metadata/cli.ts
+++ b/packages/base/src/commands/git-metadata/cli.ts
@@ -1,3 +1,7 @@
-import {UploadCommand} from './upload'
+/* eslint-disable import-x/order */
+import {GitMetadataUploadCommand} from './upload'
 
-export const commands = [UploadCommand]
+// prettier-ignore
+export const commands = [
+  GitMetadataUploadCommand,
+]

--- a/packages/base/src/commands/git-metadata/upload.ts
+++ b/packages/base/src/commands/git-metadata/upload.ts
@@ -28,7 +28,7 @@ import {
   renderSuccessfulCommand,
 } from './renderer'
 
-export class UploadCommand extends Command {
+export class GitMetadataUploadCommand extends Command {
   public static paths = [['git-metadata', 'upload']]
 
   public static usage = Command.Usage({

--- a/packages/base/src/commands/lambda/cli.ts
+++ b/packages/base/src/commands/lambda/cli.ts
@@ -1,5 +1,10 @@
 import {LambdaFlareCommand} from './flare'
-import {InstrumentCommand} from './instrument'
-import {UninstrumentCommand} from './uninstrument'
+import {LambdaInstrumentCommand} from './instrument'
+import {LambdaUninstrumentCommand} from './uninstrument'
 
-export const commands = [InstrumentCommand, UninstrumentCommand, LambdaFlareCommand]
+// prettier-ignore
+export const commands = [
+  LambdaFlareCommand,
+  LambdaInstrumentCommand,
+  LambdaUninstrumentCommand,
+]

--- a/packages/base/src/commands/lambda/cli.ts
+++ b/packages/base/src/commands/lambda/cli.ts
@@ -1,3 +1,4 @@
+/* eslint-disable import-x/order */
 import {LambdaFlareCommand} from './flare'
 import {LambdaInstrumentCommand} from './instrument'
 import {LambdaUninstrumentCommand} from './uninstrument'

--- a/packages/base/src/commands/lambda/instrument.ts
+++ b/packages/base/src/commands/lambda/instrument.ts
@@ -2,7 +2,7 @@ import {Command, Option} from 'clipanion'
 
 import {executePluginCommand} from '../../helpers/plugin'
 
-export class InstrumentCommand extends Command {
+export class LambdaInstrumentCommand extends Command {
   public static paths = [['lambda', 'instrument']]
 
   public static usage = Command.Usage({

--- a/packages/base/src/commands/lambda/uninstrument.ts
+++ b/packages/base/src/commands/lambda/uninstrument.ts
@@ -2,7 +2,7 @@ import {Command, Option} from 'clipanion'
 
 import {executePluginCommand} from '../../helpers/plugin'
 
-export class UninstrumentCommand extends Command {
+export class LambdaUninstrumentCommand extends Command {
   public static paths = [['lambda', 'uninstrument']]
 
   public static usage = Command.Usage({

--- a/packages/base/src/commands/plugin/check.ts
+++ b/packages/base/src/commands/plugin/check.ts
@@ -2,7 +2,7 @@ import {Command, Option} from 'clipanion'
 
 import {checkPlugin} from '../../helpers/plugin'
 
-export class CheckCommand extends Command {
+export class PluginCheckCommand extends Command {
   public static paths = [['plugin', 'check']]
 
   public static usage = Command.Usage({

--- a/packages/base/src/commands/plugin/cli.ts
+++ b/packages/base/src/commands/plugin/cli.ts
@@ -1,3 +1,9 @@
-import {CheckCommand} from './check'
+/* eslint-disable import-x/order */
+import {PluginCheckCommand} from './check'
+import {PluginInstallCommand} from './install'
 
-export const commands = [CheckCommand]
+// prettier-ignore
+export const commands = [
+  PluginCheckCommand,
+  PluginInstallCommand,
+]

--- a/packages/base/src/commands/plugin/install.ts
+++ b/packages/base/src/commands/plugin/install.ts
@@ -2,7 +2,7 @@ import {Command, Option} from 'clipanion'
 
 import {installPlugin} from '../../helpers/plugin'
 
-export class InstallCommand extends Command {
+export class PluginInstallCommand extends Command {
   public static paths = [['plugin', 'install']]
 
   public static usage = Command.Usage({

--- a/packages/base/src/commands/sarif/cli.ts
+++ b/packages/base/src/commands/sarif/cli.ts
@@ -1,3 +1,6 @@
 import {SarifUploadCommand} from './upload'
 
-export const commands = [SarifUploadCommand]
+// prettier-ignore
+export const commands = [
+  SarifUploadCommand,
+]

--- a/packages/base/src/commands/sarif/cli.ts
+++ b/packages/base/src/commands/sarif/cli.ts
@@ -1,3 +1,4 @@
+/* eslint-disable import-x/order */
 import {SarifUploadCommand} from './upload'
 
 // prettier-ignore

--- a/packages/base/src/commands/sbom/cli.ts
+++ b/packages/base/src/commands/sbom/cli.ts
@@ -1,3 +1,6 @@
 import {SbomUploadCommand} from './upload'
 
-export const commands = [SbomUploadCommand]
+// prettier-ignore
+export const commands = [
+  SbomUploadCommand,
+]

--- a/packages/base/src/commands/sbom/cli.ts
+++ b/packages/base/src/commands/sbom/cli.ts
@@ -1,3 +1,4 @@
+/* eslint-disable import-x/order */
 import {SbomUploadCommand} from './upload'
 
 // prettier-ignore

--- a/packages/base/src/commands/stepfunctions/cli.ts
+++ b/packages/base/src/commands/stepfunctions/cli.ts
@@ -1,3 +1,4 @@
+/* eslint-disable import-x/order */
 import {StepfunctionsInstrumentCommand} from './instrument'
 import {StepfunctionsUninstrumentCommand} from './uninstrument'
 

--- a/packages/base/src/commands/stepfunctions/cli.ts
+++ b/packages/base/src/commands/stepfunctions/cli.ts
@@ -1,4 +1,8 @@
-import {InstrumentStepFunctionsCommand} from './instrument'
-import {UninstrumentStepFunctionsCommand} from './uninstrument'
+import {StepfunctionsInstrumentCommand} from './instrument'
+import {StepfunctionsUninstrumentCommand} from './uninstrument'
 
-export const commands = [InstrumentStepFunctionsCommand, UninstrumentStepFunctionsCommand]
+// prettier-ignore
+export const commands = [
+  StepfunctionsInstrumentCommand,
+  StepfunctionsUninstrumentCommand,
+]

--- a/packages/base/src/commands/stepfunctions/instrument.ts
+++ b/packages/base/src/commands/stepfunctions/instrument.ts
@@ -2,7 +2,7 @@ import {Command, Option} from 'clipanion'
 
 import {executePluginCommand} from '../../helpers/plugin'
 
-export class InstrumentStepFunctionsCommand extends Command {
+export class StepfunctionsInstrumentCommand extends Command {
   public static paths = [['stepfunctions', 'instrument']]
 
   public static usage = Command.Usage({

--- a/packages/base/src/commands/stepfunctions/uninstrument.ts
+++ b/packages/base/src/commands/stepfunctions/uninstrument.ts
@@ -2,7 +2,7 @@ import {Command, Option} from 'clipanion'
 
 import {executePluginCommand} from '../../helpers/plugin'
 
-export class UninstrumentStepFunctionsCommand extends Command {
+export class StepfunctionsUninstrumentCommand extends Command {
   public static paths = [['stepfunctions', 'uninstrument']]
 
   public static usage = Command.Usage({

--- a/packages/base/src/commands/synthetics/cli.ts
+++ b/packages/base/src/commands/synthetics/cli.ts
@@ -1,6 +1,12 @@
-import {DeployTestsCommand} from './deploy-tests'
-import {ImportTestsCommand} from './import-tests'
-import {RunTestsCommand} from './run-tests'
-import {UploadApplicationCommand} from './upload-application'
+import {SyntheticsDeployTestsCommand} from './deploy-tests'
+import {SyntheticsImportTestsCommand} from './import-tests'
+import {SyntheticsRunTestsCommand} from './run-tests'
+import {SyntheticsUploadApplicationCommand} from './upload-application'
 
-export const commands = [RunTestsCommand, DeployTestsCommand, UploadApplicationCommand, ImportTestsCommand]
+// prettier-ignore
+export const commands = [
+  SyntheticsDeployTestsCommand,
+  SyntheticsImportTestsCommand,
+  SyntheticsRunTestsCommand,
+  SyntheticsUploadApplicationCommand,
+]

--- a/packages/base/src/commands/synthetics/cli.ts
+++ b/packages/base/src/commands/synthetics/cli.ts
@@ -1,3 +1,4 @@
+/* eslint-disable import-x/order */
 import {SyntheticsDeployTestsCommand} from './deploy-tests'
 import {SyntheticsImportTestsCommand} from './import-tests'
 import {SyntheticsRunTestsCommand} from './run-tests'

--- a/packages/base/src/commands/synthetics/deploy-tests.ts
+++ b/packages/base/src/commands/synthetics/deploy-tests.ts
@@ -16,7 +16,7 @@ const $B3 = makeTerminalLink(`${datadogDocsBaseUrl}/getting_started/site/#access
 
 const $1 = makeTerminalLink(`${datadogDocsBaseUrl}/continuous_testing/cicd_integrations/configuration#test-files`)
 
-export class DeployTestsCommand extends Command {
+export class SyntheticsDeployTestsCommand extends Command {
   public static paths = [['synthetics', 'deploy-tests']]
 
   public static usage = Command.Usage({

--- a/packages/base/src/commands/synthetics/import-tests.ts
+++ b/packages/base/src/commands/synthetics/import-tests.ts
@@ -19,7 +19,7 @@ const $1 = makeTerminalLink(`${datadogDocsBaseUrl}/continuous_testing/cicd_integ
 const $2 = makeTerminalLink(`${datadogDocsBaseUrl}/synthetics/explore/#search`)
 const $3 = makeTerminalLink(`${datadogAppBaseUrl}/synthetics/tests`)
 
-export class ImportTestsCommand extends Command {
+export class SyntheticsImportTestsCommand extends Command {
   public static paths = [['synthetics', 'import-tests']]
 
   public static usage = Command.Usage({

--- a/packages/base/src/commands/synthetics/run-tests.ts
+++ b/packages/base/src/commands/synthetics/run-tests.ts
@@ -25,7 +25,7 @@ const $5 = makeTerminalLink(
 )
 const $6 = makeTerminalLink(`${datadogDocsBaseUrl}/synthetics/mobile_app_testing/`)
 
-export class RunTestsCommand extends Command {
+export class SyntheticsRunTestsCommand extends Command {
   public static paths = [
     ['synthetics', 'run-tests'],
     ['synthetics', 'build-and-test'],

--- a/packages/base/src/commands/synthetics/upload-application.ts
+++ b/packages/base/src/commands/synthetics/upload-application.ts
@@ -14,7 +14,7 @@ const $B2 = makeTerminalLink(
 const $B3 = makeTerminalLink(`${datadogDocsBaseUrl}/getting_started/site/#access-the-datadog-site`)
 // BASE COMMAND END
 
-export class UploadApplicationCommand extends Command {
+export class SyntheticsUploadApplicationCommand extends Command {
   public static paths = [['synthetics', 'upload-application']]
 
   public static usage = Command.Usage({

--- a/packages/base/src/commands/tag/cli.ts
+++ b/packages/base/src/commands/tag/cli.ts
@@ -1,3 +1,7 @@
+/* eslint-disable import-x/order */
 import {TagCommand} from './tag'
 
-export const commands = [TagCommand]
+// prettier-ignore
+export const commands = [
+  TagCommand,
+]

--- a/packages/base/src/helpers/git/source-code-integration.ts
+++ b/packages/base/src/helpers/git/source-code-integration.ts
@@ -1,7 +1,7 @@
 import {BaseContext, Cli} from 'clipanion'
 
 import {getCommitInfo, newSimpleGit} from '../../commands/git-metadata/git'
-import {UploadCommand} from '../../commands/git-metadata/upload'
+import {GitMetadataUploadCommand} from '../../commands/git-metadata/upload'
 
 import {renderSoftWarning} from '../renderer'
 import {filterAndFormatGithubRemote} from '../utils'
@@ -71,7 +71,7 @@ export const getCurrentGitStatus = async () => {
 // Only exported to be mocked in unit tests
 export const uploadGitData = async (context: BaseContext) => {
   const cli = new Cli()
-  cli.register(UploadCommand)
+  cli.register(GitMetadataUploadCommand)
   if ((await cli.run(['git-metadata', 'upload'], context)) !== 0) {
     throw Error("Couldn't upload git metadata")
   }

--- a/packages/datadog-ci/src/commands/coverage/__tests__/upload.test.ts
+++ b/packages/datadog-ci/src/commands/coverage/__tests__/upload.test.ts
@@ -2,7 +2,7 @@ import {createCommand, createMockContext, makeRunCLI} from '@datadog/datadog-ci-
 import {SpanTags} from '@datadog/datadog-ci-base/helpers/interfaces'
 import upath from 'upath'
 
-import {UploadCodeCoverageReportCommand} from '../upload'
+import {CoverageUploadCommand} from '../upload'
 import {jacocoFormat} from '../utils'
 
 jest.mock('@datadog/datadog-ci-base/helpers/id', () => jest.fn())
@@ -15,7 +15,7 @@ describe('upload', () => {
     test('should throw an error if API key is undefined', () => {
       process.env = {}
       const write = jest.fn()
-      const command = createCommand(UploadCodeCoverageReportCommand, {stdout: {write}})
+      const command = createCommand(CoverageUploadCommand, {stdout: {write}})
 
       expect(command['getApiHelper'].bind(command)).toThrow('API key is missing')
       expect(write.mock.calls[0][0]).toContain('DD_API_KEY')
@@ -24,7 +24,7 @@ describe('upload', () => {
 
   describe('getMatchingCoverageReportFilesByFormat', () => {
     test('should read all coverage report files and reject invalid ones', () => {
-      const command = createCommand(UploadCodeCoverageReportCommand)
+      const command = createCommand(CoverageUploadCommand)
       command['reportPaths'] = ['src/commands/coverage/__tests__/fixtures']
 
       const result = command['getMatchingCoverageReportFilesByFormat']()
@@ -44,7 +44,7 @@ describe('upload', () => {
     })
 
     test('should filter by format', () => {
-      const command = createCommand(UploadCodeCoverageReportCommand)
+      const command = createCommand(CoverageUploadCommand)
       command['format'] = jacocoFormat
       command['reportPaths'] = ['src/commands/coverage/__tests__/fixtures']
 
@@ -58,7 +58,7 @@ describe('upload', () => {
     })
 
     test('should read all coverage report files excluding ignored paths', () => {
-      const command = createCommand(UploadCodeCoverageReportCommand)
+      const command = createCommand(CoverageUploadCommand)
       command['ignoredPaths'] = 'src/commands/coverage/__tests__/fixtures/subfolder.xml'
       command['reportPaths'] = ['src/commands/coverage/__tests__/fixtures']
 
@@ -76,7 +76,7 @@ describe('upload', () => {
     })
 
     test('should read all coverage report files excluding ignored paths specified partially', () => {
-      const command = createCommand(UploadCodeCoverageReportCommand)
+      const command = createCommand(CoverageUploadCommand)
       command['ignoredPaths'] = 'subfolder.xml'
       command['reportPaths'] = ['src/commands/coverage/__tests__/fixtures']
 
@@ -94,7 +94,7 @@ describe('upload', () => {
     })
 
     test('should allow specifying files directly', () => {
-      const command = createCommand(UploadCodeCoverageReportCommand)
+      const command = createCommand(CoverageUploadCommand)
       command['reportPaths'] = [
         'src/commands/coverage/__tests__/fixtures/jacoco-report.xml',
         'src/commands/coverage/__tests__/fixtures/lcov.info',
@@ -110,7 +110,7 @@ describe('upload', () => {
     })
 
     test('should filter files by format if format is provided', () => {
-      const command = createCommand(UploadCodeCoverageReportCommand)
+      const command = createCommand(CoverageUploadCommand)
       command['format'] = 'lcov'
       command['reportPaths'] = [
         'src/commands/coverage/__tests__/fixtures/jacoco-report.xml',
@@ -126,7 +126,7 @@ describe('upload', () => {
     })
 
     test('should not fail for invalid single files', () => {
-      const command = createCommand(UploadCodeCoverageReportCommand)
+      const command = createCommand(CoverageUploadCommand)
       command['reportPaths'] = ['src/commands/coverage/__tests__/fixtures/does-not-exist.xml']
 
       const result = command['getMatchingCoverageReportFilesByFormat']()
@@ -137,7 +137,7 @@ describe('upload', () => {
     })
 
     test('should allow folder and single unit paths', () => {
-      const command = createCommand(UploadCodeCoverageReportCommand)
+      const command = createCommand(CoverageUploadCommand)
       command['format'] = jacocoFormat
       command['reportPaths'] = [
         'src/commands/coverage/__tests__/fixtures',
@@ -154,7 +154,7 @@ describe('upload', () => {
     })
 
     test('should not have repeated files', () => {
-      const command = createCommand(UploadCodeCoverageReportCommand)
+      const command = createCommand(CoverageUploadCommand)
       command['format'] = jacocoFormat
       command['reportPaths'] = [
         'src/commands/coverage/__tests__/fixtures',
@@ -172,7 +172,7 @@ describe('upload', () => {
     })
 
     test('should fetch nested folders when using glob patterns', () => {
-      const command = createCommand(UploadCodeCoverageReportCommand)
+      const command = createCommand(CoverageUploadCommand)
       command['reportPaths'] = ['**/coverage/**/*.xml']
 
       const result = command['getMatchingCoverageReportFilesByFormat']()
@@ -190,7 +190,7 @@ describe('upload', () => {
     })
 
     test('should filter by format when using glob patterns', () => {
-      const command = createCommand(UploadCodeCoverageReportCommand)
+      const command = createCommand(CoverageUploadCommand)
       command['format'] = 'lcov'
       command['reportPaths'] = ['**/coverage/**']
 
@@ -203,7 +203,7 @@ describe('upload', () => {
     })
 
     test('should fetch nested folders and ignore files that are not coverage reports', () => {
-      const command = createCommand(UploadCodeCoverageReportCommand)
+      const command = createCommand(CoverageUploadCommand)
       command['format'] = jacocoFormat
       command['reportPaths'] = ['**/coverage/**']
 
@@ -221,7 +221,7 @@ describe('upload', () => {
     test('should parse DD_ENV environment variable', async () => {
       process.env.DD_ENV = 'ci'
       const context = createMockContext()
-      const command = createCommand(UploadCodeCoverageReportCommand)
+      const command = createCommand(CoverageUploadCommand)
       const spanTags: SpanTags = await command['getSpanTags'].call({
         config: {
           env: process.env.DD_ENV,
@@ -237,7 +237,7 @@ describe('upload', () => {
   describe('parseCustomTags', () => {
     test('should parse tags argument', () => {
       const context = createMockContext()
-      const command = createCommand(UploadCodeCoverageReportCommand)
+      const command = createCommand(CoverageUploadCommand)
       const spanTags: SpanTags = command['getCustomTags'].call({
         config: {},
         context,
@@ -253,7 +253,7 @@ describe('upload', () => {
     test('should parse DD_TAGS environment variable', () => {
       process.env.DD_TAGS = 'key1:https://google.com,key2:value2,key3:1234321'
       const context = createMockContext()
-      const command = createCommand(UploadCodeCoverageReportCommand)
+      const command = createCommand(CoverageUploadCommand)
       const spanTags: SpanTags = command['getCustomTags'].call({
         config: {
           envVarTags: process.env.DD_TAGS,
@@ -269,7 +269,7 @@ describe('upload', () => {
 
     test('should parse measures argument', () => {
       const context = createMockContext()
-      const command = createCommand(UploadCodeCoverageReportCommand)
+      const command = createCommand(CoverageUploadCommand)
       const spanTags: SpanTags = command['getCustomMeasures'].call({
         config: {},
         context,
@@ -285,7 +285,7 @@ describe('upload', () => {
     test('should parse DD_MEASURES environment variable', () => {
       process.env.DD_MEASURES = 'key1:321,key2:123,key3:321.1,key4:abc,key5:-12.1'
       const context = createMockContext()
-      const command = createCommand(UploadCodeCoverageReportCommand)
+      const command = createCommand(CoverageUploadCommand)
       const spanTags: SpanTags = command['getCustomMeasures'].call({
         config: {
           envVarMeasures: process.env.DD_MEASURES,
@@ -304,7 +304,7 @@ describe('upload', () => {
     test('should ignore DD_MEASURES if a non-numeric value is passed', () => {
       process.env.DD_MEASURES = 'key1:321,key2:abc'
       const context = createMockContext()
-      const command = createCommand(UploadCodeCoverageReportCommand)
+      const command = createCommand(CoverageUploadCommand)
       const spanTags: SpanTags = command['getCustomMeasures'].call({
         config: {
           envVarMeasures: process.env.DD_MEASURES,
@@ -318,7 +318,7 @@ describe('upload', () => {
 })
 
 describe('execute', () => {
-  const runCLI = makeRunCLI(UploadCodeCoverageReportCommand, ['coverage', 'upload', '--dry-run'])
+  const runCLI = makeRunCLI(CoverageUploadCommand, ['coverage', 'upload', '--dry-run'])
 
   test('relative path with double dots', async () => {
     const {context, code} = await runCLI(['src/commands/coverage/__tests__/doesnotexist/../fixtures'])

--- a/packages/datadog-ci/src/commands/coverage/cli.ts
+++ b/packages/datadog-ci/src/commands/coverage/cli.ts
@@ -1,3 +1,3 @@
-import {UploadCodeCoverageReportCommand} from './upload'
+import {CoverageUploadCommand} from './upload'
 
-export const commands = [UploadCodeCoverageReportCommand]
+export const commands = [CoverageUploadCommand]

--- a/packages/datadog-ci/src/commands/coverage/upload.ts
+++ b/packages/datadog-ci/src/commands/coverage/upload.ts
@@ -55,7 +55,7 @@ const errorCodesStopUpload = [400, 403]
 
 const MAX_REPORTS_PER_REQUEST = 8 // backend supports 10 attachments, to keep the logic simple we subtract 2: for PR diff and commit diff
 
-export class UploadCodeCoverageReportCommand extends Command {
+export class CoverageUploadCommand extends Command {
   public static paths = [['coverage', 'upload']]
 
   public static usage = Command.Usage({

--- a/packages/datadog-ci/src/commands/dsyms/__tests__/upload.test.ts
+++ b/packages/datadog-ci/src/commands/dsyms/__tests__/upload.test.ts
@@ -9,7 +9,7 @@ import {Cli} from 'clipanion'
 import upath from 'upath'
 
 import {Dsym} from '../interfaces'
-import {UploadCommand} from '../upload'
+import {DsymsUploadCommand} from '../upload'
 import {createUniqueTmpDirectory, deleteDirectory} from '../utils'
 
 /**
@@ -96,7 +96,7 @@ describe('upload', () => {
   })
 
   describe('findDsyms', () => {
-    const command = new UploadCommand()
+    const command = new DsymsUploadCommand()
 
     test('Should find dSYMs recursively', async () => {
       const actualDSYMs = await command['findDsyms']('src/commands/dsyms/__tests__/fixtures')
@@ -108,7 +108,7 @@ describe('upload', () => {
   })
 
   describe('parseDwarfdumpOutput', () => {
-    const command = new UploadCommand()
+    const command = new DsymsUploadCommand()
 
     test('Should read arch slice from single-line output', () => {
       const output = 'UUID: 00000000-1111-2222-3333-444444444444 (arm64) /folder/Foo.dSYM/Contents/Resources/DWARF/Foo'
@@ -170,7 +170,7 @@ describe('upload', () => {
   })
 
   describe('processDsyms', () => {
-    const command = new UploadCommand()
+    const command = new DsymsUploadCommand()
 
     test('Given fat dSYM, it should extract each arch slice to separate dSYM in target folder', async () => {
       const tmpDirectory = await createUniqueTmpDirectory()
@@ -243,7 +243,7 @@ describe('upload', () => {
   })
 
   describe('compressDsyms', () => {
-    const command = new UploadCommand()
+    const command = new DsymsUploadCommand()
 
     test('Should archive dSYMs to target directory and name archives by their UUIDs', async () => {
       const tmpDirectory = await createUniqueTmpDirectory()
@@ -269,7 +269,7 @@ describe('upload', () => {
 describe('execute', () => {
   const runCLI = async (dsymPath: string, options?: {configPath?: string; env?: Record<string, string>}) => {
     const cli = new Cli()
-    cli.register(UploadCommand)
+    cli.register(DsymsUploadCommand)
 
     const context = createMockContext()
     const command = ['dsyms', 'upload', dsymPath, '--dry-run']

--- a/packages/datadog-ci/src/commands/dsyms/cli.ts
+++ b/packages/datadog-ci/src/commands/dsyms/cli.ts
@@ -1,3 +1,3 @@
-import {UploadCommand} from './upload'
+import {DsymsUploadCommand} from './upload'
 
-export const commands = [UploadCommand]
+export const commands = [DsymsUploadCommand]

--- a/packages/datadog-ci/src/commands/dsyms/upload.ts
+++ b/packages/datadog-ci/src/commands/dsyms/upload.ts
@@ -41,7 +41,7 @@ import {
   zipDirectoryToArchive,
 } from './utils'
 
-export class UploadCommand extends Command {
+export class DsymsUploadCommand extends Command {
   public static paths = [['dsyms', 'upload']]
 
   public static usage = Command.Usage({

--- a/packages/datadog-ci/src/commands/elf-symbols/__tests__/upload.test.ts
+++ b/packages/datadog-ci/src/commands/elf-symbols/__tests__/upload.test.ts
@@ -15,7 +15,7 @@ import upath from 'upath'
 import {ElfClass} from '../elf-constants'
 import {uploadMultipartHelper} from '../helpers'
 import {renderArgumentMissingError, renderInvalidSymbolsLocation} from '../renderer'
-import {UploadCommand} from '../upload'
+import {ElfSymbolsUploadCommand} from '../upload'
 
 jest.mock('@datadog/datadog-ci-base/helpers/utils', () => ({
   ...jest.requireActual('@datadog/datadog-ci-base/helpers/utils'),
@@ -42,8 +42,8 @@ const commonMetadata = {
 }
 
 describe('elf-symbols upload', () => {
-  const runCommand = async (prepFunction: (command: UploadCommand) => void) => {
-    const command = createCommand(UploadCommand)
+  const runCommand = async (prepFunction: (command: ElfSymbolsUploadCommand) => void) => {
+    const command = createCommand(ElfSymbolsUploadCommand)
     prepFunction(command)
 
     const exitCode = await command.execute()
@@ -90,7 +90,7 @@ describe('elf-symbols upload', () => {
 
   describe('getElfSymbolFiles', () => {
     test('should find all symbol files', async () => {
-      const command = createCommand(UploadCommand)
+      const command = createCommand(ElfSymbolsUploadCommand)
       const files = await command['getElfSymbolFiles'](fixtureDir)
       expect(files.map((f) => f.filename)).toEqual([
         `${fixtureDir}/.debug/dyn_aarch64.debug`,
@@ -104,7 +104,7 @@ describe('elf-symbols upload', () => {
     })
 
     test('should accept elf file with only dynamic symbols if --upload-dynamic-symbols option is passed', async () => {
-      const command = createCommand(UploadCommand)
+      const command = createCommand(ElfSymbolsUploadCommand)
       command['acceptDynamicSymbolTableAsSymbolSource'] = true
       const files = await command['getElfSymbolFiles'](fixtureDir)
 
@@ -122,17 +122,17 @@ describe('elf-symbols upload', () => {
     })
 
     test('should throw an error when input is a single non-elf file', async () => {
-      const command = createCommand(UploadCommand)
+      const command = createCommand(ElfSymbolsUploadCommand)
       await expect(command['getElfSymbolFiles'](`${fixtureDir}/non_elf_file`)).rejects.toThrow()
     })
 
     test('should throw an error when input is a single elf file without symbols', async () => {
-      const command = createCommand(UploadCommand)
+      const command = createCommand(ElfSymbolsUploadCommand)
       await expect(command['getElfSymbolFiles'](`${fixtureDir}/go_x86_64_only_go_build_id`)).rejects.toThrow()
     })
 
     test('should not throw an error when a directory (except top-level) is not readable', async () => {
-      const command = createCommand(UploadCommand)
+      const command = createCommand(ElfSymbolsUploadCommand)
       let tmpDir
       let tmpSubDir
       try {
@@ -154,7 +154,7 @@ describe('elf-symbols upload', () => {
 
   describe('upload', () => {
     test('creates correct metadata payload', async () => {
-      const command = createCommand(UploadCommand)
+      const command = createCommand(ElfSymbolsUploadCommand)
       command['symbolsLocations'] = [fixtureDir]
 
       command['gitData'] = {

--- a/packages/datadog-ci/src/commands/elf-symbols/cli.ts
+++ b/packages/datadog-ci/src/commands/elf-symbols/cli.ts
@@ -1,3 +1,3 @@
-import {UploadCommand} from './upload'
+import {ElfSymbolsUploadCommand} from './upload'
 
-export const commands = [UploadCommand]
+export const commands = [ElfSymbolsUploadCommand]

--- a/packages/datadog-ci/src/commands/elf-symbols/upload.ts
+++ b/packages/datadog-ci/src/commands/elf-symbols/upload.ts
@@ -52,7 +52,7 @@ import {
   renderWarning,
 } from './renderer'
 
-export class UploadCommand extends Command {
+export class ElfSymbolsUploadCommand extends Command {
   public static paths = [['elf-symbols', 'upload']]
 
   public static usage = Command.Usage({

--- a/packages/datadog-ci/src/commands/flutter-symbols/__tests__/upload.test.ts
+++ b/packages/datadog-ci/src/commands/flutter-symbols/__tests__/upload.test.ts
@@ -4,8 +4,8 @@ import {MultipartFileValue, MultipartPayload, MultipartStringValue} from '@datad
 import {performSubCommand} from '@datadog/datadog-ci-base/helpers/utils'
 import {cliVersion} from '@datadog/datadog-ci-base/version'
 
-import * as dsyms from '../../dsyms/upload'
-import * as sourcemaps from '../../sourcemaps/upload'
+import {DsymsUploadCommand} from '../../dsyms/upload'
+import {SourcemapsUploadCommand} from '../../sourcemaps/upload'
 
 import {getArchInfoFromFilename, uploadMultipartHelper} from '../helpers'
 import {
@@ -18,7 +18,7 @@ import {
   renderPubspecMissingVersionError,
   renderVersionBuildNumberWarning,
 } from '../renderer'
-import {UploadCommand} from '../upload'
+import {FlutterSymbolsUploadCommand} from '../upload'
 
 jest.mock('@datadog/datadog-ci-base/helpers/utils', () => ({
   ...jest.requireActual('@datadog/datadog-ci-base/helpers/utils'),
@@ -38,8 +38,8 @@ jest.mock('../helpers', () => ({
 const fixtureDir = './src/commands/flutter-symbols/__tests__/fixtures'
 
 describe('flutter-symbol upload', () => {
-  const runCommand = async (prepFunction: (command: UploadCommand) => void) => {
-    const command = createCommand(UploadCommand)
+  const runCommand = async (prepFunction: (command: FlutterSymbolsUploadCommand) => void) => {
+    const command = createCommand(FlutterSymbolsUploadCommand)
     prepFunction(command)
 
     const exitCode = await command.execute()
@@ -121,7 +121,7 @@ describe('flutter-symbol upload', () => {
 
   describe('getFlutterSymbolFiles', () => {
     test('should read all symbol files', async () => {
-      const command = new UploadCommand()
+      const command = new FlutterSymbolsUploadCommand()
       const searchDir = `${fixtureDir}/dart-symbols`
       const files = command['getFlutterSymbolFiles'](searchDir)
 
@@ -136,7 +136,7 @@ describe('flutter-symbol upload', () => {
 
   describe('parsePubspec', () => {
     test('writes error on missing pubspec', async () => {
-      const command = createCommand(UploadCommand)
+      const command = createCommand(FlutterSymbolsUploadCommand)
       const context = command.context
       const exitCode = await command['parsePubspecVersion']('./pubspec.yaml')
 
@@ -147,7 +147,7 @@ describe('flutter-symbol upload', () => {
     })
 
     test('writes error on invalid pubspec', async () => {
-      const command = createCommand(UploadCommand)
+      const command = createCommand(FlutterSymbolsUploadCommand)
       const context = command.context
       const exitCode = await command['parsePubspecVersion'](`${fixtureDir}/pubspecs/invalidPubspec.yaml`)
 
@@ -158,7 +158,7 @@ describe('flutter-symbol upload', () => {
     })
 
     test('writes error on missing version in pubspec', async () => {
-      const command = createCommand(UploadCommand)
+      const command = createCommand(FlutterSymbolsUploadCommand)
       const context = command.context
       const exitCode = await command['parsePubspecVersion'](`${fixtureDir}/pubspecs/missingVersionPubspec.yaml`)
 
@@ -169,7 +169,7 @@ describe('flutter-symbol upload', () => {
     })
 
     test('populates version from valid pubspec', async () => {
-      const command = createCommand(UploadCommand)
+      const command = createCommand(FlutterSymbolsUploadCommand)
       const context = command.context
       const exitCode = await command['parsePubspecVersion'](`${fixtureDir}/pubspecs/validPubspec.yaml`)
 
@@ -181,7 +181,7 @@ describe('flutter-symbol upload', () => {
     })
 
     test('strips pre-release from pre-release pubspec and shows warning', async () => {
-      const command = createCommand(UploadCommand)
+      const command = createCommand(FlutterSymbolsUploadCommand)
       const context = command.context
       const exitCode = await command['parsePubspecVersion'](`${fixtureDir}/pubspecs/prereleasePubspec.yaml`)
 
@@ -193,7 +193,7 @@ describe('flutter-symbol upload', () => {
     })
 
     test('strips build from build pubspec and shows warning', async () => {
-      const command = createCommand(UploadCommand)
+      const command = createCommand(FlutterSymbolsUploadCommand)
       const context = command.context
       const exitCode = await command['parsePubspecVersion'](`${fixtureDir}/pubspecs/buildPubspec.yaml`)
 
@@ -215,7 +215,7 @@ describe('flutter-symbol upload', () => {
 
       expect(exitCode).toBe(0)
       expect(performSubCommand).toHaveBeenCalledWith(
-        dsyms.UploadCommand,
+        DsymsUploadCommand,
         ['dsyms', 'upload', './build/ios/archive/Runner.xcarchive/dSYMs'],
         expect.anything()
       )
@@ -231,7 +231,7 @@ describe('flutter-symbol upload', () => {
 
       expect(exitCode).toBe(0)
       expect(performSubCommand).toHaveBeenCalledWith(
-        dsyms.UploadCommand,
+        DsymsUploadCommand,
         ['dsyms', 'upload', './build/ios/archive/Runner.xcarchive/dSYMs', '--dry-run'],
         expect.anything()
       )
@@ -248,7 +248,7 @@ describe('flutter-symbol upload', () => {
 
       expect(exitCode).toBe(0)
       expect(performSubCommand).toHaveBeenCalledWith(
-        dsyms.UploadCommand,
+        DsymsUploadCommand,
         ['dsyms', 'upload', './dsym-location'],
         expect.anything()
       )
@@ -257,12 +257,12 @@ describe('flutter-symbol upload', () => {
   })
 
   describe('android mapping upload', () => {
-    const addDefaultCommandParameters = (command: UploadCommand) => {
+    const addDefaultCommandParameters = (command: FlutterSymbolsUploadCommand) => {
       command['serviceName'] = 'fake.service'
       command['version'] = '1.0.0'
     }
 
-    const mockGitRepoParameters = (command: UploadCommand) => {
+    const mockGitRepoParameters = (command: FlutterSymbolsUploadCommand) => {
       command['gitData'] = {
         hash: 'fake-git-hash',
         remote: 'fake-git-remote',
@@ -299,7 +299,7 @@ describe('flutter-symbol upload', () => {
     })
 
     test('creates correct metadata payload', () => {
-      const command = createCommand(UploadCommand)
+      const command = createCommand(FlutterSymbolsUploadCommand)
       addDefaultCommandParameters(command)
       mockGitRepoParameters(command)
 
@@ -317,7 +317,7 @@ describe('flutter-symbol upload', () => {
     })
 
     test('build in version is sanitized in metadata payload', () => {
-      const command = createCommand(UploadCommand)
+      const command = createCommand(FlutterSymbolsUploadCommand)
       addDefaultCommandParameters(command)
       mockGitRepoParameters(command)
       command['version'] = '1.2.4+987'
@@ -438,7 +438,7 @@ describe('flutter-symbol upload', () => {
 
       expect(exitCode).toBe(0)
       expect(performSubCommand).toHaveBeenCalledWith(
-        sourcemaps.UploadCommand,
+        SourcemapsUploadCommand,
         [
           'sourcemaps',
           'upload',
@@ -462,7 +462,7 @@ describe('flutter-symbol upload', () => {
 
       expect(exitCode).toBe(0)
       expect(performSubCommand).toHaveBeenCalledWith(
-        sourcemaps.UploadCommand,
+        SourcemapsUploadCommand,
         [
           'sourcemaps',
           'upload',
@@ -485,7 +485,7 @@ describe('flutter-symbol upload', () => {
 
       expect(exitCode).toBe(0)
       expect(performSubCommand).toHaveBeenCalledWith(
-        sourcemaps.UploadCommand,
+        SourcemapsUploadCommand,
         [
           'sourcemaps',
           'upload',
@@ -509,7 +509,7 @@ describe('flutter-symbol upload', () => {
 
       expect(exitCode).toBe(0)
       expect(performSubCommand).toHaveBeenCalledWith(
-        sourcemaps.UploadCommand,
+        SourcemapsUploadCommand,
         [
           'sourcemaps',
           'upload',
@@ -525,12 +525,12 @@ describe('flutter-symbol upload', () => {
   })
 
   describe('flutter symbol upload', () => {
-    const addDefaultCommandParameters = (command: UploadCommand) => {
+    const addDefaultCommandParameters = (command: FlutterSymbolsUploadCommand) => {
       command['serviceName'] = 'fake.service'
       command['version'] = '1.0.0'
     }
 
-    const mockGitRepoParameters = (command: UploadCommand) => {
+    const mockGitRepoParameters = (command: FlutterSymbolsUploadCommand) => {
       command['gitData'] = {
         hash: 'fake-git-hash',
         remote: 'fake-git-remote',
@@ -567,7 +567,7 @@ describe('flutter-symbol upload', () => {
     })
 
     test('creates correct metadata payloads', () => {
-      const command = createCommand(UploadCommand)
+      const command = createCommand(FlutterSymbolsUploadCommand)
       addDefaultCommandParameters(command)
       mockGitRepoParameters(command)
 
@@ -587,7 +587,7 @@ describe('flutter-symbol upload', () => {
     })
 
     test('sanitizes build in version number payload', () => {
-      const command = createCommand(UploadCommand)
+      const command = createCommand(FlutterSymbolsUploadCommand)
       addDefaultCommandParameters(command)
       mockGitRepoParameters(command)
       command['version'] = '1.2.4+567'

--- a/packages/datadog-ci/src/commands/flutter-symbols/cli.ts
+++ b/packages/datadog-ci/src/commands/flutter-symbols/cli.ts
@@ -1,3 +1,3 @@
-import {UploadCommand} from './upload'
+import {FlutterSymbolsUploadCommand} from './upload'
 
-export const commands = [UploadCommand]
+export const commands = [FlutterSymbolsUploadCommand]

--- a/packages/datadog-ci/src/commands/flutter-symbols/upload.ts
+++ b/packages/datadog-ci/src/commands/flutter-symbols/upload.ts
@@ -23,8 +23,8 @@ import {Command, Option} from 'clipanion'
 import yaml from 'js-yaml'
 import semver from 'semver'
 
-import * as dsyms from '../dsyms/upload'
-import * as sourcemaps from '../sourcemaps/upload'
+import {DsymsUploadCommand} from '../dsyms/upload'
+import {SourcemapsUploadCommand} from '../sourcemaps/upload'
 
 import {getArchInfoFromFilename, getFlutterRequestBuilder, uploadMultipartHelper} from './helpers'
 import {
@@ -57,7 +57,7 @@ import {
   UploadInfo,
 } from './renderer'
 
-export class UploadCommand extends Command {
+export class FlutterSymbolsUploadCommand extends Command {
   public static paths = [['flutter-symbols', 'upload']]
 
   public static usage = Command.Usage({
@@ -463,7 +463,7 @@ export class UploadCommand extends Command {
       dsymUploadCommand.push('--dry-run')
     }
 
-    const exitCode = await performSubCommand(dsyms.UploadCommand, dsymUploadCommand, this.context)
+    const exitCode = await performSubCommand(DsymsUploadCommand, dsymUploadCommand, this.context)
     if (exitCode && exitCode !== 0) {
       return UploadStatus.Failure
     }
@@ -484,7 +484,7 @@ export class UploadCommand extends Command {
       sourceMapUploadCommand.push('--dry-run')
     }
 
-    const exitCode = await performSubCommand(sourcemaps.UploadCommand, sourceMapUploadCommand, this.context)
+    const exitCode = await performSubCommand(SourcemapsUploadCommand, sourceMapUploadCommand, this.context)
     if (exitCode && exitCode !== 0) {
       return UploadStatus.Failure
     }

--- a/packages/datadog-ci/src/commands/junit/__tests__/upload.test.ts
+++ b/packages/datadog-ci/src/commands/junit/__tests__/upload.test.ts
@@ -6,7 +6,7 @@ import {SpanTags} from '@datadog/datadog-ci-base/helpers/interfaces'
 import upath from 'upath'
 
 import {renderInvalidFile} from '../renderer'
-import {UploadJUnitXMLCommand} from '../upload'
+import {JunitUploadCommand} from '../upload'
 
 jest.mock('@datadog/datadog-ci-base/helpers/id', () => jest.fn())
 
@@ -18,7 +18,7 @@ describe('upload', () => {
     test('should throw an error if API key is undefined', () => {
       process.env = {}
       const write = jest.fn()
-      const command = createCommand(UploadJUnitXMLCommand, {stdout: {write}})
+      const command = createCommand(JunitUploadCommand, {stdout: {write}})
 
       expect(command['getApiHelper'].bind(command)).toThrow('API key is missing')
       expect(write.mock.calls[0][0]).toContain('DD_API_KEY')
@@ -26,7 +26,7 @@ describe('upload', () => {
   })
   describe('getMatchingJUnitXMLFiles', () => {
     test('should read all xml files and reject invalid ones', async () => {
-      const command = createCommand(UploadJUnitXMLCommand)
+      const command = createCommand(JunitUploadCommand)
       const files = await command['getMatchingJUnitXMLFiles'].call(
         {
           basePaths: ['src/commands/junit/__tests__/fixtures'],
@@ -59,7 +59,7 @@ describe('upload', () => {
     })
 
     test('should allow single files', async () => {
-      const command = createCommand(UploadJUnitXMLCommand)
+      const command = createCommand(JunitUploadCommand)
       const files = await command['getMatchingJUnitXMLFiles'].call(
         {
           basePaths: ['src/commands/junit/__tests__/fixtures/go-report.xml'],
@@ -82,7 +82,7 @@ describe('upload', () => {
     })
 
     test('should not fail for invalid single files', async () => {
-      const command = createCommand(UploadJUnitXMLCommand)
+      const command = createCommand(JunitUploadCommand)
       const files = await command['getMatchingJUnitXMLFiles'].call(
         {
           basePaths: ['src/commands/junit/__tests__/fixtures/does-not-exist.xml'],
@@ -101,7 +101,7 @@ describe('upload', () => {
     })
 
     test('should allow folder and single unit paths', async () => {
-      const command = createCommand(UploadJUnitXMLCommand)
+      const command = createCommand(JunitUploadCommand)
       const files = await command['getMatchingJUnitXMLFiles'].call(
         {
           basePaths: [
@@ -128,7 +128,7 @@ describe('upload', () => {
     })
 
     test('should allow folders with extensions', async () => {
-      const command = createCommand(UploadJUnitXMLCommand)
+      const command = createCommand(JunitUploadCommand)
       const files = await command['getMatchingJUnitXMLFiles'].call(
         {
           basePaths: ['src/commands/junit/__tests__/fixtures/junit.xml'],
@@ -150,7 +150,7 @@ describe('upload', () => {
     })
 
     test('should not have repeated files', async () => {
-      const command = createCommand(UploadJUnitXMLCommand)
+      const command = createCommand(JunitUploadCommand)
       const files = await command['getMatchingJUnitXMLFiles'].call(
         {
           basePaths: ['src/commands/junit/__tests__/fixtures', 'src/commands/junit/__tests__/fixtures/go-report.xml'],
@@ -169,7 +169,7 @@ describe('upload', () => {
     })
 
     test('should set hostname', async () => {
-      const command = createCommand(UploadJUnitXMLCommand)
+      const command = createCommand(JunitUploadCommand)
       const files = await command['getMatchingJUnitXMLFiles'].call(
         {
           basePaths: ['src/commands/junit/__tests__/fixtures'],
@@ -192,7 +192,7 @@ describe('upload', () => {
 
     test('should set logsEnabled for each file', async () => {
       process.env.DD_CIVISIBILITY_LOGS_ENABLED = 'true'
-      const command = createCommand(UploadJUnitXMLCommand)
+      const command = createCommand(JunitUploadCommand)
       const files = await command['getMatchingJUnitXMLFiles'].call(
         {
           basePaths: ['src/commands/junit/__tests__/fixtures'],
@@ -216,7 +216,7 @@ describe('upload', () => {
 
     test('should show different error on no test report', async () => {
       process.env.DD_CIVISIBILITY_LOGS_ENABLED = 'true'
-      const command = createCommand(UploadJUnitXMLCommand)
+      const command = createCommand(JunitUploadCommand)
       await command['getMatchingJUnitXMLFiles'].call(
         {
           basePaths: ['src/commands/junit/__tests__/fixtures/subfolder/invalid-no-tests.xml'],
@@ -241,7 +241,7 @@ describe('upload', () => {
     })
 
     test('should fetch nested folders', async () => {
-      const command = createCommand(UploadJUnitXMLCommand)
+      const command = createCommand(JunitUploadCommand)
       const files = await command['getMatchingJUnitXMLFiles'].call(
         {
           basePaths: ['**/junit/**/*.xml'],
@@ -269,7 +269,7 @@ describe('upload', () => {
     })
 
     test('should fetch nested folders and ignore non xml files', async () => {
-      const command = createCommand(UploadJUnitXMLCommand)
+      const command = createCommand(JunitUploadCommand)
       const files = await command['getMatchingJUnitXMLFiles'].call(
         {
           basePaths: ['**/junit/**'],
@@ -297,7 +297,7 @@ describe('upload', () => {
     })
 
     test('should discover junit XML files automatically with recursive search', async () => {
-      const command = createCommand(UploadJUnitXMLCommand)
+      const command = createCommand(JunitUploadCommand)
       const files = await command['getMatchingJUnitXMLFiles'].call(
         {
           basePaths: ['src/commands/junit/__tests__/fixtures/autodiscovery'],
@@ -322,7 +322,7 @@ describe('upload', () => {
     })
 
     test('should discover junit XML files automatically excluding ignored paths', async () => {
-      const command = createCommand(UploadJUnitXMLCommand)
+      const command = createCommand(JunitUploadCommand)
       const files = await command['getMatchingJUnitXMLFiles'].call(
         {
           basePaths: ['src/commands/junit/__tests__/fixtures/autodiscovery'],
@@ -346,7 +346,7 @@ describe('upload', () => {
     })
 
     test('should combine explicit file paths with auto-discovered files', async () => {
-      const command = createCommand(UploadJUnitXMLCommand)
+      const command = createCommand(JunitUploadCommand)
       const files = await command['getMatchingJUnitXMLFiles'].call(
         {
           basePaths: [
@@ -374,7 +374,7 @@ describe('upload', () => {
   describe('getSpanTags', () => {
     test('should parse DD_ENV environment variable', async () => {
       process.env.DD_ENV = 'ci'
-      const command = createCommand(UploadJUnitXMLCommand)
+      const command = createCommand(JunitUploadCommand)
       const spanTags: SpanTags = await command['getSpanTags'].call({
         config: {
           env: process.env.DD_ENV,
@@ -388,7 +388,7 @@ describe('upload', () => {
   })
   describe('parseCustomTags', () => {
     test('should parse tags argument', async () => {
-      const command = createCommand(UploadJUnitXMLCommand)
+      const command = createCommand(JunitUploadCommand)
       const spanTags: SpanTags = command['getCustomTags'].call({
         config: {},
         context: command.context,
@@ -403,7 +403,7 @@ describe('upload', () => {
 
     test('should parse DD_TAGS environment variable', async () => {
       process.env.DD_TAGS = 'key1:https://google.com,key2:value2'
-      const command = createCommand(UploadJUnitXMLCommand)
+      const command = createCommand(JunitUploadCommand)
       const spanTags: SpanTags = command['getCustomTags'].call({
         config: {
           envVarTags: process.env.DD_TAGS,
@@ -417,7 +417,7 @@ describe('upload', () => {
     })
 
     test('should parse measures argument', async () => {
-      const command = createCommand(UploadJUnitXMLCommand)
+      const command = createCommand(JunitUploadCommand)
       const spanTags: SpanTags = command['getCustomMeasures'].call({
         config: {},
         context: command.context,
@@ -432,7 +432,7 @@ describe('upload', () => {
 
     test('should parse DD_MEASURES environment variable', async () => {
       process.env.DD_MEASURES = 'key1:321,key2:123,key3:321.1,key4:abc,key5:-12.1'
-      const command = createCommand(UploadJUnitXMLCommand)
+      const command = createCommand(JunitUploadCommand)
       const spanTags: SpanTags = command['getCustomMeasures'].call({
         config: {
           envVarMeasures: process.env.DD_MEASURES,
@@ -449,7 +449,7 @@ describe('upload', () => {
     })
 
     test('should parse report tags argument', async () => {
-      const command = createCommand(UploadJUnitXMLCommand)
+      const command = createCommand(JunitUploadCommand)
       const spanTags: SpanTags = command['getReportTags'].call({
         config: {},
         context: command.context,
@@ -463,7 +463,7 @@ describe('upload', () => {
     })
 
     test('should parse report measures argument', async () => {
-      const command = createCommand(UploadJUnitXMLCommand)
+      const command = createCommand(JunitUploadCommand)
       const spanTags: SpanTags = command['getReportMeasures'].call({
         config: {},
         context: command.context,
@@ -478,7 +478,7 @@ describe('upload', () => {
   })
   describe('parseXPathTags', () => {
     test('should parse xpath assignments', async () => {
-      const command = createCommand(UploadJUnitXMLCommand)
+      const command = createCommand(JunitUploadCommand)
       const xPathTags = command['parseXPathTags'].call(
         {
           basePaths: ['src/commands/junit/__tests__/fixtures'],
@@ -495,7 +495,7 @@ describe('upload', () => {
     })
 
     test('should alert of invalid values', async () => {
-      const command = createCommand(UploadJUnitXMLCommand)
+      const command = createCommand(JunitUploadCommand)
       command['parseXPathTags'].call(
         {
           basePaths: ['src/commands/junit/__tests__/fixtures'],
@@ -512,14 +512,7 @@ describe('upload', () => {
 })
 
 describe('execute', () => {
-  const runCLI = makeRunCLI(UploadJUnitXMLCommand, [
-    'junit',
-    'upload',
-    '--service',
-    'test-service',
-    '--dry-run',
-    '--logs',
-  ])
+  const runCLI = makeRunCLI(JunitUploadCommand, ['junit', 'upload', '--service', 'test-service', '--dry-run', '--logs'])
 
   test('relative path with double dots', async () => {
     const {context, code} = await runCLI(['src/commands/junit/__tests__/doesnotexist/../fixtures'])

--- a/packages/datadog-ci/src/commands/junit/cli.ts
+++ b/packages/datadog-ci/src/commands/junit/cli.ts
@@ -1,3 +1,3 @@
-import {UploadJUnitXMLCommand} from './upload'
+import {JunitUploadCommand} from './upload'
 
-export const commands = [UploadJUnitXMLCommand]
+export const commands = [JunitUploadCommand]

--- a/packages/datadog-ci/src/commands/junit/upload.ts
+++ b/packages/datadog-ci/src/commands/junit/upload.ts
@@ -76,7 +76,7 @@ const validateXml = (xmlFilePath: string) => {
   return undefined
 }
 
-export class UploadJUnitXMLCommand extends Command {
+export class JunitUploadCommand extends Command {
   public static paths = [['junit', 'upload']]
 
   public static usage = Command.Usage({

--- a/packages/datadog-ci/src/commands/pe-symbols/cli.ts
+++ b/packages/datadog-ci/src/commands/pe-symbols/cli.ts
@@ -1,3 +1,3 @@
-import {UploadCommand} from './upload'
+import {PeSymbolsUploadCommand} from './upload'
 
-export const commands = [UploadCommand]
+export const commands = [PeSymbolsUploadCommand]

--- a/packages/datadog-ci/src/commands/pe-symbols/upload.ts
+++ b/packages/datadog-ci/src/commands/pe-symbols/upload.ts
@@ -43,7 +43,7 @@ import {
   renderWarning,
 } from './renderer'
 
-export class UploadCommand extends Command {
+export class PeSymbolsUploadCommand extends Command {
   public static paths = [['pe-symbols', 'upload']]
 
   public static usage = Command.Usage({

--- a/packages/datadog-ci/src/commands/react-native/__tests__/codepush.test.ts
+++ b/packages/datadog-ci/src/commands/react-native/__tests__/codepush.test.ts
@@ -3,7 +3,7 @@ import {readFileSync} from 'fs'
 import {createMockContext, getEnvVarPlaceholders} from '@datadog/datadog-ci-base/helpers/__tests__/testing-tools'
 import {Cli} from 'clipanion'
 
-import {CodepushCommand} from '../codepush'
+import {ReactNativeCodepushCommand} from '../codepush'
 
 jest.mock('child_process', () => ({
   exec: jest.fn().mockImplementation((command: string, callback) => {
@@ -57,7 +57,7 @@ jest.mock('child_process', () => ({
 
 const runCLI = async (appName: string, options?: {uploadBundle?: boolean}) => {
   const cli = new Cli()
-  cli.register(CodepushCommand)
+  cli.register(ReactNativeCodepushCommand)
 
   const context = createMockContext()
   process.env = {...process.env, ...getEnvVarPlaceholders()}

--- a/packages/datadog-ci/src/commands/react-native/__tests__/inject-debug-id.test.ts
+++ b/packages/datadog-ci/src/commands/react-native/__tests__/inject-debug-id.test.ts
@@ -4,10 +4,10 @@ import os from 'os'
 import {makeRunCLI} from '@datadog/datadog-ci-base/helpers/__tests__/testing-tools'
 import upath from 'upath'
 
-import {InjectDebugIdCommand} from '../injectDebugId'
+import {ReactNativeInjectDebugIdCommand} from '../injectDebugId'
 
 const tmpDir = upath.join(os.tmpdir(), 'inject-debug-id-tests')
-const runCLI = makeRunCLI(InjectDebugIdCommand, ['react-native', 'inject-debug-id'])
+const runCLI = makeRunCLI(ReactNativeInjectDebugIdCommand, ['react-native', 'inject-debug-id'])
 
 describe('inject-debug-id', () => {
   beforeEach(async () => {

--- a/packages/datadog-ci/src/commands/react-native/__tests__/upload.test.ts
+++ b/packages/datadog-ci/src/commands/react-native/__tests__/upload.test.ts
@@ -9,13 +9,13 @@ import chalk from 'chalk'
 import {Cli} from 'clipanion'
 
 import {RNSourcemap} from '../interfaces'
-import {UploadCommand} from '../upload'
+import {ReactNativeUploadCommand} from '../upload'
 
 describe('upload', () => {
   describe('getApiHelper', () => {
     test('should throw an error if API key is undefined', async () => {
       process.env = {}
-      const command = new UploadCommand()
+      const command = new ReactNativeUploadCommand()
 
       expect(command['getRequestBuilder'].bind(command)).toThrow(
         `Missing ${chalk.bold('DATADOG_API_KEY')} or ${chalk.bold('DD_API_KEY')} in your environment.`
@@ -52,7 +52,7 @@ describe('upload', () => {
   describe('addRepositoryDataToPayloads', () => {
     test('repository url and commit still defined without payload', async () => {
       const write = jest.fn()
-      const command = createCommand(UploadCommand, {stdout: {write}})
+      const command = createCommand(ReactNativeUploadCommand, {stdout: {write}})
 
       const sourcemaps = new Array<RNSourcemap>(
         new RNSourcemap(
@@ -71,7 +71,7 @@ describe('upload', () => {
 
     test('should include payload', async () => {
       const write = jest.fn()
-      const command = createCommand(UploadCommand, {stdout: {write}})
+      const command = createCommand(ReactNativeUploadCommand, {stdout: {write}})
 
       const sourcemaps = new Array<RNSourcemap>(
         new RNSourcemap('main.jsbundle', 'src/commands/react-native/__tests__/fixtures/basic-ios/main.jsbundle.map')
@@ -95,7 +95,7 @@ describe('execute', () => {
     options?: {configPath?: string; uploadBundle?: boolean; env?: Record<string, string>}
   ) => {
     const cli = new Cli()
-    cli.register(UploadCommand)
+    cli.register(ReactNativeUploadCommand)
 
     const context = createMockContext()
     const command = [

--- a/packages/datadog-ci/src/commands/react-native/__tests__/xcode.test.ts
+++ b/packages/datadog-ci/src/commands/react-native/__tests__/xcode.test.ts
@@ -5,7 +5,7 @@ import * as formatGitSourcemapsData from '@datadog/datadog-ci-base/helpers/git/f
 import {Cli} from 'clipanion'
 
 import * as utils from '../utils'
-import {XCodeCommand} from '../xcode'
+import {ReactNativeXcodeCommand} from '../xcode'
 
 beforeEach(() => {
   delete process.env.CONFIGURATION
@@ -52,7 +52,7 @@ const runCLI = async (
   }
 ) => {
   const cli = new Cli()
-  cli.register(XCodeCommand)
+  cli.register(ReactNativeXcodeCommand)
 
   const context = createMockContext()
   process.env = {...process.env, ...getEnvVarPlaceholders()}
@@ -108,14 +108,14 @@ describe('xcode', () => {
   describe('getBundleLocation', () => {
     test('should return the location from CONFIGURATION_BUILD_DIR', () => {
       process.env.CONFIGURATION_BUILD_DIR = './src/commands/react-native/__tests__/fixtures/basic-ios'
-      const command = new XCodeCommand()
+      const command = new ReactNativeXcodeCommand()
       expect(command['getBundleLocation']()).toBe(
         './src/commands/react-native/__tests__/fixtures/basic-ios/main.jsbundle'
       )
     })
 
     test('should return null if no CONFIGURATION_BUILD_DIR is specified', () => {
-      const command = new XCodeCommand()
+      const command = new ReactNativeXcodeCommand()
       expect(command['getBundleLocation']()).toBeNull()
     })
   })
@@ -123,24 +123,24 @@ describe('xcode', () => {
   describe('getSourcemapsLocation', () => {
     test('should return the location from SOURCEMAP_FILE', () => {
       process.env.SOURCEMAP_FILE = './main.jsbundle.map'
-      const command = new XCodeCommand()
+      const command = new ReactNativeXcodeCommand()
       expect(command['getSourcemapsLocation']()).toMatch('./main.jsbundle.map')
     })
 
     test('should return the location from EXTRA_PACKAGER_ARGS', () => {
       process.env.EXTRA_PACKAGER_ARGS = '--bundle-output ./main.jsbundle --sourcemap-output ./main.jsbundle.map'
-      const command = new XCodeCommand()
+      const command = new ReactNativeXcodeCommand()
       expect(command['getSourcemapsLocation']()).toBe('./main.jsbundle.map')
     })
 
     test('should return null if no location is in EXTRA_PACKAGER_ARGS and SOURCEMAP_FILE is undefined', () => {
       process.env.EXTRA_PACKAGER_ARGS = '--bundle-output ./main.jsbundle'
-      const command = new XCodeCommand()
+      const command = new ReactNativeXcodeCommand()
       expect(command['getSourcemapsLocation']()).toBeNull()
     })
 
     test('should return null if EXTRA_PACKAGER_ARGS and SOURCEMAP_FILE are undefined', () => {
-      const command = new XCodeCommand()
+      const command = new ReactNativeXcodeCommand()
       expect(command['getSourcemapsLocation']()).toBeNull()
     })
   })

--- a/packages/datadog-ci/src/commands/react-native/cli.ts
+++ b/packages/datadog-ci/src/commands/react-native/cli.ts
@@ -1,6 +1,11 @@
-import {CodepushCommand} from './codepush'
-import {InjectDebugIdCommand} from './injectDebugId'
-import {UploadCommand} from './upload'
-import {XCodeCommand} from './xcode'
+import {ReactNativeCodepushCommand} from './codepush'
+import {ReactNativeInjectDebugIdCommand} from './injectDebugId'
+import {ReactNativeUploadCommand} from './upload'
+import {ReactNativeXcodeCommand} from './xcode'
 
-export const commands = [CodepushCommand, UploadCommand, XCodeCommand, InjectDebugIdCommand]
+export const commands = [
+  ReactNativeCodepushCommand,
+  ReactNativeUploadCommand,
+  ReactNativeXcodeCommand,
+  ReactNativeInjectDebugIdCommand,
+]

--- a/packages/datadog-ci/src/commands/react-native/codepush.ts
+++ b/packages/datadog-ci/src/commands/react-native/codepush.ts
@@ -7,10 +7,10 @@ import {Cli, Command, Option} from 'clipanion'
 
 import {CodepushHistoryCommandError, CodepushHistoryParseError, NoCodepushReleaseError} from './errors'
 import {RNPlatform, RN_SUPPORTED_PLATFORMS} from './interfaces'
-import {UploadCommand} from './upload'
+import {ReactNativeUploadCommand} from './upload'
 import {sanitizeReleaseVersion} from './utils'
 
-export class CodepushCommand extends Command {
+export class ReactNativeCodepushCommand extends Command {
   public static paths = [['react-native', 'codepush']]
 
   public static usage = Command.Usage({
@@ -108,7 +108,7 @@ export class CodepushCommand extends Command {
 
     // Run upload script in the background
     const cli = new Cli()
-    cli.register(UploadCommand)
+    cli.register(ReactNativeUploadCommand)
 
     const uploadCommand = [
       'react-native',

--- a/packages/datadog-ci/src/commands/react-native/injectDebugId.ts
+++ b/packages/datadog-ci/src/commands/react-native/injectDebugId.ts
@@ -12,7 +12,7 @@ import upath from 'upath'
  */
 const DEBUG_ID_METADATA_PREFIX = 'datadog-debug-id-'
 
-export class InjectDebugIdCommand extends Command {
+export class ReactNativeInjectDebugIdCommand extends Command {
   public static paths = [['react-native', 'inject-debug-id']]
   public static usage = Command.Usage({
     category: 'RUM',

--- a/packages/datadog-ci/src/commands/react-native/upload.ts
+++ b/packages/datadog-ci/src/commands/react-native/upload.ts
@@ -37,7 +37,7 @@ import {
 import {getBundleName} from './utils'
 import {InvalidPayload, validatePayload} from './validation'
 
-export class UploadCommand extends Command {
+export class ReactNativeUploadCommand extends Command {
   public static paths = [['react-native', 'upload']]
 
   public static usage = Command.Usage({

--- a/packages/datadog-ci/src/commands/react-native/xcode.ts
+++ b/packages/datadog-ci/src/commands/react-native/xcode.ts
@@ -8,7 +8,7 @@ import {enableFips} from '@datadog/datadog-ci-base/helpers/fips'
 import {parsePlist} from '@datadog/datadog-ci-base/helpers/plist'
 import {Cli, Command, Option} from 'clipanion'
 
-import {UploadCommand} from './upload'
+import {ReactNativeUploadCommand} from './upload'
 import {getReactNativeVersion} from './utils'
 
 /**
@@ -65,7 +65,7 @@ const getDatadogReactNativePath = () => {
   }
 }
 
-export class XCodeCommand extends Command {
+export class ReactNativeXcodeCommand extends Command {
   public static paths = [['react-native', 'xcode']]
 
   public static usage = Command.Usage({
@@ -251,7 +251,7 @@ export class XCodeCommand extends Command {
 
     // Run upload script in the background
     const cli = new Cli()
-    cli.register(UploadCommand)
+    cli.register(ReactNativeUploadCommand)
 
     const uploadCommand = [
       'react-native',

--- a/packages/datadog-ci/src/commands/sourcemaps/__tests__/upload.test.ts
+++ b/packages/datadog-ci/src/commands/sourcemaps/__tests__/upload.test.ts
@@ -3,7 +3,7 @@ import chalk from 'chalk'
 import upath from 'upath'
 
 import {Sourcemap} from '../interfaces'
-import {UploadCommand} from '../upload'
+import {SourcemapsUploadCommand} from '../upload'
 
 // Always posix, even on Windows.
 const CWD = upath.normalize(process.cwd())
@@ -11,7 +11,7 @@ const CWD = upath.normalize(process.cwd())
 describe('upload', () => {
   describe('getMinifiedURL', () => {
     test('should return correct URL', () => {
-      const command = createCommand(UploadCommand)
+      const command = createCommand(SourcemapsUploadCommand)
       command['basePath'] = '/js/sourcemaps'
       command['minifiedPathPrefix'] = 'http://datadog.com/js'
       expect(command['getMinifiedURLAndRelativePath']('/js/sourcemaps/common.min.js.map')).toStrictEqual([
@@ -23,7 +23,7 @@ describe('upload', () => {
 
   describe('getMinifiedURL: minifiedPathPrefix has the protocol omitted', () => {
     test('should return correct URL', () => {
-      const command = createCommand(UploadCommand)
+      const command = createCommand(SourcemapsUploadCommand)
       command['basePath'] = '/js/sourcemaps'
       command['minifiedPathPrefix'] = '//datadog.com/js'
       expect(command['getMinifiedURLAndRelativePath']('/js/sourcemaps/common.min.js.map')).toStrictEqual([
@@ -35,7 +35,7 @@ describe('upload', () => {
 
   describe('getMinifiedURL: minifiedPathPrefix is an absolute path', () => {
     test('should return correct URL', () => {
-      const command = createCommand(UploadCommand)
+      const command = createCommand(SourcemapsUploadCommand)
       command['basePath'] = '/js/sourcemaps'
       command['minifiedPathPrefix'] = '/js'
       expect(command['getMinifiedURLAndRelativePath']('/js/sourcemaps/common.min.js.map')).toStrictEqual([
@@ -47,7 +47,7 @@ describe('upload', () => {
 
   describe('isMinifiedPathPrefixValid: full URL', () => {
     test('should return true', () => {
-      const command = createCommand(UploadCommand)
+      const command = createCommand(SourcemapsUploadCommand)
       command['minifiedPathPrefix'] = 'http://datadog.com/js'
 
       expect(command['isMinifiedPathPrefixValid']()).toBe(true)
@@ -56,7 +56,7 @@ describe('upload', () => {
 
   describe('isMinifiedPathPrefixValid: URL without protocol', () => {
     test('should return true', () => {
-      const command = createCommand(UploadCommand)
+      const command = createCommand(SourcemapsUploadCommand)
       command['minifiedPathPrefix'] = '//datadog.com/js'
 
       expect(command['isMinifiedPathPrefixValid']()).toBe(true)
@@ -65,7 +65,7 @@ describe('upload', () => {
 
   describe('isMinifiedPathPrefixValid: leading slash', () => {
     test('should return true', () => {
-      const command = createCommand(UploadCommand)
+      const command = createCommand(SourcemapsUploadCommand)
       command['minifiedPathPrefix'] = '/js'
 
       expect(command['isMinifiedPathPrefixValid']()).toBe(true)
@@ -74,7 +74,7 @@ describe('upload', () => {
 
   describe('isMinifiedPathPrefixValid: no leading slash', () => {
     test('should return false', () => {
-      const command = createCommand(UploadCommand)
+      const command = createCommand(SourcemapsUploadCommand)
       command['minifiedPathPrefix'] = 'js'
 
       expect(command['isMinifiedPathPrefixValid']()).toBe(false)
@@ -83,7 +83,7 @@ describe('upload', () => {
 
   describe('isMinifiedPathPrefixValid: invalid URL without host', () => {
     test('should return false', () => {
-      const command = createCommand(UploadCommand)
+      const command = createCommand(SourcemapsUploadCommand)
       command['minifiedPathPrefix'] = 'info: undesired log line\nhttps://example.com/static/js/'
 
       expect(command['isMinifiedPathPrefixValid']()).toBe(false)
@@ -93,7 +93,7 @@ describe('upload', () => {
   describe('getApiHelper', () => {
     test('should throw an error if API key is undefined', async () => {
       process.env = {}
-      const command = createCommand(UploadCommand)
+      const command = createCommand(SourcemapsUploadCommand)
 
       expect(command['getRequestBuilder'].bind(command)).toThrow(
         `Missing ${chalk.bold('DATADOG_API_KEY')} or ${chalk.bold('DD_API_KEY')} in your environment.`
@@ -104,7 +104,7 @@ describe('upload', () => {
   describe('addRepositoryDataToPayloads', () => {
     test('repository url and commit still defined without payload', async () => {
       const write = jest.fn()
-      const command = createCommand(UploadCommand, {stdout: {write}})
+      const command = createCommand(SourcemapsUploadCommand, {stdout: {write}})
       const sourcemaps = new Array<Sourcemap>(
         new Sourcemap(
           'src/commands/sourcemaps/__tests__/fixtures/sourcemap-with-no-files/empty.min.js',
@@ -125,7 +125,7 @@ describe('upload', () => {
 
     test('should include payload', async () => {
       const write = jest.fn()
-      const command = createCommand(UploadCommand, {stdout: {write}})
+      const command = createCommand(SourcemapsUploadCommand, {stdout: {write}})
       const sourcemaps = new Array<Sourcemap>(
         new Sourcemap(
           'src/commands/sourcemaps/__tests__/fixtures/basic/common.min.js',
@@ -149,7 +149,7 @@ describe('upload', () => {
 })
 
 describe('execute', () => {
-  const runCLI = makeRunCLI(UploadCommand, [
+  const runCLI = makeRunCLI(SourcemapsUploadCommand, [
     'sourcemaps',
     'upload',
     '--release-version',

--- a/packages/datadog-ci/src/commands/sourcemaps/cli.ts
+++ b/packages/datadog-ci/src/commands/sourcemaps/cli.ts
@@ -1,3 +1,3 @@
-import {UploadCommand} from './upload'
+import {SourcemapsUploadCommand} from './upload'
 
-export const commands = [UploadCommand]
+export const commands = [SourcemapsUploadCommand]

--- a/packages/datadog-ci/src/commands/sourcemaps/upload.ts
+++ b/packages/datadog-ci/src/commands/sourcemaps/upload.ts
@@ -39,7 +39,7 @@ import {
 import {getMinifiedFilePath} from './utils'
 import {InvalidPayload, validatePayload} from './validation'
 
-export class UploadCommand extends Command {
+export class SourcemapsUploadCommand extends Command {
   public static paths = [['sourcemaps', 'upload']]
 
   public static usage = Command.Usage({

--- a/packages/datadog-ci/src/commands/unity-symbols/__tests__/upload.test.ts
+++ b/packages/datadog-ci/src/commands/unity-symbols/__tests__/upload.test.ts
@@ -9,7 +9,7 @@ import {
 import {performSubCommand} from '@datadog/datadog-ci-base/helpers/utils'
 import {cliVersion} from '@datadog/datadog-ci-base/version'
 
-import * as dsyms from '../../dsyms/upload'
+import {DsymsUploadCommand} from '../../dsyms/upload'
 
 import {uploadMultipartHelper} from '../helpers'
 import {
@@ -19,7 +19,7 @@ import {
   renderMissingIL2CPPMappingFile,
   renderMustSupplyPlatform,
 } from '../renderer'
-import {UploadCommand} from '../upload'
+import {UnitySymbolsUploadCommand} from '../upload'
 
 const fixtureDir = 'src/commands/unity-symbols/__tests__/fixtures'
 
@@ -39,8 +39,8 @@ jest.mock('../helpers', () => ({
 }))
 
 describe('unity-symbols upload', () => {
-  const runCommand = async (prepFunction: (command: UploadCommand) => void) => {
-    const command = createCommand(UploadCommand)
+  const runCommand = async (prepFunction: (command: UnitySymbolsUploadCommand) => void) => {
+    const command = createCommand(UnitySymbolsUploadCommand)
     prepFunction(command)
 
     const exitCode = await command.execute()
@@ -48,7 +48,7 @@ describe('unity-symbols upload', () => {
     return {exitCode, context: command.context}
   }
 
-  const mockGitRepoParameters = (command: UploadCommand) => {
+  const mockGitRepoParameters = (command: UnitySymbolsUploadCommand) => {
     command['gitData'] = {
       hash: 'fake-git-hash',
       remote: 'fake-git-remote',
@@ -57,7 +57,7 @@ describe('unity-symbols upload', () => {
   }
 
   test('creates correct metadata payload with arch when supplied', async () => {
-    const command = createCommand(UploadCommand)
+    const command = createCommand(UnitySymbolsUploadCommand)
     command['ios'] = true
     command['symbolsLocation'] = `${fixtureDir}/mappingFile`
     await command['verifyParameters']()
@@ -100,7 +100,7 @@ describe('unity-symbols upload', () => {
     })
 
     test('default ios symbol location is ./datadogSymbols', async () => {
-      let captureCmd: UploadCommand
+      let captureCmd: UnitySymbolsUploadCommand
       const {exitCode} = await runCommand((cmd) => {
         cmd['ios'] = true
         captureCmd = cmd
@@ -111,7 +111,7 @@ describe('unity-symbols upload', () => {
     })
 
     test('default android symbol location is ./unityLibrary/symbols', async () => {
-      let captureCmd: UploadCommand
+      let captureCmd: UnitySymbolsUploadCommand
       const {exitCode} = await runCommand((cmd) => {
         cmd['android'] = true
         captureCmd = cmd
@@ -182,7 +182,7 @@ describe('unity-symbols upload', () => {
       expect(exitCode).toBe(0)
 
       expect(performSubCommand).toHaveBeenCalledWith(
-        dsyms.UploadCommand,
+        DsymsUploadCommand,
         ['dsyms', 'upload', symbolsLocation, '--max-concurrency', '20'],
         expect.anything()
       )
@@ -197,7 +197,7 @@ describe('unity-symbols upload', () => {
 
       expect(exitCode).toBe(0)
       expect(performSubCommand).toHaveBeenCalledWith(
-        dsyms.UploadCommand,
+        DsymsUploadCommand,
         ['dsyms', 'upload', symbolsLocation, '--max-concurrency', '20', '--dry-run'],
         expect.anything()
       )
@@ -212,7 +212,7 @@ describe('unity-symbols upload', () => {
 
       expect(exitCode).toBe(0)
       expect(performSubCommand).toHaveBeenCalledWith(
-        dsyms.UploadCommand,
+        DsymsUploadCommand,
         ['dsyms', 'upload', symbolsLocation, '--max-concurrency', '12'],
         expect.anything()
       )
@@ -334,7 +334,7 @@ describe('unity-symbols upload', () => {
       })
 
       test(`creates correct metadata payload for ${platform}`, async () => {
-        const command = createCommand(UploadCommand)
+        const command = createCommand(UnitySymbolsUploadCommand)
         ;(command as any)[platform] = true
         command['symbolsLocation'] = `${fixtureDir}/mappingFile`
         await command['verifyParameters']()

--- a/packages/datadog-ci/src/commands/unity-symbols/cli.ts
+++ b/packages/datadog-ci/src/commands/unity-symbols/cli.ts
@@ -1,3 +1,3 @@
-import {UploadCommand} from './upload'
+import {UnitySymbolsUploadCommand} from './upload'
 
-export const commands = [UploadCommand]
+export const commands = [UnitySymbolsUploadCommand]

--- a/packages/datadog-ci/src/commands/unity-symbols/upload.ts
+++ b/packages/datadog-ci/src/commands/unity-symbols/upload.ts
@@ -25,7 +25,7 @@ import {cliVersion} from '@datadog/datadog-ci-base/version'
 import {Command, Option} from 'clipanion'
 import upath from 'upath'
 
-import * as dsyms from '../dsyms/upload'
+import {DsymsUploadCommand} from '../dsyms/upload'
 import {createUniqueTmpDirectory} from '../dsyms/utils'
 import * as elf from '../elf-symbols/elf'
 
@@ -54,7 +54,7 @@ import {
   renderUseOnlyOnePlatform,
 } from './renderer'
 
-export class UploadCommand extends Command {
+export class UnitySymbolsUploadCommand extends Command {
   public static paths = [['unity-symbols', 'upload']]
 
   public static usage = Command.Usage({
@@ -217,7 +217,7 @@ export class UploadCommand extends Command {
       dsymUploadCommand.push('--dry-run')
     }
 
-    const exitCode = await performSubCommand(dsyms.UploadCommand, dsymUploadCommand, this.context)
+    const exitCode = await performSubCommand(DsymsUploadCommand, dsymUploadCommand, this.context)
     if (exitCode && exitCode !== 0) {
       return UploadStatus.Failure
     }

--- a/packages/plugin-aas/src/commands/instrument.ts
+++ b/packages/plugin-aas/src/commands/instrument.ts
@@ -2,7 +2,7 @@ import {StringDictionary, WebSiteManagementClient} from '@azure/arm-appservice'
 import {ResourceManagementClient, TagsOperations} from '@azure/arm-resources'
 import {DefaultAzureCredential} from '@azure/identity'
 import {AasConfigOptions} from '@datadog/datadog-ci-base/commands/aas/common'
-import {InstrumentCommand} from '@datadog/datadog-ci-base/commands/aas/instrument'
+import {AasInstrumentCommand} from '@datadog/datadog-ci-base/commands/aas/instrument'
 import {DATADOG_SITE_US1} from '@datadog/datadog-ci-base/constants'
 import {newApiKeyValidator} from '@datadog/datadog-ci-base/helpers/apikey'
 import {handleSourceCodeIntegration} from '@datadog/datadog-ci-base/helpers/git/source-code-integration'
@@ -24,7 +24,7 @@ import {
   SIDECAR_PORT,
 } from '../common'
 
-export class PluginCommand extends InstrumentCommand {
+export class PluginCommand extends AasInstrumentCommand {
   public async execute(): Promise<0 | 1> {
     this.enableFips()
     const [appServicesToInstrument, config, errors] = await this.ensureConfig()

--- a/packages/plugin-aas/src/commands/uninstrument.ts
+++ b/packages/plugin-aas/src/commands/uninstrument.ts
@@ -1,7 +1,7 @@
 import {WebSiteManagementClient} from '@azure/arm-appservice'
 import {DefaultAzureCredential} from '@azure/identity'
 import {AasConfigOptions} from '@datadog/datadog-ci-base/commands/aas/common'
-import {UninstrumentCommand} from '@datadog/datadog-ci-base/commands/aas/uninstrument'
+import {AasUninstrumentCommand} from '@datadog/datadog-ci-base/commands/aas/uninstrument'
 import {renderError} from '@datadog/datadog-ci-base/helpers/renderer'
 import chalk from 'chalk'
 
@@ -15,7 +15,7 @@ import {
   SIDECAR_CONTAINER_NAME,
 } from '../common'
 
-export class PluginCommand extends UninstrumentCommand {
+export class PluginCommand extends AasUninstrumentCommand {
   public async execute(): Promise<0 | 1> {
     this.enableFips()
     const [appServicesToUninstrument, config, errors] = await this.ensureConfig()

--- a/packages/plugin-cloud-run/src/commands/instrument.ts
+++ b/packages/plugin-cloud-run/src/commands/instrument.ts
@@ -1,6 +1,6 @@
 import type {IContainer, IEnvVar, IService, IVolume, IVolumeMount, ServicesClient as IServicesClient} from '../types'
 
-import {InstrumentCommand} from '@datadog/datadog-ci-base/commands/cloud-run/instrument'
+import {CloudRunInstrumentCommand} from '@datadog/datadog-ci-base/commands/cloud-run/instrument'
 import {
   API_KEY_ENV_VAR,
   DATADOG_SITE_US1,
@@ -51,7 +51,7 @@ const DEFAULT_ENV_VARS: IEnvVar[] = [
   {name: HEALTH_PORT_ENV_VAR, value: DEFAULT_HEALTH_CHECK_PORT.toString()},
 ]
 
-export class PluginCommand extends InstrumentCommand {
+export class PluginCommand extends CloudRunInstrumentCommand {
   protected fipsConfig = {
     fips: toBoolean(process.env[FIPS_ENV_VAR]) ?? false,
     fipsIgnoreError: toBoolean(process.env[FIPS_IGNORE_ERROR_ENV_VAR]) ?? false,

--- a/packages/plugin-cloud-run/src/commands/uninstrument.ts
+++ b/packages/plugin-cloud-run/src/commands/uninstrument.ts
@@ -1,6 +1,6 @@
 import type {IContainer, IService, IVolume, ServicesClient as IServicesClient} from '../types'
 
-import {UninstrumentCommand} from '@datadog/datadog-ci-base/commands/cloud-run/uninstrument'
+import {CloudRunUninstrumentCommand} from '@datadog/datadog-ci-base/commands/cloud-run/uninstrument'
 import {FIPS_ENV_VAR, FIPS_IGNORE_ERROR_ENV_VAR} from '@datadog/datadog-ci-base/constants'
 import {toBoolean} from '@datadog/datadog-ci-base/helpers/env'
 import {enableFips} from '@datadog/datadog-ci-base/helpers/fips'
@@ -14,7 +14,7 @@ import {checkAuthentication, fetchServiceConfigs, generateConfigDiff} from '../u
 // XXX temporary workaround for @google-cloud/run ESM/CJS module issues
 const {ServicesClient} = require('@google-cloud/run')
 
-export class PluginCommand extends UninstrumentCommand {
+export class PluginCommand extends CloudRunUninstrumentCommand {
   protected fipsConfig = {
     fips: toBoolean(process.env[FIPS_ENV_VAR]) ?? false,
     fipsIgnoreError: toBoolean(process.env[FIPS_IGNORE_ERROR_ENV_VAR]) ?? false,

--- a/packages/plugin-lambda/src/commands/instrument.ts
+++ b/packages/plugin-lambda/src/commands/instrument.ts
@@ -1,7 +1,7 @@
 import {CloudWatchLogsClient} from '@aws-sdk/client-cloudwatch-logs'
 import {LambdaClient, LambdaClientConfig} from '@aws-sdk/client-lambda'
 import {AwsCredentialIdentity} from '@aws-sdk/types'
-import {InstrumentCommand} from '@datadog/datadog-ci-base/commands/lambda/instrument'
+import {LambdaInstrumentCommand} from '@datadog/datadog-ci-base/commands/lambda/instrument'
 import {
   ENVIRONMENT_ENV_VAR,
   EXTRA_TAGS_REG_EXP,
@@ -49,7 +49,7 @@ import {
 import * as commonRenderer from '../renderers/common-renderer'
 import * as instrumentRenderer from '../renderers/instrument-uninstrument-renderer'
 
-export class PluginCommand extends InstrumentCommand {
+export class PluginCommand extends LambdaInstrumentCommand {
   private config: LambdaConfigOptions = {
     functions: [],
     tracing: 'true',

--- a/packages/plugin-lambda/src/commands/uninstrument.ts
+++ b/packages/plugin-lambda/src/commands/uninstrument.ts
@@ -1,7 +1,7 @@
 import {CloudWatchLogsClient} from '@aws-sdk/client-cloudwatch-logs'
 import {LambdaClient, LambdaClientConfig} from '@aws-sdk/client-lambda'
 import {AwsCredentialIdentity} from '@aws-sdk/types'
-import {UninstrumentCommand} from '@datadog/datadog-ci-base/commands/lambda/uninstrument'
+import {LambdaUninstrumentCommand} from '@datadog/datadog-ci-base/commands/lambda/uninstrument'
 import {FIPS_ENV_VAR, FIPS_IGNORE_ERROR_ENV_VAR} from '@datadog/datadog-ci-base/constants'
 import {toBoolean} from '@datadog/datadog-ci-base/helpers/env'
 import {enableFips} from '@datadog/datadog-ci-base/helpers/fips'
@@ -26,7 +26,7 @@ import {requestAWSCredentials, requestFunctionSelection} from '../prompt'
 import * as commonRenderer from '../renderers/common-renderer'
 import * as instrumentRenderer from '../renderers/instrument-uninstrument-renderer'
 
-export class PluginCommand extends UninstrumentCommand {
+export class PluginCommand extends LambdaUninstrumentCommand {
   private config: any = {
     functions: [],
     region: process.env[AWS_DEFAULT_REGION_ENV_VAR],

--- a/packages/plugin-stepfunctions/src/commands/instrument.ts
+++ b/packages/plugin-stepfunctions/src/commands/instrument.ts
@@ -1,7 +1,7 @@
 import {CloudWatchLogsClient} from '@aws-sdk/client-cloudwatch-logs'
 import {IAMClient} from '@aws-sdk/client-iam'
 import {SFNClient} from '@aws-sdk/client-sfn'
-import {InstrumentStepFunctionsCommand} from '@datadog/datadog-ci-base/commands/stepfunctions/instrument'
+import {StepfunctionsInstrumentCommand} from '@datadog/datadog-ci-base/commands/stepfunctions/instrument'
 import {FIPS_ENV_VAR, FIPS_IGNORE_ERROR_ENV_VAR} from '@datadog/datadog-ci-base/constants'
 import {toBoolean} from '@datadog/datadog-ci-base/helpers/env'
 import {enableFips} from '@datadog/datadog-ci-base/helpers/fips'
@@ -28,7 +28,7 @@ import {
   injectContextIntoTasks,
 } from '../helpers'
 
-export class PluginCommand extends InstrumentStepFunctionsCommand {
+export class PluginCommand extends StepfunctionsInstrumentCommand {
   private config = {
     fips: toBoolean(process.env[FIPS_ENV_VAR]) ?? false,
     fipsIgnoreError: toBoolean(process.env[FIPS_IGNORE_ERROR_ENV_VAR]) ?? false,

--- a/packages/plugin-stepfunctions/src/commands/uninstrument.ts
+++ b/packages/plugin-stepfunctions/src/commands/uninstrument.ts
@@ -1,6 +1,6 @@
 import {CloudWatchLogsClient, DescribeSubscriptionFiltersCommandOutput} from '@aws-sdk/client-cloudwatch-logs'
 import {SFNClient} from '@aws-sdk/client-sfn'
-import {UninstrumentStepFunctionsCommand} from '@datadog/datadog-ci-base/commands/stepfunctions/uninstrument'
+import {StepfunctionsUninstrumentCommand} from '@datadog/datadog-ci-base/commands/stepfunctions/uninstrument'
 import {FIPS_ENV_VAR, FIPS_IGNORE_ERROR_ENV_VAR} from '@datadog/datadog-ci-base/constants'
 import {toBoolean} from '@datadog/datadog-ci-base/helpers/env'
 import {enableFips} from '@datadog/datadog-ci-base/helpers/fips'
@@ -14,7 +14,7 @@ import {
 import {DD_CI_IDENTIFYING_STRING, TAG_VERSION_NAME} from '../constants'
 import {getStepFunctionLogGroupArn, isValidArn, parseArn} from '../helpers'
 
-export class PluginCommand extends UninstrumentStepFunctionsCommand {
+export class PluginCommand extends StepfunctionsUninstrumentCommand {
   private config = {
     fips: toBoolean(process.env[FIPS_ENV_VAR]) ?? false,
     fipsIgnoreError: toBoolean(process.env[FIPS_IGNORE_ERROR_ENV_VAR]) ?? false,

--- a/packages/plugin-synthetics/src/commands/deploy-tests.ts
+++ b/packages/plugin-synthetics/src/commands/deploy-tests.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/member-ordering */
-import {DeployTestsCommand} from '@datadog/datadog-ci-base/commands/synthetics/deploy-tests'
+import {SyntheticsDeployTestsCommand} from '@datadog/datadog-ci-base/commands/synthetics/deploy-tests'
 import {FIPS_ENV_VAR, FIPS_IGNORE_ERROR_ENV_VAR} from '@datadog/datadog-ci-base/constants'
 import {toBoolean} from '@datadog/datadog-ci-base/helpers/env'
 import {enableFips} from '@datadog/datadog-ci-base/helpers/fips'
@@ -14,7 +14,7 @@ import {DefaultReporter} from '../reporters/default'
 import {RecursivePartial, getDefaultConfig} from '../utils/internal'
 import {getReporter} from '../utils/public'
 
-export class PluginCommand extends DeployTestsCommand {
+export class PluginCommand extends SyntheticsDeployTestsCommand {
   protected reporter!: MainReporter
   protected config: DeployTestsCommandConfig = PluginCommand.getDefaultConfig()
   protected fipsConfig = {

--- a/packages/plugin-synthetics/src/commands/import-tests.ts
+++ b/packages/plugin-synthetics/src/commands/import-tests.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/member-ordering */
-import {ImportTestsCommand} from '@datadog/datadog-ci-base/commands/synthetics/import-tests'
+import {SyntheticsImportTestsCommand} from '@datadog/datadog-ci-base/commands/synthetics/import-tests'
 import {FIPS_ENV_VAR, FIPS_IGNORE_ERROR_ENV_VAR} from '@datadog/datadog-ci-base/constants'
 import {toBoolean} from '@datadog/datadog-ci-base/helpers/env'
 import {enableFips} from '@datadog/datadog-ci-base/helpers/fips'
@@ -12,7 +12,7 @@ import {importTests} from '../import-tests-lib'
 import {ImportTestsCommandConfig, MainReporter} from '../interfaces'
 import {RecursivePartial, getDefaultConfig} from '../utils/internal'
 
-export class PluginCommand extends ImportTestsCommand {
+export class PluginCommand extends SyntheticsImportTestsCommand {
   protected reporter!: MainReporter
   protected config: ImportTestsCommandConfig = PluginCommand.getDefaultConfig()
   protected fipsConfig = {

--- a/packages/plugin-synthetics/src/commands/run-tests.ts
+++ b/packages/plugin-synthetics/src/commands/run-tests.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/member-ordering */
-import {RunTestsCommand} from '@datadog/datadog-ci-base/commands/synthetics/run-tests'
+import {SyntheticsRunTestsCommand} from '@datadog/datadog-ci-base/commands/synthetics/run-tests'
 import {FIPS_ENV_VAR, FIPS_IGNORE_ERROR_ENV_VAR} from '@datadog/datadog-ci-base/constants'
 import {toBoolean, toNumber, toStringMap} from '@datadog/datadog-ci-base/helpers/env'
 import {enableFips} from '@datadog/datadog-ci-base/helpers/fips'
@@ -20,7 +20,7 @@ import {executeTests, getDefaultConfig} from '../run-tests-lib'
 import {RecursivePartial, toExecutionRule, validateAndParseOverrides} from '../utils/internal'
 import {getExitReason, getOrgSettings, renderResults, toExitCode, reportExitLogs, getReporter} from '../utils/public'
 
-export class PluginCommand extends RunTestsCommand {
+export class PluginCommand extends SyntheticsRunTestsCommand {
   protected reporter!: MainReporter
   protected config: RunTestsCommandConfig = getDefaultConfig()
   protected fipsConfig = {

--- a/packages/plugin-synthetics/src/commands/upload-application.ts
+++ b/packages/plugin-synthetics/src/commands/upload-application.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/member-ordering */
-import {UploadApplicationCommand} from '@datadog/datadog-ci-base/commands/synthetics/upload-application'
+import {SyntheticsUploadApplicationCommand} from '@datadog/datadog-ci-base/commands/synthetics/upload-application'
 import {FIPS_ENV_VAR, FIPS_IGNORE_ERROR_ENV_VAR} from '@datadog/datadog-ci-base/constants'
 import {toBoolean} from '@datadog/datadog-ci-base/helpers/env'
 import {enableFips} from '@datadog/datadog-ci-base/helpers/fips'
@@ -15,7 +15,7 @@ import {uploadMobileApplicationVersion} from '../mobile'
 import {AppUploadReporter} from '../reporters/mobile/app-upload'
 import {RecursivePartial, getDefaultConfig} from '../utils/internal'
 
-export class PluginCommand extends UploadApplicationCommand {
+export class PluginCommand extends SyntheticsUploadApplicationCommand {
   protected config: UploadApplicationCommandConfig = PluginCommand.getDefaultConfig()
   protected fipsConfig = {
     fips: toBoolean(process.env[FIPS_ENV_VAR]) ?? false,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,5 +18,5 @@
     {"path": "./packages/plugin-stepfunctions"},
     {"path": "./packages/plugin-synthetics"}
   ],
-  "include": ["bin/lint-packages.ts"]
+  "exclude": ["*"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5412,7 +5412,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "datadog-ci-monorepo@workspace:."
   dependencies:
-    "@datadog/datadog-ci-base": "workspace:*"
     "@microsoft/eslint-formatter-sarif": "npm:^3.1.0"
     "@stylistic/eslint-plugin": "npm:^5.3.1"
     "@types/node": "npm:^20.19.18"


### PR DESCRIPTION
### What and why?

This PR update the `yarn lint:packages` script to also auto-generate `packages/base/src/commands/<scope>/cli.ts` so we never miss a command by accident.

We now enforce command classes to follow the naming convention:
- `{CamelCase(scope)}{CamelCase(command)}Command`
- e.g. `ReactNativeInjectDebugIdCommand` for `datadog-ci react-native inject-debug-id`

### How?

Update the script, and all classes that are either already migrated, or that we plan to migrate.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
