### PR TITLE
[chores] Avoid double CI on tagged commits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,17 @@
 
 name: Continuous Integration
 
-on: push
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+on:
+  push:
+    # Run on every commit of any branch, and not on tags
+    branches:
+      - '**'
+    tags-ignore:
+      - '**'
 
 jobs:
   build-and-test:


### PR DESCRIPTION
### What and why?

This PR ensures we don't waste resources by running `ci.yml` twice for tagged commits:

<img width="1292" height="167" alt="image" src="https://github.com/user-attachments/assets/d968be09-0bc5-4611-b051-8ab19b5bd566" />

(Unrelated: those jobs were abnormally long because they were queued for a long time)

### How?

Use `tags-ignore: '**'` and cancel previous CI with a concurrency group

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
