### PR TITLE
fix(request): Fix JSON response parsing for v2 endpoints

### DIFF
--- a/e2e/git-metadata.test.ts
+++ b/e2e/git-metadata.test.ts
@@ -1,0 +1,15 @@
+import {DATADOG_CI_COMMAND, execPromise} from './helpers/exec'
+
+describe('git-metadata', () => {
+  it('uploads without errors', async () => {
+    const result = await execPromise(`${DATADOG_CI_COMMAND} git-metadata upload`, {
+      DD_API_KEY: process.env.DD_API_KEY,
+      DATADOG_API_KEY: undefined,
+    })
+
+    const output = `${result.stdout}\n${result.stderr}`
+    expect(output).not.toContain('Failed getting commits to exclude')
+    expect(output).not.toContain('Could not write to GitDB')
+    expect(result.exitCode).toBe(0)
+  })
+})

--- a/packages/base/src/helpers/__tests__/request.test.ts
+++ b/packages/base/src/helpers/__tests__/request.test.ts
@@ -74,4 +74,37 @@ describe('httpRequest', () => {
     expect(mockedFetch).toHaveBeenCalledWith('https://example.com', expect.any(Object))
     expect(getLastFetchHeaders()['User-Agent']).toBe(`${getUserAgent()} datadog-ci-plugin-synthetics/9.9.9`)
   })
+
+  describe('JSON response parsing', () => {
+    test.each([
+      ['application/json'],
+      ['application/json; charset=utf-8'],
+      ['application/vnd.api+json'],
+      ['application/vnd.api+json; charset=utf-8'],
+    ])('parses JSON body when content-type is %s', async (contentType) => {
+      const body = JSON.stringify({data: [{id: 'abc', type: 'commit'}]})
+      const response = {
+        ...createResponse({'content-type': contentType}),
+        text: async () => body,
+      }
+      mockedFetch.mockResolvedValue(response as Awaited<ReturnType<typeof fetch>>)
+
+      const result = await httpRequest({url: 'https://example.com'})
+
+      expect(result.data).toEqual({data: [{id: 'abc', type: 'commit'}]})
+    })
+
+    test('does not parse body when content-type is text/plain', async () => {
+      const body = JSON.stringify({data: 'value'})
+      const response = {
+        ...createResponse({'content-type': 'text/plain'}),
+        text: async () => body,
+      }
+      mockedFetch.mockResolvedValue(response as Awaited<ReturnType<typeof fetch>>)
+
+      const result = await httpRequest({url: 'https://example.com'})
+
+      expect(result.data).toBe(body)
+    })
+  })
 })

--- a/packages/base/src/helpers/request.ts
+++ b/packages/base/src/helpers/request.ts
@@ -171,10 +171,10 @@ export const httpRequest = async <T = any>(config: RequestConfig): Promise<Reque
   }
 
   const responseHeaders = parseResponseHeaders(response.headers)
-  const contentType = responseHeaders['content-type'] ?? ''
+  const mediaType = (responseHeaders['content-type'] ?? '').split(';')[0].trim()
   const rawBody = await response.text()
   let data: any = rawBody
-  if (contentType.includes('application/json') && rawBody.length > 0) {
+  if (rawBody.length > 0 && (mediaType === 'application/json' || mediaType === 'application/vnd.api+json')) {
     try {
       data = JSON.parse(rawBody)
     } catch {


### PR DESCRIPTION
### What and why?

The axios-to-undici migration (#2201) introduced a regression: `httpRequest` only auto-parsed JSON responses when the `content-type` header was exactly `application/json`. Some Datadog API endpoints (e.g. `/api/v2/git/repository/search_commits`) return `application/vnd.api+json`, which was not handled — leaving `response.data` as a raw string instead of a parsed object.

This caused `git-metadata upload` to fail with `Invalid API response: [object Object]` during GitDB sync.

### How?

- Extract the media type from the content-type header (stripping parameters like `; charset=utf-8`) and compare with strict equality
- Add `application/vnd.api+json` as an accepted JSON content-type alongside `application/json`
- Added unit tests covering both content-types with and without charset parameters, plus a negative case for `text/plain`

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)