### PR TITLE
[dep] Bump `lodash` to `4.17.23`

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -8904,14 +8904,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash@npm:^4.17.14":
-  version: 4.17.21
-  resolution: "lodash@npm:4.17.21"
-  checksum: 10/c08619c038846ea6ac754abd6dd29d2568aa705feb69339e836dfa8d8b09abbb2f859371e86863eda41848221f9af43714491467b5b0299122431e202bb0c532
-  languageName: node
-  linkType: hard
-
-"lodash@npm:^4.17.21, lodash@npm:^4.17.5":
+"lodash@npm:^4.17.14, lodash@npm:^4.17.21, lodash@npm:^4.17.5":
   version: 4.17.23
   resolution: "lodash@npm:4.17.23"
   checksum: 10/82504c88250f58da7a5a4289f57a4f759c44946c005dd232821c7688b5fcfbf4a6268f6a6cdde4b792c91edd2f3b5398c1d2a0998274432cff76def48735e233


### PR DESCRIPTION
### What and why?

https://github.com/DataDog/datadog-ci/security/dependabot/79

```
yarn why -R lodash
├─ @datadog/datadog-ci-base@workspace:packages/base
│  ├─ datadog-metrics@npm:0.9.3 (via npm:0.9.3)
│  │  └─ dogapi@npm:2.8.4 (via npm:2.8.4)
│  │     └─ lodash@npm:4.17.21 (via npm:^4.17.21)
│  └─ inquirer@npm:8.2.6 (via npm:^8.2.5)
│     └─ lodash@npm:4.17.21 (via npm:^4.17.21)
│
├─ @datadog/datadog-ci-plugin-cloud-run@workspace:packages/plugin-cloud-run
│  ├─ inquirer-checkbox-plus-prompt@npm:1.4.2 [55889] (via npm:^1.4.2 [55889])
│  │  └─ lodash@npm:4.17.21 (via npm:^4.17.5)
│  └─ inquirer@npm:8.2.6 (via npm:^8.2.5)
│
├─ @datadog/datadog-ci-plugin-lambda@workspace:packages/plugin-lambda
│  ├─ inquirer-checkbox-plus-prompt@npm:1.4.2 [55889] (via npm:^1.4.2 [2f4e4])
│  └─ inquirer@npm:8.2.6 (via npm:^8.2.5)
│
├─ @datadog/datadog-ci@workspace:packages/datadog-ci
│  └─ @datadog/datadog-ci-base@workspace:packages/base [3da8e] (via workspace:* [3da8e])
│
└─ datadog-ci-monorepo@workspace:.
   └─ @microsoft/eslint-formatter-sarif@npm:3.1.0 (via npm:^3.1.0)
      └─ lodash@npm:4.17.21 (via npm:^4.17.14)
```

### How?

See commands in each commit.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
