### PR TITLE
[chore] Add notice for next major release

### DIFF
--- a/packages/base/src/helpers/plugin.ts
+++ b/packages/base/src/helpers/plugin.ts
@@ -15,6 +15,8 @@ export type PluginSubModule = {PluginCommand: CommandClass}
 // Use `DEBUG=plugins` to enable debug logs
 const debug = createDebug('plugins')
 
+const PLUGINS_INSTALLABLE_IN_NEXT_MAJOR_RELEASE = new Set(['aas', 'cloud-run', 'lambda', 'stepfunctions', 'synthetics'])
+
 export const executePluginCommand = async <T extends Command>(instance: T): Promise<number | void> => {
   const [scope, command] = instance.path
   debug(`Executing command ${command} in plugin ${scope}`)
@@ -24,6 +26,7 @@ export const executePluginCommand = async <T extends Command>(instance: T): Prom
     debug(`Done importing plugin command`)
 
     const pluginCommand = Object.assign(new submodule.PluginCommand(), instance)
+    handleNextMajorReleaseNotice(scope)
 
     return pluginCommand.execute()
   } catch (error) {
@@ -119,6 +122,21 @@ export const installPlugin = async (packageOrScope: string): Promise<boolean> =>
 
     return false
   }
+}
+
+const handleNextMajorReleaseNotice = (scope: string) => {
+  if (!PLUGINS_INSTALLABLE_IN_NEXT_MAJOR_RELEASE.has(scope)) {
+    return
+  }
+
+  console.log()
+  messageBox('Datadog-ci 4.0: Plugins 🔌', 'magenta', [
+    `In the next major release of datadog-ci, the commands in the ${chalk.magenta(scope)} scope will be moved to a separate plugin (${chalk.magenta(scopeToPackageName(scope))}).`,
+    `To reduce friction, running a command requiring a plugin in ${chalk.bold('version 4.x')} will automatically install it if necessary. ${chalk.bold('No action needed.')}`,
+    '',
+    `More information at ${chalk.cyan('https://github.com/DataDog/datadog-ci/blob/master/MIGRATING.md#30-to-40')}`,
+  ])
+  console.log()
 }
 
 const handlePluginAutoInstall = async (scope: string) => {


### PR DESCRIPTION
### What and why?

**Related PRs:**
- https://github.com/DataDog/datadog-ci/pull/1887
- https://github.com/DataDog/datadog-ci/pull/1886
- https://github.com/DataDog/datadog-ci/pull/1890
- https://github.com/DataDog/datadog-ci/pull/1891

This PR adds a notice in the CLI to inform customers about next major release.

**Example output:**

<img width="1110" height="399" alt="image" src="https://github.com/user-attachments/assets/fc8e60b3-18a1-4e63-b755-e8530afd93fc" />

### How?

- Update `plugin.ts` to handle the notice

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
