### PR TITLE
[chore] Use Node `v22.22.2` Security Release for SEA binary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -628,7 +628,7 @@ jobs:
         with:
           # Must be aligned to avoid version skew with blob generated with `--experimental-sea-config`
           # See https://github.com/yao-pkg/pkg/discussions/236
-          node-version: ${{ env.STANDALONE_NODE_VERSION }}
+          node-version: v22.19.0
       - run: yarn install --immutable
       - run: yarn build
       - name: Create standalone binary

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ on:
       - '**'
 
 env:
-  STANDALONE_NODE_VERSION: 22.19.0
+  STANDALONE_NODE_VERSION: 22.22.2
 
 jobs:
   build-and-test:

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -10,7 +10,7 @@ permissions:
   contents: write # Required for the draft release
 
 env:
-  STANDALONE_NODE_VERSION: 22.19.0
+  STANDALONE_NODE_VERSION: 22.22.2
 
 jobs:
   create-draft-release:

--- a/scripts/pkg-wrapper.mjs
+++ b/scripts/pkg-wrapper.mjs
@@ -17,7 +17,8 @@ export const PKG_FETCH_RELEASE = 'https://github.com/Drarig29/pkg-fetch/releases
 
 // Should be aligned with `STANDALONE_NODE_VERSION` in CI
 const NODE_VERSIONS = {
-  node22: 'v22.22.2',
+  [`node22`]: 'v22.22.2',
+  [`node22-macos-x64`]: 'v22.19.0',
 }
 
 const downloadToFile = async (url, destPath) => {
@@ -53,7 +54,7 @@ const adHocSign = async (filePath) => {
  */
 const downloadTrimmedNodeBinary = async (target) => {
   const [nodeRange, platform, arch] = target.split('-')
-  const nodeVersion = NODE_VERSIONS[nodeRange]
+  const nodeVersion = NODE_VERSIONS[target] ?? NODE_VERSIONS[`node${nodeRange}`]
   if (!nodeVersion || !platform || !arch) {
     throw new Error(`Unsupported target "${target}"`)
   }

--- a/scripts/pkg-wrapper.mjs
+++ b/scripts/pkg-wrapper.mjs
@@ -17,7 +17,7 @@ export const PKG_FETCH_RELEASE = 'https://github.com/Drarig29/pkg-fetch/releases
 
 // Should be aligned with `STANDALONE_NODE_VERSION` in CI
 const NODE_VERSIONS = {
-  node22: 'v22.19.0',
+  node22: 'v22.22.2',
 }
 
 const downloadToFile = async (url, destPath) => {


### PR DESCRIPTION
### What and why?

We were using an older version of Node 22 (`v22.19.0`), and a more recent one was [published as a security release](https://nodejs.org/en/blog/release/v22.22.2). There is a more recent one ([`v22.22.3`](https://nodejs.org/en/blog/release/v22.22.3)), but it's not a security release.

### How?

Bump from v22.19.0 to v22.22.2

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
