### PR TITLE
[dep] Bump `ajv` to `8.18.0`

### DIFF
--- a/packages/plugin-sarif/package.json
+++ b/packages/plugin-sarif/package.json
@@ -38,7 +38,7 @@
     "@datadog/datadog-ci-base": "workspace:*"
   },
   "dependencies": {
-    "ajv": "^8.12.0",
+    "ajv": "^8.18.0",
     "ajv-formats": "^2.1.1",
     "axios": "^1.13.5",
     "chalk": "3.0.0",

--- a/packages/plugin-sbom/package.json
+++ b/packages/plugin-sbom/package.json
@@ -38,7 +38,7 @@
     "@datadog/datadog-ci-base": "workspace:*"
   },
   "dependencies": {
-    "ajv": "^8.12.0",
+    "ajv": "^8.18.0",
     "ajv-formats": "^2.1.1",
     "axios": "^1.13.5",
     "chalk": "3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1819,7 +1819,7 @@ __metadata:
   dependencies:
     "@types/jest": "npm:29.5.3"
     "@types/uuid": "npm:^9.0.2"
-    ajv: "npm:^8.12.0"
+    ajv: "npm:^8.18.0"
     ajv-formats: "npm:^2.1.1"
     axios: "npm:^1.13.5"
     chalk: "npm:3.0.0"
@@ -1837,7 +1837,7 @@ __metadata:
   resolution: "@datadog/datadog-ci-plugin-sbom@workspace:packages/plugin-sbom"
   dependencies:
     "@types/jest": "npm:29.5.3"
-    ajv: "npm:^8.12.0"
+    ajv: "npm:^8.18.0"
     ajv-formats: "npm:^2.1.1"
     axios: "npm:^1.13.5"
     chalk: "npm:3.0.0"
@@ -4945,7 +4945,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ajv@npm:^8.0.0, ajv@npm:^8.12.0":
+"ajv@npm:^8.0.0":
   version: 8.17.1
   resolution: "ajv@npm:8.17.1"
   dependencies:
@@ -4954,6 +4954,18 @@ __metadata:
     json-schema-traverse: "npm:^1.0.0"
     require-from-string: "npm:^2.0.2"
   checksum: 10/ee3c62162c953e91986c838f004132b6a253d700f1e51253b99791e2dbfdb39161bc950ebdc2f156f8568035bb5ed8be7bd78289cd9ecbf3381fe8f5b82e3f33
+  languageName: node
+  linkType: hard
+
+"ajv@npm:^8.18.0":
+  version: 8.18.0
+  resolution: "ajv@npm:8.18.0"
+  dependencies:
+    fast-deep-equal: "npm:^3.1.3"
+    fast-uri: "npm:^3.0.1"
+    json-schema-traverse: "npm:^1.0.0"
+    require-from-string: "npm:^2.0.2"
+  checksum: 10/bfed9de827a2b27c6d4084324eda76a4e32bdde27410b3e9b81d06e6f8f5c78370fc6b93fe1d869f1939ff1d7c4ae8896960995acb8425e3e9288c8884247c48
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### What and why?

Closes https://github.com/DataDog/datadog-ci/security/dependabot/88

### How?

See commit titles.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
