### PR TITLE
v4.0.0

### DIFF
--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-base",
-  "version": "3.22.2",
+  "version": "4.0.0",
   "description": "Base package for Datadog CI",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/datadog-ci/package.json
+++ b/packages/datadog-ci/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci",
-  "version": "3.22.2",
+  "version": "4.0.0",
   "description": "Use Datadog from your CI.",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-aas/package.json
+++ b/packages/plugin-aas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-aas",
-  "version": "3.22.2",
+  "version": "4.0.0",
   "license": "Apache-2.0",
   "description": "Datadog CI plugin for `aas` commands",
   "keywords": [

--- a/packages/plugin-cloud-run/package.json
+++ b/packages/plugin-cloud-run/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-cloud-run",
-  "version": "3.22.2",
+  "version": "4.0.0",
   "license": "Apache-2.0",
   "description": "Datadog CI plugin for `cloud-run` commands",
   "keywords": [

--- a/packages/plugin-deployment/package.json
+++ b/packages/plugin-deployment/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-deployment",
-  "version": "3.22.2",
+  "version": "4.0.0",
   "license": "Apache-2.0",
   "description": "Datadog CI plugin for `deployment` commands",
   "keywords": [

--- a/packages/plugin-dora/package.json
+++ b/packages/plugin-dora/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-dora",
-  "version": "3.22.2",
+  "version": "4.0.0",
   "license": "Apache-2.0",
   "description": "Datadog CI plugin for `dora` commands",
   "keywords": [

--- a/packages/plugin-gate/package.json
+++ b/packages/plugin-gate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-gate",
-  "version": "3.22.2",
+  "version": "4.0.0",
   "license": "Apache-2.0",
   "description": "Datadog CI plugin for `gate` commands",
   "keywords": [

--- a/packages/plugin-lambda/package.json
+++ b/packages/plugin-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-lambda",
-  "version": "3.22.2",
+  "version": "4.0.0",
   "license": "Apache-2.0",
   "description": "Datadog CI plugin for `lambda` commands",
   "keywords": [

--- a/packages/plugin-sarif/package.json
+++ b/packages/plugin-sarif/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-sarif",
-  "version": "3.22.2",
+  "version": "4.0.0",
   "license": "Apache-2.0",
   "description": "Datadog CI plugin for `sarif` commands",
   "keywords": [

--- a/packages/plugin-sbom/package.json
+++ b/packages/plugin-sbom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-sbom",
-  "version": "3.22.2",
+  "version": "4.0.0",
   "license": "Apache-2.0",
   "description": "Datadog CI plugin for `sbom` commands",
   "keywords": [

--- a/packages/plugin-stepfunctions/package.json
+++ b/packages/plugin-stepfunctions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-stepfunctions",
-  "version": "3.22.2",
+  "version": "4.0.0",
   "license": "Apache-2.0",
   "description": "Datadog CI plugin for `stepfunctions` commands",
   "keywords": [

--- a/packages/plugin-synthetics/package.json
+++ b/packages/plugin-synthetics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-synthetics",
-  "version": "3.22.2",
+  "version": "4.0.0",
   "license": "Apache-2.0",
   "description": "Datadog CI plugin for `synthetics` commands",
   "keywords": [


### PR DESCRIPTION
<!-- Release notes generated using configuration in .github/release.yml at v4.0.0 -->

## What's changed

> [!IMPORTANT]  
> This release includes breaking changes. **Read the [migration guide](https://github.com/DataDog/datadog-ci/blob/master/MIGRATING.md)** to understand the changes and how to adapt your scripts.

### datadog-ci
* Drop `aas`, `cloud-run`, `lambda`, `stepfunctions` and `synthetics` plugins by @Drarig29 in https://github.com/DataDog/datadog-ci/pull/1891
### Static Analysis
* [K9VULN-7903] SARIF upload pull request err msg v2 by @colemaring in https://github.com/DataDog/datadog-ci/pull/1901


**Full Changelog**: https://github.com/DataDog/datadog-ci/compare/v3.22.2...v4.0.0

[K9VULN-7903]: https://datadoghq.atlassian.net/browse/K9VULN-7903?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ