### PR TITLE
feat(elf-symbols): support separate debug info files via .gnu_debuglink

### DIFF
--- a/packages/base/src/commands/elf-symbols/__tests__/elf.test.ts
+++ b/packages/base/src/commands/elf-symbols/__tests__/elf.test.ts
@@ -745,6 +745,8 @@ describe('elf', () => {
         hasDynamicSymbolTable: true,
         hasSymbolTable: true,
         hasCode: true,
+        gnuDebugLink: '',
+        gnuDebugLinkCrc32: 0,
       })
 
       expect(await getElfFileMetadata(`${fixtureDir}/.debug/dyn_aarch64.debug`)).toEqual({
@@ -761,6 +763,8 @@ describe('elf', () => {
         hasDynamicSymbolTable: false,
         hasSymbolTable: true,
         hasCode: false,
+        gnuDebugLink: '',
+        gnuDebugLinkCrc32: 0,
       })
 
       expect(await getElfFileMetadata(`${fixtureDir}/dyn_aarch64_nobuildid`)).toEqual({
@@ -777,6 +781,8 @@ describe('elf', () => {
         hasDynamicSymbolTable: true,
         hasSymbolTable: true,
         hasCode: true,
+        gnuDebugLink: '',
+        gnuDebugLinkCrc32: 0,
       })
 
       expect(await getElfFileMetadata(`${fixtureDir}/go_x86_64_both_gnu_and_go_build_id`)).toEqual({
@@ -793,6 +799,8 @@ describe('elf', () => {
         hasDynamicSymbolTable: true,
         hasSymbolTable: false,
         hasCode: true,
+        gnuDebugLink: '',
+        gnuDebugLinkCrc32: 0,
       })
 
       expect(await getElfFileMetadata(`${fixtureDir}/go_x86_64_only_go_build_id`)).toEqual({
@@ -809,6 +817,8 @@ describe('elf', () => {
         hasDynamicSymbolTable: true,
         hasSymbolTable: false,
         hasCode: true,
+        gnuDebugLink: '',
+        gnuDebugLinkCrc32: 0,
       })
 
       expect(await getElfFileMetadata(`${fixtureDir}/exec_arm_big`)).toEqual({
@@ -825,6 +835,8 @@ describe('elf', () => {
         hasDynamicSymbolTable: false,
         hasSymbolTable: true,
         hasCode: true,
+        gnuDebugLink: '',
+        gnuDebugLinkCrc32: 0,
       })
     })
   })

--- a/packages/base/src/commands/elf-symbols/__tests__/upload.test.ts
+++ b/packages/base/src/commands/elf-symbols/__tests__/upload.test.ts
@@ -187,6 +187,8 @@ describe('elf-symbols upload', () => {
         goBuildId: 'fake-go-build-id',
         fileHash: 'fake-file-hash',
         elfType: 'EXEC',
+        gnuDebugLink: '',
+        gnuDebugLinkCrc32: 0,
       }
       const metadata = command['getMappingMetadata'](elfFileMatadata)
 

--- a/packages/base/src/commands/elf-symbols/elf.ts
+++ b/packages/base/src/commands/elf-symbols/elf.ts
@@ -1,7 +1,10 @@
 import {createHash} from 'crypto'
 import fs from 'fs'
+import zlib from 'zlib'
 
 import type {ExecException} from 'child_process'
+
+import upath from 'upath'
 
 import {createReadFunctions, FileReader} from '@datadog/datadog-ci-base/helpers/filereader'
 import {execute} from '@datadog/datadog-ci-base/helpers/utils'
@@ -30,6 +33,9 @@ export type ElfFileMetadata = {
   hasDynamicSymbolTable: boolean
   hasSymbolTable: boolean
   hasCode: boolean
+  gnuDebugLink: string
+  gnuDebugLinkCrc32: number
+  debugInfoFile?: string
   error?: Error
 }
 
@@ -354,6 +360,44 @@ const readElfNote = async (reader: Reader, sectionHeader: SectionHeader, elfHead
   return {type, name, desc}
 }
 
+export type GnuDebugLink = {
+  filename: string
+  crc32: number
+}
+
+export const readGnuDebugLink = async (
+  reader: Reader,
+  sectionHeaders: SectionHeader[]
+): Promise<GnuDebugLink | undefined> => {
+  const section = sectionHeaders.find((s) => s.name === '.gnu_debuglink')
+  if (!section || section.sh_size === BigInt(0)) {
+    return undefined
+  }
+
+  const buf = await reader.read(Number(section.sh_size), Number(section.sh_offset))
+  // The section contains a null-terminated filename, 0-3 bytes of padding to align to 4 bytes, then a CRC32
+  const nullByteOffset = buf.indexOf(0)
+  if (nullByteOffset <= 0) {
+    return undefined
+  }
+
+  const filename = buf.toString('ascii', 0, nullByteOffset)
+  // CRC32 is at the next 4-byte aligned offset after the null-terminated string
+  const crcOffset = (nullByteOffset + 4) & ~3
+  if (crcOffset + 4 > buf.length) {
+    return undefined
+  }
+  const crc32 = buf.readUInt32LE(crcOffset)
+
+  return {filename, crc32}
+}
+
+export const verifyDebugLinkCrc32 = async (debugFilePath: string, expectedCrc32: number): Promise<boolean> => {
+  const fileData = await fs.promises.readFile(debugFilePath)
+
+  return zlib.crc32(fileData) === expectedCrc32
+}
+
 export const getBuildIds = async (
   reader: Reader,
   sectionHeaders: SectionHeader[],
@@ -423,6 +467,8 @@ export const getElfFileMetadata = async (filename: string): Promise<ElfFileMetad
     hasSymbolTable: false,
     hasDynamicSymbolTable: false,
     hasCode: false,
+    gnuDebugLink: '',
+    gnuDebugLinkCrc32: 0,
   }
 
   let fileHandle: fs.promises.FileHandle | undefined
@@ -447,6 +493,8 @@ export const getElfFileMetadata = async (filename: string): Promise<ElfFileMetad
     const sectionHeaders = await readElfSectionHeaderTable(reader, elfHeader!)
     const {gnuBuildId, goBuildId} = await getBuildIds(reader, sectionHeaders, elfHeader!)
     const {hasDebugInfo, hasSymbolTable, hasDynamicSymbolTable, hasCode} = getSectionInfo(sectionHeaders)
+    const debugLink = await readGnuDebugLink(reader, sectionHeaders)
+    const gnuDebugLink = debugLink?.filename ?? ''
     let fileHash = ''
     if (hasCode) {
       // Only compute file hash if the file has code:
@@ -461,6 +509,8 @@ export const getElfFileMetadata = async (filename: string): Promise<ElfFileMetad
       hasSymbolTable,
       hasDynamicSymbolTable,
       hasCode,
+      gnuDebugLink,
+      gnuDebugLinkCrc32: debugLink?.crc32 ?? 0,
     })
   } catch (error) {
     metadata.error = error
@@ -594,14 +644,73 @@ export const copyElfDebugInfo = async (
   }
 
   if (bfdTargetOption) {
-    // Replace the ELF header in the extracted debug info file with the one from the initial file to keep the original architecture
-    await replaceElfHeader(outputFile, filename)
+    // Replace the ELF header in the extracted debug info file with the one from the original file to keep the original architecture
+    // Use elfFileMetadata.filename (the main file) for the header source, which may differ from the objcopy input
+    // when debug info comes from a separate file via .gnu_debuglink
+    await replaceElfHeader(outputFile, elfFileMetadata.filename)
   }
 }
 
 export const getOutputFilenameFromBuildId = (buildId: string): string => {
   // Go build id may contain slashes, replace them with dashes so it can be used as a filename
   return buildId.replace(/\//g, '-')
+}
+
+/**
+ * When a main ELF file has no debug info but contains a .gnu_debuglink section,
+ * try to resolve the linked debug info file and merge metadata.
+ * The file hash comes from the main file, but debug info flags come from the debug file.
+ * Returns the updated metadata if a valid debug file is found, or undefined otherwise.
+ */
+export const resolveDebugInfoFromDebugLink = async (
+  metadata: ElfFileMetadata
+): Promise<ElfFileMetadata | undefined> => {
+  if (!metadata.gnuDebugLink) {
+    return undefined
+  }
+
+  const dir = upath.dirname(metadata.filename)
+
+  // Search paths per GDB convention: same dir, .debug/ subdir
+  const candidates = [
+    upath.join(dir, metadata.gnuDebugLink),
+    upath.join(dir, '.debug', metadata.gnuDebugLink),
+  ]
+
+  for (const candidate of candidates) {
+    try {
+      await fs.promises.access(candidate, fs.constants.R_OK)
+    } catch {
+      continue
+    }
+
+    // Verify CRC32 if present in the debuglink section
+    if (metadata.gnuDebugLinkCrc32 !== 0) {
+      const crcValid = await verifyDebugLinkCrc32(candidate, metadata.gnuDebugLinkCrc32)
+      if (!crcValid) {
+        continue
+      }
+    }
+
+    const debugMetadata = await getElfFileMetadata(candidate)
+    if (!debugMetadata.isElf || debugMetadata.error) {
+      continue
+    }
+    if (!debugMetadata.hasDebugInfo && !debugMetadata.hasSymbolTable) {
+      continue
+    }
+
+    // Merge: use the main file's identity (filename, fileHash) with the debug file's symbols
+    return {
+      ...metadata,
+      hasDebugInfo: debugMetadata.hasDebugInfo,
+      hasSymbolTable: debugMetadata.hasSymbolTable,
+      hasDynamicSymbolTable: metadata.hasDynamicSymbolTable || debugMetadata.hasDynamicSymbolTable,
+      debugInfoFile: candidate,
+    }
+  }
+
+  return undefined
 }
 
 export const getBuildIdWithArch = (fileMetadata: ElfFileMetadata): string => {

--- a/packages/base/src/commands/elf-symbols/upload.ts
+++ b/packages/base/src/commands/elf-symbols/upload.ts
@@ -38,6 +38,7 @@ import {
   getOutputFilenameFromBuildId,
   copyElfDebugInfo,
   isSupportedArch,
+  resolveDebugInfoFromDebugLink,
 } from './elf'
 import {getElfRequestBuilder, uploadMultipartHelper} from './helpers'
 import {ELF_DEBUG_INFOS_FILENAME, TYPE_ELF_DEBUG_INFOS, VALUE_NAME_ELF_DEBUG_INFOS} from './interfaces'
@@ -281,6 +282,12 @@ export class ElfSymbolsUploadCommand extends BaseCommand {
           !metadata.hasSymbolTable &&
           (!metadata.hasDynamicSymbolTable || !this.acceptDynamicSymbolTableAsSymbolSource)
         ) {
+          // Try to resolve debug info from a .gnu_debuglink section
+          const resolved = await resolveDebugInfoFromDebugLink(metadata)
+          if (resolved) {
+            filesMetadata.push(resolved)
+            continue
+          }
           reportFailure(`Skipped ${p} because it has no debug info, nor symbols`)
           continue
         }
@@ -345,7 +352,8 @@ export class ElfSymbolsUploadCommand extends BaseCommand {
         const metadata = this.getMappingMetadata(fileMetadata)
         const outputFilename = getOutputFilenameFromBuildId(getBuildIdWithArch(fileMetadata))
         const outputFilePath = buildPath(tmpDirectory, outputFilename)
-        await copyElfDebugInfo(fileMetadata.filename, outputFilePath, fileMetadata, true)
+        const debugInfoSource = fileMetadata.debugInfoFile || fileMetadata.filename
+        await copyElfDebugInfo(debugInfoSource, outputFilePath, fileMetadata, true)
 
         if (this.dryRun) {
           this.context.stdout.write(`[DRYRUN] ${renderUpload(fileMetadata.filename, metadata)}`)


### PR DESCRIPTION
## Summary

- Adds support for ELF files that have no build ID and no debug info but contain a `.gnu_debuglink` section pointing to a separate debug file
- The file hash is computed from the main file (for identification), while debug info is extracted via `objcopy` from the linked debug file
- The CRC32 stored in the `.gnu_debuglink` section is verified against the candidate debug file before using it

## Details

When uploading an ELF that has code but no debug info/symbols, the tool now:
1. Reads the `.gnu_debuglink` section to get the debug filename and CRC32
2. Searches for the debug file in the same directory and `.debug/` subdirectory (GDB convention)
3. Verifies the CRC32 of the candidate file matches the one in the debuglink section
4. Merges metadata: file hash from the main file, debug info flags from the debug file
5. Runs `objcopy --only-keep-debug` on the debug file (not the main file)

## Test plan

- [ ] Existing unit tests all pass (`yarn jest --testPathPattern 'elf-symbols'`)
- [ ] Tested manually with a real `libpython3.13.so.1.0` + `libpython3.13.so.1.0.dbg` pair (no build IDs, linked via `.gnu_debuglink`)
- [ ] File hash matches expected value (`f94722205e14bd1a40977521041a66fe`)
- [ ] CRC32 verification correctly accepts the right debug file and rejects wrong files

🤖 Generated with [Claude Code](https://claude.com/claude-code)