### PR TITLE
dd-octo-sts: correct token

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -287,7 +287,7 @@ jobs:
       - name: Create bump datadog-ci PR
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
-          github-token: ${{ steps.get-token.outputs.token }}
+          github-token: ${{ steps.octo-sts.outputs.token }}
           script: |
             const tagName = '${{ github.event.release.tag_name }}'.replace('v', '')
 


### PR DESCRIPTION
### What and why?

Corrects this error https://github.com/DataDog/datadog-ci/actions/runs/19476546055/job/55739189696, because the token was not renamed correctly in the workflow, when we migrated to dd-octo-sts

### How?

A brief description of implementation details of this PR.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
