### PR TITLE
fix(sourcemaps): use upath.relative to prevent dot-stripping when basePath is "."

### DIFF
--- a/packages/base/src/commands/sourcemaps/__tests__/upload.test.ts
+++ b/packages/base/src/commands/sourcemaps/__tests__/upload.test.ts
@@ -17,7 +17,7 @@ describe('upload', () => {
       command['minifiedPathPrefix'] = 'http://datadog.com/js'
       expect(command['getMinifiedURLAndRelativePath']('/js/sourcemaps/common.min.js.map')).toStrictEqual([
         'http://datadog.com/js/common.min.js.map',
-        '/common.min.js.map',
+        'common.min.js.map',
       ])
     })
   })
@@ -29,7 +29,7 @@ describe('upload', () => {
       command['minifiedPathPrefix'] = '//datadog.com/js'
       expect(command['getMinifiedURLAndRelativePath']('/js/sourcemaps/common.min.js.map')).toStrictEqual([
         '//datadog.com/js/common.min.js.map',
-        '/common.min.js.map',
+        'common.min.js.map',
       ])
     })
   })
@@ -41,7 +41,29 @@ describe('upload', () => {
       command['minifiedPathPrefix'] = '/js'
       expect(command['getMinifiedURLAndRelativePath']('/js/sourcemaps/common.min.js.map')).toStrictEqual([
         '/js/common.min.js.map',
-        '/common.min.js.map',
+        'common.min.js.map',
+      ])
+    })
+  })
+
+  describe('getMinifiedURL: basePath is current directory', () => {
+    test('should preserve dots in filenames when basePath is "."', () => {
+      const command = createCommand(SourcemapsUploadCommand)
+      command['basePath'] = '.'
+      command['minifiedPathPrefix'] = '/dist/app/'
+      expect(command['getMinifiedURLAndRelativePath']('main.bundle.js')).toStrictEqual([
+        '/dist/app/main.bundle.js',
+        'main.bundle.js',
+      ])
+    })
+
+    test('should preserve dots in subdirectory paths when basePath is "."', () => {
+      const command = createCommand(SourcemapsUploadCommand)
+      command['basePath'] = '.'
+      command['minifiedPathPrefix'] = '/dist/app/'
+      expect(command['getMinifiedURLAndRelativePath']('subdir/component.module.js')).toStrictEqual([
+        '/dist/app/subdir/component.module.js',
+        'subdir/component.module.js',
       ])
     })
   })

--- a/packages/base/src/commands/sourcemaps/upload.ts
+++ b/packages/base/src/commands/sourcemaps/upload.ts
@@ -278,7 +278,7 @@ export class SourcemapsUploadCommand extends BaseCommand {
   }
 
   private getMinifiedURLAndRelativePath(minifiedFilePath: string): [string, string] {
-    const relativePath = minifiedFilePath.replace(this.basePath, '')
+    const relativePath = upath.relative(this.basePath, minifiedFilePath)
 
     return [buildPath(this.minifiedPathPrefix!, relativePath), relativePath]
   }


### PR DESCRIPTION
### What and why?

Closes https://github.com/DataDog/datadog-ci/issues/1577 (still reproduces on v5.13.1)

When users run `datadog-ci sourcemaps upload .` (basePath = current directory), uploaded filenames have their first `.` stripped — e.g., `main.bundle.js` becomes `mainbundle.js`. This causes sourcemap path mismatches and unminification failures.

**Reported in:** [RUMS-5803](https://datadoghq.atlassian.net/browse/RUMS-5803) — customer on Windows/PowerShell, pinned to v2.44.0 as workaround.

### Root cause

`getMinifiedURLAndRelativePath` uses `String.replace(this.basePath, '')` to strip the base path prefix. `String.replace` with a string argument replaces the **first occurrence**. When basePath is `"."`, it matches the first `.` in the filename instead of the path prefix.

This became visible after #1559 (glob v7 → v10+, merged Feb 2025). Old glob returned `./main.bundle.js` (replace hit the `./` dot — harmless). New glob returns `main.bundle.js` after `upath.normalizeSafe` (replace hits the filename dot — destructive).

The fix in #1624 (v3.5.0) addressed Windows backslash handling but `getMinifiedURLAndRelativePath` was not modified.

### How?

Replace `minifiedFilePath.replace(this.basePath, '')` with `upath.relative(this.basePath, minifiedFilePath)`.

| basePath | Input | Before (bug) | After (fix) |
|----------|-------|-------------|-------------|
| `.` | `main.bundle.js` | `mainbundle.js` | `main.bundle.js` |
| `.` | `subdir/component.module.js` | `subdir/componentmodule.js` | `subdir/component.module.js` |
| `/js/sourcemaps` | `/js/sourcemaps/common.min.js` | `/common.min.js` | `common.min.js` |

The `relativePath` change from `/common.min.js` → `common.min.js` (no leading slash) is safe:
- `buildPath()` already strips leading `/` from non-first parts — URL output unchanged
- `extractRepeatedPath()` trims leading slashes internally — validation unchanged
- `renderer.ts` warning message — cosmetic only

### Review checklist

- [x] 2 new unit tests for `basePath = "."` with dotted filenames
- [x] 3 existing test expectations updated (`relativePath` leading `/` removed)
- [x] All 25 sourcemaps upload tests pass
- [x] Verified tests fail without the fix (5 failures), pass with it


[RUMS-5803]: https://datadoghq.atlassian.net/browse/RUMS-5803?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ