### PR TITLE
Fix GitHub job / step-level tag correlation on recent versions

### DIFF
--- a/packages/base/src/helpers/__tests__/ci.test.ts
+++ b/packages/base/src/helpers/__tests__/ci.test.ts
@@ -749,12 +749,15 @@ describe('getGithubJobDisplayNameFromLogs', () => {
       const derivedDiagDir = upath.join(runnerRoot, ...routeParts)
       const logContent = sampleLogContent(sampleJobDisplayName)
 
-      // The `cached/**/_diag` globs emitted by getGithubDiagnosticDirsFromEnv
-      // are the only way `cached` paths are reached now, so expand them to the
-      // test's target when the route includes `cached`.
+      // The bounded-depth globs emitted by getGithubDiagnosticDirsFromEnv are
+      // the only way paths with intermediate segments (e.g. cached/_diag) are
+      // reached now, so expand them to the test's target when the route
+      // contains an intermediate segment.
       const cachedPatterns = new Set([
-        `${runnerRoot}/cached/**/_diag`,
-        `${runnerRoot}/actions-runner/cached/**/_diag`,
+        `${runnerRoot}/*/_diag`,
+        `${runnerRoot}/*/*/_diag`,
+        `${runnerRoot}/actions-runner/*/_diag`,
+        `${runnerRoot}/actions-runner/*/*/_diag`,
         ...githubWellKnownDiagnosticDirPatternsUnix,
         ...githubWellKnownDiagnosticDirPatternsWin,
       ])

--- a/packages/base/src/helpers/__tests__/ci.test.ts
+++ b/packages/base/src/helpers/__tests__/ci.test.ts
@@ -6,15 +6,13 @@ import type {BaseContext} from 'clipanion'
 import upath from 'upath'
 
 jest.mock('../glob', () => {
-  const actual = jest.requireActual('../glob') as typeof import('../glob')
+  const actual = jest.requireActual('../glob')
 
   return {
     ...actual,
     globSync: jest.fn<string[], [string]>(() => []),
   }
 })
-
-import {globSync} from '../glob'
 
 import {
   getCIEnv,
@@ -30,7 +28,7 @@ import {
   isInteractive,
   shouldGetGithubJobDisplayName,
 } from '../ci'
-
+import {globSync} from '../glob'
 import {
   CI_ENV_VARS,
   CI_NODE_LABELS,

--- a/packages/base/src/helpers/__tests__/ci.test.ts
+++ b/packages/base/src/helpers/__tests__/ci.test.ts
@@ -5,18 +5,32 @@ import type {BaseContext} from 'clipanion'
 
 import upath from 'upath'
 
+jest.mock('../glob', () => {
+  const actual = jest.requireActual('../glob') as typeof import('../glob')
+
+  return {
+    ...actual,
+    globSync: jest.fn<string[], [string]>(() => []),
+  }
+})
+
+import {globSync} from '../glob'
+
 import {
   getCIEnv,
   getCIMetadata,
   getCISpanTags,
   getGithubJobNameFromLogs,
   getGithubStepInfoFromLogs,
+  githubWellKnownDiagnosticDirPatternsUnix,
+  githubWellKnownDiagnosticDirPatternsWin,
   githubWellKnownDiagnosticDirsUnix,
   githubWellKnownDiagnosticDirsWin,
   isGithubWindowsRunner,
   isInteractive,
   shouldGetGithubJobDisplayName,
 } from '../ci'
+
 import {
   CI_ENV_VARS,
   CI_NODE_LABELS,
@@ -30,6 +44,14 @@ import {
 import {getUserCISpanTags, getUserGitSpanTags} from '../user-provided-git'
 
 import {createMockContext} from './testing-tools'
+
+const mockedGlobSync = globSync as jest.MockedFunction<typeof globSync>
+
+// Synthetic hosted-runner diag dirs used to exercise the glob-expansion path.
+// The real patterns live in githubWellKnownDiagnosticDirPatternsUnix/Win; these
+// are the paths that globSync is made to "expand" to in tests.
+const HOSTED_SAAS_DIAG_DIR_UNIX = '/home/runner/actions-runner/cached/2.334.0/_diag'
+const HOSTED_SAAS_DIAG_DIR_WIN = 'C:/actions-runner/cached/2.334.0/_diag'
 
 const CI_PROVIDERS = fs.readdirSync(upath.join(__dirname, 'ci-env'))
 
@@ -522,6 +544,18 @@ describe('getGithubJobDisplayNameFromLogs', () => {
     process.env = {
       GITHUB_ACTIONS: 'true',
     }
+    // Default: SaaS patterns expand to the synthetic hosted dirs; everything
+    // else expands to nothing. Individual tests can override.
+    mockedGlobSync.mockImplementation((pattern: string) => {
+      if (githubWellKnownDiagnosticDirPatternsUnix.includes(pattern)) {
+        return [HOSTED_SAAS_DIAG_DIR_UNIX]
+      }
+      if (githubWellKnownDiagnosticDirPatternsWin.includes(pattern)) {
+        return [HOSTED_SAAS_DIAG_DIR_WIN]
+      }
+
+      return []
+    })
   })
   afterEach(() => {
     jest.resetAllMocks()
@@ -592,7 +626,7 @@ describe('getGithubJobDisplayNameFromLogs', () => {
   }
 
   test('should find and return the job display name (SaaS)', () => {
-    const targetDir = githubWellKnownDiagnosticDirsUnix[0] // SaaS directory
+    const targetDir = HOSTED_SAAS_DIAG_DIR_UNIX // SaaS directory
     const logContent = sampleLogContent(sampleJobDisplayName)
 
     mockReaddirSync(targetDir, sampleLogFileName)
@@ -606,7 +640,7 @@ describe('getGithubJobDisplayNameFromLogs', () => {
   })
 
   test('should find and return the job display name (self-hosted)', () => {
-    const targetDir = githubWellKnownDiagnosticDirsUnix[1] // self-hosted directory
+    const targetDir = githubWellKnownDiagnosticDirsUnix[0] // self-hosted directory
     const logContent = sampleLogContent(sampleJobDisplayName)
 
     mockReaddirSync(targetDir, sampleLogFileName)
@@ -620,7 +654,7 @@ describe('getGithubJobDisplayNameFromLogs', () => {
   })
 
   test('should find and return the job display name in opt directory', () => {
-    const targetDir = githubWellKnownDiagnosticDirsUnix[2]
+    const targetDir = githubWellKnownDiagnosticDirsUnix[1]
     const logContent = sampleLogContent(sampleJobDisplayName)
 
     mockReaddirSync(targetDir, sampleLogFileName)
@@ -635,7 +669,7 @@ describe('getGithubJobDisplayNameFromLogs', () => {
 
   test('should find and return the job display name windows (SaaS)', () => {
     process.env.RUNNER_OS = 'Windows'
-    const targetDir = githubWellKnownDiagnosticDirsWin[0]
+    const targetDir = HOSTED_SAAS_DIAG_DIR_WIN
     const logContent = sampleLogContent(sampleJobDisplayName)
 
     mockReaddirSync(targetDir, sampleLogFileName)
@@ -650,7 +684,7 @@ describe('getGithubJobDisplayNameFromLogs', () => {
 
   test('should find and return the job display name windows (self-hosted)', () => {
     process.env.RUNNER_OS = 'Windows'
-    const targetDir = githubWellKnownDiagnosticDirsWin[1]
+    const targetDir = githubWellKnownDiagnosticDirsWin[0]
     const logContent = sampleLogContent(sampleJobDisplayName)
 
     mockReaddirSync(targetDir, sampleLogFileName)
@@ -717,6 +751,23 @@ describe('getGithubJobDisplayNameFromLogs', () => {
       const derivedDiagDir = upath.join(runnerRoot, ...routeParts)
       const logContent = sampleLogContent(sampleJobDisplayName)
 
+      // The `cached/**/_diag` globs emitted by getGithubDiagnosticDirsFromEnv
+      // are the only way `cached` paths are reached now, so expand them to the
+      // test's target when the route includes `cached`.
+      const cachedPatterns = new Set([
+        `${runnerRoot}/cached/**/_diag`,
+        `${runnerRoot}/actions-runner/cached/**/_diag`,
+        ...githubWellKnownDiagnosticDirPatternsUnix,
+        ...githubWellKnownDiagnosticDirPatternsWin,
+      ])
+      mockedGlobSync.mockImplementation((pattern: string) => {
+        if (routeParts.includes('cached') && cachedPatterns.has(pattern)) {
+          return [derivedDiagDir]
+        }
+
+        return []
+      })
+
       mockReaddirSync(derivedDiagDir, sampleLogFileName)
       jest.spyOn(fs, 'readFileSync').mockReturnValue(logContent)
     })
@@ -728,7 +779,7 @@ describe('getGithubJobDisplayNameFromLogs', () => {
   })
 
   test('log files found but none contain the display name', () => {
-    const targetDir = githubWellKnownDiagnosticDirsUnix[0]
+    const targetDir = HOSTED_SAAS_DIAG_DIR_UNIX
     const logContent = 'This log does not have the job display name.'
 
     mockReaddirSync(targetDir, sampleLogFileName)
@@ -784,7 +835,7 @@ describe('getGithubJobDisplayNameFromLogs', () => {
   describe('job names with quotes', () => {
     test('should parse job name with single quoted word', () => {
       const jobName = 'Build "production" artifacts'
-      const targetDir = githubWellKnownDiagnosticDirsUnix[0]
+      const targetDir = HOSTED_SAAS_DIAG_DIR_UNIX
       const logContent = sampleLogContent(jobName)
 
       mockReaddirSync(targetDir, sampleLogFileName)
@@ -797,7 +848,7 @@ describe('getGithubJobDisplayNameFromLogs', () => {
 
     test('should parse job name with multiple quotes', () => {
       const jobName = 'Test "foo" and "bar"'
-      const targetDir = githubWellKnownDiagnosticDirsUnix[0]
+      const targetDir = HOSTED_SAAS_DIAG_DIR_UNIX
       const logContent = sampleLogContent(jobName)
 
       mockReaddirSync(targetDir, sampleLogFileName)
@@ -810,7 +861,7 @@ describe('getGithubJobDisplayNameFromLogs', () => {
 
     test('should parse complex job name with quotes and special chars', () => {
       const jobName = 'End-to-End Tests (@org/backend, "features/a*", apps/backend)'
-      const targetDir = githubWellKnownDiagnosticDirsUnix[0]
+      const targetDir = HOSTED_SAAS_DIAG_DIR_UNIX
       const logContent = sampleLogContent(jobName)
 
       mockReaddirSync(targetDir, sampleLogFileName)
@@ -825,7 +876,7 @@ describe('getGithubJobDisplayNameFromLogs', () => {
   describe('job names with backslashes', () => {
     test('should parse job name with Windows paths', () => {
       const jobName = 'Path\\\\to\\\\file'
-      const targetDir = githubWellKnownDiagnosticDirsUnix[0]
+      const targetDir = HOSTED_SAAS_DIAG_DIR_UNIX
       const logContent = sampleLogContent(jobName)
 
       mockReaddirSync(targetDir, sampleLogFileName)
@@ -838,7 +889,7 @@ describe('getGithubJobDisplayNameFromLogs', () => {
 
     test('should parse job name with regex patterns', () => {
       const jobName = 'Regex \\\\d+ test'
-      const targetDir = githubWellKnownDiagnosticDirsUnix[0]
+      const targetDir = HOSTED_SAAS_DIAG_DIR_UNIX
       const logContent = sampleLogContent(jobName)
 
       mockReaddirSync(targetDir, sampleLogFileName)
@@ -851,7 +902,7 @@ describe('getGithubJobDisplayNameFromLogs', () => {
 
     test('should parse job name with literal escape sequences', () => {
       const jobName = 'Literal \\\\n and \\\\t'
-      const targetDir = githubWellKnownDiagnosticDirsUnix[0]
+      const targetDir = HOSTED_SAAS_DIAG_DIR_UNIX
       const logContent = sampleLogContent(jobName)
 
       mockReaddirSync(targetDir, sampleLogFileName)
@@ -866,7 +917,7 @@ describe('getGithubJobDisplayNameFromLogs', () => {
   describe('matrix jobs', () => {
     test('should parse basic matrix job', () => {
       const jobName = 'Build (ubuntu-latest, 18.x)'
-      const targetDir = githubWellKnownDiagnosticDirsUnix[0]
+      const targetDir = HOSTED_SAAS_DIAG_DIR_UNIX
       const logContent = sampleLogContent(jobName)
 
       mockReaddirSync(targetDir, sampleLogFileName)
@@ -879,7 +930,7 @@ describe('getGithubJobDisplayNameFromLogs', () => {
 
     test('should parse matrix job with quotes', () => {
       const jobName = 'Test (macos, "3.9")'
-      const targetDir = githubWellKnownDiagnosticDirsUnix[0]
+      const targetDir = HOSTED_SAAS_DIAG_DIR_UNIX
       const logContent = sampleLogContent(jobName)
 
       mockReaddirSync(targetDir, sampleLogFileName)
@@ -894,7 +945,7 @@ describe('getGithubJobDisplayNameFromLogs', () => {
   describe('reusable workflows', () => {
     test('should parse job name with slashes', () => {
       const jobName = 'Terraform CI / Validate'
-      const targetDir = githubWellKnownDiagnosticDirsUnix[0]
+      const targetDir = HOSTED_SAAS_DIAG_DIR_UNIX
       const logContent = sampleLogContent(jobName)
 
       mockReaddirSync(targetDir, sampleLogFileName)
@@ -907,7 +958,7 @@ describe('getGithubJobDisplayNameFromLogs', () => {
 
     test('should parse job name with multiple levels', () => {
       const jobName = 'CI / CD / Deploy'
-      const targetDir = githubWellKnownDiagnosticDirsUnix[0]
+      const targetDir = HOSTED_SAAS_DIAG_DIR_UNIX
       const logContent = sampleLogContent(jobName)
 
       mockReaddirSync(targetDir, sampleLogFileName)
@@ -922,7 +973,7 @@ describe('getGithubJobDisplayNameFromLogs', () => {
   describe('unicode and emojis', () => {
     test('should parse job name with emojis', () => {
       const jobName = '🚀 Deploy to production'
-      const targetDir = githubWellKnownDiagnosticDirsUnix[0]
+      const targetDir = HOSTED_SAAS_DIAG_DIR_UNIX
       const logContent = sampleLogContent(jobName)
 
       mockReaddirSync(targetDir, sampleLogFileName)
@@ -935,7 +986,7 @@ describe('getGithubJobDisplayNameFromLogs', () => {
 
     test('should parse job name with Chinese characters', () => {
       const jobName = '测试任务'
-      const targetDir = githubWellKnownDiagnosticDirsUnix[0]
+      const targetDir = HOSTED_SAAS_DIAG_DIR_UNIX
       const logContent = sampleLogContent(jobName)
 
       mockReaddirSync(targetDir, sampleLogFileName)
@@ -948,7 +999,7 @@ describe('getGithubJobDisplayNameFromLogs', () => {
 
     test('should parse job name with Japanese characters', () => {
       const jobName = 'テストジョブ'
-      const targetDir = githubWellKnownDiagnosticDirsUnix[0]
+      const targetDir = HOSTED_SAAS_DIAG_DIR_UNIX
       const logContent = sampleLogContent(jobName)
 
       mockReaddirSync(targetDir, sampleLogFileName)
@@ -961,7 +1012,7 @@ describe('getGithubJobDisplayNameFromLogs', () => {
 
     test('should parse job name with Arabic characters', () => {
       const jobName = 'اختبار العمل'
-      const targetDir = githubWellKnownDiagnosticDirsUnix[0]
+      const targetDir = HOSTED_SAAS_DIAG_DIR_UNIX
       const logContent = sampleLogContent(jobName)
 
       mockReaddirSync(targetDir, sampleLogFileName)
@@ -974,7 +1025,7 @@ describe('getGithubJobDisplayNameFromLogs', () => {
 
     test('should parse job name with Cyrillic characters', () => {
       const jobName = 'Тестовое задание'
-      const targetDir = githubWellKnownDiagnosticDirsUnix[0]
+      const targetDir = HOSTED_SAAS_DIAG_DIR_UNIX
       const logContent = sampleLogContent(jobName)
 
       mockReaddirSync(targetDir, sampleLogFileName)
@@ -989,7 +1040,7 @@ describe('getGithubJobDisplayNameFromLogs', () => {
   describe('special characters', () => {
     test('should parse job name with parentheses and brackets', () => {
       const jobName = 'Test [feature] (branch)'
-      const targetDir = githubWellKnownDiagnosticDirsUnix[0]
+      const targetDir = HOSTED_SAAS_DIAG_DIR_UNIX
       const logContent = sampleLogContent(jobName)
 
       mockReaddirSync(targetDir, sampleLogFileName)
@@ -1002,7 +1053,7 @@ describe('getGithubJobDisplayNameFromLogs', () => {
 
     test('should parse job name with symbols', () => {
       const jobName = 'Build @scope/package #123'
-      const targetDir = githubWellKnownDiagnosticDirsUnix[0]
+      const targetDir = HOSTED_SAAS_DIAG_DIR_UNIX
       const logContent = sampleLogContent(jobName)
 
       mockReaddirSync(targetDir, sampleLogFileName)
@@ -1017,7 +1068,7 @@ describe('getGithubJobDisplayNameFromLogs', () => {
   describe('complex combinations', () => {
     test('should parse job name with everything combined', () => {
       const jobName = '🔧 Build "app-v2.0" (@org/repo, ubuntu-latest, node-18.x) ✅'
-      const targetDir = githubWellKnownDiagnosticDirsUnix[0]
+      const targetDir = HOSTED_SAAS_DIAG_DIR_UNIX
       const logContent = sampleLogContent(jobName)
 
       mockReaddirSync(targetDir, sampleLogFileName)
@@ -1053,7 +1104,7 @@ describe('getGithubJobDisplayNameFromLogs', () => {
       const originalEnv = process.env
       process.env = {...originalEnv, ACTIONS_ORCHESTRATION_ID: orchestrationId}
 
-      const targetDir = githubWellKnownDiagnosticDirsUnix[0]
+      const targetDir = HOSTED_SAAS_DIAG_DIR_UNIX
       mockReaddirSync(targetDir, 'Worker_20251014-083000.log')
       jest
         .spyOn(fs, 'readFileSync')
@@ -1073,7 +1124,7 @@ describe('getGithubJobDisplayNameFromLogs', () => {
       process.env = {...originalEnv}
       delete process.env.ACTIONS_ORCHESTRATION_ID
 
-      const targetDir = githubWellKnownDiagnosticDirsUnix[0]
+      const targetDir = HOSTED_SAAS_DIAG_DIR_UNIX
 
       jest.spyOn(fs, 'readdirSync').mockImplementation((pathToRead) => {
         if (String(pathToRead) === String(targetDir)) {
@@ -1114,7 +1165,7 @@ describe('getGithubJobDisplayNameFromLogs', () => {
       const originalEnv = process.env
       process.env = {...originalEnv, ACTIONS_ORCHESTRATION_ID: orchestrationId}
 
-      const targetDir = githubWellKnownDiagnosticDirsUnix[0]
+      const targetDir = HOSTED_SAAS_DIAG_DIR_UNIX
 
       jest.spyOn(fs, 'readdirSync').mockImplementation((pathToRead) => {
         if (String(pathToRead) === String(targetDir)) {

--- a/packages/base/src/helpers/ci.ts
+++ b/packages/base/src/helpers/ci.ts
@@ -120,20 +120,17 @@ export const validateLevel = (level: string | undefined): string | undefined => 
 }
 
 export const githubWellKnownDiagnosticDirsUnix = [
-  '/home/runner/actions-runner/cached/_diag', // for SaaS
   '/home/runner/actions-runner/_diag', // for self-hosted
   '/opt/actions-runner/_diag', // self-hosted in some cases
 ]
 export const githubWellKnownDiagnosticDirsWin = [
-  'C:/actions-runner/cached/_diag', // for SaaS
   'C:/actions-runner/_diag', // for self-hosted
 ]
 
-// Glob patterns covering the version-namespaced layout deployed on GitHub-hosted
-// runners alongside runner v2.334.0 (2026-04-21): _diag moved from
-// <runnerRoot>/cached/_diag to <runnerRoot>/cached/<version>/_diag.
-// With globstar, `**` matches zero or more segments, so a single pattern covers
-// both the old and the new layout.
+// Glob patterns covering the SaaS layout. With globstar, `**` matches zero or
+// more segments, so a single pattern covers both the pre-2.334.0 layout
+// (<runnerRoot>/cached/_diag) and the version-namespaced layout deployed on
+// GitHub-hosted runners alongside v2.334.0 (<runnerRoot>/cached/<version>/_diag).
 export const githubWellKnownDiagnosticDirPatternsUnix = [
   '/home/runner/actions-runner/cached/**/_diag',
 ]
@@ -178,12 +175,10 @@ const getGithubDiagnosticDirsFromEnv = (): string[] => {
   if (runnerTemp) {
     // RUNNER_TEMP is typically: <runnerRoot>/_work/_temp
     const runnerRoot = upath.resolve(runnerTemp, '..', '..')
-    dirs.push(upath.join(runnerRoot, 'cached', '_diag'))
-    // Version-namespaced layout deployed alongside runner v2.334.0.
+    // `cached/**/_diag` matches both pre-2.334.0 (cached/_diag) and the
+    // version-namespaced layout (cached/<version>/_diag) via globstar.
     dirs.push(`${runnerRoot}/cached/**/_diag`)
     dirs.push(upath.join(runnerRoot, '_diag'))
-    // actions-runner variants
-    dirs.push(upath.join(runnerRoot, 'actions-runner', 'cached', '_diag'))
     dirs.push(`${runnerRoot}/actions-runner/cached/**/_diag`)
     dirs.push(upath.join(runnerRoot, 'actions-runner', '_diag'))
   }

--- a/packages/base/src/helpers/ci.ts
+++ b/packages/base/src/helpers/ci.ts
@@ -126,12 +126,20 @@ export const githubWellKnownDiagnosticDirsWin = [
   'C:/actions-runner/_diag', // for self-hosted
 ]
 
-// Glob patterns covering the SaaS layout. With globstar, `**` matches zero or
-// more segments, so a single pattern covers both the pre-2.334.0 layout
-// (<runnerRoot>/cached/_diag) and the version-namespaced layout deployed on
-// GitHub-hosted runners alongside v2.334.0 (<runnerRoot>/cached/<version>/_diag).
-export const githubWellKnownDiagnosticDirPatternsUnix = ['/home/runner/actions-runner/cached/**/_diag']
-export const githubWellKnownDiagnosticDirPatternsWin = ['C:/actions-runner/cached/**/_diag']
+// Glob patterns covering layouts that namespace `_diag` under one or two
+// intermediate directories. This includes both observed SaaS layouts
+// (<runnerRoot>/cached/_diag pre-2.334.0, <runnerRoot>/cached/<version>/_diag
+// since v2.334.0) and hypothetical future layouts that follow the same shape
+// without a `cached` wrapper (e.g. <runnerRoot>/<version>/_diag). Depth is
+// bounded on purpose: `*` matches a single segment, so no filesystem walk.
+export const githubWellKnownDiagnosticDirPatternsUnix = [
+  '/home/runner/actions-runner/*/_diag',
+  '/home/runner/actions-runner/*/*/_diag',
+]
+export const githubWellKnownDiagnosticDirPatternsWin = [
+  'C:/actions-runner/*/_diag',
+  'C:/actions-runner/*/*/_diag',
+]
 
 const githubJobDisplayNameRegex = /"jobDisplayName":\s*"((?:[^"\\]|\\.)*)"/
 const githubJodIDRegex = /"job":\s*{[\s\S]*?"v"\s*:\s*(\d+)(?:\.0)?/
@@ -170,11 +178,14 @@ const getGithubDiagnosticDirsFromEnv = (): string[] => {
   if (runnerTemp) {
     // RUNNER_TEMP is typically: <runnerRoot>/_work/_temp
     const runnerRoot = upath.resolve(runnerTemp, '..', '..')
-    // `cached/**/_diag` matches both pre-2.334.0 (cached/_diag) and the
-    // version-namespaced layout (cached/<version>/_diag) via globstar.
-    dirs.push(`${runnerRoot}/cached/**/_diag`)
+    // Bounded-depth patterns cover every runner layout we've observed
+    // (including cached/<version>/_diag) without assuming a `cached` wrapper
+    // and without walking the whole tree.
+    dirs.push(`${runnerRoot}/*/_diag`)
+    dirs.push(`${runnerRoot}/*/*/_diag`)
     dirs.push(upath.join(runnerRoot, '_diag'))
-    dirs.push(`${runnerRoot}/actions-runner/cached/**/_diag`)
+    dirs.push(`${runnerRoot}/actions-runner/*/_diag`)
+    dirs.push(`${runnerRoot}/actions-runner/*/*/_diag`)
     dirs.push(upath.join(runnerRoot, 'actions-runner', '_diag'))
   }
 

--- a/packages/base/src/helpers/ci.ts
+++ b/packages/base/src/helpers/ci.ts
@@ -6,6 +6,8 @@ import type {BaseContext} from 'clipanion'
 import chalk from 'chalk'
 import upath from 'upath'
 
+import {globSync, hasMagic} from './glob'
+
 import {
   CI_ENV_VARS,
   CI_JOB_NAME,
@@ -127,6 +129,18 @@ export const githubWellKnownDiagnosticDirsWin = [
   'C:/actions-runner/_diag', // for self-hosted
 ]
 
+// Glob patterns covering the version-namespaced layout deployed on GitHub-hosted
+// runners alongside runner v2.334.0 (2026-04-21): _diag moved from
+// <runnerRoot>/cached/_diag to <runnerRoot>/cached/<version>/_diag.
+// With globstar, `**` matches zero or more segments, so a single pattern covers
+// both the old and the new layout.
+export const githubWellKnownDiagnosticDirPatternsUnix = [
+  '/home/runner/actions-runner/cached/**/_diag',
+]
+export const githubWellKnownDiagnosticDirPatternsWin = [
+  'C:/actions-runner/cached/**/_diag',
+]
+
 const githubJobDisplayNameRegex = /"jobDisplayName":\s*"((?:[^"\\]|\\.)*)"/
 const githubJodIDRegex = /"job":\s*{[\s\S]*?"v"\s*:\s*(\d+)(?:\.0)?/
 
@@ -165,13 +179,37 @@ const getGithubDiagnosticDirsFromEnv = (): string[] => {
     // RUNNER_TEMP is typically: <runnerRoot>/_work/_temp
     const runnerRoot = upath.resolve(runnerTemp, '..', '..')
     dirs.push(upath.join(runnerRoot, 'cached', '_diag'))
+    // Version-namespaced layout deployed alongside runner v2.334.0.
+    dirs.push(`${runnerRoot}/cached/**/_diag`)
     dirs.push(upath.join(runnerRoot, '_diag'))
     // actions-runner variants
     dirs.push(upath.join(runnerRoot, 'actions-runner', 'cached', '_diag'))
+    dirs.push(`${runnerRoot}/actions-runner/cached/**/_diag`)
     dirs.push(upath.join(runnerRoot, 'actions-runner', '_diag'))
   }
 
   return uniq(dirs.filter(Boolean))
+}
+
+/**
+ * Expands a mixed list of literal directories and glob patterns into concrete
+ * directories. Literals pass through unchanged (existence is checked later).
+ */
+const expandDiagnosticDirCandidates = (candidates: string[]): string[] => {
+  const expanded: string[] = []
+  for (const candidate of candidates) {
+    if (hasMagic(candidate)) {
+      try {
+        expanded.push(...globSync(candidate))
+      } catch {
+        // If the glob walk fails for any reason (permissions, etc.), skip.
+      }
+    } else {
+      expanded.push(candidate)
+    }
+  }
+
+  return uniq(expanded)
 }
 
 // Receives a string with the form 'John Doe <john.doe@gmail.com>'
@@ -1164,9 +1202,17 @@ const getGithubWorkerLogFiles = (context: BaseContext): [string, string[]] | und
   let foundDiagDir = ''
   let workerLogFiles: string[] = []
 
-  let wellKnownDirs = uniq([...getGithubDiagnosticDirsFromEnv(), ...githubWellKnownDiagnosticDirsUnix])
+  let wellKnownDirs = expandDiagnosticDirCandidates([
+    ...getGithubDiagnosticDirsFromEnv(),
+    ...githubWellKnownDiagnosticDirPatternsUnix,
+    ...githubWellKnownDiagnosticDirsUnix,
+  ])
   if (isGithubWindowsRunner()) {
-    wellKnownDirs = uniq([...getGithubDiagnosticDirsFromEnv(), ...githubWellKnownDiagnosticDirsWin])
+    wellKnownDirs = expandDiagnosticDirCandidates([
+      ...getGithubDiagnosticDirsFromEnv(),
+      ...githubWellKnownDiagnosticDirPatternsWin,
+      ...githubWellKnownDiagnosticDirsWin,
+    ])
   }
 
   // Iterate through well known directories to check for worker logs

--- a/packages/base/src/helpers/ci.ts
+++ b/packages/base/src/helpers/ci.ts
@@ -136,10 +136,7 @@ export const githubWellKnownDiagnosticDirPatternsUnix = [
   '/home/runner/actions-runner/*/_diag',
   '/home/runner/actions-runner/*/*/_diag',
 ]
-export const githubWellKnownDiagnosticDirPatternsWin = [
-  'C:/actions-runner/*/_diag',
-  'C:/actions-runner/*/*/_diag',
-]
+export const githubWellKnownDiagnosticDirPatternsWin = ['C:/actions-runner/*/_diag', 'C:/actions-runner/*/*/_diag']
 
 const githubJobDisplayNameRegex = /"jobDisplayName":\s*"((?:[^"\\]|\\.)*)"/
 const githubJodIDRegex = /"job":\s*{[\s\S]*?"v"\s*:\s*(\d+)(?:\.0)?/

--- a/packages/base/src/helpers/ci.ts
+++ b/packages/base/src/helpers/ci.ts
@@ -7,7 +7,6 @@ import chalk from 'chalk'
 import upath from 'upath'
 
 import {globSync, hasMagic} from './glob'
-
 import {
   CI_ENV_VARS,
   CI_JOB_NAME,
@@ -131,12 +130,8 @@ export const githubWellKnownDiagnosticDirsWin = [
 // more segments, so a single pattern covers both the pre-2.334.0 layout
 // (<runnerRoot>/cached/_diag) and the version-namespaced layout deployed on
 // GitHub-hosted runners alongside v2.334.0 (<runnerRoot>/cached/<version>/_diag).
-export const githubWellKnownDiagnosticDirPatternsUnix = [
-  '/home/runner/actions-runner/cached/**/_diag',
-]
-export const githubWellKnownDiagnosticDirPatternsWin = [
-  'C:/actions-runner/cached/**/_diag',
-]
+export const githubWellKnownDiagnosticDirPatternsUnix = ['/home/runner/actions-runner/cached/**/_diag']
+export const githubWellKnownDiagnosticDirPatternsWin = ['C:/actions-runner/cached/**/_diag']
 
 const githubJobDisplayNameRegex = /"jobDisplayName":\s*"((?:[^"\\]|\\.)*)"/
 const githubJodIDRegex = /"job":\s*{[\s\S]*?"v"\s*:\s*(\d+)(?:\.0)?/


### PR DESCRIPTION

### What and why?
Some runners now unpack the runner binary under a version-namespaced subdirectory: `/home/runner/actions-runner/cached/<version>/_diag/` instead of `/home/runner/actions-runner/cached/_diag/`. The hardcoded and env-derived paths only covered the pre-2.334.0 layout, so `datadog-ci tag --level step` errors with "Could not find GitHub diagnostic log files".

### How?


Add `cached/**/_diag` glob patterns (globstar matches zero or more segments, so a single pattern covers both layouts) and expand them at lookup time. Literal paths are retained for self-hosted runners and test compatibility.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
