### PR TITLE
[dev] Fix unit test failing when no API/App keys set locally

### DIFF
--- a/packages/base/src/commands/elf-symbols/__tests__/elf.test.ts
+++ b/packages/base/src/commands/elf-symbols/__tests__/elf.test.ts
@@ -1,3 +1,5 @@
+import {execSync} from 'child_process'
+
 import type {ElfFileMetadata} from '../elf'
 import type {ExecException} from 'child_process'
 
@@ -24,6 +26,16 @@ import * as elfModule from '../elf'
 import {MachineType, ElfFileType, ElfClass, SectionHeaderType, ProgramHeaderType} from '../elf-constants'
 
 const fixtureDir = './src/commands/elf-symbols/__tests__/fixtures'
+
+const requireObjcopy = () => {
+  try {
+    execSync('objcopy --version', {stdio: 'ignore'})
+  } catch {
+    throw new Error(
+      'objcopy is not installed — these tests require binutils.\nTo install on macOS: brew install binutils'
+    )
+  }
+}
 
 describe('elf', () => {
   describe('readElfHeader', () => {
@@ -859,6 +871,7 @@ describe('elf', () => {
     }
 
     test('copy debug info from elf files', async () => {
+      requireObjcopy()
       const testFiles = [
         'dyn_aarch64',
         'exec_aarch64',

--- a/packages/base/src/commands/elf-symbols/__tests__/upload.test.ts
+++ b/packages/base/src/commands/elf-symbols/__tests__/upload.test.ts
@@ -1,3 +1,4 @@
+import {execSync} from 'child_process'
 import fs from 'fs'
 import os from 'os'
 
@@ -39,6 +40,16 @@ const commonMetadata = {
   overwrite: false,
 }
 
+const requireObjcopy = () => {
+  try {
+    execSync('objcopy --version', {stdio: 'ignore'})
+  } catch {
+    throw new Error(
+      'objcopy is not installed — these tests require binutils.\nTo install on macOS: brew install binutils'
+    )
+  }
+}
+
 describe('elf-symbols upload', () => {
   const runCommand = async (prepFunction: (command: ElfSymbolsUploadCommand) => void) => {
     const command = createCommand(ElfSymbolsUploadCommand)
@@ -72,6 +83,7 @@ describe('elf-symbols upload', () => {
     })
 
     test('uses API Key from env over config from JSON file', async () => {
+      requireObjcopy()
       const {exitCode, context} = await runCommand((cmd) => {
         cmd['configPath'] = `${fixtureDir}/config/datadog-ci.json`
         cmd['symbolsLocations'] = [fixtureDir]
@@ -197,6 +209,7 @@ describe('elf-symbols upload', () => {
     })
 
     test('uploads correct multipart payload with multiple locations', async () => {
+      requireObjcopy()
       const {exitCode} = await runCommand((cmd) => {
         cmd['symbolsLocations'] = [
           `${fixtureDir}/dyn_aarch64`,
@@ -253,6 +266,7 @@ describe('elf-symbols upload', () => {
     })
 
     test('uploads correct multipart payload without repository', async () => {
+      requireObjcopy()
       const {exitCode} = await runCommand((cmd) => {
         cmd['symbolsLocations'] = [fixtureDir]
       })
@@ -331,6 +345,7 @@ describe('elf-symbols upload', () => {
     })
 
     test('skips upload on dry run', async () => {
+      requireObjcopy()
       const {exitCode} = await runCommand((cmd) => {
         cmd['symbolsLocations'] = [fixtureDir]
         cmd['dryRun'] = true

--- a/packages/base/src/commands/unity-symbols/__tests__/upload.test.ts
+++ b/packages/base/src/commands/unity-symbols/__tests__/upload.test.ts
@@ -1,3 +1,5 @@
+import {execSync} from 'child_process'
+
 import type {
   MultipartFileValue,
   MultipartPayload,
@@ -22,6 +24,16 @@ import {
 import {UnitySymbolsUploadCommand} from '../upload'
 
 const fixtureDir = 'src/commands/unity-symbols/__tests__/fixtures'
+
+const requireObjcopy = () => {
+  try {
+    execSync('objcopy --version', {stdio: 'ignore'})
+  } catch {
+    throw new Error(
+      'objcopy is not installed — these tests require binutils.\nTo install on macOS: brew install binutils'
+    )
+  }
+}
 
 jest.mock('@datadog/datadog-ci-base/helpers/utils', () => ({
   ...jest.requireActual('@datadog/datadog-ci-base/helpers/utils'),
@@ -242,6 +254,7 @@ describe('unity-symbols upload', () => {
     })
 
     test('uploads correct multipart payloads without repository', async () => {
+      requireObjcopy()
       ;(uploadMultipartHelper as jest.Mock).mockResolvedValue('')
 
       await runCommand((cmd) => {

--- a/packages/base/src/helpers/__tests__/plugin.test.ts
+++ b/packages/base/src/helpers/__tests__/plugin.test.ts
@@ -1,3 +1,5 @@
+import {PluginCommand as SyntheticsRunTestsPluginCommand} from '@datadog/datadog-ci-plugin-synthetics/commands/run-tests'
+
 import {SyntheticsRunTestsCommand} from '../../commands/synthetics/run-tests'
 
 import {isStandaloneBinary} from '../is-standalone-binary'
@@ -63,6 +65,8 @@ describe('checkPlugin', () => {
 
 describe('executePluginCommand', () => {
   test('executes plugin command successfully', async () => {
+    // Mock the plugin command's `execute` method, but not the `@datadog/datadog-ci-base/commands/synthetics/run-tests` one.
+    jest.spyOn(SyntheticsRunTestsPluginCommand.prototype, 'execute').mockResolvedValue(0)
     const command = createCommand(SyntheticsRunTestsCommand)
     const result = await executePluginCommand(command)
     expect(result).toBe(0)


### PR DESCRIPTION
### What and why?

- https://github.com/DataDog/datadog-ci/pull/2183/s
- https://github.com/DataDog/datadog-ci/pull/2185/s
- https://github.com/DataDog/datadog-ci/pull/2182/s  (← **you are here**)

The `yarn test` command isn't passing on my fresh laptop.

### How?

- Fix a unit test that was failing when no API/App keys are set locally
- Fix some unit tests that were failing with cryptic errors because `objcopy` wasn't installed

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
