### PR TITLE
chore: remove axios compat cruft from base package

### DIFF
--- a/packages/base/src/helpers/interfaces.ts
+++ b/packages/base/src/helpers/interfaces.ts
@@ -1,3 +1,4 @@
+import type {RequestConfig, RequestResponse} from './request'
 import type {
   CI_ENV_VARS,
   CI_JOB_NAME,
@@ -121,8 +122,7 @@ export type SpanTag =
 
 export type SpanTags = Partial<Record<SpanTag, string>>
 
-// Permissive until plugin-synthetics is migrated (Stage 3)
-export type RequestBuilder = (args: any) => Promise<any>
+export type RequestBuilder = (args: RequestConfig) => Promise<RequestResponse>
 
 /**
  * A subset of Clipanion's {@link BaseContext}.

--- a/packages/base/src/helpers/request.ts
+++ b/packages/base/src/helpers/request.ts
@@ -8,18 +8,14 @@ export interface RequestConfig {
   baseURL?: string
   data?: any
   dispatcher?: any // undici Dispatcher — typed as any to avoid @types/node version conflict
-  headers?: any // permissive to allow AxiosHeaders during Stage 1 migration
+  headers?: any
   maxBodyLength?: number // accepted for compat, ignored (no limit with fetch)
   maxContentLength?: number // accepted for compat, ignored (no limit with fetch)
   method?: string
   params?: any
-  paramsSerializer?: any // Stage 1 compat: axios uses CustomParamsSerializer | ParamsSerializerOptions
+  paramsSerializer?: any
   timeout?: number
   url?: string
-  // Compat fields accepted but not used by httpRequest — allows callers
-  // to pass them without type errors during the migration.
-  httpAgent?: any
-  httpsAgent?: any
 }
 
 export interface RequestResponse<T = any> {
@@ -32,7 +28,6 @@ export interface RequestResponse<T = any> {
 
 export class RequestError extends Error {
   public config: RequestConfig
-  public isAxiosError = true as const
   public isRequestError = true as const
   public response?: {data: any; status: number; statusText: string}
 


### PR DESCRIPTION
### What and why?

Stage 4 (final) of the axios-to-fetch migration. Removes all backward-compat fields, types, and comments that were needed during the staged migration.

Depends on #2248 (Stage 3: plugin-synthetics migration).

### How?

- Removed `isAxiosError` compat field from `RequestError`
- Removed `httpAgent`/`httpsAgent` compat fields from `RequestConfig`
- Cleaned up stale Stage 1 migration comments
- Tightened `RequestBuilder` type from `(args: any) => Promise<any>` to `(args: RequestConfig) => Promise<RequestResponse>`

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)