### PR TITLE
[SVLS-7942] add startup probe to container app sidecar

### DIFF
--- a/packages/plugin-container-app/src/__tests__/instrument.test.ts
+++ b/packages/plugin-container-app/src/__tests__/instrument.test.ts
@@ -140,7 +140,7 @@ Updating tags for my-container-app
               },
               probes: [
                 {
-                  type: 'Liveness',
+                  type: 'Startup',
                   tcpSocket: {
                     port: 5555,
                   },
@@ -358,7 +358,7 @@ Updating tags for my-container-app
               },
               probes: [
                 {
-                  type: 'Liveness',
+                  type: 'Startup',
                   tcpSocket: {
                     port: 5555,
                   },
@@ -460,7 +460,7 @@ Updating tags for my-container-app
               },
               probes: [
                 {
-                  type: 'Liveness',
+                  type: 'Startup',
                   tcpSocket: {
                     port: 5555,
                   },
@@ -548,7 +548,7 @@ Updating tags for my-container-app
               },
               probes: [
                 {
-                  type: 'Liveness',
+                  type: 'Startup',
                   tcpSocket: {
                     port: 5555,
                   },
@@ -628,7 +628,7 @@ Updating tags for my-container-app
               },
               probes: [
                 {
-                  type: 'Liveness',
+                  type: 'Startup',
                   tcpSocket: {
                     port: 5555,
                   },
@@ -710,7 +710,7 @@ Updating tags for my-container-app
               },
               probes: [
                 {
-                  type: 'Liveness',
+                  type: 'Startup',
                   tcpSocket: {
                     port: 5555,
                   },
@@ -811,7 +811,7 @@ Updating tags for my-container-app
               },
               probes: [
                 {
-                  type: 'Liveness',
+                  type: 'Startup',
                   tcpSocket: {
                     port: 5555,
                   },
@@ -913,7 +913,7 @@ Updating tags for my-container-app
               },
               probes: [
                 {
-                  type: 'Liveness',
+                  type: 'Startup',
                   tcpSocket: {
                     port: 5555,
                   },
@@ -985,7 +985,7 @@ Updating tags for my-container-app
               },
               probes: [
                 {
-                  type: 'Liveness',
+                  type: 'Startup',
                   tcpSocket: {
                     port: 5555,
                   },
@@ -1068,7 +1068,7 @@ Updating tags for my-container-app
               },
               probes: [
                 {
-                  type: 'Liveness',
+                  type: 'Startup',
                   tcpSocket: {
                     port: 5555,
                   },
@@ -1149,7 +1149,7 @@ Updating tags for my-container-app
               },
               probes: [
                 {
-                  type: 'Liveness',
+                  type: 'Startup',
                   tcpSocket: {
                     port: 5555,
                   },
@@ -1234,7 +1234,7 @@ Updating tags for my-container-app
               },
               probes: [
                 {
-                  type: 'Liveness',
+                  type: 'Startup',
                   tcpSocket: {
                     port: 5555,
                   },
@@ -1364,7 +1364,7 @@ Updating tags for my-container-app
               resources: {cpu: 0.25, memory: '0.5Gi'},
               probes: [
                 {
-                  type: 'Liveness',
+                  type: 'Startup',
                   tcpSocket: {
                     port: 5555,
                   },

--- a/packages/plugin-container-app/src/commands/instrument.ts
+++ b/packages/plugin-container-app/src/commands/instrument.ts
@@ -213,7 +213,7 @@ export class PluginCommand extends ContainerAppInstrumentCommand {
       },
       probes: [
         {
-          type: 'Liveness',
+          type: 'Startup',
           tcpSocket: {
             port: DEFAULT_HEALTH_CHECK_PORT,
           },


### PR DESCRIPTION
### What and why?

Adds a startup probe for the sidecar to ensure more robust deployments, like we have with cloud run.

### Testing

Updated unit tests and validated the command works as expected with a manual end to end test


### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
