### PR TITLE
[K9VULN-13636] Allowlist datadog:version-constraint SBOM component property

### DIFF
--- a/packages/plugin-sbom/src/__tests__/fixtures/sbom-with-version-constraint.json
+++ b/packages/plugin-sbom/src/__tests__/fixtures/sbom-with-version-constraint.json
@@ -1,0 +1,46 @@
+{
+    "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
+    "bomFormat": "CycloneDX",
+    "specVersion": "1.5",
+    "version": 1,
+    "components": [
+        {
+            "bom-ref": "pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@11.0.21",
+            "type": "library",
+            "name": "org.apache.tomcat.embed:tomcat-embed-core",
+            "version": "11.0.21",
+            "purl": "pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@11.0.21",
+            "properties": [
+                {
+                    "name": "datadog:version-constraint",
+                    "value": "true"
+                },
+                {
+                    "name": "datadog:package-manager",
+                    "value": "Maven"
+                }
+            ],
+            "evidence": {
+                "occurrences": [
+                    {
+                        "location": "{\"block\":{\"file_name\":\"pom.xml\",\"line_start\":12,\"line_end\":17,\"column_start\":7,\"column_end\":22},\"name\":{\"file_name\":\"pom.xml\",\"line_start\":13,\"line_end\":14,\"column_start\":9,\"column_end\":50},\"version\":{\"file_name\":\"pom.xml\",\"line_start\":15,\"line_end\":15,\"column_start\":18,\"column_end\":25}}"
+                    }
+                ]
+            }
+        },
+        {
+            "bom-ref": "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.9.10",
+            "type": "library",
+            "name": "com.fasterxml.jackson.core:jackson-databind",
+            "version": "2.9.10",
+            "purl": "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.9.10",
+            "properties": [
+                {
+                    "name": "datadog:package-manager",
+                    "value": "Maven"
+                }
+            ]
+        }
+    ],
+    "vulnerabilities": []
+}

--- a/packages/plugin-sbom/src/__tests__/payload.test.ts
+++ b/packages/plugin-sbom/src/__tests__/payload.test.ts
@@ -586,6 +586,44 @@ describe('generation of payload', () => {
     expect(dependencies[1].opaque).toBeUndefined()
   })
 
+  test('should correctly set version_constraint flag and preserve locations from evidence.occurrences', async () => {
+    const sbomFile = './src/__tests__/fixtures/sbom-with-version-constraint.json'
+    const sbomContent = JSON.parse(fs.readFileSync(sbomFile).toString('utf8'))
+    const config: DatadogCiConfig = {
+      apiKey: undefined,
+      env: undefined,
+      envVarTags: undefined,
+    }
+    const tags = await getSpanTags(config, [], true)
+
+    const payload = generatePayload(sbomContent, tags, 'service', 'env')
+
+    expect(payload?.dependencies.length).toStrictEqual(2)
+    const dependencies = payload!.dependencies
+
+    // First component has the version-constraint marker
+    expect(dependencies[0].name).toEqual('org.apache.tomcat.embed:tomcat-embed-core')
+    expect(dependencies[0].version).toEqual('11.0.21')
+    expect(dependencies[0].version_constraint).toStrictEqual(true)
+    expect(dependencies[0].package_manager).toEqual('Maven')
+
+    // Verify that evidence.occurrences location data is preserved
+    expect(dependencies[0].locations).toHaveLength(1)
+    expect(dependencies[0].locations![0].block!.file_name).toEqual('pom.xml')
+    expect(dependencies[0].locations![0].block!.start.line).toEqual(12)
+    expect(dependencies[0].locations![0].block!.start.col).toEqual(7)
+    expect(dependencies[0].locations![0].block!.end.line).toEqual(17)
+    expect(dependencies[0].locations![0].block!.end.col).toEqual(22)
+    expect(dependencies[0].locations![0].name!.file_name).toEqual('pom.xml')
+    expect(dependencies[0].locations![0].name!.start.line).toEqual(13)
+    expect(dependencies[0].locations![0].version!.file_name).toEqual('pom.xml')
+    expect(dependencies[0].locations![0].version!.start.line).toEqual(15)
+
+    // Second component does not have the version-constraint marker
+    expect(dependencies[1].name).toEqual('com.fasterxml.jackson.core:jackson-databind')
+    expect(dependencies[1].version_constraint).toBeUndefined()
+  })
+
   test('should fail to read git information', async () => {
     const nonExistingGitRepository = '/you/cannot/find/me'
     const config: DatadogCiConfig = {

--- a/packages/plugin-sbom/src/__tests__/validation.test.ts
+++ b/packages/plugin-sbom/src/__tests__/validation.test.ts
@@ -98,6 +98,7 @@ describe('validation of sbom file', () => {
         exclusions: undefined,
         target_frameworks: undefined,
         opaque: undefined,
+        version_constraint: undefined,
       })
     ).toBeFalsy()
     expect(
@@ -116,6 +117,7 @@ describe('validation of sbom file', () => {
         exclusions: undefined,
         target_frameworks: undefined,
         opaque: undefined,
+        version_constraint: undefined,
       })
     ).toBeTruthy()
     expect(
@@ -134,6 +136,7 @@ describe('validation of sbom file', () => {
         exclusions: undefined,
         target_frameworks: undefined,
         opaque: undefined,
+        version_constraint: undefined,
       })
     ).toBeTruthy()
     expect(
@@ -152,6 +155,7 @@ describe('validation of sbom file', () => {
         exclusions: undefined,
         target_frameworks: undefined,
         opaque: undefined,
+        version_constraint: undefined,
       })
     ).toBeTruthy()
   })

--- a/packages/plugin-sbom/src/constants.ts
+++ b/packages/plugin-sbom/src/constants.ts
@@ -17,3 +17,4 @@ export const REACHABLE_SYMBOL_LOCATION_KEY_PREFIX = 'datadog:reachable-symbol-lo
 // datadog-sca specific SBOM properties
 export const TARGET_FRAMEWORK_KEY = 'datadog:target-framework'
 export const OPAQUE_KEY = 'datadog:opaque'
+export const VERSION_CONSTRAINT_KEY = 'datadog:version-constraint'

--- a/packages/plugin-sbom/src/payload.ts
+++ b/packages/plugin-sbom/src/payload.ts
@@ -42,6 +42,7 @@ import {
   PACKAGE_MANAGER_PROPERTY_KEY,
   REACHABLE_SYMBOL_LOCATION_KEY_PREFIX,
   TARGET_FRAMEWORK_KEY,
+  VERSION_CONSTRAINT_KEY,
 } from './constants'
 import {getLanguageFromComponent} from './language'
 
@@ -263,6 +264,7 @@ const extractingDependency = (component: any): Dependency | undefined => {
   const targetFrameworks: string[] = []
   const reachableSymbolProperties: Property[] = []
   let opaque: boolean | undefined
+  let versionConstraint: boolean | undefined
 
   for (const property of component['properties'] ?? []) {
     const propertyName: string = property.name
@@ -286,7 +288,9 @@ const extractingDependency = (component: any): Dependency | undefined => {
     } else if (propertyName === TARGET_FRAMEWORK_KEY) {
       targetFrameworks.push(propertyValue)
     } else if (propertyName === OPAQUE_KEY) {
-      opaque = propertyValue.toLowerCase() === 'true' ? true : undefined
+      opaque = parseTrueOrUndefined(propertyValue)
+    } else if (propertyName === VERSION_CONSTRAINT_KEY) {
+      versionConstraint = parseTrueOrUndefined(propertyValue)
     } else if (
       propertyName.startsWith(LEGACY_REACHABLE_SYMBOL_LOCATION_KEY_PREFIX) ||
       propertyName.startsWith(REACHABLE_SYMBOL_LOCATION_KEY_PREFIX)
@@ -326,6 +330,7 @@ const extractingDependency = (component: any): Dependency | undefined => {
     target_frameworks: targetFrameworks,
     exclusions: Array.from(exclusions),
     opaque,
+    version_constraint: versionConstraint,
   }
 
   return dependency

--- a/packages/plugin-sbom/src/types.ts
+++ b/packages/plugin-sbom/src/types.ts
@@ -101,6 +101,7 @@ export interface Dependency {
   exclusions: undefined | string[]
   target_frameworks: undefined | string[]
   opaque: undefined | boolean
+  version_constraint: undefined | boolean
 }
 
 export interface ReachableSymbolLocationValue extends LocationFromFile {


### PR DESCRIPTION
## 🚀 Motivation 

The `datadog:version-constraint` SBOM component property needs to be recognized and forwarded during SBOM uploads so it is not stripped from the payload. This is part of a broader effort to support dependency management version constraint tracking in SCA results.

## 📝 Summary

- Added `VERSION_CONSTRAINT_KEY = 'datadog:version-constraint'` constant to `constants.ts`
- Added handling of the new property key in the component extraction loop in `payload.ts`, mapping it to a `version_constraint` boolean field on `Dependency`
- Also refactored `opaque` to reuse the same `parseTrueOrUndefined` helper for consistency
- Added `version_constraint` to the `Dependency` interface in `types.ts`
- Added a fixture and test cases verifying the property is correctly extracted and that `evidence.occurrences` location data is preserved alongside it

## 🧪 Testing
- [x] New tests were added for new logic.
- [x] Existing tests were updated for new logic, and not only so that they pass!
- [ ] Benchmark results prove that performance is the same or better.

Run locally, field uploaded
<img width="1182" height="177" alt="Screenshot 2026-04-27 at 11 08 49" src="https://github.com/user-attachments/assets/01898d52-917e-4c17-a03c-59df872e5d7b" />

## 🆘 Recovery
Notes for on-call - **select only one**:
- [x] The change can be rolled back.
- [ ] Do not roll back. Why?: