### PR TITLE
chore: add pre-commit config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,6 +68,9 @@ dist
 # JetBrains files
 .idea
 
+# Claude local settings
+.claude
+
 # Test generated files
 packages/datadog-ci/src/commands/react-native/__tests__/fixtures/with-sources-content/main.jsbundle.map.no-sources-content
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,20 @@
+repos:
+  - repo: local
+    hooks:
+      - id: format
+        name: format
+        entry: yarn format
+        language: system
+        types: [ts]
+      - id: lint-packages
+        name: lint packages
+        entry: yarn lint:packages --fix
+        language: system
+        types: [json]
+        pass_filenames: false
+      - id: lint-readmes
+        name: lint readme usage
+        entry: yarn lint:readme-usage --fix
+        language: system
+        types: [ts, markdown]
+        pass_filenames: false


### PR DESCRIPTION
### What and why?

Adds a pre-commit config which is optional but allows us to ensure format/linting fixes are applied before committing. I kept having issues with this where my IDE didn't fix formatting issues before I committed, so this helps with that.

### How?

Adds a .pre-commit-config.yaml file

Also added .claude to the gitignore for folks using that who want it to have project memory.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
