### PR TITLE
[synthetics] Add batch ID to BatchTimeoutRunawayError (SYNTH-25024)

### DIFF
--- a/packages/plugin-synthetics/src/__tests__/batch.test.ts
+++ b/packages/plugin-synthetics/src/__tests__/batch.test.ts
@@ -929,7 +929,7 @@ describe('waitForResults', () => {
         },
         mockReporter
       )
-    ).rejects.toThrow(new BatchTimeoutRunawayError())
+    ).rejects.toThrow(new BatchTimeoutRunawayError('bid'))
 
     // Residual results are never 'received': we force-end them.
     expect(mockReporter.resultReceived).toHaveBeenCalledTimes(1)

--- a/packages/plugin-synthetics/src/batch.ts
+++ b/packages/plugin-synthetics/src/batch.ts
@@ -208,7 +208,7 @@ const waitForBatchToFinish = async (
     oldIncompleteResultIds = incompleteResultIds
 
     if (safeDeadlineReached) {
-      throw new BatchTimeoutRunawayError()
+      throw new BatchTimeoutRunawayError(batchId)
     }
 
     if (!shouldContinuePolling) {

--- a/packages/plugin-synthetics/src/errors.ts
+++ b/packages/plugin-synthetics/src/errors.ts
@@ -51,7 +51,10 @@ export class CriticalError extends CiError {
 }
 
 export class BatchTimeoutRunawayError extends CriticalError {
-  constructor() {
-    super('BATCH_TIMEOUT_RUNAWAY', "The batch didn't timeout after the expected timeout period.")
+  constructor(public batchId?: string) {
+    super(
+      'BATCH_TIMEOUT_RUNAWAY',
+      `The batch didn't timeout after the expected timeout period.${batchId ? ` Batch ID: ${batchId}` : ''}`
+    )
   }
 }


### PR DESCRIPTION
### What and why?

When a synthetics batch hits a timeout runaway error, the `BatchTimeoutRunawayError` didn't include the batch ID, making it difficult to debug in the synthetics-batch-smoke-tester.

### How?

- Added an optional `batchId` property to `BatchTimeoutRunawayError` and appended it to the error message
- Passed the `batchId` when throwing the error from the polling loop

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)