### PR TITLE
v5.9.0

### DIFF
--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-base",
-  "version": "5.8.0",
+  "version": "5.9.0",
   "description": "Base package for Datadog CI",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/datadog-ci/package.json
+++ b/packages/datadog-ci/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci",
-  "version": "5.8.0",
+  "version": "5.9.0",
   "description": "Use Datadog from your CI.",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-aas/package.json
+++ b/packages/plugin-aas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-aas",
-  "version": "5.8.0",
+  "version": "5.9.0",
   "description": "Datadog CI plugin for `aas` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-cloud-run/package.json
+++ b/packages/plugin-cloud-run/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-cloud-run",
-  "version": "5.8.0",
+  "version": "5.9.0",
   "description": "Datadog CI plugin for `cloud-run` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-container-app/package.json
+++ b/packages/plugin-container-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-container-app",
-  "version": "5.8.0",
+  "version": "5.9.0",
   "description": "Datadog CI plugin for `container-app` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-coverage/package.json
+++ b/packages/plugin-coverage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-coverage",
-  "version": "5.8.0",
+  "version": "5.9.0",
   "description": "Datadog CI plugin for `coverage` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-deployment/package.json
+++ b/packages/plugin-deployment/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-deployment",
-  "version": "5.8.0",
+  "version": "5.9.0",
   "description": "Datadog CI plugin for `deployment` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-dora/package.json
+++ b/packages/plugin-dora/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-dora",
-  "version": "5.8.0",
+  "version": "5.9.0",
   "description": "Datadog CI plugin for `dora` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-gate/package.json
+++ b/packages/plugin-gate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-gate",
-  "version": "5.8.0",
+  "version": "5.9.0",
   "description": "Datadog CI plugin for `gate` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-junit/package.json
+++ b/packages/plugin-junit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-junit",
-  "version": "5.8.0",
+  "version": "5.9.0",
   "description": "Datadog CI plugin for `junit` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-lambda/package.json
+++ b/packages/plugin-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-lambda",
-  "version": "5.8.0",
+  "version": "5.9.0",
   "description": "Datadog CI plugin for `lambda` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-sarif/package.json
+++ b/packages/plugin-sarif/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-sarif",
-  "version": "5.8.0",
+  "version": "5.9.0",
   "description": "Datadog CI plugin for `sarif` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-sbom/package.json
+++ b/packages/plugin-sbom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-sbom",
-  "version": "5.8.0",
+  "version": "5.9.0",
   "description": "Datadog CI plugin for `sbom` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-stepfunctions/package.json
+++ b/packages/plugin-stepfunctions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-stepfunctions",
-  "version": "5.8.0",
+  "version": "5.9.0",
   "description": "Datadog CI plugin for `stepfunctions` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-synthetics/package.json
+++ b/packages/plugin-synthetics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-synthetics",
-  "version": "5.8.0",
+  "version": "5.9.0",
   "description": "Datadog CI plugin for `synthetics` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-terraform/package.json
+++ b/packages/plugin-terraform/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-terraform",
-  "version": "5.8.0",
+  "version": "5.9.0",
   "description": "Datadog CI plugin for `terraform` commands",
   "license": "Apache-2.0",
   "keywords": [


### PR DESCRIPTION
<!-- Release notes generated using configuration in .github/release.yml at v5.9.0 -->

## What's Changed
### datadog-ci
* Add `ci-env read` subcommand to print extracted CI env info by @Bit-Doctor in https://github.com/DataDog/datadog-ci/pull/2123
* Add more directories to GitHub job name detection by @rodrigo-roca in https://github.com/DataDog/datadog-ci/pull/2127
* [IACP-673] Add terraform upload command for IaC artifact ingestion by @vishal-joshi-datadog in https://github.com/DataDog/datadog-ci/pull/2129
* Update release workflow to publish checksums of released binaries by @nikita-tkachenko-datadog in https://github.com/DataDog/datadog-ci/pull/2094
* chore: auto-fix duplicate imports by @ava-silver in https://github.com/DataDog/datadog-ci/pull/2140
### Dependencies
* [dep] Bump `ajv` to `8.18.0` by @Drarig29 in https://github.com/DataDog/datadog-ci/pull/2119
* [dep] Bump `tar` to `7.5.8` by @Drarig29 in https://github.com/DataDog/datadog-ci/pull/2120
* [dep] Bump `glob`, `minimatch@10.2.1` by @Drarig29 in https://github.com/DataDog/datadog-ci/pull/2121
* [dep] Bump `ajv-formats` to `3.0.1` by @Drarig29 in https://github.com/DataDog/datadog-ci/pull/2124
* [dep] Bump `@aws-sdk/credential-provider-ini`, `fast-xml-parser@5.3.6` by @Drarig29 in https://github.com/DataDog/datadog-ci/pull/2118
### Documentation
* docs(plugin-coverage): add file-fixes flags to README by @CarlosNietoP in https://github.com/DataDog/datadog-ci/pull/2128
### Software Delivery
* [chores] Move `measure`, `span` and `trace` to base package by @Drarig29 in https://github.com/DataDog/datadog-ci/pull/2105
* Add file fixes generation for code coverage uploads by @CarlosNietoP in https://github.com/DataDog/datadog-ci/pull/2125
### RUM
* [chores] Move `elf-symbols` and `unity-symbols` to base package by @Drarig29 in https://github.com/DataDog/datadog-ci/pull/2101
* [chores] Move `flutter-symbols` and `sourcemaps` to base package by @Drarig29 in https://github.com/DataDog/datadog-ci/pull/2102
* [chores] Move `react-native` to base package by @Drarig29 in https://github.com/DataDog/datadog-ci/pull/2104
### Serverless
* chore: Update Lambda layer versions by @gh-worker-engraver-d31c25[bot] in https://github.com/DataDog/datadog-ci/pull/2122
* chore: Update Lambda layer versions by @gh-worker-engraver-d31c25[bot] in https://github.com/DataDog/datadog-ci/pull/2131
* chore: Update Lambda layer versions by @gh-worker-engraver-d31c25[bot] in https://github.com/DataDog/datadog-ci/pull/2132
* [SVLS-8622] add web app slot support by @ava-silver in https://github.com/DataDog/datadog-ci/pull/2130
* chore: Update Lambda layer versions by @gh-worker-engraver-d31c25[bot] in https://github.com/DataDog/datadog-ci/pull/2139
### Static Analysis
* [K9VULN-11577] Support both canonical and legacy SBOM component property names in the datadog-ci by @cespio in https://github.com/DataDog/datadog-ci/pull/2138
### Synthetics
* [synthetics] Add batch ID to BatchTimeoutRunawayError (SYNTH-25024) by @AntoineDona in https://github.com/DataDog/datadog-ci/pull/2136
### Profiling
* [chores] Move `pe-symbols` to base package by @Drarig29 in https://github.com/DataDog/datadog-ci/pull/2103
### Chores
* [chores] Finalize plugin migration and clean up by @Drarig29 in https://github.com/DataDog/datadog-ci/pull/2106
* chore: make plugin install message yellow instead of red by @ava-silver in https://github.com/DataDog/datadog-ci/pull/2126
* chore: add other serverless products to advanced-issue-labeler.yml by @ava-silver in https://github.com/DataDog/datadog-ci/pull/2135

## New Contributors
* @gh-worker-engraver-d31c25[bot] made their first contribution in https://github.com/DataDog/datadog-ci/pull/2122
* @Bit-Doctor made their first contribution in https://github.com/DataDog/datadog-ci/pull/2123
* @vishal-joshi-datadog made their first contribution in https://github.com/DataDog/datadog-ci/pull/2129
* @cespio made their first contribution in https://github.com/DataDog/datadog-ci/pull/2138

**Full Changelog**: https://github.com/DataDog/datadog-ci/compare/v5.8.0...v5.9.0

[IACP-673]: https://datadoghq.atlassian.net/browse/IACP-673?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SVLS-8622]: https://datadoghq.atlassian.net/browse/SVLS-8622?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ