### PR TITLE
[plugin-coverage] resolve config/codeowners blob sha at the reported commit

### DIFF
--- a/packages/base/src/commands/git-metadata/__tests__/git.test.ts
+++ b/packages/base/src/commands/git-metadata/__tests__/git.test.ts
@@ -3,7 +3,7 @@ import fs from 'fs'
 import * as simpleGit from 'simple-git'
 import path from 'upath'
 
-import {getCommitInfo, newSimpleGit, stripCredentials, parseGitDiff, getGitDiff} from '../git'
+import {getCommitInfo, getGitFileHash, newSimpleGit, stripCredentials, parseGitDiff, getGitDiff} from '../git'
 
 interface MockConfig {
   hash?: string
@@ -142,6 +142,28 @@ describe('git', () => {
       jest.spyOn(mock, 'revparse').mockResolvedValue('1234')
 
       await expect(newSimpleGit()).resolves.not.toThrow()
+    })
+  })
+
+  describe('getGitFileHash', () => {
+    test('resolves the blob against HEAD by default', async () => {
+      const mock = createMockSimpleGit({hash: 'blob-sha'}) as any
+      const revparse = jest.spyOn(mock, 'revparse')
+
+      const sha = await getGitFileHash(mock, 'code-coverage.datadog.yml')
+
+      expect(sha).toBe('blob-sha')
+      expect(revparse).toHaveBeenCalledWith(['HEAD:code-coverage.datadog.yml'])
+    })
+
+    test('resolves the blob against the provided ref', async () => {
+      const mock = createMockSimpleGit({hash: 'blob-sha'}) as any
+      const revparse = jest.spyOn(mock, 'revparse')
+
+      const sha = await getGitFileHash(mock, 'code-coverage.datadog.yml', 'deadbeef')
+
+      expect(sha).toBe('blob-sha')
+      expect(revparse).toHaveBeenCalledWith(['deadbeef:code-coverage.datadog.yml'])
     })
   })
 })

--- a/packages/base/src/commands/git-metadata/git.ts
+++ b/packages/base/src/commands/git-metadata/git.ts
@@ -106,8 +106,8 @@ export const getGitDiff = async (git: simpleGit.SimpleGit, from: string, to: str
   }
 }
 
-export const getGitFileHash = async (git: simpleGit.SimpleGit, path: string): Promise<string> => {
-  return git.revparse([`HEAD:${path}`])
+export const getGitFileHash = async (git: simpleGit.SimpleGit, path: string, ref = 'HEAD'): Promise<string> => {
+  return git.revparse([`${ref}:${path}`])
 }
 
 export interface DiffData {

--- a/packages/plugin-coverage/src/__tests__/upload.test.ts
+++ b/packages/plugin-coverage/src/__tests__/upload.test.ts
@@ -244,6 +244,57 @@ describe('upload', () => {
     })
   })
 
+  describe('getRepoFile', () => {
+    test('returns undefined when no git is available', async () => {
+      const command = createCommand(CoverageUploadCommand)
+      command['git'] = undefined
+
+      const result = await command['getRepoFile'].call(command, ['code-coverage.datadog.yml'], 'deadbeef')
+
+      expect(result).toBeUndefined()
+    })
+
+    test('returns undefined when no commit ref is available', async () => {
+      // Without a commit ref, the (commit, path, file_sha) triple sent to the
+      // splitter cannot be made consistent, so we must not ship a blob sha.
+      const revparse = jest.fn()
+      const command = createCommand(CoverageUploadCommand)
+      command['git'] = {revparse} as any
+
+      const result = await command['getRepoFile'].call(command, ['code-coverage.datadog.yml'], undefined)
+
+      expect(result).toBeUndefined()
+      expect(revparse).not.toHaveBeenCalled()
+    })
+
+    test('resolves the blob sha against the provided ref', async () => {
+      const revparse = jest.fn().mockResolvedValue('blob-sha')
+      const command = createCommand(CoverageUploadCommand)
+      command['git'] = {revparse} as any
+
+      const result = await command['getRepoFile'].call(command, ['code-coverage.datadog.yml'], 'deadbeef')
+
+      expect(result).toEqual({path: 'code-coverage.datadog.yml', sha: 'blob-sha'})
+      expect(revparse).toHaveBeenCalledWith(['deadbeef:code-coverage.datadog.yml'])
+    })
+
+    test('falls through to the next path when the first does not exist at ref', async () => {
+      const revparse = jest.fn().mockRejectedValueOnce(new Error('does not exist')).mockResolvedValueOnce('blob-sha')
+      const command = createCommand(CoverageUploadCommand)
+      command['git'] = {revparse} as any
+
+      const result = await command['getRepoFile'].call(
+        command,
+        ['code-coverage.datadog.yml', 'code-coverage.datadog.yaml'],
+        'deadbeef'
+      )
+
+      expect(result).toEqual({path: 'code-coverage.datadog.yaml', sha: 'blob-sha'})
+      expect(revparse).toHaveBeenNthCalledWith(1, ['deadbeef:code-coverage.datadog.yml'])
+      expect(revparse).toHaveBeenNthCalledWith(2, ['deadbeef:code-coverage.datadog.yaml'])
+    })
+  })
+
   describe('getFlags', () => {
     test('should return undefined when no flags provided', () => {
       const command = createCommand(CoverageUploadCommand)

--- a/packages/plugin-coverage/src/commands/upload.ts
+++ b/packages/plugin-coverage/src/commands/upload.ts
@@ -182,8 +182,9 @@ export class PluginCommand extends CoverageUploadCommand {
   private async generatePayloads(spanTags: SpanTags): Promise<Payload[]> {
     const flags = this.getFlags()
 
-    const coverageConfig = await this.getRepoFile(COVERAGE_CONFIG_PATHS)
-    const codeowners = await this.getRepoFile(CODEOWNERS_PATHS)
+    const reportedCommit = spanTags[GIT_HEAD_SHA] || spanTags[GIT_SHA]
+    const coverageConfig = await this.getRepoFile(COVERAGE_CONFIG_PATHS, reportedCommit)
+    const codeowners = await this.getRepoFile(CODEOWNERS_PATHS, reportedCommit)
     const commitDiff = await this.getCommitDiff(spanTags)
     const prDiff = await this.getPrDiff(spanTags)
     const fileFixes = await this.getFileFixes()
@@ -237,19 +238,19 @@ export class PluginCommand extends CoverageUploadCommand {
     }
   }
 
-  private async getRepoFile(possiblePaths: string[]): Promise<RepoFile | undefined> {
-    if (!this.git) {
+  private async getRepoFile(possiblePaths: string[], ref: string | undefined): Promise<RepoFile | undefined> {
+    if (!this.git || !ref) {
       return undefined
     }
 
     for (const path of possiblePaths) {
       try {
-        const sha = await getGitFileHash(this.git, path)
+        const sha = await getGitFileHash(this.git, path, ref)
         if (sha) {
           return {path, sha}
         }
       } catch (e) {
-        this.logger.debug(`Error while trying to get repo file ${path} details: ${e}`)
+        this.logger.debug(`Error while trying to get repo file ${path} details at ${ref}: ${e}`)
       }
     }
 

--- a/packages/plugin-coverage/src/commands/upload.ts
+++ b/packages/plugin-coverage/src/commands/upload.ts
@@ -64,6 +64,10 @@ const COVERAGE_CONFIG_PATHS = ['code-coverage.datadog.yml', 'code-coverage.datad
 
 const CODEOWNERS_PATHS = ['.github/CODEOWNERS', 'CODEOWNERS', 'docs/CODEOWNERS']
 
+// The head SHA the payload carries on the wire (api.ts spreads `...payload.spanTags`,
+// so this matches what the splitter reads as `coalesce(HeadSHA, SHA)`).
+const getReportedCommitSha = (spanTags: SpanTags): string | undefined => spanTags[GIT_HEAD_SHA] || spanTags[GIT_SHA]
+
 export class PluginCommand extends CoverageUploadCommand {
   private config = {
     apiKey: process.env.DATADOG_API_KEY || process.env.DD_API_KEY,
@@ -182,7 +186,7 @@ export class PluginCommand extends CoverageUploadCommand {
   private async generatePayloads(spanTags: SpanTags): Promise<Payload[]> {
     const flags = this.getFlags()
 
-    const reportedCommit = spanTags[GIT_HEAD_SHA] || spanTags[GIT_SHA]
+    const reportedCommit = getReportedCommitSha(spanTags)
     const coverageConfig = await this.getRepoFile(COVERAGE_CONFIG_PATHS, reportedCommit)
     const codeowners = await this.getRepoFile(CODEOWNERS_PATHS, reportedCommit)
     const commitDiff = await this.getCommitDiff(spanTags)
@@ -277,7 +281,7 @@ export class PluginCommand extends CoverageUploadCommand {
   }
 
   private async getHeadAndBase(spanTags: SpanTags): Promise<{headSha?: string; baseSha?: string}> {
-    const headSha = spanTags[GIT_HEAD_SHA] || spanTags[GIT_SHA]
+    const headSha = getReportedCommitSha(spanTags)
     if (!headSha) {
       return {}
     }
@@ -311,7 +315,7 @@ export class PluginCommand extends CoverageUploadCommand {
       return undefined
     }
 
-    const commit = spanTags[GIT_HEAD_SHA] || spanTags[GIT_SHA]
+    const commit = getReportedCommitSha(spanTags)
     if (!commit) {
       return undefined
     }


### PR DESCRIPTION
## Summary

- Coverage uploads previously took the blob SHA of `code-coverage.datadog.{yml,yaml}` and `CODEOWNERS` from local **HEAD** (`git rev-parse HEAD:<path>`), while the commit SHA on the same payload comes from CI env vars (`GIT_HEAD_SHA || GIT_SHA`). Those two values aren't tied to each other — when they diverge, the splitter receives a `(commit, path, blob_sha)` triple where the file isn't actually in the reported commit's tree.
- This causes downstream `ci-coverage-splitter` to call `source-code-query.GetCodeContent` with that triple, get `NotFound: resource not found`, retry 10× (NotFound is treated as transient), then reject/stash the event. Coverage silently disappears for that build.
- Fix: resolve the blob SHA against the same commit that ends up on the wire (`git rev-parse <reportedCommit>:<path>`). The triple becomes internally consistent by construction; if the file isn't at that commit, `getRepoFile` returns `undefined` and the splitter falls back to its gitdb lookup as before.

## Why local HEAD and the reported commit diverge in practice

- **GitHub Actions PR builds** check out the synthetic `refs/pull/N/merge` ref; HEAD's tree contains files brought in by merging with the base, but `GITHUB_SHA` (and therefore the reported commit) is the PR head. Files added on base only land in the merge tree, not at the PR head.
- **`DD_GIT_COMMIT_SHA` / `--git-commit-sha`** overrides the commit reported on the payload but not the blob computation.
- **CI generates/commits the config locally before upload** — local HEAD has it, but that commit isn't pushed and doesn't match the reported commit.
- Any detached-HEAD setup where env vars and the working tree don't agree.

## Repro that motivated this

A real prod failure: ci-coverage-splitter rejected events for `github.com/gojitsucom/mobile-warehouse-flutter` with
```
*fmt.wrapError: failed to split coverage data for event:
  failed to get code content: rpc error: code = NotFound desc = resource not found
```
- Reported `commit_sha`: `c0f9b4840cca576286661e5af25b666261e56919` — gitdb tree at that commit has 2,015 files, **none** named `code-coverage.datadog.yml`.
- Reported `(path, blob_sha)`: `code-coverage.datadog.yml`, `dbf70404459f7c35ee75ae1621e8a4af4c128af2`.
- Sibling commit `f71ded839e08d43c221fa827c39801320c343d1c` does contain `code-coverage.datadog.yml`, and its blob SHA there is exactly `dbf70404459f7c35ee75ae1621e8a4af4c128af2` — i.e. the upload was generated when local HEAD pointed at `f71ded8…` while CI declared `c0f9b484…` as the commit.

After this change, the blob sha is taken from `c0f9b484…:code-coverage.datadog.yml`, which doesn't exist → `getRepoFile` returns `undefined` → splitter falls back to gitdb (which won't find it either, but that path is handled gracefully and doesn't reject the event).

## Test plan

- [x] `yarn build` clean
- [x] `yarn lint` clean
- [x] `yarn test packages/plugin-coverage packages/base/src/commands/git-metadata` — all 160 tests pass
- [ ] Manual end-to-end on a CI provider where local HEAD differs from the reported commit (e.g., a GitHub Actions PR build) and confirm:
  - when the file exists at the reported commit, it is shipped and resolved correctly downstream;
  - when it doesn't, `getRepoFile` returns `undefined` (no event rejection downstream).

🤖 Generated with [Claude Code](https://claude.com/claude-code)