### PR TITLE
chore: de-flake aas tests

### DIFF
--- a/e2e/aas-windows.test.ts
+++ b/e2e/aas-windows.test.ts
@@ -12,6 +12,9 @@ describeOrSkip('aas (Windows)', () => {
   const windowsPlan = process.env.AZURE_AAS_WINDOWS_PLAN!
 
   beforeAll(async () => {
+    // Stagger parallel matrix runs to avoid Azure extension install conflicts
+    await new Promise((resolve) => setTimeout(resolve, Math.random() * 60_000))
+
     const result = await execPromiseWithRetries(
       `az webapp create` +
         ` --name "${windowsAppName}"` +
@@ -42,7 +45,8 @@ describeOrSkip('aas (Windows)', () => {
       `${DATADOG_CI_COMMAND} aas instrument -s "${subscriptionId}" -g "${resourceGroup}" -n "${windowsAppName}" --windows-runtime node --no-source-code-integration`,
       {
         DD_API_KEY: process.env.DD_API_KEY,
-      }
+      },
+      {maxAttempts: 5, delaySeconds: 30}
     )
     expect(result.exitCode).toBe(0)
 


### PR DESCRIPTION
### What and why?

The Windows AAS e2e tests were flaky due to two related issues:

1. The CI matrix runs Node 20, 22, and 24 in parallel, all sharing a single Azure App Service Plan. Simultaneous extension installs on the same plan caused transient `RestError` failures from the Azure API.
2. The retry logic used a 5s delay between attempts, which is too short for Azure site extension provisioning (~4min).

### How?

- Added a random 0–60s jitter in `beforeAll` to stagger the parallel matrix runs, reducing the chance of concurrent extension installs on the shared plan.
- Increased retry attempts from 3→5 and delay from 5s→30s for the `instrument` command in the Windows e2e test.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)