### PR TITLE
[chore] Add permission for provenance

### DIFF
--- a/.github/workflows/publish-prerelease.yml
+++ b/.github/workflows/publish-prerelease.yml
@@ -2,6 +2,10 @@ name: Publish package on NPM (pre-release)
 on:
   release:
     types: [prereleased]
+
+permissions:
+  id-token: write # To publish on NPM with provenance
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -6,6 +6,7 @@ on:
       - v* # Any version tag
 
 permissions:
+  id-token: write # To publish on NPM with provenance
   contents: write # Required for the draft release
 
 jobs:


### PR DESCRIPTION
### What and why?

Forgot doing that in #1880 

Resulted in [this error](https://github.com/DataDog/datadog-ci/actions/runs/18275756223/job/52027725729):
```sh
[@datadog/datadog-ci-base]: ➤ YN0000: Generating provenance statement because `--provenance` flag is set.
[@datadog/datadog-ci-base]: ➤ YN0091: Provenance generation in GitHub Actions requires "write" access to the "id-token" permission
[@datadog/datadog-ci-base]: ➤ YN0000: Failed with errors in 0s 878ms
```

### How?

Add `id-token: write` permission to both NPM publish workflows

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
