### PR TITLE
v5.2.0

### DIFF
--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-base",
-  "version": "5.1.0",
+  "version": "5.2.0",
   "description": "Base package for Datadog CI",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/datadog-ci/package.json
+++ b/packages/datadog-ci/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci",
-  "version": "5.1.0",
+  "version": "5.2.0",
   "description": "Use Datadog from your CI.",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-aas/package.json
+++ b/packages/plugin-aas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-aas",
-  "version": "5.1.0",
+  "version": "5.2.0",
   "description": "Datadog CI plugin for `aas` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-cloud-run/package.json
+++ b/packages/plugin-cloud-run/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-cloud-run",
-  "version": "5.1.0",
+  "version": "5.2.0",
   "description": "Datadog CI plugin for `cloud-run` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-container-app/package.json
+++ b/packages/plugin-container-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-container-app",
-  "version": "5.1.0",
+  "version": "5.2.0",
   "description": "Datadog CI plugin for `container-app` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-deployment/package.json
+++ b/packages/plugin-deployment/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-deployment",
-  "version": "5.1.0",
+  "version": "5.2.0",
   "description": "Datadog CI plugin for `deployment` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-dora/package.json
+++ b/packages/plugin-dora/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-dora",
-  "version": "5.1.0",
+  "version": "5.2.0",
   "description": "Datadog CI plugin for `dora` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-gate/package.json
+++ b/packages/plugin-gate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-gate",
-  "version": "5.1.0",
+  "version": "5.2.0",
   "description": "Datadog CI plugin for `gate` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-lambda/package.json
+++ b/packages/plugin-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-lambda",
-  "version": "5.1.0",
+  "version": "5.2.0",
   "description": "Datadog CI plugin for `lambda` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-sarif/package.json
+++ b/packages/plugin-sarif/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-sarif",
-  "version": "5.1.0",
+  "version": "5.2.0",
   "description": "Datadog CI plugin for `sarif` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-sbom/package.json
+++ b/packages/plugin-sbom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-sbom",
-  "version": "5.1.0",
+  "version": "5.2.0",
   "description": "Datadog CI plugin for `sbom` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-stepfunctions/package.json
+++ b/packages/plugin-stepfunctions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-stepfunctions",
-  "version": "5.1.0",
+  "version": "5.2.0",
   "description": "Datadog CI plugin for `stepfunctions` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-synthetics/package.json
+++ b/packages/plugin-synthetics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-synthetics",
-  "version": "5.1.0",
+  "version": "5.2.0",
   "description": "Datadog CI plugin for `synthetics` commands",
   "license": "Apache-2.0",
   "keywords": [


### PR DESCRIPTION
<!-- Release notes generated using configuration in .github/release.yml at v5.2.0 -->

## What's Changed
### datadog-ci
* [SYNTH-23730] Fix plugin import on Windows by @Drarig29 in https://github.com/DataDog/datadog-ci/pull/2033
### Dependencies
* [chore] Bump stefanbuck/github-issue-parser from 3.2.1 to 3.2.2 by @dependabot[bot] in https://github.com/DataDog/datadog-ci/pull/2037
* [chore] Bump actions/setup-node from 4.4.0 to 6.1.0 by @dependabot[bot] in https://github.com/DataDog/datadog-ci/pull/2044
* [chore] Bump actions/upload-artifact from 4.6.2 to 6.0.0 by @dependabot[bot] in https://github.com/DataDog/datadog-ci/pull/2041
* [chore] Bump actions/download-artifact from 4.3.0 to 7.0.0 by @dependabot[bot] in https://github.com/DataDog/datadog-ci/pull/2039
* [chore] Bump DataDog/datadog-static-analyzer-github-action from 1.2.3 to 2.0.0 by @dependabot[bot] in https://github.com/DataDog/datadog-ci/pull/2038
* [chore] Bump actions/github-script from 7.0.1 to 8.0.0 by @dependabot[bot] in https://github.com/DataDog/datadog-ci/pull/2042
* [chore] Bump actions/checkout from 4.3.0 to 6.0.1 by @dependabot[bot] in https://github.com/DataDog/datadog-ci/pull/2043
* [chore] Bump redhat-plumbers-in-action/advanced-issue-labeler from 3.0.0 to 3.2.4 by @dependabot[bot] in https://github.com/DataDog/datadog-ci/pull/2040
### Documentation
* [docs] Add note about `--disable-git` for `sourcemaps upload` by @Drarig29 in https://github.com/DataDog/datadog-ci/pull/2031
### RUM
* [sourcemaps] sourceMappingURL support by @buranmert in https://github.com/DataDog/datadog-ci/pull/2035
* [sourcemaps] Windows newline fix by @buranmert in https://github.com/DataDog/datadog-ci/pull/2048
### Serverless
* chore: Update Lambda layer versions by @campaigner-staging[bot] in https://github.com/DataDog/datadog-ci/pull/2029
* [SVLS-8267] fix error on unspecified runtime by @ava-silver in https://github.com/DataDog/datadog-ci/pull/2047
### Chores
* [chore] Enable dependabot for github actions by @Drarig29 in https://github.com/DataDog/datadog-ci/pull/2036
* [CHORE] migrate to serverless onboarding managed team by @ava-silver in https://github.com/DataDog/datadog-ci/pull/2046
* [chore] Add warning about github actions in `lint:packages` script by @Drarig29 in https://github.com/DataDog/datadog-ci/pull/1909


**Full Changelog**: https://github.com/DataDog/datadog-ci/compare/v5.1.0...v5.2.0

[SYNTH-23730]: https://datadoghq.atlassian.net/browse/SYNTH-23730?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SVLS-8267]: https://datadoghq.atlassian.net/browse/SVLS-8267?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ