### PR TITLE
[FRSLES-848] add --sidecar-image flag to aas and container-app instrument

### DIFF
--- a/packages/base/src/commands/aas/common.ts
+++ b/packages/base/src/commands/aas/common.ts
@@ -82,6 +82,7 @@ export type AasConfigOptions = Partial<{
   uploadGitMetadata: boolean
   extraTags: string
   windowsRuntime: WindowsRuntime
+  sidecarImage: string
 }>
 
 export abstract class AasCommand extends BaseCommand {

--- a/packages/base/src/commands/aas/instrument.ts
+++ b/packages/base/src/commands/aas/instrument.ts
@@ -61,7 +61,7 @@ export class AasInstrumentCommand extends AasCommand {
       'Manually specify the Windows runtime (`node`, `dotnet`, or `java`) used by the extension to override automatic detection.',
   })
   private sidecarImage = Option.String('--sidecar-image', SIDECAR_IMAGE, {
-    description: `The image to use for the sidecar container. Only applies to Linux web apps. Defaults to '${SIDECAR_IMAGE}'`,
+    description: `Override to pin a specific version tag or to use a mirrored image from a custom registry (e.g., ACR) to avoid pull rate limits. Only applies to Linux web apps. Defaults to '${SIDECAR_IMAGE}'`,
   })
 
   public get additionalConfig(): Partial<AasConfigOptions> {

--- a/packages/base/src/commands/aas/instrument.ts
+++ b/packages/base/src/commands/aas/instrument.ts
@@ -3,6 +3,7 @@ import type {AasConfigOptions, WindowsRuntime} from './common'
 import {Command, Option} from 'clipanion'
 
 import {executePluginCommand} from '../../helpers/plugin'
+import {SIDECAR_IMAGE} from '../../helpers/serverless/constants'
 
 import {AasCommand} from './common'
 
@@ -59,6 +60,9 @@ export class AasInstrumentCommand extends AasCommand {
     description:
       'Manually specify the Windows runtime (`node`, `dotnet`, or `java`) used by the extension to override automatic detection.',
   })
+  private sidecarImage = Option.String('--sidecar-image', SIDECAR_IMAGE, {
+    description: `The image to use for the sidecar container. Only applies to Linux web apps. Defaults to '${SIDECAR_IMAGE}'`,
+  })
 
   public get additionalConfig(): Partial<AasConfigOptions> {
     return {
@@ -74,6 +78,7 @@ export class AasInstrumentCommand extends AasCommand {
       uploadGitMetadata: this.uploadGitMetadata,
       extraTags: this.extraTags,
       windowsRuntime: this.windowsRuntime as WindowsRuntime | undefined,
+      sidecarImage: this.sidecarImage,
     }
   }
 

--- a/packages/base/src/commands/container-app/common.ts
+++ b/packages/base/src/commands/container-app/common.ts
@@ -33,6 +33,7 @@ export type ContainerAppConfigOptions = Partial<{
   sidecarName: string
   sidecarCpu: number
   sidecarMemory: number
+  sidecarImage: string
   sharedVolumeName: string
   sharedVolumePath: string
   logsPath: string

--- a/packages/base/src/commands/container-app/instrument.ts
+++ b/packages/base/src/commands/container-app/instrument.ts
@@ -9,6 +9,7 @@ import {
   DEFAULT_LOGS_PATH,
   DEFAULT_VOLUME_NAME,
   DEFAULT_SIDECAR_NAME,
+  SIDECAR_IMAGE,
 } from '../../helpers/serverless/constants'
 
 import {ContainerAppCommand} from './common'
@@ -55,6 +56,9 @@ export class ContainerAppInstrumentCommand extends ContainerAppCommand {
     description: `The amount of memory (in GiB) to allocate to the sidecar container. Defaults to '${DEFAULT_SIDECAR_MEMORY}'.`,
     validator: isNumber(),
   })
+  private sidecarImage = Option.String('--sidecar-image', SIDECAR_IMAGE, {
+    description: `The image to use for the sidecar container. Defaults to '${SIDECAR_IMAGE}'`,
+  })
 
   private sourceCodeIntegration = Option.Boolean('--source-code-integration,--sourceCodeIntegration', true, {
     description:
@@ -81,6 +85,7 @@ export class ContainerAppInstrumentCommand extends ContainerAppCommand {
       logsPath: this.logsPath,
       sidecarCpu: this.sidecarCpu,
       sidecarMemory: this.sidecarMemory,
+      sidecarImage: this.sidecarImage,
       sourceCodeIntegration: this.sourceCodeIntegration,
       uploadGitMetadata: this.uploadGitMetadata,
       extraTags: this.extraTags,

--- a/packages/base/src/commands/container-app/instrument.ts
+++ b/packages/base/src/commands/container-app/instrument.ts
@@ -57,7 +57,7 @@ export class ContainerAppInstrumentCommand extends ContainerAppCommand {
     validator: isNumber(),
   })
   private sidecarImage = Option.String('--sidecar-image', SIDECAR_IMAGE, {
-    description: `The image to use for the sidecar container. Defaults to '${SIDECAR_IMAGE}'`,
+    description: `Override to pin a specific version tag or to use a mirrored image from a custom registry (e.g., ACR) to avoid pull rate limits. Defaults to '${SIDECAR_IMAGE}'`,
   })
 
   private sourceCodeIntegration = Option.Boolean('--source-code-integration,--sourceCodeIntegration', true, {

--- a/packages/plugin-aas/README.md
+++ b/packages/plugin-aas/README.md
@@ -106,7 +106,7 @@ You can pass the following arguments to `instrument` to specify its behavior. Th
 | `--upload-git-metadata` or `--uploadGitMetadata` |  | Upload git metadata to Datadog. Specify `--no-upload-git-metadata` to disable. | `true` |
 | `--extra-tags` or `--extraTags` |  | Additional tags to add to the service in the format "key1:value1,key2:value2" |  |
 | `--windows-runtime` |  | Manually specify the Windows runtime (`node`, `dotnet`, or `java`) used by the extension to override automatic detection. |  |
-| `--sidecar-image` |  | The image to use for the sidecar container. Only applies to Linux web apps. | `index.docker.io/datadog/serverless-init:latest` |
+| `--sidecar-image` |  | Override to pin a specific version tag or to use a mirrored image from a custom registry (e.g., ACR) to avoid pull rate limits. Only applies to Linux web apps. | `index.docker.io/datadog/serverless-init:latest` |
 <!-- END_USAGE:instrument -->
 
 #### `uninstrument`

--- a/packages/plugin-aas/README.md
+++ b/packages/plugin-aas/README.md
@@ -106,6 +106,7 @@ You can pass the following arguments to `instrument` to specify its behavior. Th
 | `--upload-git-metadata` or `--uploadGitMetadata` |  | Upload git metadata to Datadog. Specify `--no-upload-git-metadata` to disable. | `true` |
 | `--extra-tags` or `--extraTags` |  | Additional tags to add to the service in the format "key1:value1,key2:value2" |  |
 | `--windows-runtime` |  | Manually specify the Windows runtime (`node`, `dotnet`, or `java`) used by the extension to override automatic detection. |  |
+| `--sidecar-image` |  | The image to use for the sidecar container. Only applies to Linux web apps. | `index.docker.io/datadog/serverless-init:latest` |
 <!-- END_USAGE:instrument -->
 
 #### `uninstrument`

--- a/packages/plugin-aas/src/__tests__/common.ts
+++ b/packages/plugin-aas/src/__tests__/common.ts
@@ -70,6 +70,14 @@ export const CONTAINER_WEB_APP: Site = {
   sku: 'PremiumV2',
 }
 
+export const LINUX_CODE_WEB_APP: Site = {
+  ...CONTAINER_WEB_APP,
+  siteConfig: {
+    ...CONTAINER_WEB_APP.siteConfig,
+    linuxFxVersion: 'NODE|18',
+  },
+}
+
 export const WINDOWS_DOTNET_WEB_APP: Site = {
   ...CONTAINER_WEB_APP,
   kind: 'app,windows',

--- a/packages/plugin-aas/src/__tests__/instrument.test.ts
+++ b/packages/plugin-aas/src/__tests__/instrument.test.ts
@@ -65,6 +65,7 @@ import {PluginCommand as InstrumentCommand} from '../commands/instrument'
 
 import {
   CONTAINER_WEB_APP,
+  LINUX_CODE_WEB_APP,
   WINDOWS_DOTNET_WEB_APP,
   WINDOWS_NODE_WEB_APP,
   WINDOWS_JAVA_WEB_APP,
@@ -218,6 +219,31 @@ describe('aas instrument', () => {
         properties: {tags: {service: 'my-web-app', dd_sls_ci: 'vXXXX'}},
       })
       expect(webAppsOperations.restart).not.toHaveBeenCalled()
+    })
+
+    test('Uses a custom sidecar image when --sidecar-image is passed (containerized Linux)', async () => {
+      const customImage = 'custom.io/my-image:tag'
+      const {code} = await runCLI([...DEFAULT_INSTRUMENT_ARGS, '--sidecar-image', customImage])
+      expect(code).toEqual(0)
+      expect(webAppsOperations.createOrUpdateSiteContainer).toHaveBeenCalledWith(
+        'my-resource-group',
+        'my-web-app',
+        'datadog-sidecar',
+        expect.objectContaining({image: customImage})
+      )
+    })
+
+    test('Uses a custom sidecar image when --sidecar-image is passed (code-based Linux)', async () => {
+      webAppsOperations.get.mockResolvedValue(LINUX_CODE_WEB_APP)
+      const customImage = 'custom.io/my-image:tag'
+      const {code} = await runCLI([...DEFAULT_INSTRUMENT_ARGS, '--sidecar-image', customImage])
+      expect(code).toEqual(0)
+      expect(webAppsOperations.createOrUpdateSiteContainer).toHaveBeenCalledWith(
+        'my-resource-group',
+        'my-web-app',
+        'datadog-sidecar',
+        expect.objectContaining({image: customImage})
+      )
     })
 
     test('Fails if not authenticated with Azure', async () => {

--- a/packages/plugin-aas/src/commands/instrument.ts
+++ b/packages/plugin-aas/src/commands/instrument.ts
@@ -307,7 +307,7 @@ This flag is only applicable for containerized .NET apps (on musl-based distribu
     // env values point to env keys in the main App Settings. (essentially env var forwarding)
     if (
       sidecarContainer === undefined ||
-      sidecarContainer.image !== SIDECAR_IMAGE ||
+      sidecarContainer.image !== (config.sidecarImage ?? SIDECAR_IMAGE) ||
       sidecarContainer.targetPort !== String(SIDECAR_PORT) ||
       !sidecarContainer.environmentVariables?.every(({name, value}) => name === value) ||
       !sortedEqual(new Set(sidecarContainer.environmentVariables.map(({name}) => name)), new Set(Object.keys(envVars)))
@@ -319,7 +319,7 @@ This flag is only applicable for containerized .NET apps (on musl-based distribu
       )
       if (!this.dryRun) {
         const sidecar: SiteContainer = {
-          image: SIDECAR_IMAGE,
+          image: config.sidecarImage ?? SIDECAR_IMAGE,
           targetPort: String(SIDECAR_PORT),
           isMain: false,
           // We're allowing access to all env vars since it is simpler

--- a/packages/plugin-container-app/README.md
+++ b/packages/plugin-container-app/README.md
@@ -123,7 +123,7 @@ You can pass the following arguments to `instrument` to specify its behavior. Th
 | `--logs-path` |  | (Not recommended) Specify a custom log file path. Must begin with the shared volume path. | `/shared-volume/logs/*.log` |
 | `--sidecar-cpu` |  | The number of CPUs to allocate to the sidecar container. | `0.5` |
 | `--sidecar-memory` |  | The amount of memory (in GiB) to allocate to the sidecar container. | `1` |
-| `--sidecar-image` |  | The image to use for the sidecar container. | `index.docker.io/datadog/serverless-init:latest` |
+| `--sidecar-image` |  | Override to pin a specific version tag or to use a mirrored image from a custom registry (e.g., ACR) to avoid pull rate limits. | `index.docker.io/datadog/serverless-init:latest` |
 | `--source-code-integration` or `--sourceCodeIntegration` |  | Whether to enable the Datadog Source Code integration. This tags your service(s) with the Git repository and the latest commit hash of the local directory. Specify `--no-source-code-integration` to disable. | `true` |
 | `--upload-git-metadata` or `--uploadGitMetadata` |  | Whether to enable Git metadata uploading, as a part of the source code integration. Git metadata uploading is only required if you don't have the Datadog GitHub integration installed. Specify `--no-upload-git-metadata` to disable. | `true` |
 | `--extra-tags` or `--extraTags` |  | Additional tags to add to the app in the format "key1:value1,key2:value2". |  |

--- a/packages/plugin-container-app/README.md
+++ b/packages/plugin-container-app/README.md
@@ -123,6 +123,7 @@ You can pass the following arguments to `instrument` to specify its behavior. Th
 | `--logs-path` |  | (Not recommended) Specify a custom log file path. Must begin with the shared volume path. | `/shared-volume/logs/*.log` |
 | `--sidecar-cpu` |  | The number of CPUs to allocate to the sidecar container. | `0.5` |
 | `--sidecar-memory` |  | The amount of memory (in GiB) to allocate to the sidecar container. | `1` |
+| `--sidecar-image` |  | The image to use for the sidecar container. | `index.docker.io/datadog/serverless-init:latest` |
 | `--source-code-integration` or `--sourceCodeIntegration` |  | Whether to enable the Datadog Source Code integration. This tags your service(s) with the Git repository and the latest commit hash of the local directory. Specify `--no-source-code-integration` to disable. | `true` |
 | `--upload-git-metadata` or `--uploadGitMetadata` |  | Whether to enable Git metadata uploading, as a part of the source code integration. Git metadata uploading is only required if you don't have the Datadog GitHub integration installed. Specify `--no-upload-git-metadata` to disable. | `true` |
 | `--extra-tags` or `--extraTags` |  | Additional tags to add to the app in the format "key1:value1,key2:value2". |  |

--- a/packages/plugin-container-app/src/__tests__/instrument.test.ts
+++ b/packages/plugin-container-app/src/__tests__/instrument.test.ts
@@ -168,6 +168,26 @@ describe('container-app instrument', () => {
       })
     })
 
+    test('Uses a custom sidecar image when --sidecar-image is passed', async () => {
+      const customImage = 'custom.io/my-image:tag'
+      const {code} = await runCLI([...DEFAULT_INSTRUMENT_ARGS, '--sidecar-image', customImage])
+      expect(code).toEqual(0)
+      expect(containerAppsOperations.beginUpdateAndWait).toHaveBeenCalledWith(
+        'my-resource-group',
+        'my-container-app',
+        expect.objectContaining({
+          template: expect.objectContaining({
+            containers: expect.arrayContaining([
+              expect.objectContaining({
+                name: 'datadog-sidecar',
+                image: customImage,
+              }),
+            ]),
+          }),
+        })
+      )
+    })
+
     test('Performs no actions in dry run mode', async () => {
       const {code, context} = await runCLI([...DEFAULT_INSTRUMENT_ARGS, '--dry-run'])
       const output = context.stdout.toString()

--- a/packages/plugin-container-app/src/commands/instrument.ts
+++ b/packages/plugin-container-app/src/commands/instrument.ts
@@ -216,7 +216,7 @@ export class PluginCommand extends ContainerAppInstrumentCommand {
     // Build base sidecar container
     const baseSidecar: Container = {
       name: config.sidecarName,
-      image: SIDECAR_IMAGE,
+      image: config.sidecarImage ?? SIDECAR_IMAGE,
       resources: {
         cpu: config.sidecarCpu ?? DEFAULT_SIDECAR_CPU,
         memory: (config.sidecarMemory ?? DEFAULT_SIDECAR_MEMORY) + 'Gi',


### PR DESCRIPTION
### What and why?

Adds `--sidecar-image` flag to `aas instrument` and `container-app instrument`, matching the existing flag on `cloud-run instrument`. Allows users to pin or override the sidecar container image (e.g. to a specific digest) rather than always using the default `index.docker.io/datadog/serverless-init:latest`.

### How?

- Added `sidecarImage` to `AasConfigOptions` and `ContainerAppConfigOptions`
- Added `--sidecar-image` option to both base instrument commands, defaulting to `SIDECAR_IMAGE`
- Updated plugin implementations to use `config.sidecarImage` in place of the hardcoded constant
- For AAS, also updated the validation check in `instrumentSidecar` so existing sidecars with a matching custom image aren't unnecessarily re-deployed
- READMEs auto-updated by the lint-readme hook

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)