### PR TITLE
[K9VULN-8294] SBOM upload pull request error (BREAKING CHANGE) 

### DIFF
--- a/packages/plugin-sbom/src/commands/upload.ts
+++ b/packages/plugin-sbom/src/commands/upload.ts
@@ -64,24 +64,30 @@ export class PluginCommand extends SbomUploadCommand {
     if (githubEvent === 'pull_request') {
       // https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-commands#example-setting-an-error-message
       this.context.stdout.write(
-        '::warning title=Unsupported Trigger::The `pull_request` event will become unsupported in the next release. ' +
-          'To continue using Datadog Code Security, use `push` instead. See: https://docs.datadoghq.com/security/code_security/software_composition_analysis/setup_static/?tab=github#run-via-pipelines-integration for more information.\n'
+        '::error title=Unsupported Trigger::The `pull_request` event is not supported by Datadog Code Security and will cause issues with the product. ' +
+          'To continue using Datadog Code Security, use `push` instead. See: https://docs.datadoghq.com/security/code_security/software_composition_analysis/setup_static/?tab=github#run-via-pipelines-integration for more information.'
       )
+
+      return 1
     }
 
     if (gitlabEvent === 'merge_request_event') {
       this.context.stderr.write(
-        'The `merge_request_event` pipeline source will become unsupported in the next release. ' +
-          'To continue using Datadog Code Security, use `push` instead. See: https://docs.datadoghq.com/security/code_security/software_composition_analysis/setup_static/?tab=github#run-via-pipelines-integration for more information.\n'
+        'The `merge_request_event` pipeline source is not supported by Datadog Code Security and will cause issues with the product. ' +
+          'To continue using Datadog Code Security, use `push` instead. See: https://docs.datadoghq.com/security/code_security/software_composition_analysis/setup_static/?tab=github#run-via-pipelines-integration for more information.'
       )
+
+      return 1
     }
 
     if (azureReason === 'PullRequest') {
       // https://learn.microsoft.com/en-us/azure/devops/pipelines/scripts/logging-commands?view=azure-devops&tabs=bash#logging-commands-for-build-pipelines
       this.context.stdout.write(
-        '##vso[task.logissue type=warning]The `PullRequest` build reason will become unsupported in the next release. ' +
-          'To continue using Datadog Code Security, use `push` instead. See: https://docs.datadoghq.com/security/code_security/software_composition_analysis/setup_static/?tab=github#run-via-pipelines-integration for more information.\n'
+        '##vso[task.logissue type=error]The `PullRequest` build reason is not supported by Datadog Code Security and will cause issues with the product. ' +
+          'To continue using Datadog Code Security, use `push` instead. See: https://docs.datadoghq.com/security/code_security/software_composition_analysis/setup_static/?tab=github#run-via-pipelines-integration for more information.'
       )
+
+      return 1
     }
 
     const service = 'datadog-ci'


### PR DESCRIPTION
### Motivation
Users who use the SBOM upload in CI should be given an error message when CI is triggered from a pull request. [see ticket](https://datadoghq.atlassian.net/browse/K9VULN-8294).

## This is a breaking change, as CI jobs will fail due to being triggered by a `pull_request` event. 


### Changes
 - Add error messages on pull request event for each platform. See [Github](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-commands#example-setting-an-error-message), [Gitlab](https://docs.gitlab.com/ci/pipelines/merge_request_pipelines/), and [Azure](https://learn.microsoft.com/en-us/azure/devops/pipelines/scripts/logging-commands?view=azure-devops&tabs=bash#logging-commands-for-build-pipelines) error logging docs.

### Testing

 - Tested on Github repo on pull_request event
<img width="906" height="184" alt="Screenshot 2025-10-16 at 10 38 38 AM" src="https://github.com/user-attachments/assets/afca9736-66a5-4c7e-ad1c-372fd1c945bf" /><br><br>

The screenshots below were from the [SARIF error PR](https://github.com/DataDog/datadog-ci/pull/1901), but the only change from that PR has been the SBOM -> SARIF copy.

 - Tested on Gitlab cloud personal organization repo on merge_request_event event:
<img width="956" height="106" alt="Screenshot 2025-09-29 at 1 22 37 PM" src="https://github.com/user-attachments/assets/73a77a66-8b5e-47b8-bfdf-c9ec194c0dc2" /><br>

 - Tested on Azure DevOps repo on PullRequest event on self hosted runner:
<img width="1465" height="145" alt="Screenshot 2025-09-29 at 2 29 51 PM" src="https://github.com/user-attachments/assets/96f34be1-f86a-4360-a91a-e00e8ae43a1a" />

## Follow Up
This should be included in the next major release.