### PR TITLE
chore(plugin-lambda): externalize AWS SDK from extra bundles

### DIFF
--- a/.syncpackrc.json
+++ b/.syncpackrc.json
@@ -23,13 +23,23 @@
   ],
   "versionGroups": [
     {
-      "label": "Always use workspace:* for local packages",
+      "label": "Always use workspace:* for local packages, including peer dependencies in base package",
       "dependencyTypes": [
         "local"
       ]
     }
   ],
   "semverGroups": [
+    {
+      "label": "Always use ^ for peer dependencies in plugin packages",
+      "dependencies": [
+        "@aws-sdk/*"
+      ],
+      "dependencyTypes": [
+        "peer"
+      ],
+      "range": "^"
+    },
     {
       "label": "Always pin exact versions",
       "packages": [

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -138,6 +138,60 @@ Optionally, you can create a pre-release for your command by following the [Pre-
   - Update [`advanced-issue-labeler.yml`](.github/advanced-issue-labeler.yml).
   - Update the `changelog` configuration in [`release.yml`](.github/release.yml).
 
+### Plugin bundle architecture
+
+Each plugin is bundled with [tsdown](https://tsdown.dev/) via `scripts/tsdown-plugin.mjs` (triggered by `yarn prepack`). The build produces three kinds of outputs, configured in part by `datadog-ci.meta.json` at the repo root.
+
+#### Main bundle (`dist/bundle.js` + `dist/bundle.d.ts`)
+
+The main bundle is a **fully self-contained** CJS file with zero runtime dependencies. All `devDependencies` (including heavy ones like `@aws-sdk/*`) are inlined into the bundle. This is what the `datadog-ci` CLI loads at runtime.
+
+The entry point is a virtual file that re-exports `src/index.ts` (if present) and all command implementations as a `commands` map.
+
+#### Command entrypoints (`dist/commands/<command>.js`)
+
+Thin JS wrappers that re-export a single command from the main bundle:
+
+```js
+module.exports = require("../bundle.js").commands["<command>"]
+```
+
+These exist for backwards compatibility with the CLI's plugin loader. They have no `.d.ts` — they are not meant to be imported by external consumers.
+
+#### Extra bundles (`dist/<subpath>.js` + `dist/<subpath>.d.ts`)
+
+Extra bundles are separate entrypoints exposed via `package.json` `exports` for **programmatic use by external projects** (e.g. `serverless-remote-instrumentation` importing `@datadog/datadog-ci-plugin-lambda/functions/instrument`).
+
+Unlike the main bundle, extra bundles may **externalize** certain dependencies so that the consumer's own copies are used at runtime and — critically — so that TypeScript types are compatible. Without externalization, the `.d.ts` would inline all transitive type definitions (e.g. 22K+ lines from `@smithy/types`), causing type conflicts when the consumer also depends on those packages.
+
+Extra bundles are configured in `datadog-ci.meta.json`.
+
+#### `datadog-ci.meta.json`
+
+This file configures per-plugin bundle behavior. Structure:
+
+```jsonc
+{
+  "plugins": {
+    "<plugin-package-name>": {
+      "bundle": {
+        // Glob patterns (relative to plugin root) for extra bundle entry files.
+        // Each matched .ts file becomes a separate bundle under dist/.
+        "extraBundlePatterns": ["./src/functions/*.ts"],
+
+        // Package name prefixes to externalize in extra bundles only.
+        // Matching packages become `require()` calls in JS and proper
+        // `import` statements in .d.ts (instead of being inlined).
+        // The main bundle is NOT affected — it always bundles everything.
+        "extraBundleExternalPatterns": ["@aws-sdk/", "@smithy/"]
+      }
+    }
+  }
+}
+```
+
+When `extraBundleExternalPatterns` is set, the plugin's `package.json` should declare matching packages as optional `peerDependencies`, since consumers of extra bundles need them installed.
+
 ### Continuous Integration tests
 
 The CI performs tests to avoid regressions by building the project, running unit tests and running end-to-end tests.

--- a/datadog-ci.meta.json
+++ b/datadog-ci.meta.json
@@ -4,6 +4,10 @@
       "bundle": {
         "extraBundlePatterns": [
           "./src/functions/*.ts"
+        ],
+        "extraBundleExternalPatterns": [
+          "@aws-sdk/",
+          "@smithy/"
         ]
       }
     }

--- a/package.json
+++ b/package.json
@@ -76,7 +76,9 @@
       "@datadog/datadog-ci-plugin-*",
       "@microsoft/eslint-formatter-sarif",
       "dd-trace",
-      "syncpack"
+      "glob",
+      "syncpack",
+      "tsdown"
     ]
   },
   "packageManager": "yarn@4.10.3",

--- a/packages/plugin-lambda/package.json
+++ b/packages/plugin-lambda/package.json
@@ -37,6 +37,10 @@
     "dist/bundle.js.LEGAL.txt",
     "dist/bundle.d.ts",
     "dist/commands/*.js",
+    "dist/functions/*.js",
+    "dist/functions/*.js.map",
+    "dist/functions/*.js.LEGAL.txt",
+    "dist/functions/*.d.ts",
     "README",
     "LICENSE"
   ],
@@ -47,6 +51,26 @@
     "build": "yarn package:clean; yarn package:build",
     "lint": "yarn package:lint",
     "prepack": "yarn package:clean-dist; yarn package:bundle:npm"
+  },
+  "peerDependencies": {
+    "@aws-sdk/client-cloudwatch-logs": "^3.0.0",
+    "@aws-sdk/client-iam": "^3.0.0",
+    "@aws-sdk/client-lambda": "^3.0.0",
+    "@aws-sdk/credential-providers": "^3.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@aws-sdk/client-cloudwatch-logs": {
+      "optional": true
+    },
+    "@aws-sdk/client-iam": {
+      "optional": true
+    },
+    "@aws-sdk/client-lambda": {
+      "optional": true
+    },
+    "@aws-sdk/credential-providers": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@aws-sdk/client-cloudwatch-logs": "3.981.0",

--- a/packages/plugin-lambda/package.json
+++ b/packages/plugin-lambda/package.json
@@ -53,10 +53,10 @@
     "prepack": "yarn package:clean-dist; yarn package:bundle:npm"
   },
   "peerDependencies": {
-    "@aws-sdk/client-cloudwatch-logs": "^3.0.0",
-    "@aws-sdk/client-iam": "^3.0.0",
-    "@aws-sdk/client-lambda": "^3.0.0",
-    "@aws-sdk/credential-providers": "^3.0.0"
+    "@aws-sdk/client-cloudwatch-logs": "^3.981.0",
+    "@aws-sdk/client-iam": "^3.981.0",
+    "@aws-sdk/client-lambda": "^3.981.0",
+    "@aws-sdk/credential-providers": "^3.981.0"
   },
   "peerDependenciesMeta": {
     "@aws-sdk/client-cloudwatch-logs": {

--- a/scripts/tsdown-plugin.mjs
+++ b/scripts/tsdown-plugin.mjs
@@ -23,6 +23,9 @@ const rootMetaPath = path.join(REPO_ROOT, 'datadog-ci.meta.json')
 const rootMeta = JSON.parse(await readFile(rootMetaPath, 'utf8'))
 const bundleConfig = rootMeta.plugins?.[pluginName]?.bundle ?? {}
 const extraBundlePatterns = Array.isArray(bundleConfig.extraBundlePatterns) ? bundleConfig.extraBundlePatterns : []
+const extraBundleExternalPatterns = Array.isArray(bundleConfig.extraBundleExternalPatterns)
+  ? bundleConfig.extraBundleExternalPatterns
+  : []
 const srcDir = path.join(packageDir, 'src')
 
 const srcCommandsDir = path.join(packageDir, 'src', 'commands')
@@ -117,10 +120,22 @@ try {
     },
   })
 
+  const extraBuildDeps =
+    extraBundleExternalPatterns.length > 0
+      ? {
+          ...buildOptions.deps,
+          neverBundle: [
+            ...buildOptions.deps.neverBundle,
+            ...extraBundleExternalPatterns.map((prefix) => new RegExp(`^${prefix.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`)),
+          ],
+        }
+      : buildOptions.deps
+
   const extraBundles = []
   for (const {outputName, sourcePath} of extraBundleEntries) {
     const entryBundles = await build({
       ...buildOptions,
+      deps: extraBuildDeps,
       outputOptions: createOutputOptions(),
       entry: {
         [outputName]: sourcePath,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2151,6 +2151,20 @@ __metadata:
     inquirer-checkbox-plus-prompt: "npm:1.4.2"
     ora: "npm:5.4.1"
     upath: "npm:2.0.1"
+  peerDependencies:
+    "@aws-sdk/client-cloudwatch-logs": ^3.981.0
+    "@aws-sdk/client-iam": ^3.981.0
+    "@aws-sdk/client-lambda": ^3.981.0
+    "@aws-sdk/credential-providers": ^3.981.0
+  peerDependenciesMeta:
+    "@aws-sdk/client-cloudwatch-logs":
+      optional: true
+    "@aws-sdk/client-iam":
+      optional: true
+    "@aws-sdk/client-lambda":
+      optional: true
+    "@aws-sdk/credential-providers":
+      optional: true
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
### What and why?

Externalize `@aws-sdk/*` and `@smithy/*` packages from extra bundle builds (`functions/*`) in the lambda plugin.

When a consumer imports `@datadog/datadog-ci-plugin-lambda/functions/instrument` and passes their own `LambdaClient`, TypeScript fails with `TS2345` because the bundled `.d.ts` inlines all ~22K lines of `@smithy/types` and `@aws-sdk/client-lambda` type definitions, creating a separate type tree that conflicts with the consumer's installed packages.

### How?

- Added `extraBundleExternalPatterns` config in `datadog-ci.meta.json` for the lambda plugin (`@aws-sdk/`, `@smithy/`)
- `tsdown-plugin.mjs` reads these patterns and adds them to `neverBundle` (as regexes) for extra bundle builds only — the main `bundle.js` remains fully self-contained
- Added optional `peerDependencies` for the AWS SDK packages that `functions/*` exports require at runtime
- `functions/instrument.d.ts` goes from ~22K lines (inlined types) to 68 lines with proper `import { LambdaClient } from "@aws-sdk/client-lambda"` references
- Documented the plugin bundle architecture (main bundle vs command entrypoints vs extra bundles) and `datadog-ci.meta.json` schema in `CONTRIBUTING.md`

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)