### PR TITLE
[synthetics] Export type of JUnit report files

### DIFF
--- a/packages/plugin-synthetics/src/index.ts
+++ b/packages/plugin-synthetics/src/index.ts
@@ -4,6 +4,7 @@ export {CiError, CriticalError} from './errors'
 export * from './interfaces'
 export {DefaultReporter} from './reporters/default'
 export {JUnitReporter} from './reporters/junit'
+export type {XMLJSON} from './reporters/junit'
 export {executeTests, execute} from './run-tests-lib'
 export * as utils from './utils/public'
 


### PR DESCRIPTION
### What and why?

In v3.x.x, there was no package.json exports field, meaning that consumers of datadog-ci could dig into dist files arbitrarily and use exported values.

As of 4.x.x, this is no longer the case, with the splitting out of the plugins, their new respective package.json files now use the more modern "exports" format instead of solely relying on a "main" entrypoint.

With the usage of "exports" comes the encapsulation of code not explicitly exported from package.json or transitively through the already present exported files.

My team has code relying on some types in the junit reporter, and by adding an export for this file, we are able to once again consume the exported types there.

This will enable us to upgrade from 3.x.x to 4.x.x.

### How?

I modified the package.json and tested locally using yarn portals to make my other repository depend on my local working copy of datadog-ci. I verified that the types, such as XMLJSON were able to be imported via the path: `@datadog/datadog-ci-plugin-synthetics/reporters/junit`

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
