### PR TITLE
[SCICM-4973] Add quality gate deprecation message to ci evaluate command

### DIFF
--- a/packages/datadog-ci/README.md
+++ b/packages/datadog-ci/README.md
@@ -109,9 +109,9 @@ The following `<scope>` and `<command>` values are available.
 
 <sub>**README:** [📚](/packages/plugin-gate) | **Documentation:** [🔗](https://docs.datadoghq.com/quality_gates/)</sub>
 
-=> ⚠️ **Deprecation Warning**
+> [!WARNING]
 >
-> Datadog Quality Gates is being replaced by the new PR Gates in January, 2026. Please initiate the migration process by filling out this form: https://forms.gle/qnhANsE1ABtHrjqz9
+> **Deprecated:** Datadog Quality Gates is being replaced by the new PR Gates in 2026. To start the migration, please fill out this form: https://forms.gle/qnhANsE1ABtHrjqz9
 >
 > Learn more about PR Gates: https://docs.datadoghq.com/pr_gates
 

--- a/packages/plugin-gate/README.md
+++ b/packages/plugin-gate/README.md
@@ -1,8 +1,8 @@
 # GATE command
 
-=> ⚠️ **Deprecation Warning**
+> [!WARNING]
 >
-> Datadog Quality Gates is being replaced by the new PR Gates in January, 2026. Please initiate the migration process by filling out this form: https://forms.gle/qnhANsE1ABtHrjqz9
+> **Deprecated:** Datadog Quality Gates is being replaced by the new PR Gates in 2026. To start the migration, please fill out this form: https://forms.gle/qnhANsE1ABtHrjqz9
 >
 > Learn more about PR Gates: https://docs.datadoghq.com/pr_gates
 

--- a/packages/plugin-gate/src/__tests__/evaluate.test.ts
+++ b/packages/plugin-gate/src/__tests__/evaluate.test.ts
@@ -24,7 +24,7 @@ describe('evaluate', () => {
 
       const output = write.mock.calls.map((c) => c[0]).join('\n')
       expect(output).toContain(
-        'Deprecation Warning: Datadog Quality Gates is being replaced by the new PR Gates in January, 2026'
+        'Deprecation Warning: Datadog Quality Gates is being replaced by the new PR Gates in 2026'
       )
       expect(output).toContain('https://forms.gle/qnhANsE1ABtHrjqz9')
       expect(output).toContain('https://docs.datadoghq.com/pr_gates')

--- a/packages/plugin-gate/src/commands/evaluate.ts
+++ b/packages/plugin-gate/src/commands/evaluate.ts
@@ -46,7 +46,7 @@ export class PluginCommand extends GateEvaluateCommand {
 
     // Deprecation notice for Quality Gates evaluate command
     this.logger.warn(
-      `${ICONS.WARNING} Deprecation Warning: Datadog Quality Gates is being replaced by the new PR Gates in January, 2026. Please initiate the migration process by filling out this form: https://forms.gle/qnhANsE1ABtHrjqz9 \n\nLearn more about PR Gates in https://docs.datadoghq.com/pr_gates`
+      `${ICONS.WARNING} Deprecation Warning: Datadog Quality Gates is being replaced by the new PR Gates in 2026. To start the migration, please fill out this form: https://forms.gle/qnhANsE1ABtHrjqz9 \n\nLearn more about PR Gates in https://docs.datadoghq.com/pr_gates`
     )
 
     const options: PayloadOptions = {


### PR DESCRIPTION
### What and why?

Adding a quality gate deprecation warning to the ci evaluate command
