### PR TITLE
[chores] Require all files to be owned

### DIFF
--- a/.datadog-ci.datadog.yml
+++ b/.datadog-ci.datadog.yml
@@ -2,3 +2,4 @@ schema-version: v1
 kind: mergegate
 rules:
   - require: reviewers-approval
+  - require: all-files-are-owned


### PR DESCRIPTION
### What and why?

Add `all-files-are-owned` mergegate rule for all new files to be owned by a codeowner.

### How?

Update mergegate config

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
