### PR TITLE
v4.2.0

### DIFF
--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-base",
-  "version": "4.1.3",
+  "version": "4.2.0",
   "description": "Base package for Datadog CI",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/datadog-ci/package.json
+++ b/packages/datadog-ci/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci",
-  "version": "4.1.3",
+  "version": "4.2.0",
   "description": "Use Datadog from your CI.",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-aas/package.json
+++ b/packages/plugin-aas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-aas",
-  "version": "4.1.3",
+  "version": "4.2.0",
   "description": "Datadog CI plugin for `aas` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-cloud-run/package.json
+++ b/packages/plugin-cloud-run/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-cloud-run",
-  "version": "4.1.3",
+  "version": "4.2.0",
   "description": "Datadog CI plugin for `cloud-run` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-container-app/package.json
+++ b/packages/plugin-container-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-container-app",
-  "version": "4.1.3",
+  "version": "4.2.0",
   "description": "Datadog CI plugin for `container-app` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-deployment/package.json
+++ b/packages/plugin-deployment/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-deployment",
-  "version": "4.1.3",
+  "version": "4.2.0",
   "description": "Datadog CI plugin for `deployment` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-dora/package.json
+++ b/packages/plugin-dora/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-dora",
-  "version": "4.1.3",
+  "version": "4.2.0",
   "description": "Datadog CI plugin for `dora` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-gate/package.json
+++ b/packages/plugin-gate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-gate",
-  "version": "4.1.3",
+  "version": "4.2.0",
   "description": "Datadog CI plugin for `gate` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-lambda/package.json
+++ b/packages/plugin-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-lambda",
-  "version": "4.1.3",
+  "version": "4.2.0",
   "description": "Datadog CI plugin for `lambda` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-sarif/package.json
+++ b/packages/plugin-sarif/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-sarif",
-  "version": "4.1.3",
+  "version": "4.2.0",
   "description": "Datadog CI plugin for `sarif` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-sbom/package.json
+++ b/packages/plugin-sbom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-sbom",
-  "version": "4.1.3",
+  "version": "4.2.0",
   "description": "Datadog CI plugin for `sbom` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-stepfunctions/package.json
+++ b/packages/plugin-stepfunctions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-stepfunctions",
-  "version": "4.1.3",
+  "version": "4.2.0",
   "description": "Datadog CI plugin for `stepfunctions` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-synthetics/package.json
+++ b/packages/plugin-synthetics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-synthetics",
-  "version": "4.1.3",
+  "version": "4.2.0",
   "description": "Datadog CI plugin for `synthetics` commands",
   "license": "Apache-2.0",
   "keywords": [


### PR DESCRIPTION
<!-- Release notes generated using configuration in .github/release.yml at v4.2.0 -->

## What's Changed
### Documentation
* [DOCS-12487] Update copy for style, consistency by @buraizu in https://github.com/DataDog/datadog-ci/pull/1963
* [SVLS-7985] add readme lint script by @ava-silver in https://github.com/DataDog/datadog-ci/pull/1964
* [SVLS-7969] release container app command by @ava-silver in https://github.com/DataDog/datadog-ci/pull/1962
### Serverless
* [SVLS] refactor container apps and cloud run to use the same logic by @ava-silver in https://github.com/DataDog/datadog-ci/pull/1943
* [SVLS-7942] add startup probe to container app sidecar by @ava-silver in https://github.com/DataDog/datadog-ci/pull/1958
* [SVLS-7764] add container app uninstrument command by @ava-silver in https://github.com/DataDog/datadog-ci/pull/1959
* [SVLS] add diff to container app (un)instrument by @ava-silver in https://github.com/DataDog/datadog-ci/pull/1961
* [CHORE] restore llmobs behavior by @ava-silver in https://github.com/DataDog/datadog-ci/pull/1974
### Synthetics
* [Exports] Export executeWithDetails function by @hegrec in https://github.com/DataDog/datadog-ci/pull/1960
### Chores
* [SINT-4287] create dd-octo-sts self policy by @ikraemer-dd in https://github.com/DataDog/datadog-ci/pull/1965
* [SINT-4287] issue-labeler now uses dd-octo-sts by @ikraemer-dd in https://github.com/DataDog/datadog-ci/pull/1967

## New Contributors
* @buraizu made their first contribution in https://github.com/DataDog/datadog-ci/pull/1963
* @ikraemer-dd made their first contribution in https://github.com/DataDog/datadog-ci/pull/1965

**Full Changelog**: https://github.com/DataDog/datadog-ci/compare/v4.1.3...v4.2.0

[DOCS-12487]: https://datadoghq.atlassian.net/browse/DOCS-12487?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SVLS-7985]: https://datadoghq.atlassian.net/browse/SVLS-7985?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SVLS-7969]: https://datadoghq.atlassian.net/browse/SVLS-7969?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SVLS-7942]: https://datadoghq.atlassian.net/browse/SVLS-7942?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SVLS-7764]: https://datadoghq.atlassian.net/browse/SVLS-7764?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SINT-4287]: https://datadoghq.atlassian.net/browse/SINT-4287?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ