### PR TITLE
[dep] Bump `jws` to fix vulnerability

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -5212,7 +5212,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"buffer-equal-constant-time@npm:1.0.1, buffer-equal-constant-time@npm:^1.0.1":
+"buffer-equal-constant-time@npm:^1.0.1":
   version: 1.0.1
   resolution: "buffer-equal-constant-time@npm:1.0.1"
   checksum: 10/80bb945f5d782a56f374b292770901065bad21420e34936ecbe949e57724b4a13874f735850dd1cc61f078773c4fb5493a41391e7bda40d1fa388d6bd80daaab
@@ -8671,17 +8671,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jwa@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "jwa@npm:2.0.0"
-  dependencies:
-    buffer-equal-constant-time: "npm:1.0.1"
-    ecdsa-sig-formatter: "npm:1.0.11"
-    safe-buffer: "npm:^5.0.1"
-  checksum: 10/ab983f6685d99d13ddfbffef9b1c66309a536362a8412d49ba6e687d834a1240ce39290f30ac7dbe241e0ab6c76fee7ff795776ce534e11d148158c9b7193498
-  languageName: node
-  linkType: hard
-
 "jwa@npm:^2.0.1":
   version: 2.0.1
   resolution: "jwa@npm:2.0.1"
@@ -8693,17 +8682,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jws@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "jws@npm:4.0.0"
-  dependencies:
-    jwa: "npm:^2.0.0"
-    safe-buffer: "npm:^5.0.1"
-  checksum: 10/1d15f4cdea376c6bd6a81002bd2cb0bf3d51d83da8f0727947b5ba3e10cf366721b8c0d099bf8c1eb99eb036e2c55e5fd5efd378ccff75a2b4e0bd10002348b9
-  languageName: node
-  linkType: hard
-
-"jws@npm:^4.0.1":
+"jws@npm:^4.0.0, jws@npm:^4.0.1":
   version: 4.0.1
   resolution: "jws@npm:4.0.1"
   dependencies:


### PR DESCRIPTION
### What and why?

https://github.com/DataDog/datadog-ci/security/dependabot/74

```sh
yarn why -R jws
├─ @datadog/datadog-ci-plugin-aas@workspace:packages/plugin-aas
│  └─ @azure/identity@npm:4.10.1 (via npm:^4.10.1)
│     └─ @azure/msal-node@npm:3.6.0 (via npm:^3.5.0)
│        └─ jsonwebtoken@npm:9.0.2 (via npm:^9.0.0)
│           └─ jws@npm:3.2.2 (via npm:^3.2.2)
│
├─ @datadog/datadog-ci-plugin-cloud-run@workspace:packages/plugin-cloud-run
│  ├─ @google-cloud/logging@npm:11.2.0 (via npm:^11.2.0)
│  │  ├─ @google-cloud/common@npm:5.0.2 (via npm:^5.0.0)
│  │  │  └─ google-auth-library@npm:9.7.0 (via npm:^9.0.0)
│  │  │     ├─ gtoken@npm:7.1.0 (via npm:^7.0.0)
│  │  │     │  └─ jws@npm:4.0.0 (via npm:^4.0.0)
│  │  │     └─ jws@npm:4.0.0 (via npm:^4.0.0)
│  │  ├─ google-auth-library@npm:9.7.0 (via npm:^9.0.0)
│  │  └─ google-gax@npm:4.3.8 (via npm:^4.0.3)
│  │     └─ google-auth-library@npm:9.7.0 (via npm:^9.3.0)
│  ├─ @google-cloud/run@npm:3.0.0 (via npm:^3.0.0)
│  │  └─ google-gax@npm:5.0.1 (via npm:^5.0.0)
│  │     └─ google-auth-library@npm:10.2.0 (via npm:^10.1.0)
│  │        ├─ gtoken@npm:8.0.0 (via npm:^8.0.0)
│  │        │  └─ jws@npm:4.0.0 (via npm:^4.0.0)
│  │        └─ jws@npm:4.0.0 (via npm:^4.0.0)
│  └─ google-auth-library@npm:10.2.1 (via npm:^10.2.1)
│     ├─ gtoken@npm:8.0.0 (via npm:^8.0.0)
│     └─ jws@npm:4.0.0 (via npm:^4.0.0)
│
└─ @datadog/datadog-ci-plugin-container-app@workspace:packages/plugin-container-app
   └─ @azure/identity@npm:4.10.1 (via npm:^4.10.1)
```

### How?

See commands in each commit.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
