### PR TITLE
[chore] Print datadog-ci and plugin versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -339,7 +339,7 @@ jobs:
         env:
           DEBUG: plugins
           # Needed during releases, to avoid a "No matching version found" errors
-          PLUGIN_AUTO_INSTALL_PLUGIN_VERSION_OVERRIDE: file:./artifacts/@datadog-datadog-ci-plugin-aas-20.tgz
+          PLUGIN_INSTALL_VERSION_OVERRIDE: file:./artifacts/@datadog-datadog-ci-plugin-aas-20.tgz
 
   # Using `npx datadog-ci` only runs the binary without fetching any package.
   test-plugin-auto-install-in-project-npm:
@@ -392,7 +392,7 @@ jobs:
         env:
           DEBUG: plugins
           # Needed during releases, to avoid a "No matching version found" errors
-          PLUGIN_AUTO_INSTALL_PLUGIN_VERSION_OVERRIDE: file:./artifacts/@datadog-datadog-ci-plugin-aas-20.tgz
+          PLUGIN_INSTALL_VERSION_OVERRIDE: file:./artifacts/@datadog-datadog-ci-plugin-aas-20.tgz
         run: |
           output=$(npx datadog-ci aas instrument || true)
           if echo "$output" | grep "Successfully installed"; then
@@ -408,7 +408,7 @@ jobs:
         env:
           DEBUG: plugins
           # Needed during releases, to avoid a "No matching version found" errors
-          PLUGIN_AUTO_INSTALL_PLUGIN_VERSION_OVERRIDE: file:./artifacts/@datadog-datadog-ci-plugin-aas-20.tgz
+          PLUGIN_INSTALL_VERSION_OVERRIDE: file:./artifacts/@datadog-datadog-ci-plugin-aas-20.tgz
       - name: Check that AAS plugin is installed
         run: |
           if npx datadog-ci plugin check aas; then
@@ -469,7 +469,7 @@ jobs:
         env:
           DEBUG: plugins
           # Needed during releases, to avoid a "No matching version found" errors
-          PLUGIN_AUTO_INSTALL_PLUGIN_VERSION_OVERRIDE: file:./artifacts/@datadog-datadog-ci-plugin-aas-20.tgz
+          PLUGIN_INSTALL_VERSION_OVERRIDE: file:./artifacts/@datadog-datadog-ci-plugin-aas-20.tgz
         run: |
           output=$(yarn datadog-ci aas instrument || true)
           if echo "$output" | grep "Successfully installed"; then
@@ -485,7 +485,7 @@ jobs:
         env:
           DEBUG: plugins
           # Needed during releases, to avoid a "No matching version found" errors
-          PLUGIN_AUTO_INSTALL_PLUGIN_VERSION_OVERRIDE: file:./artifacts/@datadog-datadog-ci-plugin-aas-20.tgz
+          PLUGIN_INSTALL_VERSION_OVERRIDE: file:./artifacts/@datadog-datadog-ci-plugin-aas-20.tgz
       - name: Check that AAS plugin is installed
         run: |
           if yarn datadog-ci plugin check aas; then

--- a/e2e/version.test.ts
+++ b/e2e/version.test.ts
@@ -16,8 +16,8 @@ describe('version', () => {
         GIT_DIR: tmpDir,
       })
 
-      expect(result.exitCode).toBe(0)
       expect(result.stdout).toMatch(/^v?\d+\.\d+\.\d+/)
+      expect(result.exitCode).toBe(0)
     } finally {
       fs.rmSync(tmpDir, {recursive: true, force: true})
     }

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "knip:strict": "knip --include dependencies --no-config-hints --strict",
     "launch": "tsx --conditions=development packages/datadog-ci/src/cli.ts",
     "launch:debug": "tsx --conditions=development --inspect-brk packages/datadog-ci/src/cli.ts",
+    "launch:dist": "tsx packages/datadog-ci/dist/cli.js",
     "lint": "yarn lint:all $@ || (echo \"\nYou can fix this by running ==> yarn format <==\n\" && false)",
     "lint:all": "eslint --cache --quiet '**/*.ts'",
     "lint:ci": "yarn lint:all -f @microsoft/sarif -o 'sarif-datadog-ci.sarif'",

--- a/packages/base/src/commands/plugin/install.ts
+++ b/packages/base/src/commands/plugin/install.ts
@@ -11,12 +11,21 @@ export class PluginInstallCommand extends BaseCommand {
   public static usage = Command.Usage({
     category: 'Plugins',
     description: 'Install or upgrade a plugin.',
+    details: `
+      This command will install or upgrade a plugin, matching the currently running version of datadog-ci.
+
+      You may override the plugin version with \`PLUGIN_INSTALL_VERSION_OVERRIDE\`.
+    `,
     examples: [
       [
         'Install the plugin by passing its package name',
         'datadog-ci plugin install @datadog/datadog-ci-plugin-synthetics',
       ],
       ['Install the plugin by passing its scope', 'datadog-ci plugin install synthetics'],
+      [
+        'Install a specific version of the plugin',
+        'PLUGIN_INSTALL_VERSION_OVERRIDE=1.0.0 datadog-ci plugin install synthetics',
+      ],
     ],
   })
 

--- a/packages/base/src/helpers/__tests__/plugin.test.ts
+++ b/packages/base/src/helpers/__tests__/plugin.test.ts
@@ -56,10 +56,11 @@ describe('checkPlugin', () => {
 
   test('returns true for standalone binary', async () => {
     mockIsStandaloneBinary.mockResolvedValueOnce(true)
+    const consoleLogSpy = jest.spyOn(console, 'log').mockImplementation()
 
     const result = await checkPlugin('test')
     expect(result).toBe(true)
-    expect(console.log).toHaveBeenCalledWith(expect.stringContaining('The plugin is ready to be used! 🔌'))
+    expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining('The plugin is ready to be used! 🔌'))
   })
 
   test('returns true for valid plugin', async () => {

--- a/packages/base/src/helpers/__tests__/plugin.test.ts
+++ b/packages/base/src/helpers/__tests__/plugin.test.ts
@@ -128,7 +128,7 @@ describe('installPlugin', () => {
   })
 
   test('uses version overrides when provided', async () => {
-    process.env['PLUGIN_AUTO_INSTALL_PLUGIN_VERSION_OVERRIDE'] = '1.0.2'
+    process.env['PLUGIN_INSTALL_VERSION_OVERRIDE'] = '1.0.2'
 
     const mockInstallPackage = jest.fn().mockResolvedValue({
       exitCode: 0,
@@ -144,7 +144,7 @@ describe('installPlugin', () => {
       dev: true,
     })
 
-    delete process.env['PLUGIN_AUTO_INSTALL_PLUGIN_VERSION_OVERRIDE']
+    delete process.env['PLUGIN_INSTALL_VERSION_OVERRIDE']
   })
 
   test('handles full package name', async () => {

--- a/packages/base/src/helpers/__tests__/plugin.test.ts
+++ b/packages/base/src/helpers/__tests__/plugin.test.ts
@@ -66,6 +66,16 @@ describe('checkPlugin', () => {
     const result = await checkPlugin('synthetics')
     expect(result).toBe(true)
   })
+
+  test('prints plugin version when plugin is found without command', async () => {
+    const consoleLogSpy = jest.spyOn(console, 'log').mockImplementation()
+
+    const result = await checkPlugin('synthetics')
+    expect(result).toBe(true)
+    expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining('@datadog/datadog-ci-plugin-synthetics'))
+
+    consoleLogSpy.mockRestore()
+  })
 })
 
 describe('executePluginCommand', () => {

--- a/packages/base/src/helpers/plugin.ts
+++ b/packages/base/src/helpers/plugin.ts
@@ -380,11 +380,10 @@ export const VERSION_OVERRIDE_REGEX = /^(\d+\.\d+\.\d+|file:\.\/[a-zA-Z0-9.\-/@]
 
 const getPackageToInstall = (scope: string): PackageInfo => {
   const pluginName = scopeToPackageName(scope)
-
-  const pluginVersionOverride = process.env['PLUGIN_AUTO_INSTALL_PLUGIN_VERSION_OVERRIDE']
+  const pluginVersionOverride = process.env['PLUGIN_INSTALL_VERSION_OVERRIDE']
 
   if (pluginVersionOverride && !VERSION_OVERRIDE_REGEX.test(pluginVersionOverride)) {
-    throw new Error(`Invalid PLUGIN_AUTO_INSTALL_PLUGIN_VERSION_OVERRIDE value: ${pluginVersionOverride}`)
+    throw new Error(`Invalid PLUGIN_INSTALL_VERSION_OVERRIDE value: ${pluginVersionOverride}`)
   }
 
   const pluginVersion = pluginVersionOverride ?? cliVersion

--- a/packages/base/src/helpers/plugin.ts
+++ b/packages/base/src/helpers/plugin.ts
@@ -16,7 +16,7 @@ import {cliVersion} from '../version'
 import {isStandaloneBinary} from './is-standalone-binary'
 import {messageBox} from './message-box'
 
-export type PackageInfo = {name: string; version: string; descriptor: string}
+export type PackageInfo = {name: string; version: string}
 export type PluginSubModule = {PluginCommand: CommandClass<CommandContext>}
 
 // Use `DEBUG=plugins` to enable debug logs
@@ -146,23 +146,24 @@ export const installPlugin = async (packageOrScope: string): Promise<boolean> =>
   }
 
   const pluginPackage = getPackageToInstall(packageOrScope)
+  const pluginDescriptor = packageDescriptor(pluginPackage.name, pluginPackage.version)
 
-  console.log(chalk.dim(`Installing ${pluginPackage.descriptor}...`))
+  console.log(chalk.dim(`Installing ${pluginDescriptor}...`))
 
   const {installPackage} = await importInstallPkg()
-  const output = await installPackage([pluginPackage.descriptor], {
+  const output = await installPackage([pluginDescriptor], {
     silent: !debug.enabled,
     dev: true,
   })
 
   if (output.exitCode === 0) {
     console.log()
-    messageBox('Installed plugin 🔌', 'green', [`Successfully installed ${chalk.bold(pluginPackage.descriptor)}`])
+    messageBox('Installed plugin 🔌', 'green', [`Successfully installed ${chalk.bold(pluginDescriptor)}`])
     console.log()
 
     return true
   } else {
-    console.log(chalk.bold.red(`Failed to install ${pluginPackage.descriptor}! 🔌`))
+    console.log(chalk.bold.red(`Failed to install ${pluginDescriptor}! 🔌`))
     console.log('Stdout:', output.stdout)
     console.log('Stderr:', output.stderr)
 
@@ -191,9 +192,10 @@ export const importInstallPkg = async () => {
 const temporarilyInstallPluginWithNpx = async (scope: string) => {
   const isWindows = process.platform === 'win32'
   const pluginPackage = getPackageToInstall(scope)
+  const pluginDescriptor = packageDescriptor(pluginPackage.name, pluginPackage.version)
 
   const emitPath = isWindows ? 'set PATH' : 'printenv PATH'
-  const cmd = `npx --ignore-scripts -y -p ${pluginPackage.descriptor} ${emitPath}`
+  const cmd = `npx --ignore-scripts -y -p ${pluginDescriptor} ${emitPath}`
 
   debug('Using npx to install the missing plugin:', cmd)
   const output = await new Promise<string>((resolve, reject) => {
@@ -219,7 +221,7 @@ const temporarilyInstallPluginWithNpx = async (scope: string) => {
 
   console.log()
   messageBox('Installed plugin 🔌', 'green', [
-    `Successfully installed ${chalk.bold(pluginPackage.descriptor)} into ${chalk.dim(nodeModulesPath)}`,
+    `Successfully installed ${chalk.bold(pluginDescriptor)} into ${chalk.dim(nodeModulesPath)}`,
     '',
     `Consider installing the plugin explicitly with ${chalk.bold.cyan('datadog-ci plugin install')} ${chalk.magenta(scope)}.`,
   ])
@@ -394,7 +396,6 @@ const getPackageToInstall = (scope: string): PackageInfo => {
   return {
     name: pluginName,
     version: pluginVersion,
-    descriptor: packageDescriptor(pluginName, pluginVersion),
   }
 }
 
@@ -433,7 +434,6 @@ const extractPackageJson = (content: unknown): PackageInfo => {
   return {
     name,
     version,
-    descriptor: packageDescriptor(name, version),
   }
 }
 

--- a/packages/base/src/helpers/plugin.ts
+++ b/packages/base/src/helpers/plugin.ts
@@ -16,7 +16,7 @@ import {cliVersion} from '../version'
 import {isStandaloneBinary} from './is-standalone-binary'
 import {messageBox} from './message-box'
 
-export type PluginPackageJson = {name: string; version: string}
+export type PackageInfo = {name: string; version: string; descriptor: string}
 export type PluginSubModule = {PluginCommand: CommandClass<CommandContext>}
 
 // Use `DEBUG=plugins` to enable debug logs
@@ -92,7 +92,7 @@ export const checkPlugin = async (scope: string, command?: string): Promise<bool
   }
 
   try {
-    const module = await importPlugin(scope, command)
+    const module = command ? await importPluginSubmodule(scope, command) : await importPlugin(scope)
 
     console.log(
       [
@@ -148,19 +148,19 @@ export const installPlugin = async (packageOrScope: string): Promise<boolean> =>
   const pluginPackage = getPackageToInstall(packageOrScope)
 
   const {installPackage} = await importInstallPkg()
-  const output = await installPackage([pluginPackage], {
+  const output = await installPackage([pluginPackage.descriptor], {
     silent: !debug.enabled,
     dev: true,
   })
 
   if (output.exitCode === 0) {
     console.log()
-    messageBox('Installed plugin 🔌', 'green', [`Successfully installed ${chalk.bold(pluginPackage)}`])
+    messageBox('Installed plugin 🔌', 'green', [`Successfully installed ${chalk.bold(pluginPackage.descriptor)}`])
     console.log()
 
     return true
   } else {
-    console.log(chalk.bold.red(`Failed to install ${pluginPackage}! 🔌`))
+    console.log(chalk.bold.red(`Failed to install ${pluginPackage.descriptor}! 🔌`))
     console.log('Stdout:', output.stdout)
     console.log('Stderr:', output.stderr)
 
@@ -191,7 +191,7 @@ const temporarilyInstallPluginWithNpx = async (scope: string) => {
   const pluginPackage = getPackageToInstall(scope)
 
   const emitPath = isWindows ? 'set PATH' : 'printenv PATH'
-  const cmd = `npx --ignore-scripts -y -p ${pluginPackage} ${emitPath}`
+  const cmd = `npx --ignore-scripts -y -p ${pluginPackage.descriptor} ${emitPath}`
 
   debug('Using npx to install the missing plugin:', cmd)
   const output = await new Promise<string>((resolve, reject) => {
@@ -217,14 +217,16 @@ const temporarilyInstallPluginWithNpx = async (scope: string) => {
 
   console.log()
   messageBox('Installed plugin 🔌', 'green', [
-    `Successfully installed ${chalk.bold(pluginPackage)} into ${chalk.dim(nodeModulesPath)}`,
+    `Successfully installed ${chalk.bold(pluginPackage.descriptor)} into ${chalk.dim(nodeModulesPath)}`,
     '',
-    `To skip this step in the future, run ${chalk.bold.cyan('datadog-ci plugin install')} ${chalk.magenta(scope)} in your project.`,
+    `Consider installing the plugin explicitly with ${chalk.bold.cyan('datadog-ci plugin install')} ${chalk.magenta(scope)}.`,
   ])
   console.log()
 
   // Make the plugin resolvable.
   patchModulePaths(nodeModulesPath)
+
+  printPluginVersion(pluginPackage)
 }
 
 const handlePluginAutoInstall = async (scope: string) => {
@@ -235,7 +237,8 @@ const handlePluginAutoInstall = async (scope: string) => {
   }
 
   try {
-    await importPlugin(scope)
+    const plugin = await importPlugin(scope)
+    printPluginVersion(plugin)
 
     debug('Auto-install check: plugin is installed, skipping installation')
   } catch (error) {
@@ -258,12 +261,23 @@ const handlePluginAutoInstall = async (scope: string) => {
   }
 }
 
+const printPluginVersion = (plugin: PackageInfo) => {
+  console.log(chalk.dim(`${plugin.name} v${plugin.version}`))
+  if (plugin.version !== cliVersion) {
+    console.log(
+      chalk.yellow(
+        `The plugin is not the same version as datadog-ci, which could lead to unexpected behavior. Consider syncing the plugin version with datadog-ci.`
+      )
+    )
+  }
+}
+
 // Injected by esbuild in bundled builds (SEA and NPM bundle).
 // eslint-disable-next-line @typescript-eslint/naming-convention
 declare const __getInjectedPlugins:
   | (() => {
       injectedPluginSubmodules?: Record<string, Record<string, PluginSubModule>>
-      injectedPluginPackageJsons?: Record<string, PluginPackageJson>
+      injectedPluginPackageJsons?: Record<string, PackageInfo>
     })
   | undefined
 
@@ -275,7 +289,7 @@ const getInjectedPluginSubmodules = () => {
   return __getInjectedPlugins().injectedPluginSubmodules
 }
 
-const getInjectedPluginPackageJson = (scope: string): PluginPackageJson | undefined => {
+const getInjectedPluginPackageJson = (scope: string): PackageInfo | undefined => {
   if (typeof __getInjectedPlugins === 'undefined') {
     return undefined
   }
@@ -364,7 +378,7 @@ const isValidScope = (scope: string): boolean => {
  */
 export const VERSION_OVERRIDE_REGEX = /^(\d+\.\d+\.\d+|file:\.\/[a-zA-Z0-9.\-/@]+)$/
 
-const getPackageToInstall = (scope: string) => {
+const getPackageToInstall = (scope: string): PackageInfo => {
   const pluginName = scopeToPackageName(scope)
 
   const pluginVersionOverride = process.env['PLUGIN_AUTO_INSTALL_PLUGIN_VERSION_OVERRIDE']
@@ -373,39 +387,36 @@ const getPackageToInstall = (scope: string) => {
     throw new Error(`Invalid PLUGIN_AUTO_INSTALL_PLUGIN_VERSION_OVERRIDE value: ${pluginVersionOverride}`)
   }
 
-  return `${pluginName}@${pluginVersionOverride ?? cliVersion}`
+  const pluginVersion = pluginVersionOverride ?? cliVersion
+
+  return {
+    name: pluginName,
+    version: pluginVersion,
+    descriptor: `${pluginName}@${pluginVersion}`,
+  }
 }
 
-const importPlugin = async (scope: string, command?: string): Promise<PluginPackageJson | PluginSubModule> => {
+const importPlugin = async (scope: string): Promise<PackageInfo> => {
   const packageNameMatch = scope.match(/^@datadog\/datadog-ci-plugin-([a-z-]+)$/)
   const normalizedScope = packageNameMatch?.[1] ?? scope
 
-  if (scope.match(/^@datadog\/datadog-ci-plugin-[a-z-]+$/)) {
-    const injectedPackageJson = getInjectedPluginPackageJson(normalizedScope)
-    if (injectedPackageJson) {
-      return injectedPackageJson
-    }
+  const injectedPackageJson = getInjectedPluginPackageJson(normalizedScope)
+  if (injectedPackageJson) {
+    return injectedPackageJson
+  }
 
+  if (scope.match(/^@datadog\/datadog-ci-plugin-[a-z-]+$/)) {
     // Use `require()` instead of `await import()` to avoid `ERR_IMPORT_ATTRIBUTE_MISSING` due to missing `{with: {type: 'json'}}`.
     // This is only supported with `--module` set to `esnext`, `node16`, or `nodenext`.
     return extractPackageJson(require(`${scope}/package.json`))
   }
 
-  if (!command) {
-    const injectedPackageJson = getInjectedPluginPackageJson(normalizedScope)
-    if (injectedPackageJson) {
-      return injectedPackageJson
-    }
-
-    // Use `require()` instead of `await import()` to avoid `ERR_IMPORT_ATTRIBUTE_MISSING` due to missing `{with: {type: 'json'}}`.
-    // This is only supported with `--module` set to `esnext`, `node16`, or `nodenext`.
-    return extractPackageJson(require(`@datadog/datadog-ci-plugin-${normalizedScope}/package.json`))
-  }
-
-  return importPluginSubmodule(normalizedScope, command)
+  // Use `require()` instead of `await import()` to avoid `ERR_IMPORT_ATTRIBUTE_MISSING` due to missing `{with: {type: 'json'}}`.
+  // This is only supported with `--module` set to `esnext`, `node16`, or `nodenext`.
+  return extractPackageJson(require(`@datadog/datadog-ci-plugin-${normalizedScope}/package.json`))
 }
 
-const extractPackageJson = (content: unknown): PluginPackageJson => {
+const extractPackageJson = (content: unknown): PackageInfo => {
   if (typeof content !== 'object' || !content) {
     throw new Error('Invalid package.json: not an object')
   }
@@ -420,7 +431,7 @@ const extractPackageJson = (content: unknown): PluginPackageJson => {
 
   const {name, version} = content
 
-  return {name, version}
+  return {name, version, descriptor: `${name}@${version}`}
 }
 
 const showPluginNotInstalledMessageBox = (scope: string, command?: string) => {

--- a/packages/base/src/helpers/plugin.ts
+++ b/packages/base/src/helpers/plugin.ts
@@ -391,7 +391,7 @@ const getPackageToInstall = (scope: string): PackageInfo => {
   return {
     name: pluginName,
     version: pluginVersion,
-    descriptor: `${pluginName}@${pluginVersion}`,
+    descriptor: packageDescriptor(pluginName, pluginVersion),
   }
 }
 
@@ -430,8 +430,14 @@ const extractPackageJson = (content: unknown): PackageInfo => {
 
   const {name, version} = content
 
-  return {name, version, descriptor: `${name}@${version}`}
+  return {
+    name,
+    version,
+    descriptor: packageDescriptor(name, version),
+  }
 }
+
+const packageDescriptor = (name: string, version: string) => `${name}@${version}`
 
 const showPluginNotInstalledMessageBox = (scope: string, command?: string) => {
   const packageName = `@datadog/datadog-ci-plugin-${scope}`

--- a/packages/base/src/helpers/plugin.ts
+++ b/packages/base/src/helpers/plugin.ts
@@ -147,6 +147,8 @@ export const installPlugin = async (packageOrScope: string): Promise<boolean> =>
 
   const pluginPackage = getPackageToInstall(packageOrScope)
 
+  console.log(chalk.dim(`Installing ${pluginPackage.descriptor}...`))
+
   const {installPackage} = await importInstallPkg()
   const output = await installPackage([pluginPackage.descriptor], {
     silent: !debug.enabled,
@@ -262,13 +264,14 @@ const handlePluginAutoInstall = async (scope: string) => {
 }
 
 const printPluginVersion = (plugin: PackageInfo) => {
-  console.log(chalk.dim(`${plugin.name} v${plugin.version}`))
   if (plugin.version !== cliVersion) {
     console.log(
-      chalk.yellow(
-        `The plugin is not the same version as datadog-ci, which could lead to unexpected behavior. Consider syncing the plugin version with datadog-ci.`
+      chalk.dim(
+        `${plugin.name} v${plugin.version} (run ${chalk.cyan('datadog-ci plugin install')} to sync with datadog-ci)`
       )
     )
+  } else {
+    console.log(chalk.dim(`${plugin.name} v${plugin.version}`))
   }
 }
 

--- a/packages/base/src/helpers/plugin.ts
+++ b/packages/base/src/helpers/plugin.ts
@@ -239,8 +239,7 @@ const handlePluginAutoInstall = async (scope: string) => {
   }
 
   try {
-    const plugin = await importPlugin(scope)
-    printPluginVersion(plugin)
+    await importPlugin(scope)
 
     debug('Auto-install check: plugin is installed, skipping installation')
   } catch (error) {
@@ -265,6 +264,7 @@ const handlePluginAutoInstall = async (scope: string) => {
 
 const printPluginVersion = (plugin: PackageInfo) => {
   if (plugin.version !== cliVersion) {
+    // CTA about syncing the plugin version with datadog-ci, but it's dimmed to not be too intrusive.
     console.log(
       chalk.dim(
         `${plugin.name} v${plugin.version} (run ${chalk.cyan('datadog-ci plugin install')} to sync with datadog-ci)`
@@ -407,15 +407,12 @@ const importPlugin = async (scope: string): Promise<PackageInfo> => {
     return injectedPackageJson
   }
 
-  if (scope.match(/^@datadog\/datadog-ci-plugin-[a-z-]+$/)) {
-    // Use `require()` instead of `await import()` to avoid `ERR_IMPORT_ATTRIBUTE_MISSING` due to missing `{with: {type: 'json'}}`.
-    // This is only supported with `--module` set to `esnext`, `node16`, or `nodenext`.
-    return extractPackageJson(require(`${scope}/package.json`))
-  }
-
   // Use `require()` instead of `await import()` to avoid `ERR_IMPORT_ATTRIBUTE_MISSING` due to missing `{with: {type: 'json'}}`.
   // This is only supported with `--module` set to `esnext`, `node16`, or `nodenext`.
-  return extractPackageJson(require(`@datadog/datadog-ci-plugin-${normalizedScope}/package.json`))
+  const pluginInfo = extractPackageJson(require(`@datadog/datadog-ci-plugin-${normalizedScope}/package.json`))
+  printPluginVersion(pluginInfo)
+
+  return pluginInfo
 }
 
 const extractPackageJson = (content: unknown): PackageInfo => {

--- a/packages/base/src/version.ts
+++ b/packages/base/src/version.ts
@@ -1,3 +1,15 @@
+import chalk from 'chalk'
+
 import {version} from '@datadog/datadog-ci-base/package.json'
 
-export const cliVersion: string = version
+export const cliVersion = version
+
+/**
+ * Prints version in all commands, except version commands.
+ */
+export const printVersion = () => {
+  const isVersionCommand = process.argv.at(-1) === '--version' || process.argv.at(-1) === 'version'
+  if (!isVersionCommand) {
+    process.stdout.write(chalk.dim(`datadog-ci v${cliVersion}\n`))
+  }
+}

--- a/packages/datadog-ci/src/cli.ts
+++ b/packages/datadog-ci/src/cli.ts
@@ -4,14 +4,14 @@ import type {CommandContext} from '@datadog/datadog-ci-base'
 import type {PluginSubModule} from '@datadog/datadog-ci-base/helpers/plugin'
 
 import {commands as commandDeclarations} from '@datadog/datadog-ci-base/cli'
-import {cliVersion} from '@datadog/datadog-ci-base/version'
+import {cliVersion, printVersion} from '@datadog/datadog-ci-base/version'
 import {Builtins, Cli} from 'clipanion'
 
 import packageJson from '@datadog/datadog-ci/package.json'
 
 export * as gitMetadata from '@datadog/datadog-ci-base/commands/git-metadata/library'
 export * as utils from '@datadog/datadog-ci-base/helpers/utils'
-export {cliVersion as version} from '@datadog/datadog-ci-base/version'
+export {cliVersion, printVersion} from '@datadog/datadog-ci-base/version'
 
 export const BETA_COMMANDS = new Set(['deployment', 'elf-symbols'])
 
@@ -62,6 +62,8 @@ const builtinPlugins =
     : Object.keys(packageJson.devDependencies).filter((plugin) => plugin.startsWith('@datadog/datadog-ci-plugin-'))
 
 if (require.main === module) {
+  printVersion()
+
   void cli.runExit(process.argv.slice(2), {
     stderr: process.stderr,
     stdin: process.stdin,


### PR DESCRIPTION
### What and why?

This PR prints the datadog-ci version (and plugin version if applicable) at the beginning of every command for visibility. This is useful to know in CI logs what version was downloaded if the version is unpinned.

### How?

- Print datadog-ci version
- Print plugin version
- CTA about version skew: if the installed plugin version is different than the installed datadog-ci version

<img width="856" height="285" alt="image" src="https://github.com/user-attachments/assets/32c10820-4d87-44e6-81ad-9703dbcdfd7f" />

Also improves `datadog-ci plugin install --help`:

<img width="764" height="358" alt="image" src="https://github.com/user-attachments/assets/2c6da2d4-efce-4720-af76-6eaf684c1fed" />


### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
