### PR TITLE
chore: migrate plugins from axios to fetch/undici types

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -32,7 +32,6 @@ Component,Origin,Licence,Copyright
 async-retry,import,MIT,"Copyright (c) 2017 ZEIT, Inc."
 aws-sdk-client-mock,dev,MIT,Copyright (c) 2021 Maciej Radzikowski
 aws-sdk-client-mock-jest,dev,MIT,Copyright (c) 2021 Maciej Radzikowski
-axios,import,MIT,Copyright (c) 2014-present Matt Zabriskie
 chalk,import,MIT,Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (https://sindresorhus.com)
 clipanion,import,MIT,Copyright (c) 2019 Mael Nison
 datadog-metrics,import,MIT,Copyright (c) 2014 Daniel Bader

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -381,20 +381,7 @@ export default defineConfig(
       'jest/no-interpolation-in-snapshots': 'off', // allow showing from which variable comes a specific value in inline snapshots
       'jest/padding-around-test-blocks': 'error',
       'no-prototype-builtins': 'off',
-      'no-restricted-imports': [
-        'error',
-        {
-          paths: [
-            ...restrictedImports,
-            // We only allow this in unit tests to mock `axios.create()`.
-            {
-              name: 'axios',
-              importNames: ['default'],
-              message: 'Please only import what you need from axios, e.g. `import {isAxiosError} from "axios"`',
-            },
-          ],
-        },
-      ],
+      'no-restricted-imports': ['error', {paths: restrictedImports}],
       'no-restricted-syntax': [
         'error',
         {

--- a/packages/base/src/commands/git-metadata/__tests__/gitdb.test.ts
+++ b/packages/base/src/commands/git-metadata/__tests__/gitdb.test.ts
@@ -115,7 +115,7 @@ describe('gitdb', () => {
     revparse: MockParam<string, any>[]
     version: MockParam<void, simpleGit.VersionResult>[]
     execSync: MockParam<string, Buffer>[]
-    axios: MockParam<
+    httpRequest: MockParam<
       {
         url: string
         data: any
@@ -147,7 +147,7 @@ describe('gitdb', () => {
     private execSyncMetExpectations: () => void
     private httpRequestMetExpectations: () => void
 
-    private axiosCalls: {
+    private httpRequestCalls: {
       url: string
       data: string | undefined
     }[]
@@ -226,12 +226,12 @@ describe('gitdb', () => {
       this.versionMetExpectations = initMockWithParams(this.simpleGit.version, mockParams.version, true, 'version')
       this.execSyncMetExpectations = initMockWithParams(this.execSync, mockParams.execSync, false, 'execSync')
 
-      this.axiosCalls = []
+      this.httpRequestCalls = []
 
       // custom way of handling httpRequest
-      mockParams.axios.forEach((param) => {
+      mockParams.httpRequest.forEach((param) => {
         this.httpRequest = this.httpRequest.mockImplementationOnce(async (config: any) => {
-          this.axiosCalls.push({url: config.url, data: config.data})
+          this.httpRequestCalls.push({url: config.url, data: config.data})
           if (param.output instanceof Error) {
             throw param.output
           }
@@ -240,12 +240,12 @@ describe('gitdb', () => {
         })
       })
       this.httpRequestMetExpectations = () => {
-        expect(this.httpRequest.mock.calls).toHaveLength(mockParams.axios.length)
-        mockParams.axios.forEach((param, i) => {
+        expect(this.httpRequest.mock.calls).toHaveLength(mockParams.httpRequest.length)
+        mockParams.httpRequest.forEach((param, i) => {
           if (param.input !== undefined) {
-            expect(this.axiosCalls[i].url).toBe(param.input.url)
+            expect(this.httpRequestCalls[i].url).toBe(param.input.url)
             if (param.input.data !== undefined) {
-              const data = this.axiosCalls[i].data as string
+              const data = this.httpRequestCalls[i].data as string
               expect(JSON.parse(data)).toStrictEqual(param.input.data)
             }
           }
@@ -276,7 +276,7 @@ describe('gitdb', () => {
       revparse: [],
       version: [],
       execSync: [],
-      axios: [],
+      httpRequest: [],
     })
     const upload = uploadToGitDB(logger, request, mocks.simpleGit as any, false)
     await expect(upload).rejects.toThrow(testError)
@@ -339,7 +339,7 @@ describe('gitdb', () => {
       ],
       version: [{input: undefined, output: newGitVersion}],
       execSync: [],
-      axios: [
+      httpRequest: [
         {
           input: {
             url: '/api/v2/git/repository/search_commits',
@@ -437,7 +437,7 @@ describe('gitdb', () => {
       ],
       version: [{input: undefined, output: newGitVersion}],
       execSync: [],
-      axios: [
+      httpRequest: [
         {
           input: {
             url: '/api/v2/git/repository/search_commits',
@@ -501,7 +501,7 @@ describe('gitdb', () => {
       revparse: [],
       version: [{input: undefined, output: oldGitVersion}],
       execSync: [],
-      axios: [
+      httpRequest: [
         {
           input: {
             url: '/api/v2/git/repository/search_commits',
@@ -564,7 +564,7 @@ describe('gitdb', () => {
       revparse: [],
       version: [],
       execSync: [],
-      axios: [
+      httpRequest: [
         {
           input: {
             url: '/api/v2/git/repository/search_commits',
@@ -685,7 +685,7 @@ describe('gitdb', () => {
       ],
       version: [{input: undefined, output: newGitVersion}],
       execSync: [],
-      axios: [
+      httpRequest: [
         {
           input: {
             url: '/api/v2/git/repository/search_commits',
@@ -803,7 +803,7 @@ describe('gitdb', () => {
       ],
       version: [{input: undefined, output: newGitVersion}],
       execSync: [],
-      axios: [
+      httpRequest: [
         {
           input: {
             url: '/api/v2/git/repository/search_commits',
@@ -884,7 +884,7 @@ describe('gitdb', () => {
           output: Buffer.from('87ce64f636853fbebc05edfcefe9cccc28a7968b\ncc424c261da5e261b76d982d5d361a023556e2aa\n'),
         },
       ],
-      axios: [
+      httpRequest: [
         {
           input: {
             url: '/api/v2/git/repository/search_commits',
@@ -969,7 +969,7 @@ describe('gitdb', () => {
           output: Buffer.from('87ce64f636853fbebc05edfcefe9cccc28a7968b\ncc424c261da5e261b76d982d5d361a023556e2aa\n'),
         },
       ],
-      axios: [
+      httpRequest: [
         {
           input: {
             url: '/api/v2/git/repository/search_commits',
@@ -1070,7 +1070,7 @@ describe('gitdb', () => {
           output: Buffer.from('cc424c261da5e261b76d982d5d361a023556e2aa\n'),
         },
       ],
-      axios: [
+      httpRequest: [
         {
           input: {
             url: '/api/v2/git/repository/search_commits',
@@ -1167,7 +1167,7 @@ describe('gitdb', () => {
           output: Buffer.from('cc424c261da5e261b76d982d5d361a023556e2aa\n'),
         },
       ],
-      axios: [
+      httpRequest: [
         {
           input: {
             url: '/api/v2/git/repository/search_commits',
@@ -1267,7 +1267,7 @@ describe('gitdb', () => {
       revparse: [],
       version: [],
       execSync: [],
-      axios: [
+      httpRequest: [
         {
           input: {
             url: '/api/v2/git/repository/search_commits',
@@ -1372,7 +1372,7 @@ describe('gitdb', () => {
       revparse: [],
       version: [],
       execSync: [],
-      axios: [
+      httpRequest: [
         {
           input: {
             url: '/api/v2/git/repository/search_commits',
@@ -1446,7 +1446,7 @@ describe('gitdb', () => {
       revparse: [],
       version: [],
       execSync: [],
-      axios: [
+      httpRequest: [
         {
           input: {
             url: '/api/v2/git/repository/search_commits',

--- a/packages/base/src/helpers/__tests__/testing-tools.ts
+++ b/packages/base/src/helpers/__tests__/testing-tools.ts
@@ -143,6 +143,3 @@ export const getRequestError = (status: number, {errors, message}: {errors?: str
     {baseURL: MOCK_BASE_URL, url: 'example'},
     {data: {errors}, status, statusText: ''}
   )
-
-// Backward-compat alias for plugin tests (removed in Stage 2)
-export const getAxiosError = getRequestError

--- a/packages/base/src/helpers/interfaces.ts
+++ b/packages/base/src/helpers/interfaces.ts
@@ -1,4 +1,3 @@
-import type {RequestConfig, RequestResponse} from './request'
 import type {
   CI_ENV_VARS,
   CI_JOB_NAME,
@@ -122,12 +121,8 @@ export type SpanTag =
 
 export type SpanTags = Partial<Record<SpanTag, string>>
 
-// Stage 1 compat: permissive enough for both RequestConfig and AxiosRequestConfig callers
+// Permissive until plugin-synthetics is migrated (Stage 3)
 export type RequestBuilder = (args: any) => Promise<any>
-
-// Backward-compat aliases for downstream plugins (removed in Stage 2)
-export type {RequestConfig as AxiosRequestConfig}
-export type AxiosPromise<T = any> = Promise<RequestResponse<T>>
 
 /**
  * A subset of Clipanion's {@link BaseContext}.

--- a/packages/base/src/helpers/interfaces.ts
+++ b/packages/base/src/helpers/interfaces.ts
@@ -1,3 +1,4 @@
+import type {RequestConfig, RequestResponse} from './request'
 import type {
   CI_ENV_VARS,
   CI_JOB_NAME,
@@ -121,8 +122,7 @@ export type SpanTag =
 
 export type SpanTags = Partial<Record<SpanTag, string>>
 
-// Permissive until plugin-synthetics is migrated (Stage 3)
-export type RequestBuilder = (args: any) => Promise<any>
+export type RequestBuilder = (args: RequestConfig) => Promise<RequestResponse>
 
 /**
  * A subset of Clipanion's {@link BaseContext}.

--- a/packages/base/src/helpers/request.ts
+++ b/packages/base/src/helpers/request.ts
@@ -31,7 +31,7 @@ export interface RequestResponse<T = any> {
 
 export class RequestError extends Error {
   public config: RequestConfig
-  public isAxiosError = true as const // compat: passes axios isAxiosError() check (removed in Stage 2)
+  public isAxiosError = true as const
   public isRequestError = true as const
   public response?: {data: any; status: number; statusText: string}
 

--- a/packages/base/src/helpers/request.ts
+++ b/packages/base/src/helpers/request.ts
@@ -135,6 +135,15 @@ export const httpRequest = async <T = any>(config: RequestConfig): Promise<Reque
   const method = (config.method ?? 'GET').toUpperCase()
   const {body, headers} = serializeBody(config.data, config.headers ?? {})
 
+  // Strip null/undefined header values (callers pass null to explicitly unset a header)
+  const cleanHeaders: Record<string, string> = {}
+  for (const [k, v] of Object.entries(headers)) {
+    // eslint-disable-next-line no-null/no-null
+    if (v !== undefined && v !== null) {
+      cleanHeaders[k] = String(v)
+    }
+  }
+
   const fetchOptions: Record<string, any> = {
     method,
     headers,

--- a/packages/base/src/helpers/request.ts
+++ b/packages/base/src/helpers/request.ts
@@ -8,17 +8,14 @@ export interface RequestConfig {
   baseURL?: string
   data?: any
   dispatcher?: any // undici Dispatcher — typed as any to avoid @types/node version conflict
-  headers?: any // permissive to allow AxiosHeaders during Stage 1 migration
+  headers?: any
+  maxBodyLength?: number // accepted for compat, ignored (no limit with fetch)
+  maxContentLength?: number // accepted for compat, ignored (no limit with fetch)
   method?: string
   params?: any
-  paramsSerializer?: any // Stage 1 compat: axios uses CustomParamsSerializer | ParamsSerializerOptions
+  paramsSerializer?: any
   timeout?: number
   url?: string
-  // Compat fields accepted but not used by httpRequest — allows callers
-  // to pass them without type errors during the migration.
-  httpAgent?: any
-  httpsAgent?: any
-  maxBodyLength?: number
 }
 
 export interface RequestResponse<T = any> {

--- a/packages/base/src/helpers/request.ts
+++ b/packages/base/src/helpers/request.ts
@@ -10,8 +10,6 @@ export interface RequestConfig {
   data?: unknown
   dispatcher?: Dispatcher
   headers?: Record<string, string | null | undefined>
-  maxBodyLength?: number // accepted for compat, ignored (no limit with fetch)
-  maxContentLength?: number // accepted for compat, ignored (no limit with fetch)
   method?: string
   params?: Record<string, unknown>
   paramsSerializer?:

--- a/packages/base/src/helpers/request.ts
+++ b/packages/base/src/helpers/request.ts
@@ -31,7 +31,6 @@ export interface RequestResponse<T = any> {
 
 export class RequestError extends Error {
   public config: RequestConfig
-  public isAxiosError = true as const
   public isRequestError = true as const
   public response?: {data: any; status: number; statusText: string}
 

--- a/packages/base/src/helpers/request.ts
+++ b/packages/base/src/helpers/request.ts
@@ -1,19 +1,22 @@
 import {PassThrough} from 'stream'
 
 import type {Readable} from 'stream'
+import type {Dispatcher} from 'undici'
 
 import {EnvHttpProxyAgent, ProxyAgent, fetch} from 'undici'
 
 export interface RequestConfig {
   baseURL?: string
-  data?: any
-  dispatcher?: any // undici Dispatcher — typed as any to avoid @types/node version conflict
-  headers?: any
+  data?: unknown
+  dispatcher?: Dispatcher
+  headers?: Record<string, string | null | undefined>
   maxBodyLength?: number // accepted for compat, ignored (no limit with fetch)
   maxContentLength?: number // accepted for compat, ignored (no limit with fetch)
   method?: string
-  params?: any
-  paramsSerializer?: any
+  params?: Record<string, unknown>
+  paramsSerializer?:
+    | ((params: Record<string, unknown>) => string)
+    | {serialize: (params: Record<string, unknown>) => string}
   timeout?: number
   url?: string
 }
@@ -76,7 +79,7 @@ const resolveUrl = (config: RequestConfig): string => {
 
   if (params) {
     const serializer = typeof paramsSerializer === 'function' ? paramsSerializer : paramsSerializer?.serialize
-    const qs = serializer ? serializer(params) : new URLSearchParams(params).toString()
+    const qs = serializer ? serializer(params) : new URLSearchParams(params as Record<string, string>).toString()
     const separator = resolved.includes('?') ? '&' : '?'
     resolved = `${resolved}${separator}${qs}`
   }
@@ -84,7 +87,10 @@ const resolveUrl = (config: RequestConfig): string => {
   return resolved
 }
 
-const serializeBody = (data: unknown, headers: any): {body: any; headers: any} => {
+const serializeBody = (
+  data: unknown,
+  headers: Record<string, string | null | undefined>
+): {body: unknown; headers: Record<string, string | null | undefined>} => {
   if (data === undefined) {
     return {body: undefined, headers}
   }

--- a/packages/base/src/helpers/retry.ts
+++ b/packages/base/src/helpers/retry.ts
@@ -12,14 +12,14 @@ export const retryRequest = async <T>(
       return await requestPerformer(bail, attempt)
     } catch (error) {
       if (error.response && errorCodesNoRetry.includes(error.response.status)) {
-        // If it's an axios error with a status code that is excluded from retries, we bail to avoid retrying
+        // If it's an HTTP error with a status code that is excluded from retries, we bail to avoid retrying
         bail(error)
 
         // bail interrupt the flow by throwing an exception, the code below is not executed
         return {} as T
       }
-      // Other cases are retried: other axios HTTP errors as well as
-      // non-axios errors such as DNS resolution errors and connection timeouts
+      // Other cases are retried: other HTTP errors as well as
+      // non-HTTP errors such as DNS resolution errors and connection timeouts
       throw error
     }
   }

--- a/packages/base/src/helpers/upload.ts
+++ b/packages/base/src/helpers/upload.ts
@@ -94,10 +94,6 @@ export const upload =
     }
   }
 
-// Dependency follows-redirects sets a default maxBodyLength of 10 MB https://github.com/follow-redirects/follow-redirects/blob/b774a77e582b97174813b3eaeb86931becba69db/index.js#L391
-// We don't want any hard limit enforced by the CLI, the backend will enforce a max size by returning 413 errors.
-const maxBodyLength = Infinity
-
 const uploadMultipart = async (request: RequestBuilder, payload: MultipartPayload, useGzip: boolean) => {
   const form = new FormData()
   payload.content.forEach((value: MultipartValue, key: string) => {
@@ -125,7 +121,6 @@ const uploadMultipart = async (request: RequestBuilder, payload: MultipartPayloa
   return request({
     data,
     headers,
-    maxBodyLength,
     method: 'POST',
     url: 'v1/input',
   })

--- a/packages/datadog-ci/src/__tests__/cli.test.ts
+++ b/packages/datadog-ci/src/__tests__/cli.test.ts
@@ -15,7 +15,7 @@ const builtins: CommandClass[] = [Builtins.HelpCommand, Builtins.VersionCommand]
 jest.mock('@datadog/datadog-ci-base/helpers/fips')
 
 // Prevent real network calls and expensive I/O in fips tests
-jest.mock('axios')
+jest.mock('@datadog/datadog-ci-base/helpers/request')
 jest.mock('simple-git')
 jest.mock('@datadog/datadog-ci-base/helpers/metrics')
 

--- a/packages/plugin-coverage/package.json
+++ b/packages/plugin-coverage/package.json
@@ -44,7 +44,6 @@
     "upath": "2.0.1"
   },
   "devDependencies": {
-    "axios": "1.13.5",
     "simple-git": "3.33.0"
   }
 }

--- a/packages/plugin-coverage/src/api.ts
+++ b/packages/plugin-coverage/src/api.ts
@@ -2,7 +2,7 @@ import fs from 'fs'
 import {createGzip, gzipSync} from 'zlib'
 
 import type {Payload} from './interfaces'
-import type {AxiosPromise, AxiosRequestConfig, AxiosResponse} from 'axios'
+import type {RequestConfig, RequestResponse} from '@datadog/datadog-ci-base/helpers/request'
 
 import {getApiUrl, getIntakeUrl} from '@datadog/datadog-ci-base/helpers/api'
 import {doWithMaxConcurrency} from '@datadog/datadog-ci-base/helpers/concurrency'
@@ -17,7 +17,7 @@ export const intakeUrl = getIntakeUrl('ci-intake')
 export const apiUrl = getApiUrl()
 
 export const uploadCodeCoverageReport =
-  (request: (args: AxiosRequestConfig) => AxiosPromise<AxiosResponse>) => async (payload: Payload) => {
+  (request: (args: RequestConfig) => Promise<RequestResponse>) => async (payload: Payload) => {
     const form = new FormData()
 
     const event: Record<string, any> = {

--- a/packages/plugin-coverage/src/api.ts
+++ b/packages/plugin-coverage/src/api.ts
@@ -9,10 +9,6 @@ import {doWithMaxConcurrency} from '@datadog/datadog-ci-base/helpers/concurrency
 import {getRequestBuilder} from '@datadog/datadog-ci-base/helpers/utils'
 import FormData from 'form-data'
 
-// Dependency follows-redirects sets a default maxBodyLength of 10 MB https://github.com/follow-redirects/follow-redirects/blob/b774a77e582b97174813b3eaeb86931becba69db/index.js#L391
-// We don't want any hard limit enforced by the CLI, the backend will enforce a max size by returning 413 errors.
-const maxBodyLength = Infinity
-
 export const intakeUrl = getIntakeUrl('ci-intake')
 export const apiUrl = getApiUrl()
 
@@ -67,7 +63,6 @@ export const uploadCodeCoverageReport =
     return request({
       data: form,
       headers: form.getHeaders(),
-      maxBodyLength,
       method: 'POST',
       url: 'api/v2/cicovreprt',
     })

--- a/packages/plugin-coverage/src/commands/upload.ts
+++ b/packages/plugin-coverage/src/commands/upload.ts
@@ -409,7 +409,7 @@ export class PluginCommand extends CoverageUploadCommand {
     } catch (error) {
       this.context.stderr.write(renderFailedUpload(codeCoverageReport, error))
       if (error.response) {
-        // If it's an axios error
+        // If it's an HTTP error
         if (!errorCodesStopUpload.includes(error.response.status)) {
           // And a status code that should not stop the whole upload, just return
           return

--- a/packages/plugin-coverage/src/interfaces.ts
+++ b/packages/plugin-coverage/src/interfaces.ts
@@ -1,6 +1,6 @@
 import type {DiffData} from '@datadog/datadog-ci-base/commands/git-metadata/git'
 import type {SpanTags} from '@datadog/datadog-ci-base/helpers/interfaces'
-import type {AxiosPromise, AxiosResponse} from 'axios'
+import type {RequestResponse} from '@datadog/datadog-ci-base/helpers/request'
 
 export type FileFixes = Record<string, {lines: number; bitmap: string}>
 
@@ -24,5 +24,5 @@ export interface RepoFile {
 }
 
 export interface APIHelper {
-  uploadCodeCoverageReport(codeCoverageReport: Payload): AxiosPromise<AxiosResponse>
+  uploadCodeCoverageReport(codeCoverageReport: Payload): Promise<RequestResponse>
 }

--- a/packages/plugin-deployment/package.json
+++ b/packages/plugin-deployment/package.json
@@ -38,7 +38,6 @@
     "@datadog/datadog-ci-base": "workspace:*"
   },
   "dependencies": {
-    "axios": "1.13.5",
     "chalk": "3.0.0",
     "simple-git": "3.33.0"
   }

--- a/packages/plugin-deployment/src/__tests__/correlate-image.test.ts
+++ b/packages/plugin-deployment/src/__tests__/correlate-image.test.ts
@@ -1,4 +1,4 @@
-import {createCommand, getAxiosError, makeRunCLI} from '@datadog/datadog-ci-base/helpers/__tests__/testing-tools'
+import {createCommand, getRequestError, makeRunCLI} from '@datadog/datadog-ci-base/helpers/__tests__/testing-tools'
 
 import {PluginCommand as DeploymentCorrelateImageCommand} from '../commands/correlate-image'
 
@@ -68,12 +68,12 @@ describe('execute', () => {
   test('handleError', async () => {
     const command = createCommand(DeploymentCorrelateImageCommand)
 
-    const axiosError = getAxiosError(400, {
+    const requestError = getRequestError(400, {
       message: 'Request failed with status code 400',
       errors: ['Some validation error'],
     })
 
-    command['handleError'](axiosError)
+    command['handleError'](requestError)
 
     expect(command.context.stderr.toString()).toStrictEqual(
       `[ERROR] Could not send deployment correlation data: {

--- a/packages/plugin-deployment/src/__tests__/correlate.test.ts
+++ b/packages/plugin-deployment/src/__tests__/correlate.test.ts
@@ -1,4 +1,4 @@
-import {createCommand, getAxiosError, makeRunCLI} from '@datadog/datadog-ci-base/helpers/__tests__/testing-tools'
+import {createCommand, getRequestError, makeRunCLI} from '@datadog/datadog-ci-base/helpers/__tests__/testing-tools'
 
 import {PluginCommand as DeploymentCorrelateCommand} from '../commands/correlate'
 
@@ -80,12 +80,12 @@ describe('execute', () => {
   test('handleError', async () => {
     const command = createCommand(DeploymentCorrelateCommand)
 
-    const axiosError = getAxiosError(400, {
+    const requestError = getRequestError(400, {
       message: 'Request failed with status code 400',
       errors: ['Some validation error'],
     })
 
-    command['handleError'](axiosError)
+    command['handleError'](requestError)
 
     expect(command.context.stderr.toString()).toStrictEqual(
       `[ERROR] Could not send deployment correlation data: {

--- a/packages/plugin-deployment/src/__tests__/gate.test.ts
+++ b/packages/plugin-deployment/src/__tests__/gate.test.ts
@@ -168,7 +168,7 @@ describe('gate', () => {
 
       test('should succeed when requests fail but succeed on retry', async () => {
         const mockError = Object.assign(new Error('Request failed with status code 500'), {
-          isAxiosError: true,
+          isRequestError: true,
           response: {
             status: 500,
             statusText: 'Internal Server Error',
@@ -210,7 +210,7 @@ describe('gate', () => {
       describe('on gate evaluation request', () => {
         test('should fail when gate evaluation request fails with 400', async () => {
           const mockError = Object.assign(new Error('Request failed with status code 400'), {
-            isAxiosError: true,
+            isRequestError: true,
             response: {
               status: 400,
               statusText: 'Bad Request',
@@ -234,7 +234,7 @@ describe('gate', () => {
 
         test('should pass when gate evaluation request fails with 500', async () => {
           const mockError = Object.assign(new Error('Request failed with status code 500'), {
-            isAxiosError: true,
+            isRequestError: true,
             response: {
               status: 500,
               statusText: 'Internal Server Error',
@@ -262,7 +262,7 @@ describe('gate', () => {
 
         test('should fail when gate evaluation request fails with 500 and fail-on-error is true', async () => {
           const mockError = Object.assign(new Error('Request failed with status code 500'), {
-            isAxiosError: true,
+            isRequestError: true,
             response: {
               status: 500,
               statusText: 'Internal Server Error',
@@ -293,7 +293,7 @@ describe('gate', () => {
       describe('on gate evaluation result', () => {
         test('pass with a 500 error', async () => {
           const mockError = Object.assign(new Error('Request failed with status code 500'), {
-            isAxiosError: true,
+            isRequestError: true,
             response: {
               status: 500,
               statusText: 'Internal Server Error',
@@ -321,7 +321,7 @@ describe('gate', () => {
 
         test('pass with a 404 error', async () => {
           const mockError = Object.assign(new Error('Gate evaluation not found'), {
-            isAxiosError: true,
+            isRequestError: true,
             response: {
               status: 404,
               statusText: 'Not Found',
@@ -349,7 +349,7 @@ describe('gate', () => {
 
         test('should fail with 500 error when fail-on-error is true', async () => {
           const mockError = Object.assign(new Error('Request failed with status code 500'), {
-            isAxiosError: true,
+            isRequestError: true,
             response: {
               status: 500,
               statusText: 'Internal Server Error',
@@ -385,7 +385,7 @@ describe('gate', () => {
 
         test('should fail with 404 error when fail-on-error is true', async () => {
           const mockError = Object.assign(new Error('Gate evaluation not found'), {
-            isAxiosError: true,
+            isRequestError: true,
             response: {
               status: 404,
               statusText: 'Not Found',
@@ -446,7 +446,7 @@ describe('gate', () => {
 
         test('should retry when gate evaluation result returns 404', async () => {
           const mock404Error = Object.assign(new Error('Gate evaluation not found'), {
-            isAxiosError: true,
+            isRequestError: true,
             response: {
               status: 404,
               statusText: 'Not Found',

--- a/packages/plugin-deployment/src/api.ts
+++ b/packages/plugin-deployment/src/api.ts
@@ -4,12 +4,12 @@ import type {
   GateEvaluationRequestResponse,
   GateEvaluationStatusResponse,
 } from './interfaces'
-import type {AxiosPromise, AxiosRequestConfig} from 'axios'
+import type {RequestConfig, RequestResponse} from '@datadog/datadog-ci-base/helpers/request'
 
 import {getRequestBuilder} from '@datadog/datadog-ci-base/helpers/utils'
 
 const requestGateEvaluation =
-  (request: (args: AxiosRequestConfig) => AxiosPromise<GateEvaluationRequestResponse>) =>
+  (request: (args: RequestConfig) => Promise<RequestResponse<GateEvaluationRequestResponse>>) =>
   async (evaluationRequest: GateEvaluationRequest) => {
     const payload = {
       data: {
@@ -38,7 +38,7 @@ const requestGateEvaluation =
   }
 
 const getGateEvaluationResult =
-  (request: (args: AxiosRequestConfig) => AxiosPromise<GateEvaluationStatusResponse>) =>
+  (request: (args: RequestConfig) => Promise<RequestResponse<GateEvaluationStatusResponse>>) =>
   async (evaluationId: string) => {
     return request({
       method: 'GET',

--- a/packages/plugin-deployment/src/commands/correlate-image.ts
+++ b/packages/plugin-deployment/src/commands/correlate-image.ts
@@ -4,9 +4,9 @@ import {getDatadogSite} from '@datadog/datadog-ci-base/helpers/api'
 import {toBoolean} from '@datadog/datadog-ci-base/helpers/env'
 import {enableFips} from '@datadog/datadog-ci-base/helpers/fips'
 import {Logger, LogLevel} from '@datadog/datadog-ci-base/helpers/logger'
+import {isRequestError} from '@datadog/datadog-ci-base/helpers/request'
 import {retryRequest} from '@datadog/datadog-ci-base/helpers/retry'
 import {getApiHostForSite, getRequestBuilder} from '@datadog/datadog-ci-base/helpers/utils'
-import {isAxiosError} from 'axios'
 import chalk from 'chalk'
 
 export class PluginCommand extends DeploymentCorrelateImageCommand {
@@ -98,7 +98,7 @@ export class PluginCommand extends DeploymentCorrelateImageCommand {
   private handleError(error: Error) {
     this.context.stderr.write(
       `${chalk.red.bold('[ERROR]')} Could not send deployment correlation data: ${
-        isAxiosError(error)
+        isRequestError(error)
           ? JSON.stringify(
               {
                 status: error.response?.status,

--- a/packages/plugin-deployment/src/commands/correlate.ts
+++ b/packages/plugin-deployment/src/commands/correlate.ts
@@ -6,10 +6,10 @@ import {toBoolean} from '@datadog/datadog-ci-base/helpers/env'
 import {enableFips} from '@datadog/datadog-ci-base/helpers/fips'
 import {gitRepositoryURL, gitLocalCommitShas, gitCurrentBranch} from '@datadog/datadog-ci-base/helpers/git/get-git-data'
 import {Logger, LogLevel} from '@datadog/datadog-ci-base/helpers/logger'
+import {isRequestError} from '@datadog/datadog-ci-base/helpers/request'
 import {retryRequest} from '@datadog/datadog-ci-base/helpers/retry'
 import {CI_PROVIDER_NAME, CI_ENV_VARS, GIT_REPOSITORY_URL, GIT_SHA} from '@datadog/datadog-ci-base/helpers/tags'
 import {getApiHostForSite, getRequestBuilder} from '@datadog/datadog-ci-base/helpers/utils'
-import {isAxiosError} from 'axios'
 import chalk from 'chalk'
 import simpleGit from 'simple-git'
 
@@ -158,7 +158,7 @@ export class PluginCommand extends DeploymentCorrelateCommand {
   private handleError(error: Error) {
     this.context.stderr.write(
       `${chalk.red.bold('[ERROR]')} Could not send deployment correlation data: ${
-        isAxiosError(error)
+        isRequestError(error)
           ? JSON.stringify(
               {
                 status: error.response?.status,

--- a/packages/plugin-deployment/src/commands/gate.ts
+++ b/packages/plugin-deployment/src/commands/gate.ts
@@ -7,9 +7,9 @@ import {toBoolean} from '@datadog/datadog-ci-base/helpers/env'
 import {enableFips} from '@datadog/datadog-ci-base/helpers/fips'
 import {ICONS} from '@datadog/datadog-ci-base/helpers/formatting'
 import {Logger, LogLevel} from '@datadog/datadog-ci-base/helpers/logger'
+import {isRequestError} from '@datadog/datadog-ci-base/helpers/request'
 import {retryRequest} from '@datadog/datadog-ci-base/helpers/retry'
 import {getApiHostForSite} from '@datadog/datadog-ci-base/helpers/utils'
-import {isAxiosError} from 'axios'
 import chalk from 'chalk'
 
 import {apiConstructor} from '../api'
@@ -102,7 +102,7 @@ export class PluginCommand extends DeploymentGateCommand {
       const errorMessage = error instanceof Error ? error.message : String(error)
       this.logger.error(`Deployment gate evaluation failed due to a non-retryable error: ${errorMessage}`)
 
-      if (isAxiosError(error) && error.response?.status) {
+      if (isRequestError(error) && error.response?.status) {
         if (error.response.status >= 400 && error.response.status < 500) {
           this.logger.error(`${ICONS.FAILED} Request failed with client error, exiting with status 1`)
 
@@ -160,7 +160,7 @@ export class PluginCommand extends DeploymentGateCommand {
 
         return id
       } catch (error) {
-        if (isAxiosError(error) && error.response?.status) {
+        if (isRequestError(error) && error.response?.status) {
           this.logger.error(`Request failed with error: ${error.response.status} ${error.response.statusText}`)
         } else {
           const errorMessage = error instanceof Error ? error.message : String(error)
@@ -247,7 +247,7 @@ export class PluginCommand extends DeploymentGateCommand {
           this.logger.warn(`Unknown gate evaluation status: ${status as string}`)
       }
     } catch (error) {
-      if (isAxiosError(error) && error.response?.status) {
+      if (isRequestError(error) && error.response?.status) {
         const status = error.response.status
         const statusText = error.response.statusText
         if (status === 404 || status >= 500) {

--- a/packages/plugin-deployment/src/interfaces.ts
+++ b/packages/plugin-deployment/src/interfaces.ts
@@ -1,4 +1,4 @@
-import type {AxiosPromise} from 'axios'
+import type {RequestResponse} from '@datadog/datadog-ci-base/helpers/request'
 
 export interface GateEvaluationRequest {
   service: string
@@ -42,6 +42,6 @@ export interface GateEvaluationStatusResponse {
 }
 
 export interface APIHelper {
-  requestGateEvaluation(request: GateEvaluationRequest): AxiosPromise<GateEvaluationRequestResponse>
-  getGateEvaluationResult(evaluationId: string): AxiosPromise<GateEvaluationStatusResponse>
+  requestGateEvaluation(request: GateEvaluationRequest): Promise<RequestResponse<GateEvaluationRequestResponse>>
+  getGateEvaluationResult(evaluationId: string): Promise<RequestResponse<GateEvaluationStatusResponse>>
 }

--- a/packages/plugin-dora/package.json
+++ b/packages/plugin-dora/package.json
@@ -40,8 +40,5 @@
   "dependencies": {
     "chalk": "3.0.0",
     "simple-git": "3.33.0"
-  },
-  "devDependencies": {
-    "axios": "1.13.5"
   }
 }

--- a/packages/plugin-dora/src/api.ts
+++ b/packages/plugin-dora/src/api.ts
@@ -1,5 +1,5 @@
 import type {DeploymentEvent} from './interfaces'
-import type {AxiosPromise, AxiosRequestConfig, AxiosResponse} from 'axios'
+import type {RequestConfig, RequestResponse} from '@datadog/datadog-ci-base/helpers/request'
 
 import {getApiUrl} from '@datadog/datadog-ci-base/helpers/api'
 import {getRequestBuilder} from '@datadog/datadog-ci-base/helpers/utils'
@@ -7,7 +7,7 @@ import {getRequestBuilder} from '@datadog/datadog-ci-base/helpers/utils'
 export const apiUrl = getApiUrl()
 
 export const sendDeploymentEvent =
-  (request: (args: AxiosRequestConfig) => AxiosPromise<AxiosResponse>) => async (deployment: DeploymentEvent) => {
+  (request: (args: RequestConfig) => Promise<RequestResponse>) => async (deployment: DeploymentEvent) => {
     const attrs: Record<string, any> = {
       service: deployment.service,
       started_at: deployment.startedAt.getTime() * 1e6, // ms to ns

--- a/packages/plugin-dora/src/commands/deployment.ts
+++ b/packages/plugin-dora/src/commands/deployment.ts
@@ -1,5 +1,5 @@
 import type {APIHelper, DeploymentEvent, GitInfo} from '../interfaces'
-import type {AxiosError} from 'axios'
+import type {RequestError} from '@datadog/datadog-ci-base/helpers/request'
 
 import {DoraDeploymentCommand} from '@datadog/datadog-ci-base/commands/dora/deployment'
 import {FIPS_ENV_VAR, FIPS_IGNORE_ERROR_ENV_VAR} from '@datadog/datadog-ci-base/constants'
@@ -136,9 +136,8 @@ export class PluginCommand extends DoraDeploymentCommand {
         retries: 5,
       })
     } catch (error) {
-      this.logger.error(renderFailedRequest(this.service, error as AxiosError))
+      this.logger.error(renderFailedRequest(this.service, error as RequestError))
       if (error.response) {
-        // If it's an axios error
         if (!nonRetriableErrorCodes.includes(error.response.status)) {
           return
         }

--- a/packages/plugin-dora/src/interfaces.ts
+++ b/packages/plugin-dora/src/interfaces.ts
@@ -1,4 +1,4 @@
-import type {AxiosPromise, AxiosResponse} from 'axios'
+import type {RequestResponse} from '@datadog/datadog-ci-base/helpers/request'
 
 export interface DeploymentEvent {
   service: string
@@ -17,5 +17,5 @@ export interface GitInfo {
 }
 
 export interface APIHelper {
-  sendDeploymentEvent(deployment: DeploymentEvent): AxiosPromise<AxiosResponse>
+  sendDeploymentEvent(deployment: DeploymentEvent): Promise<RequestResponse>
 }

--- a/packages/plugin-dora/src/renderer.ts
+++ b/packages/plugin-dora/src/renderer.ts
@@ -1,5 +1,5 @@
 import type {DeploymentEvent, GitInfo} from './interfaces'
-import type {AxiosError} from 'axios'
+import type {RequestError} from '@datadog/datadog-ci-base/helpers/request'
 
 const ICONS = {
   FAILED: '❌',
@@ -7,7 +7,7 @@ const ICONS = {
   WARNING: '⚠️',
 }
 
-export const renderFailedRequest = (service: string, error: AxiosError) =>
+export const renderFailedRequest = (service: string, error: RequestError) =>
   `${ICONS.FAILED} Failed to send DORA deployment event for service: ${service}: ` +
   (error.response ? JSON.stringify(error.response.data, undefined, 2) : '')
 

--- a/packages/plugin-gate/package.json
+++ b/packages/plugin-gate/package.json
@@ -41,8 +41,5 @@
     "@types/uuid": "9.0.8",
     "chalk": "3.0.0",
     "uuid": "9.0.1"
-  },
-  "devDependencies": {
-    "axios": "1.13.5"
   }
 }

--- a/packages/plugin-gate/src/__tests__/evaluate.test.ts
+++ b/packages/plugin-gate/src/__tests__/evaluate.test.ts
@@ -1,7 +1,7 @@
 import fs from 'fs'
 
 import type {EvaluationResponse, EvaluationResponsePayload, Payload} from '../interfaces'
-import type {AxiosResponse, InternalAxiosRequestConfig} from 'axios'
+import type {RequestConfig, RequestResponse} from '@datadog/datadog-ci-base/helpers/request'
 
 import {createCommand} from '@datadog/datadog-ci-base/helpers/__tests__/testing-tools'
 
@@ -245,12 +245,12 @@ describe('evaluate', () => {
         },
       }
     }
-    const waitMockResponse = (waitTime: number): AxiosResponse<EvaluationResponsePayload> => {
+    const waitMockResponse = (waitTime: number): RequestResponse<EvaluationResponsePayload> => {
       return {
         status: 200,
         statusText: 'OK',
         headers: {},
-        config: {} as InternalAxiosRequestConfig,
+        config: {} as RequestConfig,
         data: {
           data: {
             attributes: {
@@ -264,11 +264,11 @@ describe('evaluate', () => {
         },
       }
     }
-    const passedMockResponse: AxiosResponse<EvaluationResponsePayload> = {
+    const passedMockResponse: RequestResponse<EvaluationResponsePayload> = {
       status: 200,
       statusText: 'OK',
       headers: {},
-      config: {} as InternalAxiosRequestConfig,
+      config: {} as RequestConfig,
       data: {
         data: {
           attributes: {

--- a/packages/plugin-gate/src/api.ts
+++ b/packages/plugin-gate/src/api.ts
@@ -1,11 +1,11 @@
 import type {EvaluationResponsePayload, Payload} from './interfaces'
-import type {AxiosPromise, AxiosRequestConfig} from 'axios'
+import type {RequestConfig, RequestResponse} from '@datadog/datadog-ci-base/helpers/request'
 import type {Writable} from 'stream'
 
 import {getRequestBuilder} from '@datadog/datadog-ci-base/helpers/utils'
 
 export const evaluateGateRules =
-  (request: (args: AxiosRequestConfig) => AxiosPromise<EvaluationResponsePayload>) =>
+  (request: (args: RequestConfig) => Promise<RequestResponse<EvaluationResponsePayload>>) =>
   async (evaluateRequest: Payload, write: Writable['write']) => {
     const payload = JSON.stringify({
       data: {

--- a/packages/plugin-gate/src/commands/evaluate.ts
+++ b/packages/plugin-gate/src/commands/evaluate.ts
@@ -1,6 +1,6 @@
 import type {APIHelper, EvaluationResponse, EvaluationResponsePayload, Payload, PayloadOptions} from '../interfaces'
 import type {SpanTags} from '@datadog/datadog-ci-base/helpers/interfaces'
-import type {AxiosResponse} from 'axios'
+import type {RequestResponse} from '@datadog/datadog-ci-base/helpers/request'
 
 import {GateEvaluateCommand} from '@datadog/datadog-ci-base/commands/gate/evaluate'
 import {FIPS_ENV_VAR, FIPS_IGNORE_ERROR_ENV_VAR} from '@datadog/datadog-ci-base/constants'
@@ -153,7 +153,7 @@ export class PluginCommand extends GateEvaluateCommand {
     evaluateRequest: Payload,
     attempt?: number,
     bail?: (e: Error) => void
-  ): Promise<AxiosResponse<EvaluationResponsePayload>> {
+  ): Promise<RequestResponse<EvaluationResponsePayload>> {
     const timePassed = new Date().getTime() - evaluateRequest.startTimeMs
     const timeoutInSeconds =
       this.timeoutInSeconds !== undefined ? parseInt(String(this.timeoutInSeconds), 10) : this.defaultTimeout

--- a/packages/plugin-gate/src/interfaces.ts
+++ b/packages/plugin-gate/src/interfaces.ts
@@ -1,5 +1,5 @@
 import type {SpanTags} from '@datadog/datadog-ci-base/helpers/interfaces'
-import type {AxiosPromise} from 'axios'
+import type {RequestResponse} from '@datadog/datadog-ci-base/helpers/request'
 import type {Writable} from 'stream'
 
 export interface Payload {
@@ -41,5 +41,8 @@ export interface RuleEvaluation {
 }
 
 export interface APIHelper {
-  evaluateGateRules(evaluateRequest: Payload, write: Writable['write']): AxiosPromise<EvaluationResponsePayload>
+  evaluateGateRules(
+    evaluateRequest: Payload,
+    write: Writable['write']
+  ): Promise<RequestResponse<EvaluationResponsePayload>>
 }

--- a/packages/plugin-junit/package.json
+++ b/packages/plugin-junit/package.json
@@ -43,8 +43,5 @@
     "form-data": "4.0.4",
     "upath": "2.0.1",
     "uuid": "9.0.1"
-  },
-  "devDependencies": {
-    "axios": "1.13.5"
   }
 }

--- a/packages/plugin-junit/src/api.ts
+++ b/packages/plugin-junit/src/api.ts
@@ -10,10 +10,6 @@ import FormData from 'form-data'
 import upath from 'upath'
 import {v4 as uuidv4} from 'uuid'
 
-// Dependency follows-redirects sets a default maxBodyLength of 10 MB https://github.com/follow-redirects/follow-redirects/blob/b774a77e582b97174813b3eaeb86931becba69db/index.js#L391
-// We don't want any hard limit enforced by the CLI, the backend will enforce a max size by returning 413 errors.
-const maxBodyLength = Infinity
-
 export const intakeUrl = getIntakeUrl('cireport-intake')
 export const apiUrl = getApiUrl()
 
@@ -60,7 +56,6 @@ export const uploadJUnitXML =
     return request({
       data: form,
       headers: form.getHeaders(),
-      maxBodyLength,
       method: 'POST',
       url: 'api/v2/cireport',
     })

--- a/packages/plugin-junit/src/api.ts
+++ b/packages/plugin-junit/src/api.ts
@@ -2,7 +2,7 @@ import fs from 'fs'
 import {createGzip} from 'zlib'
 
 import type {Payload} from './interfaces'
-import type {AxiosPromise, AxiosRequestConfig, AxiosResponse} from 'axios'
+import type {RequestConfig, RequestResponse} from '@datadog/datadog-ci-base/helpers/request'
 
 import {getApiUrl, getIntakeUrl} from '@datadog/datadog-ci-base/helpers/api'
 import {getRequestBuilder} from '@datadog/datadog-ci-base/helpers/utils'
@@ -18,7 +18,7 @@ export const intakeUrl = getIntakeUrl('cireport-intake')
 export const apiUrl = getApiUrl()
 
 export const uploadJUnitXML =
-  (request: (args: AxiosRequestConfig) => AxiosPromise<AxiosResponse>) => async (jUnitXML: Payload) => {
+  (request: (args: RequestConfig) => Promise<RequestResponse>) => async (jUnitXML: Payload) => {
     const form = new FormData()
 
     let fileName

--- a/packages/plugin-junit/src/commands/upload.ts
+++ b/packages/plugin-junit/src/commands/upload.ts
@@ -317,7 +317,7 @@ export class PluginCommand extends JunitUploadCommand {
     } catch (error) {
       this.context.stderr.write(renderFailedUpload(jUnitXML, error))
       if (error.response) {
-        // If it's an axios error
+        // If it's an HTTP error
         if (!errorCodesStopUpload.includes(error.response.status)) {
           // And a status code that should not stop the whole upload, just return
           return

--- a/packages/plugin-junit/src/interfaces.ts
+++ b/packages/plugin-junit/src/interfaces.ts
@@ -1,5 +1,5 @@
 import type {SpanTags} from '@datadog/datadog-ci-base/helpers/interfaces'
-import type {AxiosPromise, AxiosResponse} from 'axios'
+import type {RequestResponse} from '@datadog/datadog-ci-base/helpers/request'
 
 export interface Payload {
   hostname: string
@@ -14,5 +14,5 @@ export interface Payload {
 }
 
 export interface APIHelper {
-  uploadJUnitXML(jUnitXML: Payload): AxiosPromise<AxiosResponse>
+  uploadJUnitXML(jUnitXML: Payload): Promise<RequestResponse>
 }

--- a/packages/plugin-sarif/package.json
+++ b/packages/plugin-sarif/package.json
@@ -48,7 +48,6 @@
   "devDependencies": {
     "@types/jest": "29.5.3",
     "@types/uuid": "9.0.8",
-    "axios": "1.13.5",
     "simple-git": "3.33.0"
   }
 }

--- a/packages/plugin-sarif/src/api.ts
+++ b/packages/plugin-sarif/src/api.ts
@@ -11,10 +11,6 @@ import {v4 as uuidv4} from 'uuid'
 
 import {renderUpload} from './renderer'
 
-// Dependency follows-redirects sets a default maxBodyLength of 10 MB https://github.com/follow-redirects/follow-redirects/blob/b774a77e582b97174813b3eaeb86931becba69db/index.js#L391
-// We don't want any hard limit enforced by the CLI, the backend will enforce a max size by returning 413 errors.
-const maxBodyLength = Infinity
-
 export const uploadSarifReport =
   (request: (args: RequestConfig) => Promise<RequestResponse>) =>
   async (sarifReport: Payload, write: Writable['write']) => {
@@ -38,7 +34,6 @@ export const uploadSarifReport =
     return request({
       data: form,
       headers: form.getHeaders(),
-      maxBodyLength,
       method: 'POST',
       url: 'api/v2/cicodescan',
     })

--- a/packages/plugin-sarif/src/api.ts
+++ b/packages/plugin-sarif/src/api.ts
@@ -2,7 +2,7 @@ import fs from 'fs'
 import {createGzip} from 'zlib'
 
 import type {Payload} from './interfaces'
-import type {AxiosPromise, AxiosRequestConfig, AxiosResponse} from 'axios'
+import type {RequestConfig, RequestResponse} from '@datadog/datadog-ci-base/helpers/request'
 import type {Writable} from 'stream'
 
 import {getRequestBuilder} from '@datadog/datadog-ci-base/helpers/utils'
@@ -16,7 +16,7 @@ import {renderUpload} from './renderer'
 const maxBodyLength = Infinity
 
 export const uploadSarifReport =
-  (request: (args: AxiosRequestConfig) => AxiosPromise<AxiosResponse>) =>
+  (request: (args: RequestConfig) => Promise<RequestResponse>) =>
   async (sarifReport: Payload, write: Writable['write']) => {
     const form = new FormData()
     write(renderUpload(sarifReport))

--- a/packages/plugin-sarif/src/interfaces.ts
+++ b/packages/plugin-sarif/src/interfaces.ts
@@ -1,5 +1,5 @@
 import type {SpanTags} from '@datadog/datadog-ci-base/helpers/interfaces'
-import type {AxiosPromise, AxiosResponse} from 'axios'
+import type {RequestResponse} from '@datadog/datadog-ci-base/helpers/request'
 import type {Writable} from 'stream'
 
 export interface Payload {
@@ -9,5 +9,5 @@ export interface Payload {
 }
 
 export interface APIHelper {
-  uploadSarifReport(sarifReport: Payload, write: Writable['write']): AxiosPromise<AxiosResponse>
+  uploadSarifReport(sarifReport: Payload, write: Writable['write']): Promise<RequestResponse>
 }

--- a/packages/plugin-sbom/package.json
+++ b/packages/plugin-sbom/package.json
@@ -40,7 +40,6 @@
   "dependencies": {
     "ajv": "8.18.0",
     "ajv-formats": "3.0.1",
-    "axios": "1.13.5",
     "chalk": "3.0.0",
     "packageurl-js": "2.0.1"
   },

--- a/packages/plugin-sbom/src/api.ts
+++ b/packages/plugin-sbom/src/api.ts
@@ -20,7 +20,7 @@ export const getApiHelper = (
 ): ((scaRequest: ScaRequest) => Promise<RequestResponse>) => {
   /**
    * function used to marshall and send the data
-   * @param request - the AXIOS element used to send the request
+   * @param request - the request function used to send the request
    */
   const uploadSBomPayload =
     (request: (args: RequestConfig) => Promise<RequestResponse>) => async (scaPayload: ScaRequest) => {

--- a/packages/plugin-sbom/src/api.ts
+++ b/packages/plugin-sbom/src/api.ts
@@ -1,5 +1,5 @@
 import type {ScaRequest} from './types'
-import type {AxiosPromise, AxiosRequestConfig, AxiosResponse} from 'axios'
+import type {RequestConfig, RequestResponse} from '@datadog/datadog-ci-base/helpers/request'
 
 import {CONTENT_TYPE_HEADER, CONTENT_TYPE_VALUE_JSON, METHOD_POST} from '@datadog/datadog-ci-base/constants'
 import {getBaseUrl} from '@datadog/datadog-ci-base/helpers/app'
@@ -17,13 +17,13 @@ export const getApiHelper = (
   apiKey: string,
   appKey: string,
   source?: string
-): ((scaRequest: ScaRequest) => AxiosPromise<AxiosResponse>) => {
+): ((scaRequest: ScaRequest) => Promise<RequestResponse>) => {
   /**
    * function used to marshall and send the data
    * @param request - the AXIOS element used to send the request
    */
   const uploadSBomPayload =
-    (request: (args: AxiosRequestConfig) => AxiosPromise<AxiosResponse>) => async (scaPayload: ScaRequest) => {
+    (request: (args: RequestConfig) => Promise<RequestResponse>) => async (scaPayload: ScaRequest) => {
       // Make sure we follow the API signature
       const payload = {
         data: {

--- a/packages/plugin-sbom/src/api.ts
+++ b/packages/plugin-sbom/src/api.ts
@@ -7,8 +7,6 @@ import {getRequestBuilder} from '@datadog/datadog-ci-base/helpers/utils'
 
 import {API_ENDPOINT} from './constants'
 
-const maxBodyLength = Infinity
-
 /**
  * Get the function to upload our results to the intake.
  * @param apiKey
@@ -40,7 +38,6 @@ export const getApiHelper = (
           'DD-EVP-ORIGIN-VERSION': '0.0.1',
           'DD-SOURCE': source || 'CI',
         },
-        maxBodyLength,
         method: METHOD_POST,
         url: API_ENDPOINT,
       })

--- a/packages/plugin-sbom/src/commands/upload.ts
+++ b/packages/plugin-sbom/src/commands/upload.ts
@@ -2,13 +2,14 @@ import fs from 'fs'
 import process from 'process'
 
 import type {ScaRequest} from '../types'
+import type {RequestResponse} from '@datadog/datadog-ci-base/helpers/request'
 import type Ajv from 'ajv'
-import type {AxiosPromise, AxiosResponse} from 'axios'
 
 import {SbomUploadCommand} from '@datadog/datadog-ci-base/commands/sbom/upload'
 import {FIPS_ENV_VAR, FIPS_IGNORE_ERROR_ENV_VAR} from '@datadog/datadog-ci-base/constants'
 import {toBoolean} from '@datadog/datadog-ci-base/helpers/env'
 import {enableFips} from '@datadog/datadog-ci-base/helpers/fips'
+import {isRequestError} from '@datadog/datadog-ci-base/helpers/request'
 import {
   GIT_SHA,
   GIT_REPOSITORY_URL,
@@ -16,7 +17,6 @@ import {
   getMissingRequiredGitTags,
   GIT_BRANCH,
 } from '@datadog/datadog-ci-base/helpers/tags'
-import {isAxiosError} from 'axios'
 
 import {getApiHelper} from '../api'
 import {generatePayload} from '../payload'
@@ -115,7 +115,7 @@ export class PluginCommand extends SbomUploadCommand {
     }
 
     // Get the API helper to send the payload
-    const api: (sbomPayload: ScaRequest) => AxiosPromise<AxiosResponse> = getApiHelper(
+    const api: (sbomPayload: ScaRequest) => Promise<RequestResponse> = getApiHelper(
       this.config.apiKey,
       this.config.appKey,
       this.source
@@ -174,7 +174,7 @@ export class PluginCommand extends SbomUploadCommand {
         this.context.stdout.write(`Upload done for ${basePath}.\n`)
       }
     } catch (error) {
-      if (isAxiosError(error)) {
+      if (isRequestError(error)) {
         if (error.response?.status === 409) {
           const sha = tags[GIT_SHA] || 'sha-not-found'
           const branch = tags[GIT_BRANCH] || 'branch-not-found'

--- a/packages/plugin-synthetics/package.json
+++ b/packages/plugin-synthetics/package.json
@@ -43,7 +43,6 @@
     "@datadog/datadog-ci-base": "workspace:*"
   },
   "dependencies": {
-    "axios": "1.13.5",
     "chalk": "3.0.0",
     "debug": "4.4.1",
     "deep-extend": "0.6.0",
@@ -64,6 +63,7 @@
     "@types/ssh2": "1.15.5",
     "@types/sshpk": "1.10.7",
     "@types/ws": "7.2.9",
-    "@types/xml2js": "0.4.14"
+    "@types/xml2js": "0.4.14",
+    "axios": "1.13.5"
   }
 }

--- a/packages/plugin-synthetics/package.json
+++ b/packages/plugin-synthetics/package.json
@@ -63,7 +63,6 @@
     "@types/ssh2": "1.15.5",
     "@types/sshpk": "1.10.7",
     "@types/ws": "7.2.9",
-    "@types/xml2js": "0.4.14",
-    "axios": "1.13.5"
+    "@types/xml2js": "0.4.14"
   }
 }

--- a/packages/plugin-synthetics/src/__tests__/api.test.ts
+++ b/packages/plugin-synthetics/src/__tests__/api.test.ts
@@ -7,12 +7,11 @@ import {createServer} from 'http'
 
 import type {PollResult, RawPollResult, ServerResult, ServerTrigger, Test, TestPayload} from '../interfaces'
 import type {RecursivePartial} from '../utils/internal'
-import type {AxiosResponse} from 'axios'
 import type {AddressInfo} from 'net'
 
 import {getAxiosError} from '@datadog/datadog-ci-base/helpers/__tests__/testing-tools'
 import * as requestModule from '@datadog/datadog-ci-base/helpers/request'
-import {AxiosError} from 'axios'
+import {RequestError} from '@datadog/datadog-ci-base/helpers/request'
 
 import {apiConstructor, formatBackendErrors, getApiHelper} from '../api'
 import {CriticalError} from '../errors'
@@ -236,7 +235,7 @@ describe('dd-api', () => {
     test.each(cases)(
       'should retry "$name" request (HTTP 404: $shouldBeRetriedOn404, HTTP 429: $shouldBeRetriedOn429, HTTP 5xx: $shouldBeRetriedOn5xx)',
       async ({makeApiRequest, shouldBeRetriedOn404, shouldBeRetriedOn429, shouldBeRetriedOn5xx}) => {
-        const serverError = new AxiosError('Server Error')
+        const serverError = new RequestError('Server Error', {baseURL: '', url: ''})
 
         const requestMock = jest.mocked(requestModule.httpRequest)
         requestMock.mockImplementation(() => {
@@ -244,7 +243,7 @@ describe('dd-api', () => {
         })
 
         {
-          serverError.response = {status: 404} as AxiosResponse
+          serverError.response = {data: undefined, status: 404, statusText: ''}
 
           const requestPromise = makeApiRequest()
           await fastForwardRetries()
@@ -256,7 +255,7 @@ describe('dd-api', () => {
         requestMock.mockClear()
 
         {
-          serverError.response = {status: 429} as AxiosResponse
+          serverError.response = {data: undefined, status: 429, statusText: ''}
 
           const requestPromise = makeApiRequest()
           await fastForwardRetries()
@@ -268,7 +267,7 @@ describe('dd-api', () => {
         requestMock.mockClear()
 
         {
-          serverError.response = {status: 502} as AxiosResponse
+          serverError.response = {data: undefined, status: 502, statusText: ''}
 
           const requestPromise = makeApiRequest()
           await fastForwardRetries()

--- a/packages/plugin-synthetics/src/__tests__/api.test.ts
+++ b/packages/plugin-synthetics/src/__tests__/api.test.ts
@@ -235,7 +235,7 @@ describe('dd-api', () => {
     test.each(cases)(
       'should retry "$name" request (HTTP 404: $shouldBeRetriedOn404, HTTP 429: $shouldBeRetriedOn429, HTTP 5xx: $shouldBeRetriedOn5xx)',
       async ({makeApiRequest, shouldBeRetriedOn404, shouldBeRetriedOn429, shouldBeRetriedOn5xx}) => {
-        const serverError = new RequestError('Server Error', {baseURL: '', url: ''})
+        const serverError = new RequestError('Server Error', {})
 
         const requestMock = jest.mocked(requestModule.httpRequest)
         requestMock.mockImplementation(() => {
@@ -243,7 +243,7 @@ describe('dd-api', () => {
         })
 
         {
-          serverError.response = {data: undefined, status: 404, statusText: ''}
+          serverError.response = {status: 404, statusText: '', data: undefined}
 
           const requestPromise = makeApiRequest()
           await fastForwardRetries()
@@ -255,7 +255,7 @@ describe('dd-api', () => {
         requestMock.mockClear()
 
         {
-          serverError.response = {data: undefined, status: 429, statusText: ''}
+          serverError.response = {status: 429, statusText: '', data: undefined}
 
           const requestPromise = makeApiRequest()
           await fastForwardRetries()
@@ -267,7 +267,7 @@ describe('dd-api', () => {
         requestMock.mockClear()
 
         {
-          serverError.response = {data: undefined, status: 502, statusText: ''}
+          serverError.response = {status: 502, statusText: '', data: undefined}
 
           const requestPromise = makeApiRequest()
           await fastForwardRetries()

--- a/packages/plugin-synthetics/src/__tests__/api.test.ts
+++ b/packages/plugin-synthetics/src/__tests__/api.test.ts
@@ -9,7 +9,7 @@ import type {PollResult, RawPollResult, ServerResult, ServerTrigger, Test, TestP
 import type {RecursivePartial} from '../utils/internal'
 import type {AddressInfo} from 'net'
 
-import {getAxiosError} from '@datadog/datadog-ci-base/helpers/__tests__/testing-tools'
+import {getRequestError} from '@datadog/datadog-ci-base/helpers/__tests__/testing-tools'
 import * as requestModule from '@datadog/datadog-ci-base/helpers/request'
 import {RequestError} from '@datadog/datadog-ci-base/helpers/request'
 
@@ -574,31 +574,31 @@ describe('getApiHelper', () => {
 
 describe('formatBackendErrors', () => {
   test('backend error - no error', () => {
-    const backendError = getAxiosError(500, {errors: []})
+    const backendError = getRequestError(500, {errors: []})
     expect(formatBackendErrors(backendError)).toBe('error querying https://app.datadoghq.com/example')
   })
 
   test('backend error - single error', () => {
-    const backendError = getAxiosError(500, {errors: ['single error']})
+    const backendError = getRequestError(500, {errors: ['single error']})
     expect(formatBackendErrors(backendError)).toBe(
       'query on https://app.datadoghq.com/example returned: "single error"'
     )
   })
 
   test('backend error - multiple errors', () => {
-    const backendError = getAxiosError(500, {errors: ['error 1', 'error 2']})
+    const backendError = getRequestError(500, {errors: ['error 1', 'error 2']})
     expect(formatBackendErrors(backendError)).toBe(
       'query on https://app.datadoghq.com/example returned:\n  - error 1\n  - error 2'
     )
   })
 
   test('not a backend error', () => {
-    const requestError = getAxiosError(403, {message: 'Forbidden'})
+    const requestError = getRequestError(403, {message: 'Forbidden'})
     expect(formatBackendErrors(requestError)).toBe('could not query https://app.datadoghq.com/example\nForbidden')
   })
 
   test('missing scope error', () => {
-    const requestError = getAxiosError(403, {errors: ['Forbidden', 'Failed permission authorization checks']})
+    const requestError = getRequestError(403, {errors: ['Forbidden', 'Failed permission authorization checks']})
     expect(formatBackendErrors(requestError, 'synthetics_default_settings_read')).toBe(
       'query on https://app.datadoghq.com/example returned:\n  - Forbidden\n  - Failed permission authorization checks\nIs the App key granted the synthetics_default_settings_read scope?'
     )

--- a/packages/plugin-synthetics/src/__tests__/batch.test.ts
+++ b/packages/plugin-synthetics/src/__tests__/batch.test.ts
@@ -7,7 +7,7 @@ import type {BaseResult, Batch, PollResult, Result, ResultInBatch, ServerResult,
 import type {RecursivePartial} from '../utils/internal'
 import type {ProxyConfiguration} from '@datadog/datadog-ci-base/helpers/utils'
 
-import {MOCK_BASE_URL, getAxiosError} from '@datadog/datadog-ci-base/helpers/__tests__/testing-tools'
+import {MOCK_BASE_URL, getRequestError} from '@datadog/datadog-ci-base/helpers/__tests__/testing-tools'
 import * as requestModule from '@datadog/datadog-ci-base/helpers/request'
 import deepExtend from 'deep-extend'
 
@@ -140,7 +140,7 @@ describe('runTests', () => {
 
   test('triggerTests throws', async () => {
     jest.spyOn(api, 'triggerTests').mockImplementation(() => {
-      throw getAxiosError(502, {message: 'Server Error'})
+      throw getRequestError(502, {message: 'Server Error'})
     })
 
     await expect(
@@ -736,7 +736,7 @@ describe('waitForResults', () => {
         ],
       }),
       pollResultsImplementation: async () => {
-        throw getAxiosError(404, {message: 'Test results not found'})
+        throw getRequestError(404, {message: 'Test results not found'})
       },
     })
 
@@ -787,7 +787,7 @@ describe('waitForResults', () => {
         ],
       }),
       pollResultsImplementation: async () => {
-        throw getAxiosError(404, {message: 'Test results not found'})
+        throw getRequestError(404, {message: 'Test results not found'})
       },
     })
 
@@ -1204,7 +1204,7 @@ describe('waitForResults', () => {
   test('pollResults throws', async () => {
     const {pollResultsMock} = mockApi({
       pollResultsImplementation: () => {
-        throw getAxiosError(502, {message: 'Poll results server error'})
+        throw getRequestError(502, {message: 'Poll results server error'})
       },
     })
 
@@ -1230,7 +1230,7 @@ describe('waitForResults', () => {
   test('getBatch throws', async () => {
     const {getBatchMock} = mockApi({
       getBatchImplementation: () => {
-        throw getAxiosError(502, {message: 'Get batch server error'})
+        throw getRequestError(502, {message: 'Get batch server error'})
       },
     })
 

--- a/packages/plugin-synthetics/src/__tests__/run-tests-lib.test.ts
+++ b/packages/plugin-synthetics/src/__tests__/run-tests-lib.test.ts
@@ -3,7 +3,7 @@ import os from 'os'
 
 import type {Suite, Summary} from '../interfaces'
 
-import {getAxiosError} from '@datadog/datadog-ci-base/helpers/__tests__/testing-tools'
+import {getRequestError} from '@datadog/datadog-ci-base/helpers/__tests__/testing-tools'
 import * as ciUtils from '@datadog/datadog-ci-base/helpers/utils'
 
 import * as api from '../api'
@@ -218,7 +218,7 @@ describe('run-test', () => {
     test(`403 in getTestsList throws AUTHORIZATION_ERROR`, async () => {
       const apiHelper = {
         searchTests: jest.fn(() => {
-          throw getAxiosError(403, {message: 'Some message'})
+          throw getRequestError(403, {message: 'Some message'})
         }),
       }
       jest.spyOn(api, 'getApiHelper').mockImplementation(() => apiHelper as any)
@@ -233,7 +233,7 @@ describe('run-test', () => {
     test(`502 in getTestsList throws UNAVAILABLE_TEST_CONFIG`, async () => {
       const apiHelper = {
         searchTests: jest.fn(() => {
-          throw getAxiosError(502, {message: 'Some message'})
+          throw getRequestError(502, {message: 'Some message'})
         }),
       }
       jest.spyOn(api, 'getApiHelper').mockImplementation(() => apiHelper as any)
@@ -248,7 +248,7 @@ describe('run-test', () => {
     test(`403 in getTestsToTrigger is not a critical error`, async () => {
       const apiHelper = {
         getTest: jest.fn(() => {
-          throw getAxiosError(403, {errors: ['Some message']})
+          throw getRequestError(403, {errors: ['Some message']})
         }),
       }
       jest.spyOn(api, 'getApiHelper').mockImplementation(() => apiHelper as any)
@@ -263,7 +263,7 @@ describe('run-test', () => {
     test(`502 in getTestsToTrigger throws UNAVAILABLE_TEST_CONFIG`, async () => {
       const apiHelper = {
         getTest: jest.fn(() => {
-          throw getAxiosError(502, {errors: ['Some message']})
+          throw getRequestError(502, {errors: ['Some message']})
         }),
       }
       jest.spyOn(api, 'getApiHelper').mockImplementation(() => apiHelper as any)
@@ -296,7 +296,7 @@ describe('run-test', () => {
 
       const apiHelper = {
         getTunnelPresignedURL: jest.fn(() => {
-          throw getAxiosError(502, {message: 'Server Error'})
+          throw getRequestError(502, {message: 'Server Error'})
         }),
       }
 
@@ -331,7 +331,7 @@ describe('run-test', () => {
 
       const apiHelper = {
         getMobileApplicationPresignedURLs: jest.fn(() => {
-          throw getAxiosError(502, {message: 'Server Error'})
+          throw getRequestError(502, {message: 'Server Error'})
         }),
       }
 
@@ -369,7 +369,7 @@ describe('run-test', () => {
       const apiHelper = {
         getMobileApplicationPresignedURLs: jest.fn(() => MOBILE_PRESIGNED_URLS_PAYLOAD),
         uploadMobileApplicationPart: jest.fn(() => {
-          throw getAxiosError(502, {message: 'Server Error'})
+          throw getRequestError(502, {message: 'Server Error'})
         }),
       }
 
@@ -405,7 +405,7 @@ describe('run-test', () => {
       const apiHelper = {
         getTunnelPresignedURL: () => ({url: 'url'}),
         triggerTests: jest.fn(() => {
-          throw getAxiosError(502, {errors: ['Bad Gateway']})
+          throw getRequestError(502, {errors: ['Bad Gateway']})
         }),
       }
 
@@ -453,7 +453,7 @@ describe('run-test', () => {
         getBatch: () => ({results: []}),
         getTunnelPresignedURL: () => ({url: 'url'}),
         pollResults: jest.fn(() => {
-          throw getAxiosError(502, {errors: ['Bad Gateway']})
+          throw getRequestError(502, {errors: ['Bad Gateway']})
         }),
       }
 

--- a/packages/plugin-synthetics/src/__tests__/test.test.ts
+++ b/packages/plugin-synthetics/src/__tests__/test.test.ts
@@ -7,7 +7,7 @@ import type {APIHelper} from '../api'
 import type {InitialSummary} from '../utils/public'
 import type {ProxyConfiguration} from '@datadog/datadog-ci-base/helpers/utils'
 
-import {getAxiosError} from '@datadog/datadog-ci-base/helpers/__tests__/testing-tools'
+import {getRequestError} from '@datadog/datadog-ci-base/helpers/__tests__/testing-tools'
 import * as requestModule from '@datadog/datadog-ci-base/helpers/request'
 
 import {apiConstructor} from '../api'
@@ -91,7 +91,7 @@ describe('getTestsToTrigger', () => {
         return Promise.resolve({data: fakeTests[publicId], status: 200, statusText: 'OK', headers: {}, config: e})
       }
 
-      throw getAxiosError(404, {errors: ['Not found']})
+      throw getRequestError(404, {errors: ['Not found']})
     }) as any)
   })
 
@@ -196,7 +196,7 @@ describe('getTestAndOverrideConfig', () => {
 
   test('Forbidden error when getting a test', async () => {
     jest.mocked(requestModule.httpRequest).mockImplementation(((_e: any) => {
-      throw getAxiosError(403, {message: 'Forbidden'})
+      throw getRequestError(403, {message: 'Forbidden'})
     }) as any)
 
     const triggerConfig = {suite: 'Suite 1', id: '123-456-789'}
@@ -233,7 +233,7 @@ describe('getTestAndOverrideConfig', () => {
   test('Version not found error when version is provided', async () => {
     jest.mocked(requestModule.httpRequest).mockImplementation(((e: any) => {
       if (e.url?.includes('/synthetics/tests/123-456-789/version_history/50')) {
-        throw getAxiosError(404, {errors: ['Version not found']})
+        throw getRequestError(404, {errors: ['Version not found']})
       }
 
       return Promise.resolve({

--- a/packages/plugin-synthetics/src/__tests__/utils/public.test.ts
+++ b/packages/plugin-synthetics/src/__tests__/utils/public.test.ts
@@ -45,7 +45,7 @@ import process from 'process'
 import type {MockedReporter, RenderResultsTestCase} from '../fixtures'
 import type * as path from 'upath'
 
-import {getAxiosError} from '@datadog/datadog-ci-base/helpers/__tests__/testing-tools'
+import {getRequestError} from '@datadog/datadog-ci-base/helpers/__tests__/testing-tools'
 import * as glob from '@datadog/datadog-ci-base/helpers/glob'
 
 import * as api from '../../api'
@@ -885,7 +885,7 @@ describe('utils', () => {
       jest.spyOn(api, 'getApiHelper').mockReturnValue(
         mockApi({
           getSyntheticsOrgSettings: jest.fn().mockImplementation(() => {
-            throw getAxiosError(502, {message: 'Server Error'})
+            throw getRequestError(502, {message: 'Server Error'})
           }),
         })
       )

--- a/packages/plugin-synthetics/src/api.ts
+++ b/packages/plugin-synthetics/src/api.ts
@@ -20,8 +20,7 @@ import type {
   TestSearchResult,
   ServerTrigger,
 } from './interfaces'
-import type {RequestError} from '@datadog/datadog-ci-base/helpers/request'
-import type {AxiosPromise, AxiosRequestConfig} from 'axios'
+import type {RequestConfig, RequestError, RequestResponse} from '@datadog/datadog-ci-base/helpers/request'
 
 import {isRequestError} from '@datadog/datadog-ci-base/helpers/request'
 import {getRequestBuilder} from '@datadog/datadog-ci-base/helpers/utils'
@@ -92,23 +91,25 @@ export const formatBackendErrors = (requestError: RequestError, scopeName?: stri
   return `could not query ${requestError.config?.baseURL}${requestError.config?.url}\n${requestError.message}`
 }
 
-const triggerTests = (request: (args: AxiosRequestConfig) => AxiosPromise<ServerTrigger>) => async (data: Payload) => {
-  const resp = await retryRequest(
-    {
-      data,
-      headers: {'X-Trigger-App': ciTriggerApp},
-      method: 'POST',
-      url: '/synthetics/tests/trigger/ci',
-    },
-    request,
-    {retryOn429: true}
-  )
+const triggerTests =
+  (request: (args: RequestConfig) => Promise<RequestResponse<ServerTrigger>>) => async (data: Payload) => {
+    const resp = await retryRequest(
+      {
+        data,
+        headers: {'X-Trigger-App': ciTriggerApp},
+        method: 'POST',
+        url: '/synthetics/tests/trigger/ci',
+      },
+      request,
+      {retryOn429: true}
+    )
 
-  return resp.data
-}
+    return resp.data
+  }
 
 const getTest =
-  (request: (args: AxiosRequestConfig) => AxiosPromise<ServerTest>) => async (testId: string, testType?: string) => {
+  (request: (args: RequestConfig) => Promise<RequestResponse<ServerTest>>) =>
+  async (testId: string, testType?: string) => {
     const resp = await retryRequest(
       {
         url: !!testType ? `/synthetics/tests/${testType}/${testId}` : `/synthetics/tests/${testId}`,
@@ -121,7 +122,7 @@ const getTest =
   }
 
 const getTestVersion =
-  (request: (args: AxiosRequestConfig) => AxiosPromise<void>) => async (testId: string, version: number) => {
+  (request: (args: RequestConfig) => Promise<RequestResponse<void>>) => async (testId: string, version: number) => {
     await retryRequest(
       {
         url: `/synthetics/tests/${testId}/version_history/${version}?only_check_existence=true`,
@@ -132,7 +133,7 @@ const getTestVersion =
   }
 
 const getLocalTestDefinition =
-  (request: (args: AxiosRequestConfig) => AxiosPromise<LocalTestDefinition>) =>
+  (request: (args: RequestConfig) => Promise<RequestResponse<LocalTestDefinition>>) =>
   async (testId: string, testType?: string) => {
     const resp = await retryRequest(
       {
@@ -149,7 +150,7 @@ const getLocalTestDefinition =
   }
 
 const editTest =
-  (request: (args: AxiosRequestConfig) => AxiosPromise<void>) => async (testId: string, data: ServerTest) => {
+  (request: (args: RequestConfig) => Promise<RequestResponse<void>>) => async (testId: string, data: ServerTest) => {
     await retryRequest(
       {
         data,
@@ -162,7 +163,7 @@ const editTest =
   }
 
 const searchTests =
-  (request: (args: AxiosRequestConfig) => AxiosPromise<TestSearchResult>) => async (query: string) => {
+  (request: (args: RequestConfig) => Promise<RequestResponse<TestSearchResult>>) => async (query: string) => {
     const resp = await retryRequest(
       {
         params: {
@@ -179,7 +180,7 @@ const searchTests =
   }
 
 const getSyntheticsOrgSettings =
-  (request: (args: AxiosRequestConfig) => AxiosPromise<SyntheticsOrgSettings>) => async () => {
+  (request: (args: RequestConfig) => Promise<RequestResponse<SyntheticsOrgSettings>>) => async () => {
     const resp = await retryRequest(
       {
         url: '/synthetics/settings',
@@ -191,7 +192,7 @@ const getSyntheticsOrgSettings =
   }
 
 const getBatch =
-  (request: (args: AxiosRequestConfig) => AxiosPromise<{data: ServerBatch}>) =>
+  (request: (args: RequestConfig) => Promise<RequestResponse<{data: ServerBatch}>>) =>
   async (batchId: string): Promise<Batch> => {
     const resp = await retryRequest({url: `/synthetics/ci/batch/${batchId}`}, request, {
       retryOn404: true,
@@ -207,7 +208,7 @@ const getBatch =
   }
 
 const pollResults =
-  (request: (args: AxiosRequestConfig) => AxiosPromise<RawPollResult>) => async (resultIds: string[]) => {
+  (request: (args: RequestConfig) => Promise<RequestResponse<RawPollResult>>) => async (resultIds: string[]) => {
     const resp = await retryRequest(
       {
         params: {
@@ -265,13 +266,13 @@ const parseIncludedTest = (test: RawPollResultTest): PollResult['test'] => {
 }
 
 const getTunnelPresignedURL =
-  (request: (args: AxiosRequestConfig) => AxiosPromise<{url: string}>) => async (testIds: string[]) => {
+  (request: (args: RequestConfig) => Promise<RequestResponse<{url: string}>>) => async (testIds: string[]) => {
     const resp = await retryRequest(
       {
         params: {
           test_id: testIds,
         },
-        paramsSerializer: (params) => stringify(params),
+        paramsSerializer: (params) => stringify(params as Record<string, string>),
         url: '/synthetics/ci/tunnel',
       },
       request
@@ -281,7 +282,7 @@ const getTunnelPresignedURL =
   }
 
 const getMobileApplicationPresignedURLs =
-  (request: (args: AxiosRequestConfig) => AxiosPromise<MultipartPresignedUrlsResponse>) =>
+  (request: (args: RequestConfig) => Promise<RequestResponse<MultipartPresignedUrlsResponse>>) =>
   async (
     applicationId: string,
     appSize: number,
@@ -308,7 +309,7 @@ const getMobileApplicationPresignedURLs =
   }
 
 const uploadMobileApplicationPart =
-  (request: (args: AxiosRequestConfig) => AxiosPromise<void>) =>
+  (request: (args: RequestConfig) => Promise<RequestResponse<void>>) =>
   async (
     parts: MobileApplicationUploadPart[],
     multipartPresignedUrlsParams: MultipartPresignedUrlsResponse['multipart_presigned_urls_params']
@@ -325,8 +326,6 @@ const uploadMobileApplicationPart =
             // eslint-disable-next-line no-null/no-null
             'Content-Type': null,
           },
-          maxBodyLength: Infinity,
-          maxContentLength: Infinity,
           method: 'PUT',
           url: presignedUrl,
         },
@@ -334,7 +333,7 @@ const uploadMobileApplicationPart =
       )
 
       // Azure part-upload does not return ETag headers, so our backend ignores it for Azure
-      const quotedEtag = isAzureUrl(presignedUrl) ? '' : (resp.headers.etag as string)
+      const quotedEtag = isAzureUrl(presignedUrl) ? '' : resp.headers.etag
 
       return {
         ETag: quotedEtag.replace(/"/g, ''),
@@ -346,7 +345,7 @@ const uploadMobileApplicationPart =
   }
 
 export const completeMultipartMobileApplicationUpload =
-  (request: (args: AxiosRequestConfig) => AxiosPromise<{job_id: string}>) =>
+  (request: (args: RequestConfig) => Promise<RequestResponse<{job_id: string}>>) =>
   async (
     applicationId: string,
     uploadId: string,
@@ -373,7 +372,7 @@ export const completeMultipartMobileApplicationUpload =
   }
 
 export const pollMobileApplicationUploadResponse =
-  (request: (args: AxiosRequestConfig) => AxiosPromise<MobileAppUploadResult>) =>
+  (request: (args: RequestConfig) => Promise<RequestResponse<MobileAppUploadResult>>) =>
   async (jobId: string): Promise<MobileAppUploadResult> => {
     const response = await retryRequest(
       {
@@ -439,8 +438,8 @@ export const is5xxError = (error: Error): boolean => {
 }
 
 const retryRequest = <T>(
-  args: AxiosRequestConfig,
-  request: (args: AxiosRequestConfig) => AxiosPromise<T>,
+  args: RequestConfig,
+  request: (args: RequestConfig) => Promise<RequestResponse<T>>,
   statusCodesToRetryOn?: RetryPolicy
 ) =>
   retry(

--- a/packages/plugin-synthetics/src/api.ts
+++ b/packages/plugin-synthetics/src/api.ts
@@ -23,8 +23,8 @@ import type {
 import type {RequestError} from '@datadog/datadog-ci-base/helpers/request'
 import type {AxiosPromise, AxiosRequestConfig} from 'axios'
 
+import {isRequestError} from '@datadog/datadog-ci-base/helpers/request'
 import {getRequestBuilder} from '@datadog/datadog-ci-base/helpers/utils'
-import {isAxiosError} from 'axios'
 
 import {CriticalError} from './errors'
 import {MAX_TESTS_TO_TRIGGER} from './test'
@@ -422,7 +422,7 @@ export const determineRetryDelay = (
 const isEndpointError = (error: Error): error is EndpointError => error instanceof EndpointError
 
 export const getErrorHttpStatus = (error: Error): number | undefined =>
-  isEndpointError(error) ? error.status : isAxiosError(error) ? error.response?.status : undefined
+  isEndpointError(error) ? error.status : isRequestError(error) ? error.response?.status : undefined
 
 export const isForbiddenError = (error: Error): boolean => getErrorHttpStatus(error) === 403
 

--- a/packages/plugin-synthetics/src/api.ts
+++ b/packages/plugin-synthetics/src/api.ts
@@ -20,7 +20,7 @@ import type {
   TestSearchResult,
   ServerTrigger,
 } from './interfaces'
-import type {RequestConfig, RequestError, RequestResponse} from '@datadog/datadog-ci-base/helpers/request'
+import type {RequestConfig, RequestResponse, RequestError} from '@datadog/datadog-ci-base/helpers/request'
 
 import {isRequestError} from '@datadog/datadog-ci-base/helpers/request'
 import {getRequestBuilder} from '@datadog/datadog-ci-base/helpers/utils'
@@ -272,7 +272,7 @@ const getTunnelPresignedURL =
         params: {
           test_id: testIds,
         },
-        paramsSerializer: (params) => stringify(params as Record<string, string>),
+        paramsSerializer: (params: any) => stringify(params),
         url: '/synthetics/ci/tunnel',
       },
       request
@@ -321,8 +321,7 @@ const uploadMobileApplicationPart =
           headers: {
             'Content-MD5': parts[Number(partNumber) - 1].md5,
             // Presigned URL *requires* unset content-type since it's used for signature
-            // We can clear axios default by setting to null
-            // https://github.com/axios/axios/pull/1845
+            // Pass null to strip the header (handled in httpRequest)
             // eslint-disable-next-line no-null/no-null
             'Content-Type': null,
           },

--- a/packages/plugin-synthetics/src/commands/__tests__/run-tests.test.ts
+++ b/packages/plugin-synthetics/src/commands/__tests__/run-tests.test.ts
@@ -1,4 +1,4 @@
-import {createCommand, getAxiosError} from '@datadog/datadog-ci-base/helpers/__tests__/testing-tools'
+import {createCommand, getRequestError} from '@datadog/datadog-ci-base/helpers/__tests__/testing-tools'
 import {toBoolean, toNumber, toStringMap} from '@datadog/datadog-ci-base/helpers/env'
 import * as ciUtils from '@datadog/datadog-ci-base/helpers/utils'
 
@@ -889,7 +889,7 @@ describe('run-tests', () => {
       }
 
       const triggerTests = jest.fn(() => {
-        throw getAxiosError(502, {message: 'Bad Gateway'})
+        throw getRequestError(502, {message: 'Bad Gateway'})
       })
       const apiHelper = mockApi({
         getTest: jest.fn(async () => ({...getApiTest('publicId')})),
@@ -1083,7 +1083,7 @@ describe('run-tests', () => {
 
       const apiHelper = mockApi({
         getTest: jest.fn(() => {
-          throw getAxiosError(404, {errors: ['Test not found']})
+          throw getRequestError(404, {errors: ['Test not found']})
         }),
       })
       jest.spyOn(ciUtils, 'resolveConfigFromFile').mockImplementation(async (config, _) => config)
@@ -1106,7 +1106,7 @@ describe('run-tests', () => {
 
           const apiHelper = mockApi({
             searchTests: jest.fn(() => {
-              throw errorCode ? getAxiosError(errorCode, {message: 'Error'}) : new Error('Unknown error')
+              throw errorCode ? getRequestError(errorCode, {message: 'Error'}) : new Error('Unknown error')
             }),
           })
           jest.spyOn(api, 'getApiHelper').mockReturnValue(apiHelper)
@@ -1122,7 +1122,7 @@ describe('run-tests', () => {
 
           const apiHelper = mockApi({
             getTest: jest.fn(() => {
-              throw errorCode ? getAxiosError(errorCode, {message: 'Error'}) : new Error('Unknown error')
+              throw errorCode ? getRequestError(errorCode, {message: 'Error'}) : new Error('Unknown error')
             }),
           })
           jest.spyOn(ciUtils, 'resolveConfigFromFile').mockImplementation(async (config, __) => config)
@@ -1140,7 +1140,7 @@ describe('run-tests', () => {
           const apiHelper = mockApi({
             getTest: async () => getApiTest('123-456-789'),
             triggerTests: jest.fn(() => {
-              throw errorCode ? getAxiosError(errorCode, {message: 'Error'}) : new Error('Unknown error')
+              throw errorCode ? getRequestError(errorCode, {message: 'Error'}) : new Error('Unknown error')
             }),
           })
           jest.spyOn(ciUtils, 'resolveConfigFromFile').mockImplementation(async (config, __) => config)
@@ -1159,7 +1159,7 @@ describe('run-tests', () => {
             getBatch: async () => ({results: [], status: 'passed'}),
             getTest: async () => getApiTest('123-456-789'),
             pollResults: jest.fn(() => {
-              throw errorCode ? getAxiosError(errorCode, {message: 'Error'}) : new Error('Unknown error')
+              throw errorCode ? getRequestError(errorCode, {message: 'Error'}) : new Error('Unknown error')
             }),
             triggerTests: async () => mockServerTriggerResponse,
           })
@@ -1205,10 +1205,10 @@ describe('run-tests', () => {
         const apiHelper = mockApi({
           getTest: jest.fn(async (testId: string) => {
             if (testId === 'mis-sin-ggg') {
-              throw getAxiosError(404, {errors: ['Any message']})
+              throw getRequestError(404, {errors: ['Any message']})
             }
             if (testId === 'una-uth-rzd') {
-              throw getAxiosError(403, {errors: ['Any message']})
+              throw getRequestError(403, {errors: ['Any message']})
             }
 
             return {} as ServerTest
@@ -1241,7 +1241,7 @@ describe('run-tests', () => {
       const apiHelper = mockApi({
         getTest: jest.fn(async (testId: string) => {
           if (testId === 'for-bid-den') {
-            const serverError = getAxiosError(403, {errors: ['Forbidden']})
+            const serverError = getRequestError(403, {errors: ['Forbidden']})
             serverError.config.url = 'tests/for-bid-den'
             throw serverError
           }

--- a/packages/plugin-synthetics/src/commands/__tests__/upload-application.test.ts
+++ b/packages/plugin-synthetics/src/commands/__tests__/upload-application.test.ts
@@ -1,4 +1,4 @@
-import {createCommand, getAxiosError} from '@datadog/datadog-ci-base/helpers/__tests__/testing-tools'
+import {createCommand, getRequestError} from '@datadog/datadog-ci-base/helpers/__tests__/testing-tools'
 import {toBoolean} from '@datadog/datadog-ci-base/helpers/env'
 import * as ciUtils from '@datadog/datadog-ci-base/helpers/utils'
 
@@ -175,7 +175,7 @@ describe('upload-application', () => {
       ['Endpoint error', new EndpointError('some message', 404), 'A backend error occurred: some message (404)'],
       [
         'Axios error',
-        getAxiosError(400, {message: 'Bad Request'}),
+        getRequestError(400, {message: 'Bad Request'}),
         'An unexpected error occurred: RequestError: Bad Request\n    at getRequestError',
       ],
       ['Unknown error', new Error('Unknown error'), 'An unexpected error occurred: Error: Unknown error\n    at '],

--- a/packages/plugin-terraform/package.json
+++ b/packages/plugin-terraform/package.json
@@ -45,7 +45,6 @@
   },
   "devDependencies": {
     "@types/jest": "29.5.3",
-    "axios": "1.13.5",
     "simple-git": "3.33.0",
     "upath": "2.0.1"
   }

--- a/packages/plugin-terraform/src/api.ts
+++ b/packages/plugin-terraform/src/api.ts
@@ -1,7 +1,7 @@
 import {createGzip} from 'zlib'
 
 import type {TerraformArtifactPayload} from './interfaces'
-import type {AxiosPromise, AxiosRequestConfig, AxiosResponse} from 'axios'
+import type {RequestConfig, RequestResponse} from '@datadog/datadog-ci-base/helpers/request'
 
 import {getApiUrl, getIntakeUrl} from '@datadog/datadog-ci-base/helpers/api'
 import {getRequestBuilder} from '@datadog/datadog-ci-base/helpers/utils'
@@ -13,7 +13,7 @@ export const intakeUrl = getIntakeUrl('ci-intake')
 export const apiUrl = getApiUrl()
 
 export const uploadTerraformArtifact =
-  (request: (args: AxiosRequestConfig) => AxiosPromise<AxiosResponse>) => async (payload: TerraformArtifactPayload) => {
+  (request: (args: RequestConfig) => Promise<RequestResponse>) => async (payload: TerraformArtifactPayload) => {
     const form = new FormData()
 
     // Build event envelope according to RFC spec

--- a/packages/plugin-terraform/src/api.ts
+++ b/packages/plugin-terraform/src/api.ts
@@ -7,8 +7,6 @@ import {getApiUrl, getIntakeUrl} from '@datadog/datadog-ci-base/helpers/api'
 import {getRequestBuilder} from '@datadog/datadog-ci-base/helpers/utils'
 import FormData from 'form-data'
 
-const maxBodyLength = Infinity
-
 export const intakeUrl = getIntakeUrl('ci-intake')
 export const apiUrl = getApiUrl()
 
@@ -46,7 +44,6 @@ export const uploadTerraformArtifact =
     return request({
       data: form,
       headers: form.getHeaders(),
-      maxBodyLength,
       method: 'POST',
       url: 'api/v2/ciiac',
     })

--- a/packages/plugin-terraform/src/interfaces.ts
+++ b/packages/plugin-terraform/src/interfaces.ts
@@ -1,5 +1,5 @@
 import type {SpanTags} from '@datadog/datadog-ci-base/helpers/interfaces'
-import type {AxiosPromise, AxiosResponse} from 'axios'
+import type {RequestResponse} from '@datadog/datadog-ci-base/helpers/request'
 
 export interface TerraformArtifactPayload {
   artifactType: 'plan' | 'state'
@@ -12,5 +12,5 @@ export interface TerraformArtifactPayload {
 }
 
 export interface APIHelper {
-  uploadTerraformArtifact(payload: TerraformArtifactPayload): AxiosPromise<AxiosResponse>
+  uploadTerraformArtifact(payload: TerraformArtifactPayload): Promise<RequestResponse>
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2172,7 +2172,6 @@ __metadata:
     "@types/sshpk": "npm:1.10.7"
     "@types/ws": "npm:7.2.9"
     "@types/xml2js": "npm:0.4.14"
-    axios: "npm:1.13.5"
     chalk: "npm:3.0.0"
     debug: "npm:4.4.1"
     deep-extend: "npm:0.6.0"
@@ -5568,17 +5567,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios@npm:1.13.5":
-  version: 1.13.5
-  resolution: "axios@npm:1.13.5"
-  dependencies:
-    follow-redirects: "npm:^1.15.11"
-    form-data: "npm:^4.0.5"
-    proxy-from-env: "npm:^1.1.0"
-  checksum: 10/db726d09902565ef9a0632893530028310e2ec2b95b727114eca1b101450b00014133dfc3871cffc87983fb922bca7e4874d7e2826d1550a377a157cdf3f05b6
-  languageName: node
-  linkType: hard
-
 "babel-jest@npm:^29.7.0":
   version: 29.7.0
   resolution: "babel-jest@npm:29.7.0"
@@ -7479,16 +7467,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"follow-redirects@npm:^1.15.11":
-  version: 1.15.11
-  resolution: "follow-redirects@npm:1.15.11"
-  peerDependenciesMeta:
-    debug:
-      optional: true
-  checksum: 10/07372fd74b98c78cf4d417d68d41fdaa0be4dcacafffb9e67b1e3cf090bc4771515e65020651528faab238f10f9b9c0d9707d6c1574a6c0387c5de1042cde9ba
-  languageName: node
-  linkType: hard
-
 "foreground-child@npm:^3.1.0":
   version: 3.2.1
   resolution: "foreground-child@npm:3.2.1"
@@ -7533,19 +7511,6 @@ __metadata:
     mime-types: "npm:^2.1.35"
     safe-buffer: "npm:^5.2.1"
   checksum: 10/4b6a8d07bb67089da41048e734215f68317a8e29dd5385a972bf5c458a023313c69d3b5d6b8baafbb7f808fa9881e0e2e030ffe61e096b3ddc894c516401271d
-  languageName: node
-  linkType: hard
-
-"form-data@npm:^4.0.5":
-  version: 4.0.5
-  resolution: "form-data@npm:4.0.5"
-  dependencies:
-    asynckit: "npm:^0.4.0"
-    combined-stream: "npm:^1.0.8"
-    es-set-tostringtag: "npm:^2.1.0"
-    hasown: "npm:^2.0.2"
-    mime-types: "npm:^2.1.12"
-  checksum: 10/52ecd6e927c8c4e215e68a7ad5e0f7c1031397439672fd9741654b4a94722c4182e74cc815b225dcb5be3f4180f36428f67c6dd39eaa98af0dcfdd26c00c19cd
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2030,7 +2030,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@datadog/datadog-ci-plugin-coverage@workspace:packages/plugin-coverage"
   dependencies:
-    axios: "npm:1.13.5"
     chalk: "npm:3.0.0"
     fast-xml-parser: "npm:5.5.9"
     form-data: "npm:4.0.4"
@@ -2045,7 +2044,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@datadog/datadog-ci-plugin-deployment@workspace:packages/plugin-deployment"
   dependencies:
-    axios: "npm:1.13.5"
     chalk: "npm:3.0.0"
     simple-git: "npm:3.33.0"
   peerDependencies:
@@ -2057,7 +2055,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@datadog/datadog-ci-plugin-dora@workspace:packages/plugin-dora"
   dependencies:
-    axios: "npm:1.13.5"
     chalk: "npm:3.0.0"
     simple-git: "npm:3.33.0"
   peerDependencies:
@@ -2070,7 +2067,6 @@ __metadata:
   resolution: "@datadog/datadog-ci-plugin-gate@workspace:packages/plugin-gate"
   dependencies:
     "@types/uuid": "npm:9.0.8"
-    axios: "npm:1.13.5"
     chalk: "npm:3.0.0"
     uuid: "npm:9.0.1"
   peerDependencies:
@@ -2082,7 +2078,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@datadog/datadog-ci-plugin-junit@workspace:packages/plugin-junit"
   dependencies:
-    axios: "npm:1.13.5"
     chalk: "npm:3.0.0"
     fast-xml-parser: "npm:5.5.9"
     form-data: "npm:4.0.4"
@@ -2127,7 +2122,6 @@ __metadata:
     "@types/uuid": "npm:9.0.8"
     ajv: "npm:8.18.0"
     ajv-formats: "npm:3.0.1"
-    axios: "npm:1.13.5"
     chalk: "npm:3.0.0"
     form-data: "npm:4.0.4"
     simple-git: "npm:3.33.0"
@@ -2145,7 +2139,6 @@ __metadata:
     "@types/jest": "npm:29.5.3"
     ajv: "npm:8.18.0"
     ajv-formats: "npm:3.0.1"
-    axios: "npm:1.13.5"
     chalk: "npm:3.0.0"
     packageurl-js: "npm:2.0.1"
     simple-git: "npm:3.33.0"
@@ -2203,7 +2196,6 @@ __metadata:
   resolution: "@datadog/datadog-ci-plugin-terraform@workspace:packages/plugin-terraform"
   dependencies:
     "@types/jest": "npm:29.5.3"
-    axios: "npm:1.13.5"
     chalk: "npm:3.0.0"
     form-data: "npm:4.0.4"
     simple-git: "npm:3.33.0"


### PR DESCRIPTION
### What and why?

Completes the axios-to-fetch/undici migration. Migrates all 9 downstream plugins from axios types to the new `RequestConfig`/`RequestResponse`/`RequestError` types introduced in the base package (#2246), and removes axios from the codebase entirely.

After this PR, axios has zero references in source code, package.json files, or LICENSE-3rdparty.csv.

Depends on #2246 (Stage 1: base package migration).

### How?

**Type migration across 9 plugins** (coverage, deployment, dora, gate, junit, sarif, sbom, synthetics, terraform):

- `AxiosRequestConfig` → `RequestConfig`
- `AxiosPromise<T>` → `Promise<RequestResponse<T>>`
- `AxiosResponse` → `RequestResponse`
- `AxiosError` → `RequestError`
- `isAxiosError()` → `isRequestError()`
- `getAxiosError()` → `getRequestError()` in tests

**Base package cleanup:**

- Removed backward-compat type aliases from `base/helpers/interfaces.ts`
- Removed axios compat fields (`httpAgent`, `httpsAgent`) from `RequestConfig`
- Properly typed `RequestConfig` fields (`headers`, `params`, `dispatcher`, `paramsSerializer`) -- previously `any`
- Removed `maxBodyLength`/`maxContentLength` from `RequestConfig` and all call sites (no-ops with fetch)
- Removed `getAxiosError` compat alias from test helpers
- Removed axios-specific eslint import restriction
- Updated gitdb test mocks from `axios` → `httpRequest`
- Updated CLI test mock from `axios` → `httpRequest`

**Dependency removal:**

- Removed `axios` from all 9 plugin `package.json` files
- Removed `axios` from `LICENSE-3rdparty.csv`
- Cleaned up `yarn.lock`

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)