### PR TITLE
Add JUnit long attribute regression test

### DIFF
--- a/packages/plugin-junit/src/__tests__/upload.test.ts
+++ b/packages/plugin-junit/src/__tests__/upload.test.ts
@@ -115,6 +115,40 @@ describe('upload', () => {
       }
     })
 
+    test('should allow junit reports with very long attribute values', async () => {
+      const tempDir = fs.mkdtempSync(upath.join(os.tmpdir(), 'junit-upload-'))
+      const junitPath = upath.join(tempDir, 'junit-long-attribute-report.xml')
+      const longAttributeValue = 'x'.repeat(200000)
+      // Regression for fast-xml-parser 5.5.12, which overflows when parsing long tag expressions.
+      const junitXml = `<testsuite><testcase name="${longAttributeValue}" /></testsuite>`
+
+      fs.writeFileSync(junitPath, junitXml)
+
+      try {
+        const command = createCommand(JunitUploadCommand)
+        const files = await command['getMatchingJUnitXMLFiles'].call(
+          {
+            basePaths: [junitPath],
+            config: {},
+            context: command.context,
+            service: 'service',
+          },
+          {},
+          {},
+          {},
+          {},
+          {}
+        )
+
+        expect(files).toHaveLength(1)
+        expect(files[0]).toMatchObject({
+          xmlPath: junitPath,
+        })
+      } finally {
+        fs.rmSync(tempDir, {recursive: true, force: true})
+      }
+    })
+
     test('should not fail for invalid single files', async () => {
       const command = createCommand(JunitUploadCommand)
       const files = await command['getMatchingJUnitXMLFiles'].call(


### PR DESCRIPTION
### What and why?

Adds a JUnit upload regression test for `fast-xml-parser@5.5.12` overflowing on very long XML tag expressions. The dependency bump in DataDog/datadog-ci#2315 to `fast-xml-parser@5.7.2` picks up the upstream long tag-expression stack overflow fix discussed in NaturalIntelligence/fast-xml-parser#820, and this keeps the JUnit upload flow covered.

### How?

Creates a temporary JUnit XML report with a 200k-character `testcase` attribute value, then verifies `getMatchingJUnitXMLFiles` accepts it as a valid upload payload.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)