### PR TITLE
Parse datadog:opaque property from CycloneDX SBOM

### DIFF
--- a/packages/plugin-sbom/src/__tests__/fixtures/sbom-with-opaque.json
+++ b/packages/plugin-sbom/src/__tests__/fixtures/sbom-with-opaque.json
@@ -1,0 +1,39 @@
+{
+    "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
+    "bomFormat": "CycloneDX",
+    "specVersion": "1.5",
+    "version": 1,
+    "components": [
+        {
+            "bom-ref": "pkg:maven/org.apache.logging.log4j/log4j-core@2.14.1",
+            "type": "library",
+            "name": "log4j-core",
+            "version": "2.14.1",
+            "purl": "pkg:maven/org.apache.logging.log4j/log4j-core@2.14.1",
+            "properties": [
+                {
+                    "name": "datadog:opaque",
+                    "value": "true"
+                },
+                {
+                    "name": "datadog:package-manager",
+                    "value": "Maven"
+                }
+            ]
+        },
+        {
+            "bom-ref": "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.9.10",
+            "type": "library",
+            "name": "jackson-databind",
+            "version": "2.9.10",
+            "purl": "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.9.10",
+            "properties": [
+                {
+                    "name": "datadog:package-manager",
+                    "value": "Maven"
+                }
+            ]
+        }
+    ],
+    "vulnerabilities": []
+}

--- a/packages/plugin-sbom/src/__tests__/payload.test.ts
+++ b/packages/plugin-sbom/src/__tests__/payload.test.ts
@@ -564,6 +564,28 @@ describe('generation of payload', () => {
     expect(dependencies[1].target_frameworks).toHaveLength(0)
   })
 
+  test('should correctly set opaque flag from datadog:opaque property', async () => {
+    const sbomFile = './src/__tests__/fixtures/sbom-with-opaque.json'
+    const sbomContent = JSON.parse(fs.readFileSync(sbomFile).toString('utf8'))
+    const config: DatadogCiConfig = {
+      apiKey: undefined,
+      env: undefined,
+      envVarTags: undefined,
+    }
+    const tags = await getSpanTags(config, [], true)
+
+    const payload = generatePayload(sbomContent, tags, 'service', 'env')
+
+    expect(payload?.dependencies.length).toStrictEqual(2)
+    const dependencies = payload!.dependencies
+
+    expect(dependencies[0].name).toEqual('log4j-core')
+    expect(dependencies[0].opaque).toStrictEqual(true)
+
+    expect(dependencies[1].name).toEqual('jackson-databind')
+    expect(dependencies[1].opaque).toBeUndefined()
+  })
+
   test('should fail to read git information', async () => {
     const nonExistingGitRepository = '/you/cannot/find/me'
     const config: DatadogCiConfig = {

--- a/packages/plugin-sbom/src/__tests__/validation.test.ts
+++ b/packages/plugin-sbom/src/__tests__/validation.test.ts
@@ -97,6 +97,7 @@ describe('validation of sbom file', () => {
         reachable_symbol_properties: undefined,
         exclusions: undefined,
         target_frameworks: undefined,
+        opaque: undefined,
       })
     ).toBeFalsy()
     expect(
@@ -114,6 +115,7 @@ describe('validation of sbom file', () => {
         reachable_symbol_properties: undefined,
         exclusions: undefined,
         target_frameworks: undefined,
+        opaque: undefined,
       })
     ).toBeTruthy()
     expect(
@@ -131,6 +133,7 @@ describe('validation of sbom file', () => {
         reachable_symbol_properties: undefined,
         exclusions: undefined,
         target_frameworks: undefined,
+        opaque: undefined,
       })
     ).toBeTruthy()
     expect(
@@ -148,6 +151,7 @@ describe('validation of sbom file', () => {
         reachable_symbol_properties: undefined,
         exclusions: undefined,
         target_frameworks: undefined,
+        opaque: undefined,
       })
     ).toBeTruthy()
   })

--- a/packages/plugin-sbom/src/constants.ts
+++ b/packages/plugin-sbom/src/constants.ts
@@ -18,3 +18,4 @@ export const REACHABLE_SYMBOL_LOCATION_KEY_PREFIX = 'datadog:reachable-symbol-lo
 
 // datadog-sca specific SBOM properties
 export const TARGET_FRAMEWORK_KEY = 'datadog:target-framework'
+export const OPAQUE_KEY = 'datadog:opaque'

--- a/packages/plugin-sbom/src/payload.ts
+++ b/packages/plugin-sbom/src/payload.ts
@@ -38,6 +38,7 @@ import {
   LEGACY_IS_DEPENDENCY_DIRECT_PROPERTY_KEY,
   LEGACY_PACKAGE_MANAGER_PROPERTY_KEY,
   LEGACY_REACHABLE_SYMBOL_LOCATION_KEY_PREFIX,
+  OPAQUE_KEY,
   PACKAGE_MANAGER_PROPERTY_KEY,
   REACHABLE_SYMBOL_LOCATION_KEY_PREFIX,
   TARGET_FRAMEWORK_KEY,
@@ -261,6 +262,7 @@ const extractingDependency = (component: any): Dependency | undefined => {
   const exclusions: Set<string> = new Set<string>()
   const targetFrameworks: string[] = []
   const reachableSymbolProperties: Property[] = []
+  let opaque: boolean | undefined
 
   for (const property of component['properties'] ?? []) {
     const propertyName: string = property.name
@@ -283,6 +285,8 @@ const extractingDependency = (component: any): Dependency | undefined => {
       isDev = parseTrueOrUndefined(propertyValue)
     } else if (propertyName === TARGET_FRAMEWORK_KEY) {
       targetFrameworks.push(propertyValue)
+    } else if (propertyName === OPAQUE_KEY) {
+      opaque = propertyValue.toLowerCase() === 'true' ? true : undefined
     } else if (
       propertyName.startsWith(LEGACY_REACHABLE_SYMBOL_LOCATION_KEY_PREFIX) ||
       propertyName.startsWith(REACHABLE_SYMBOL_LOCATION_KEY_PREFIX)
@@ -321,6 +325,7 @@ const extractingDependency = (component: any): Dependency | undefined => {
     reachable_symbol_properties: reachableSymbolProperties,
     target_frameworks: targetFrameworks,
     exclusions: Array.from(exclusions),
+    opaque,
   }
 
   return dependency

--- a/packages/plugin-sbom/src/types.ts
+++ b/packages/plugin-sbom/src/types.ts
@@ -100,6 +100,7 @@ export interface Dependency {
   reachable_symbol_properties: undefined | Property[]
   exclusions: undefined | string[]
   target_frameworks: undefined | string[]
+  opaque: undefined | boolean
 }
 
 export interface ReachableSymbolLocationValue extends LocationFromFile {


### PR DESCRIPTION
## 🚀 Motivation 

\`datadog-sbom-generator\` marks certain JAR packages as **opaque** — JARs whose contents cannot be fully analyzed (e.g., nested JARs in fat JARs) — using a custom \`datadog:opaque\` CycloneDX property. This information was being lost during ingestion in \`datadog-ci\`, preventing the SCA backend from applying the appropriate analysis strategy for those packages.

This PR propagates the \`datadog:opaque\` flag from the CycloneDX SBOM through \`datadog-ci\` all the way to the SCA API payload.

## Documentation
**Document** | **Link or Detail**
-------------|------------------
RFC | N/A
Incident | N/A
Jira Ticket | N/A


## 📝 Summary

- Added \`OPAQUE_KEY = 'datadog:opaque'\` constant in \`constants.ts\`
- Added \`opaque?: boolean\` field to the \`Dependency\` interface in \`types.ts\`
- Extended \`extractingDependency()\` in \`payload.ts\` to parse the \`datadog:opaque\` property from CycloneDX SBOM components and map it to the \`opaque\` field (\`\"true\"\` → \`true\`, anything else → \`undefined\`)
- Added fixture \`sbom-with-opaque.json\` with one opaque and one non-opaque Maven component
- Added unit tests covering correct propagation of the \`opaque\` flag and absence of the field for non-opaque dependencies


## 🧪 Testing
- [X] New tests were added for new logic.
- [X] Existing tests were updated for new logic, and not only so that they pass!
- [ ] Benchmark results prove that performance is the same or better.


## 🚧 Staging validation
- [ ] Deployed and monitored using Datadog dashboards.
- [ ] Proof that it works as expected, including profiling or UX screenshots.


## 🆘 Recovery
Notes for on-call - **select only one**:
- [X] The change can be rolled back.
- [ ] Do not roll back. Why?: