### PR TITLE
chore: add zed config

### DIFF
--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -1,0 +1,35 @@
+{
+  // Prevents displaying warnings for formatting errors,
+  // since Prettier already takes care of the formatting.
+  "lsp": {
+    "eslint": {
+      "settings": {
+        "rulesCustomizations": [
+          {
+            "rule": "prettier/prettier",
+            "severity": "off"
+          }
+        ]
+      }
+    },
+    "typescript-language-server": {
+      "initialization_options": {
+        "tsdk": "node_modules/typescript/lib"
+      }
+    }
+  },
+  "languages": {
+    "Markdown": {
+      // Easier to read tables without word wrapping.
+      "soft_wrap": "none"
+    },
+    "JSON": {
+      "formatter": {
+        "external": {
+          "command": "prettier",
+          "arguments": ["--stdin-filepath", "{buffer_path}"]
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
### What and why?

Adds a `.zed/settings.json` to give Zed users equivalent editor config to the existing `.vscode/settings.json`.

### How?

Maps each VSCode setting to its Zed equivalent:

| VSCode | Zed |
|---|---|
| `eslint.rules.customizations` (suppress `prettier/prettier` warnings) | `lsp.eslint.settings.rulesCustomizations` |
| `typescript.tsdk` | `lsp.typescript-language-server.initialization_options.tsdk` |
| `[markdown] editor.wordWrap: off` | `languages.Markdown.soft_wrap: none` |
| `[json] editor.defaultFormatter: prettier` | `languages.JSON.formatter` (external prettier) |

Note: there's no Zed equivalent of `.vscode/extensions.json` -- tracked in [zed-industries/zed#46080](https://github.com/zed-industries/zed/discussions/46080).

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)