### PR TITLE
v5.0.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -328,7 +328,6 @@ jobs:
             "name": "datadog-ci-plugin-auto-install-yarn",
             "resolutions": {
               "@datadog/datadog-ci-base": "file:./artifacts/@datadog-datadog-ci-base-20.tgz",
-              "@datadog/datadog-ci-plugin-aas": "file:./artifacts/@datadog-datadog-ci-plugin-aas-20.tgz",
               "@datadog/datadog-ci-plugin-deployment": "file:./artifacts/@datadog-datadog-ci-plugin-deployment-20.tgz",
               "@datadog/datadog-ci-plugin-dora": "file:./artifacts/@datadog-datadog-ci-plugin-dora-20.tgz",
               "@datadog/datadog-ci-plugin-gate": "file:./artifacts/@datadog-datadog-ci-plugin-gate-20.tgz",
@@ -365,6 +364,9 @@ jobs:
           fi
       - name: Install AAS plugin
         run: yarn datadog-ci plugin install aas
+        env:
+          DEBUG: plugins
+          PLUGIN_AUTO_INSTALL_PLUGIN_VERSION_OVERRIDE: file:./artifacts/@datadog-datadog-ci-plugin-aas-20.tgz
       - name: Check that AAS plugin is installed
         run: |
           if yarn datadog-ci plugin check aas; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -266,7 +266,7 @@ jobs:
               "@datadog/datadog-ci-plugin-sbom": "file:./artifacts/@datadog-datadog-ci-plugin-sbom-20.tgz"
             },
             "dependencies": {
-              "@datadog/datadog-ci": "file:./artifacts/@datadog-datadog-ci-20.tgz",
+              "@datadog/datadog-ci": "file:./artifacts/@datadog-datadog-ci-20.tgz"
             }
           }' > package.json
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -323,15 +323,20 @@ jobs:
         with:
           name: artifacts-20
           path: artifacts/
-      - name: Create test project
+      - name: Create test project (Yarn)
         run: |
           echo '{
-            "name": "datadog-ci-plugin-auto-install",
+            "name": "datadog-ci-plugin-auto-install-yarn",
             "resolutions": {
-              "@datadog/datadog-ci-base": "file:./artifacts/@datadog-datadog-ci-base-20.tgz"
+              "@datadog/datadog-ci-base": "file:./artifacts/@datadog-datadog-ci-base-20.tgz",
+              "@datadog/datadog-ci-plugin-deployment": "file:./artifacts/@datadog-datadog-ci-plugin-deployment-20.tgz",
+              "@datadog/datadog-ci-plugin-dora": "file:./artifacts/@datadog-datadog-ci-plugin-dora-20.tgz",
+              "@datadog/datadog-ci-plugin-gate": "file:./artifacts/@datadog-datadog-ci-plugin-gate-20.tgz",
+              "@datadog/datadog-ci-plugin-sarif": "file:./artifacts/@datadog-datadog-ci-plugin-sarif-20.tgz",
+              "@datadog/datadog-ci-plugin-sbom": "file:./artifacts/@datadog-datadog-ci-plugin-sbom-20.tgz"
             },
             "dependencies": {
-              "@datadog/datadog-ci": "./artifacts/@datadog-datadog-ci-20.tgz"
+              "@datadog/datadog-ci": "file:./artifacts/@datadog-datadog-ci-20.tgz"
             }
           }' > package.json
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -258,7 +258,7 @@ jobs:
           echo '{
             "name": "datadog-ci-plugin-auto-install-npm",
             "overrides": {
-              "@datadog/datadog-ci-base": "file:./artifacts/@datadog-datadog-ci-base-20.tgz",
+              "@datadog/datadog-ci-base": "$@datadog/datadog-ci-base",
               "@datadog/datadog-ci-plugin-deployment": "file:./artifacts/@datadog-datadog-ci-plugin-deployment-20.tgz",
               "@datadog/datadog-ci-plugin-dora": "file:./artifacts/@datadog-datadog-ci-plugin-dora-20.tgz",
               "@datadog/datadog-ci-plugin-gate": "file:./artifacts/@datadog-datadog-ci-plugin-gate-20.tgz",
@@ -266,7 +266,8 @@ jobs:
               "@datadog/datadog-ci-plugin-sbom": "file:./artifacts/@datadog-datadog-ci-plugin-sbom-20.tgz"
             },
             "dependencies": {
-              "@datadog/datadog-ci": "file:./artifacts/@datadog-datadog-ci-20.tgz"
+              "@datadog/datadog-ci": "file:./artifacts/@datadog-datadog-ci-20.tgz",
+              "@datadog/datadog-ci-base": "file:./artifacts/@datadog-datadog-ci-base-20.tgz"
             }
           }' > package.json
 
@@ -281,6 +282,10 @@ jobs:
             exit 0
           fi
       - name: Run AAS command with auto-install
+        env:
+          DEBUG: plugins
+          # Needed during releases, to avoid a "No matching version found for @datadog/datadog-ci-plugin-aas@x.x.x" error
+          PLUGIN_AUTO_INSTALL_PLUGIN_VERSION_OVERRIDE: file:./artifacts/@datadog-datadog-ci-plugin-aas-20.tgz
         run: |
           output=$(npx datadog-ci aas instrument || true)
           if echo "$output" | grep "Successfully installed"; then
@@ -295,7 +300,10 @@ jobs:
         run: npx datadog-ci plugin install aas
         env:
           DEBUG: plugins
+          # Needed during releases, to avoid a "No matching version found for @datadog/datadog-ci-base@x.x.x" error
           PLUGIN_AUTO_INSTALL_BASE_VERSION_OVERRIDE: file:./artifacts/@datadog-datadog-ci-base-20.tgz
+          # Needed during releases, to avoid a "No matching version found for @datadog/datadog-ci-plugin-aas@x.x.x" error
+          PLUGIN_AUTO_INSTALL_PLUGIN_VERSION_OVERRIDE: file:./artifacts/@datadog-datadog-ci-plugin-aas-20.tgz
       - name: Check that AAS plugin is installed
         run: |
           if npx datadog-ci plugin check aas; then
@@ -354,6 +362,7 @@ jobs:
       - name: Run AAS command with auto-install
         env:
           DEBUG: plugins
+          # Needed during releases, to avoid a "No matching version found for @datadog/datadog-ci-plugin-aas@x.x.x" error
           PLUGIN_AUTO_INSTALL_PLUGIN_VERSION_OVERRIDE: file:./artifacts/@datadog-datadog-ci-plugin-aas-20.tgz
         run: |
           output=$(yarn datadog-ci aas instrument || true)
@@ -367,6 +376,12 @@ jobs:
           fi
       - name: Install AAS plugin
         run: yarn datadog-ci plugin install aas
+        env:
+          DEBUG: plugins
+          # Needed during releases, to avoid a "No matching version found for @datadog/datadog-ci-base@x.x.x" error
+          PLUGIN_AUTO_INSTALL_BASE_VERSION_OVERRIDE: file:./artifacts/@datadog-datadog-ci-base-20.tgz
+          # Needed during releases, to avoid a "No matching version found for @datadog/datadog-ci-plugin-aas@x.x.x" error
+          PLUGIN_AUTO_INSTALL_PLUGIN_VERSION_OVERRIDE: file:./artifacts/@datadog-datadog-ci-plugin-aas-20.tgz
       - name: Check that AAS plugin is installed
         run: |
           if yarn datadog-ci plugin check aas; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -253,12 +253,17 @@ jobs:
         with:
           name: artifacts-20
           path: artifacts/
-      - name: Create test project
+      - name: Create test project (NPM)
         run: |
           echo '{
-            "name": "datadog-ci-plugin-auto-install",
+            "name": "datadog-ci-plugin-auto-install-npm",
             "overrides": {
-              "@datadog/datadog-ci-base": "$@datadog/datadog-ci-base"
+              "@datadog/datadog-ci-base": "$@datadog/datadog-ci-base",
+              "@datadog/datadog-ci-plugin-deployment": "file:./artifacts/@datadog-datadog-ci-plugin-deployment-20.tgz",
+              "@datadog/datadog-ci-plugin-dora": "file:./artifacts/@datadog-datadog-ci-plugin-dora-20.tgz",
+              "@datadog/datadog-ci-plugin-gate": "file:./artifacts/@datadog-datadog-ci-plugin-gate-20.tgz",
+              "@datadog/datadog-ci-plugin-sarif": "file:./artifacts/@datadog-datadog-ci-plugin-sarif-20.tgz",
+              "@datadog/datadog-ci-plugin-sbom": "file:./artifacts/@datadog-datadog-ci-plugin-sbom-20.tgz"
             },
             "dependencies": {
               "@datadog/datadog-ci": "file:./artifacts/@datadog-datadog-ci-20.tgz",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -271,7 +271,8 @@ jobs:
             }
           }' > package.json
 
-          npm install
+          # Ignore peer dependencies to fix infinite loop and ignore warnings
+          npm install --legacy-peer-deps
       - name: Check that AAS plugin is not installed
         run: |
           if npx datadog-ci plugin check aas; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,10 +209,9 @@ jobs:
         with:
           name: artifacts-20
           path: artifacts/
-      - name: Override base package with artifacts
+      - name: Run AAS command with auto-install (NPX)
         run: |
-          TMP_PATH=$(
-            npx \
+          output=$(npx \
               -p ./artifacts/@datadog-datadog-ci-20.tgz \
               -p ./artifacts/@datadog-datadog-ci-base-20.tgz \
               -p ./artifacts/@datadog-datadog-ci-plugin-deployment-20.tgz \
@@ -220,16 +219,8 @@ jobs:
               -p ./artifacts/@datadog-datadog-ci-plugin-gate-20.tgz \
               -p ./artifacts/@datadog-datadog-ci-plugin-sarif-20.tgz \
               -p ./artifacts/@datadog-datadog-ci-plugin-sbom-20.tgz \
-              printenv PATH | cut -d ':' -f 1
+              datadog-ci aas instrument || true
           )
-          echo "Initial TMP_PATH: $TMP_PATH"
-          TMP_PATH=$(realpath $TMP_PATH/../..)
-          echo "NPX project path: $TMP_PATH"
-      - name: Run AAS command with auto-install
-        env:
-          DEBUG: plugins
-        run: |
-          output=$(npx @datadog/datadog-ci aas instrument || true)
           if echo "$output" | grep "Successfully installed"; then
             echo "AAS plugin was automatically installed"
             exit 0
@@ -238,6 +229,12 @@ jobs:
             echo "Output: $output"
             exit 1
           fi
+        env:
+          DEBUG: plugins
+          # Needed during releases, to avoid a "No matching version found for @datadog/datadog-ci-base@x.x.x" error
+          PLUGIN_AUTO_INSTALL_BASE_VERSION_OVERRIDE: file:./artifacts/@datadog-datadog-ci-base-20.tgz
+          # Needed during releases, to avoid a "No matching version found for @datadog/datadog-ci-plugin-aas@x.x.x" error
+          PLUGIN_AUTO_INSTALL_PLUGIN_VERSION_OVERRIDE: file:./artifacts/@datadog-datadog-ci-plugin-aas-20.tgz
 
   # Using `npx datadog-ci` only runs the binary without fetching any package.
   test-plugin-auto-install-in-project-npm:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,17 +211,20 @@ jobs:
           path: artifacts/
       - name: Override base package with artifacts
         run: |
-          TMP_PATH=$(npx -p @datadog/datadog-ci printenv PATH | cut -d ':' -f 1)
+          TMP_PATH=$(
+            npx \
+              -p ./artifacts/@datadog-datadog-ci-20.tgz \
+              -p ./artifacts/@datadog-datadog-ci-base-20.tgz \
+              -p ./artifacts/@datadog-datadog-ci-plugin-deployment-20.tgz \
+              -p ./artifacts/@datadog-datadog-ci-plugin-dora-20.tgz \
+              -p ./artifacts/@datadog-datadog-ci-plugin-gate-20.tgz \
+              -p ./artifacts/@datadog-datadog-ci-plugin-sarif-20.tgz \
+              -p ./artifacts/@datadog-datadog-ci-plugin-sbom-20.tgz \
+              printenv PATH | cut -d ':' -f 1
+          )
           echo "Initial TMP_PATH: $TMP_PATH"
           TMP_PATH=$(realpath $TMP_PATH/../..)
           echo "NPX project path: $TMP_PATH"
-
-          echo "Extracting base package from artifacts"
-          tar -xzf ./artifacts/@datadog-datadog-ci-base-20.tgz
-
-          echo "Moving base package to temporary node_modules"
-          rm -rf $TMP_PATH/node_modules/@datadog/datadog-ci-base
-          mv package/ $TMP_PATH/node_modules/@datadog/datadog-ci-base
       - name: Run AAS command with auto-install
         env:
           DEBUG: plugins

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -328,6 +328,7 @@ jobs:
             "name": "datadog-ci-plugin-auto-install-yarn",
             "resolutions": {
               "@datadog/datadog-ci-base": "file:./artifacts/@datadog-datadog-ci-base-20.tgz",
+              "@datadog/datadog-ci-plugin-aas": "file:./artifacts/@datadog-datadog-ci-plugin-aas-20.tgz",
               "@datadog/datadog-ci-plugin-deployment": "file:./artifacts/@datadog-datadog-ci-plugin-deployment-20.tgz",
               "@datadog/datadog-ci-plugin-dora": "file:./artifacts/@datadog-datadog-ci-plugin-dora-20.tgz",
               "@datadog/datadog-ci-plugin-gate": "file:./artifacts/@datadog-datadog-ci-plugin-gate-20.tgz",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -352,6 +352,9 @@ jobs:
             exit 0
           fi
       - name: Run AAS command with auto-install
+        env:
+          DEBUG: plugins
+          PLUGIN_AUTO_INSTALL_PLUGIN_VERSION_OVERRIDE: file:./artifacts/@datadog-datadog-ci-plugin-aas-20.tgz
         run: |
           output=$(yarn datadog-ci aas instrument || true)
           if echo "$output" | grep "Successfully installed"; then
@@ -364,9 +367,6 @@ jobs:
           fi
       - name: Install AAS plugin
         run: yarn datadog-ci plugin install aas
-        env:
-          DEBUG: plugins
-          PLUGIN_AUTO_INSTALL_PLUGIN_VERSION_OVERRIDE: file:./artifacts/@datadog-datadog-ci-plugin-aas-20.tgz
       - name: Check that AAS plugin is installed
         run: |
           if yarn datadog-ci plugin check aas; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -258,7 +258,7 @@ jobs:
           echo '{
             "name": "datadog-ci-plugin-auto-install-npm",
             "overrides": {
-              "@datadog/datadog-ci-base": "$@datadog/datadog-ci-base",
+              "@datadog/datadog-ci-base": "file:./artifacts/@datadog-datadog-ci-base-20.tgz",
               "@datadog/datadog-ci-plugin-deployment": "file:./artifacts/@datadog-datadog-ci-plugin-deployment-20.tgz",
               "@datadog/datadog-ci-plugin-dora": "file:./artifacts/@datadog-datadog-ci-plugin-dora-20.tgz",
               "@datadog/datadog-ci-plugin-gate": "file:./artifacts/@datadog-datadog-ci-plugin-gate-20.tgz",
@@ -267,7 +267,6 @@ jobs:
             },
             "dependencies": {
               "@datadog/datadog-ci": "file:./artifacts/@datadog-datadog-ci-20.tgz",
-              "@datadog/datadog-ci-base": "file:./artifacts/@datadog-datadog-ci-base-20.tgz"
             }
           }' > package.json
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -285,7 +285,8 @@ jobs:
       - name: Run AAS command with auto-install
         env:
           DEBUG: plugins
-          # Needed during releases, to avoid a "No matching version found for @datadog/datadog-ci-plugin-aas@x.x.x" error
+          # Needed during releases, to avoid a "No matching version found" errors
+          PLUGIN_AUTO_INSTALL_BASE_VERSION_OVERRIDE: file:./artifacts/@datadog-datadog-ci-base-20.tgz
           PLUGIN_AUTO_INSTALL_PLUGIN_VERSION_OVERRIDE: file:./artifacts/@datadog-datadog-ci-plugin-aas-20.tgz
         run: |
           output=$(npx datadog-ci aas instrument || true)
@@ -301,9 +302,8 @@ jobs:
         run: npx datadog-ci plugin install aas
         env:
           DEBUG: plugins
-          # Needed during releases, to avoid a "No matching version found for @datadog/datadog-ci-base@x.x.x" error
+          # Needed during releases, to avoid a "No matching version found" errors
           PLUGIN_AUTO_INSTALL_BASE_VERSION_OVERRIDE: file:./artifacts/@datadog-datadog-ci-base-20.tgz
-          # Needed during releases, to avoid a "No matching version found for @datadog/datadog-ci-plugin-aas@x.x.x" error
           PLUGIN_AUTO_INSTALL_PLUGIN_VERSION_OVERRIDE: file:./artifacts/@datadog-datadog-ci-plugin-aas-20.tgz
       - name: Check that AAS plugin is installed
         run: |
@@ -363,7 +363,8 @@ jobs:
       - name: Run AAS command with auto-install
         env:
           DEBUG: plugins
-          # Needed during releases, to avoid a "No matching version found for @datadog/datadog-ci-plugin-aas@x.x.x" error
+          # Needed during releases, to avoid a "No matching version found" errors
+          PLUGIN_AUTO_INSTALL_BASE_VERSION_OVERRIDE: file:./artifacts/@datadog-datadog-ci-base-20.tgz
           PLUGIN_AUTO_INSTALL_PLUGIN_VERSION_OVERRIDE: file:./artifacts/@datadog-datadog-ci-plugin-aas-20.tgz
         run: |
           output=$(yarn datadog-ci aas instrument || true)
@@ -379,9 +380,8 @@ jobs:
         run: yarn datadog-ci plugin install aas
         env:
           DEBUG: plugins
-          # Needed during releases, to avoid a "No matching version found for @datadog/datadog-ci-base@x.x.x" error
+          # Needed during releases, to avoid a "No matching version found" errors
           PLUGIN_AUTO_INSTALL_BASE_VERSION_OVERRIDE: file:./artifacts/@datadog-datadog-ci-base-20.tgz
-          # Needed during releases, to avoid a "No matching version found for @datadog/datadog-ci-plugin-aas@x.x.x" error
           PLUGIN_AUTO_INSTALL_PLUGIN_VERSION_OVERRIDE: file:./artifacts/@datadog-datadog-ci-plugin-aas-20.tgz
       - name: Check that AAS plugin is installed
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -231,9 +231,8 @@ jobs:
           fi
         env:
           DEBUG: plugins
-          # Needed during releases, to avoid a "No matching version found for @datadog/datadog-ci-base@x.x.x" error
+          # Needed during releases, to avoid a "No matching version found" errors
           PLUGIN_AUTO_INSTALL_BASE_VERSION_OVERRIDE: file:./artifacts/@datadog-datadog-ci-base-20.tgz
-          # Needed during releases, to avoid a "No matching version found for @datadog/datadog-ci-plugin-aas@x.x.x" error
           PLUGIN_AUTO_INSTALL_PLUGIN_VERSION_OVERRIDE: file:./artifacts/@datadog-datadog-ci-plugin-aas-20.tgz
 
   # Using `npx datadog-ci` only runs the binary without fetching any package.
@@ -271,8 +270,9 @@ jobs:
             }
           }' > package.json
 
-          # Ignore peer dependencies to fix infinite loop and ignore warnings
-          npm install --legacy-peer-deps
+          # Ignore peer dependencies to fix infinite loop and ignore warnings about tarballs
+          npm config set legacy-peer-deps true
+          npm install
       - name: Check that AAS plugin is not installed
         run: |
           if npx datadog-ci plugin check aas; then

--- a/bin/lint-packages.ts
+++ b/bin/lint-packages.ts
@@ -375,7 +375,11 @@ ${overridesNode20}
 }`
 
 // No matrix version for auto-install e2e tests.
-const resolutionsNode20 = ['@datadog/datadog-ci-base', ...builtinPlugins.map((p) => p.packageJson.name)]
+const resolutionsNode20 = [
+  '@datadog/datadog-ci-base',
+  '@datadog/datadog-ci-plugin-aas', // Explicit resolution for AAS auto-install only.
+  ...builtinPlugins.map((p) => p.packageJson.name),
+]
   .map((name) => `    "${name}": "file:./artifacts/${name.replace('/', '-')}-20.tgz"`)
   .join(',\n')
 

--- a/bin/lint-packages.ts
+++ b/bin/lint-packages.ts
@@ -358,10 +358,35 @@ ${dependencies}
   }
 }`
 
+// No matrix version for auto-install e2e tests.
+const overrides = builtinPlugins
+  .map((p) => p.packageJson.name)
+  .map((name) => `    "${name}": "file:./artifacts/${name.replace('/', '-')}-20.tgz"`)
+  .join(',\n')
+
+// No plugins installed. Only the built-in plugins are overridden.
+const npmTestProjectPackageJson = `{
+  "name": "datadog-ci-plugin-auto-install-npm",
+  "overrides": {
+    "@datadog/datadog-ci-base": "$@datadog/datadog-ci-base",
+${overrides}
+  },
+  "dependencies": {
+    "@datadog/datadog-ci": "file:./artifacts/@datadog-datadog-ci-20.tgz",
+    "@datadog/datadog-ci-base": "file:./artifacts/@datadog-datadog-ci-base-20.tgz"
+  }
+}`
+
 TO_APPLY.push(matchAndReplace('.github/workflows/ci.yml')`
       - name: Create e2e project
         run: |
           echo '${e2eProjectPackageJson}' > package.json
+`)
+
+TO_APPLY.push(matchAndReplace('.github/workflows/ci.yml')`
+      - name: Create test project (NPM)
+        run: |
+          echo '${npmTestProjectPackageJson}' > package.json
 `)
 // #endregion
 

--- a/bin/lint-packages.ts
+++ b/bin/lint-packages.ts
@@ -375,11 +375,7 @@ ${overridesNode20}
 }`
 
 // No matrix version for auto-install e2e tests.
-const resolutionsNode20 = [
-  '@datadog/datadog-ci-base',
-  '@datadog/datadog-ci-plugin-aas', // Explicit resolution for AAS auto-install only.
-  ...builtinPlugins.map((p) => p.packageJson.name),
-]
+const resolutionsNode20 = ['@datadog/datadog-ci-base', ...builtinPlugins.map((p) => p.packageJson.name)]
   .map((name) => `    "${name}": "file:./artifacts/${name.replace('/', '-')}-20.tgz"`)
   .join(',\n')
 

--- a/bin/lint-packages.ts
+++ b/bin/lint-packages.ts
@@ -410,12 +410,11 @@ TO_APPLY.push(matchAndReplace('.github/workflows/ci.yml')`
 `)
 
 TO_APPLY.push(matchAndReplace('.github/workflows/ci.yml')`
-      - name: Override base package with artifacts
+      - name: Run AAS command with auto-install (NPX)
         run: |
-          TMP_PATH=$(
-            npx \\
+          output=$(npx \\
               ${npxArguments}
-              printenv PATH | cut -d ':' -f 1
+              datadog-ci aas instrument || true
           )
 `)
 

--- a/bin/lint-packages.ts
+++ b/bin/lint-packages.ts
@@ -359,7 +359,7 @@ ${dependencies}
 }`
 
 // No matrix version for auto-install e2e tests.
-const overrides = builtinPlugins
+const overridesNode20 = builtinPlugins
   .map((p) => p.packageJson.name)
   .map((name) => `    "${name}": "file:./artifacts/${name.replace('/', '-')}-20.tgz"`)
   .join(',\n')
@@ -369,11 +369,27 @@ const npmTestProjectPackageJson = `{
   "name": "datadog-ci-plugin-auto-install-npm",
   "overrides": {
     "@datadog/datadog-ci-base": "$@datadog/datadog-ci-base",
-${overrides}
+${overridesNode20}
   },
   "dependencies": {
     "@datadog/datadog-ci": "file:./artifacts/@datadog-datadog-ci-20.tgz",
     "@datadog/datadog-ci-base": "file:./artifacts/@datadog-datadog-ci-base-20.tgz"
+  }
+}`
+
+// No matrix version for auto-install e2e tests.
+const resolutionsNode20 = ['@datadog/datadog-ci-base', ...builtinPlugins.map((p) => p.packageJson.name)]
+  .map((name) => `    "${name}": "file:./artifacts/${name.replace('/', '-')}-20.tgz"`)
+  .join(',\n')
+
+// No plugins installed. Only the built-in plugins are overridden.
+const yarnTestProjectPackageJson = `{
+  "name": "datadog-ci-plugin-auto-install-yarn",
+  "resolutions": {
+${resolutionsNode20}
+  },
+  "dependencies": {
+    "@datadog/datadog-ci": "file:./artifacts/@datadog-datadog-ci-20.tgz"
   }
 }`
 
@@ -387,6 +403,12 @@ TO_APPLY.push(matchAndReplace('.github/workflows/ci.yml')`
       - name: Create test project (NPM)
         run: |
           echo '${npmTestProjectPackageJson}' > package.json
+`)
+
+TO_APPLY.push(matchAndReplace('.github/workflows/ci.yml')`
+      - name: Create test project (Yarn)
+        run: |
+          echo '${yarnTestProjectPackageJson}' > package.json
 `)
 // #endregion
 

--- a/bin/lint-packages.ts
+++ b/bin/lint-packages.ts
@@ -359,18 +359,23 @@ ${dependencies}
 }`
 
 // No matrix version for auto-install e2e tests.
-const overridesNode20 = ['@datadog/datadog-ci-base', ...builtinPlugins.map((p) => p.packageJson.name)]
+const overridesNode20 = builtinPlugins
+  .map((p) => p.packageJson.name)
   .map((name) => `    "${name}": "file:./artifacts/${name.replace('/', '-')}-20.tgz"`)
   .join(',\n')
 
 // No plugins installed. Only the built-in plugins are overridden.
+// In NPM, to avoid a "Override for @datadog/datadog-ci-base@x.x.x conflicts with direct dependency" error
+// during `datadog-ci plugin install`, we need to use the `$` syntax to refer to the dependency listed in `dependencies`.
 const npmTestProjectPackageJson = `{
   "name": "datadog-ci-plugin-auto-install-npm",
   "overrides": {
+    "@datadog/datadog-ci-base": "$@datadog/datadog-ci-base",
 ${overridesNode20}
   },
   "dependencies": {
-    "@datadog/datadog-ci": "file:./artifacts/@datadog-datadog-ci-20.tgz"
+    "@datadog/datadog-ci": "file:./artifacts/@datadog-datadog-ci-20.tgz",
+    "@datadog/datadog-ci-base": "file:./artifacts/@datadog-datadog-ci-base-20.tgz"
   }
 }`
 

--- a/bin/lint-packages.ts
+++ b/bin/lint-packages.ts
@@ -358,6 +358,14 @@ ${dependencies}
   }
 }`
 
+const npxArguments = [
+  '@datadog/datadog-ci',
+  '@datadog/datadog-ci-base',
+  ...builtinPlugins.map((p) => p.packageJson.name),
+]
+  .map((name) => `-p ./artifacts/${name.replace('/', '-')}-20.tgz \\`)
+  .join('\n')
+
 // No matrix version for auto-install e2e tests.
 const overridesNode20 = builtinPlugins
   .map((p) => p.packageJson.name)
@@ -399,6 +407,16 @@ TO_APPLY.push(matchAndReplace('.github/workflows/ci.yml')`
       - name: Create e2e project
         run: |
           echo '${e2eProjectPackageJson}' > package.json
+`)
+
+TO_APPLY.push(matchAndReplace('.github/workflows/ci.yml')`
+      - name: Override base package with artifacts
+        run: |
+          TMP_PATH=$(
+            npx \\
+              ${npxArguments}
+              printenv PATH | cut -d ':' -f 1
+          )
 `)
 
 TO_APPLY.push(matchAndReplace('.github/workflows/ci.yml')`

--- a/bin/lint-packages.ts
+++ b/bin/lint-packages.ts
@@ -370,7 +370,7 @@ const npmTestProjectPackageJson = `{
 ${overridesNode20}
   },
   "dependencies": {
-    "@datadog/datadog-ci": "file:./artifacts/@datadog-datadog-ci-20.tgz",
+    "@datadog/datadog-ci": "file:./artifacts/@datadog-datadog-ci-20.tgz"
   }
 }`
 

--- a/bin/lint-packages.ts
+++ b/bin/lint-packages.ts
@@ -359,8 +359,7 @@ ${dependencies}
 }`
 
 // No matrix version for auto-install e2e tests.
-const overridesNode20 = builtinPlugins
-  .map((p) => p.packageJson.name)
+const overridesNode20 = ['@datadog/datadog-ci-base', ...builtinPlugins.map((p) => p.packageJson.name)]
   .map((name) => `    "${name}": "file:./artifacts/${name.replace('/', '-')}-20.tgz"`)
   .join(',\n')
 
@@ -368,12 +367,10 @@ const overridesNode20 = builtinPlugins
 const npmTestProjectPackageJson = `{
   "name": "datadog-ci-plugin-auto-install-npm",
   "overrides": {
-    "@datadog/datadog-ci-base": "$@datadog/datadog-ci-base",
 ${overridesNode20}
   },
   "dependencies": {
     "@datadog/datadog-ci": "file:./artifacts/@datadog-datadog-ci-20.tgz",
-    "@datadog/datadog-ci-base": "file:./artifacts/@datadog-datadog-ci-base-20.tgz"
   }
 }`
 

--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-base",
-  "version": "4.4.0",
+  "version": "5.0.0",
   "description": "Base package for Datadog CI",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/datadog-ci/package.json
+++ b/packages/datadog-ci/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci",
-  "version": "4.4.0",
+  "version": "5.0.0",
   "description": "Use Datadog from your CI.",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-aas/package.json
+++ b/packages/plugin-aas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-aas",
-  "version": "4.4.0",
+  "version": "5.0.0",
   "description": "Datadog CI plugin for `aas` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-cloud-run/package.json
+++ b/packages/plugin-cloud-run/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-cloud-run",
-  "version": "4.4.0",
+  "version": "5.0.0",
   "description": "Datadog CI plugin for `cloud-run` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-container-app/package.json
+++ b/packages/plugin-container-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-container-app",
-  "version": "4.4.0",
+  "version": "5.0.0",
   "description": "Datadog CI plugin for `container-app` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-deployment/package.json
+++ b/packages/plugin-deployment/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-deployment",
-  "version": "4.4.0",
+  "version": "5.0.0",
   "description": "Datadog CI plugin for `deployment` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-dora/package.json
+++ b/packages/plugin-dora/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-dora",
-  "version": "4.4.0",
+  "version": "5.0.0",
   "description": "Datadog CI plugin for `dora` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-gate/package.json
+++ b/packages/plugin-gate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-gate",
-  "version": "4.4.0",
+  "version": "5.0.0",
   "description": "Datadog CI plugin for `gate` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-lambda/package.json
+++ b/packages/plugin-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-lambda",
-  "version": "4.4.0",
+  "version": "5.0.0",
   "description": "Datadog CI plugin for `lambda` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-sarif/package.json
+++ b/packages/plugin-sarif/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-sarif",
-  "version": "4.4.0",
+  "version": "5.0.0",
   "description": "Datadog CI plugin for `sarif` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-sbom/package.json
+++ b/packages/plugin-sbom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-sbom",
-  "version": "4.4.0",
+  "version": "5.0.0",
   "description": "Datadog CI plugin for `sbom` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-stepfunctions/package.json
+++ b/packages/plugin-stepfunctions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-stepfunctions",
-  "version": "4.4.0",
+  "version": "5.0.0",
   "description": "Datadog CI plugin for `stepfunctions` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-synthetics/package.json
+++ b/packages/plugin-synthetics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-synthetics",
-  "version": "4.4.0",
+  "version": "5.0.0",
   "description": "Datadog CI plugin for `synthetics` commands",
   "license": "Apache-2.0",
   "keywords": [


### PR DESCRIPTION
<!-- Release notes generated using configuration in .github/release.yml at v5.0.0 -->

## What's Changed
### Documentation
* [docs] Update MIGRATING.md by @Drarig29 in https://github.com/DataDog/datadog-ci/pull/2015
### RUM
* [SYNTH-21705] Move `dsyms` to base package by @Drarig29 in https://github.com/DataDog/datadog-ci/pull/2009
### Serverless
* [SVLS-8092] use layer versions from a cached file by @ava-silver in https://github.com/DataDog/datadog-ci/pull/2004
* [SVLS-8092][BREAKING CHANGE] use latest layer as default instead of none by @ava-silver in https://github.com/DataDog/datadog-ci/pull/2012
* chore: Update Lambda layer versions by @campaigner-staging[bot] in https://github.com/DataDog/datadog-ci/pull/2019
* [APMSVLS-160] add java25 by @ojproductions in https://github.com/DataDog/datadog-ci/pull/2002
### Static Analysis
* [K9VULN-8294] SBOM upload pull request error (BREAKING CHANGE)  by @colemaring in https://github.com/DataDog/datadog-ci/pull/1920
### Synthetics
* [chores] Drop built-in `synthetics` plugin by @Drarig29 in https://github.com/DataDog/datadog-ci/pull/2013
### Chores
* [chores] Drop support for Node 18 by @Drarig29 in https://github.com/DataDog/datadog-ci/pull/2011
* [chores] Remove `git-metadata` exports entry by @Drarig29 in https://github.com/DataDog/datadog-ci/pull/2010
* [SYNTH-22415] Temporary auto-install with NPX by @Drarig29 in https://github.com/DataDog/datadog-ci/pull/2005
* [chores] Add `--all` to `plugin list` command by @Drarig29 in https://github.com/DataDog/datadog-ci/pull/2014
* [chore] Fix CI with all recent PRs merged by @Drarig29 in https://github.com/DataDog/datadog-ci/pull/2018

## New Contributors
* @campaigner-staging[bot] made their first contribution in https://github.com/DataDog/datadog-ci/pull/2019

**Full Changelog**: https://github.com/DataDog/datadog-ci/compare/v4.4.0...v5.0.0

[SYNTH-21705]: https://datadoghq.atlassian.net/browse/SYNTH-21705?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SVLS-8092]: https://datadoghq.atlassian.net/browse/SVLS-8092?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SVLS-8092]: https://datadoghq.atlassian.net/browse/SVLS-8092?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[APMSVLS-160]: https://datadoghq.atlassian.net/browse/APMSVLS-160?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[K9VULN-8294]: https://datadoghq.atlassian.net/browse/K9VULN-8294?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SYNTH-22415]: https://datadoghq.atlassian.net/browse/SYNTH-22415?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ