### PR TITLE
[chore] Upgrade `datadog-metrics` with patch to use `undici`

### DIFF
--- a/.yarn/patches/datadog-metrics-npm-0.13.0-pre.1-d40793195b.patch
+++ b/.yarn/patches/datadog-metrics-npm-0.13.0-pre.1-d40793195b.patch
@@ -1,0 +1,41 @@
+diff --git a/lib/reporters.js b/lib/reporters.js
+index ebde40f910026af9503179a89ca29057310d88f7..0f093f78651d86532945915cfe799c1dc1c730f6 100644
+--- a/lib/reporters.js
++++ b/lib/reporters.js
+@@ -1,5 +1,5 @@
+ 'use strict';
+-const { fetch } = require('cross-fetch');
++const { fetch, EnvHttpProxyAgent } = require('undici');
+ const { AuthorizationError, DatadogMetricsError, HttpError } = require('./errors');
+ const { logDebug, logDeprecation } = require('./logging');
+ 
+@@ -34,6 +34,7 @@ class HttpApi {
+         this.maxRetries = options.maxRetries;
+         this.backoffBase = options.backoffBase;
+         this.backoffMultiplier = 2;
++        this.dispatcher = new EnvHttpProxyAgent();
+     }
+ 
+     async send(url, options) {
+@@ -42,7 +43,7 @@ class HttpApi {
+             let response, body, error;
+             try {
+                 logDebug(`Sending HTTP request to "${url}"`);
+-                response = await fetch(url, options);
++                response = await fetch(url, {...options, dispatcher: this.dispatcher});
+                 body = await response.json();
+             } catch (e) {
+                 error = e;
+diff --git a/package.json b/package.json
+index 4dc60548b5f86bf4cf7a3ed354a9768a8bc38da7..4b77c5e012cc583c122c0ff91821c5260ac1ce10 100644
+--- a/package.json
++++ b/package.json
+@@ -40,7 +40,7 @@
+     "typescript": "^4.8.4"
+   },
+   "dependencies": {
+-    "cross-fetch": "^4.0.0",
++    "undici": "7.24.6",
+     "debug": "^4.1.0"
+   },
+   "engines": {

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -14,7 +14,6 @@ Component,Origin,Licence,Copyright
 @smithy/property-provider,import,Apache-2.0,"Copyright 2018-2020 Amazon.com, Inc. or its affiliates."
 @smithy/util-retry,import,Apache-2.0,"Copyright 2019 Amazon.com, Inc. or its affiliates."
 @types/async-retry,dev,MIT,Copyright (c) Microsoft Corporation
-@types/datadog-metrics,dev,MIT,Copyright (c) Microsoft Corporation
 @types/debug,dev,MIT,Copyright (c) Microsoft Corporation
 @types/tiny-async-pool,dev,MIT,Copyright (c) Microsoft Corporation
 @types/deep-extend,dev,MIT,Copyright Microsoft Corporation

--- a/packages/__mocks__/datadog-metrics.js
+++ b/packages/__mocks__/datadog-metrics.js
@@ -3,17 +3,13 @@ const metrics = require('datadog-metrics')
 const BufferedMetricsLogger = metrics.BufferedMetricsLogger
 
 function NullReporter() {}
-NullReporter.prototype.report = jest.fn((metrics, onSuccess, onError) => {
-  if (typeof onSuccess === 'function') {
-    onSuccess()
-  }
-})
+NullReporter.prototype.report = jest.fn(async () => {})
 
-function NullBufferedMetricsLogger(opts = {}) {
-  BufferedMetricsLogger.call(this, {...opts, reporter: new NullReporter()})
+class NullBufferedMetricsLogger extends BufferedMetricsLogger {
+  constructor(opts = {}) {
+    super({...opts, reporter: new NullReporter()})
+  }
 }
-NullBufferedMetricsLogger.prototype = Object.create(BufferedMetricsLogger.prototype)
-NullBufferedMetricsLogger.prototype.constructor = NullBufferedMetricsLogger
 
 module.exports = metrics
 module.exports.BufferedMetricsLogger = NullBufferedMetricsLogger

--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -117,11 +117,10 @@
   },
   "dependencies": {
     "@antfu/install-pkg": "1.1.0",
-    "@types/datadog-metrics": "0.6.1",
     "async-retry": "1.3.3",
     "chalk": "3.0.0",
     "clipanion": "3.2.1",
-    "datadog-metrics": "0.9.3",
+    "datadog-metrics": "patch:datadog-metrics@npm%3A0.13.0-pre.1#~/.yarn/patches/datadog-metrics-npm-0.13.0-pre.1-d40793195b.patch",
     "debug": "4.4.1",
     "deep-extend": "0.6.0",
     "fast-xml-parser": "5.5.9",

--- a/packages/base/src/helpers/metrics.ts
+++ b/packages/base/src/helpers/metrics.ts
@@ -1,10 +1,9 @@
-import metrics from 'datadog-metrics'
-import {ProxyAgent} from 'proxy-agent'
+import {BufferedMetricsLogger} from 'datadog-metrics'
 
 import {getDatadogSite} from './api'
 
 export interface MetricsLogger {
-  logger: metrics.BufferedMetricsLogger
+  logger: BufferedMetricsLogger
   flush(): Promise<void>
 }
 
@@ -18,24 +17,22 @@ export interface MetricsLoggerOptions {
 export const getMetricsLogger = (opts: MetricsLoggerOptions): MetricsLogger => {
   const apiUrl = 'api.' + getDatadogSite(opts.datadogSite)
 
-  const metricsOpts = {
-    // ProxyAgent will retrieve proxy agent from env vars when relevant
-    // agent is not in the type definitions file but has been introduced in datadog-metrics 0.8.x
-    agent: new ProxyAgent(),
-    apiHost: apiUrl,
+  const logger = new BufferedMetricsLogger({
     apiKey: opts.apiKey,
+    site: opts.datadogSite,
     defaultTags: opts.defaultTags,
     flushIntervalSeconds: 15,
     prefix: opts.prefix,
-  }
-
-  const logger = new metrics.BufferedMetricsLogger(metricsOpts)
+  })
 
   return {
-    flush: () =>
-      new Promise((resolve, reject) => {
-        logger.flush(resolve, (err) => reject(new Error(`Could not flush metrics to ${apiUrl}: ${err}`)))
-      }),
+    flush: async () => {
+      try {
+        await logger.flush()
+      } catch (error) {
+        throw new Error(`Could not flush metrics to ${apiUrl}: ${error}`)
+      }
+    },
     logger,
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1956,7 +1956,6 @@ __metadata:
   dependencies:
     "@antfu/install-pkg": "npm:1.1.0"
     "@types/async-retry": "npm:1.4.8"
-    "@types/datadog-metrics": "npm:0.6.1"
     "@types/debug": "npm:4.1.12"
     "@types/deep-extend": "npm:0.4.31"
     "@types/inquirer": "npm:8.2.6"
@@ -1966,7 +1965,7 @@ __metadata:
     async-retry: "npm:1.3.3"
     chalk: "npm:3.0.0"
     clipanion: "npm:3.2.1"
-    datadog-metrics: "npm:0.9.3"
+    datadog-metrics: "patch:datadog-metrics@npm%3A0.13.0-pre.1#~/.yarn/patches/datadog-metrics-npm-0.13.0-pre.1-d40793195b.patch"
     debug: "npm:4.4.1"
     deep-extend: "npm:0.6.0"
     fast-xml-parser: "npm:5.5.9"
@@ -4732,13 +4731,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/datadog-metrics@npm:0.6.1":
-  version: 0.6.1
-  resolution: "@types/datadog-metrics@npm:0.6.1"
-  checksum: 10/a55e5661b91318ca5786675c56d054bb5b54a7e8882d87d359a844add1c06d44bf45b1cf8f33b67e1b4f017f617a023e044788a370244a912a0141dfbe55e441
-  languageName: node
-  linkType: hard
-
 "@types/debug@npm:4.1.12":
   version: 4.1.12
   resolution: "@types/debug@npm:4.1.12"
@@ -6366,6 +6358,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cross-fetch@npm:^4.0.0":
+  version: 4.1.0
+  resolution: "cross-fetch@npm:4.1.0"
+  dependencies:
+    node-fetch: "npm:^2.7.0"
+  checksum: 10/07624940607b64777d27ec9c668ddb6649e8c59ee0a5a10e63a51ce857e2bbb1294a45854a31c10eccb91b65909a5b199fcb0217339b44156f85900a7384f489
+  languageName: node
+  linkType: hard
+
 "cross-spawn@npm:^7.0.0, cross-spawn@npm:^7.0.2, cross-spawn@npm:^7.0.3, cross-spawn@npm:^7.0.6":
   version: 7.0.6
   resolution: "cross-spawn@npm:7.0.6"
@@ -6442,13 +6443,23 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"datadog-metrics@npm:0.9.3":
-  version: 0.9.3
-  resolution: "datadog-metrics@npm:0.9.3"
+"datadog-metrics@npm:0.13.0-pre.1":
+  version: 0.13.0-pre.1
+  resolution: "datadog-metrics@npm:0.13.0-pre.1"
   dependencies:
-    debug: "npm:3.1.0"
-    dogapi: "npm:2.8.4"
-  checksum: 10/c22ad483fe072cf288ec27aa94550b354d209c626aeebadb4ef5e02875a8d65aea5184d256b5a040f2a01ff3a447e40423e9b12d89ea4af2aadc23bba7ea8189
+    cross-fetch: "npm:^4.0.0"
+    debug: "npm:^4.1.0"
+  checksum: 10/d6a548e2e6b45e05bd81fdeac19f1a30dd7405140ddbc1f7fb335e47e1e29717e557f6260b77b0729d8999078577428e566998ca2a24aabbe3038f44aca4da7a
+  languageName: node
+  linkType: hard
+
+"datadog-metrics@patch:datadog-metrics@npm%3A0.13.0-pre.1#~/.yarn/patches/datadog-metrics-npm-0.13.0-pre.1-d40793195b.patch":
+  version: 0.13.0-pre.1
+  resolution: "datadog-metrics@patch:datadog-metrics@npm%3A0.13.0-pre.1#~/.yarn/patches/datadog-metrics-npm-0.13.0-pre.1-d40793195b.patch::version=0.13.0-pre.1&hash=9f9b86"
+  dependencies:
+    cross-fetch: "npm:^4.0.0"
+    debug: "npm:^4.1.0"
+  checksum: 10/a43f0364eeef7b8fb4543b3eac4e102151814c1a7a253abbf13f81b9028653d7f3b5f9839b88d6536e142cd3ac07ca4cd7486cc7db59f8140cc53f11f57819c3
   languageName: node
   linkType: hard
 
@@ -6508,15 +6519,6 @@ __metadata:
     "@openfeature/server-sdk":
       optional: true
   checksum: 10/dae1e084fe47a70f1462d20628215ef0a77f8f68ddafe168ddd35884bbd77808ccb30099f942146c588f0bc27ca75ea9745aeda7db78e845114c64f39b2990e9
-  languageName: node
-  linkType: hard
-
-"debug@npm:3.1.0":
-  version: 3.1.0
-  resolution: "debug@npm:3.1.0"
-  dependencies:
-    ms: "npm:2.0.0"
-  checksum: 10/f5fd4b1390dd3b03a78aa30133a4b4db62acc3e6cd86af49f114bf7f7bd57c41a5c5c2eced2ad2c8190d70c60309f2dd5782feeaa0704dbaa5697890e3c5ad07
   languageName: node
   linkType: hard
 
@@ -6711,21 +6713,6 @@ __metadata:
   dependencies:
     esutils: "npm:^2.0.2"
   checksum: 10/b4b28f1df5c563f7d876e7461254a4597b8cabe915abe94d7c5d1633fed263fcf9a85e8d3836591fc2d040108e822b0d32758e5ec1fe31c590dc7e08086e3e48
-  languageName: node
-  linkType: hard
-
-"dogapi@npm:2.8.4":
-  version: 2.8.4
-  resolution: "dogapi@npm:2.8.4"
-  dependencies:
-    extend: "npm:^3.0.2"
-    json-bigint: "npm:^1.0.0"
-    lodash: "npm:^4.17.21"
-    minimist: "npm:^1.2.5"
-    rc: "npm:^1.2.8"
-  bin:
-    dogapi: bin/dogapi
-  checksum: 10/1c4010411a7fa8f16db96f00169d07d4b40230a7828e72aca430e6a7389ee064696a6c03d5e8a67a4c71fe53d9b6ce25581fe5f3a6262a4745d98d47d11edfaa
   languageName: node
   linkType: hard
 
@@ -9922,7 +9909,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimist@npm:^1.2.0, minimist@npm:^1.2.3, minimist@npm:^1.2.5, minimist@npm:^1.2.6, minimist@npm:^1.2.8":
+"minimist@npm:^1.2.0, minimist@npm:^1.2.3, minimist@npm:^1.2.6, minimist@npm:^1.2.8":
   version: 1.2.8
   resolution: "minimist@npm:1.2.8"
   checksum: 10/908491b6cc15a6c440ba5b22780a0ba89b9810e1aea684e253e43c4e3b8d56ec1dcdd7ea96dde119c29df59c936cde16062159eae4225c691e19c70b432b6e6f
@@ -10030,13 +10017,6 @@ __metadata:
   version: 1.0.4
   resolution: "module-details-from-path@npm:1.0.4"
   checksum: 10/2ebfada5358492f6ab496b70f70a1042f2ee7a4c79d29467f59ed6704f741fb4461d7cecb5082144ed39a05fec4d19e9ff38b731c76228151be97227240a05b2
-  languageName: node
-  linkType: hard
-
-"ms@npm:2.0.0":
-  version: 2.0.0
-  resolution: "ms@npm:2.0.0"
-  checksum: 10/0e6a22b8b746d2e0b65a430519934fefd41b6db0682e3477c10f60c76e947c4c0ad06f63ffdf1d78d335f83edee8c0aa928aa66a36c7cd95b69b26f468d527f4
   languageName: node
   linkType: hard
 
@@ -10976,7 +10956,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rc@npm:^1.2.7, rc@npm:^1.2.8":
+"rc@npm:^1.2.7":
   version: 1.2.8
   resolution: "rc@npm:1.2.8"
   dependencies:


### PR DESCRIPTION
### What and why?

Upgrades `datadog-metrics` from `0.9.3` to `0.13.0-pre.1` and patches it to use `undici` instead of `cross-fetch` as its HTTP transport. This lets metrics honor proxy settings (via undici's dispatcher) without relying on the removed `agent` option or `proxy-agent`.

### How?

- upgrade `datadog-metrics` to `0.13.0-pre.1` and remove the legacy `@types/datadog-metrics` dependency
- apply a yarn patch to swap `cross-fetch` → `undici` in `datadog-metrics`'s reporter
- remove the `ProxyAgent` instantiation and `agent` option from `metrics.ts`
- update the `flush` call to use `async/await` to match the new promise-based API
- update the Jest mock to match the new async reporter and class-based logger

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)