### PR TITLE
Add `plugin list` command

### DIFF
--- a/bin/lint-packages.ts
+++ b/bin/lint-packages.ts
@@ -75,7 +75,7 @@ const findCommands = (folder: string, scope: string): string[] => {
         }
 
         const content = fs.readFileSync(path.join(folder, file), 'utf8')
-        if (!content.match(/export class \w+ extends Command/)) {
+        if (!content.match(/export class \w+ extends BaseCommand/)) {
           return acc
         }
 

--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -22,6 +22,7 @@ export default {
     '^@datadog/datadog-ci-plugin-([\\w-]+)(.*)$': '<rootDir>/packages/plugin-$1/src$2',
     '^@datadog/datadog-ci-base/package.json$': '<rootDir>/packages/base/package.json',
     '^@datadog/datadog-ci-base(.*)$': '<rootDir>/packages/base/src$1',
+    '^@datadog/datadog-ci/package.json$': '<rootDir>/packages/datadog-ci/package.json',
     '^@datadog/datadog-ci(.*)$': '<rootDir>/packages/datadog-ci/src$1',
   },
   cache: true,

--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -15,6 +15,10 @@
   },
   "exports": {
     "./package.json": "./package.json",
+    ".": {
+      "development": "./src/index.ts",
+      "default": "./dist/index.js"
+    },
     "./cli": {
       "development": "./src/cli.ts",
       "default": "./dist/cli.js"

--- a/packages/base/src/commands/aas/common.ts
+++ b/packages/base/src/commands/aas/common.ts
@@ -1,10 +1,12 @@
-import {Command, Option} from 'clipanion'
+import {Option} from 'clipanion'
 
 import {EXTRA_TAGS_REG_EXP, FIPS_ENV_VAR, FIPS_IGNORE_ERROR_ENV_VAR} from '../../constants'
 import {toBoolean} from '../../helpers/env'
 import {enableFips} from '../../helpers/fips'
 import {dryRunTag} from '../../helpers/renderer'
 import {DEFAULT_CONFIG_PATHS, resolveConfigFromFile} from '../../helpers/utils'
+
+import {BaseCommand} from '../..'
 
 export const ENV_VAR_REGEX = /^([\w.]+)=(.*)$/
 
@@ -59,7 +61,7 @@ export const parseResourceId = (resourceId: string): Resource | undefined => {
   }
 }
 
-export abstract class AasCommand extends Command {
+export abstract class AasCommand extends BaseCommand {
   public dryRun = Option.Boolean('-d,--dry-run', false, {
     description: 'Run the command in dry-run mode, without making any changes',
   })

--- a/packages/base/src/commands/cloud-run/flare.ts
+++ b/packages/base/src/commands/cloud-run/flare.ts
@@ -2,7 +2,9 @@ import {Command, Option} from 'clipanion'
 
 import {executePluginCommand} from '../../helpers/plugin'
 
-export class CloudRunFlareCommand extends Command {
+import {BaseCommand} from '../..'
+
+export class CloudRunFlareCommand extends BaseCommand {
   public static paths = [['cloud-run', 'flare']]
 
   public static usage = Command.Usage({

--- a/packages/base/src/commands/cloud-run/instrument.ts
+++ b/packages/base/src/commands/cloud-run/instrument.ts
@@ -2,6 +2,8 @@ import {Command, Option} from 'clipanion'
 
 import {executePluginCommand} from '../../helpers/plugin'
 
+import {BaseCommand} from '../..'
+
 import {DEFAULT_SIDECAR_NAME, DEFAULT_VOLUME_NAME} from './constants'
 
 const DEFAULT_VOLUME_PATH = '/shared-volume'
@@ -9,7 +11,7 @@ const DEFAULT_LOGS_PATH = '/shared-volume/logs/*.log'
 
 const DEFAULT_SIDECAR_IMAGE = 'gcr.io/datadoghq/serverless-init:latest'
 
-export class CloudRunInstrumentCommand extends Command {
+export class CloudRunInstrumentCommand extends BaseCommand {
   public static paths = [['cloud-run', 'instrument']]
 
   public static usage = Command.Usage({

--- a/packages/base/src/commands/cloud-run/uninstrument.ts
+++ b/packages/base/src/commands/cloud-run/uninstrument.ts
@@ -2,9 +2,11 @@ import {Command, Option} from 'clipanion'
 
 import {executePluginCommand} from '../../helpers/plugin'
 
+import {BaseCommand} from '../..'
+
 import {DEFAULT_SIDECAR_NAME, DEFAULT_VOLUME_NAME} from './constants'
 
-export class CloudRunUninstrumentCommand extends Command {
+export class CloudRunUninstrumentCommand extends BaseCommand {
   public static paths = [['cloud-run', 'uninstrument']]
 
   public static usage = Command.Usage({

--- a/packages/base/src/commands/deployment/correlate-image.ts
+++ b/packages/base/src/commands/deployment/correlate-image.ts
@@ -2,7 +2,9 @@ import {Command, Option} from 'clipanion'
 
 import {executePluginCommand} from '@datadog/datadog-ci-base/helpers/plugin'
 
-export class DeploymentCorrelateImageCommand extends Command {
+import {BaseCommand} from '../..'
+
+export class DeploymentCorrelateImageCommand extends BaseCommand {
   public static paths = [['deployment', 'correlate-image']]
 
   public static usage = Command.Usage({

--- a/packages/base/src/commands/deployment/correlate.ts
+++ b/packages/base/src/commands/deployment/correlate.ts
@@ -2,12 +2,14 @@ import {Command, Option} from 'clipanion'
 
 import {executePluginCommand} from '@datadog/datadog-ci-base/helpers/plugin'
 
+import {BaseCommand} from '../..'
+
 /**
  * This command collects environment variables and git information to correlate commits from the
  * source code repository to the configuration repository. This allows to connect pipelines triggering
  * changes on the configuration repository to deployments from gitOps CD providers
  */
-export class DeploymentCorrelateCommand extends Command {
+export class DeploymentCorrelateCommand extends BaseCommand {
   public static paths = [['deployment', 'correlate']]
 
   public static usage = Command.Usage({

--- a/packages/base/src/commands/deployment/gate.ts
+++ b/packages/base/src/commands/deployment/gate.ts
@@ -3,12 +3,14 @@ import * as t from 'typanion'
 
 import {executePluginCommand} from '@datadog/datadog-ci-base/helpers/plugin'
 
+import {BaseCommand} from '../..'
+
 /**
  * This command allows to evaluate a deployment gate in Datadog.
  * It handles the entire process of requesting a gate evaluation and polling for results
  * The command will exit with status 0 when the gate passes and status 1 otherwise.
  */
-export class DeploymentGateCommand extends Command {
+export class DeploymentGateCommand extends BaseCommand {
   public static paths = [['deployment', 'gate']]
 
   public static usage = Command.Usage({

--- a/packages/base/src/commands/deployment/mark.ts
+++ b/packages/base/src/commands/deployment/mark.ts
@@ -2,11 +2,13 @@ import {Command, Option} from 'clipanion'
 
 import {executePluginCommand} from '@datadog/datadog-ci-base/helpers/plugin'
 
+import {BaseCommand} from '../..'
+
 /**
  * This command is a wrapper around the datadog-ci tag command, allowing customers to mark CI jobs
  * as deployments and setting specific properties, like the environment or the revision in a simple way.
  */
-export class DeploymentMarkCommand extends Command {
+export class DeploymentMarkCommand extends BaseCommand {
   public static paths = [['deployment', 'mark']]
 
   public static usage = Command.Usage({

--- a/packages/base/src/commands/dora/deployment.ts
+++ b/packages/base/src/commands/dora/deployment.ts
@@ -3,7 +3,9 @@ import * as t from 'typanion'
 
 import {executePluginCommand} from '@datadog/datadog-ci-base/helpers/plugin'
 
-export class DoraDeploymentCommand extends Command {
+import {BaseCommand} from '../..'
+
+export class DoraDeploymentCommand extends BaseCommand {
   public static paths = [['dora', 'deployment']]
 
   public static usage = Command.Usage({

--- a/packages/base/src/commands/gate/evaluate.ts
+++ b/packages/base/src/commands/gate/evaluate.ts
@@ -3,7 +3,9 @@ import {Command, Option} from 'clipanion'
 import {executePluginCommand} from '@datadog/datadog-ci-base/helpers/plugin'
 import * as validation from '@datadog/datadog-ci-base/helpers/validation'
 
-export class GateEvaluateCommand extends Command {
+import {BaseCommand} from '../..'
+
+export class GateEvaluateCommand extends BaseCommand {
   public static paths = [['gate', 'evaluate']]
 
   public static usage = Command.Usage({

--- a/packages/base/src/commands/git-metadata/upload.ts
+++ b/packages/base/src/commands/git-metadata/upload.ts
@@ -14,6 +14,8 @@ import {UploadStatus} from '../../helpers/upload'
 import {getRequestBuilder, timedExecAsync} from '../../helpers/utils'
 import {cliVersion} from '../../version'
 
+import {BaseCommand} from '../..'
+
 import {apiHost, datadogSite, getBaseIntakeUrl} from './api'
 import {getCommitInfo, newSimpleGit} from './git'
 import {uploadToGitDB} from './gitdb'
@@ -28,7 +30,7 @@ import {
   renderSuccessfulCommand,
 } from './renderer'
 
-export class GitMetadataUploadCommand extends Command {
+export class GitMetadataUploadCommand extends BaseCommand {
   public static paths = [['git-metadata', 'upload']]
 
   public static usage = Command.Usage({

--- a/packages/base/src/commands/lambda/flare.ts
+++ b/packages/base/src/commands/lambda/flare.ts
@@ -2,7 +2,9 @@ import {Command, Option} from 'clipanion'
 
 import {executePluginCommand} from '../../helpers/plugin'
 
-export class LambdaFlareCommand extends Command {
+import {BaseCommand} from '../..'
+
+export class LambdaFlareCommand extends BaseCommand {
   public static paths = [['lambda', 'flare']]
 
   public static usage = Command.Usage({

--- a/packages/base/src/commands/lambda/instrument.ts
+++ b/packages/base/src/commands/lambda/instrument.ts
@@ -2,7 +2,9 @@ import {Command, Option} from 'clipanion'
 
 import {executePluginCommand} from '../../helpers/plugin'
 
-export class LambdaInstrumentCommand extends Command {
+import {BaseCommand} from '../..'
+
+export class LambdaInstrumentCommand extends BaseCommand {
   public static paths = [['lambda', 'instrument']]
 
   public static usage = Command.Usage({

--- a/packages/base/src/commands/lambda/uninstrument.ts
+++ b/packages/base/src/commands/lambda/uninstrument.ts
@@ -2,7 +2,9 @@ import {Command, Option} from 'clipanion'
 
 import {executePluginCommand} from '../../helpers/plugin'
 
-export class LambdaUninstrumentCommand extends Command {
+import {BaseCommand} from '../..'
+
+export class LambdaUninstrumentCommand extends BaseCommand {
   public static paths = [['lambda', 'uninstrument']]
 
   public static usage = Command.Usage({

--- a/packages/base/src/commands/plugin/__tests__/list.test.ts
+++ b/packages/base/src/commands/plugin/__tests__/list.test.ts
@@ -1,0 +1,48 @@
+import {Cli} from 'clipanion'
+
+import {createMockContext} from '../../../helpers/__tests__/testing-tools'
+import {listAllPlugins} from '../../../helpers/plugin'
+
+import {CommandContext} from '../../..'
+import {PluginListCommand} from '../list'
+
+describe('PluginListCommand', () => {
+  test.each([
+    ['', 'All plugins are currently built-in. We will start splitting them in next major release.\n'],
+    [' (--json)', '[]\n'],
+  ])('all plugins are built-in%s', async (jsonArg, expectedOutput) => {
+    const cli = new Cli<CommandContext>()
+    cli.register(PluginListCommand)
+
+    const context = createMockContext() as CommandContext
+    context.builtinPlugins = listAllPlugins()
+
+    const code = await cli.run(['plugin', 'list', ...(jsonArg ? ['--json'] : [])], context)
+
+    expect(context.stdout.toString()).toStrictEqual(expectedOutput)
+    expect(code).toBe(0)
+  })
+
+  test.each([
+    [
+      '',
+      `The following plugins are available:\n\n - @datadog/datadog-ci-plugin-aas (install with datadog-ci plugin install aas)\n`,
+    ],
+    [' (--json)', `[{"name":"@datadog/datadog-ci-plugin-aas","scope":"aas"}]\n`],
+  ])('list available plugins%s', async (jsonArg, expectedOutput) => {
+    const cli = new Cli<CommandContext>()
+    cli.register(PluginListCommand)
+
+    const context = createMockContext() as CommandContext
+    context.builtinPlugins = listAllPlugins().filter(
+      // Arbitrarily remove a plugin from the list of built-in plugins.
+      // This simulates `@datadog/datadog-ci` having all plugins listed as dependencies, except one.
+      (plugin) => plugin !== '@datadog/datadog-ci-plugin-aas'
+    )
+
+    const code = await cli.run(['plugin', 'list', ...(jsonArg ? ['--json'] : [])], context)
+
+    expect(context.stdout.toString()).toStrictEqual(expectedOutput)
+    expect(code).toBe(0)
+  })
+})

--- a/packages/base/src/commands/plugin/__tests__/list.test.ts
+++ b/packages/base/src/commands/plugin/__tests__/list.test.ts
@@ -8,28 +8,41 @@ import {PluginListCommand} from '../list'
 
 describe('PluginListCommand', () => {
   test.each([
-    ['', 'All plugins are currently built-in. We will start splitting them in next major release.\n'],
-    [' (--json)', '[]\n'],
-  ])('all plugins are built-in%s', async (jsonArg, expectedOutput) => {
+    {
+      title: 'no args',
+      args: [],
+      expectedOutput: 'All plugins are currently built-in. We will start splitting them in next major release.\n',
+    },
+    {
+      title: '--json',
+      args: ['--json'],
+      expectedOutput: '[]\n',
+    },
+  ])('all plugins are built-in ($title)', async ({args, expectedOutput}) => {
     const cli = new Cli<CommandContext>()
     cli.register(PluginListCommand)
 
     const context = createMockContext() as CommandContext
     context.builtinPlugins = listAllPlugins()
 
-    const code = await cli.run(['plugin', 'list', ...(jsonArg ? ['--json'] : [])], context)
+    const code = await cli.run(['plugin', 'list', ...args], context)
 
     expect(context.stdout.toString()).toStrictEqual(expectedOutput)
     expect(code).toBe(0)
   })
 
   test.each([
-    [
-      '',
-      `The following plugins are available:\n\n - @datadog/datadog-ci-plugin-aas (install with datadog-ci plugin install aas)\n`,
-    ],
-    [' (--json)', `[{"name":"@datadog/datadog-ci-plugin-aas","scope":"aas"}]\n`],
-  ])('list available plugins%s', async (jsonArg, expectedOutput) => {
+    {
+      title: 'no args',
+      args: [],
+      expectedOutput: `The following plugins are available:\n\n - @datadog/datadog-ci-plugin-aas (install with datadog-ci plugin install aas)\n`,
+    },
+    {
+      title: '--json',
+      args: ['--json'],
+      expectedOutput: `[{"name":"@datadog/datadog-ci-plugin-aas","scope":"aas"}]\n`,
+    },
+  ])('list available plugins ($title)', async ({args, expectedOutput}) => {
     const cli = new Cli<CommandContext>()
     cli.register(PluginListCommand)
 
@@ -40,7 +53,7 @@ describe('PluginListCommand', () => {
       (plugin) => plugin !== '@datadog/datadog-ci-plugin-aas'
     )
 
-    const code = await cli.run(['plugin', 'list', ...(jsonArg ? ['--json'] : [])], context)
+    const code = await cli.run(['plugin', 'list', ...args], context)
 
     expect(context.stdout.toString()).toStrictEqual(expectedOutput)
     expect(code).toBe(0)

--- a/packages/base/src/commands/plugin/check.ts
+++ b/packages/base/src/commands/plugin/check.ts
@@ -2,7 +2,9 @@ import {Command, Option} from 'clipanion'
 
 import {checkPlugin} from '../../helpers/plugin'
 
-export class PluginCheckCommand extends Command {
+import {BaseCommand} from '../..'
+
+export class PluginCheckCommand extends BaseCommand {
   public static paths = [['plugin', 'check']]
 
   public static usage = Command.Usage({

--- a/packages/base/src/commands/plugin/cli.ts
+++ b/packages/base/src/commands/plugin/cli.ts
@@ -1,9 +1,11 @@
 /* eslint-disable import-x/order */
 import {PluginCheckCommand} from './check'
 import {PluginInstallCommand} from './install'
+import {PluginListCommand} from './list'
 
 // prettier-ignore
 export const commands = [
   PluginCheckCommand,
   PluginInstallCommand,
+  PluginListCommand,
 ]

--- a/packages/base/src/commands/plugin/install.ts
+++ b/packages/base/src/commands/plugin/install.ts
@@ -2,7 +2,9 @@ import {Command, Option} from 'clipanion'
 
 import {installPlugin} from '../../helpers/plugin'
 
-export class PluginInstallCommand extends Command {
+import {BaseCommand} from '../..'
+
+export class PluginInstallCommand extends BaseCommand {
   public static paths = [['plugin', 'install']]
 
   public static usage = Command.Usage({

--- a/packages/base/src/commands/plugin/list.ts
+++ b/packages/base/src/commands/plugin/list.ts
@@ -1,5 +1,7 @@
+import chalk from 'chalk'
 import {Command, Option} from 'clipanion'
 
+import {LogLevel, Logger} from '../../helpers/logger'
 import {listAllPlugins} from '../../helpers/plugin'
 
 import {BaseCommand} from '../..'
@@ -21,17 +23,46 @@ export class PluginListCommand extends BaseCommand {
   // Positional
   public json = Option.Boolean('--json', {required: false})
 
+  private logger: Logger = new Logger((s: string) => {
+    this.context.stdout.write(s)
+  }, LogLevel.INFO)
+
   public async execute() {
     const allPlugins = listAllPlugins()
     const builtinPlugins = new Set(this.context.builtinPlugins)
     const installablePlugins = allPlugins.filter((plugin) => !builtinPlugins.has(plugin))
 
     if (this.json) {
-      console.log(JSON.stringify(installablePlugins))
-    } else {
-      console.log(installablePlugins.join('\n'))
+      this.logger.info(
+        JSON.stringify(
+          installablePlugins.map((plugin) => ({
+            name: plugin,
+            scope: getScope(plugin),
+          }))
+        )
+      )
+
+      return 0
     }
+
+    if (installablePlugins.length === 0) {
+      this.logger.info('All plugins are currently built-in. We will start splitting them in next major release.')
+
+      return 0
+    }
+
+    this.logger.info(`The following plugins are available:\n`)
+    this.logger.info(
+      installablePlugins
+        .map(
+          (plugin) =>
+            ` - ${chalk.bold.magenta(plugin)} (install with ${chalk.bold.cyan(`datadog-ci plugin install ${getScope(plugin)}`)})`
+        )
+        .join('\n')
+    )
 
     return 0
   }
 }
+
+const getScope = (plugin: string): string => plugin.replace('@datadog/datadog-ci-plugin-', '')

--- a/packages/base/src/commands/plugin/list.ts
+++ b/packages/base/src/commands/plugin/list.ts
@@ -15,7 +15,7 @@ export class PluginListCommand extends BaseCommand {
     details: `
       This command lists the plugins that can be installed with the \`datadog-ci plugin install\` command.
 
-      All other plugins are considered **built-in** and are not listed.
+      All other plugins are **built-in** and are not listed here.
     `,
     examples: [['List the available plugins', 'datadog-ci plugin list']],
   })

--- a/packages/base/src/commands/plugin/list.ts
+++ b/packages/base/src/commands/plugin/list.ts
@@ -1,0 +1,37 @@
+import {Command, Option} from 'clipanion'
+
+import {listAllPlugins} from '../../helpers/plugin'
+
+import {BaseCommand} from '../..'
+
+export class PluginListCommand extends BaseCommand {
+  public static paths = [['plugin', 'list']]
+
+  public static usage = Command.Usage({
+    category: 'Plugins',
+    description: 'List the available plugins.',
+    details: `
+      This command lists the plugins that can be installed with the \`datadog-ci plugin install\` command.
+
+      All other plugins are considered **built-in** and are not listed.
+    `,
+    examples: [['List the available plugins', 'datadog-ci plugin list']],
+  })
+
+  // Positional
+  public json = Option.Boolean('--json', {required: false})
+
+  public async execute() {
+    const allPlugins = listAllPlugins()
+    const builtinPlugins = new Set(this.context.builtinPlugins)
+    const installablePlugins = allPlugins.filter((plugin) => !builtinPlugins.has(plugin))
+
+    if (this.json) {
+      console.log(JSON.stringify(installablePlugins))
+    } else {
+      console.log(installablePlugins.join('\n'))
+    }
+
+    return 0
+  }
+}

--- a/packages/base/src/commands/sarif/upload.ts
+++ b/packages/base/src/commands/sarif/upload.ts
@@ -3,7 +3,9 @@ import {Command, Option} from 'clipanion'
 import {executePluginCommand} from '../../helpers/plugin'
 import {isInteger} from '../../helpers/validation'
 
-export class SarifUploadCommand extends Command {
+import {BaseCommand} from '../..'
+
+export class SarifUploadCommand extends BaseCommand {
   public static paths = [['sarif', 'upload']]
 
   public static usage = Command.Usage({

--- a/packages/base/src/commands/sbom/upload.ts
+++ b/packages/base/src/commands/sbom/upload.ts
@@ -2,7 +2,9 @@ import {Command, Option} from 'clipanion'
 
 import {executePluginCommand} from '../../helpers/plugin'
 
-export class SbomUploadCommand extends Command {
+import {BaseCommand} from '../..'
+
+export class SbomUploadCommand extends BaseCommand {
   public static paths = [['sbom', 'upload']]
 
   public static usage = Command.Usage({

--- a/packages/base/src/commands/stepfunctions/instrument.ts
+++ b/packages/base/src/commands/stepfunctions/instrument.ts
@@ -2,7 +2,9 @@ import {Command, Option} from 'clipanion'
 
 import {executePluginCommand} from '../../helpers/plugin'
 
-export class StepfunctionsInstrumentCommand extends Command {
+import {BaseCommand} from '../..'
+
+export class StepfunctionsInstrumentCommand extends BaseCommand {
   public static paths = [['stepfunctions', 'instrument']]
 
   public static usage = Command.Usage({

--- a/packages/base/src/commands/stepfunctions/uninstrument.ts
+++ b/packages/base/src/commands/stepfunctions/uninstrument.ts
@@ -2,7 +2,9 @@ import {Command, Option} from 'clipanion'
 
 import {executePluginCommand} from '../../helpers/plugin'
 
-export class StepfunctionsUninstrumentCommand extends Command {
+import {BaseCommand} from '../..'
+
+export class StepfunctionsUninstrumentCommand extends BaseCommand {
   public static paths = [['stepfunctions', 'uninstrument']]
 
   public static usage = Command.Usage({

--- a/packages/base/src/commands/synthetics/deploy-tests.ts
+++ b/packages/base/src/commands/synthetics/deploy-tests.ts
@@ -4,6 +4,8 @@ import {Command, Option} from 'clipanion'
 import {executePluginCommand} from '../../helpers/plugin'
 import {makeTerminalLink} from '../../helpers/utils'
 
+import {BaseCommand} from '../..'
+
 const datadogDocsBaseUrl = 'https://docs.datadoghq.com'
 
 // BASE COMMAND START
@@ -16,7 +18,7 @@ const $B3 = makeTerminalLink(`${datadogDocsBaseUrl}/getting_started/site/#access
 
 const $1 = makeTerminalLink(`${datadogDocsBaseUrl}/continuous_testing/cicd_integrations/configuration#test-files`)
 
-export class SyntheticsDeployTestsCommand extends Command {
+export class SyntheticsDeployTestsCommand extends BaseCommand {
   public static paths = [['synthetics', 'deploy-tests']]
 
   public static usage = Command.Usage({

--- a/packages/base/src/commands/synthetics/import-tests.ts
+++ b/packages/base/src/commands/synthetics/import-tests.ts
@@ -4,6 +4,8 @@ import {Command, Option} from 'clipanion'
 import {executePluginCommand} from '../../helpers/plugin'
 import {makeTerminalLink} from '../../helpers/utils'
 
+import {BaseCommand} from '../..'
+
 const datadogDocsBaseUrl = 'https://docs.datadoghq.com'
 const datadogAppBaseUrl = 'https://app.datadoghq.com'
 
@@ -19,7 +21,7 @@ const $1 = makeTerminalLink(`${datadogDocsBaseUrl}/continuous_testing/cicd_integ
 const $2 = makeTerminalLink(`${datadogDocsBaseUrl}/synthetics/explore/#search`)
 const $3 = makeTerminalLink(`${datadogAppBaseUrl}/synthetics/tests`)
 
-export class SyntheticsImportTestsCommand extends Command {
+export class SyntheticsImportTestsCommand extends BaseCommand {
   public static paths = [['synthetics', 'import-tests']]
 
   public static usage = Command.Usage({

--- a/packages/base/src/commands/synthetics/run-tests.ts
+++ b/packages/base/src/commands/synthetics/run-tests.ts
@@ -5,6 +5,8 @@ import {executePluginCommand} from '../../helpers/plugin'
 import {makeTerminalLink} from '../../helpers/utils'
 import * as validation from '../../helpers/validation'
 
+import {BaseCommand} from '../..'
+
 const datadogDocsBaseUrl = 'https://docs.datadoghq.com'
 const datadogAppBaseUrl = 'https://app.datadoghq.com'
 
@@ -25,7 +27,7 @@ const $5 = makeTerminalLink(
 )
 const $6 = makeTerminalLink(`${datadogDocsBaseUrl}/synthetics/mobile_app_testing/`)
 
-export class SyntheticsRunTestsCommand extends Command {
+export class SyntheticsRunTestsCommand extends BaseCommand {
   public static paths = [
     ['synthetics', 'run-tests'],
     ['synthetics', 'build-and-test'],

--- a/packages/base/src/commands/synthetics/upload-application.ts
+++ b/packages/base/src/commands/synthetics/upload-application.ts
@@ -4,6 +4,8 @@ import {Command, Option} from 'clipanion'
 import {executePluginCommand} from '../../helpers/plugin'
 import {makeTerminalLink} from '../../helpers/utils'
 
+import {BaseCommand} from '../..'
+
 const datadogDocsBaseUrl = 'https://docs.datadoghq.com'
 
 // BASE COMMAND START
@@ -14,7 +16,7 @@ const $B2 = makeTerminalLink(
 const $B3 = makeTerminalLink(`${datadogDocsBaseUrl}/getting_started/site/#access-the-datadog-site`)
 // BASE COMMAND END
 
-export class SyntheticsUploadApplicationCommand extends Command {
+export class SyntheticsUploadApplicationCommand extends BaseCommand {
   public static paths = [['synthetics', 'upload-application']]
 
   public static usage = Command.Usage({

--- a/packages/base/src/commands/tag/tag.ts
+++ b/packages/base/src/commands/tag/tag.ts
@@ -10,7 +10,9 @@ import {retryRequest} from '../../helpers/retry'
 import {parseTags, parseTagsFile} from '../../helpers/tags'
 import {getApiHostForSite, getRequestBuilder} from '../../helpers/utils'
 
-export class TagCommand extends Command {
+import {BaseCommand} from '../..'
+
+export class TagCommand extends BaseCommand {
   public static paths = [['tag']]
 
   public static usage = Command.Usage({

--- a/packages/base/src/helpers/__tests__/testing-tools.ts
+++ b/packages/base/src/helpers/__tests__/testing-tools.ts
@@ -5,7 +5,7 @@ import {BaseContext, Cli, Command, CommandClass} from 'clipanion'
 import {CommandOption} from 'clipanion/lib/advanced/options'
 import upath from 'upath'
 
-import {CommandContext} from '../interfaces'
+import {MockCommandContext} from '../interfaces'
 
 export const MOCK_BASE_URL = 'https://app.datadoghq.com/'
 export const MOCK_DATADOG_API_KEY = '02aeb762fff59ac0d5ad1536cd9633bd'
@@ -22,7 +22,7 @@ interface MockContextOptions {
   /**
    * Define a custom environment for the command. That's only useful if your command uses `this.env` instead of `process.env`.
    */
-  env?: CommandContext['env']
+  env?: MockCommandContext['env']
 }
 
 interface MakeRunCLIOptions extends MockContextOptions {
@@ -32,7 +32,7 @@ interface MakeRunCLIOptions extends MockContextOptions {
   skipResetEnv?: boolean
 }
 
-export const createMockContext = (opts?: MockContextOptions): CommandContext => {
+export const createMockContext = (opts?: MockContextOptions): MockCommandContext => {
   let out = ''
   let err = ''
 

--- a/packages/base/src/helpers/interfaces.ts
+++ b/packages/base/src/helpers/interfaces.ts
@@ -127,6 +127,6 @@ export type SpanTags = Partial<Record<SpanTag, string>>
 export type RequestBuilder = (args: AxiosRequestConfig) => AxiosPromise
 
 /**
- * A subset of Clipanion's BaseContext.
+ * A subset of Clipanion's {@link BaseContext}.
  */
-export type CommandContext = Pick<BaseContext, 'stdout' | 'stderr'> & Partial<Pick<BaseContext, 'env'>>
+export type MockCommandContext = Pick<BaseContext, 'stdout' | 'stderr'> & Partial<Pick<BaseContext, 'env'>>

--- a/packages/base/src/helpers/plugin.ts
+++ b/packages/base/src/helpers/plugin.ts
@@ -6,11 +6,13 @@ import createDebug from 'debug'
 
 import {peerDependencies} from '@datadog/datadog-ci-base/package.json'
 
+import {CommandContext} from '..'
+
 import {isStandaloneBinary} from './is-standalone-binary'
 import {messageBox} from './message-box'
 
 export type PluginPackageJson = {name: string; version: string}
-export type PluginSubModule = {PluginCommand: CommandClass}
+export type PluginSubModule = {PluginCommand: CommandClass<CommandContext>}
 
 // Use `DEBUG=plugins` to enable debug logs
 const debug = createDebug('plugins')
@@ -42,6 +44,10 @@ export const executePluginCommand = async <T extends Command>(instance: T): Prom
 
     return 1
   }
+}
+
+export const listAllPlugins = (): string[] => {
+  return Object.keys(peerDependencies)
 }
 
 export const checkPlugin = async (scope: string, command?: string): Promise<boolean> => {

--- a/packages/base/src/index.ts
+++ b/packages/base/src/index.ts
@@ -1,6 +1,8 @@
 import {BaseContext, Command} from 'clipanion'
 
-export type CommandContext = BaseContext
+export type CommandContext = BaseContext & {
+  builtinPlugins: string[]
+}
 
 /**
  * This command should be extended by **every** command in the monorepo.

--- a/packages/base/src/index.ts
+++ b/packages/base/src/index.ts
@@ -1,0 +1,8 @@
+import {BaseContext, Command} from 'clipanion'
+
+export type CommandContext = BaseContext
+
+/**
+ * This command should be extended by **every** command in the monorepo.
+ */
+export abstract class BaseCommand extends Command<CommandContext> {}

--- a/packages/base/src/version.ts
+++ b/packages/base/src/version.ts
@@ -1,2 +1,1 @@
-// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-var-requires
-export const cliVersion = require('../package.json').version as string
+export {version as cliVersion} from '@datadog/datadog-ci-base/package.json'

--- a/packages/datadog-ci/package.json
+++ b/packages/datadog-ci/package.json
@@ -18,6 +18,13 @@
   },
   "bin": "dist/cli.js",
   "main": "dist/index.js",
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "development": "./src/index.ts",
+      "default": "./dist/index.js"
+    }
+  },
   "files": [
     "dist/**/*",
     "README",

--- a/packages/datadog-ci/src/__tests__/cli.test.ts
+++ b/packages/datadog-ci/src/__tests__/cli.test.ts
@@ -107,7 +107,7 @@ describe('cli', () => {
 
       test('supports the --fips option', async () => {
         // When running the command with the --fips option
-        const exitCode = await cli.run([...command, '--fips'])
+        const exitCode = await cli.run([...command, '--fips'], {builtinPlugins: []})
 
         // The command calls the enableFips function with the right parameters
         expect([0, 1]).toContain(exitCode)
@@ -116,7 +116,7 @@ describe('cli', () => {
 
       test('supports the --fips-ignore-error option', async () => {
         // When running the command with the --fips and --fips-ignore-error options
-        const exitCode = await cli.run([...command, '--fips', '--fips-ignore-error'])
+        const exitCode = await cli.run([...command, '--fips', '--fips-ignore-error'], {builtinPlugins: []})
 
         // The command calls the enableFips function with the right parameters
         expect([0, 1]).toContain(exitCode)

--- a/packages/datadog-ci/src/cli.ts
+++ b/packages/datadog-ci/src/cli.ts
@@ -1,8 +1,11 @@
 #!/usr/bin/env node
 
+import {CommandContext} from '@datadog/datadog-ci-base'
 import {commands as migratedCommands} from '@datadog/datadog-ci-base/cli'
 import {cliVersion} from '@datadog/datadog-ci-base/version'
 import {Builtins, Cli} from 'clipanion'
+
+import {dependencies} from '@datadog/datadog-ci/package.json'
 
 import {commands as commandsToMigrate} from './commands/cli'
 
@@ -19,7 +22,7 @@ const onError = (err: any) => {
 process.on('uncaughtException', onError)
 process.on('unhandledRejection', onError)
 
-const cli = new Cli({
+const cli = new Cli<CommandContext>({
   binaryLabel: 'Datadog CI',
   binaryName: 'datadog-ci',
   binaryVersion: cliVersion,
@@ -36,11 +39,14 @@ Object.entries({...migratedCommands, ...commandsToMigrate}).forEach(([scope, com
   commands.forEach((command) => cli.register(command))
 })
 
+const builtinPlugins = Object.keys(dependencies).filter((plugin) => plugin.startsWith('@datadog/datadog-ci-plugin-'))
+
 if (require.main === module) {
   void cli.runExit(process.argv.slice(2), {
     stderr: process.stderr,
     stdin: process.stdin,
     stdout: process.stdout,
+    builtinPlugins,
   })
 }
 

--- a/packages/datadog-ci/src/commands/coverage/upload.ts
+++ b/packages/datadog-ci/src/commands/coverage/upload.ts
@@ -1,5 +1,6 @@
 import os from 'os'
 
+import {BaseCommand} from '@datadog/datadog-ci-base'
 import {DiffData, getGitDiff, getMergeBase, newSimpleGit} from '@datadog/datadog-ci-base/commands/git-metadata/git'
 import {uploadToGitDB} from '@datadog/datadog-ci-base/commands/git-metadata/gitdb'
 import {isGitRepo} from '@datadog/datadog-ci-base/commands/git-metadata/library'
@@ -55,7 +56,7 @@ const errorCodesStopUpload = [400, 403]
 
 const MAX_REPORTS_PER_REQUEST = 8 // backend supports 10 attachments, to keep the logic simple we subtract 2: for PR diff and commit diff
 
-export class CoverageUploadCommand extends Command {
+export class CoverageUploadCommand extends BaseCommand {
   public static paths = [['coverage', 'upload']]
 
   public static usage = Command.Usage({

--- a/packages/datadog-ci/src/commands/dsyms/upload.ts
+++ b/packages/datadog-ci/src/commands/dsyms/upload.ts
@@ -1,5 +1,6 @@
 import {promises} from 'fs'
 
+import {BaseCommand} from '@datadog/datadog-ci-base'
 import {FIPS_ENV_VAR, FIPS_IGNORE_ERROR_ENV_VAR} from '@datadog/datadog-ci-base/constants'
 import {ApiKeyValidator, newApiKeyValidator} from '@datadog/datadog-ci-base/helpers/apikey'
 import {doWithMaxConcurrency} from '@datadog/datadog-ci-base/helpers/concurrency'
@@ -41,7 +42,7 @@ import {
   zipDirectoryToArchive,
 } from './utils'
 
-export class DsymsUploadCommand extends Command {
+export class DsymsUploadCommand extends BaseCommand {
   public static paths = [['dsyms', 'upload']]
 
   public static usage = Command.Usage({

--- a/packages/datadog-ci/src/commands/elf-symbols/upload.ts
+++ b/packages/datadog-ci/src/commands/elf-symbols/upload.ts
@@ -1,5 +1,6 @@
 import fs from 'fs'
 
+import {BaseCommand} from '@datadog/datadog-ci-base'
 import {FIPS_ENV_VAR, FIPS_IGNORE_ERROR_ENV_VAR} from '@datadog/datadog-ci-base/constants'
 import {newApiKeyValidator} from '@datadog/datadog-ci-base/helpers/apikey'
 import {doWithMaxConcurrency} from '@datadog/datadog-ci-base/helpers/concurrency'
@@ -52,7 +53,7 @@ import {
   renderWarning,
 } from './renderer'
 
-export class ElfSymbolsUploadCommand extends Command {
+export class ElfSymbolsUploadCommand extends BaseCommand {
   public static paths = [['elf-symbols', 'upload']]
 
   public static usage = Command.Usage({

--- a/packages/datadog-ci/src/commands/flutter-symbols/upload.ts
+++ b/packages/datadog-ci/src/commands/flutter-symbols/upload.ts
@@ -1,5 +1,6 @@
 import fs from 'fs'
 
+import {BaseCommand} from '@datadog/datadog-ci-base'
 import {newSimpleGit} from '@datadog/datadog-ci-base/commands/git-metadata/git'
 import {FIPS_ENV_VAR, FIPS_IGNORE_ERROR_ENV_VAR} from '@datadog/datadog-ci-base/constants'
 import {newApiKeyValidator} from '@datadog/datadog-ci-base/helpers/apikey'
@@ -57,7 +58,7 @@ import {
   UploadInfo,
 } from './renderer'
 
-export class FlutterSymbolsUploadCommand extends Command {
+export class FlutterSymbolsUploadCommand extends BaseCommand {
   public static paths = [['flutter-symbols', 'upload']]
 
   public static usage = Command.Usage({

--- a/packages/datadog-ci/src/commands/junit/upload.ts
+++ b/packages/datadog-ci/src/commands/junit/upload.ts
@@ -1,6 +1,7 @@
 import fs from 'fs'
 import os from 'os'
 
+import {BaseCommand} from '@datadog/datadog-ci-base'
 import {newSimpleGit} from '@datadog/datadog-ci-base/commands/git-metadata/git'
 import {uploadToGitDB} from '@datadog/datadog-ci-base/commands/git-metadata/gitdb'
 import {isGitRepo} from '@datadog/datadog-ci-base/commands/git-metadata/library'
@@ -76,7 +77,7 @@ const validateXml = (xmlFilePath: string) => {
   return undefined
 }
 
-export class JunitUploadCommand extends Command {
+export class JunitUploadCommand extends BaseCommand {
   public static paths = [['junit', 'upload']]
 
   public static usage = Command.Usage({

--- a/packages/datadog-ci/src/commands/measure/measure.ts
+++ b/packages/datadog-ci/src/commands/measure/measure.ts
@@ -1,5 +1,6 @@
 import type {AxiosError} from 'axios'
 
+import {BaseCommand} from '@datadog/datadog-ci-base'
 import {FIPS_ENV_VAR, FIPS_IGNORE_ERROR_ENV_VAR} from '@datadog/datadog-ci-base/constants'
 import {getCIEnv} from '@datadog/datadog-ci-base/helpers/ci'
 import {toBoolean} from '@datadog/datadog-ci-base/helpers/env'
@@ -28,7 +29,7 @@ export const parseMeasures = (measures: string[]) =>
     }
   }, {})
 
-export class MeasureCommand extends Command {
+export class MeasureCommand extends BaseCommand {
   public static paths = [['measure']]
 
   public static usage = Command.Usage({

--- a/packages/datadog-ci/src/commands/pe-symbols/upload.ts
+++ b/packages/datadog-ci/src/commands/pe-symbols/upload.ts
@@ -1,5 +1,6 @@
 import fs from 'fs'
 
+import {BaseCommand} from '@datadog/datadog-ci-base'
 import {FIPS_ENV_VAR, FIPS_IGNORE_ERROR_ENV_VAR} from '@datadog/datadog-ci-base/constants'
 import {newApiKeyValidator} from '@datadog/datadog-ci-base/helpers/apikey'
 import {doWithMaxConcurrency} from '@datadog/datadog-ci-base/helpers/concurrency'
@@ -43,7 +44,7 @@ import {
   renderWarning,
 } from './renderer'
 
-export class PeSymbolsUploadCommand extends Command {
+export class PeSymbolsUploadCommand extends BaseCommand {
   public static paths = [['pe-symbols', 'upload']]
 
   public static usage = Command.Usage({

--- a/packages/datadog-ci/src/commands/react-native/__tests__/interfaces.test.ts
+++ b/packages/datadog-ci/src/commands/react-native/__tests__/interfaces.test.ts
@@ -1,5 +1,6 @@
 import fs from 'fs/promises'
 
+import {CommandContext} from '@datadog/datadog-ci-base'
 import {createMockContext} from '@datadog/datadog-ci-base/helpers/__tests__/testing-tools'
 import {MultipartFileValue} from '@datadog/datadog-ci-base/helpers/upload'
 
@@ -24,7 +25,7 @@ describe('interfaces', () => {
         '',
         'android',
         '102030',
-        createMockContext()
+        createMockContext() as CommandContext
       )
       const sourcemapFilePath = (payload.content.get('source_map') as MultipartFileValue).path
 

--- a/packages/datadog-ci/src/commands/react-native/__tests__/upload.test.ts
+++ b/packages/datadog-ci/src/commands/react-native/__tests__/upload.test.ts
@@ -1,3 +1,4 @@
+import {CommandContext} from '@datadog/datadog-ci-base'
 import {
   createCommand,
   createMockContext,
@@ -39,7 +40,7 @@ describe('upload', () => {
         'projectPath',
         'android',
         'build',
-        createMockContext()
+        createMockContext() as CommandContext
       )
 
       // THEN

--- a/packages/datadog-ci/src/commands/react-native/codepush.ts
+++ b/packages/datadog-ci/src/commands/react-native/codepush.ts
@@ -1,5 +1,6 @@
 import {exec} from 'child_process'
 
+import {BaseCommand} from '@datadog/datadog-ci-base'
 import {FIPS_ENV_VAR, FIPS_IGNORE_ERROR_ENV_VAR} from '@datadog/datadog-ci-base/constants'
 import {toBoolean} from '@datadog/datadog-ci-base/helpers/env'
 import {enableFips} from '@datadog/datadog-ci-base/helpers/fips'
@@ -10,7 +11,7 @@ import {RNPlatform, RN_SUPPORTED_PLATFORMS} from './interfaces'
 import {ReactNativeUploadCommand} from './upload'
 import {sanitizeReleaseVersion} from './utils'
 
-export class ReactNativeCodepushCommand extends Command {
+export class ReactNativeCodepushCommand extends BaseCommand {
   public static paths = [['react-native', 'codepush']]
 
   public static usage = Command.Usage({

--- a/packages/datadog-ci/src/commands/react-native/injectDebugId.ts
+++ b/packages/datadog-ci/src/commands/react-native/injectDebugId.ts
@@ -1,6 +1,7 @@
 import {createHash} from 'crypto'
 import {existsSync, promises} from 'fs'
 
+import {BaseCommand} from '@datadog/datadog-ci-base'
 import {FIPS_ENV_VAR, FIPS_IGNORE_ERROR_ENV_VAR} from '@datadog/datadog-ci-base/constants'
 import {toBoolean} from '@datadog/datadog-ci-base/helpers/env'
 import {enableFips} from '@datadog/datadog-ci-base/helpers/fips'
@@ -12,7 +13,7 @@ import upath from 'upath'
  */
 const DEBUG_ID_METADATA_PREFIX = 'datadog-debug-id-'
 
-export class ReactNativeInjectDebugIdCommand extends Command {
+export class ReactNativeInjectDebugIdCommand extends BaseCommand {
   public static paths = [['react-native', 'inject-debug-id']]
   public static usage = Command.Usage({
     category: 'RUM',

--- a/packages/datadog-ci/src/commands/react-native/interfaces.ts
+++ b/packages/datadog-ci/src/commands/react-native/interfaces.ts
@@ -1,6 +1,6 @@
 import fs from 'fs'
 
-import {CommandContext} from '@datadog/datadog-ci-base/helpers/interfaces'
+import {CommandContext} from '@datadog/datadog-ci-base'
 import {MultipartPayload, MultipartValue} from '@datadog/datadog-ci-base/helpers/upload'
 
 export class RNSourcemap {

--- a/packages/datadog-ci/src/commands/react-native/upload.ts
+++ b/packages/datadog-ci/src/commands/react-native/upload.ts
@@ -1,3 +1,4 @@
+import {BaseCommand} from '@datadog/datadog-ci-base'
 import {FIPS_ENV_VAR, FIPS_IGNORE_ERROR_ENV_VAR} from '@datadog/datadog-ci-base/constants'
 import {ApiKeyValidator, newApiKeyValidator} from '@datadog/datadog-ci-base/helpers/apikey'
 import {getBaseSourcemapIntakeUrl} from '@datadog/datadog-ci-base/helpers/base-intake-url'
@@ -37,7 +38,7 @@ import {
 import {getBundleName} from './utils'
 import {InvalidPayload, validatePayload} from './validation'
 
-export class ReactNativeUploadCommand extends Command {
+export class ReactNativeUploadCommand extends BaseCommand {
   public static paths = [['react-native', 'upload']]
 
   public static usage = Command.Usage({

--- a/packages/datadog-ci/src/commands/react-native/xcode.ts
+++ b/packages/datadog-ci/src/commands/react-native/xcode.ts
@@ -2,6 +2,7 @@
 import {spawn} from 'child_process'
 import {existsSync, readFileSync, statSync, unlinkSync, writeFileSync} from 'fs'
 
+import {BaseCommand} from '@datadog/datadog-ci-base'
 import {FIPS_ENV_VAR, FIPS_IGNORE_ERROR_ENV_VAR} from '@datadog/datadog-ci-base/constants'
 import {toBoolean} from '@datadog/datadog-ci-base/helpers/env'
 import {enableFips} from '@datadog/datadog-ci-base/helpers/fips'
@@ -65,7 +66,7 @@ const getDatadogReactNativePath = () => {
   }
 }
 
-export class ReactNativeXcodeCommand extends Command {
+export class ReactNativeXcodeCommand extends BaseCommand {
   public static paths = [['react-native', 'xcode']]
 
   public static usage = Command.Usage({

--- a/packages/datadog-ci/src/commands/sourcemaps/upload.ts
+++ b/packages/datadog-ci/src/commands/sourcemaps/upload.ts
@@ -1,5 +1,6 @@
 import {URL} from 'url'
 
+import {BaseCommand} from '@datadog/datadog-ci-base'
 import {FIPS_ENV_VAR, FIPS_IGNORE_ERROR_ENV_VAR} from '@datadog/datadog-ci-base/constants'
 import {ApiKeyValidator, newApiKeyValidator} from '@datadog/datadog-ci-base/helpers/apikey'
 import {getBaseSourcemapIntakeUrl} from '@datadog/datadog-ci-base/helpers/base-intake-url'
@@ -39,7 +40,7 @@ import {
 import {getMinifiedFilePath} from './utils'
 import {InvalidPayload, validatePayload} from './validation'
 
-export class SourcemapsUploadCommand extends Command {
+export class SourcemapsUploadCommand extends BaseCommand {
   public static paths = [['sourcemaps', 'upload']]
 
   public static usage = Command.Usage({

--- a/packages/datadog-ci/src/commands/trace/helper.ts
+++ b/packages/datadog-ci/src/commands/trace/helper.ts
@@ -1,5 +1,6 @@
 import crypto from 'crypto'
 
+import {BaseCommand} from '@datadog/datadog-ci-base'
 import {FIPS_ENV_VAR, FIPS_IGNORE_ERROR_ENV_VAR} from '@datadog/datadog-ci-base/constants'
 import {getCIProvider, getCISpanTags} from '@datadog/datadog-ci-base/helpers/ci'
 import {toBoolean} from '@datadog/datadog-ci-base/helpers/env'
@@ -10,12 +11,12 @@ import {parseTags} from '@datadog/datadog-ci-base/helpers/tags'
 import {getUserGitSpanTags} from '@datadog/datadog-ci-base/helpers/user-provided-git'
 import {AxiosError} from 'axios'
 import chalk from 'chalk'
-import {Command, Option} from 'clipanion'
+import {Option} from 'clipanion'
 
 import {apiConstructor} from './api'
 import {APIHelper, Payload, SUPPORTED_PROVIDERS} from './interfaces'
 
-export abstract class CustomSpanCommand extends Command {
+export abstract class CustomSpanCommand extends BaseCommand {
   private measures = Option.Array('--measures')
   private dryRun = Option.Boolean('--dry-run')
   private tags = Option.Array('--tags')

--- a/packages/datadog-ci/src/commands/unity-symbols/upload.ts
+++ b/packages/datadog-ci/src/commands/unity-symbols/upload.ts
@@ -1,5 +1,6 @@
 import fs from 'fs'
 
+import {BaseCommand} from '@datadog/datadog-ci-base'
 import {FIPS_ENV_VAR, FIPS_IGNORE_ERROR_ENV_VAR} from '@datadog/datadog-ci-base/constants'
 import {newApiKeyValidator} from '@datadog/datadog-ci-base/helpers/apikey'
 import {doWithMaxConcurrency} from '@datadog/datadog-ci-base/helpers/concurrency'
@@ -54,7 +55,7 @@ import {
   renderUseOnlyOnePlatform,
 } from './renderer'
 
-export class UnitySymbolsUploadCommand extends Command {
+export class UnitySymbolsUploadCommand extends BaseCommand {
   public static paths = [['unity-symbols', 'upload']]
 
   public static usage = Command.Usage({

--- a/packages/datadog-ci/src/commands/version/cli.ts
+++ b/packages/datadog-ci/src/commands/version/cli.ts
@@ -1,7 +1,8 @@
+import {BaseCommand} from '@datadog/datadog-ci-base'
 import {cliVersion} from '@datadog/datadog-ci-base/version'
 import {Command} from 'clipanion'
 
-class VersionCommand extends Command {
+class VersionCommand extends BaseCommand {
   public static paths = [['version']]
 
   public static usage = Command.Usage({

--- a/packages/plugin-stepfunctions/src/__tests__/helpers.test.ts
+++ b/packages/plugin-stepfunctions/src/__tests__/helpers.test.ts
@@ -1,5 +1,6 @@
 import {DescribeStateMachineCommandOutput, LogLevel} from '@aws-sdk/client-sfn'
-import {CommandContext} from '@datadog/datadog-ci-base/helpers/interfaces'
+import {CommandContext} from '@datadog/datadog-ci-base'
+import {MockCommandContext} from '@datadog/datadog-ci-base/helpers/interfaces'
 
 import {
   buildArn,
@@ -17,18 +18,18 @@ import {
 
 import {describeStateMachineFixture} from './fixtures/aws-resources'
 
-const createMockContext = (): CommandContext => {
+const createMockContext = (): MockCommandContext => {
   return {
     stdout: {
       write: (input: string) => {
         return true
       },
     },
-  } as CommandContext
+  } as MockCommandContext
 }
 
 describe('stepfunctions command helpers tests', () => {
-  const context = createMockContext()
+  const context = createMockContext() as CommandContext
   describe('injectContextForLambdaFunctions test', () => {
     test.each([
       [

--- a/packages/plugin-stepfunctions/src/awsCommands.ts
+++ b/packages/plugin-stepfunctions/src/awsCommands.ts
@@ -31,7 +31,7 @@ import {
   UpdateStateMachineCommandOutput,
 } from '@aws-sdk/client-sfn'
 import {SFNClient} from '@aws-sdk/client-sfn/dist-types/SFNClient'
-import {CommandContext} from '@datadog/datadog-ci-base/helpers/interfaces'
+import {CommandContext} from '@datadog/datadog-ci-base'
 
 import {buildLogAccessPolicyName, displayChanges, StateMachineDefinitionType} from './helpers'
 

--- a/packages/plugin-stepfunctions/src/helpers.ts
+++ b/packages/plugin-stepfunctions/src/helpers.ts
@@ -1,6 +1,6 @@
 import {DescribeStateMachineCommandOutput} from '@aws-sdk/client-sfn'
 import {SFNClient} from '@aws-sdk/client-sfn/dist-types/SFNClient'
-import {CommandContext} from '@datadog/datadog-ci-base/helpers/interfaces'
+import {CommandContext} from '@datadog/datadog-ci-base'
 import {diff} from 'deep-object-diff'
 
 import {updateStateMachineDefinition} from './awsCommands'

--- a/packages/plugin-synthetics/src/__tests__/reporters/default.test.ts
+++ b/packages/plugin-synthetics/src/__tests__/reporters/default.test.ts
@@ -9,8 +9,8 @@ Object.defineProperty(process, 'platform', {
   writable: true,
 })
 
+import {CommandContext} from '@datadog/datadog-ci-base'
 import {MOCK_BASE_URL} from '@datadog/datadog-ci-base/helpers/__tests__/testing-tools'
-import {CommandContext} from '@datadog/datadog-ci-base/helpers/interfaces'
 
 import {
   ExecutionRule,

--- a/packages/plugin-synthetics/src/__tests__/reporters/junit.test.ts
+++ b/packages/plugin-synthetics/src/__tests__/reporters/junit.test.ts
@@ -2,8 +2,8 @@ import fs from 'fs'
 import fsp from 'fs/promises'
 import {Writable} from 'stream'
 
+import {CommandContext} from '@datadog/datadog-ci-base'
 import {MOCK_BASE_URL} from '@datadog/datadog-ci-base/helpers/__tests__/testing-tools'
-import {CommandContext} from '@datadog/datadog-ci-base/helpers/interfaces'
 
 import {PluginCommand as RunTestsCommand} from '../../commands/run-tests'
 import {Device, ExecutionRule, Result, ServerTest} from '../../interfaces'

--- a/packages/plugin-synthetics/src/__tests__/reporters/mobile/app-upload.test.ts
+++ b/packages/plugin-synthetics/src/__tests__/reporters/mobile/app-upload.test.ts
@@ -9,7 +9,7 @@ Object.defineProperty(process, 'platform', {
   writable: true,
 })
 
-import {CommandContext} from '@datadog/datadog-ci-base/helpers/interfaces'
+import {CommandContext} from '@datadog/datadog-ci-base'
 
 import {AppUploadReporter} from '../../../reporters/mobile/app-upload'
 

--- a/packages/plugin-synthetics/src/interfaces.ts
+++ b/packages/plugin-synthetics/src/interfaces.ts
@@ -1,3 +1,5 @@
+import {Writable} from 'stream'
+
 import {Metadata} from '@datadog/datadog-ci-base/helpers/interfaces'
 import {ProxyConfiguration} from '@datadog/datadog-ci-base/helpers/utils'
 
@@ -17,6 +19,11 @@ export interface MainReporter {
   resultEnd(result: Result, baseUrl: string, batchId: string): void
   reportStart(timings: {startTime: number}): void
   runEnd(summary: Summary, baseUrl: string, orgSettings?: SyntheticsOrgSettings): void
+}
+
+export interface ReporterContext {
+  stdout: Writable
+  stderr: Writable
 }
 
 export type Reporter = Partial<MainReporter>

--- a/packages/plugin-synthetics/src/reporters/default.ts
+++ b/packages/plugin-synthetics/src/reporters/default.ts
@@ -1,5 +1,4 @@
 import type {TunnelReporter} from '../tunnel/tunnel'
-import type {CommandContext} from '@datadog/datadog-ci-base/helpers/interfaces'
 import type {Writable} from 'stream'
 
 import {getTestRunsUrlPath} from '@datadog/datadog-ci-base/helpers/app'
@@ -20,6 +19,7 @@ import {
   UserConfigOverride,
   ResultInBatch,
   TestRequest,
+  ReporterContext,
 } from '../interfaces'
 import {isBaseResult, isTimedOutRetry, getPublicIdOrPlaceholder} from '../utils/internal'
 import {
@@ -356,12 +356,12 @@ const getResultIconAndColor = (resultOutcome: ResultOutcome): [string, chalk.Cha
 }
 
 export class DefaultReporter implements MainReporter {
-  private context: CommandContext
+  private context: ReporterContext
   private testWaitSpinner?: ora.Ora
   private write: Writable['write']
   private totalDuration?: number
 
-  constructor({context}: {context: CommandContext}) {
+  constructor({context}: {context: ReporterContext}) {
     this.context = context
     this.write = context.stdout.write.bind(context.stdout)
   }

--- a/packages/plugin-synthetics/src/reporters/junit.ts
+++ b/packages/plugin-synthetics/src/reporters/junit.ts
@@ -1,6 +1,5 @@
 import fs from 'fs'
 
-import type {CommandContext} from '@datadog/datadog-ci-base/helpers/interfaces'
 import type {Writable} from 'stream'
 
 import c from 'chalk'
@@ -14,6 +13,7 @@ import {
   ExecutionRule,
   MultiStep,
   Reporter,
+  ReporterContext,
   Result,
   SelectiveRerunDecision,
   Step,
@@ -116,7 +116,7 @@ interface XMLError {
 }
 
 export interface Args {
-  context: CommandContext
+  context: ReporterContext
   jUnitReport?: string
   runName?: string
 }

--- a/packages/plugin-synthetics/src/reporters/mobile/app-upload.ts
+++ b/packages/plugin-synthetics/src/reporters/mobile/app-upload.ts
@@ -1,17 +1,16 @@
-import {CommandContext} from '@datadog/datadog-ci-base/helpers/interfaces'
 import chalk from 'chalk'
 import ora from 'ora'
 
-import {AppUploadDetails} from '../../interfaces'
+import {AppUploadDetails, ReporterContext} from '../../interfaces'
 
 import {ICONS} from '../constants'
 
 export class AppUploadReporter {
-  private context: CommandContext
+  private context: ReporterContext
   private spinner?: ora.Ora
   private startTime: number
 
-  constructor(context: CommandContext) {
+  constructor(context: ReporterContext) {
     this.context = context
     this.startTime = Date.now()
   }

--- a/packages/plugin-synthetics/src/run-tests-lib.ts
+++ b/packages/plugin-synthetics/src/run-tests-lib.ts
@@ -24,8 +24,11 @@ import {DefaultReporter, getTunnelReporter} from './reporters/default'
 import {JUnitReporter} from './reporters/junit'
 import {getTestConfigs, getTestsFromSearchQuery, getTestsToTrigger} from './test'
 import {Tunnel} from './tunnel'
-import {getDefaultConfig as getDefaultConfigBase} from './utils/internal'
-import {getTriggerConfigPublicId, isLocalTriggerConfig} from './utils/internal'
+import {
+  getDefaultConfig as getDefaultConfigBase,
+  getTriggerConfigPublicId,
+  isLocalTriggerConfig,
+} from './utils/internal'
 import {
   getReporter,
   getOrgSettings,


### PR DESCRIPTION
### What and why?

**Related PRs:**
- https://github.com/DataDog/datadog-ci/pull/1887
- https://github.com/DataDog/datadog-ci/pull/1886
- https://github.com/DataDog/datadog-ci/pull/1890
- https://github.com/DataDog/datadog-ci/pull/1891

This PR adds a `plugin list` command that lists the plugins that are **NOT built-in**, and thus installable separately by the user. For now, there is none. But after next major version, there will be `aas`, `cloud-run`, `lambda`, `stepfunctions` and `synthetics`.

### How?

Set a custom `CommandContext` for all commands thanks to a `BaseCommand`. This is required to have the right typings.

Thanks to this, the `@datadog/datadog-ci` package can pass any kind of information globally to all commands of the CLI – including plugin commands – through `this.context`.

For now, I only added `this.context.builtinPlugins`, but we may add more in the future.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
