### PR TITLE
[SYNTH-24187] Add `planDryRun` public API and `--dry-run` flag to `run-tests`

### DIFF
--- a/packages/base/src/commands/synthetics/run-tests.ts
+++ b/packages/base/src/commands/synthetics/run-tests.ts
@@ -131,6 +131,10 @@ export class SyntheticsRunTestsCommand extends BaseCommand {
     description: 'The build command to generate the assets to run the tests against.',
   })
 
+  public dryRun = Option.Boolean('--dryRun,--dry-run', {
+    description: 'List the tests that would be triggered without actually running them.',
+  })
+
   public async execute(): Promise<number | void> {
     return executePluginCommand(this)
   }

--- a/packages/plugin-synthetics/src/__tests__/fixtures.ts
+++ b/packages/plugin-synthetics/src/__tests__/fixtures.ts
@@ -48,6 +48,7 @@ export type MockedReporter = {
 }
 
 export const mockReporter: MainReporter = {
+  dryRunEnd: jest.fn(),
   error: jest.fn(),
   initErrors: jest.fn(),
   log: jest.fn(),
@@ -684,6 +685,7 @@ export const getMobileTestWithOverride = (appId: string): MobileTestWithOverride
   return {
     test: getMobileTest('abc-def-ghi', appId),
     overriddenConfig: getTestPayload(),
+    executionRule: ExecutionRule.BLOCKING,
   }
 }
 

--- a/packages/plugin-synthetics/src/__tests__/reporters/__snapshots__/default.test.ts.snap
+++ b/packages/plugin-synthetics/src/__tests__/reporters/__snapshots__/default.test.ts.snap
@@ -1,5 +1,105 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Default reporter dryRunEnd Simple case: 1 blocking test to trigger 1`] = `
+"[1mDry Run Summary:[22m
+• Would trigger [1m1[22m test
+• Fail on timeout: [1mtrue[22m
+• Fail on missing tests: [1mfalse[22m
+• Fail on critical errors: [1mfalse[22m
+• Batch timeout: [1m120000[22mms
+"
+`;
+
+exports[`Default reporter dryRunEnd With all config options 1`] = `
+"[1mDry Run Summary:[22m
+• Would trigger [1m1[22m test
+• Fail on timeout: [1mfalse[22m
+• Fail on missing tests: [1mtrue[22m
+• Fail on critical errors: [1mtrue[22m
+• Selective rerun: [1mtrue[22m
+• Tunnel: [1menabled[22m
+• Batch timeout: [1m120000[22mms
+"
+`;
+
+exports[`Default reporter dryRunEnd With default overrides 1`] = `
+"[1mDry Run Summary:[22m
+• Would trigger [1m1[22m test
+• Default overrides applied to all tests: [90mstartUrl, body[39m
+• Fail on timeout: [1mtrue[22m
+• Fail on missing tests: [1mfalse[22m
+• Fail on critical errors: [1mfalse[22m
+• Batch timeout: [1m120000[22mms
+"
+`;
+
+exports[`Default reporter dryRunEnd With onDemandConcurrencyCap set 1`] = `
+"[1mDry Run Summary:[22m
+• Would trigger [1m1[22m test
+• Fail on timeout: [1mtrue[22m
+• Fail on missing tests: [1mfalse[22m
+• Fail on critical errors: [1mfalse[22m
+• Batch timeout: [1m120000[22mms
+"
+`;
+
+exports[`Default reporter dryRunEnd With skipped tests 1`] = `
+"[1mDry Run Summary:[22m
+• Would trigger [1m2[22m tests
+• [1m1[22m skipped
+• Fail on timeout: [1mtrue[22m
+• Fail on missing tests: [1mfalse[22m
+• Fail on critical errors: [1mfalse[22m
+• Batch timeout: [1m120000[22mms
+"
+`;
+
+exports[`Default reporter dryRunEnd With tests not found and not authorized 1`] = `
+"[33m[1m1[22m test not found[39m [90m(aaa-aaa-aaa)[39m
+
+[31m[1m2[22m tests not authorized[39m [90m(bbb-bbb-bbb, ccc-ccc-ccc)[39m
+
+[1mDry Run Summary:[22m
+• Would trigger [1m1[22m test
+• Fail on timeout: [1mtrue[22m
+• Fail on missing tests: [1mfalse[22m
+• Fail on critical errors: [1mfalse[22m
+• Batch timeout: [1m120000[22mms
+"
+`;
+
+exports[`Default reporter dryRunEnd communicates N tests parallelization 1`] = `
+"[1mDry Run Summary:[22m
+• Would trigger [1m1[22m test
+• Fail on timeout: [1mtrue[22m
+• Fail on missing tests: [1mfalse[22m
+• Fail on critical errors: [1mfalse[22m
+• Batch timeout: [1m120000[22mms
+• Max parallelization configured: [1m3[22m tests running at the same time
+"
+`;
+
+exports[`Default reporter dryRunEnd communicates no parallelization (1 test at a time) 1`] = `
+"[1mDry Run Summary:[22m
+• Would trigger [1m1[22m test
+• Fail on timeout: [1mtrue[22m
+• Fail on missing tests: [1mfalse[22m
+• Fail on critical errors: [1mfalse[22m
+• Batch timeout: [1m120000[22mms
+• Max parallelization configured: [1m1[22m test running at the same time
+"
+`;
+
+exports[`Default reporter dryRunEnd does not communicate for uncapped orgs 1`] = `
+"[1mDry Run Summary:[22m
+• Would trigger [1m1[22m test
+• Fail on timeout: [1mtrue[22m
+• Fail on missing tests: [1mfalse[22m
+• Fail on critical errors: [1mfalse[22m
+• Batch timeout: [1m120000[22mms
+"
+`;
+
 exports[`Default reporter renderApiRequestDescription dns result 1`] = `"Query for example.org"`;
 
 exports[`Default reporter renderApiRequestDescription dns result 2`] = `"Query for example.org on server 1.2.3.4"`;

--- a/packages/plugin-synthetics/src/__tests__/reporters/default.test.ts
+++ b/packages/plugin-synthetics/src/__tests__/reporters/default.test.ts
@@ -16,15 +16,19 @@ import {
   ExecutionRule,
   MainReporter,
   Result,
+  RunTestsCommandConfig,
   SelectiveRerunDecision,
   ServerTest,
   Summary,
+  TestPlan,
   UserConfigOverride,
 } from '../../interfaces'
 import {DefaultReporter, renderApiRequestDescription} from '../../reporters/default'
 import {isTimedOutRetry} from '../../utils/internal'
+import {createInitialSummary, InitialSummary} from '../../utils/public'
 
 import {
+  ciConfig,
   getApiResult,
   getApiTest,
   getBrowserResult,
@@ -545,6 +549,98 @@ describe('Default reporter', () => {
       )
       const mostRecentOutput = writeMock.mock.calls[writeMock.mock.calls.length - 1][0]
       expect(mostRecentOutput).toMatchSnapshot()
+    })
+  })
+
+  describe('dryRunEnd', () => {
+    beforeEach(() => {
+      writeMock.mockClear()
+    })
+
+    const baseConfig: RunTestsCommandConfig = ciConfig
+
+    const makeTestPlan = (items: {executionRule: ExecutionRule}[]): TestPlan =>
+      items.map(({executionRule}) => ({
+        executionRule,
+        test: getApiTest(),
+        testOverrides: {public_id: getApiTest().public_id},
+      }))
+
+    const baseSummary: InitialSummary = createInitialSummary()
+
+    const cases: {description: string; summary: InitialSummary; testPlan: TestPlan; config: RunTestsCommandConfig}[] = [
+      {
+        description: 'Simple case: 1 blocking test to trigger',
+        summary: baseSummary,
+        testPlan: makeTestPlan([{executionRule: ExecutionRule.BLOCKING}]),
+        config: baseConfig,
+      },
+      {
+        description: 'With skipped tests',
+        summary: baseSummary,
+        testPlan: makeTestPlan([
+          {executionRule: ExecutionRule.BLOCKING},
+          {executionRule: ExecutionRule.BLOCKING},
+          {executionRule: ExecutionRule.SKIPPED},
+        ]),
+        config: baseConfig,
+      },
+      {
+        description: 'With tests not found and not authorized',
+        summary: {
+          ...baseSummary,
+          testsNotFound: new Set(['aaa-aaa-aaa']),
+          testsNotAuthorized: new Set(['bbb-bbb-bbb', 'ccc-ccc-ccc']),
+        },
+        testPlan: makeTestPlan([{executionRule: ExecutionRule.BLOCKING}]),
+        config: baseConfig,
+      },
+      {
+        description: 'With default overrides',
+        summary: baseSummary,
+        testPlan: makeTestPlan([{executionRule: ExecutionRule.BLOCKING}]),
+        config: {...baseConfig, defaultTestOverrides: {startUrl: 'https://example.org', body: 'payload'}},
+      },
+      {
+        description: 'With all config options',
+        summary: baseSummary,
+        testPlan: makeTestPlan([{executionRule: ExecutionRule.BLOCKING}]),
+        config: {
+          ...baseConfig,
+          batchTimeout: 120000,
+          failOnCriticalErrors: true,
+          failOnMissingTests: true,
+          failOnTimeout: false,
+          selectiveRerun: true,
+          tunnel: true,
+        },
+      },
+      {
+        description: 'With onDemandConcurrencyCap set',
+        summary: baseSummary,
+        testPlan: makeTestPlan([{executionRule: ExecutionRule.BLOCKING}]),
+        config: baseConfig,
+      },
+    ]
+
+    test.each(cases)('$description', ({summary, testPlan, config}) => {
+      reporter.dryRunEnd(summary, testPlan, config)
+      const output = writeMock.mock.calls.map((c) => c[0]).join('')
+      expect(output).toMatchSnapshot()
+    })
+
+    const onDemandConcurrencyCaps: {description: string; cap: number}[] = [
+      {cap: 0, description: 'does not communicate for uncapped orgs'},
+      {cap: 1, description: 'communicates no parallelization (1 test at a time)'},
+      {cap: 3, description: 'communicates N tests parallelization'},
+    ]
+
+    test.each(onDemandConcurrencyCaps)('$description', ({cap}) => {
+      reporter.dryRunEnd(baseSummary, makeTestPlan([{executionRule: ExecutionRule.BLOCKING}]), baseConfig, {
+        onDemandConcurrencyCap: cap,
+      })
+      const output = writeMock.mock.calls.map((c) => c[0]).join('')
+      expect(output).toMatchSnapshot()
     })
   })
 })

--- a/packages/plugin-synthetics/src/__tests__/run-tests-lib.test.ts
+++ b/packages/plugin-synthetics/src/__tests__/run-tests-lib.test.ts
@@ -39,9 +39,8 @@ describe('run-test', () => {
     test('should apply config override for tests triggered by public id', async () => {
       const getTestsToTriggersMock = jest.spyOn(testUtils, 'getTestsToTrigger').mockReturnValue(
         Promise.resolve({
+          testPlan: [],
           initialSummary: utils.createInitialSummary(),
-          overriddenTestsToTrigger: [],
-          tests: [],
         })
       )
       jest.spyOn(batchUtils, 'runTests').mockImplementation()
@@ -77,9 +76,8 @@ describe('run-test', () => {
     test('Use appropriate list of locations for tests triggered by public id', async () => {
       const getTestsToTriggersMock = jest.spyOn(testUtils, 'getTestsToTrigger').mockReturnValue(
         Promise.resolve({
+          testPlan: [],
           initialSummary: utils.createInitialSummary(),
-          overriddenTestsToTrigger: [],
-          tests: [],
         })
       )
 
@@ -109,9 +107,8 @@ describe('run-test', () => {
     test('should not wait for `skipped` only tests batch results', async () => {
       const getTestsToTriggersMock = jest.spyOn(testUtils, 'getTestsToTrigger').mockReturnValue(
         Promise.resolve({
+          testPlan: [],
           initialSummary: utils.createInitialSummary(),
-          overriddenTestsToTrigger: [],
-          tests: [],
         })
       )
 
@@ -142,9 +139,8 @@ describe('run-test', () => {
     test('should not open tunnel if no test to run', async () => {
       const getTestsToTriggersMock = jest.spyOn(testUtils, 'getTestsToTrigger').mockReturnValue(
         Promise.resolve({
+          testPlan: [],
           initialSummary: utils.createInitialSummary(),
-          overriddenTestsToTrigger: [],
-          tests: [],
         })
       )
 
@@ -185,9 +181,14 @@ describe('run-test', () => {
 
       jest.spyOn(testUtils, 'getTestsToTrigger').mockReturnValue(
         Promise.resolve({
+          testPlan: [
+            {
+              test: {options: {ci: {executionRule: ExecutionRule.BLOCKING}}, public_id: '123-456-789'} as any,
+              testOverrides: {} as any,
+              executionRule: ExecutionRule.BLOCKING,
+            },
+          ],
           initialSummary: utils.createInitialSummary(),
-          overriddenTestsToTrigger: [],
-          tests: [{options: {ci: {executionRule: ExecutionRule.BLOCKING}}, public_id: '123-456-789'} as any],
         })
       )
 
@@ -280,9 +281,14 @@ describe('run-test', () => {
     test('getTunnelPresignedURL throws', async () => {
       jest.spyOn(testUtils, 'getTestsToTrigger').mockReturnValue(
         Promise.resolve({
+          testPlan: [
+            {
+              test: {options: {ci: {executionRule: ExecutionRule.BLOCKING}}, public_id: 'publicId'} as any,
+              testOverrides: {} as any,
+              executionRule: ExecutionRule.BLOCKING,
+            },
+          ],
           initialSummary: utils.createInitialSummary(),
-          overriddenTestsToTrigger: [],
-          tests: [{options: {ci: {executionRule: ExecutionRule.BLOCKING}}, public_id: 'publicId'} as any],
         })
       )
 
@@ -308,6 +314,7 @@ describe('run-test', () => {
         Promise.resolve({
           overriddenConfig: {executionRule: ExecutionRule.NON_BLOCKING, public_id: mobileTest.public_id},
           test: mobileTest,
+          executionRule: ExecutionRule.NON_BLOCKING,
         })
       )
 
@@ -342,6 +349,7 @@ describe('run-test', () => {
         Promise.resolve({
           overriddenConfig: {executionRule: ExecutionRule.NON_BLOCKING, public_id: mobileTest.public_id},
           test: mobileTest,
+          executionRule: ExecutionRule.NON_BLOCKING,
         })
       )
 
@@ -381,9 +389,14 @@ describe('run-test', () => {
 
       jest.spyOn(testUtils, 'getTestsToTrigger').mockReturnValue(
         Promise.resolve({
+          testPlan: [
+            {
+              test: {options: {ci: {executionRule: ExecutionRule.BLOCKING}}, public_id: 'publicId'} as any,
+              testOverrides: {public_id: 'publicId'} as any,
+              executionRule: ExecutionRule.BLOCKING,
+            },
+          ],
           initialSummary: utils.createInitialSummary(),
-          overriddenTestsToTrigger: [],
-          tests: [{options: {ci: {executionRule: ExecutionRule.BLOCKING}}, public_id: 'publicId'} as any],
         })
       )
 
@@ -404,7 +417,7 @@ describe('run-test', () => {
       ).rejects.toThrow(
         new CriticalError(
           'TRIGGER_TESTS_FAILED',
-          '[] Failed to trigger tests: query on https://app.datadoghq.com/example returned: "Bad Gateway"\n'
+          '[publicId] Failed to trigger tests: query on https://app.datadoghq.com/example returned: "Bad Gateway"\n'
         )
       )
       expect(stopTunnelSpy).toHaveBeenCalledTimes(1)
@@ -423,9 +436,14 @@ describe('run-test', () => {
         .mockImplementation(async () => ({host: 'host', id: 'id', privateKey: 'key'}))
       const stopTunnelSpy = jest.spyOn(Tunnel.prototype, 'stop')
       jest.spyOn(testUtils, 'getTestsToTrigger').mockResolvedValue({
+        testPlan: [
+          {
+            test: {options: {ci: {executionRule: ExecutionRule.BLOCKING}}, public_id: 'publicId'} as any,
+            testOverrides: {} as any,
+            executionRule: ExecutionRule.BLOCKING,
+          },
+        ],
         initialSummary: utils.createInitialSummary(),
-        overriddenTestsToTrigger: [],
-        tests: [{options: {ci: {executionRule: ExecutionRule.BLOCKING}}, public_id: 'publicId'} as any],
       })
       jest.spyOn(batchUtils, 'runTests').mockResolvedValue({...mockTriggerInfo, locations: [location]})
 
@@ -457,9 +475,14 @@ describe('run-test', () => {
     test('log when selective rerun is rate-limited', async () => {
       jest.spyOn(testUtils, 'getTestsToTrigger').mockReturnValue(
         Promise.resolve({
+          testPlan: [
+            {
+              test: {options: {ci: {executionRule: ExecutionRule.BLOCKING}}, public_id: 'aaa-aaa-aaa'} as any,
+              testOverrides: {} as any,
+              executionRule: ExecutionRule.BLOCKING,
+            },
+          ],
           initialSummary: utils.createInitialSummary(),
-          overriddenTestsToTrigger: [],
-          tests: [{options: {ci: {executionRule: ExecutionRule.BLOCKING}}, public_id: 'aaa-aaa-aaa'} as any],
         })
       )
       jest.spyOn(batchUtils, 'runTests').mockImplementation(async () => ({
@@ -491,9 +514,14 @@ describe('run-test', () => {
     test('selective rerun defaults to undefined', async () => {
       jest.spyOn(testUtils, 'getTestsToTrigger').mockReturnValue(
         Promise.resolve({
+          testPlan: [
+            {
+              test: {options: {ci: {executionRule: ExecutionRule.BLOCKING}}, public_id: 'aaa-aaa-aaa'} as any,
+              testOverrides: {} as any,
+              executionRule: ExecutionRule.BLOCKING,
+            },
+          ],
           initialSummary: utils.createInitialSummary(),
-          overriddenTestsToTrigger: [],
-          tests: [{options: {ci: {executionRule: ExecutionRule.BLOCKING}}, public_id: 'aaa-aaa-aaa'} as any],
         })
       )
 
@@ -513,7 +541,7 @@ describe('run-test', () => {
       })
 
       expect(triggerTestsSpy).toHaveBeenCalledWith({
-        tests: [],
+        tests: expect.any(Array),
         options: {
           batch_timeout: ciConfig.batchTimeout,
           selective_rerun: undefined,
@@ -549,6 +577,8 @@ describe('run-test', () => {
       expect(runTests.executeTests).toHaveBeenCalledWith(
         expect.anything(),
         expect.objectContaining(runConfig),
+        undefined,
+        undefined,
         undefined
       )
     })
@@ -559,7 +589,9 @@ describe('run-test', () => {
       expect(runTests.executeTests).toHaveBeenCalledWith(
         expect.anything(),
         expect.objectContaining({files: []}),
-        suites
+        suites,
+        undefined,
+        undefined
       )
     })
 
@@ -1008,5 +1040,60 @@ describe('run-test', () => {
         },
       ])
     })
+  })
+})
+
+describe('filterTestPlan', () => {
+  const makeItem = (publicId: string, executionRule: ExecutionRule) => ({
+    test: {public_id: publicId} as any,
+    testOverrides: {} as any,
+    executionRule,
+  })
+
+  const blocking = makeItem('aaa', ExecutionRule.BLOCKING)
+  const nonBlocking = makeItem('bbb', ExecutionRule.NON_BLOCKING)
+  const skipped = makeItem('ccc', ExecutionRule.SKIPPED)
+
+  const makeSummary = (overrides = {}) => ({
+    ...utils.createInitialSummary(),
+    testsNotFound: new Set(['missing-test']),
+    testsNotAuthorized: new Set(['forbidden-test']),
+    skipped: 1,
+    ...overrides,
+  })
+
+  test('filters items by predicate', () => {
+    const {testPlan} = utils.filterTestPlan(
+      [blocking, nonBlocking, skipped],
+      makeSummary(),
+      (item) => item.executionRule === ExecutionRule.BLOCKING
+    )
+    expect(testPlan).toEqual([blocking])
+  })
+
+  test('adjusts skipped count based on filtered plan', () => {
+    const {initialSummary} = utils.filterTestPlan(
+      [blocking, skipped],
+      makeSummary({skipped: 1}),
+      (item) => item.executionRule !== ExecutionRule.SKIPPED
+    )
+    expect(initialSummary.skipped).toBe(0)
+  })
+
+  test('preserves testsNotFound and testsNotAuthorized', () => {
+    const original = makeSummary()
+    const {initialSummary} = utils.filterTestPlan(
+      [blocking, nonBlocking],
+      original,
+      (item) => item.executionRule === ExecutionRule.BLOCKING
+    )
+    expect(initialSummary.testsNotFound).toBe(original.testsNotFound)
+    expect(initialSummary.testsNotAuthorized).toBe(original.testsNotAuthorized)
+  })
+
+  test('returns empty plan when no items match', () => {
+    const {testPlan, initialSummary} = utils.filterTestPlan([blocking, nonBlocking], makeSummary(), () => false)
+    expect(testPlan).toEqual([])
+    expect(initialSummary.skipped).toBe(0)
   })
 })

--- a/packages/plugin-synthetics/src/__tests__/test.test.ts
+++ b/packages/plugin-synthetics/src/__tests__/test.test.ts
@@ -95,10 +95,10 @@ describe('getTestsToTrigger', () => {
       {suite: 'Suite 2', id: '987-654-321'},
       {suite: 'Suite 3', id: 'ski-ppe-d01'},
     ]
-    const {tests, overriddenTestsToTrigger, initialSummary} = await getTestsToTrigger(api, triggerConfigs, mockReporter)
+    const {testPlan, initialSummary} = await getTestsToTrigger(api, triggerConfigs, mockReporter)
 
-    expect(tests).toStrictEqual([fakeTests['123-456-789']])
-    expect(overriddenTestsToTrigger).toStrictEqual([
+    expect(testPlan.map((item) => item.test)).toStrictEqual([fakeTests['123-456-789'], fakeTests['ski-ppe-d01']])
+    expect(testPlan.map((item) => item.testOverrides)).toStrictEqual([
       {public_id: '123-456-789', version: undefined},
       {public_id: 'ski-ppe-d01', version: undefined},
     ])
@@ -142,7 +142,9 @@ describe('getTestsToTrigger', () => {
     test('trim and warn if from search', async () => {
       const tooManyTests = Array(MAX_TESTS_TO_TRIGGER + 10).fill({id: 'stu-vwx-yza'})
       const tests = await getTestsToTrigger(fakeApi, tooManyTests, mockReporter, true)
-      expect(tests.tests.length).toBe(MAX_TESTS_TO_TRIGGER)
+      expect(tests.testPlan.filter((item) => item.executionRule !== ExecutionRule.SKIPPED).length).toBe(
+        MAX_TESTS_TO_TRIGGER
+      )
       expect(mockReporter.initErrors).toMatchSnapshot()
     })
 
@@ -156,7 +158,9 @@ describe('getTestsToTrigger', () => {
     test('does not account for skipped/not found tests outside of search', async () => {
       const tooManyTests = [...Array(MAX_TESTS_TO_TRIGGER).fill({id: 'stu-vwx-yza'}), {id: 'skipped'}, {id: 'missing'}]
       const tests = await getTestsToTrigger(fakeApi, tooManyTests, mockReporter, true)
-      expect(tests.tests.length).toBe(MAX_TESTS_TO_TRIGGER)
+      expect(tests.testPlan.filter((item) => item.executionRule !== ExecutionRule.SKIPPED).length).toBe(
+        MAX_TESTS_TO_TRIGGER
+      )
     })
   })
 

--- a/packages/plugin-synthetics/src/commands/run-tests.ts
+++ b/packages/plugin-synthetics/src/commands/run-tests.ts
@@ -17,7 +17,7 @@ import {CiError} from '../errors'
 import {MainReporter, Reporter, Result, RunTestsCommandConfig, Summary} from '../interfaces'
 import {DefaultReporter} from '../reporters/default'
 import {JUnitReporter} from '../reporters/junit'
-import {executeTests, getDefaultConfig} from '../run-tests-lib'
+import {planDryRun, executeTests, getDefaultConfig} from '../run-tests-lib'
 import {RecursivePartial, toExecutionRule, validateAndParseOverrides} from '../utils/internal'
 import {getExitReason, getOrgSettings, renderResults, toExitCode, reportExitLogs, getReporter} from '../utils/public'
 
@@ -87,6 +87,22 @@ export class PluginCommand extends SyntheticsRunTestsCommand {
     let results: Result[]
     let summary: Summary
 
+    const orgSettings = await getOrgSettings(this.reporter, this.config)
+
+    if (this.dryRun) {
+      try {
+        const {testPlan, initialSummary} = await planDryRun(this.reporter, this.config)
+
+        this.reporter.dryRunEnd(initialSummary, testPlan, this.config, orgSettings)
+      } catch (error) {
+        reportExitLogs(this.reporter, this.config, {error})
+
+        return toExitCode(getExitReason(this.config, {error}))
+      }
+
+      return 0
+    }
+
     let teardown = async () => {}
 
     const [_, command] = this.path ?? []
@@ -122,8 +138,6 @@ export class PluginCommand extends SyntheticsRunTestsCommand {
     } finally {
       await teardown()
     }
-
-    const orgSettings = await getOrgSettings(this.reporter, this.config)
 
     renderResults({
       config: this.config,

--- a/packages/plugin-synthetics/src/index.ts
+++ b/packages/plugin-synthetics/src/index.ts
@@ -5,7 +5,7 @@ export * from './interfaces'
 export {DefaultReporter} from './reporters/default'
 export {JUnitReporter} from './reporters/junit'
 export type {XMLJSON} from './reporters/junit'
-export {executeTests, execute, executeWithDetails} from './run-tests-lib'
+export {executeTests, execute, executeWithDetails, planDryRun} from './run-tests-lib'
 export * as utils from './utils/public'
 
 export const DEFAULT_COMMAND_CONFIG = getDefaultConfig()

--- a/packages/plugin-synthetics/src/interfaces.ts
+++ b/packages/plugin-synthetics/src/interfaces.ts
@@ -1,5 +1,7 @@
 import {Writable} from 'stream'
 
+import type {InitialSummary} from './utils/public'
+
 import {Metadata} from '@datadog/datadog-ci-base/helpers/interfaces'
 import {ProxyConfiguration} from '@datadog/datadog-ci-base/helpers/utils'
 
@@ -19,6 +21,12 @@ export interface MainReporter {
   resultEnd(result: Result, baseUrl: string, batchId: string): void
   reportStart(timings: {startTime: number}): void
   runEnd(summary: Summary, baseUrl: string, orgSettings?: SyntheticsOrgSettings): void
+  dryRunEnd(
+    summary: InitialSummary,
+    testPlan: TestPlan,
+    config: RunTestsCommandConfig,
+    orgSettings?: SyntheticsOrgSettings
+  ): void
 }
 
 export interface ReporterContext {
@@ -202,6 +210,17 @@ export interface Summary {
   /** The number of results that failed due to the CI batch timing out. */
   timedOut: number // XXX: When a batch times out, all the results that were in progress are timed out.
 }
+
+export interface TestPlanItem {
+  /** The execution rule to apply to the test. This is read-only and only here for filtering purposes. To apply overrides, you may edit the `testOverrides`. */
+  executionRule: Readonly<ExecutionRule>
+  /** The definition of the test to run. This is read-only and only here for filtering purposes. To apply overrides, you may edit the `testOverrides`. */
+  test: Readonly<Test>
+  /** The overrides to apply to the test. You can edit this to alter the test plan. */
+  testOverrides: TestPayload
+}
+
+export type TestPlan = TestPlanItem[]
 
 // Note: This is exposed in CI integrations as a JSON-encoded string in the `rawResults` output.
 export interface BaseResult {
@@ -633,12 +652,15 @@ export interface TestMissing {
 }
 
 export interface TestSkipped {
+  test: Test
   overriddenConfig: TestPayload
+  executionRule: ExecutionRule.SKIPPED
 }
 
 export interface TestWithOverride {
   test: Test
   overriddenConfig: TestPayload
+  executionRule: ExecutionRule
 }
 
 export interface MobileTestWithOverride extends TestWithOverride {

--- a/packages/plugin-synthetics/src/reporters/default.ts
+++ b/packages/plugin-synthetics/src/reporters/default.ts
@@ -20,6 +20,8 @@ import {
   ResultInBatch,
   TestRequest,
   ReporterContext,
+  RunTestsCommandConfig,
+  TestPlan,
 } from '../interfaces'
 import {isBaseResult, isTimedOutRetry, getPublicIdOrPlaceholder} from '../utils/internal'
 import {
@@ -33,6 +35,7 @@ import {
   pluralize,
   readableOperation,
   ResultOutcome,
+  InitialSummary,
 } from '../utils/public'
 
 import {ICONS} from './constants'
@@ -398,6 +401,74 @@ export class DefaultReporter implements MainReporter {
 
   public resultReceived(result: ResultInBatch): void {
     return
+  }
+
+  public dryRunEnd(
+    summary: InitialSummary,
+    testPlan: TestPlan,
+    config: RunTestsCommandConfig,
+    orgSettings?: SyntheticsOrgSettings
+  ) {
+    const {bold: b, gray, red, yellow} = chalk
+
+    const lines: string[] = []
+
+    if (summary.testsNotFound.size > 0) {
+      const testsNotFoundListStr = gray(`(${[...summary.testsNotFound].join(', ')})`)
+      lines.push(
+        `${yellow(
+          `${b(summary.testsNotFound.size)} ${pluralize('test', summary.testsNotFound.size)} not found`
+        )} ${testsNotFoundListStr}\n`
+      )
+    }
+
+    if (summary.testsNotAuthorized.size > 0) {
+      const testsNotAuthorizedListStr = gray(`(${[...summary.testsNotAuthorized].join(', ')})`)
+      lines.push(
+        `${red(
+          `${b(summary.testsNotAuthorized.size)} ${pluralize('test', summary.testsNotAuthorized.size)} not authorized`
+        )} ${testsNotAuthorizedListStr}\n`
+      )
+    }
+
+    const testsToTriggerCount = testPlan.filter((item) => item.executionRule !== ExecutionRule.SKIPPED).length
+    lines.push(`${b('Dry Run Summary:')}`)
+    lines.push(`• Would trigger ${b(testsToTriggerCount)} ${pluralize('test', testsToTriggerCount)}`)
+
+    const skippedCount = testPlan.filter((item) => item.executionRule === ExecutionRule.SKIPPED).length
+    if (skippedCount) {
+      lines.push(`• ${b(skippedCount)} skipped`)
+    }
+
+    if (config.defaultTestOverrides) {
+      const defaultOverrideKeys = Object.keys(config.defaultTestOverrides)
+      if (defaultOverrideKeys.length > 0) {
+        lines.push(`• Default overrides applied to all tests: ${gray(defaultOverrideKeys.join(', '))}`)
+      }
+    }
+
+    if (config) {
+      const {batchTimeout, failOnCriticalErrors, failOnMissingTests, failOnTimeout, selectiveRerun, tunnel} = config
+      lines.push(`• Fail on timeout: ${b(failOnTimeout)}`)
+      lines.push(`• Fail on missing tests: ${b(failOnMissingTests)}`)
+      lines.push(`• Fail on critical errors: ${b(failOnCriticalErrors)}`)
+      if (selectiveRerun !== undefined) {
+        lines.push(`• Selective rerun: ${b(selectiveRerun)}`)
+      }
+      if (tunnel) {
+        lines.push(`• Tunnel: ${b('enabled')}`)
+      }
+      if (batchTimeout !== undefined) {
+        lines.push(`• Batch timeout: ${b(batchTimeout)}ms`)
+      }
+    }
+
+    if (orgSettings && orgSettings.onDemandConcurrencyCap > 0) {
+      const cap = orgSettings.onDemandConcurrencyCap
+      lines.push(`• Max parallelization configured: ${b(cap)} ${pluralize('test', cap)} running at the same time`)
+    }
+
+    this.write(lines.join('\n') + '\n')
   }
 
   public runEnd(summary: Summary, baseUrl: string, orgSettings?: SyntheticsOrgSettings) {

--- a/packages/plugin-synthetics/src/run-tests-lib.ts
+++ b/packages/plugin-synthetics/src/run-tests-lib.ts
@@ -6,6 +6,7 @@ import {APIHelper, getApiHelper, isForbiddenError} from './api'
 import {DEFAULT_BATCH_TIMEOUT, runTests, waitForResults} from './batch'
 import {CiError, CriticalError, BatchTimeoutRunawayError} from './errors'
 import {
+  ExecutionRule,
   MainReporter,
   Reporter,
   Result,
@@ -15,6 +16,7 @@ import {
   SupportedReporter,
   Test,
   TestPayload,
+  TestPlan,
   TriggerConfig,
   TriggerInfo,
   WrapperConfig,
@@ -27,11 +29,13 @@ import {Tunnel} from './tunnel'
 import {
   getDefaultConfig as getDefaultConfigBase,
   getTriggerConfigPublicId,
+  isLocalTestPayload,
   isLocalTriggerConfig,
 } from './utils/internal'
 import {
   getReporter,
   getOrgSettings,
+  createInitialSummary,
   InitialSummary,
   parsePublicIdWithVersion,
   renderResults,
@@ -41,10 +45,12 @@ import {
 } from './utils/public'
 
 type ExecuteOptions = {
+  initialSummary?: InitialSummary
   jUnitReport?: string
   reporters?: (SupportedReporter | Reporter)[]
   runId?: string
   suites?: Suite[]
+  testPlan?: TestPlan
 }
 
 export const getDefaultConfig = (): RunTestsCommandConfig => {
@@ -67,14 +73,15 @@ export const getDefaultConfig = (): RunTestsCommandConfig => {
 export const executeTests = async (
   reporter: MainReporter,
   config: RunTestsCommandConfig,
-  suites?: Suite[]
+  suites?: Suite[],
+  testPlan?: TestPlan,
+  providedInitialSummary?: InitialSummary
 ): Promise<{
   results: Result[]
   summary: Summary
 }> => {
   const api = getApiHelper(config)
   let tunnel: Tunnel | undefined
-  let triggerConfigs: TriggerConfig[] = []
 
   const stopTunnel = async () => {
     if (tunnel) {
@@ -82,49 +89,59 @@ export const executeTests = async (
     }
   }
 
-  try {
-    triggerConfigs = await getTriggerConfigs(api, config, reporter, suites)
-  } catch (error) {
-    throw new CriticalError(isForbiddenError(error) ? 'AUTHORIZATION_ERROR' : 'UNAVAILABLE_TEST_CONFIG', error.message)
-  }
+  let hasLTD: boolean
+  let tests: Test[]
+  let overriddenTestsToTrigger: TestPayload[]
+  let initialSummary: InitialSummary
 
-  let hasLTD = false
-  for (const triggerConfig of triggerConfigs) {
-    if (isLocalTriggerConfig(triggerConfig)) {
-      hasLTD = true
-      break
-    }
-  }
+  if (testPlan) {
+    overriddenTestsToTrigger = testPlan.map((item) => item.testOverrides)
+    tests = testPlan.filter((item) => item.executionRule !== ExecutionRule.SKIPPED).map((item) => item.test)
+    initialSummary = providedInitialSummary ?? createInitialSummary()
+    hasLTD = overriddenTestsToTrigger.some(isLocalTestPayload)
+  } else {
+    let triggerConfigs: TriggerConfig[] = []
 
-  if (triggerConfigs.length === 0) {
-    throw new CiError('NO_TESTS_TO_RUN')
-  }
-
-  let testsToTriggerResult: {
-    initialSummary: InitialSummary
-    overriddenTestsToTrigger: TestPayload[]
-    tests: Test[]
-  }
-
-  try {
-    const triggerFromSearch = !!config.testSearchQuery
-    testsToTriggerResult = await getTestsToTrigger(
-      api,
-      triggerConfigs,
-      reporter,
-      triggerFromSearch,
-      config.failOnMissingTests,
-      config.tunnel
-    )
-  } catch (error) {
-    if (error instanceof CiError) {
-      throw error
+    try {
+      triggerConfigs = await getTriggerConfigs(api, config, reporter, suites)
+    } catch (error) {
+      throw new CriticalError(
+        isForbiddenError(error) ? 'AUTHORIZATION_ERROR' : 'UNAVAILABLE_TEST_CONFIG',
+        error.message
+      )
     }
 
-    throw new CriticalError(isForbiddenError(error) ? 'AUTHORIZATION_ERROR' : 'UNAVAILABLE_TEST_CONFIG', error.message)
-  }
+    hasLTD = triggerConfigs.some(isLocalTriggerConfig)
 
-  const {tests, overriddenTestsToTrigger, initialSummary} = testsToTriggerResult
+    if (triggerConfigs.length === 0) {
+      throw new CiError('NO_TESTS_TO_RUN')
+    }
+
+    try {
+      const triggerFromSearch = !!config.testSearchQuery
+      let resolvedTestPlan: TestPlan
+      ;({testPlan: resolvedTestPlan, initialSummary} = await getTestsToTrigger(
+        api,
+        triggerConfigs,
+        reporter,
+        triggerFromSearch,
+        config.failOnMissingTests,
+        config.tunnel
+      ))
+      overriddenTestsToTrigger = resolvedTestPlan.map((item) => item.testOverrides)
+      tests = resolvedTestPlan.filter((item) => item.executionRule !== ExecutionRule.SKIPPED).map((item) => item.test)
+      hasLTD = overriddenTestsToTrigger.some(isLocalTestPayload)
+    } catch (error) {
+      if (error instanceof CiError) {
+        throw error
+      }
+
+      throw new CriticalError(
+        isForbiddenError(error) ? 'AUTHORIZATION_ERROR' : 'UNAVAILABLE_TEST_CONFIG',
+        error.message
+      )
+    }
+  }
 
   // All tests have been skipped or are missing.
   if (!tests.length) {
@@ -306,9 +323,52 @@ export const getTriggerConfigs = async (
   return triggerConfigsWithId.concat(localTriggerConfigsWithoutId)
 }
 
+export const planDryRun = async (
+  reporter: MainReporter,
+  runConfig: WrapperConfig,
+  suites?: Suite[]
+): Promise<{testPlan: TestPlan; initialSummary: InitialSummary}> => {
+  const config = {
+    ...getDefaultConfig(),
+    ...runConfig,
+  }
+  const api = getApiHelper(config)
+  let triggerConfigs: TriggerConfig[]
+
+  try {
+    triggerConfigs = await getTriggerConfigs(api, config, reporter, suites)
+  } catch (error) {
+    throw new CriticalError(isForbiddenError(error) ? 'AUTHORIZATION_ERROR' : 'UNAVAILABLE_TEST_CONFIG', error.message)
+  }
+
+  if (triggerConfigs.length === 0) {
+    throw new CiError('NO_TESTS_TO_RUN')
+  }
+
+  try {
+    const triggerFromSearch = !!config.testSearchQuery
+    const {testPlan, initialSummary} = await getTestsToTrigger(
+      api,
+      triggerConfigs,
+      reporter,
+      triggerFromSearch,
+      config.failOnMissingTests,
+      false
+    )
+
+    return {testPlan, initialSummary}
+  } catch (error) {
+    if (error instanceof CiError) {
+      throw error
+    }
+
+    throw new CriticalError(isForbiddenError(error) ? 'AUTHORIZATION_ERROR' : 'UNAVAILABLE_TEST_CONFIG', error.message)
+  }
+}
+
 export const executeWithDetails = async (
   runConfig: WrapperConfig,
-  {jUnitReport, reporters, runId, suites}: ExecuteOptions
+  {initialSummary, jUnitReport, reporters, runId, suites, testPlan}: ExecuteOptions
 ): Promise<{
   results: Result[]
   summary: Summary
@@ -348,7 +408,7 @@ export const executeWithDetails = async (
   }
 
   const mainReporter = getReporter(localReporters)
-  const {results, summary} = await executeTests(mainReporter, localConfig, suites)
+  const {results, summary} = await executeTests(mainReporter, localConfig, suites, testPlan, initialSummary)
 
   const orgSettings = await getOrgSettings(mainReporter, localConfig)
 

--- a/packages/plugin-synthetics/src/test.ts
+++ b/packages/plugin-synthetics/src/test.ts
@@ -15,7 +15,7 @@ import {
   TestMissing,
   TestSkipped,
   TestWithOverride,
-  TestPayload,
+  TestPlanItem,
   DeployTestsCommandConfig,
 } from './interfaces'
 import {uploadMobileApplicationsAndUpdateOverrideConfigs} from './mobile'
@@ -138,19 +138,12 @@ export const getTestsToTrigger = async (
     testsAndConfigsOverride.filter(isMobileTestWithOverride)
   )
 
-  const overriddenTestsToTrigger: TestPayload[] = []
-  const waitedTests: Test[] = []
+  const testPlan: TestPlanItem[] = []
   testsAndConfigsOverride.forEach((item) => {
     if ('errorMessage' in item) {
       errorMessages.push(item.errorMessage)
-    }
-
-    if ('overriddenConfig' in item) {
-      overriddenTestsToTrigger.push(item.overriddenConfig)
-    }
-
-    if ('test' in item) {
-      waitedTests.push(item.test)
+    } else {
+      testPlan.push({test: item.test, testOverrides: item.overriddenConfig, executionRule: item.executionRule})
     }
   })
 
@@ -167,16 +160,16 @@ export const getTestsToTrigger = async (
     throw new CiError('UNAUTHORIZED_TESTS', testsNotAuthorizedListStr)
   }
 
-  if (!overriddenTestsToTrigger.length) {
+  if (!testPlan.length) {
     throw new CiError('NO_TESTS_TO_RUN')
-  } else if (overriddenTestsToTrigger.length > MAX_TESTS_TO_TRIGGER) {
+  } else if (testPlan.length > MAX_TESTS_TO_TRIGGER) {
     throw new CriticalError(
       'TOO_MANY_TESTS_TO_TRIGGER',
       `Cannot trigger more than ${MAX_TESTS_TO_TRIGGER} tests (received ${triggerConfigs.length})`
     )
   }
 
-  return {tests: waitedTests, overriddenTestsToTrigger, initialSummary}
+  return {testPlan, initialSummary}
 }
 
 export const getTestAndOverrideConfig = async (
@@ -215,7 +208,7 @@ export const getTestAndOverrideConfig = async (
   if (executionRule === ExecutionRule.SKIPPED) {
     summary.skipped++
 
-    return {overriddenConfig}
+    return {test, overriddenConfig, executionRule: ExecutionRule.SKIPPED}
   }
   reporter.testWait(test)
 
@@ -240,7 +233,7 @@ export const getTestAndOverrideConfig = async (
     )
   }
 
-  return {test, overriddenConfig}
+  return {test, overriddenConfig, executionRule}
 }
 
 const getTest = async (

--- a/packages/plugin-synthetics/src/utils/internal.ts
+++ b/packages/plugin-synthetics/src/utils/internal.ts
@@ -111,11 +111,11 @@ export const isTimedOutRetry = (
 }
 
 export const isLocalTriggerConfig = (triggerConfig?: TriggerConfig): triggerConfig is LocalTriggerConfig => {
-  return triggerConfig ? 'localTestDefinition' in triggerConfig : false
+  return !!triggerConfig && 'localTestDefinition' in triggerConfig
 }
 
 export const isLocalTestPayload = (testPayload: TestPayload): testPayload is LocalTestPayload => {
-  return testPayload ? 'local_test_definition' in testPayload : false
+  return !!testPayload && 'local_test_definition' in testPayload
 }
 
 export const isBrowserServerResult = (serverResult: ServerResult): serverResult is BrowserServerResult => {

--- a/packages/plugin-synthetics/src/utils/internal.ts
+++ b/packages/plugin-synthetics/src/utils/internal.ts
@@ -23,6 +23,7 @@ import {
   TestWithOverride,
   TriggerConfig,
   UserConfigOverride,
+  LocalTestPayload,
 } from '../interfaces'
 
 import {getStrictestExecutionRule, isResultSkippedBySelectiveRerun} from './public'
@@ -111,6 +112,10 @@ export const isTimedOutRetry = (
 
 export const isLocalTriggerConfig = (triggerConfig?: TriggerConfig): triggerConfig is LocalTriggerConfig => {
   return triggerConfig ? 'localTestDefinition' in triggerConfig : false
+}
+
+export const isLocalTestPayload = (testPayload: TestPayload): testPayload is LocalTestPayload => {
+  return testPayload ? 'local_test_definition' in testPayload : false
 }
 
 export const isBrowserServerResult = (serverResult: ServerResult): serverResult is BrowserServerResult => {

--- a/packages/plugin-synthetics/src/utils/public.ts
+++ b/packages/plugin-synthetics/src/utils/public.ts
@@ -25,6 +25,8 @@ import {
   SyntheticsOrgSettings,
   Test,
   TestPayload,
+  TestPlan,
+  TestPlanItem,
   TriggerConfig,
   UserConfigOverride,
 } from '../interfaces'
@@ -295,6 +297,13 @@ export const getReporter = (reporters: Reporter[]): MainReporter => ({
     for (const reporter of reporters) {
       if (typeof reporter.resultReceived === 'function') {
         reporter.resultReceived(result)
+      }
+    }
+  },
+  dryRunEnd: (summary, testPlan, config, orgSettings) => {
+    for (const reporter of reporters) {
+      if (typeof reporter.dryRunEnd === 'function') {
+        reporter.dryRunEnd(summary, testPlan, config, orgSettings)
       }
     }
   },
@@ -610,5 +619,21 @@ export const reportCiError = (error: CiError, reporter: MainReporter) => {
 
     default:
       reporter.error(`\n${chalk.bgRed.bold(' ERROR ')}\n${error.message}\n\n`)
+  }
+}
+
+export const filterTestPlan = (
+  testPlan: TestPlan,
+  initialSummary: InitialSummary,
+  predicate: (item: TestPlanItem) => boolean
+): {testPlan: TestPlan; initialSummary: InitialSummary} => {
+  const filteredPlan = testPlan.filter(predicate)
+
+  return {
+    testPlan: filteredPlan,
+    initialSummary: {
+      ...initialSummary,
+      skipped: filteredPlan.filter((item) => item.executionRule === ExecutionRule.SKIPPED).length,
+    },
   }
 }


### PR DESCRIPTION
### What and why?

Exposes test planning as a public library API so callers can inspect what would be triggered before (or instead of) running.

- **`planDryRun`**: New public function that resolves the test plan (tests, overrides, execution rules) without running anything. Exported from `index.ts`.
- **`--dry-run` flag**: When passed to `run-tests`, calls `planDryRun` and prints a human-readable summary via the new `dryRunEnd` reporter method.
- **`TestPlan` / `TestPlanItem`**: New exported types representing the resolved plan. Each item carries `test`, `testOverrides`, and `executionRule`.
- **`filterTestPlan`**: New public utility to filter a plan while keeping `initialSummary` in sync — useful for callers who want to customize what gets run before calling `executeTests`.
- **`executeTests` / `executeWithDetails`**: Accept an optional pre-resolved `testPlan` and `initialSummary` to skip re-fetching when planning and executing separately.

### How?

`planDryRun` reuses the existing `getTriggerConfigs` + `getTestsToTrigger` pipeline and returns `{testPlan, initialSummary}`. `executeTests` was updated to accept an optional `testPlan`; when provided it skips the fetch phase and goes straight to triggering. `TestSkipped` and `TestWithOverride` were extended with `executionRule` so callers have full context.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)