### PR TITLE
Increase file size limit to 100Mb

### DIFF
--- a/packages/plugin-sarif/src/validation.ts
+++ b/packages/plugin-sarif/src/validation.ts
@@ -7,7 +7,7 @@ import addFormats from 'ajv-formats'
 
 import sarifJsonSchema from './json-schema/sarif-schema-2.1.0.json'
 
-const maxSarifFileSize = 100 * 1024 * 1024 // 20MB in bytes
+const maxSarifFileSize = 100 * 1024 * 1024 // 100MB in bytes
 
 /**
  * Validate the SARIF file and check if the file is too large or not valid


### PR DESCRIPTION
- Customers are asking about the option to add 100MB files.
- This PR increases the limit from 20Mb to 100Mb (new limit in the track side).
- [JIRA link](https://datadoghq.atlassian.net/browse/K9VULN-7207)