### PR TITLE
fix self.create-release.sts.yaml

### DIFF
--- a/.github/chainguard/self.create-release.sts.yaml
+++ b/.github/chainguard/self.create-release.sts.yaml
@@ -1,6 +1,6 @@
 issuer: https://token.actions.githubusercontent.com
 
-subject: repo:DataDog/datadog-ci:ref:refs/tags/v.*
+subject_pattern: repo:DataDog/datadog-ci:ref:refs/tags/v.*
 claim_pattern:
   event_name: "push"
   job_workflow_ref: DataDog/datadog-ci/\.github/workflows/publish-release\.yml@refs/tags/v.*


### PR DESCRIPTION
### What and why?

Fixes the error from that [workflow](https://github.com/DataDog/datadog-ci/actions/runs/19475852113). The error is 

using the sanitised token claims from the failed run:
```
DDOCTOSTS_ID_TOKEN='{"actor":"Drarig29","actor_id":"9317502","aud":"dd-octo-sts","base_ref":"","check_run_id":"55735295596","enterprise":"datadog-inc","enterprise_id":"42","event_name":"push","exp":1763488435,"head_ref":"","iat":1763488135,"iss":"https://token.actions.githubusercontent.com","job_workflow_ref":"DataDog/datadog-ci/.github/workflows/publish-release.yml@refs/tags/v4.2.1","job_workflow_sha":"d7665a6709ced45b484abd349135ed4b0218b067","jti":"ed8c1d84-795a-40ac-8447-7d8d7da9aa92","nbf":1763487835,"ref":"refs/tags/v4.2.1","ref_protected":"false","ref_type":"tag","repository":"DataDog/datadog-ci","repository_id":"193929371","repository_owner":"DataDog","repository_owner_id":"365230","repository_visibility":"public","run_attempt":"1","run_id":"19475852113","run_number":"128","runner_environment":"github-hosted","sha":"d7665a6709ced45b484abd349135ed4b0218b067","sub":"repo:DataDog/datadog-ci:ref:refs/tags/v4.2.1","workflow":"Publish package on NPM","workflow_ref":"DataDog/datadog-ci/.github/workflows/publish-release.yml@refs/tags/v4.2.1","workflow_sha":"d7665a6709ced45b484abd349135ed4b0218b067"}' \
dd-octo-sts check -s DataDog/datadog-ci -p self.create-release
```
the output used to be:
```
🛑 Token does not match policy
Error: check token: rpc error: code = PermissionDenied desc = trust policy: subject "repo:DataDog/datadog-ci:ref:refs/tags/v4.2.1" did not match "repo:DataDog/datadog-ci:ref:refs/tags/*"
```
and is now
```
✅ Supplied token is valid for policy
   Matching claims:
   - event_name: push
   - job_workflow_ref: DataDog/datadog-ci/.github/workflows/publish-release.yml@refs/tags/v4.2.1
   - ref: refs/tags/v4.2.1
```

### How?

A brief description of implementation details of this PR.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
