### PR TITLE
chore: add smithy optional peer deps to plugin-lambda

### DIFF
--- a/packages/plugin-lambda/package.json
+++ b/packages/plugin-lambda/package.json
@@ -56,7 +56,9 @@
     "@aws-sdk/client-cloudwatch-logs": "^3.981.0",
     "@aws-sdk/client-iam": "^3.981.0",
     "@aws-sdk/client-lambda": "^3.981.0",
-    "@aws-sdk/credential-providers": "^3.981.0"
+    "@aws-sdk/credential-providers": "^3.981.0",
+    "@smithy/property-provider": "2.2.0",
+    "@smithy/util-retry": "2.2.0"
   },
   "peerDependenciesMeta": {
     "@aws-sdk/client-cloudwatch-logs": {
@@ -69,6 +71,12 @@
       "optional": true
     },
     "@aws-sdk/credential-providers": {
+      "optional": true
+    },
+    "@smithy/property-provider": {
+      "optional": true
+    },
+    "@smithy/util-retry": {
       "optional": true
     }
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2156,6 +2156,8 @@ __metadata:
     "@aws-sdk/client-iam": ^3.981.0
     "@aws-sdk/client-lambda": ^3.981.0
     "@aws-sdk/credential-providers": ^3.981.0
+    "@smithy/property-provider": 2.2.0
+    "@smithy/util-retry": 2.2.0
   peerDependenciesMeta:
     "@aws-sdk/client-cloudwatch-logs":
       optional: true
@@ -2164,6 +2166,10 @@ __metadata:
     "@aws-sdk/client-lambda":
       optional: true
     "@aws-sdk/credential-providers":
+      optional: true
+    "@smithy/property-provider":
+      optional: true
+    "@smithy/util-retry":
       optional: true
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
### What and why?

`@smithy/property-provider` and `@smithy/util-retry` are already [direct devDependencies](https://github.com/DataDog/datadog-ci/blob/b44c8024d521f096b847f8a4999ba961b65fc9ce/packages/plugin-lambda/package.json#L83-L84) of `plugin-lambda`, but they weren't declared as `peerDependencies`. This means consumers using the `./functions/*` sub-exports (rather than the main `bundle.js`) can hit a missing module error at runtime -- e.g. in AWS Lambda where `@smithy/util-retry` isn't available despite the rest of the AWS SDK being present.

This adds both packages as optional peer dependencies, matching the existing pattern for the `@aws-sdk/*` packages.

### How?

Added `@smithy/property-provider` and `@smithy/util-retry` to `peerDependencies` and `peerDependenciesMeta` (as optional) in `packages/plugin-lambda/package.json`.

### Review checklist

- [x] No code changes -- only package.json metadata