### PR TITLE
[security] Set `User-Agent` for requests done by datadog-ci

### DIFF
--- a/packages/base/src/helpers/__tests__/plugin.test.ts
+++ b/packages/base/src/helpers/__tests__/plugin.test.ts
@@ -11,6 +11,7 @@ import {
   executePluginCommand,
   VERSION_OVERRIDE_REGEX,
 } from '../plugin'
+import {getUserAgent} from '../user-agent'
 
 import {createCommand} from './testing-tools'
 
@@ -80,14 +81,30 @@ describe('checkPlugin', () => {
 })
 
 describe('executePluginCommand', () => {
+  const module = require('@datadog/datadog-ci-plugin-synthetics/commands/run-tests')
+  const SyntheticsRunTestsPluginCommand = module.PluginCommand.prototype
+
   test('executes plugin command successfully', async () => {
     // Mock the plugin command's `execute` method, but not the `@datadog/datadog-ci-base/commands/synthetics/run-tests` one.
-    const module = require('@datadog/datadog-ci-plugin-synthetics/commands/run-tests')
-    const SyntheticsRunTestsPluginCommand = module.PluginCommand.prototype
     jest.spyOn(SyntheticsRunTestsPluginCommand, 'execute').mockResolvedValue(0)
     const command = createCommand(SyntheticsRunTestsCommand)
     const result = await executePluginCommand(command)
     expect(result).toBe(0)
+  })
+
+  test('injects plugin identity into the user agent context during execution', async () => {
+    let userAgent = ''
+    jest.spyOn(SyntheticsRunTestsPluginCommand, 'execute').mockImplementation(async () => {
+      userAgent = getUserAgent()
+
+      return 0
+    })
+
+    const command = createCommand(SyntheticsRunTestsCommand)
+    const result = await executePluginCommand(command)
+
+    expect(result).toBe(0)
+    expect(userAgent).toMatch(/^datadog-ci\/1\.0\.0 \(node .+; os .+; arch .+\) datadog-ci-plugin-synthetics\/.+$/)
   })
 })
 

--- a/packages/base/src/helpers/__tests__/request.test.ts
+++ b/packages/base/src/helpers/__tests__/request.test.ts
@@ -1,0 +1,77 @@
+import type * as Undici from 'undici'
+
+jest.mock('undici', () => {
+  const actualUndici = jest.requireActual<typeof Undici>('undici')
+
+  return {
+    ...actualUndici,
+    fetch: jest.fn(),
+  }
+})
+
+import {fetch} from 'undici'
+
+import {httpRequest} from '../request'
+import {getUserAgent, withPluginUserAgent} from '../user-agent'
+
+type MockFetchResponse = {
+  headers: {
+    forEach: (callback: (value: string, key: string) => void) => void
+  }
+  ok: boolean
+  status: number
+  statusText: string
+  text: () => Promise<string>
+}
+
+const mockedFetch = jest.mocked(fetch)
+const getLastFetchHeaders = (): Record<string, string> => {
+  const lastCall = mockedFetch.mock.calls.at(-1)
+  if (!lastCall) {
+    throw new Error('Expected fetch to be called')
+  }
+
+  const options = lastCall[1] as {headers: Record<string, string>}
+
+  return options.headers
+}
+
+const createResponse = (headers: Record<string, string> = {}): MockFetchResponse => ({
+  headers: {
+    forEach: (callback) => {
+      for (const [key, value] of Object.entries(headers)) {
+        callback(value, key)
+      }
+    },
+  },
+  ok: true,
+  status: 200,
+  statusText: 'OK',
+  text: async () => '',
+})
+
+describe('httpRequest', () => {
+  beforeEach(() => {
+    mockedFetch.mockResolvedValue(createResponse() as Awaited<ReturnType<typeof fetch>>)
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  test('adds the default datadog-ci user agent header', async () => {
+    await httpRequest({url: 'https://example.com'})
+
+    expect(mockedFetch).toHaveBeenCalledWith('https://example.com', expect.any(Object))
+    expect(getLastFetchHeaders()['User-Agent']).toBe(getUserAgent())
+  })
+
+  test('appends the active plugin token when a plugin command is running', async () => {
+    await withPluginUserAgent('@datadog/datadog-ci-plugin-synthetics', '9.9.9', async () => {
+      await httpRequest({url: 'https://example.com'})
+    })
+
+    expect(mockedFetch).toHaveBeenCalledWith('https://example.com', expect.any(Object))
+    expect(getLastFetchHeaders()['User-Agent']).toBe(`${getUserAgent()} datadog-ci-plugin-synthetics/9.9.9`)
+  })
+})

--- a/packages/base/src/helpers/plugin.ts
+++ b/packages/base/src/helpers/plugin.ts
@@ -15,6 +15,7 @@ import {cliVersion} from '../version'
 
 import {isStandaloneBinary} from './is-standalone-binary'
 import {messageBox} from './message-box'
+import {withPluginUserAgent} from './user-agent'
 
 export type PackageInfo = {name: string; version: string}
 export type PluginSubModule = {PluginCommand: CommandClass<CommandContext>}
@@ -30,9 +31,12 @@ export const executePluginCommand = async <T extends Command>(instance: T): Prom
     const submodule = await importPluginSubmodule(scope, command)
     debug(`Done importing plugin command`)
 
+    const plugin = await importPlugin(scope)
+    printPluginVersion(plugin)
+
     const pluginCommand = Object.assign(new submodule.PluginCommand(), instance)
 
-    return pluginCommand.execute()
+    return withPluginUserAgent(plugin.name, plugin.version, () => pluginCommand.execute())
   } catch (error) {
     debug('Error in executePluginCommand:', error)
 
@@ -92,7 +96,10 @@ export const checkPlugin = async (scope: string, command?: string): Promise<bool
   }
 
   try {
-    const module = command ? await importPluginSubmodule(scope, command) : await importPlugin(scope)
+    const plugin = await importPlugin(scope)
+    printPluginVersion(plugin)
+
+    const module = command ? await importPluginSubmodule(scope, command) : plugin
 
     console.log(
       [
@@ -410,10 +417,7 @@ const importPlugin = async (scope: string): Promise<PackageInfo> => {
 
   // Use `require()` instead of `await import()` to avoid `ERR_IMPORT_ATTRIBUTE_MISSING` due to missing `{with: {type: 'json'}}`.
   // This is only supported with `--module` set to `esnext`, `node16`, or `nodenext`.
-  const pluginInfo = extractPackageJson(require(`@datadog/datadog-ci-plugin-${normalizedScope}/package.json`))
-  printPluginVersion(pluginInfo)
-
-  return pluginInfo
+  return extractPackageJson(require(`@datadog/datadog-ci-plugin-${normalizedScope}/package.json`))
 }
 
 const extractPackageJson = (content: unknown): PackageInfo => {

--- a/packages/base/src/helpers/request.ts
+++ b/packages/base/src/helpers/request.ts
@@ -5,6 +5,8 @@ import type {Dispatcher} from 'undici'
 
 import {EnvHttpProxyAgent, ProxyAgent, fetch} from 'undici'
 
+import {getUserAgent} from './user-agent'
+
 export interface RequestConfig {
   baseURL?: string
   data?: unknown
@@ -132,10 +134,11 @@ export const httpRequest = async <T = any>(config: RequestConfig): Promise<Reque
   const resolvedUrl = resolveUrl(config)
   const method = (config.method ?? 'GET').toUpperCase()
   const {body, headers} = serializeBody(config.data, config.headers ?? {})
+  const headersWithUserAgent = {...headers, 'User-Agent': getUserAgent()}
 
   // Strip null/undefined header values (callers pass null to explicitly unset a header)
   const cleanHeaders: Record<string, string> = {}
-  for (const [k, v] of Object.entries(headers)) {
+  for (const [k, v] of Object.entries(headersWithUserAgent)) {
     // eslint-disable-next-line no-null/no-null
     if (v !== undefined && v !== null) {
       cleanHeaders[k] = String(v)
@@ -144,7 +147,7 @@ export const httpRequest = async <T = any>(config: RequestConfig): Promise<Reque
 
   const fetchOptions: Record<string, any> = {
     method,
-    headers,
+    headers: cleanHeaders,
     body,
     dispatcher: config.dispatcher,
     duplex: body !== undefined && isStream(config.data) ? 'half' : undefined,

--- a/packages/base/src/helpers/user-agent.ts
+++ b/packages/base/src/helpers/user-agent.ts
@@ -1,0 +1,41 @@
+import {AsyncLocalStorage} from 'node:async_hooks'
+
+import {cliVersion} from '../version'
+
+const pluginUserAgentStorage = new AsyncLocalStorage<string | undefined>()
+
+const formatPluginName = (pluginName: string) => pluginName.replace(/^@datadog\//, '')
+const formatPluginUserAgent = (pluginName: string, pluginVersion: string) =>
+  `${formatPluginName(pluginName)}/${pluginVersion}`
+
+// The user agent has the same format as the one used in the Datadog API client for TypeScript.
+// https://github.com/DataDog/datadog-api-client-typescript/blob/507c098afb5224efe8bf4cbcd0e3d84fd2bc4525/userAgent.ts#L5
+
+let baseUserAgent: string
+if (typeof process !== 'undefined' && process.release && process.release.name === 'node') {
+  baseUserAgent = `datadog-ci/${cliVersion} (node ${process.versions.node}; os ${process.platform}; arch ${process.arch})`
+} else {
+  baseUserAgent = `datadog-ci/${cliVersion} (runtime unknown)`
+}
+
+/**
+ * Gets the user agent for requests made by the CLI.
+ *
+ * @example `datadog-ci/1.0.0 (node v18.17.0; os darwin; arch arm64) datadog-ci-plugin-synthetics/1.0.0`
+ * @example `datadog-ci/1.0.0 (runtime unknown) datadog-ci-plugin-synthetics/1.0.0`
+ * @example `datadog-ci/1.0.0 (runtime unknown)`
+ */
+export const getUserAgent = (): string => {
+  const activePlugin = pluginUserAgentStorage.getStore()
+  if (activePlugin) {
+    return `${baseUserAgent} ${activePlugin}`
+  }
+
+  return baseUserAgent
+}
+
+export const withPluginUserAgent = async <T>(
+  pluginName: string,
+  pluginVersion: string,
+  callback: () => Promise<T>
+): Promise<T> => pluginUserAgentStorage.run(formatPluginUserAgent(pluginName, pluginVersion), callback)

--- a/packages/base/src/helpers/user-agent.ts
+++ b/packages/base/src/helpers/user-agent.ts
@@ -2,7 +2,7 @@ import {AsyncLocalStorage} from 'node:async_hooks'
 
 import {cliVersion} from '../version'
 
-const pluginUserAgentStorage = new AsyncLocalStorage<string | undefined>()
+const pluginUserAgentStorage = new AsyncLocalStorage<string>()
 
 const formatPluginName = (pluginName: string) => pluginName.replace(/^@datadog\//, '')
 const formatPluginUserAgent = (pluginName: string, pluginVersion: string) =>
@@ -21,7 +21,7 @@ if (typeof process !== 'undefined' && process.release && process.release.name ==
 /**
  * Gets the user agent for requests made by the CLI.
  *
- * @example `datadog-ci/1.0.0 (node v18.17.0; os darwin; arch arm64) datadog-ci-plugin-synthetics/1.0.0`
+ * @example `datadog-ci/1.0.0 (node 18.17.0; os darwin; arch arm64) datadog-ci-plugin-synthetics/1.0.0`
  * @example `datadog-ci/1.0.0 (runtime unknown) datadog-ci-plugin-synthetics/1.0.0`
  * @example `datadog-ci/1.0.0 (runtime unknown)`
  */


### PR DESCRIPTION
### What and why?

This PR replaces the default `unidici` user-agent by a value with [same format as `datadog-api-client-typescript`](https://github.com/DataDog/datadog-api-client-typescript/blob/507c098afb5224efe8bf4cbcd0e3d84fd2bc4525/userAgent.ts#L5):

- Node.js, with plugin: `datadog-ci/1.0.0 (node 18.17.0; os darwin; arch arm64) datadog-ci-plugin-synthetics/1.0.0`
- Node.js, without plugin: `datadog-ci/1.0.0 (node 18.17.0; os darwin; arch arm64)`
- Unknown runtime, with plugin: `datadog-ci/1.0.0 (runtime unknown) datadog-ci-plugin-synthetics/1.0.0`
- Unknown runtime, without plugin: `datadog-ci/1.0.0 (runtime unknown)`

### How?

- Use `AsyncLocalStorage` to store plugin version as async context when a plugin is loaded
- Override user-agent header

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
