### PR TITLE
v4.1.0

### DIFF
--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-base",
-  "version": "4.0.2",
+  "version": "4.1.0",
   "description": "Base package for Datadog CI",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/datadog-ci/package.json
+++ b/packages/datadog-ci/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci",
-  "version": "4.0.2",
+  "version": "4.1.0",
   "description": "Use Datadog from your CI.",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-aas/package.json
+++ b/packages/plugin-aas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-aas",
-  "version": "4.0.2",
+  "version": "4.1.0",
   "license": "Apache-2.0",
   "description": "Datadog CI plugin for `aas` commands",
   "keywords": [

--- a/packages/plugin-cloud-run/package.json
+++ b/packages/plugin-cloud-run/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-cloud-run",
-  "version": "4.0.2",
+  "version": "4.1.0",
   "license": "Apache-2.0",
   "description": "Datadog CI plugin for `cloud-run` commands",
   "keywords": [

--- a/packages/plugin-deployment/package.json
+++ b/packages/plugin-deployment/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-deployment",
-  "version": "4.0.2",
+  "version": "4.1.0",
   "license": "Apache-2.0",
   "description": "Datadog CI plugin for `deployment` commands",
   "keywords": [

--- a/packages/plugin-dora/package.json
+++ b/packages/plugin-dora/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-dora",
-  "version": "4.0.2",
+  "version": "4.1.0",
   "license": "Apache-2.0",
   "description": "Datadog CI plugin for `dora` commands",
   "keywords": [

--- a/packages/plugin-gate/package.json
+++ b/packages/plugin-gate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-gate",
-  "version": "4.0.2",
+  "version": "4.1.0",
   "license": "Apache-2.0",
   "description": "Datadog CI plugin for `gate` commands",
   "keywords": [

--- a/packages/plugin-lambda/package.json
+++ b/packages/plugin-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-lambda",
-  "version": "4.0.2",
+  "version": "4.1.0",
   "license": "Apache-2.0",
   "description": "Datadog CI plugin for `lambda` commands",
   "keywords": [

--- a/packages/plugin-sarif/package.json
+++ b/packages/plugin-sarif/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-sarif",
-  "version": "4.0.2",
+  "version": "4.1.0",
   "license": "Apache-2.0",
   "description": "Datadog CI plugin for `sarif` commands",
   "keywords": [

--- a/packages/plugin-sbom/package.json
+++ b/packages/plugin-sbom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-sbom",
-  "version": "4.0.2",
+  "version": "4.1.0",
   "license": "Apache-2.0",
   "description": "Datadog CI plugin for `sbom` commands",
   "keywords": [

--- a/packages/plugin-stepfunctions/package.json
+++ b/packages/plugin-stepfunctions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-stepfunctions",
-  "version": "4.0.2",
+  "version": "4.1.0",
   "license": "Apache-2.0",
   "description": "Datadog CI plugin for `stepfunctions` commands",
   "keywords": [

--- a/packages/plugin-synthetics/package.json
+++ b/packages/plugin-synthetics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-synthetics",
-  "version": "4.0.2",
+  "version": "4.1.0",
   "license": "Apache-2.0",
   "description": "Datadog CI plugin for `synthetics` commands",
   "keywords": [


### PR DESCRIPTION
<!-- Release notes generated using configuration in .github/release.yml at v4.1.0 -->

## What's Changed
### datadog-ci
* Add dry run options to tag, measure and deployment mark commands by @rodrigo-roca in https://github.com/DataDog/datadog-ci/pull/1916
* Extract Github job name automatically for `tag`, `measure`, `trace`, `span` and `deployment mark` by @rodrigo-roca in https://github.com/DataDog/datadog-ci/pull/1911
### Dependencies
* [test optimization] Bump `dd-trace` to `5.72.0` by @juan-fernandez in https://github.com/DataDog/datadog-ci/pull/1926
### Documentation
* [test-optimization] Update junit upload README to reflect actual flag defaults by @juan-fernandez in https://github.com/DataDog/datadog-ci/pull/1925
* [docs] Suggest pinning major version with `npx` by @Drarig29 in https://github.com/DataDog/datadog-ci/pull/1923
* Cloud Run CLI - docs edits by @cswatt in https://github.com/DataDog/datadog-ci/pull/1934
### Serverless
* [Cloud Run Instrument] Set label `service` to DD_SERVICE value by @nhulston in https://github.com/DataDog/datadog-ci/pull/1924
* feat(appsec): use in-tracer appsec when supported by @florentinl in https://github.com/DataDog/datadog-ci/pull/1921
* [SVLS-7793] add version and env to cloud run labels by @ava-silver in https://github.com/DataDog/datadog-ci/pull/1928
* [SVLS-7795] add default service tag and remove instrumented tags by @ava-silver in https://github.com/DataDog/datadog-ci/pull/1930
* [SVLS-7834] add serverless cli tag to all serverless commands by @ava-silver in https://github.com/DataDog/datadog-ci/pull/1931
### Static Analysis
* [K9VULN-8294] SBOM upload warning message on pull request event by @colemaring in https://github.com/DataDog/datadog-ci/pull/1918
* [K9VULN-8923] Update documentation links by @dastrong in https://github.com/DataDog/datadog-ci/pull/1919
* Increase file size limit to 100Mb by @xaldama in https://github.com/DataDog/datadog-ci/pull/1922
### Profiling
* [elf-symbols] Fallback to `--compress-debug-sections` if binutils not built with zstd support by @Drarig29 in https://github.com/DataDog/datadog-ci/pull/1927
### Chores
* [chore] Fix CI status badge by @Drarig29 in https://github.com/DataDog/datadog-ci/pull/1908
* [CHORE] fix CI failures due to test pollution by @ava-silver in https://github.com/DataDog/datadog-ci/pull/1929

## New Contributors
* @florentinl made their first contribution in https://github.com/DataDog/datadog-ci/pull/1921
* @xaldama made their first contribution in https://github.com/DataDog/datadog-ci/pull/1922
* @cswatt made their first contribution in https://github.com/DataDog/datadog-ci/pull/1934

**Full Changelog**: https://github.com/DataDog/datadog-ci/compare/v4.0.2...v4.1.0

[SVLS-7793]: https://datadoghq.atlassian.net/browse/SVLS-7793?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ