### PR TITLE
[SINT-4287] create dd-octo-sts self policy

### DIFF
--- a/.github/chainguard/self.create-release.sts.yaml
+++ b/.github/chainguard/self.create-release.sts.yaml
@@ -1,0 +1,12 @@
+issuer: https://token.actions.githubusercontent.com
+
+subject: repo:DataDog/datadog-ci:ref:refs/tags/v.*
+claim_pattern:
+  event_name: "push"
+  job_workflow_ref: DataDog/datadog-ci/\.github/workflows/publish-release\.yml@refs/tags/v.*
+  ref: refs/tags/v.*
+
+# https://docs.github.com/en/rest/releases/releases?apiVersion=2022-11-28#create-a-release
+# https://docs.github.com/en/rest/releases/releases?apiVersion=2022-11-28#generate-release-notes-content-for-a-release
+permissions:
+  contents: write

--- a/.github/chainguard/self.issue-labeler.sts.yaml
+++ b/.github/chainguard/self.issue-labeler.sts.yaml
@@ -1,0 +1,13 @@
+issuer: https://token.actions.githubusercontent.com
+
+subject: repo:DataDog/datadog-ci:ref:refs/heads/master
+
+claim_pattern:
+  event_name: issues
+  ref: refs/heads/master
+  ref_protected: "true"
+  job_workflow_ref: DataDog/datadog-ci/\.github/workflows/issue-labeler\.yml@refs/heads/master
+
+# https://docs.github.com/en/rest/issues/labels?apiVersion=2022-11-28#add-labels-to-an-issue
+permissions:
+  issues: write


### PR DESCRIPTION
This PR creates a dd-octo-sts policy for datadog-ci to stop using `secrets.GITHUB_TOKEN` in https://github.com/DataDog/datadog-ci/blob/a45504547b3b4c65dcae857455e53a975646382f/.github/workflows/publish-release.yml

End goal is to remove `secrets.GITHUB_TOKEN`.