### PR TITLE
v5.9.2

### DIFF
--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-base",
-  "version": "5.9.1",
+  "version": "5.9.2",
   "description": "Base package for Datadog CI",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/datadog-ci/package.json
+++ b/packages/datadog-ci/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci",
-  "version": "5.9.1",
+  "version": "5.9.2",
   "description": "Use Datadog from your CI.",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-aas/package.json
+++ b/packages/plugin-aas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-aas",
-  "version": "5.9.1",
+  "version": "5.9.2",
   "description": "Datadog CI plugin for `aas` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-cloud-run/package.json
+++ b/packages/plugin-cloud-run/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-cloud-run",
-  "version": "5.9.1",
+  "version": "5.9.2",
   "description": "Datadog CI plugin for `cloud-run` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-container-app/package.json
+++ b/packages/plugin-container-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-container-app",
-  "version": "5.9.1",
+  "version": "5.9.2",
   "description": "Datadog CI plugin for `container-app` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-coverage/package.json
+++ b/packages/plugin-coverage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-coverage",
-  "version": "5.9.1",
+  "version": "5.9.2",
   "description": "Datadog CI plugin for `coverage` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-deployment/package.json
+++ b/packages/plugin-deployment/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-deployment",
-  "version": "5.9.1",
+  "version": "5.9.2",
   "description": "Datadog CI plugin for `deployment` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-dora/package.json
+++ b/packages/plugin-dora/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-dora",
-  "version": "5.9.1",
+  "version": "5.9.2",
   "description": "Datadog CI plugin for `dora` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-gate/package.json
+++ b/packages/plugin-gate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-gate",
-  "version": "5.9.1",
+  "version": "5.9.2",
   "description": "Datadog CI plugin for `gate` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-junit/package.json
+++ b/packages/plugin-junit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-junit",
-  "version": "5.9.1",
+  "version": "5.9.2",
   "description": "Datadog CI plugin for `junit` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-lambda/package.json
+++ b/packages/plugin-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-lambda",
-  "version": "5.9.1",
+  "version": "5.9.2",
   "description": "Datadog CI plugin for `lambda` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-sarif/package.json
+++ b/packages/plugin-sarif/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-sarif",
-  "version": "5.9.1",
+  "version": "5.9.2",
   "description": "Datadog CI plugin for `sarif` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-sbom/package.json
+++ b/packages/plugin-sbom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-sbom",
-  "version": "5.9.1",
+  "version": "5.9.2",
   "description": "Datadog CI plugin for `sbom` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-stepfunctions/package.json
+++ b/packages/plugin-stepfunctions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-stepfunctions",
-  "version": "5.9.1",
+  "version": "5.9.2",
   "description": "Datadog CI plugin for `stepfunctions` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-synthetics/package.json
+++ b/packages/plugin-synthetics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-synthetics",
-  "version": "5.9.1",
+  "version": "5.9.2",
   "description": "Datadog CI plugin for `synthetics` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-terraform/package.json
+++ b/packages/plugin-terraform/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-terraform",
-  "version": "5.9.1",
+  "version": "5.9.2",
   "description": "Datadog CI plugin for `terraform` commands",
   "license": "Apache-2.0",
   "keywords": [


### PR DESCRIPTION

<!-- Release notes generated using configuration in .github/release.yml at manuel.palenzuela/release-v5.9.2 -->

## What's Changed
### datadog-ci
* fix(junit): disable entity processing during XML validation by @ManuelPalenzuelaDD in https://github.com/DataDog/datadog-ci/pull/2184
### Software Delivery
* added functionality to extract job id when using github actions by @cbasitodx in https://github.com/DataDog/datadog-ci/pull/2156
### RUM
* Improve sourcemaps upload output formatting by @Drarig29 in https://github.com/DataDog/datadog-ci/pull/2171
### Serverless
* [SVLS-7940] add container-app integration tests by @ava-silver in https://github.com/DataDog/datadog-ci/pull/2170
* chore: Update Lambda layer versions by @gh-worker-engraver-d31c25[bot] in https://github.com/DataDog/datadog-ci/pull/2176
### Synthetics
* [SYNTH-24187] Add `planDryRun` public API and `--dry-run` flag to `run-tests` by @Drarig29 in https://github.com/DataDog/datadog-ci/pull/2165
### Chores
* [chore] Update CODEOWNERS to reflect monorepo package structure by @Drarig29 in https://github.com/DataDog/datadog-ci/pull/2172
* chore: refactor e2e tests to jest by @ava-silver in https://github.com/DataDog/datadog-ci/pull/2173
* chore: support local integration testing by @ava-silver in https://github.com/DataDog/datadog-ci/pull/2174
* [chore] Enable `@typescript-eslint/consistent-type-imports` rule by @Drarig29 in https://github.com/DataDog/datadog-ci/pull/2183

## New Contributors
* @cbasitodx made their first contribution in https://github.com/DataDog/datadog-ci/pull/2156

**Full Changelog**: https://github.com/DataDog/datadog-ci/compare/v5.9.1...v5.9.2
