### PR TITLE
chore: migrate plugin-synthetics and finish migration from axios to fetch/undici

### DIFF
--- a/packages/plugin-synthetics/src/__tests__/api.test.ts
+++ b/packages/plugin-synthetics/src/__tests__/api.test.ts
@@ -235,7 +235,7 @@ describe('dd-api', () => {
     test.each(cases)(
       'should retry "$name" request (HTTP 404: $shouldBeRetriedOn404, HTTP 429: $shouldBeRetriedOn429, HTTP 5xx: $shouldBeRetriedOn5xx)',
       async ({makeApiRequest, shouldBeRetriedOn404, shouldBeRetriedOn429, shouldBeRetriedOn5xx}) => {
-        const serverError = new RequestError('Server Error', {baseURL: '', url: ''})
+        const serverError = new RequestError('Server Error', {})
 
         const requestMock = jest.mocked(requestModule.httpRequest)
         requestMock.mockImplementation(() => {
@@ -243,7 +243,7 @@ describe('dd-api', () => {
         })
 
         {
-          serverError.response = {data: undefined, status: 404, statusText: ''}
+          serverError.response = {status: 404, statusText: '', data: undefined}
 
           const requestPromise = makeApiRequest()
           await fastForwardRetries()
@@ -255,7 +255,7 @@ describe('dd-api', () => {
         requestMock.mockClear()
 
         {
-          serverError.response = {data: undefined, status: 429, statusText: ''}
+          serverError.response = {status: 429, statusText: '', data: undefined}
 
           const requestPromise = makeApiRequest()
           await fastForwardRetries()
@@ -267,7 +267,7 @@ describe('dd-api', () => {
         requestMock.mockClear()
 
         {
-          serverError.response = {data: undefined, status: 502, statusText: ''}
+          serverError.response = {status: 502, statusText: '', data: undefined}
 
           const requestPromise = makeApiRequest()
           await fastForwardRetries()

--- a/packages/plugin-synthetics/src/api.ts
+++ b/packages/plugin-synthetics/src/api.ts
@@ -20,7 +20,7 @@ import type {
   TestSearchResult,
   ServerTrigger,
 } from './interfaces'
-import type {RequestConfig, RequestError, RequestResponse} from '@datadog/datadog-ci-base/helpers/request'
+import type {RequestConfig, RequestResponse, RequestError} from '@datadog/datadog-ci-base/helpers/request'
 
 import {isRequestError} from '@datadog/datadog-ci-base/helpers/request'
 import {getRequestBuilder} from '@datadog/datadog-ci-base/helpers/utils'
@@ -272,7 +272,7 @@ const getTunnelPresignedURL =
         params: {
           test_id: testIds,
         },
-        paramsSerializer: (params) => stringify(params as Record<string, string>),
+        paramsSerializer: (params: any) => stringify(params),
         url: '/synthetics/ci/tunnel',
       },
       request
@@ -321,8 +321,7 @@ const uploadMobileApplicationPart =
           headers: {
             'Content-MD5': parts[Number(partNumber) - 1].md5,
             // Presigned URL *requires* unset content-type since it's used for signature
-            // We can clear axios default by setting to null
-            // https://github.com/axios/axios/pull/1845
+            // Pass null to strip the header (handled in httpRequest)
             // eslint-disable-next-line no-null/no-null
             'Content-Type': null,
           },


### PR DESCRIPTION
### What and why?

Stage 3 (final) of the axios-to-fetch migration. Migrates `plugin-synthetics` -- the most complex plugin -- from axios types to the new `RequestConfig`/`RequestResponse`/`RequestError` types, removes `axios` from the last `package.json`, and cleans up all remaining compat cruft from the base package.

Depends on #2247 (Stage 2: plugin migrations).

### How?

**Source changes (`api.ts`):**
- Replaced all axios type imports with `RequestConfig`, `RequestResponse`, `RequestError`, `isRequestError`
- Updated 14 API function signatures and the `retryRequest` wrapper
- `extractUnauthorizedTestPublicIds` and `formatBackendErrors` now take `RequestError` instead of `AxiosError<BackendError>`
- Removed unused `BackendError` interface
- Added explicit type annotation for `paramsSerializer` param and `.find()` callback

**Base package fixes:**
- Added `maxContentLength` to `RequestConfig` (accepted for compat, ignored by fetch)
- Added null header filtering in `httpRequest` to handle the `Content-Type: null` pattern used for presigned URL uploads
- Removed `getAxiosError` backward-compat alias from testing-tools
- Removed `isAxiosError` compat field from `RequestError`
- Removed `httpAgent`/`httpsAgent` compat fields from `RequestConfig`
- Cleaned up stale Stage 1 migration comments
- Tightened `RequestBuilder` type from `(args: any) => Promise<any>` to `(args: RequestConfig) => Promise<RequestResponse>`

**Other cleanup:**
- Removed `axios` from `LICENSE-3rdparty.csv`
- Replaced stale `jest.mock('axios')` with `jest.mock('@datadog/datadog-ci-base/helpers/request')` in `cli.test.ts`

**Test changes (8 files):**
- `api.test.ts`: Replaced `new AxiosError()` with `new RequestError()` for retry tests
- All test files: Renamed `getAxiosError` -> `getRequestError` (including 2 deployment test files that also used the alias)

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)