### PR TITLE
[chores] Drop built-in `synthetics` plugin

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -10,6 +10,7 @@ RUN npm install -g @datadog/datadog-ci@$VERSION \
     @datadog/datadog-ci-plugin-container-app@$VERSION \
     @datadog/datadog-ci-plugin-lambda@$VERSION \
     @datadog/datadog-ci-plugin-stepfunctions@$VERSION \
+    @datadog/datadog-ci-plugin-synthetics@$VERSION \
     && echo -e "Installed packages:\n$(npm list -g | grep -o '@datadog/.*')"
 
 COPY entrypoint.sh /entrypoint.sh

--- a/packages/datadog-ci/package.json
+++ b/packages/datadog-ci/package.json
@@ -47,7 +47,6 @@
     "@datadog/datadog-ci-plugin-gate": "workspace:*",
     "@datadog/datadog-ci-plugin-sarif": "workspace:*",
     "@datadog/datadog-ci-plugin-sbom": "workspace:*",
-    "@datadog/datadog-ci-plugin-synthetics": "workspace:*",
     "axios": "^1.12.1",
     "chalk": "3.0.0",
     "clipanion": "^3.2.1",

--- a/packages/datadog-ci/tsconfig.json
+++ b/packages/datadog-ci/tsconfig.json
@@ -13,7 +13,6 @@
     {"path": "../plugin-dora"},
     {"path": "../plugin-gate"},
     {"path": "../plugin-sarif"},
-    {"path": "../plugin-sbom"},
-    {"path": "../plugin-synthetics"}
+    {"path": "../plugin-sbom"}
   ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1718,7 +1718,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@datadog/datadog-ci-plugin-synthetics@workspace:*, @datadog/datadog-ci-plugin-synthetics@workspace:packages/plugin-synthetics":
+"@datadog/datadog-ci-plugin-synthetics@workspace:packages/plugin-synthetics":
   version: 0.0.0-use.local
   resolution: "@datadog/datadog-ci-plugin-synthetics@workspace:packages/plugin-synthetics"
   dependencies:
@@ -1757,7 +1757,6 @@ __metadata:
     "@datadog/datadog-ci-plugin-gate": "workspace:*"
     "@datadog/datadog-ci-plugin-sarif": "workspace:*"
     "@datadog/datadog-ci-plugin-sbom": "workspace:*"
-    "@datadog/datadog-ci-plugin-synthetics": "workspace:*"
     "@types/jest": "npm:29.5.3"
     "@types/js-yaml": "npm:^4.0.5"
     "@types/semver": "npm:^7.7.1"


### PR DESCRIPTION
### What and why?

We already dropped that plugin in the past (https://github.com/DataDog/datadog-ci/pull/1891) but had to reintroduce it (https://github.com/DataDog/datadog-ci/pull/1914) to unblock users in [this issue](https://github.com/DataDog/datadog-ci/issues/1912).

Thanks to #2005, the auto-install should now be compatible with NPX. So we want to finally drop the `synthetics` plugin like we had initially planned.

### How?

Drop the built-in plugin, so that it's separately installable.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
