### PR TITLE
[Security] Add 2-day minimum release age cooldown (incident-51987)

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -4,4 +4,6 @@ enableGlobalCache: false
 
 nodeLinker: node-modules
 
+npmMinimalAgeGate: "2d"
+
 yarnPath: .yarn/releases/yarn-4.10.3.cjs


### PR DESCRIPTION
## Summary
- Adds `npmMinimalAgeGate: "2d"` to `.yarnrc.yml` to enforce a 2-day minimum release age cooldown
- Configures Yarn Berry to refuse packages published less than 2 days ago during lockfile generation
- Part of the security campaign (incident-51987) to protect against supply chain attacks

## Details
This is a Yarn Berry 4.10+ feature that adds a time-based gate on package versions. When regenerating the lockfile, Yarn will reject any package version that was published less than 2 days ago. This provides a window to detect and respond to compromised packages before they enter the dependency tree.

**Requires:** Yarn Berry >= 4.10.0 (this repo uses 4.10.3 via `packageManager` field)

## Test plan
- [ ] Verify `yarn install` succeeds with existing lockfile (no-op, cooldown only applies during resolution)
- [ ] Confirm `.yarnrc.yml` is valid YAML and Yarn parses it without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)