### PR TITLE
chore: bundle lambda function export deps

### DIFF
--- a/datadog-ci.meta.json
+++ b/datadog-ci.meta.json
@@ -4,10 +4,6 @@
       "bundle": {
         "extraBundlePatterns": [
           "./src/functions/*.ts"
-        ],
-        "extraBundleExternalPatterns": [
-          "@aws-sdk/",
-          "@smithy/"
         ]
       }
     }


### PR DESCRIPTION
### What and why?

`@datadog/datadog-ci-plugin-lambda@5.13.0` changed AWS SDK packages from direct dependencies to optional peer deps and introduced Rolldown bundling. The main `dist/bundle.js` correctly bundles everything inline, but the function entry points (`dist/functions/*.js`) externalize `@aws-sdk/*` and `@smithy/*` via the `extraBundleExternalPatterns` config in `datadog-ci.meta.json`.

This means consumers that don't have these packages installed -- e.g. the Lambda Node.js 24 runtime which dropped `@smithy/util-retry` -- crash at import time with `Runtime.ImportModuleError`.

### How?

Remove the `extraBundleExternalPatterns` field from `datadog-ci.meta.json`. The build script (`scripts/tsdown-plugin.mjs`) already handles the absent field by falling back to `buildOptions.deps` which bundles everything via `alwaysBundle: [/.*/]`.

After rebuilding, `dist/functions/instrument.js` (and siblings) have zero `require("@smithy/...")` or `require("@aws-sdk/...")` calls -- all dependencies are inlined.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)

N/A -- config-only change. Verified by rebuilding and confirming no external requires remain, plus all 334 existing tests pass.