### PR TITLE
[coverage] Add support for Go code coverage reports in `datadog-ci`

### DIFF
--- a/packages/datadog-ci/src/commands/coverage/__tests__/fixtures/coverage-invalid.out
+++ b/packages/datadog-ci/src/commands/coverage/__tests__/fixtures/coverage-invalid.out
@@ -1,0 +1,3 @@
+mode: foo
+github.com/foo/a.go:51.148,53.2 1 0
+github.com/foo/a.go:55.190,61.15 3 0

--- a/packages/datadog-ci/src/commands/coverage/__tests__/fixtures/coverage.out
+++ b/packages/datadog-ci/src/commands/coverage/__tests__/fixtures/coverage.out
@@ -1,0 +1,14 @@
+mode: atomic
+github.com/foo/a.go:51.148,53.2 1 0
+github.com/foo/a.go:55.190,61.15 3 0
+github.com/foo/a.go:61.15,64.3 2 0
+github.com/foo/a.go:66.2,67.16 2 0
+github.com/foo/a.go:67.16,69.3 1 0
+github.com/foo/b.go:27.87,31.2 3 2
+github.com/foo/b.go:34.85,36.2 1 3
+github.com/foo/b.go:39.126,44.2 4 3
+github.com/foo/b.go:47.106,50.2 2 3
+github.com/foo/main.go:44.13,49.16 4 0
+github.com/foo/main.go:49.16,51.3 1 1
+github.com/foo/main.go:51.4,52.3 1 0
+github.com/foo/main.go:53.2,55.16 16 0

--- a/packages/datadog-ci/src/commands/coverage/__tests__/upload.test.ts
+++ b/packages/datadog-ci/src/commands/coverage/__tests__/upload.test.ts
@@ -30,7 +30,7 @@ describe('upload', () => {
       const result = command['getMatchingCoverageReportFilesByFormat']()
       const fileNames = Object.values(result).flatMap((paths) => paths)
 
-      expect(fileNames.length).toEqual(10)
+      expect(fileNames.length).toEqual(11)
       expect(fileNames).toContain('src/commands/coverage/__tests__/fixtures/other-Jacoco-report.xml')
       expect(fileNames).toContain('src/commands/coverage/__tests__/fixtures/jacoco-report.xml')
       expect(fileNames).toContain('src/commands/coverage/__tests__/fixtures/subfolder.xml/nested-Jacoco-report.xml')
@@ -41,6 +41,7 @@ describe('upload', () => {
       expect(fileNames).toContain('src/commands/coverage/__tests__/fixtures/clover-php.xml')
       expect(fileNames).toContain('src/commands/coverage/__tests__/fixtures/subfolder.xml/opencover-coverage.xml')
       expect(fileNames).toContain('src/commands/coverage/__tests__/fixtures/subfolder.xml/cobertura.xml')
+      expect(fileNames).toContain('src/commands/coverage/__tests__/fixtures/coverage.out')
     })
 
     test('should filter by format', () => {
@@ -65,7 +66,7 @@ describe('upload', () => {
       const result = command['getMatchingCoverageReportFilesByFormat']()
       const fileNames = Object.values(result).flatMap((paths) => paths)
 
-      expect(fileNames.length).toEqual(7)
+      expect(fileNames.length).toEqual(8)
       expect(fileNames).toContain('src/commands/coverage/__tests__/fixtures/other-Jacoco-report.xml')
       expect(fileNames).toContain('src/commands/coverage/__tests__/fixtures/jacoco-report.xml')
       expect(fileNames).toContain('src/commands/coverage/__tests__/fixtures/lcov.info')
@@ -73,6 +74,7 @@ describe('upload', () => {
       expect(fileNames).toContain('src/commands/coverage/__tests__/fixtures/.resultset.json')
       expect(fileNames).toContain('src/commands/coverage/__tests__/fixtures/clover.xml')
       expect(fileNames).toContain('src/commands/coverage/__tests__/fixtures/clover-php.xml')
+      expect(fileNames).toContain('src/commands/coverage/__tests__/fixtures/coverage.out')
     })
 
     test('should read all coverage report files excluding ignored paths specified partially', () => {
@@ -83,7 +85,7 @@ describe('upload', () => {
       const result = command['getMatchingCoverageReportFilesByFormat']()
       const fileNames = Object.values(result).flatMap((paths) => paths)
 
-      expect(fileNames.length).toEqual(7)
+      expect(fileNames.length).toEqual(8)
       expect(fileNames).toContain('src/commands/coverage/__tests__/fixtures/other-Jacoco-report.xml')
       expect(fileNames).toContain('src/commands/coverage/__tests__/fixtures/jacoco-report.xml')
       expect(fileNames).toContain('src/commands/coverage/__tests__/fixtures/lcov.info')
@@ -91,6 +93,7 @@ describe('upload', () => {
       expect(fileNames).toContain('src/commands/coverage/__tests__/fixtures/.resultset.json')
       expect(fileNames).toContain('src/commands/coverage/__tests__/fixtures/clover.xml')
       expect(fileNames).toContain('src/commands/coverage/__tests__/fixtures/clover-php.xml')
+      expect(fileNames).toContain('src/commands/coverage/__tests__/fixtures/coverage.out')
     })
 
     test('should allow specifying files directly', () => {

--- a/packages/datadog-ci/src/commands/coverage/__tests__/utils.test.ts
+++ b/packages/datadog-ci/src/commands/coverage/__tests__/utils.test.ts
@@ -2,6 +2,7 @@ import {
   cloverFormat,
   coberturaFormat,
   detectFormat,
+  goCoverprofileFormat,
   jacocoFormat,
   lcovFormat,
   opencoverFormat,
@@ -102,6 +103,16 @@ describe('utils', () => {
       expect(validateCoverageReport(filePath, cloverFormat)).toBeUndefined()
     })
 
+    test('Returns error message for an invalid go-coverprofile report', async () => {
+      const filePath = './src/commands/coverage/__tests__/fixtures/coverage-invalid.out'
+      expect(validateCoverageReport(filePath, goCoverprofileFormat)).toMatch(/.+/)
+    })
+
+    test('Returns undefined for a valid go-coverprofile report', async () => {
+      const filePath = './src/commands/coverage/__tests__/fixtures/coverage.out'
+      expect(validateCoverageReport(filePath, goCoverprofileFormat)).toBeUndefined()
+    })
+
     test('Returns error message for an invalid clover report', async () => {
       const filePath = './src/commands/coverage/__tests__/fixtures/clover-invalid.xml'
       expect(validateCoverageReport(filePath, cloverFormat)).toMatch(/.+/)
@@ -147,6 +158,11 @@ describe('utils', () => {
     test('Detects clover format for a PHP clover report', async () => {
       const filePath = './src/commands/coverage/__tests__/fixtures/clover-php.xml'
       expect(detectFormat(filePath)).toEqual(cloverFormat)
+    })
+
+    test('Detects go-coverprofile format for a valid go-coverprofile report', async () => {
+      const filePath = './src/commands/coverage/__tests__/fixtures/coverage.out'
+      expect(detectFormat(filePath)).toEqual(goCoverprofileFormat)
     })
 
     test('Returns undefined for an XML file that is not a coverage report', async () => {


### PR DESCRIPTION
### What and why?

Add Go code coverage format support for the `datadog-ci coverage upload` command

### How?
- Added a new constant 
- Updated auto-detection and validation logic for the report

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
