### PR TITLE
[SINT-4287] update worflows to use dd-octo-sts

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -6,7 +6,7 @@ on:
       - v* # Any version tag
 
 permissions:
-  id-token: write # To publish on NPM with provenance
+  id-token: write # To publish on NPM with provenance and to federate tokens
   contents: write # Required for the draft release
 
 jobs:
@@ -15,11 +15,16 @@ jobs:
     outputs:
       release-id: ${{ steps.draft-release.outputs.result }}
     steps:
+      - uses: DataDog/dd-octo-sts-action@acaa02eee7e3bb0839e4272dacb37b8f3b58ba80 # v1.0.3
+        id: octo-sts
+        with:
+          scope: DataDog/datadog-ci
+          policy: self.create-release
       - name: Create a draft release
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         id: draft-release
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ steps.octo-sts.outputs.token }}
           script: |
             const { data: release } = await github.rest.repos.createRelease({
               owner: context.repo.owner,
@@ -47,6 +52,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: create-draft-release
     steps:
+      - uses: DataDog/dd-octo-sts-action@acaa02eee7e3bb0839e4272dacb37b8f3b58ba80 # v1.0.3
+        id: octo-sts
+        with:
+          scope: DataDog/datadog-ci
+          policy: self.create-release
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
       - name: Install node
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
@@ -65,7 +75,7 @@ jobs:
       - name: Upload release asset
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ steps.octo-sts.outputs.token }}
           script: |
             const fs = require("fs").promises
 
@@ -83,6 +93,11 @@ jobs:
       labels: arm-4core-linux
     needs: create-draft-release
     steps:
+      - uses: DataDog/dd-octo-sts-action@acaa02eee7e3bb0839e4272dacb37b8f3b58ba80 # v1.0.3
+        id: octo-sts
+        with:
+          scope: DataDog/datadog-ci
+          policy: self.create-release
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
       - name: Install node
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
@@ -103,7 +118,7 @@ jobs:
       - name: Upload release asset
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ steps.octo-sts.outputs.token }}
           script: |
             const fs = require("fs").promises
 
@@ -119,6 +134,11 @@ jobs:
     runs-on: windows-latest
     needs: create-draft-release
     steps:
+      - uses: DataDog/dd-octo-sts-action@acaa02eee7e3bb0839e4272dacb37b8f3b58ba80 # v1.0.3
+        id: octo-sts
+        with:
+          scope: DataDog/datadog-ci
+          policy: self.create-release
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
       - name: Install node
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
@@ -137,7 +157,7 @@ jobs:
       - name: Upload release asset
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ steps.octo-sts.outputs.token }}
           script: |
             const fs = require("fs").promises
 
@@ -155,6 +175,11 @@ jobs:
     runs-on: macos-latest-large
     needs: create-draft-release
     steps:
+      - uses: DataDog/dd-octo-sts-action@acaa02eee7e3bb0839e4272dacb37b8f3b58ba80 # v1.0.3
+        id: octo-sts
+        with:
+          scope: DataDog/datadog-ci
+          policy: self.create-release
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
       - name: Install node
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
@@ -173,7 +198,7 @@ jobs:
       - name: Upload release asset
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ steps.octo-sts.outputs.token }}
           script: |
             const fs = require("fs").promises
 
@@ -189,6 +214,11 @@ jobs:
     runs-on: macos-latest
     needs: create-draft-release
     steps:
+      - uses: DataDog/dd-octo-sts-action@acaa02eee7e3bb0839e4272dacb37b8f3b58ba80 # v1.0.3
+        id: octo-sts
+        with:
+          scope: DataDog/datadog-ci
+          policy: self.create-release
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
       - name: Install node
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
@@ -207,7 +237,7 @@ jobs:
       - name: Upload release asset
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ steps.octo-sts.outputs.token }}
           script: |
             const fs = require("fs").promises
 
@@ -249,14 +279,11 @@ jobs:
           - synthetics-test-automation-bitrise-step-upload-application
           - synthetics-batch-smoke-tester
     steps:
-      - name: Get GitHub App token
-        id: get-token
-        uses: actions/create-github-app-token@a8d616148505b5069dccd32f177bb87d7f39123b # v2.1.1
+      - uses: DataDog/dd-octo-sts-action@acaa02eee7e3bb0839e4272dacb37b8f3b58ba80 # v1.0.3
+        id: octo-sts
         with:
-          app-id: ${{ secrets.RELEASE_AUTOMATION_GITHUB_APP_ID }}
-          private-key: ${{ secrets.RELEASE_AUTOMATION_GITHUB_APP_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
-          repositories: ${{ matrix.integration-repo }}
+          scope: DataDog/${{ matrix.integration-repo }}
+          policy: datadog-ci.publish-release.create-workflow-dispatch
       - name: Create bump datadog-ci PR
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:


### PR DESCRIPTION
End goal is to remove secrets.GITHUB_TOKEN, secrets.RELEASE_AUTOMATION_GITHUB_APP_ID and secrets.RELEASE_AUTOMATION_GITHUB_APP_PRIVATE_KEY.

To do so, we will create dd-octo-sts policies in this repo and the repo it interacts with:
- https://github.com/DataDog/datadog-ci/pull/1965
- synthetics-ci-github-action: https://github.com/DataDog/synthetics-ci-github-action/pull/379
- datadog-ci-azure-devops: https://github.com/DataDog/datadog-ci-azure-devops/pull/273
- synthetics-test-automation-circleci-orb: https://github.com/DataDog/synthetics-test-automation-circleci-orb/pull/216
- synthetics-test-automation-bitrise-step-run-tests: https://github.com/DataDog/synthetics-test-automation-bitrise-step-run-tests/pull/135
- synthetics-test-automation-bitrise-step-upload-application: https://github.com/DataDog/synthetics-test-automation-bitrise-step-upload-application/pull/134
- synthetics-batch-smoke-tester: https://github.com/DataDog/synthetics-batch-smoke-tester/pull/76

This PR uses these policies to get the needed permissions, instead of relying on secrets.