### PR TITLE
[SVLS-7727] export lambda function helpers

### DIFF
--- a/packages/plugin-lambda/package.json
+++ b/packages/plugin-lambda/package.json
@@ -16,6 +16,10 @@
   },
   "exports": {
     "./package.json": "./package.json",
+    "./functions/*": {
+      "development": "./src/functions/*.ts",
+      "default": "./dist/functions/*.js"
+    },
     "./commands/*": {
       "development": "./src/commands/*.ts",
       "default": "./dist/commands/*.js"


### PR DESCRIPTION
### What and why?

We're working on simplifying remote instrumentation which relies on this, so exporting these functions will allow us to use the exported helpers directly rather than creating a new command

### How?

Adds function modules to the exports in the package.json

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)