### PR TITLE
fix(ci): use `jobId` to disambiguate Worker logs on multi-runners sharing same `planId`

### DIFF
--- a/packages/base/src/helpers/__tests__/ci.test.ts
+++ b/packages/base/src/helpers/__tests__/ci.test.ts
@@ -572,6 +572,19 @@ describe('getGithubJobDisplayNameFromLogs', () => {
       "jobName": "__default"
     }`
 
+  // Variant with explicit jobId for testing same-planId disambiguation on multi-runners
+  const sampleLogContentWithPlanIdAndJobId = (jobDisplayName: string, planId: string, jobId: string): string => `
+    [2025-09-15 10:14:00Z INFO Worker] Waiting to receive the job message from the channel.
+    [2025-09-15 10:14:00Z INFO ProcessChannel] Receiving message of length 22985, with hash 'abcdef'
+    [2025-09-15 10:14:00Z INFO Worker] Message received.
+    [2025-09-15 10:14:00Z INFO Worker] Job message:
+    {
+      "planId": "${planId}",
+      "jobId": "${jobId}",
+      "jobDisplayName": ${JSON.stringify(jobDisplayName)},
+      "jobName": "__default"
+    }`
+
   const sampleLogFileName = 'Worker_20251014-083000.log'
   const sampleJobDisplayName = 'build-and-test'
 
@@ -1025,8 +1038,10 @@ describe('getGithubJobDisplayNameFromLogs', () => {
   describe('Worker log identification with ACTIONS_ORCHESTRATION_ID', () => {
     test('should use ACTIONS_ORCHESTRATION_ID to find correct Worker log', () => {
       const planId = '9f25551c-ce16-4f8f-a662-8575df3d1354'
+      // jobId must match what sampleLogContentWithPlanId embeds in the log
+      const jobId = '95a4619c-e316-542f-8a21-74cd5a8ac9ca'
       const originalEnv = process.env
-      process.env = {...originalEnv, ACTIONS_ORCHESTRATION_ID: `${planId}.test-job.__default`}
+      process.env = {...originalEnv, ACTIONS_ORCHESTRATION_ID: `${planId}.${jobId}.__default`}
 
       const targetDir = githubWellKnownDiagnosticDirsUnix[0]
       const logContent = sampleLogContentWithPlanId('correct-job-name', planId)
@@ -1043,8 +1058,10 @@ describe('getGithubJobDisplayNameFromLogs', () => {
     test('should select correct log among multiple Worker logs on non-ephemeral runner', () => {
       const correctPlanId = '9f25551c-ce16-4f8f-a662-8575df3d1354'
       const wrongPlanId = '12345678-1234-1234-1234-123456789abc'
+      // jobId must match what sampleLogContentWithPlanId embeds in the log
+      const jobId = '95a4619c-e316-542f-8a21-74cd5a8ac9ca'
       const originalEnv = process.env
-      process.env = {...originalEnv, ACTIONS_ORCHESTRATION_ID: `${correctPlanId}.test-job.__default`}
+      process.env = {...originalEnv, ACTIONS_ORCHESTRATION_ID: `${correctPlanId}.${jobId}.__default`}
 
       const targetDir = githubWellKnownDiagnosticDirsUnix[0]
 
@@ -1080,6 +1097,50 @@ describe('getGithubJobDisplayNameFromLogs', () => {
       expect(jobName).toBe('correct-job-name')
       // Should read 2 logs searching for planId, then read the matched log again = 3 total
       expect(fs.readFileSync).toHaveBeenCalledTimes(3)
+      process.env = originalEnv
+    })
+
+    test('should disambiguate logs sharing the same planId using jobId on multi-runners', () => {
+      // On a non-ephemeral (multi) runner, sequential jobs from the same workflow run all
+      // share the same planId. The previous job's Worker log is found first (alphabetical
+      // order). Without jobId matching, the wrong log is returned.
+      const sharedPlanId = '9f25551c-ce16-4f8f-a662-8575df3d1354'
+      const previousJobId = 'aaaaaaaa-0000-0000-0000-000000000001'
+      const currentJobId = 'bbbbbbbb-0000-0000-0000-000000000002'
+      const originalEnv = process.env
+      process.env = {
+        ...originalEnv,
+        ACTIONS_ORCHESTRATION_ID: `${sharedPlanId}.${currentJobId}.__default`,
+      }
+
+      const targetDir = githubWellKnownDiagnosticDirsUnix[0]
+
+      jest.spyOn(fs, 'readdirSync').mockImplementation((pathToRead) => {
+        if (String(pathToRead) === String(targetDir)) {
+          return [
+            mockLogFileDirent('Worker_20251014-083000.log'), // previous job (same planId, different jobId)
+            mockLogFileDirent('Worker_20251014-090000.log'), // current job (same planId, matching jobId)
+          ]
+        }
+        throw getNotFoundFsError()
+      })
+
+      jest.spyOn(fs, 'readFileSync').mockImplementation((filePath: any) => {
+        const filePathStr = String(filePath)
+        if (filePathStr.includes('Worker_20251014-083000.log')) {
+          return sampleLogContentWithPlanIdAndJobId('previous-job-name', sharedPlanId, previousJobId)
+        }
+        if (filePathStr.includes('Worker_20251014-090000.log')) {
+          return sampleLogContentWithPlanIdAndJobId('current-job-name', sharedPlanId, currentJobId)
+        }
+
+        return ''
+      })
+
+      const jobName = getGithubJobNameFromLogs(createMockContext() as BaseContext)
+
+      // Must return the current job's name, not the previous job's name
+      expect(jobName).toBe('current-job-name')
       process.env = originalEnv
     })
 

--- a/packages/base/src/helpers/ci.ts
+++ b/packages/base/src/helpers/ci.ts
@@ -1215,6 +1215,17 @@ const getGithubWorkerLogFiles = (context: BaseContext): [string, string[]] | und
 /**
  * Narrows the list of Worker log files to check by using ACTIONS_ORCHESTRATION_ID
  * to identify the correct log for the current job on non-ephemeral runners.
+ *
+ * ACTIONS_ORCHESTRATION_ID format: <planId>.<jobId>.__default
+ *
+ * All jobs in the same GitHub Actions workflow run share the same planId.
+ * On multi-runners (non-ephemeral runners processing sequential jobs), multiple
+ * Worker log files can exist from different jobs of the same workflow run,
+ * all containing the same planId. Matching only on planId causes the first
+ * (chronologically oldest) log to be selected, which may belong to a previous
+ * job. The jobId (second segment of ACTIONS_ORCHESTRATION_ID) is unique per job
+ * and is serialized as "jobId" in the Worker log's job message JSON, allowing
+ * unambiguous identification of the current job's log.
  */
 const getTargetWorkerLogFiles = (context: BaseContext, foundDiagDir: string, workerLogFiles: string[]): string[] => {
   const orchestrationId = process.env.ACTIONS_ORCHESTRATION_ID
@@ -1222,23 +1233,30 @@ const getTargetWorkerLogFiles = (context: BaseContext, foundDiagDir: string, wor
     return workerLogFiles
   }
 
-  // Extract planId GUID (everything before first dot)
-  const planId = orchestrationId.split('.')[0]
+  // ACTIONS_ORCHESTRATION_ID format: <planId>.<jobId>.__default
+  const parts = orchestrationId.split('.')
+  const planId = parts[0]
+  // jobId is unique per job within a workflow run; planId is shared across all jobs
+  const jobId = parts[1]
 
-  // Find the Worker log containing this planId
+  // Find the Worker log matching both planId and jobId for the current job
   for (const logFile of workerLogFiles) {
     const filePath = upath.join(foundDiagDir, logFile)
     const content = fs.readFileSync(filePath, 'utf-8')
 
-    if (content.includes(`"planId": "${planId}"`)) {
-      context.stdout.write(`Found Worker log for planId ${planId}: ${logFile}\n`)
+    const matchesPlanId = content.includes(`"planId": "${planId}"`)
+    // jobId may be absent on older runner versions; fall back to planId-only match
+    const matchesJobId = !jobId || content.includes(`"jobId": "${jobId}"`)
+
+    if (matchesPlanId && matchesJobId) {
+      context.stdout.write(`Found Worker log for planId ${planId}, jobId ${jobId ?? 'N/A'}: ${logFile}\n`)
 
       return [logFile]
     }
   }
 
   context.stderr.write(
-    `${chalk.yellow.bold('[WARNING]')} Could not find Worker log for planId ${planId}, checking all logs\n`
+    `${chalk.yellow.bold('[WARNING]')} Could not find Worker log for planId ${planId}, jobId ${jobId ?? 'N/A'}, checking all logs\n`
   )
 
   return workerLogFiles


### PR DESCRIPTION
Fixes #2271.

## Changes

- `packages/base/src/helpers/ci.ts` — `getTargetWorkerLogFiles()` now requires both `planId` **and** `jobId` (second segment of `ACTIONS_ORCHESTRATION_ID`) to match, since `jobId` is unique per job within a workflow run. The `jobId` check is skipped gracefully when absent, preserving backward compatibility with older runner versions.
- `packages/base/src/helpers/__tests__/ci.test.ts` — update existing tests to use matching jobIds in `ACTIONS_ORCHESTRATION_ID`; add regression test for the same-planId multi-runner scenario.

## Testing

```sh
yarn test packages/base/src/helpers/__tests__/ci.test.ts
# 1026 tests pass, including the new regression test:
# ✓ should disambiguate logs sharing the same planId using jobId on multi-runners
```

Follows up on #2089 (original fix for Worker log detection on non-ephemeral runners).