### PR TITLE
[dep] Bump `basic-ftp` to `5.2.0`

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -5690,9 +5690,9 @@ __metadata:
   linkType: hard
 
 "basic-ftp@npm:^5.0.2":
-  version: 5.0.5
-  resolution: "basic-ftp@npm:5.0.5"
-  checksum: 10/3dc56b2092b10d67e84621f5b9bbb0430469499178e857869194184d46fbdd367a9aa9fad660084388744b074b5f540e6ac8c22c0826ebba4fcc86a9d1c324e2
+  version: 5.2.0
+  resolution: "basic-ftp@npm:5.2.0"
+  checksum: 10/f5a15d789aa98859af4da9e976154b2aeae19052e1762dc68d259d2bce631dafa40c667aa06d7346cd630aa6f9cc9a26f515b468e0bd24243fbae2149c7d01ad
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### What and why?

Fix dependabot alerts:
- https://github.com/DataDog/datadog-ci/security/dependabot/98

`basic-ftp < 5.2.0` (critical CVE).

The transitive chain is: `packages/base` → `proxy-agent` → `pac-proxy-agent` → `get-uri@6.0.3` → `basic-ftp@5.0.5`. Since `get-uri` uses `basic-ftp: ^5.0.2` (which allows 5.2.0), a lockfile-only resolution is sufficient.

### How?

Ran `yarn set resolution "basic-ftp@npm:^5.0.2" "npm:5.2.0"` to pin the lockfile to 5.2.0 without touching any `package.json` resolution fields.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)