### PR TITLE
v5.6.0

### DIFF
--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-base",
-  "version": "5.5.0",
+  "version": "5.6.0",
   "description": "Base package for Datadog CI",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/datadog-ci/package.json
+++ b/packages/datadog-ci/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci",
-  "version": "5.5.0",
+  "version": "5.6.0",
   "description": "Use Datadog from your CI.",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-aas/package.json
+++ b/packages/plugin-aas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-aas",
-  "version": "5.5.0",
+  "version": "5.6.0",
   "description": "Datadog CI plugin for `aas` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-cloud-run/package.json
+++ b/packages/plugin-cloud-run/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-cloud-run",
-  "version": "5.5.0",
+  "version": "5.6.0",
   "description": "Datadog CI plugin for `cloud-run` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-container-app/package.json
+++ b/packages/plugin-container-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-container-app",
-  "version": "5.5.0",
+  "version": "5.6.0",
   "description": "Datadog CI plugin for `container-app` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-coverage/package.json
+++ b/packages/plugin-coverage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-coverage",
-  "version": "5.5.0",
+  "version": "5.6.0",
   "description": "Datadog CI plugin for `coverage` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-deployment/package.json
+++ b/packages/plugin-deployment/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-deployment",
-  "version": "5.5.0",
+  "version": "5.6.0",
   "description": "Datadog CI plugin for `deployment` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-dora/package.json
+++ b/packages/plugin-dora/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-dora",
-  "version": "5.5.0",
+  "version": "5.6.0",
   "description": "Datadog CI plugin for `dora` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-gate/package.json
+++ b/packages/plugin-gate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-gate",
-  "version": "5.5.0",
+  "version": "5.6.0",
   "description": "Datadog CI plugin for `gate` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-junit/package.json
+++ b/packages/plugin-junit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-junit",
-  "version": "5.5.0",
+  "version": "5.6.0",
   "description": "Datadog CI plugin for `junit` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-lambda/package.json
+++ b/packages/plugin-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-lambda",
-  "version": "5.5.0",
+  "version": "5.6.0",
   "description": "Datadog CI plugin for `lambda` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-sarif/package.json
+++ b/packages/plugin-sarif/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-sarif",
-  "version": "5.5.0",
+  "version": "5.6.0",
   "description": "Datadog CI plugin for `sarif` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-sbom/package.json
+++ b/packages/plugin-sbom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-sbom",
-  "version": "5.5.0",
+  "version": "5.6.0",
   "description": "Datadog CI plugin for `sbom` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-stepfunctions/package.json
+++ b/packages/plugin-stepfunctions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-stepfunctions",
-  "version": "5.5.0",
+  "version": "5.6.0",
   "description": "Datadog CI plugin for `stepfunctions` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-synthetics/package.json
+++ b/packages/plugin-synthetics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-synthetics",
-  "version": "5.5.0",
+  "version": "5.6.0",
   "description": "Datadog CI plugin for `synthetics` commands",
   "license": "Apache-2.0",
   "keywords": [


### PR DESCRIPTION
<!-- Release notes generated using configuration in .github/release.yml at v5.6.0 -->

## What's Changed
### Dependencies
* [dep] Bump `ssh2` to `1.17.0` by @Drarig29 in https://github.com/DataDog/datadog-ci/pull/2078
* [dep] Bump `jws` to fix vulnerability by @Drarig29 in https://github.com/DataDog/datadog-ci/pull/2079
* [dep] Bump `inquirer` to `8.2.6` by @Drarig29 in https://github.com/DataDog/datadog-ci/pull/2080
* [dep] Bump `diff` dev dep to `5.2.2` by @Drarig29 in https://github.com/DataDog/datadog-ci/pull/2081
* [dep] Bump direct `fast-xml-parser` to `5.3.4` by @Drarig29 in https://github.com/DataDog/datadog-ci/pull/2083
* [dep] Bump `lodash` to `4.17.23` by @Drarig29 in https://github.com/DataDog/datadog-ci/pull/2082
* [chore] Bump DataDog/datadog-static-analyzer-github-action from 2.0.0 to 3.0.0 by @dependabot[bot] in https://github.com/DataDog/datadog-ci/pull/2076
* [dep] Bump AWS SDK versions by @Drarig29 in https://github.com/DataDog/datadog-ci/pull/2085
### Software Delivery
* feat: Implement custom flags support for coverage reports by @nikita-tkachenko-datadog in https://github.com/DataDog/datadog-ci/pull/2070
### Serverless
* [SVLS-8477] ensure consistency for WEBSITES_ENABLE_APP_SERVICE_STORAGE by @ava-silver in https://github.com/DataDog/datadog-ci/pull/2084
* chore: Update Lambda layer versions by @campaigner-staging[bot] in https://github.com/DataDog/datadog-ci/pull/2086


**Full Changelog**: https://github.com/DataDog/datadog-ci/compare/v5.5.0...v5.6.0

[SVLS-8477]: https://datadoghq.atlassian.net/browse/SVLS-8477?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ