### PR TITLE
[chore] Remove obsolete `ref_protected` from STS trust policies

### DIFF
--- a/.github/chainguard/self.issue-labeler.sts.yaml
+++ b/.github/chainguard/self.issue-labeler.sts.yaml
@@ -5,7 +5,6 @@ subject: repo:DataDog/datadog-ci:ref:refs/heads/master
 claim_pattern:
   event_name: issues
   ref: refs/heads/master
-  ref_protected: "true"
   job_workflow_ref: DataDog/datadog-ci/\.github/workflows/issue-labeler\.yml@refs/heads/master
 
 # https://docs.github.com/en/rest/issues/labels?apiVersion=2022-11-28#add-labels-to-an-issue


### PR DESCRIPTION
## Summary

- Remove `ref_protected: "true"` from dd-octo-sts trust policy claim patterns

The `ref_protected` OIDC claim is now obsolete in the DataDog org:

- **GitHub**: The org-level "incompatible file paths on windows" push ruleset causes ALL branches to report `ref_protected: true` in OIDC tokens, making it useless as a security signal
- **GitLab**: All branches on `gitlab.ddbuild.io` report `ref_protected: true` due to org-level `pushAccessLevels: 40` config

Since the claim is universally `true`, it provides no actual filtering — only a false sense of security. Removing it has zero functional impact on policy enforcement.

All other constraints (subject, ref, job_workflow_ref, project_path, pipeline_source, etc.) remain unchanged and continue to provide the real security boundaries.

Ticket: https://datadoghq.atlassian.net/browse/SINT-4732

## Test plan

- [ ] Verify that the remaining policy constraints are sufficient (ref, job_workflow_ref, etc. are unchanged)
- [ ] No functional change expected since ref_protected was already always true

🤖 Generated with [Claude Code](https://claude.com/claude-code)
