### PR TITLE
[chore] Fix CI status badge

### DIFF
--- a/packages/datadog-ci/README.md
+++ b/packages/datadog-ci/README.md
@@ -1,6 +1,6 @@
 # Datadog CI
 
-[![NPM Version](https://img.shields.io/npm/v/@datadog/datadog-ci)](https://www.npmjs.com/package/@datadog/datadog-ci) ![Continuous Integration](https://github.com/DataDog/datadog-ci/workflows/Continuous%20Integration/badge.svg) [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) ![NodeJS Version](https://img.shields.io/badge/Node.js-18+-green)
+[![NPM Version](https://img.shields.io/npm/v/@datadog/datadog-ci)](https://www.npmjs.com/package/@datadog/datadog-ci) [![Continuous Integration](https://github.com/DataDog/datadog-ci/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/DataDog/datadog-ci/actions/workflows/ci.yml?query=branch%3Amaster) [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) ![NodeJS Version](https://img.shields.io/badge/Node.js-18+-green)
 
 Execute commands from your Continuous Integration (CI) and Continuous Delivery (CD) pipelines to integrate with existing Datadog products.
 


### PR DESCRIPTION
### What and why?

This PR makes 2 changes:
- Shows the CI status of the `master` branch instead of latest build.
- On click, redirects to CI builds filtered on `branch: master`.

### How?

Change link

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
