### PR TITLE
chore: support local integration testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,7 @@ typings/
 
 # dotenv environment variables file
 .env
+e2e/.env.local
 
 # next.js build output
 .next

--- a/e2e/helpers/exec.ts
+++ b/e2e/helpers/exec.ts
@@ -7,8 +7,8 @@ export interface ExecResult {
 }
 
 // In CI the synthetic project installs @datadog/datadog-ci from artifact
-// tarballs, so `yarn datadog-ci` works. Locally, `yarn launch` runs from
-// source via tsx. Override with DATADOG_CI_COMMAND env var.
+// tarballs, so `yarn datadog-ci` works. Locally, create an e2e/.env.local
+// file with DATADOG_CI_COMMAND='yarn launch' to run from source via tsx.
 export const DATADOG_CI_COMMAND = process.env.DATADOG_CI_COMMAND ?? 'yarn datadog-ci'
 
 export const execPromise = async (command: string, env?: Record<string, string | undefined>): Promise<ExecResult> => {

--- a/jest.config-e2e.mjs
+++ b/jest.config-e2e.mjs
@@ -1,6 +1,18 @@
 // For a detailed explanation regarding each configuration property, visit:
 // https://jestjs.io/docs/en/configuration.html
 
+import {readFileSync} from 'node:fs'
+
+// Load e2e/.env.local if it exists (gitignored, for local overrides)
+try {
+  for (const line of readFileSync('e2e/.env.local', 'utf-8').split('\n')) {
+    const match = line.match(/^\s*([^#=]+?)\s*=\s*(.*)$/)
+    if (match && !process.env[match[1]]) {
+      process.env[match[1]] = match[2]
+    }
+  }
+} catch {}
+
 /** @type {import('ts-jest').JestConfigWithTsJest} */
 export default {
   preset: 'ts-jest',


### PR DESCRIPTION
### What and why?

This PR adds support for local environment variable overrides in e2e tests through a gitignored `e2e/.env.local` file. This allows developers to customize e2e test behavior locally without affecting the CI environment or committing sensitive configuration.

### How?

- Added `e2e/.env.local` to `.gitignore` to prevent accidental commits of local configuration
- Modified the Jest e2e configuration to automatically load environment variables from `e2e/.env.local` if the file exists
- Updated the comment in `e2e/helpers/exec.ts` to document the new local override approach using the `.env.local` file instead of directly setting environment variables

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)