### PR TITLE
[SVLS-8827] add npm minimal age gate

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -4,4 +4,6 @@ enableGlobalCache: false
 
 nodeLinker: node-modules
 
+npmMinimalAgeGate: "2d"
+
 yarnPath: .yarn/releases/yarn-4.10.3.cjs


### PR DESCRIPTION
### What and why?

Following the [supply chain attack on axios](https://socket.dev/blog/npm-malware-in-axios-packages), adding `npmMinimalAgeGate: "2d"` to `.yarnrc.yml` to refuse NPM packages published less than 2 days ago during lockfile generation. This provides a buffer for the community to detect and report compromised packages before they enter our dependency tree.

Jira: SVLS-8827

### How?

Config-only change -- added the `npmMinimalAgeGate: "2d"` setting to `.yarnrc.yml`. No functional impact on the codebase. Yarn will now reject any package version published less than 2 days ago when resolving new dependencies or updating the lockfile.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
  - N/A: config-only change, no logic to test