### PR TITLE
[dep] Bump glob transitive dependency to 10.5.0

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -7158,23 +7158,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"glob@npm:^10.2.2, glob@npm:^10.3.10, glob@npm:^10.3.7":
-  version: 10.4.5
-  resolution: "glob@npm:10.4.5"
-  dependencies:
-    foreground-child: "npm:^3.1.0"
-    jackspeak: "npm:^3.1.2"
-    minimatch: "npm:^9.0.4"
-    minipass: "npm:^7.1.2"
-    package-json-from-dist: "npm:^1.0.0"
-    path-scurry: "npm:^1.11.1"
-  bin:
-    glob: dist/esm/bin.mjs
-  checksum: 10/698dfe11828b7efd0514cd11e573eaed26b2dff611f0400907281ce3eab0c1e56143ef9b35adc7c77ecc71fba74717b510c7c223d34ca8a98ec81777b293d4ac
-  languageName: node
-  linkType: hard
-
-"glob@npm:^10.5.0":
+"glob@npm:^10.2.2, glob@npm:^10.3.10, glob@npm:^10.3.7, glob@npm:^10.5.0":
   version: 10.5.0
   resolution: "glob@npm:10.5.0"
   dependencies:


### PR DESCRIPTION
### What and why?

Dependabot didn't see this. We should consider disabling those automated PRs.

Closes https://github.com/DataDog/datadog-ci/security/dependabot/72

Related to https://github.com/DataDog/datadog-ci/issues/1982

### How?

Use `yarn workspaces focus -A --production` to ignore `devDependencies`.

**Before:**

```
yarn why -R glob
├─ @datadog/datadog-ci-base@workspace:packages/base
│  └─ glob@npm:10.5.0 (via npm:^10.5.0)
│
├─ @datadog/datadog-ci-plugin-synthetics@workspace:packages/plugin-synthetics
│  └─ ssh2@npm:1.16.0 (via npm:^1.16.0)
│     ├─ cpu-features@npm:0.0.10 (via npm:~0.0.10)
│     │  ├─ nan@npm:2.20.0 (via npm:^2.19.0)
│     │  │  └─ node-gyp@npm:10.2.0 (via npm:latest)
│     │  │     ├─ glob@npm:10.4.5 (via npm:^10.3.10)
│     │  │     └─ make-fetch-happen@npm:13.0.1 (via npm:^13.0.0)
│     │  │        └─ cacache@npm:18.0.4 (via npm:^18.0.0)
│     │  │           └─ glob@npm:10.4.5 (via npm:^10.2.2)
│     │  └─ node-gyp@npm:10.2.0 (via npm:latest)
│     └─ nan@npm:2.23.0 (via npm:^2.20.0)
│        └─ node-gyp@npm:10.2.0 (via npm:latest)
│
└─ @datadog/datadog-ci@workspace:packages/datadog-ci
   ├─ @datadog/datadog-ci-base@workspace:packages/base [3da8e] (via workspace:* [3da8e])
   └─ @datadog/datadog-ci-plugin-synthetics@workspace:packages/plugin-synthetics [3da8e] (via workspace:* [3da8e])
```

Run the following commands to bump the transitive dependency:
- `yarn set resolution glob@npm:^10.2.2 npm:10.5.0`
- `yarn set resolution glob@npm:^10.3.7 npm:10.5.0`
- `yarn set resolution glob@npm:^10.3.10 npm:10.5.0`

**After:**

```
yarn why -R glob
├─ @datadog/datadog-ci-base@workspace:packages/base
│  └─ glob@npm:10.5.0 (via npm:^10.5.0)
│
├─ @datadog/datadog-ci-plugin-synthetics@workspace:packages/plugin-synthetics
│  └─ ssh2@npm:1.16.0 (via npm:^1.16.0)
│     ├─ cpu-features@npm:0.0.10 (via npm:~0.0.10)
│     │  ├─ nan@npm:2.20.0 (via npm:^2.19.0)
│     │  │  └─ node-gyp@npm:10.2.0 (via npm:latest)
│     │  │     ├─ glob@npm:10.5.0 (via npm:^10.3.10)
│     │  │     └─ make-fetch-happen@npm:13.0.1 (via npm:^13.0.0)
│     │  │        └─ cacache@npm:18.0.4 (via npm:^18.0.0)
│     │  │           └─ glob@npm:10.5.0 (via npm:^10.2.2)
│     │  └─ node-gyp@npm:10.2.0 (via npm:latest)
│     └─ nan@npm:2.23.0 (via npm:^2.20.0)
│        └─ node-gyp@npm:10.2.0 (via npm:latest)
│
└─ @datadog/datadog-ci@workspace:packages/datadog-ci
   ├─ @datadog/datadog-ci-base@workspace:packages/base [3da8e] (via workspace:* [3da8e])
   └─ @datadog/datadog-ci-plugin-synthetics@workspace:packages/plugin-synthetics [3da8e] (via workspace:* [3da8e])
```

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
