### PR TITLE
[dep] Bump `simple-git` to `3.36.0`

### DIFF
--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -138,7 +138,7 @@
     "jszip": "^3.10.1",
     "proxy-agent": "^6.4.0",
     "semver": "^7.6.3",
-    "simple-git": "^3.33.0",
+    "simple-git": "^3.36.0",
     "terminal-link": "^2.1.1",
     "tiny-async-pool": "^2.1.0",
     "typanion": "^3.14.0",

--- a/packages/plugin-coverage/package.json
+++ b/packages/plugin-coverage/package.json
@@ -49,7 +49,7 @@
     "chalk": "3.0.0",
     "fast-xml-parser": "5.5.12",
     "form-data": "4.0.4",
-    "simple-git": "3.33.0",
+    "simple-git": "3.36.0",
     "upath": "2.0.1"
   }
 }

--- a/packages/plugin-deployment/package.json
+++ b/packages/plugin-deployment/package.json
@@ -47,6 +47,6 @@
   "devDependencies": {
     "@datadog/datadog-ci-base": "workspace:*",
     "chalk": "3.0.0",
-    "simple-git": "3.33.0"
+    "simple-git": "3.36.0"
   }
 }

--- a/packages/plugin-dora/package.json
+++ b/packages/plugin-dora/package.json
@@ -47,6 +47,6 @@
   "devDependencies": {
     "@datadog/datadog-ci-base": "workspace:*",
     "chalk": "3.0.0",
-    "simple-git": "3.33.0"
+    "simple-git": "3.36.0"
   }
 }

--- a/packages/plugin-sarif/package.json
+++ b/packages/plugin-sarif/package.json
@@ -51,7 +51,7 @@
     "ajv-formats": "3.0.1",
     "chalk": "3.0.0",
     "form-data": "4.0.4",
-    "simple-git": "3.33.0",
+    "simple-git": "3.36.0",
     "upath": "2.0.1",
     "uuid": "14.0.0"
   }

--- a/packages/plugin-sbom/package.json
+++ b/packages/plugin-sbom/package.json
@@ -51,7 +51,7 @@
     "ajv-formats": "3.0.1",
     "chalk": "3.0.0",
     "packageurl-js": "2.0.1",
-    "simple-git": "3.33.0",
+    "simple-git": "3.36.0",
     "upath": "2.0.1"
   }
 }

--- a/packages/plugin-terraform/package.json
+++ b/packages/plugin-terraform/package.json
@@ -51,7 +51,7 @@
     "@types/jest": "29.5.3",
     "chalk": "3.0.0",
     "form-data": "4.0.4",
-    "simple-git": "3.33.0",
+    "simple-git": "3.36.0",
     "upath": "2.0.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1577,7 +1577,7 @@ __metadata:
     jszip: "npm:^3.10.1"
     proxy-agent: "npm:^6.4.0"
     semver: "npm:^7.6.3"
-    simple-git: "npm:^3.33.0"
+    simple-git: "npm:^3.36.0"
     terminal-link: "npm:^2.1.1"
     tiny-async-pool: "npm:^2.1.0"
     typanion: "npm:^3.14.0"
@@ -1678,7 +1678,7 @@ __metadata:
     chalk: "npm:3.0.0"
     fast-xml-parser: "npm:5.5.12"
     form-data: "npm:4.0.4"
-    simple-git: "npm:3.33.0"
+    simple-git: "npm:3.36.0"
     upath: "npm:2.0.1"
   languageName: unknown
   linkType: soft
@@ -1689,7 +1689,7 @@ __metadata:
   dependencies:
     "@datadog/datadog-ci-base": "workspace:*"
     chalk: "npm:3.0.0"
-    simple-git: "npm:3.33.0"
+    simple-git: "npm:3.36.0"
   languageName: unknown
   linkType: soft
 
@@ -1699,7 +1699,7 @@ __metadata:
   dependencies:
     "@datadog/datadog-ci-base": "workspace:*"
     chalk: "npm:3.0.0"
-    simple-git: "npm:3.33.0"
+    simple-git: "npm:3.36.0"
   languageName: unknown
   linkType: soft
 
@@ -1781,7 +1781,7 @@ __metadata:
     ajv-formats: "npm:3.0.1"
     chalk: "npm:3.0.0"
     form-data: "npm:4.0.4"
-    simple-git: "npm:3.33.0"
+    simple-git: "npm:3.36.0"
     upath: "npm:2.0.1"
     uuid: "npm:14.0.0"
   languageName: unknown
@@ -1797,7 +1797,7 @@ __metadata:
     ajv-formats: "npm:3.0.1"
     chalk: "npm:3.0.0"
     packageurl-js: "npm:2.0.1"
-    simple-git: "npm:3.33.0"
+    simple-git: "npm:3.36.0"
     upath: "npm:2.0.1"
   languageName: unknown
   linkType: soft
@@ -1850,7 +1850,7 @@ __metadata:
     "@types/jest": "npm:29.5.3"
     chalk: "npm:3.0.0"
     form-data: "npm:4.0.4"
-    simple-git: "npm:3.33.0"
+    simple-git: "npm:3.36.0"
     upath: "npm:2.0.1"
   languageName: unknown
   linkType: soft
@@ -10643,18 +10643,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"simple-git@npm:3.33.0":
-  version: 3.33.0
-  resolution: "simple-git@npm:3.33.0"
-  dependencies:
-    "@kwsites/file-exists": "npm:^1.1.1"
-    "@kwsites/promise-deferred": "npm:^1.1.1"
-    debug: "npm:^4.4.0"
-  checksum: 10/5175133df68053f52db3c160e060939ec6584409378e89cc5e57f60a00739a507a99a7dbcec0401925fdfdca9c9c60ec6ef84d9669e815d0806f4c18bf7aa820
-  languageName: node
-  linkType: hard
-
-"simple-git@npm:^3.33.0":
+"simple-git@npm:3.36.0, simple-git@npm:^3.36.0":
   version: 3.36.0
   resolution: "simple-git@npm:3.36.0"
   dependencies:


### PR DESCRIPTION
### What and why?

This PR bumps `simple-git` to fix https://github.com/DataDog/datadog-ci/security/dependabot/163

### How?

Bump direct dependencies

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
