### PR TITLE
[chore] Enable dependabot for github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,10 @@ updates:
     open-pull-requests-limit: 0
     # Update both `package.json` and `yarn.lock`
     versioning-strategy: increase
+  - package-ecosystem: github-actions
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: '[chore] '


### PR DESCRIPTION
### What and why?

Get automated PRs to bump our github actions. According to https://github.com/DataDog/datadog-ci/pull/1802, this should support our syntax with a commit and a comment (e.g. `- uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0`)

### How?

Enable dependabot for github actions on a weekly basis

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
