### PR TITLE
[chores] Remove `git-metadata` exports entry

### DIFF
--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -27,10 +27,6 @@
       "development": "./src/commands/*.ts",
       "default": "./dist/commands/*.js"
     },
-    "./commands/git-metadata": {
-      "development": "./src/commands/git-metadata/index.ts",
-      "default": "./dist/commands/git-metadata/index.js"
-    },
     "./constants": {
       "development": "./src/constants.ts",
       "default": "./dist/constants.js"

--- a/packages/base/src/commands/git-metadata/index.ts
+++ b/packages/base/src/commands/git-metadata/index.ts
@@ -1,1 +1,0 @@
-export * from './library'

--- a/packages/datadog-ci/src/index.ts
+++ b/packages/datadog-ci/src/index.ts
@@ -1,3 +1,3 @@
-export * as gitMetadata from '@datadog/datadog-ci-base/commands/git-metadata'
+export * as gitMetadata from '@datadog/datadog-ci-base/commands/git-metadata/library'
 export * as utils from '@datadog/datadog-ci-base/helpers/utils'
 export {cliVersion as version} from '@datadog/datadog-ci-base/version'


### PR DESCRIPTION
### What and why?

Follow-up of https://github.com/DataDog/datadog-ci/pull/1873

This PR removes a redundant exports entry for `git-metadata` to have more consistent entries.

### How?

Remove an exports entry that was too specific in favor of importing the right module.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
