### PR TITLE
[Exports] Export executeWithDetails function

### DIFF
--- a/packages/plugin-synthetics/src/index.ts
+++ b/packages/plugin-synthetics/src/index.ts
@@ -5,7 +5,7 @@ export * from './interfaces'
 export {DefaultReporter} from './reporters/default'
 export {JUnitReporter} from './reporters/junit'
 export type {XMLJSON} from './reporters/junit'
-export {executeTests, execute} from './run-tests-lib'
+export {executeTests, execute, executeWithDetails} from './run-tests-lib'
 export * as utils from './utils/public'
 
 export const DEFAULT_COMMAND_CONFIG = getDefaultConfig()


### PR DESCRIPTION

This function is used by clients and is not exported anymore as of version 4.x. This change brings it back so that clients can use it again.
