### PR TITLE
[chores] Fail `pre-approval-checks` job if no PR

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -14,7 +14,7 @@ To release a new version of `datadog-ci`:
 5. Request an approval from a datadog-ci admin.
    - If a `oidc-setup-required ⚠️` label is added to your PR, ask an admin for assistance.
 6. Wait for your PR to be approved.
-   - Retry the `pre-approval-checks` job if needed.
+   - Once approved, retry the `pre-approval-checks` job.
 7. The `npm-publish` job should now be waiting for an approval from a datadog-ci admin.
    - Ask for approval and wait for it and its downstream jobs to succeed.
 8. Once all jobs are successful, merge the PR **with the "Create a merge commit" strategy**.

--- a/bin/check-npm-packages.sh
+++ b/bin/check-npm-packages.sh
@@ -77,6 +77,12 @@ if [ -n "${GITHUB_TOKEN:-}" ] && [ -n "${GITHUB_SHA:-}" ]; then
 	PR_NUMBER=$(echo "$PR_RESPONSE" | jq -r '.[0].number // empty')
 	PR_LABELS=$(echo "$PR_RESPONSE" | jq '[.[0].labels[].name]' 2>/dev/null || true)
 
+	if [ -z "$PR_NUMBER" ]; then
+		echo -e "${RED}No PR found for commit $GITHUB_SHA ❌${NC}"
+		echo "Please create a release PR first, then retry the \"pre-approval-checks\" job."
+		exit 1
+	fi
+
 	echo -e "${BLUE}PR labels:${NC} $PR_LABELS"
 
 	# Fetch review approvals for the PR


### PR DESCRIPTION
### What and why?

We should block the `npm-publish` job until a release PR is opened.

### How?

- Fail `pre-approval-checks` job if no release PR
- Make release instructions clearer

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
