### PR TITLE
chore: make plugin install message yellow instead of red

### DIFF
--- a/packages/base/src/helpers/plugin.ts
+++ b/packages/base/src/helpers/plugin.ts
@@ -252,7 +252,7 @@ const handlePluginAutoInstall = async (scope: string) => {
     }
 
     const pluginName = scopeToPackageName(scope)
-    console.log(chalk.red(`Could not find ${chalk.bold(pluginName)}. Installing...`))
+    console.log(chalk.yellowBright(`Could not find ${chalk.bold(pluginName)}. Installing...`))
     await temporarilyInstallPluginWithNpx(pluginName)
   }
 }


### PR DESCRIPTION
### What and why?

Changed the console message color for plugin auto-installation from red to yellow-bright. The red color was misleading as it suggested an error when the message is actually informational, indicating that a plugin is being automatically installed.

Different color examples: 

![image.png](https://app.graphite.com/user-attachments/assets/64af5c68-c31e-446a-b7c9-868c5180f872.png)

Feel free to run it to see how it would look with your terminal colors:
```sh
node -e "
const chalk = require('chalk');
console.log(chalk.red('red:          Could not find @datadog/plugin-example. Installing...'));
console.log(chalk.yellow('yellow:       Could not find @datadog/plugin-example. Installing...'));
console.log(chalk.yellowBright('yellowBright: Could not find @datadog/plugin-example. Installing...'));"
```

### How?

Updated the chalk color method from `chalk.red()` to `chalk.yellowBright()` in the plugin auto-install handler to better reflect the informational nature of the message.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)