### PR TITLE
Revert "[SINT-4287] update worflows to use dd-octo-sts"

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -6,7 +6,7 @@ on:
       - v* # Any version tag
 
 permissions:
-  id-token: write # To publish on NPM with provenance and to federate tokens
+  id-token: write # To publish on NPM with provenance
   contents: write # Required for the draft release
 
 jobs:
@@ -15,16 +15,11 @@ jobs:
     outputs:
       release-id: ${{ steps.draft-release.outputs.result }}
     steps:
-      - uses: DataDog/dd-octo-sts-action@acaa02eee7e3bb0839e4272dacb37b8f3b58ba80 # v1.0.3
-        id: octo-sts
-        with:
-          scope: DataDog/datadog-ci
-          policy: self.create-release
       - name: Create a draft release
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         id: draft-release
         with:
-          github-token: ${{ steps.octo-sts.outputs.token }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const { data: release } = await github.rest.repos.createRelease({
               owner: context.repo.owner,
@@ -52,11 +47,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: create-draft-release
     steps:
-      - uses: DataDog/dd-octo-sts-action@acaa02eee7e3bb0839e4272dacb37b8f3b58ba80 # v1.0.3
-        id: octo-sts
-        with:
-          scope: DataDog/datadog-ci
-          policy: self.create-release
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
       - name: Install node
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
@@ -75,7 +65,7 @@ jobs:
       - name: Upload release asset
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
-          github-token: ${{ steps.octo-sts.outputs.token }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const fs = require("fs").promises
 
@@ -93,11 +83,6 @@ jobs:
       labels: arm-4core-linux
     needs: create-draft-release
     steps:
-      - uses: DataDog/dd-octo-sts-action@acaa02eee7e3bb0839e4272dacb37b8f3b58ba80 # v1.0.3
-        id: octo-sts
-        with:
-          scope: DataDog/datadog-ci
-          policy: self.create-release
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
       - name: Install node
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
@@ -118,7 +103,7 @@ jobs:
       - name: Upload release asset
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
-          github-token: ${{ steps.octo-sts.outputs.token }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const fs = require("fs").promises
 
@@ -134,11 +119,6 @@ jobs:
     runs-on: windows-latest
     needs: create-draft-release
     steps:
-      - uses: DataDog/dd-octo-sts-action@acaa02eee7e3bb0839e4272dacb37b8f3b58ba80 # v1.0.3
-        id: octo-sts
-        with:
-          scope: DataDog/datadog-ci
-          policy: self.create-release
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
       - name: Install node
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
@@ -157,7 +137,7 @@ jobs:
       - name: Upload release asset
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
-          github-token: ${{ steps.octo-sts.outputs.token }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const fs = require("fs").promises
 
@@ -175,11 +155,6 @@ jobs:
     runs-on: macos-latest-large
     needs: create-draft-release
     steps:
-      - uses: DataDog/dd-octo-sts-action@acaa02eee7e3bb0839e4272dacb37b8f3b58ba80 # v1.0.3
-        id: octo-sts
-        with:
-          scope: DataDog/datadog-ci
-          policy: self.create-release
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
       - name: Install node
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
@@ -198,7 +173,7 @@ jobs:
       - name: Upload release asset
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
-          github-token: ${{ steps.octo-sts.outputs.token }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const fs = require("fs").promises
 
@@ -214,11 +189,6 @@ jobs:
     runs-on: macos-latest
     needs: create-draft-release
     steps:
-      - uses: DataDog/dd-octo-sts-action@acaa02eee7e3bb0839e4272dacb37b8f3b58ba80 # v1.0.3
-        id: octo-sts
-        with:
-          scope: DataDog/datadog-ci
-          policy: self.create-release
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
       - name: Install node
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
@@ -237,7 +207,7 @@ jobs:
       - name: Upload release asset
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
-          github-token: ${{ steps.octo-sts.outputs.token }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const fs = require("fs").promises
 
@@ -279,11 +249,14 @@ jobs:
           - synthetics-test-automation-bitrise-step-upload-application
           - synthetics-batch-smoke-tester
     steps:
-      - uses: DataDog/dd-octo-sts-action@acaa02eee7e3bb0839e4272dacb37b8f3b58ba80 # v1.0.3
-        id: octo-sts
+      - name: Get GitHub App token
+        id: get-token
+        uses: actions/create-github-app-token@a8d616148505b5069dccd32f177bb87d7f39123b # v2.1.1
         with:
-          scope: DataDog/${{ matrix.integration-repo }}
-          policy: datadog-ci.publish-release.create-workflow-dispatch
+          app-id: ${{ secrets.RELEASE_AUTOMATION_GITHUB_APP_ID }}
+          private-key: ${{ secrets.RELEASE_AUTOMATION_GITHUB_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ matrix.integration-repo }}
       - name: Create bump datadog-ci PR
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:


### PR DESCRIPTION
### What and why?

Reverts #1966 because of a [failure](https://github.com/DataDog/datadog-ci/actions/runs/19475852113) during release.

### How?

A brief description of implementation details of this PR.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
