### PR TITLE
v5.3.0

### DIFF
--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-base",
-  "version": "5.2.1",
+  "version": "5.3.0",
   "description": "Base package for Datadog CI",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/datadog-ci/package.json
+++ b/packages/datadog-ci/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci",
-  "version": "5.2.1",
+  "version": "5.3.0",
   "description": "Use Datadog from your CI.",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-aas/package.json
+++ b/packages/plugin-aas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-aas",
-  "version": "5.2.1",
+  "version": "5.3.0",
   "description": "Datadog CI plugin for `aas` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-cloud-run/package.json
+++ b/packages/plugin-cloud-run/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-cloud-run",
-  "version": "5.2.1",
+  "version": "5.3.0",
   "description": "Datadog CI plugin for `cloud-run` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-container-app/package.json
+++ b/packages/plugin-container-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-container-app",
-  "version": "5.2.1",
+  "version": "5.3.0",
   "description": "Datadog CI plugin for `container-app` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-coverage/package.json
+++ b/packages/plugin-coverage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-coverage",
-  "version": "5.2.1",
+  "version": "5.3.0",
   "description": "Datadog CI plugin for `coverage` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-deployment/package.json
+++ b/packages/plugin-deployment/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-deployment",
-  "version": "5.2.1",
+  "version": "5.3.0",
   "description": "Datadog CI plugin for `deployment` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-dora/package.json
+++ b/packages/plugin-dora/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-dora",
-  "version": "5.2.1",
+  "version": "5.3.0",
   "description": "Datadog CI plugin for `dora` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-gate/package.json
+++ b/packages/plugin-gate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-gate",
-  "version": "5.2.1",
+  "version": "5.3.0",
   "description": "Datadog CI plugin for `gate` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-junit/package.json
+++ b/packages/plugin-junit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-junit",
-  "version": "5.2.1",
+  "version": "5.3.0",
   "description": "Datadog CI plugin for `junit` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-lambda/package.json
+++ b/packages/plugin-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-lambda",
-  "version": "5.2.1",
+  "version": "5.3.0",
   "description": "Datadog CI plugin for `lambda` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-sarif/package.json
+++ b/packages/plugin-sarif/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-sarif",
-  "version": "5.2.1",
+  "version": "5.3.0",
   "description": "Datadog CI plugin for `sarif` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-sbom/package.json
+++ b/packages/plugin-sbom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-sbom",
-  "version": "5.2.1",
+  "version": "5.3.0",
   "description": "Datadog CI plugin for `sbom` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-stepfunctions/package.json
+++ b/packages/plugin-stepfunctions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-stepfunctions",
-  "version": "5.2.1",
+  "version": "5.3.0",
   "description": "Datadog CI plugin for `stepfunctions` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-synthetics/package.json
+++ b/packages/plugin-synthetics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-synthetics",
-  "version": "5.2.1",
+  "version": "5.3.0",
   "description": "Datadog CI plugin for `synthetics` commands",
   "license": "Apache-2.0",
   "keywords": [


### PR DESCRIPTION
<!-- Release notes generated using configuration in .github/release.yml at v5.3.0 -->

## What's Changed
### datadog-ci
* [static-analysis] Use a custom format to extract committer and author information by @jacobotb in https://github.com/DataDog/datadog-ci/pull/2053
* Add DD_API_KEY_SSM_ARN env var so Datadog CI supports SSM API Key by @nina9753 in https://github.com/DataDog/datadog-ci/pull/2057
### Dependencies
* [chore] Bump actions/setup-node from 6.1.0 to 6.2.0 by @dependabot[bot] in https://github.com/DataDog/datadog-ci/pull/2060
* [chore] Bump stefanbuck/github-issue-parser from 3.2.2 to 3.2.3 by @dependabot[bot] in https://github.com/DataDog/datadog-ci/pull/2059
### Software Delivery
* [coverage] Add support for Go code coverage reports in `datadog-ci` by @telecatser in https://github.com/DataDog/datadog-ci/pull/2030
* [coverage] Move `coverage upload` command to built-in plugin by @telecatser in https://github.com/DataDog/datadog-ci/pull/2054
* [SYNTH-21709] Migrate `junit upload` command to built-in plugin by @Drarig29 in https://github.com/DataDog/datadog-ci/pull/2056
### Serverless
* chore: Update Lambda layer versions by @campaigner-staging[bot] in https://github.com/DataDog/datadog-ci/pull/2052
* chore: Update Lambda layer versions by @campaigner-staging[bot] in https://github.com/DataDog/datadog-ci/pull/2058
### Chores
* [chores] Add process for first-time package publishing by @Drarig29 in https://github.com/DataDog/datadog-ci/pull/2055
* [chores] Add label guardrails in release process by @Drarig29 in https://github.com/DataDog/datadog-ci/pull/2063

## New Contributors
* @telecatser made their first contribution in https://github.com/DataDog/datadog-ci/pull/2030
* @jacobotb made their first contribution in https://github.com/DataDog/datadog-ci/pull/2053
* @nina9753 made their first contribution in https://github.com/DataDog/datadog-ci/pull/2057

**Full Changelog**: https://github.com/DataDog/datadog-ci/compare/v5.2.1...v5.3.0

[SYNTH-21709]: https://datadoghq.atlassian.net/browse/SYNTH-21709?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ