### PR TITLE
Release dora command

### DIFF
--- a/packages/datadog-ci/README.md
+++ b/packages/datadog-ci/README.md
@@ -55,6 +55,9 @@ See each command's linked README for more details, or click on [📚](https://do
 #### `coverage`
 - `upload`: Upload code coverage report files to Datadog. [📚](https://docs.datadoghq.com/code_coverage/)
 
+#### `dora`
+- `deployment`: Send a new deployment event for [DORA Metrics](/packages/plugin-dora) to Datadog. [📚](https://docs.datadoghq.com/dora_metrics/)
+
 #### `dsyms`
 - `upload`: Upload [iOS dSYM files](/packages/datadog-ci/src/commands/dsyms) for Error Tracking (macOS only). [📚](https://docs.datadoghq.com/real_user_monitoring/error_tracking/ios/)
 
@@ -116,9 +119,6 @@ The following are **beta** commands, you can enable them with with `DD_BETA_COMM
 - `correlate`: [Correlate](/packages/plugin-deployment#correlate) GitOps CD deployments with application repositories CI pipelines. [📚](https://docs.datadoghq.com/continuous_delivery/deployments/argocd#correlate-deployments-with-ci-pipelines)
 - `correlate-image`: [Correlate an image](/packages/plugin-deployment#correlate-image) from a CD provider with its source commit. [📚](https://docs.datadoghq.com/continuous_delivery/deployments/argocd#correlate-images-with-source-code)
 - `gate`: Evaluate a [Deployment Gate](/packages/plugin-deployment#gate). [📚](https://docs.datadoghq.com/deployment_gates/)
-
-#### `dora`
-- `deployment`: Send a new deployment event for [DORA Metrics](/packages/plugin-dora) to Datadog. [📚](https://docs.datadoghq.com/dora_metrics/)
 
 #### `elf-symbols`
 - `upload`: Upload [Elf debug info files](/packages/datadog-ci/src/commands/elf-symbols) for Profiling (requires binutils). [📚](https://docs.datadoghq.com/profiler/enabling/ddprof)

--- a/packages/datadog-ci/src/cli.ts
+++ b/packages/datadog-ci/src/cli.ts
@@ -6,7 +6,7 @@ import {Builtins, Cli} from 'clipanion'
 
 import {commands as commandsToMigrate} from './commands/cli'
 
-export const BETA_COMMANDS = new Set(['dora', 'deployment', 'elf-symbols'])
+export const BETA_COMMANDS = new Set(['deployment', 'elf-symbols'])
 
 const betaCommandsEnabled =
   process.env.DD_BETA_COMMANDS_ENABLED === '1' || process.env.DD_BETA_COMMANDS_ENABLED === 'true'

--- a/packages/plugin-dora/README.md
+++ b/packages/plugin-dora/README.md
@@ -8,12 +8,10 @@ Send deployment events for DORA Metrics from CI.
 
 #### `deployment`
 
-**Warning:** The `dora deployment` command is in beta. It requires you to set `DD_BETA_COMMANDS_ENABLED=1`.
-
 This command sends details to Datadog about a deployment of a service.
 
 ```bash
-$ DD_BETA_COMMANDS_ENABLED=1 datadog-ci dora deployment [--service #0] [--env #0] [--dry-run]
+$ datadog-ci dora deployment [--service #0] [--env #0] [--dry-run]
 
 ━━━ Options ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
@@ -29,8 +27,6 @@ $ DD_BETA_COMMANDS_ENABLED=1 datadog-ci dora deployment [--service #0] [--env #0
 For example:
 
 ```bash
-export DD_BETA_COMMANDS_ENABLED=1
-
 datadog-ci dora deployment --service my-service --env prod \
     --started-at 1699960648 --finished-at 1699961048 \
     --git-repository-url https://github.com/my-organization/my-repository \
@@ -71,7 +67,6 @@ To verify this command works as expected, you can use `--dry-run`:
 
 ```bash
 export DD_API_KEY='<API key>'
-export DD_BETA_COMMANDS_ENABLED=1
 
 yarn launch dora deployment --service test-service --started-at `date +%s` --dry-run
 ```


### PR DESCRIPTION
### What and why?

The DORA Metrics product has gone out of beta, so the command should be generally available too

### How?

Remove the need for `DD_BETA_COMMANDS_ENABLED` environment variable to run the command

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)