### PR TITLE
[RUMS-5750] Fix iOS bundle lookup path for `inject-debug-id` command

### DIFF
--- a/packages/base/src/commands/react-native/README.md
+++ b/packages/base/src/commands/react-native/README.md
@@ -210,15 +210,37 @@ The inject-debug-id command adds a debug ID to your JavaScript bundle and its so
 
 A debug ID allows Datadog to reliably match error stack traces from your application to the correct uploaded debug symbols (sourcemaps), ensuring accurate error resolution.
 
-To inject the debug ID, run the following command:
+#### Scan a directory
+
+To scan a directory and inject debug IDs into all bundles found:
 
 ```bash
 datadog-ci react-native inject-debug-id ./dist
 ```
 
-The expected path is a folder containing both the JS bundle and the sourcemap for your build (for example, index.android.bundle and index.android.bundle.map).
+The command looks for all files ending in `.bundle` (Android) or `.jsbundle` (iOS) in the given directory, and processes each one alongside its corresponding `.map` file (e.g. `index.android.bundle` + `index.android.bundle.map`, or `main.jsbundle` + `main.jsbundle.map`).
 
-The `--dry-run` optional parameter is also available, to run the command without actually injecting the debug ID in your files.
+#### Specify files directly
+
+To target a specific bundle and sourcemap instead of scanning a directory, use the `--bundle` and `--sourcemap` flags:
+
+```bash
+# iOS
+datadog-ci react-native inject-debug-id --bundle ./ios/main.jsbundle --sourcemap ./ios/main.jsbundle.map
+
+# Android
+datadog-ci react-native inject-debug-id --bundle ./android/index.android.bundle --sourcemap ./android/index.android.bundle.map
+```
+
+If `--sourcemap` is omitted, the command looks for a sourcemap at `<bundle path>.map` automatically.
+
+#### Options
+
+| Flag          | Description |
+|---------------|-------------|
+| `--bundle`    | Path to the JS bundle file. When provided, processes only this file instead of scanning a directory. Cannot be combined with a directory argument. |
+| `--sourcemap` | Path to the sourcemap file. Only used together with `--bundle`. Defaults to `<bundle>.map` if not specified. |
+| `--dry-run`   | Run the command without modifying any files. |
 
 ## End-to-end testing process
 

--- a/packages/base/src/commands/react-native/__tests__/inject-debug-id.test.ts
+++ b/packages/base/src/commands/react-native/__tests__/inject-debug-id.test.ts
@@ -158,6 +158,84 @@ describe('inject-debug-id', () => {
     expect(tmpBundleLines[0]).toMatch(/\/\/# debugId=[0-9a-fA-F]{8}\b-(?:[0-9a-fA-F]{4}\b-){3}[0-9a-fA-F]{12}/)
   })
 
+  test('debug ID is injected when --bundle and --sourcemap flags are used', async () => {
+    // GIVEN
+    const fixturePath = './src/commands/react-native/__tests__/fixtures/sourcemap-with-no-files'
+
+    const tmpBundlePath = upath.join(tmpDir, 'main.jsbundle')
+    const tmpSourcemapPath = upath.join(tmpDir, 'main.jsbundle.map')
+
+    await promises.copyFile(upath.join(fixturePath, 'empty.min.js'), tmpBundlePath)
+    await promises.copyFile(upath.join(fixturePath, 'empty.min.js.map'), tmpSourcemapPath)
+
+    // WHEN
+    const {context, code} = await runCLI(['--bundle', tmpBundlePath, '--sourcemap', tmpSourcemapPath])
+
+    // THEN
+    expect(code).toBe(0)
+
+    const logs = context.stdout.toString().split('\n')
+    expect(logs[0]).toMatch(
+      /Generated Debug ID for main\.jsbundle: ([0-9a-fA-F]{8}\b-(?:[0-9a-fA-F]{4}\b-){3}[0-9a-fA-F]{12})/
+    )
+    expect(logs[1]).toBe(`✅ Debug ID injected into ${tmpBundlePath}`)
+
+    const tmpSourcemap = await promises.readFile(tmpSourcemapPath, {encoding: 'utf8'})
+    const tmpSourcemapJson = JSON.parse(tmpSourcemap) as {debugId: string}
+    expect(tmpSourcemapJson['debugId']).toBeDefined()
+    expect(tmpSourcemapJson['debugId']).toMatch(/[0-9a-fA-F]{8}\b-(?:[0-9a-fA-F]{4}\b-){3}[0-9a-fA-F]{12}/)
+
+    const tmpBundle = await promises.readFile(tmpBundlePath, {encoding: 'utf8'})
+    const tmpBundleLines = tmpBundle.split('\n')
+    tmpBundleLines.reverse()
+    expect(tmpBundleLines[0]).toMatch(/\/\/# debugId=[0-9a-fA-F]{8}\b-(?:[0-9a-fA-F]{4}\b-){3}[0-9a-fA-F]{12}/)
+  })
+
+  test('debug ID is injected when only --bundle is used (sourcemap derived automatically)', async () => {
+    // GIVEN
+    const fixturePath = './src/commands/react-native/__tests__/fixtures/sourcemap-with-no-files'
+
+    const tmpBundlePath = upath.join(tmpDir, 'main.jsbundle')
+    const tmpSourcemapPath = upath.join(tmpDir, 'main.jsbundle.map')
+
+    await promises.copyFile(upath.join(fixturePath, 'empty.min.js'), tmpBundlePath)
+    await promises.copyFile(upath.join(fixturePath, 'empty.min.js.map'), tmpSourcemapPath)
+
+    // WHEN
+    const {context, code} = await runCLI(['--bundle', tmpBundlePath])
+
+    // THEN
+    expect(code).toBe(0)
+
+    const tmpSourcemap = await promises.readFile(tmpSourcemapPath, {encoding: 'utf8'})
+    const tmpSourcemapJson = JSON.parse(tmpSourcemap) as {debugId: string}
+    expect(tmpSourcemapJson['debugId']).toBeDefined()
+  })
+
+  test('throws error when --bundle and a directory are both provided', async () => {
+    // GIVEN
+    const fixturePath = './src/commands/react-native/__tests__/fixtures/sourcemap-with-no-files'
+    const tmpBundlePath = upath.join(tmpDir, 'main.jsbundle')
+
+    await promises.copyFile(upath.join(fixturePath, 'empty.min.js'), tmpBundlePath)
+
+    // WHEN
+    const {context, code} = await runCLI([tmpDir, '--bundle', tmpBundlePath])
+
+    // THEN
+    expect(code).toBe(1)
+    expect(context.stderr.toString()).toContain('Cannot use both a directory path and --bundle.')
+  })
+
+  test('throws error when --bundle points to a non-existent file', async () => {
+    // WHEN
+    const {context, code} = await runCLI(['--bundle', '/nonexistent/main.jsbundle'])
+
+    // THEN
+    expect(code).toBe(1)
+    expect(context.stderr.toString()).toContain('Bundle file not found: /nonexistent/main.jsbundle')
+  })
+
   test('throws error if the files do not match the correct naming convention', async () => {
     // GIVEN
     const fixturePath = './src/commands/react-native/__tests__/fixtures/sourcemap-with-no-files'

--- a/packages/base/src/commands/react-native/__tests__/inject-debug-id.test.ts
+++ b/packages/base/src/commands/react-native/__tests__/inject-debug-id.test.ts
@@ -202,7 +202,7 @@ describe('inject-debug-id', () => {
     await promises.copyFile(upath.join(fixturePath, 'empty.min.js.map'), tmpSourcemapPath)
 
     // WHEN
-    const {context, code} = await runCLI(['--bundle', tmpBundlePath])
+    const {code} = await runCLI(['--bundle', tmpBundlePath])
 
     // THEN
     expect(code).toBe(0)

--- a/packages/base/src/commands/react-native/__tests__/inject-debug-id.test.ts
+++ b/packages/base/src/commands/react-native/__tests__/inject-debug-id.test.ts
@@ -123,6 +123,41 @@ describe('inject-debug-id', () => {
     expect(tmpBundleLines[0]).toMatch(/\/\/# debugId=[0-9a-fA-F]{8}\b-(?:[0-9a-fA-F]{4}\b-){3}[0-9a-fA-F]{12}/)
   })
 
+  test('debug ID is generated and injected when iOS .jsbundle and sourcemap are valid', async () => {
+    // GIVEN
+    const fixturePath = './src/commands/react-native/__tests__/fixtures/sourcemap-with-no-files'
+
+    const tmpBundlePath = upath.join(tmpDir, 'main.jsbundle')
+    const tmpSourcemapPath = upath.join(tmpDir, 'main.jsbundle.map')
+
+    await promises.copyFile(upath.join(fixturePath, 'empty.min.js'), tmpBundlePath)
+    await promises.copyFile(upath.join(fixturePath, 'empty.min.js.map'), tmpSourcemapPath)
+
+    // WHEN
+    const {context, code} = await runCLI([tmpDir])
+
+    // THEN
+    expect(code).toBe(0)
+
+    const logs = context.stdout.toString().split('\n')
+
+    expect(logs[0]).toBe(`Scanning directory: ${tmpDir}`)
+    expect(logs[1]).toMatch(
+      /Generated Debug ID for main\.jsbundle: ([0-9a-fA-F]{8}\b-(?:[0-9a-fA-F]{4}\b-){3}[0-9a-fA-F]{12})/
+    )
+    expect(logs[2]).toBe(`✅ Debug ID injected into ${tmpBundlePath}`)
+
+    const tmpSourcemap = await promises.readFile(tmpSourcemapPath, {encoding: 'utf8'})
+    const tmpSourcemapJson = JSON.parse(tmpSourcemap) as {debugId: string}
+    expect(tmpSourcemapJson['debugId']).toBeDefined()
+    expect(tmpSourcemapJson['debugId']).toMatch(/[0-9a-fA-F]{8}\b-(?:[0-9a-fA-F]{4}\b-){3}[0-9a-fA-F]{12}/)
+
+    const tmpBundle = await promises.readFile(tmpBundlePath, {encoding: 'utf8'})
+    const tmpBundleLines = tmpBundle.split('\n')
+    tmpBundleLines.reverse()
+    expect(tmpBundleLines[0]).toMatch(/\/\/# debugId=[0-9a-fA-F]{8}\b-(?:[0-9a-fA-F]{4}\b-){3}[0-9a-fA-F]{12}/)
+  })
+
   test('throws error if the files do not match the correct naming convention', async () => {
     // GIVEN
     const fixturePath = './src/commands/react-native/__tests__/fixtures/sourcemap-with-no-files'
@@ -142,7 +177,7 @@ describe('inject-debug-id', () => {
     const errorLogs = context.stderr.toString().split('\n')
 
     expect(errorLogs[0]).toBe(
-      `[ERROR] JS bundle not found in "${tmpDir}". Ensure your files follow the "*.bundle" and "*.bundle.map" naming convention.`
+      `[ERROR] JS bundle not found in "${tmpDir}". Ensure your files follow the "*.bundle"/"*.bundle.map" (Android) or "*.jsbundle"/"*.jsbundle.map" (iOS) naming convention.`
     )
   })
 })

--- a/packages/base/src/commands/react-native/__tests__/inject-debug-id.test.ts
+++ b/packages/base/src/commands/react-native/__tests__/inject-debug-id.test.ts
@@ -236,6 +236,37 @@ describe('inject-debug-id', () => {
     expect(context.stderr.toString()).toContain('Bundle file not found: /nonexistent/main.jsbundle')
   })
 
+  test('throws error when --sourcemap points to a non-existent file', async () => {
+    // GIVEN
+    const fixturePath = './src/commands/react-native/__tests__/fixtures/sourcemap-with-no-files'
+    const tmpBundlePath = upath.join(tmpDir, 'main.jsbundle')
+
+    await promises.copyFile(upath.join(fixturePath, 'empty.min.js'), tmpBundlePath)
+
+    // WHEN
+    const {context, code} = await runCLI(['--bundle', tmpBundlePath, '--sourcemap', '/nonexistent/main.jsbundle.map'])
+
+    // THEN
+    expect(code).toBe(1)
+    expect(context.stderr.toString()).toContain('Sourcemap file not found: /nonexistent/main.jsbundle.map')
+  })
+
+  test('throws error when --bundle is used and the derived sourcemap does not exist', async () => {
+    // GIVEN
+    const fixturePath = './src/commands/react-native/__tests__/fixtures/sourcemap-with-no-files'
+    const tmpBundlePath = upath.join(tmpDir, 'main.jsbundle')
+
+    // Copy only the bundle, no sourcemap
+    await promises.copyFile(upath.join(fixturePath, 'empty.min.js'), tmpBundlePath)
+
+    // WHEN
+    const {context, code} = await runCLI(['--bundle', tmpBundlePath])
+
+    // THEN
+    expect(code).toBe(1)
+    expect(context.stderr.toString()).toContain(`Sourcemap file not found: ${tmpBundlePath}.map`)
+  })
+
   test('throws error if the files do not match the correct naming convention', async () => {
     // GIVEN
     const fixturePath = './src/commands/react-native/__tests__/fixtures/sourcemap-with-no-files'

--- a/packages/base/src/commands/react-native/injectDebugId.ts
+++ b/packages/base/src/commands/react-native/injectDebugId.ts
@@ -65,6 +65,12 @@ export class ReactNativeInjectDebugIdCommand extends BaseCommand {
 
       const sourcemapPath = this.sourcemapPath ?? `${this.bundlePath}.map`
 
+      if (!existsSync(sourcemapPath)) {
+        this.context.stderr.write(`[ERROR] Sourcemap file not found: ${sourcemapPath}\n`)
+
+        return 1
+      }
+
       return this.injectDebugIdIntoFiles(this.bundlePath, sourcemapPath, this.dryRun)
     }
 

--- a/packages/base/src/commands/react-native/injectDebugId.ts
+++ b/packages/base/src/commands/react-native/injectDebugId.ts
@@ -20,8 +20,8 @@ export class ReactNativeInjectDebugIdCommand extends BaseCommand {
     category: 'RUM',
     description: 'Inject Debug ID into JavaScript bundles and sourcemaps.',
     details: `
-        This command scans the specified directory for minified JavaScript bundles (.bundle) and their associated source maps (.map),
-        injecting a unique Debug ID into each file. These Debug IDs enable precise source map resolution in Datadog, ensuring accurate 
+        This command scans the specified directory for minified JavaScript bundles (.bundle or .jsbundle) and their associated source maps (.map),
+        injecting a unique Debug ID into each file. These Debug IDs enable precise source map resolution in Datadog, ensuring accurate
         stack traces and error symbolication.
     `,
     examples: [
@@ -67,11 +67,11 @@ export class ReactNativeInjectDebugIdCommand extends BaseCommand {
     this.context.stdout.write(`Scanning directory: ${directory}\n`)
 
     const files = await promises.readdir(directory)
-    const bundles = files.filter((file) => file.endsWith('.bundle'))
+    const bundles = files.filter((file) => file.endsWith('.bundle') || file.endsWith('.jsbundle'))
 
     if (bundles.length === 0) {
       this.context.stderr.write(
-        `[ERROR] JS bundle not found in "${directory}". Ensure your files follow the "*.bundle" and "*.bundle.map" naming convention.\n`
+        `[ERROR] JS bundle not found in "${directory}". Ensure your files follow the "*.bundle"/"*.bundle.map" (Android) or "*.jsbundle"/"*.jsbundle.map" (iOS) naming convention.\n`
       )
 
       return 1

--- a/packages/base/src/commands/react-native/injectDebugId.ts
+++ b/packages/base/src/commands/react-native/injectDebugId.ts
@@ -23,14 +23,22 @@ export class ReactNativeInjectDebugIdCommand extends BaseCommand {
         This command scans the specified directory for minified JavaScript bundles (.bundle or .jsbundle) and their associated source maps (.map),
         injecting a unique Debug ID into each file. These Debug IDs enable precise source map resolution in Datadog, ensuring accurate
         stack traces and error symbolication.
+
+        Alternatively, use --bundle and --sourcemap to target specific files directly instead of scanning a directory.
     `,
     examples: [
-      ['Inject Debug ID', 'datadog-ci react-native inject-debug-id ./dist'],
+      ['Inject Debug ID (scan directory)', 'datadog-ci react-native inject-debug-id ./dist'],
       ['Inject Debug ID (dry run)', 'datadog-ci react-native inject-debug-id ./dist --dry-run'],
+      [
+        'Inject Debug ID (explicit files)',
+        'datadog-ci react-native inject-debug-id --bundle ./ios/main.jsbundle --sourcemap ./ios/main.jsbundle.map',
+      ],
     ],
   })
 
   private assetsPath = Option.String({required: false})
+  private bundlePath = Option.String('--bundle', {required: false})
+  private sourcemapPath = Option.String('--sourcemap', {required: false})
   private dryRun = Option.Boolean('--dry-run', false)
   private fips = Option.Boolean('--fips', false)
   private fipsIgnoreError = Option.Boolean('--fips-ignore-error', false)
@@ -42,8 +50,26 @@ export class ReactNativeInjectDebugIdCommand extends BaseCommand {
   public async execute() {
     enableFips(this.fips || this.fipsConfig.fips, this.fipsIgnoreError || this.fipsConfig.fipsIgnoreError)
 
+    if (this.bundlePath) {
+      if (this.assetsPath) {
+        this.context.stderr.write('[ERROR] Cannot use both a directory path and --bundle. Use one or the other.\n')
+
+        return 1
+      }
+
+      if (!existsSync(this.bundlePath)) {
+        this.context.stderr.write(`[ERROR] Bundle file not found: ${this.bundlePath}\n`)
+
+        return 1
+      }
+
+      const sourcemapPath = this.sourcemapPath ?? `${this.bundlePath}.map`
+
+      return this.injectDebugIdIntoFiles(this.bundlePath, sourcemapPath, this.dryRun)
+    }
+
     if (!this.assetsPath) {
-      this.context.stderr.write('[ERROR] No path specified for JS bundle and sourcemap.\n')
+      this.context.stderr.write('[ERROR] No path specified. Provide a directory or use --bundle and --sourcemap.\n')
 
       return 1
     }
@@ -81,32 +107,50 @@ export class ReactNativeInjectDebugIdCommand extends BaseCommand {
       const bundlePath = upath.join(directory, bundle)
       const sourcemapPath = upath.join(directory, `${bundle}.map`)
 
-      let debugId =
-        (await this.extractDebugIdFromBundle(bundlePath)) || (await this.extractDebugIdFromSourceMap(sourcemapPath))
+      const result = await this.injectDebugIdIntoFiles(bundlePath, sourcemapPath, dryRun)
+      if (result !== 0) {
+        return result
+      }
+    }
 
-      if (!debugId) {
-        const bundleData = await promises.readFile(bundlePath, 'utf-8')
-        debugId = generateDebugId(bundleData)
-        this.context.stdout.write(`Generated Debug ID for ${bundle}: ${debugId}\n`)
-      } else {
-        this.context.stdout.write(`Found existing Debug ID for ${bundle}: ${debugId}\n`)
+    return 0
+  }
+
+  /**
+   * Injects a Debug ID into a single bundle and its associated sourcemap.
+   *
+   * @param bundlePath - The path to the JavaScript bundle file.
+   * @param sourcemapPath - The path to the sourcemap file.
+   * @param dryRun - If true, does not modify files.
+   */
+  private async injectDebugIdIntoFiles(bundlePath: string, sourcemapPath: string, dryRun: boolean): Promise<number> {
+    const bundle = upath.basename(bundlePath)
+
+    let debugId =
+      (await this.extractDebugIdFromBundle(bundlePath)) || (await this.extractDebugIdFromSourceMap(sourcemapPath))
+
+    if (!debugId) {
+      const bundleData = await promises.readFile(bundlePath, 'utf-8')
+      debugId = generateDebugId(bundleData)
+      this.context.stdout.write(`Generated Debug ID for ${bundle}: ${debugId}\n`)
+    } else {
+      this.context.stdout.write(`Found existing Debug ID for ${bundle}: ${debugId}\n`)
+    }
+
+    if (!dryRun) {
+      if (!(await this.injectDebugIdIntoBundle(bundlePath, debugId))) {
+        return 1
       }
 
-      if (!dryRun) {
-        if (!(await this.injectDebugIdIntoBundle(bundlePath, debugId))) {
+      if (existsSync(sourcemapPath)) {
+        if (!(await this.injectDebugIdIntoSourceMap(sourcemapPath, debugId))) {
           return 1
         }
 
-        if (existsSync(sourcemapPath)) {
-          if (!(await this.injectDebugIdIntoSourceMap(sourcemapPath, debugId))) {
-            return 1
-          }
-
-          this.context.stdout.write(`Updated Debug ID in ${bundle} and its sourcemap.\n`)
-        }
-      } else {
-        this.context.stdout.write(`Dry run: No files modified.\n`)
+        this.context.stdout.write(`Updated Debug ID in ${bundle} and its sourcemap.\n`)
       }
+    } else {
+      this.context.stdout.write(`Dry run: No files modified.\n`)
     }
 
     return 0


### PR DESCRIPTION
### What and why?

The `react-native inject-debug-id` command was only scanning for `*.bundle` files, which works for Android bundles but not for iOS. iOS bundles use the `*.jsbundle` extension (e.g. `main.jsbundle` and `main.jsbundle.map`), causing the command to fail with a "bundle not found" error when run on iOS build output.

Additionally, the command only supported scanning a directory, with no way to target specific bundle/sourcemap files directly. This is inconvenient for non-standard project layouts where explicitly specifying paths is preferable.

### How?

- Extended the bundle file filter in `injectDebugIds` to match both `*.bundle` (Android) and `*.jsbundle` (iOS) extensions.
- Added `--bundle` and `--sourcemap` flags to allow targeting specific files directly, bypassing directory scanning. When `--bundle` is provided without `--sourcemap`, the sourcemap path is derived automatically as `<bundle>.map`.
- Extracted shared per-file injection logic into a new `injectDebugIdIntoFiles` method, used by both the directory scan loop and the explicit-path code path.
- Updated error messages and usage description to reflect both naming conventions and the new flags.
- Added test cases for `*.jsbundle` files, `--bundle`/`--sourcemap` flag usage, auto-derived sourcemap path, and validation errors.

### Additional Notes

Solves issue https://github.com/DataDog/datadog-ci/issues/1907

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
