### PR TITLE
[test-optimization] Update junit upload README to reflect actual flag defaults

### DIFF
--- a/packages/datadog-ci/src/commands/junit/README.md
+++ b/packages/datadog-ci/src/commands/junit/README.md
@@ -36,7 +36,7 @@ datadog-ci junit upload --service my-service --tags key1:value1 --tags key2:valu
 - `--max-concurrency` (default: `20`): number of concurrent uploads to the API.
 - `--dry-run` (default: `false`): it will run the command without the final upload step. All other checks are performed.
 - `--logs` (default: `false`): it will enable collecting logs from the content in the XML reports.
-- `--skip-git-metadata-upload` (default: `true`): if you want to upload git metadata, you may pass `--skip-git-metadata-upload=0` or `--skip-git-metadata-upload=false`.
+- `--skip-git-metadata-upload` (default: `false`): Pass this flag if you want to skip uploading git metadata.
 - `--git-repository-url` is a string with the repository URL to retrieve git metadata from. If this is missing, the URL is retrieved from the local git repository.
 - `--verbose` (default: `false`): it will add extra verbosity to the output of the command.
 
@@ -79,7 +79,6 @@ service: example-upload
 [DRYRUN] Uploading jUnit XML test report file in src/commands/junit/__tests__/fixtures/java-report.xml
 ✅ Uploaded 1 files in 0 seconds.
 ```
-
 
 ## Further reading
 


### PR DESCRIPTION
### What and why?

`--skip-git-metadata-upload` has a default value of `false`

### How?

Update README

