### PR TITLE
v5.13.0

### DIFF
--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-base",
-  "version": "5.12.1",
+  "version": "5.13.0",
   "description": "Base package for Datadog CI",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/datadog-ci/package.json
+++ b/packages/datadog-ci/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci",
-  "version": "5.12.1",
+  "version": "5.13.0",
   "description": "Use Datadog from your CI.",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-aas/package.json
+++ b/packages/plugin-aas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-aas",
-  "version": "5.12.1",
+  "version": "5.13.0",
   "description": "Datadog CI plugin for `aas` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-cloud-run/package.json
+++ b/packages/plugin-cloud-run/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-cloud-run",
-  "version": "5.12.1",
+  "version": "5.13.0",
   "description": "Datadog CI plugin for `cloud-run` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-container-app/package.json
+++ b/packages/plugin-container-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-container-app",
-  "version": "5.12.1",
+  "version": "5.13.0",
   "description": "Datadog CI plugin for `container-app` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-coverage/package.json
+++ b/packages/plugin-coverage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-coverage",
-  "version": "5.12.1",
+  "version": "5.13.0",
   "description": "Datadog CI plugin for `coverage` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-deployment/package.json
+++ b/packages/plugin-deployment/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-deployment",
-  "version": "5.12.1",
+  "version": "5.13.0",
   "description": "Datadog CI plugin for `deployment` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-dora/package.json
+++ b/packages/plugin-dora/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-dora",
-  "version": "5.12.1",
+  "version": "5.13.0",
   "description": "Datadog CI plugin for `dora` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-gate/package.json
+++ b/packages/plugin-gate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-gate",
-  "version": "5.12.1",
+  "version": "5.13.0",
   "description": "Datadog CI plugin for `gate` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-junit/package.json
+++ b/packages/plugin-junit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-junit",
-  "version": "5.12.1",
+  "version": "5.13.0",
   "description": "Datadog CI plugin for `junit` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-lambda/package.json
+++ b/packages/plugin-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-lambda",
-  "version": "5.12.1",
+  "version": "5.13.0",
   "description": "Datadog CI plugin for `lambda` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-sarif/package.json
+++ b/packages/plugin-sarif/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-sarif",
-  "version": "5.12.1",
+  "version": "5.13.0",
   "description": "Datadog CI plugin for `sarif` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-sbom/package.json
+++ b/packages/plugin-sbom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-sbom",
-  "version": "5.12.1",
+  "version": "5.13.0",
   "description": "Datadog CI plugin for `sbom` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-stepfunctions/package.json
+++ b/packages/plugin-stepfunctions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-stepfunctions",
-  "version": "5.12.1",
+  "version": "5.13.0",
   "description": "Datadog CI plugin for `stepfunctions` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-synthetics/package.json
+++ b/packages/plugin-synthetics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-synthetics",
-  "version": "5.12.1",
+  "version": "5.13.0",
   "description": "Datadog CI plugin for `synthetics` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-terraform/package.json
+++ b/packages/plugin-terraform/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-terraform",
-  "version": "5.12.1",
+  "version": "5.13.0",
   "description": "Datadog CI plugin for `terraform` commands",
   "license": "Apache-2.0",
   "keywords": [


### PR DESCRIPTION
<!-- Release notes generated using configuration in .github/release.yml at v5.13.0 -->

## What's Changed
### datadog-ci
* chore: migrate base package from axios to fetch/undici by @ava-silver in https://github.com/DataDog/datadog-ci/pull/2201
* chore: migrate plugins from axios to fetch/undici types by @ava-silver in https://github.com/DataDog/datadog-ci/pull/2247
* [security] Vendor CLI and plugins as zero-dependency bundles by @Drarig29 in https://github.com/DataDog/datadog-ci/pull/2212
* chore: add claude config by @ava-silver in https://github.com/DataDog/datadog-ci/pull/2253
* [security] Set `User-Agent` for requests done by datadog-ci by @Drarig29 in https://github.com/DataDog/datadog-ci/pull/2251
### Documentation
* [docs] Improve datadog-ci install instructions in README by @Drarig29 in https://github.com/DataDog/datadog-ci/pull/2263
### RUM
* [RUMS-5750] Fix iOS bundle lookup path for `inject-debug-id` command by @marco-saia-datadog in https://github.com/DataDog/datadog-ci/pull/2211
### Chores
* [chore] Add lint packages in pre-approval checks by @rodrigo-roca in https://github.com/DataDog/datadog-ci/pull/2245
* [SVLS-8827] add npm minimal age gate by @ava-silver in https://github.com/DataDog/datadog-ci/pull/2246
* chore: update codeowners name for synthetics by @Drarig29 in https://github.com/DataDog/datadog-ci/pull/2250
* [chore] Print datadog-ci and plugin versions by @Drarig29 in https://github.com/DataDog/datadog-ci/pull/2213
* [chore] Align all plugins to export `bundle.d.ts` by @Drarig29 in https://github.com/DataDog/datadog-ci/pull/2258
* chore(plugin-lambda): externalize AWS SDK from extra bundles by @Drarig29 in https://github.com/DataDog/datadog-ci/pull/2262


**Full Changelog**: https://github.com/DataDog/datadog-ci/compare/v5.12.1...v5.13.0

[RUMS-5750]: https://datadoghq.atlassian.net/browse/RUMS-5750?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SVLS-8827]: https://datadoghq.atlassian.net/browse/SVLS-8827?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ