### PR TITLE
chore: auto-fix duplicate imports

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -285,6 +285,7 @@ export default defineConfig(
       'guard-for-in': 'error',
       'id-denylist': 'error',
       'id-match': 'error',
+      'import-x/no-duplicates': 'error',
       'import-x/no-unresolved': ['error', {ignore: ['node:sea']}],
       'import-x/no-extraneous-dependencies': 'error',
       'import-x/order': [

--- a/packages/base/src/commands/cloud-run/constants.ts
+++ b/packages/base/src/commands/cloud-run/constants.ts
@@ -1,5 +1,4 @@
-import {ENVIRONMENT_ENV_VAR, SERVICE_ENV_VAR} from '../../helpers/serverless/constants'
-import {SITE_ENV_VAR} from '../../helpers/serverless/constants'
+import {ENVIRONMENT_ENV_VAR, SERVICE_ENV_VAR, SITE_ENV_VAR} from '../../helpers/serverless/constants'
 
 export const SKIP_MASKING_CLOUDRUN_ENV_VARS = new Set([
   SITE_ENV_VAR,


### PR DESCRIPTION
### What and why?

This PR enables the `import-x/no-duplicates` ESLint rule to prevent duplicate import statements and consolidates duplicate imports

### How?

Updated the rules and then ran `yarn format`

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)