### PR TITLE
[K9VULN-8294] SBOM upload warning message on pull request event

### DIFF
--- a/packages/plugin-sbom/src/__tests__/upload.test.ts
+++ b/packages/plugin-sbom/src/__tests__/upload.test.ts
@@ -1,0 +1,100 @@
+import {createCommand} from '@datadog/datadog-ci-base/helpers/__tests__/testing-tools'
+
+import {PluginCommand as SbomUploadCommand} from '../commands/upload'
+
+// Mock context for CI event validation tests with compatible write signatures
+// We care about stdout vs stderr for validating warning messages
+const createSimpleMockContext = () => {
+  let stdoutData = ''
+  let stderrData = ''
+
+  return {
+    stdout: {
+      toString: () => stdoutData,
+      write: (input?: string) => {
+        if (input) {
+          stdoutData += input
+        }
+      },
+    },
+    stderr: {
+      toString: () => stderrData,
+      write: (input?: string) => {
+        if (input) {
+          stderrData += input
+        }
+      },
+    },
+  }
+}
+
+describe('execute', () => {
+  describe('CI event validation', () => {
+    test('should show warning for GitHub pull_request event', async () => {
+      const originalEnv = {...process.env}
+      process.env.GITHUB_EVENT_NAME = 'pull_request'
+      process.env.DATADOG_API_KEY = 'fake-api-key'
+      process.env.DATADOG_APP_KEY = 'fake-app-key'
+
+      try {
+        const context = createSimpleMockContext()
+        const command = createCommand(SbomUploadCommand, context)
+        command['basePath'] = './src/__tests__/fixtures/sbom-python.json'
+
+        await command.execute()
+        const output = context.stdout.toString()
+
+        expect(output).toContain('::warning title=Unsupported Trigger::')
+        expect(output).toContain('The `pull_request` event will become unsupported in the next release')
+        expect(output).toContain('To continue using Datadog Code Security, use `push` instead')
+      } finally {
+        process.env = originalEnv
+      }
+    })
+
+    test('should show warning for GitLab merge_request_event', async () => {
+      const originalEnv = {...process.env}
+      process.env.CI_PIPELINE_SOURCE = 'merge_request_event'
+      process.env.DATADOG_API_KEY = 'fake-api-key'
+      process.env.DATADOG_APP_KEY = 'fake-app-key'
+
+      try {
+        const context = createSimpleMockContext()
+        const command = createCommand(SbomUploadCommand, context)
+        command['basePath'] = './src/__tests__/fixtures/sbom-python.json'
+
+        await command.execute()
+        const output = context.stderr.toString()
+
+        expect(output).toContain(
+          'The `merge_request_event` pipeline source will become unsupported in the next release'
+        )
+        expect(output).toContain('To continue using Datadog Code Security, use `push` instead')
+      } finally {
+        process.env = originalEnv
+      }
+    })
+
+    test('should show warning for Azure PullRequest event', async () => {
+      const originalEnv = {...process.env}
+      process.env.BUILD_REASON = 'PullRequest'
+      process.env.DATADOG_API_KEY = 'fake-api-key'
+      process.env.DATADOG_APP_KEY = 'fake-app-key'
+
+      try {
+        const context = createSimpleMockContext()
+        const command = createCommand(SbomUploadCommand, context)
+        command['basePath'] = './src/__tests__/fixtures/sbom-python.json'
+
+        await command.execute()
+        const output = context.stdout.toString()
+
+        expect(output).toContain('##vso[task.logissue type=warning]')
+        expect(output).toContain('The `PullRequest` build reason will become unsupported in the next release')
+        expect(output).toContain('To continue using Datadog Code Security, use `push` instead')
+      } finally {
+        process.env = originalEnv
+      }
+    })
+  })
+})


### PR DESCRIPTION
### Motivation
Users who use the SBOM upload in CI should be given a warning message when CI is triggered from a pull request, as this will produce an error in the next release.

This change will be included in a patch in a `datadog-ci@v4` release to warn about the upcoming error messages in the `datadog-ci@v5` release.

### Changes
 - Add warning messages on pull request event for each platform. See [Github](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-commands#example-setting-an-error-message), [Gitlab](https://docs.gitlab.com/ci/pipelines/merge_request_pipelines/), and [Azure](https://learn.microsoft.com/en-us/azure/devops/pipelines/scripts/logging-commands?view=azure-devops&tabs=bash#logging-commands-for-build-pipelines) error logging docs.

### Testing

 - Tested on Github repo on pull_request event:
<img width="1049" height="155" alt="Screenshot 2025-10-14 at 3 22 08 PM" src="https://github.com/user-attachments/assets/2dc1504a-6b64-416a-ba14-57389356c84e" />

Identical implementation was done with the Sarif upload command and tested on Azure and Gitlab. [See PR](https://github.com/DataDog/datadog-ci/pull/1903).
