### PR TITLE
[SVLS] fix cloud run label format

### DIFF
--- a/packages/plugin-cloud-run/src/__tests__/__snapshots__/instrument.test.ts.snap
+++ b/packages/plugin-cloud-run/src/__tests__/__snapshots__/instrument.test.ts.snap
@@ -16,7 +16,7 @@ exports[`InstrumentCommand snapshot tests interactive mode 1`] = `
 🚀 Instrumenting Cloud Run services with sidecar...
   {
 +   "labels": {
-+     "dd_sls_ci": "vXXXX",
++     "dd_sls_ci": "v0_0_0",
 +     "service": "interactive-service"
 +   },
     "name": "projects/interactive-project/locations/us-west1/services/interactive-service",
@@ -143,7 +143,7 @@ exports[`InstrumentCommand snapshot tests prints dry run data with basic flags 1
 [Dry Run] 🚀 Instrumenting Cloud Run services with sidecar...
   {
 +   "labels": {
-+     "dd_sls_ci": "vXXXX",
++     "dd_sls_ci": "v0_0_0",
 +     "env": "staging",
 +     "service": "test-service",
 +     "version": "1.0.0"

--- a/packages/plugin-cloud-run/src/commands/instrument.ts
+++ b/packages/plugin-cloud-run/src/commands/instrument.ts
@@ -263,7 +263,7 @@ export class PluginCommand extends CloudRunInstrumentCommand {
     const updatedLabels: Record<string, string> = {
       ...service.labels,
       service: ddService,
-      [SERVERLESS_CLI_VERSION_TAG_NAME]: SERVERLESS_CLI_VERSION_TAG_VALUE.replace('.', '_'),
+      [SERVERLESS_CLI_VERSION_TAG_NAME]: SERVERLESS_CLI_VERSION_TAG_VALUE.replace(/\./g, '_'),
     }
     if (!!this.environment) {
       updatedLabels.env = this.environment


### PR DESCRIPTION
### What and why?

Fix for https://github.com/DataDog/datadog-ci/issues/1955

### How?

Replace `.` in the version (ie `v1.2.3`) with `_`, (ie `v1_2_3`) since GCP does not allow `.` in labels

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
