### PR TITLE
chore: only run azure e2e tests on specific files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,7 +197,10 @@ jobs:
             container-app:
               - 'packages/plugin-container-app/**'
               - 'packages/base/package.json'
-              - 'packages/base/src/helpers/serverless/**'
+              - 'packages/base/src/helpers/serverless/azure.ts'
+              - 'packages/base/src/helpers/serverless/common.ts'
+              - 'packages/base/src/helpers/serverless/constants.ts'
+              - 'packages/base/src/helpers/serverless/source-code-integration.ts'
               - 'e2e/fixtures/container-app/**'
               - 'e2e/container-app.test.ts'
               - 'e2e/helpers/container-app-verifier.ts'
@@ -217,7 +220,10 @@ jobs:
             aas:
               - 'packages/plugin-aas/**'
               - 'packages/base/package.json'
-              - 'packages/base/src/helpers/serverless/**'
+              - 'packages/base/src/helpers/serverless/azure.ts'
+              - 'packages/base/src/helpers/serverless/common.ts'
+              - 'packages/base/src/helpers/serverless/constants.ts'
+              - 'packages/base/src/helpers/serverless/source-code-integration.ts'
               - 'packages/base/src/commands/aas/**'
               - 'e2e/aas-linux.test.ts'
               - 'e2e/aas-windows.test.ts'


### PR DESCRIPTION
### What and why?

The container-app and AAS e2e test path filters used a broad glob (`packages/base/src/helpers/serverless/**`) which caused these Azure e2e tests to run on unrelated changes — e.g. bumping lambda layer versions in `lambda-layer-versions.ts`.

This PR narrows the path filters to only the specific serverless helper files that container-app and AAS actually depend on: `azure.ts`, `common.ts`, `constants.ts`, and `source-code-integration.ts`.

### How?

Replaced `packages/base/src/helpers/serverless/**` with explicit file paths in both the `check-container-app-changes` and `check-aas-changes` `dorny/paths-filter` configurations in `ci.yml`.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
  - N/A — CI config change only