### PR TITLE
chore: use dry run/mocks for fips tests

### DIFF
--- a/packages/datadog-ci/src/__tests__/cli.test.ts
+++ b/packages/datadog-ci/src/__tests__/cli.test.ts
@@ -79,9 +79,11 @@ describe('cli', () => {
     // Strip API keys so commands bail out early instead of doing real work.
     const savedApiKey = process.env.DATADOG_API_KEY
     const savedDDApiKey = process.env.DD_API_KEY
+    const originalFetch = global.fetch
     beforeAll(() => {
       delete process.env.DATADOG_API_KEY
       delete process.env.DD_API_KEY
+      global.fetch = jest.fn().mockRejectedValue(new Error('fetch calls are not allowed in tests'))
     })
     afterAll(() => {
       if (savedApiKey !== undefined) {
@@ -90,6 +92,7 @@ describe('cli', () => {
       if (savedDDApiKey !== undefined) {
         process.env.DD_API_KEY = savedDDApiKey
       }
+      global.fetch = originalFetch
     })
 
     const pluginCommandPaths = new Set<string>()


### PR DESCRIPTION
### What and why?

This PR adds automatic detection of `--dry-run` support for commands in the CLI test suite. This prevents real API calls during tests and makes the test suite more robust.

Added because I was [seeing flaky tests](https://github.com/DataDog/datadog-ci/actions/runs/21955570114/job/63420046570?pr=2097), and I think this should fix it

### How?

- Added a new `supportsDryRun` helper function that checks if a command class supports the `--dry-run` option
- Modified the test suite to automatically append `--dry-run` to commands that support it
- Removed hardcoded `--dry-run` flags from the `requiredOptions` object, as they're now added dynamically
- Added mocks for network-related modules to prevent real network calls
- Added code to strip API keys during tests to ensure commands bail out early

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)