### PR TITLE
[sourcemaps] Windows newline fix

### DIFF
--- a/packages/datadog-ci/src/commands/sourcemaps/utils.ts
+++ b/packages/datadog-ci/src/commands/sourcemaps/utils.ts
@@ -21,7 +21,8 @@ export const readLastLine = async (filePath: string): Promise<string> => {
     const tailContent = buffer.toString('utf-8')
 
     // Get the last non-empty line (handle multiple trailing newlines)
-    const lines = tailContent.split('\n')
+    // note: windows uses \r\n as line separator while unix uses \n
+    const lines = tailContent.split(/\r?\n/)
     for (const line of lines.reverse()) {
       if (line.trim().length !== 0) {
         lastLine = line


### PR DESCRIPTION
### What and why?

Windows fix for https://github.com/DataDog/datadog-ci/pull/2035

### How?

Windows uses a different newline separator. Now we use this as well while splitting lines.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
