### PR TITLE
[dep] Bump `diff` dev dep to `5.2.2`

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -5916,9 +5916,9 @@ __metadata:
   linkType: hard
 
 "diff@npm:^5.2.0":
-  version: 5.2.0
-  resolution: "diff@npm:5.2.0"
-  checksum: 10/01b7b440f83a997350a988e9d2f558366c0f90f15be19f4aa7f1bb3109a4e153dfc3b9fbf78e14ea725717017407eeaa2271e3896374a0181e8f52445740846d
+  version: 5.2.2
+  resolution: "diff@npm:5.2.2"
+  checksum: 10/8a885b38113d96138d87f6cb474ee959b7e9ab33c0c4cb1b07dcf019ec544945a2309d53d721532af020de4b3a58fb89f1026f64f42f9421aa9c3ae48a36998b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### What and why?

Fix https://github.com/DataDog/datadog-ci/security/dependabot/77

### How?

Run `yarn set resolution diff@npm:^5.2.0 npm:5.2.2`

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
