### PR TITLE
chore: Support Ruby 3.4 in lambda instrument command

### DIFF
--- a/packages/plugin-lambda/src/__tests__/__snapshots__/instrument.test.ts.snap
+++ b/packages/plugin-lambda/src/__tests__/__snapshots__/instrument.test.ts.snap
@@ -310,6 +310,8 @@ exports[`lambda instrument execute instruments Ruby application properly 1`] = `
 	- arn:aws:lambda:us-east-1:123456789012:function:ruby33
 	- arn:aws:lambda:us-east-1:123456789012:function:ruby32arm
 	- arn:aws:lambda:us-east-1:123456789012:function:ruby33arm
+	- arn:aws:lambda:us-east-1:123456789012:function:ruby34
+	- arn:aws:lambda:us-east-1:123456789012:function:ruby34arm
 
 [Dry Run] Will apply the following updates:
 UpdateFunctionConfiguration -> arn:aws:lambda:us-east-1:123456789012:function:ruby32
@@ -413,6 +415,58 @@ UpdateFunctionConfiguration -> arn:aws:lambda:us-east-1:123456789012:function:ru
   ]
 }
 TagResource -> arn:aws:lambda:us-east-1:123456789012:function:ruby33arm
+{
+  "dd_sls_ci": "vXXXX"
+}
+UpdateFunctionConfiguration -> arn:aws:lambda:us-east-1:123456789012:function:ruby34
+{
+  "FunctionName": "arn:aws:lambda:us-east-1:123456789012:function:ruby34",
+  "Environment": {
+    "Variables": {
+      "DD_API_KEY": "02**********33bd",
+      "DD_SITE": "datadoghq.com",
+      "DD_CAPTURE_LAMBDA_PAYLOAD": "false",
+      "DD_ENV": "staging",
+      "DD_TAGS": "layer:api,team:intake",
+      "DD_SERVERLESS_LOGS_ENABLED": "true",
+      "DD_MERGE_XRAY_TRACES": "false",
+      "DD_SERVICE": "middletier",
+      "DD_TRACE_ENABLED": "true",
+      "DD_VERSION": "0.2"
+    }
+  },
+  "Layers": [
+    "arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Extension:40",
+    "arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Ruby3-4:19"
+  ]
+}
+TagResource -> arn:aws:lambda:us-east-1:123456789012:function:ruby34
+{
+  "dd_sls_ci": "vXXXX"
+}
+UpdateFunctionConfiguration -> arn:aws:lambda:us-east-1:123456789012:function:ruby34arm
+{
+  "FunctionName": "arn:aws:lambda:us-east-1:123456789012:function:ruby34arm",
+  "Environment": {
+    "Variables": {
+      "DD_API_KEY": "02**********33bd",
+      "DD_SITE": "datadoghq.com",
+      "DD_CAPTURE_LAMBDA_PAYLOAD": "false",
+      "DD_ENV": "staging",
+      "DD_TAGS": "layer:api,team:intake",
+      "DD_SERVERLESS_LOGS_ENABLED": "true",
+      "DD_MERGE_XRAY_TRACES": "false",
+      "DD_SERVICE": "middletier",
+      "DD_TRACE_ENABLED": "true",
+      "DD_VERSION": "0.2"
+    }
+  },
+  "Layers": [
+    "arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Extension-ARM:40",
+    "arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Ruby3-4-ARM:19"
+  ]
+}
+TagResource -> arn:aws:lambda:us-east-1:123456789012:function:ruby34arm
 {
   "dd_sls_ci": "vXXXX"
 }

--- a/packages/plugin-lambda/src/__tests__/instrument.test.ts
+++ b/packages/plugin-lambda/src/__tests__/instrument.test.ts
@@ -1046,6 +1046,19 @@ describe('lambda', () => {
               Architectures: ['arm64'],
             },
           },
+          'arn:aws:lambda:us-east-1:123456789012:function:ruby34': {
+            config: {
+              FunctionArn: 'arn:aws:lambda:us-east-1:123456789012:function:ruby34',
+              Runtime: 'ruby3.4',
+            },
+          },
+          'arn:aws:lambda:us-east-1:123456789012:function:ruby34arm': {
+            config: {
+              FunctionArn: 'arn:aws:lambda:us-east-1:123456789012:function:ruby34arm',
+              Runtime: 'ruby3.4',
+              Architectures: ['arm64'],
+            },
+          },
         })
 
         process.env.DATADOG_API_KEY = MOCK_DATADOG_API_KEY
@@ -1058,6 +1071,10 @@ describe('lambda', () => {
           'arn:aws:lambda:us-east-1:123456789012:function:ruby32arm',
           '-f',
           'arn:aws:lambda:us-east-1:123456789012:function:ruby33arm',
+          '-f',
+          'arn:aws:lambda:us-east-1:123456789012:function:ruby34',
+          '-f',
+          'arn:aws:lambda:us-east-1:123456789012:function:ruby34arm',
           '--dry-run',
           '-e',
           '40',

--- a/packages/plugin-lambda/src/constants.ts
+++ b/packages/plugin-lambda/src/constants.ts
@@ -37,6 +37,7 @@ export const LAYER_LOOKUP = {
   'python3.14': 'Datadog-Python314',
   'ruby3.2': 'Datadog-Ruby3-2',
   'ruby3.3': 'Datadog-Ruby3-3',
+  'ruby3.4': 'Datadog-Ruby3-4',
 } as const
 
 export enum RuntimeType {
@@ -72,6 +73,7 @@ export const RUNTIME_LOOKUP: Partial<Record<Runtime, RuntimeType>> = {
   'python3.14': RuntimeType.PYTHON,
   'ruby3.2': RuntimeType.RUBY,
   'ruby3.3': RuntimeType.RUBY,
+  'ruby3.4': RuntimeType.RUBY,
 }
 
 export type LayerKey = keyof typeof LAYER_LOOKUP
@@ -88,6 +90,7 @@ export const ARM_LAYERS = [
   'python3.14',
   'ruby3.2',
   'ruby3.3',
+  'ruby3.4',
 ]
 export const ARM64_ARCHITECTURE = 'arm64'
 export const ARM_LAYER_SUFFIX = '-ARM'

--- a/packages/plugin-lambda/src/functions/commons.ts
+++ b/packages/plugin-lambda/src/functions/commons.ts
@@ -441,6 +441,7 @@ export const supportsInTracerAppsec = (runtime: Runtime, layerVersion: number | 
     case 'nodejs24.x':
     case 'ruby3.2':
     case 'ruby3.3':
+    case 'ruby3.4':
       return false
   }
 }


### PR DESCRIPTION
### What and why?

Support Ruby 3.4 in the lambda instrument command by adding the constants in the right places. Ruby 3.4 came out a few months ago but slipped through the cracks.

### How?

Adding constants + updating unit tests. Also tested manually by building datadog-ci and instrumenting a Ruby 3.4 function.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
