### PR TITLE
chore: add other serverless products to advanced-issue-labeler.yml

### DIFF
--- a/.github/advanced-issue-labeler.yml
+++ b/.github/advanced-issue-labeler.yml
@@ -29,7 +29,9 @@ policy:
               - unity-symbols
           - name: serverless
             keys:
+              - aas
               - cloud-run
+              - container-app
               - lambda
               - stepfunctions
           - name: source-code-integration


### PR DESCRIPTION
### What and why?

This PR adds `aas` and `container-app` as new keys to the serverless label configuration in the GitHub issue labeler. This enables automatic labeling of issues related to Azure App Service (aas) and Container Apps as serverless-related content.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)