### PR TITLE
fix(dora): treat 401 as non-retriable and exit non-zero

### DIFF
--- a/packages/base/src/helpers/retry.ts
+++ b/packages/base/src/helpers/retry.ts
@@ -1,6 +1,6 @@
 import retry from 'async-retry'
 
-const errorCodesNoRetry = [400, 403, 413]
+const errorCodesNoRetry = [400, 401, 403, 413]
 
 export const retryRequest = async <T>(
   requestPerformer: (bail?: (e: Error) => void, attempt?: number) => Promise<T>,

--- a/packages/plugin-dora/src/__tests__/deployment.test.ts
+++ b/packages/plugin-dora/src/__tests__/deployment.test.ts
@@ -3,6 +3,7 @@ import type {DeploymentEvent} from '../interfaces'
 import {createCommand, makeRunCLI} from '@datadog/datadog-ci-base/helpers/__tests__/testing-tools'
 import * as gitFunctions from '@datadog/datadog-ci-base/helpers/git/get-git-data'
 
+import * as apiModule from '../api'
 import {PluginCommand as DORADeploymentCommand} from '../commands/deployment'
 
 describe('deployment', () => {
@@ -144,6 +145,26 @@ describe('execute', () => {
       ])
       expect(code).not.toBe(0)
       expect(context.stdout.toString()).toContain('--started-at')
+    })
+
+    test('exits non-zero and does not show success on 401', async () => {
+      const mockError = Object.assign(new Error('Request failed with status code 401'), {
+        isRequestError: true,
+        response: {status: 401, statusText: 'Unauthorized'},
+      })
+      const mockApi = {sendDeploymentEvent: jest.fn().mockRejectedValue(mockError)}
+      jest.spyOn(apiModule, 'apiConstructor').mockReturnValue(mockApi)
+
+      // prettier-ignore
+      const {context, code} = await runCLI([
+        '--service', 'test-service',
+        '--skip-git',
+        '--started-at', '1699960648',
+      ], {DATADOG_API_KEY: 'invalid'})
+
+      expect(code).not.toBe(0)
+      expect(context.stdout.toString()).not.toContain('Successfully')
+      expect(mockApi.sendDeploymentEvent).toHaveBeenCalledTimes(1)
     })
 
     test('started-at after finished-at is rejected', async () => {

--- a/packages/plugin-dora/src/commands/deployment.ts
+++ b/packages/plugin-dora/src/commands/deployment.ts
@@ -21,7 +21,7 @@ import {
   renderSuccessfulRequest,
 } from '../renderer'
 
-const nonRetriableErrorCodes = [400, 403]
+const nonRetriableErrorCodes = [400, 401, 403]
 
 export class PluginCommand extends DoraDeploymentCommand {
   private config = {


### PR DESCRIPTION
### What and why?

Fixes #2301.

When `dora deployment` received a 401 (Unauthorized), it would retry 5 times and then silently swallow the error -- printing \"✅ Successfully sent\" and exiting with code 0 despite the API call having failed.

Two root causes:
1. `errorCodesNoRetry` in `retry.ts` was missing 401, so the request was retried unnecessarily.
2. `nonRetriableErrorCodes` in the DORA deployment command was also missing 401, so after all retries were exhausted the caught error was swallowed (returned instead of thrown), letting `execute()` fall through to the success log.

### How?

Added `401` to both lists:
- `packages/base/src/helpers/retry.ts` -- bail immediately on 401 (no retries)
- `packages/plugin-dora/src/commands/deployment.ts` -- throw on 401 (propagates out of `execute()`, skips the success log, exits non-zero)

Added a test that mocks a 401 response and asserts exit code is non-zero and the success message is absent.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)