### PR TITLE
[chore] Align all plugins to export `bundle.d.ts`

### DIFF
--- a/bin/create-plugin.sh
+++ b/bin/create-plugin.sh
@@ -61,9 +61,13 @@ cat > "$PLUGIN_DIR/package.json" <<EOF
     "directory": "$PLUGIN_DIR"
   },
   "main": "dist/bundle.js",
+  "types": "dist/bundle.d.ts",
   "exports": {
     "./package.json": "./package.json",
-    ".": "./dist/bundle.js",
+    ".": {
+      "types": "./dist/bundle.d.ts",
+      "default": "./dist/bundle.js"
+    },
     "./commands/*": {
       "development": "./src/commands/*.ts",
       "default": "./dist/commands/*.js"

--- a/packages/plugin-aas/package.json
+++ b/packages/plugin-aas/package.json
@@ -15,9 +15,13 @@
     "directory": "packages/plugin-aas"
   },
   "main": "dist/bundle.js",
+  "types": "dist/bundle.d.ts",
   "exports": {
     "./package.json": "./package.json",
-    ".": "./dist/bundle.js",
+    ".": {
+      "types": "./dist/bundle.d.ts",
+      "default": "./dist/bundle.js"
+    },
     "./commands/*": {
       "development": "./src/commands/*.ts",
       "default": "./dist/commands/*.js"

--- a/packages/plugin-cloud-run/package.json
+++ b/packages/plugin-cloud-run/package.json
@@ -15,9 +15,13 @@
     "directory": "packages/plugin-cloud-run"
   },
   "main": "dist/bundle.js",
+  "types": "dist/bundle.d.ts",
   "exports": {
     "./package.json": "./package.json",
-    ".": "./dist/bundle.js",
+    ".": {
+      "types": "./dist/bundle.d.ts",
+      "default": "./dist/bundle.js"
+    },
     "./commands/*": {
       "development": "./src/commands/*.ts",
       "default": "./dist/commands/*.js"

--- a/packages/plugin-container-app/package.json
+++ b/packages/plugin-container-app/package.json
@@ -15,9 +15,13 @@
     "directory": "packages/plugin-container-app"
   },
   "main": "dist/bundle.js",
+  "types": "dist/bundle.d.ts",
   "exports": {
     "./package.json": "./package.json",
-    ".": "./dist/bundle.js",
+    ".": {
+      "types": "./dist/bundle.d.ts",
+      "default": "./dist/bundle.js"
+    },
     "./commands/*": {
       "development": "./src/commands/*.ts",
       "default": "./dist/commands/*.js"

--- a/packages/plugin-coverage/package.json
+++ b/packages/plugin-coverage/package.json
@@ -15,9 +15,13 @@
     "directory": "packages/plugin-coverage"
   },
   "main": "dist/bundle.js",
+  "types": "dist/bundle.d.ts",
   "exports": {
     "./package.json": "./package.json",
-    ".": "./dist/bundle.js",
+    ".": {
+      "types": "./dist/bundle.d.ts",
+      "default": "./dist/bundle.js"
+    },
     "./commands/*": {
       "development": "./src/commands/*.ts",
       "default": "./dist/commands/*.js"

--- a/packages/plugin-deployment/package.json
+++ b/packages/plugin-deployment/package.json
@@ -15,9 +15,13 @@
     "directory": "packages/plugin-deployment"
   },
   "main": "dist/bundle.js",
+  "types": "dist/bundle.d.ts",
   "exports": {
     "./package.json": "./package.json",
-    ".": "./dist/bundle.js",
+    ".": {
+      "types": "./dist/bundle.d.ts",
+      "default": "./dist/bundle.js"
+    },
     "./commands/*": {
       "development": "./src/commands/*.ts",
       "default": "./dist/commands/*.js"

--- a/packages/plugin-dora/package.json
+++ b/packages/plugin-dora/package.json
@@ -15,9 +15,13 @@
     "directory": "packages/plugin-dora"
   },
   "main": "dist/bundle.js",
+  "types": "dist/bundle.d.ts",
   "exports": {
     "./package.json": "./package.json",
-    ".": "./dist/bundle.js",
+    ".": {
+      "types": "./dist/bundle.d.ts",
+      "default": "./dist/bundle.js"
+    },
     "./commands/*": {
       "development": "./src/commands/*.ts",
       "default": "./dist/commands/*.js"

--- a/packages/plugin-gate/package.json
+++ b/packages/plugin-gate/package.json
@@ -15,9 +15,13 @@
     "directory": "packages/plugin-gate"
   },
   "main": "dist/bundle.js",
+  "types": "dist/bundle.d.ts",
   "exports": {
     "./package.json": "./package.json",
-    ".": "./dist/bundle.js",
+    ".": {
+      "types": "./dist/bundle.d.ts",
+      "default": "./dist/bundle.js"
+    },
     "./commands/*": {
       "development": "./src/commands/*.ts",
       "default": "./dist/commands/*.js"

--- a/packages/plugin-junit/package.json
+++ b/packages/plugin-junit/package.json
@@ -15,9 +15,13 @@
     "directory": "packages/plugin-junit"
   },
   "main": "dist/bundle.js",
+  "types": "dist/bundle.d.ts",
   "exports": {
     "./package.json": "./package.json",
-    ".": "./dist/bundle.js",
+    ".": {
+      "types": "./dist/bundle.d.ts",
+      "default": "./dist/bundle.js"
+    },
     "./commands/*": {
       "development": "./src/commands/*.ts",
       "default": "./dist/commands/*.js"

--- a/packages/plugin-lambda/package.json
+++ b/packages/plugin-lambda/package.json
@@ -15,9 +15,13 @@
     "directory": "packages/plugin-lambda"
   },
   "main": "dist/bundle.js",
+  "types": "dist/bundle.d.ts",
   "exports": {
     "./package.json": "./package.json",
-    ".": "./dist/bundle.js",
+    ".": {
+      "types": "./dist/bundle.d.ts",
+      "default": "./dist/bundle.js"
+    },
     "./commands/*": {
       "development": "./src/commands/*.ts",
       "default": "./dist/commands/*.js"

--- a/packages/plugin-sarif/package.json
+++ b/packages/plugin-sarif/package.json
@@ -15,9 +15,13 @@
     "directory": "packages/plugin-sarif"
   },
   "main": "dist/bundle.js",
+  "types": "dist/bundle.d.ts",
   "exports": {
     "./package.json": "./package.json",
-    ".": "./dist/bundle.js",
+    ".": {
+      "types": "./dist/bundle.d.ts",
+      "default": "./dist/bundle.js"
+    },
     "./commands/*": {
       "development": "./src/commands/*.ts",
       "default": "./dist/commands/*.js"

--- a/packages/plugin-sbom/package.json
+++ b/packages/plugin-sbom/package.json
@@ -15,9 +15,13 @@
     "directory": "packages/plugin-sbom"
   },
   "main": "dist/bundle.js",
+  "types": "dist/bundle.d.ts",
   "exports": {
     "./package.json": "./package.json",
-    ".": "./dist/bundle.js",
+    ".": {
+      "types": "./dist/bundle.d.ts",
+      "default": "./dist/bundle.js"
+    },
     "./commands/*": {
       "development": "./src/commands/*.ts",
       "default": "./dist/commands/*.js"

--- a/packages/plugin-stepfunctions/package.json
+++ b/packages/plugin-stepfunctions/package.json
@@ -15,9 +15,13 @@
     "directory": "packages/plugin-stepfunctions"
   },
   "main": "dist/bundle.js",
+  "types": "dist/bundle.d.ts",
   "exports": {
     "./package.json": "./package.json",
-    ".": "./dist/bundle.js",
+    ".": {
+      "types": "./dist/bundle.d.ts",
+      "default": "./dist/bundle.js"
+    },
     "./commands/*": {
       "development": "./src/commands/*.ts",
       "default": "./dist/commands/*.js"

--- a/packages/plugin-synthetics/package.json
+++ b/packages/plugin-synthetics/package.json
@@ -15,11 +15,11 @@
     "directory": "packages/plugin-synthetics"
   },
   "main": "dist/bundle.js",
-  "types": "dist/index.d.ts",
+  "types": "dist/bundle.d.ts",
   "exports": {
     "./package.json": "./package.json",
     ".": {
-      "types": "./dist/index.d.ts",
+      "types": "./dist/bundle.d.ts",
       "default": "./dist/bundle.js"
     },
     "./commands/*": {

--- a/packages/plugin-terraform/package.json
+++ b/packages/plugin-terraform/package.json
@@ -17,9 +17,13 @@
     "directory": "packages/plugin-terraform"
   },
   "main": "dist/bundle.js",
+  "types": "dist/bundle.d.ts",
   "exports": {
     "./package.json": "./package.json",
-    ".": "./dist/bundle.js",
+    ".": {
+      "types": "./dist/bundle.d.ts",
+      "default": "./dist/bundle.js"
+    },
     "./commands/*": {
       "development": "./src/commands/*.ts",
       "default": "./dist/commands/*.js"


### PR DESCRIPTION
### What and why?

For consistency with the synthetics plugin, all plugins now export `bundle.d.ts`. It was already included in `files`, but not exported.

### How?

Update all `package.json`

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
