### PR TITLE
chore: migrate lambda and cloud-run to @inquirer/prompts

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -41,11 +41,9 @@ deep-object-diff,import,MIT,Copyright (c) 2016-present Matt Phillips
 fast-levenshtein,import,MIT,Copyright (c) 2013 Ramesh Nair
 fast-xml-parser,import,MIT,Copyright (c) 2017 Amit Kumar Gupta
 form-data,import,MIT,Copyright (c) 2012 Felix Geisendörfer (felix@debuggable.com) and contributors
-fuzzy,import,MIT,Copyright (c) 2012 Matt York
 get-value,import,MIT,"Copyright (c) 2014-present, Jon Schlinkert."
 glob,import,ISC,Copyright (c) Isaac Z. Schlueter and Contributors
 inquirer,import,MIT,Copyright (c) 2012 Simon Boudrias
-inquirer-checkbox-plus-prompt,import,MIT,Copyright (c) 2018 Mohammad Anas Fares
 is-docker,import,MIT,Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
 jest,dev,MIT,"Copyright (c) Facebook, Inc. and its affiliates."
 js-yaml,import,MIT,Copyright (C) 2011-2015 by Vitaly Puzrin
@@ -87,6 +85,8 @@ jszip,import,MIT,Copyright (c) 2009-2016 Stuart Knightley and other contributors
 @google-cloud/run,import,Apache-2.0,Copyright (c) 2023 Google LLC and other contributors
 google-auth-library,import,Apache-2.0,Copyright (c) 2023 Google LLC and other contributors
 @google-cloud/logging,import,Apache-2.0,Copyright (c) 2023 Google LLC and other contributors
+@inquirer/core,import,MIT,Copyright (c) 2025 Simon Boudrias
+@inquirer/prompts,import,MIT,Copyright (c) 2025 Simon Boudrias
 jest-diff,import,MIT,"Copyright (c) Meta Platforms, Inc. and other contributors"
 tsx,dev,MIT,Copyright (c) Hiroki Osame <hiroki.osame@gmail.com>
 typescript-eslint,dev,MIT,Copyright (c) 2019 typescript-eslint and other contributors

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -85,7 +85,6 @@ jszip,import,MIT,Copyright (c) 2009-2016 Stuart Knightley and other contributors
 @google-cloud/run,import,Apache-2.0,Copyright (c) 2023 Google LLC and other contributors
 google-auth-library,import,Apache-2.0,Copyright (c) 2023 Google LLC and other contributors
 @google-cloud/logging,import,Apache-2.0,Copyright (c) 2023 Google LLC and other contributors
-@inquirer/core,import,MIT,Copyright (c) 2025 Simon Boudrias
 @inquirer/prompts,import,MIT,Copyright (c) 2025 Simon Boudrias
 jest-diff,import,MIT,"Copyright (c) Meta Platforms, Inc. and other contributors"
 tsx,dev,MIT,Copyright (c) Hiroki Osame <hiroki.osame@gmail.com>

--- a/packages/plugin-cloud-run/package.json
+++ b/packages/plugin-cloud-run/package.json
@@ -48,10 +48,9 @@
     "@datadog/datadog-ci-base": "workspace:*",
     "@google-cloud/logging": "11.2.1",
     "@google-cloud/run": "3.0.0",
+    "@inquirer/prompts": "7.10.1",
     "chalk": "3.0.0",
     "google-auth-library": "10.2.1",
-    "inquirer": "8.2.7",
-    "inquirer-checkbox-plus-prompt": "1.4.2",
     "ora": "5.4.1",
     "upath": "2.0.1"
   }

--- a/packages/plugin-cloud-run/src/prompt.ts
+++ b/packages/plugin-cloud-run/src/prompt.ts
@@ -1,15 +1,10 @@
 import {DATADOG_SITES} from '@datadog/datadog-ci-base/constants'
-import inquirer from 'inquirer'
+import {confirm, input, select} from '@inquirer/prompts'
 
-const checkboxPlusPrompt = require('inquirer-checkbox-plus-prompt')
-inquirer.registerPrompt('checkbox-plus', checkboxPlusPrompt)
-
-export const requestGCPProject = async (): Promise<string> => {
-  const answer = await inquirer.prompt({
+export const requestGCPProject = () =>
+  input({
     message: 'Enter GCP Project ID:',
-    name: 'project',
-    type: 'input',
-    validate: (value: string) => {
+    validate: (value) => {
       if (!value || value.trim().length === 0) {
         return 'Project ID is required.'
       }
@@ -18,16 +13,11 @@ export const requestGCPProject = async (): Promise<string> => {
     },
   })
 
-  return answer.project
-}
-
-export const requestGCPRegion = async (defaultRegion?: string): Promise<string> => {
-  const answer = await inquirer.prompt({
+export const requestGCPRegion = (defaultRegion?: string) =>
+  input({
     default: defaultRegion || 'us-central1',
     message: 'Enter GCP Region:',
-    name: 'region',
-    type: 'input',
-    validate: (value: string) => {
+    validate: (value) => {
       if (!value || value.trim().length === 0) {
         return 'Region is required.'
       }
@@ -36,15 +26,10 @@ export const requestGCPRegion = async (defaultRegion?: string): Promise<string> 
     },
   })
 
-  return answer.region
-}
-
-export const requestServiceName = async (): Promise<string> => {
-  const answer = await inquirer.prompt({
+export const requestServiceName = () =>
+  input({
     message: 'Enter Cloud Run service name:',
-    name: 'serviceName',
-    type: 'input',
-    validate: (value: string) => {
+    validate: (value) => {
       if (!value || value.trim().length === 0) {
         return 'Service name is required.'
       }
@@ -53,27 +38,6 @@ export const requestServiceName = async (): Promise<string> => {
     },
   })
 
-  return answer.serviceName
-}
+export const requestSite = () => select<string>({choices: DATADOG_SITES, message: 'Select a Datadog Site:'})
 
-export const requestSite = async (): Promise<string> => {
-  const answer = await inquirer.prompt({
-    choices: DATADOG_SITES,
-    message: 'Select a Datadog Site:',
-    name: 'site',
-    type: 'list',
-  })
-
-  return answer.site
-}
-
-export const requestConfirmation = async (message: string, defaultValue = true) => {
-  const confirmationAnswer = await inquirer.prompt({
-    message,
-    name: 'confirmation',
-    type: 'confirm',
-    default: defaultValue,
-  })
-
-  return confirmationAnswer.confirmation !== false
-}
+export const requestConfirmation = (message: string, defaultValue = true) => confirm({default: defaultValue, message})

--- a/packages/plugin-lambda/package.json
+++ b/packages/plugin-lambda/package.json
@@ -88,15 +88,13 @@
     "@aws-sdk/credential-providers": "3.1045.0",
     "@aws-sdk/types": "3.973.8",
     "@datadog/datadog-ci-base": "workspace:*",
+    "@inquirer/prompts": "7.10.1",
     "@smithy/property-provider": "2.2.0",
     "@smithy/util-retry": "2.2.0",
     "aws-sdk-client-mock": "4.1.0",
     "aws-sdk-client-mock-jest": "4.1.0",
     "chalk": "3.0.0",
     "clipanion": "3.2.1",
-    "fuzzy": "0.1.3",
-    "inquirer": "8.2.7",
-    "inquirer-checkbox-plus-prompt": "1.4.2",
     "ora": "5.4.1",
     "upath": "2.0.1"
   }

--- a/packages/plugin-lambda/src/__tests__/prompt.test.ts
+++ b/packages/plugin-lambda/src/__tests__/prompt.test.ts
@@ -1,7 +1,13 @@
-jest.mock('inquirer')
+jest.mock('@inquirer/prompts', () => ({
+  checkbox: jest.fn(),
+  input: jest.fn(),
+  password: jest.fn(),
+  select: jest.fn(),
+}))
+
 import {MOCK_DATADOG_API_KEY} from '@datadog/datadog-ci-base/helpers/__tests__/testing-tools'
 import {CI_API_KEY_ENV_VAR, CI_SITE_ENV_VAR} from '@datadog/datadog-ci-base/helpers/serverless/constants'
-import {prompt} from 'inquirer'
+import {checkbox, input, password, select} from '@inquirer/prompts'
 
 import {
   AWS_ACCESS_KEY_ID_ENV_VAR,
@@ -21,76 +27,57 @@ import {
 
 import {mockAwsAccessKeyId, mockAwsSecretAccessKey} from './fixtures'
 
+const mockCheckbox = checkbox as jest.Mock
+const mockInput = input as jest.Mock
+const mockPassword = password as jest.Mock
+const mockSelect = select as jest.Mock
+
 describe('prompt', () => {
+  beforeEach(() => {
+    jest.resetAllMocks()
+  })
+
   describe('datadogApiKeyTypeQuestion', () => {
-    test('returns question with message pointing to the correct given site', async () => {
+    test('returns question with message pointing to the correct given site', () => {
       const site = 'datadoghq.com'
       const question = datadogApiKeyTypeQuestion(site)
-      expect(await question.message).toBe(
+      expect(question.message).toBe(
         `Which type of Datadog API Key you want to set? \nLearn more at https://app.${site}/organization-settings/api-keys`
       )
     })
   })
 
   describe('datadogEnvVarsQuestions', () => {
-    test('returns correct message when user selects DATADOG_API_KEY', async () => {
-      const datadogApiKeyType = {
-        envVar: CI_API_KEY_ENV_VAR,
-        message: 'API Key:',
-      }
-      const question = datadogEnvVarsQuestions(datadogApiKeyType)
-      expect(await question.message).toBe('API Key:')
-      expect(question.name).toBe(CI_API_KEY_ENV_VAR)
+    test('returns correct message when user selects DATADOG_API_KEY', () => {
+      const question = datadogEnvVarsQuestions({envVar: CI_API_KEY_ENV_VAR, message: 'API Key:'})
+      expect(question.message).toBe('API Key:')
     })
 
     test('validates DATADOG_API_KEY correctly', () => {
-      const datadogApiKeyType = {
-        envVar: CI_API_KEY_ENV_VAR,
-        message: 'API Key:',
-      }
-      const question = datadogEnvVarsQuestions(datadogApiKeyType)
+      const question = datadogEnvVarsQuestions({envVar: CI_API_KEY_ENV_VAR, message: 'API Key:'})
       expect(question.validate).not.toBeUndefined()
-
-      expect(question.validate!('')).not.toBe(true)
-      expect(question.validate!('123abc')).not.toBe(true)
-
-      expect(question.validate!('1234567890abcdef1200791a6a0de187')).toBe(true)
+      expect(question.validate('')).not.toBe(true)
+      expect(question.validate('123abc')).not.toBe(true)
+      expect(question.validate('1234567890abcdef1200791a6a0de187')).toBe(true)
     })
 
-    test('returns correct message when user selects DATADOG_KMS_API_KEY', async () => {
-      const datadogApiKeyType = {
-        envVar: CI_KMS_API_KEY_ENV_VAR,
-        message: 'KMS API Key:',
-      }
-      const question = datadogEnvVarsQuestions(datadogApiKeyType)
-      expect(await question.message).toBe('KMS API Key:')
-      expect(question.name).toBe(CI_KMS_API_KEY_ENV_VAR)
+    test('returns correct message when user selects DATADOG_KMS_API_KEY', () => {
+      const question = datadogEnvVarsQuestions({envVar: CI_KMS_API_KEY_ENV_VAR, message: 'KMS API Key:'})
+      expect(question.message).toBe('KMS API Key:')
     })
 
-    test('returns correct message when user selects DATADOG_API_KEY_SECRET_ARN', async () => {
-      const datadogApiKeyType = {
-        envVar: CI_API_KEY_SECRET_ARN_ENV_VAR,
-        message: 'API Key Secret ARN:',
-      }
-      const question = datadogEnvVarsQuestions(datadogApiKeyType)
-      expect(await question.message).toBe('API Key Secret ARN:')
-      expect(question.name).toBe(CI_API_KEY_SECRET_ARN_ENV_VAR)
+    test('returns correct message when user selects DATADOG_API_KEY_SECRET_ARN', () => {
+      const question = datadogEnvVarsQuestions({envVar: CI_API_KEY_SECRET_ARN_ENV_VAR, message: 'API Key Secret ARN:'})
+      expect(question.message).toBe('API Key Secret ARN:')
     })
 
     test('validates DATADOG_API_KEY_SECRET_ARN correctly', () => {
-      const datadogApiKeyType = {
-        envVar: CI_API_KEY_SECRET_ARN_ENV_VAR,
-        message: 'API Key Secret ARN:',
-      }
-      const question = datadogEnvVarsQuestions(datadogApiKeyType)
-
+      const question = datadogEnvVarsQuestions({envVar: CI_API_KEY_SECRET_ARN_ENV_VAR, message: 'API Key Secret ARN:'})
       expect(question.validate).not.toBeUndefined()
-
-      expect(question.validate!('')).not.toBe(true)
-      expect(question.validate!('123abc')).not.toBe(true)
-      expect(question.validate!('1234567890abcdef1200791a6a0de187')).not.toBe(true)
-
-      expect(question.validate!('arn:aws:secretsmanager:sa-east-1:123456789012:secret:dd-api-key')).toBe(true)
+      expect(question.validate('')).not.toBe(true)
+      expect(question.validate('123abc')).not.toBe(true)
+      expect(question.validate('1234567890abcdef1200791a6a0de187')).not.toBe(true)
+      expect(question.validate('arn:aws:secretsmanager:sa-east-1:123456789012:secret:dd-api-key')).toBe(true)
     })
   })
 
@@ -98,7 +85,10 @@ describe('prompt', () => {
     test('returns question with the provided function names being its choices', () => {
       const functionNames = ['my-func', 'my-func-2', 'my-third-func']
       const question = functionSelectionQuestion(functionNames)
-      expect(question.choices).toBe(functionNames)
+      expect(question.choices).toEqual(functionNames)
+      expect(question.message).toBe('Select the functions to modify (Press <space> to select)')
+      expect(question.validate(['my-func'])).toBe(true)
+      expect(question.validate([])).toBe('You must choose at least one function.')
     })
   })
 
@@ -113,12 +103,8 @@ describe('prompt', () => {
     })
 
     test('sets the AWS credentials as environment variables', async () => {
-      ;(prompt as any).mockImplementation(() =>
-        Promise.resolve({
-          [AWS_ACCESS_KEY_ID_ENV_VAR]: mockAwsAccessKeyId,
-          [AWS_SECRET_ACCESS_KEY_ENV_VAR]: mockAwsSecretAccessKey,
-        })
-      )
+      mockInput.mockResolvedValue(mockAwsAccessKeyId)
+      mockPassword.mockResolvedValueOnce(mockAwsSecretAccessKey).mockResolvedValueOnce(undefined)
 
       await requestAWSCredentials()
 
@@ -127,13 +113,8 @@ describe('prompt', () => {
     })
 
     test('sets the AWS credentials with session token as environment variables', async () => {
-      ;(prompt as any).mockImplementation(() =>
-        Promise.resolve({
-          [AWS_ACCESS_KEY_ID_ENV_VAR]: mockAwsAccessKeyId,
-          [AWS_SECRET_ACCESS_KEY_ENV_VAR]: mockAwsSecretAccessKey,
-          [AWS_SESSION_TOKEN_ENV_VAR]: 'some-session-token',
-        })
-      )
+      mockInput.mockResolvedValue(mockAwsAccessKeyId)
+      mockPassword.mockResolvedValueOnce(mockAwsSecretAccessKey).mockResolvedValueOnce('some-session-token')
 
       await requestAWSCredentials()
 
@@ -143,16 +124,8 @@ describe('prompt', () => {
     })
 
     test('throws error when something unexpected happens while prompting', async () => {
-      ;(prompt as any).mockImplementation(() => Promise.reject(new Error('Unexpected error')))
-      let error
-      try {
-        await requestAWSCredentials()
-      } catch (e) {
-        if (e instanceof Error) {
-          error = e
-        }
-      }
-      expect(error?.message).toBe("Couldn't set AWS Credentials. Unexpected error")
+      mockInput.mockRejectedValue(new Error('Unexpected error'))
+      await expect(requestAWSCredentials()).rejects.toThrow("Couldn't set AWS Credentials. Unexpected error")
     })
   })
 
@@ -168,26 +141,8 @@ describe('prompt', () => {
 
     test('sets the Datadog Environment Variables as provided/selected by user', async () => {
       const site = 'datadoghq.com'
-      ;(prompt as any).mockImplementation((question: any) => {
-        switch (question.name) {
-          case CI_API_KEY_ENV_VAR:
-            return Promise.resolve({
-              [CI_API_KEY_ENV_VAR]: MOCK_DATADOG_API_KEY,
-            })
-          case CI_SITE_ENV_VAR:
-            return Promise.resolve({
-              [CI_SITE_ENV_VAR]: 'datadoghq.com',
-            })
-          case 'type':
-            return Promise.resolve({
-              type: {
-                envVar: CI_API_KEY_ENV_VAR,
-                message: 'API Key:',
-              },
-            })
-          default:
-        }
-      })
+      mockSelect.mockResolvedValueOnce(site).mockResolvedValueOnce({envVar: CI_API_KEY_ENV_VAR, message: 'API Key:'})
+      mockInput.mockResolvedValue(MOCK_DATADOG_API_KEY)
 
       await requestDatadogEnvVars()
 
@@ -196,16 +151,10 @@ describe('prompt', () => {
     })
 
     test('throws error when something unexpected happens while prompting', async () => {
-      ;(prompt as any).mockImplementation(() => Promise.reject(new Error('Unexpected error')))
-      let error
-      try {
-        await requestDatadogEnvVars()
-      } catch (e) {
-        if (e instanceof Error) {
-          error = e
-        }
-      }
-      expect(error?.message).toBe("Couldn't set Datadog Environment Variables. Unexpected error")
+      mockSelect.mockRejectedValue(new Error('Unexpected error'))
+      await expect(requestDatadogEnvVars()).rejects.toThrow(
+        "Couldn't set Datadog Environment Variables. Unexpected error"
+      )
     })
   })
 
@@ -213,23 +162,18 @@ describe('prompt', () => {
     const selectedFunctions = ['my-func', 'my-func-2', 'my-third-func']
 
     test('returns the selected functions', async () => {
-      ;(prompt as any).mockImplementation(() => Promise.resolve({functions: selectedFunctions}))
+      mockCheckbox.mockResolvedValue(selectedFunctions)
 
       const functions = await requestFunctionSelection(selectedFunctions)
-      expect(functions).toBe(selectedFunctions)
+      expect(functions).toEqual(selectedFunctions)
+      expect(mockCheckbox).toHaveBeenCalledWith(expect.objectContaining({choices: selectedFunctions, pageSize: 10}))
     })
 
     test('throws error when something unexpected happens while prompting', async () => {
-      ;(prompt as any).mockImplementation(() => Promise.reject(new Error('Unexpected error')))
-      let error
-      try {
-        await requestFunctionSelection(selectedFunctions)
-      } catch (e) {
-        if (e instanceof Error) {
-          error = e
-        }
-      }
-      expect(error?.message).toBe("Couldn't receive selected functions. Unexpected error")
+      mockCheckbox.mockRejectedValue(new Error('Unexpected error'))
+      await expect(requestFunctionSelection(selectedFunctions)).rejects.toThrow(
+        "Couldn't receive selected functions. Unexpected error"
+      )
     })
   })
 })

--- a/packages/plugin-lambda/src/__tests__/prompt.test.ts
+++ b/packages/plugin-lambda/src/__tests__/prompt.test.ts
@@ -86,7 +86,7 @@ describe('prompt', () => {
       const functionNames = ['my-func', 'my-func-2', 'my-third-func']
       const question = functionSelectionQuestion(functionNames)
       expect(question.choices).toEqual(functionNames)
-      expect(question.message).toBe('Select the functions to modify (Press <space> to select)')
+      expect(question.message).toBe('Select the functions to modify.')
       expect(question.validate(['my-func'])).toBe(true)
       expect(question.validate([])).toBe('You must choose at least one function.')
     })

--- a/packages/plugin-lambda/src/functions/commons.ts
+++ b/packages/plugin-lambda/src/functions/commons.ts
@@ -24,8 +24,8 @@ import {
 import {LAMBDA_LAYER_VERSIONS} from '@datadog/datadog-ci-base/helpers/serverless/lambda-layer-versions'
 import {maskString} from '@datadog/datadog-ci-base/helpers/utils'
 import {isValidDatadogSite} from '@datadog/datadog-ci-base/helpers/validation'
+import {input as promptInput} from '@inquirer/prompts'
 import {CredentialsProviderError} from '@smithy/property-provider'
-import inquirer from 'inquirer'
 
 import {
   ARM64_ARCHITECTURE,
@@ -163,11 +163,7 @@ export const getAWSFileCredentialsParams = (profile: string): FromIniInit => {
 
   // If provided profile is enforced by MFA and a session
   // token is not set we must request for the MFA token.
-  init.mfaCodeProvider = async (mfaSerial) => {
-    const answer = await inquirer.prompt(awsProfileQuestion(mfaSerial))
-
-    return answer.AWS_MFA
-  }
+  init.mfaCodeProvider = (mfaSerial) => promptInput(awsProfileQuestion(mfaSerial))
 
   return init
 }

--- a/packages/plugin-lambda/src/prompt.ts
+++ b/packages/plugin-lambda/src/prompt.ts
@@ -7,9 +7,8 @@ import {
   VERSION_ENV_VAR,
 } from '@datadog/datadog-ci-base/helpers/serverless/constants'
 import {isValidDatadogSite} from '@datadog/datadog-ci-base/helpers/validation'
+import {checkbox, input, password, select} from '@inquirer/prompts'
 import chalk from 'chalk'
-import {filter} from 'fuzzy'
-import inquirer from 'inquirer'
 
 import {
   AWS_ACCESS_KEY_ID_ENV_VAR,
@@ -27,16 +26,16 @@ import {
 } from './constants'
 import {isMissingAnyDatadogApiKeyEnvVar, sentenceMatchesRegEx} from './functions/commons'
 
-const checkboxPlusPrompt = require('inquirer-checkbox-plus-prompt')
-inquirer.registerPrompt('checkbox-plus', checkboxPlusPrompt)
+type DatadogApiKeyType = {
+  envVar: string
+  message: string
+}
 
-export const awsProfileQuestion = (mfaSerial: string): inquirer.InputQuestion => ({
+export const awsProfileQuestion = (mfaSerial: string) => ({
   default: undefined,
   message: `Enter MFA code for ${mfaSerial}: `,
-  name: 'AWS_MFA',
-  type: 'input',
-  validate: (value) => {
-    if (!value || value === undefined || value.length < 6) {
+  validate: (value: string) => {
+    if (!value || value.length < 6) {
       return 'Enter a valid MFA token. Length must be greater than or equal to 6.'
     }
 
@@ -44,51 +43,40 @@ export const awsProfileQuestion = (mfaSerial: string): inquirer.InputQuestion =>
   },
 })
 
-const awsCredentialsQuestions: inquirer.QuestionCollection = [
-  {
-    // AWS_ACCESS_KEY_ID question
-    message: 'Enter AWS Access Key ID:',
-    name: AWS_ACCESS_KEY_ID_ENV_VAR,
-    type: 'input',
-    validate: (value) => {
-      if (!value || !sentenceMatchesRegEx(value, AWS_ACCESS_KEY_ID_REG_EXP)) {
-        return 'Enter a valid AWS Access Key ID.'
-      }
+const awsAccessKeyIdQuestion = {
+  message: 'Enter AWS Access Key ID:',
+  validate: (value: string) => {
+    if (!value || !sentenceMatchesRegEx(value, AWS_ACCESS_KEY_ID_REG_EXP)) {
+      return 'Enter a valid AWS Access Key ID.'
+    }
 
-      return true
-    },
+    return true
   },
-  {
-    // AWS_SECRET_ACCESS_KEY_ENV_VAR question
-    mask: true,
-    message: 'Enter AWS Secret Access Key:',
-    name: AWS_SECRET_ACCESS_KEY_ENV_VAR,
-    type: 'password',
-    validate: (value) => {
-      if (!value || !sentenceMatchesRegEx(value, AWS_SECRET_ACCESS_KEY_REG_EXP)) {
-        return 'Enter a valid AWS Secret Access Key.'
-      }
+}
 
-      return true
-    },
-  },
-  {
-    // AWS_SESSION_TOKEN
-    mask: true,
-    message: 'Enter AWS Session Token (optional):',
-    name: AWS_SESSION_TOKEN_ENV_VAR,
-    type: 'password',
-  },
-]
+const awsSecretAccessKeyQuestion = {
+  mask: true,
+  message: 'Enter AWS Secret Access Key:',
+  validate: (value: string) => {
+    if (!value || !sentenceMatchesRegEx(value, AWS_SECRET_ACCESS_KEY_REG_EXP)) {
+      return 'Enter a valid AWS Secret Access Key.'
+    }
 
-const awsRegionQuestion = (defaultRegion?: string): inquirer.InputQuestion => ({
+    return true
+  },
+}
+
+const awsSessionTokenQuestion = {
+  mask: true,
+  message: 'Enter AWS Session Token (optional):',
+}
+
+const awsRegionQuestion = (defaultRegion?: string) => ({
   default: defaultRegion,
   message: 'Which AWS region (e.g., us-east-1) your Lambda functions are deployed?',
-  name: AWS_DEFAULT_REGION_ENV_VAR,
-  type: 'input',
 })
 
-export const datadogApiKeyTypeQuestion = (datadogSite: string): inquirer.ListQuestion => ({
+export const datadogApiKeyTypeQuestion = (datadogSite: string) => ({
   choices: [
     {
       name: `Plain text ${chalk.bold('API Key')} (Recommended for trial users) `,
@@ -97,7 +85,6 @@ export const datadogApiKeyTypeQuestion = (datadogSite: string): inquirer.ListQue
         message: 'API Key:',
       },
     },
-    new inquirer.Separator(),
     {
       name: `API key encrypted with AWS Key Management Service ${chalk.bold('(KMS) API Key')}`,
       value: {
@@ -123,53 +110,36 @@ export const datadogApiKeyTypeQuestion = (datadogSite: string): inquirer.ListQue
   message: `Which type of Datadog API Key you want to set? \nLearn more at ${chalk.blueBright(
     `https://app.${datadogSite}/organization-settings/api-keys`
   )}`,
-  name: 'type',
-  type: 'list',
 })
 
-const datadogSiteQuestion: inquirer.ListQuestion = {
-  // DATADOG SITE
+const datadogSiteQuestion = {
   choices: DATADOG_SITES,
   message: `Select the Datadog site to send data. \nLearn more at ${chalk.blueBright(
     'https://docs.datadoghq.com/getting_started/site/'
   )}`,
-  name: CI_SITE_ENV_VAR,
-  type: 'list',
 }
 
-const envQuestion: inquirer.InputQuestion = {
+const envQuestion = {
   default: undefined,
-  message: 'Enter a value for the environment variable DD_ENV',
-  suffix: chalk.dim(' (recommended)'),
-  name: ENVIRONMENT_ENV_VAR,
-  type: 'input',
+  message: `Enter a value for the environment variable DD_ENV${chalk.dim(' (recommended)')}`,
 }
 
-const serviceQuestion: inquirer.InputQuestion = {
+const serviceQuestion = {
   default: undefined,
-  message: 'Enter a value for the environment variable DD_SERVICE',
-  suffix: chalk.dim(' (recommended)'),
-  name: SERVICE_ENV_VAR,
-  type: 'input',
+  message: `Enter a value for the environment variable DD_SERVICE${chalk.dim(' (recommended)')}`,
 }
 
-const versionQuestion: inquirer.InputQuestion = {
+const versionQuestion = {
   default: undefined,
-  message: 'Enter a value for the environment variable DD_VERSION',
-  suffix: chalk.dim(' (recommended)'),
-  name: VERSION_ENV_VAR,
-  type: 'input',
+  message: `Enter a value for the environment variable DD_VERSION${chalk.dim(' (recommended)')}`,
 }
 
 const INVALID_KEY_MESSAGE = 'Enter a valid Datadog API Key.'
 
-export const datadogEnvVarsQuestions = (datadogApiKeyType: Record<string, any>): inquirer.InputQuestion => ({
-  // DATADOG API KEY given type
+export const datadogEnvVarsQuestions = (datadogApiKeyType: DatadogApiKeyType) => ({
   default: process.env[datadogApiKeyType.envVar],
   message: datadogApiKeyType.message,
-  name: datadogApiKeyType.envVar,
-  type: 'input',
-  validate: (value) => {
+  validate: (value: string) => {
     if (!value) {
       return INVALID_KEY_MESSAGE
     }
@@ -193,26 +163,12 @@ export const datadogEnvVarsQuestions = (datadogApiKeyType: Record<string, any>):
   },
 })
 
-export const functionSelectionQuestion = (functionNames: string[]): typeof checkboxPlusPrompt => ({
+export const functionSelectionQuestion = (functionNames: string[]) => ({
   choices: functionNames,
-  highlight: true,
-  message:
-    'Select the functions to modify (Press <space> to select, p.s. start typing the name instead of manually scrolling)',
-  name: 'functions',
+  message: 'Select the functions to modify (Press <space> to select)',
   pageSize: 10,
-  searchable: true,
-  source: (answersSoFar: unknown, input: string) => {
-    input = input || ''
-
-    return new Promise((resolve) => {
-      const fuzzyResult = filter(input, functionNames)
-      const data = fuzzyResult.map((element) => element.original)
-      resolve(data)
-    })
-  },
-  type: 'checkbox-plus',
-  validate: (selectedFunctions: string | string[]) => {
-    if (selectedFunctions.length < 1) {
+  validate: (selected: readonly unknown[]) => {
+    if (selected.length < 1) {
       return 'You must choose at least one function.'
     }
 
@@ -222,11 +178,12 @@ export const functionSelectionQuestion = (functionNames: string[]): typeof check
 
 export const requestAWSCredentials = async (): Promise<void> => {
   try {
-    const awsCredentialsAnswers = await inquirer.prompt(awsCredentialsQuestions)
-    process.env[AWS_ACCESS_KEY_ID_ENV_VAR] = awsCredentialsAnswers[AWS_ACCESS_KEY_ID_ENV_VAR]
-    process.env[AWS_SECRET_ACCESS_KEY_ENV_VAR] = awsCredentialsAnswers[AWS_SECRET_ACCESS_KEY_ENV_VAR]
-    if (awsCredentialsAnswers[AWS_SESSION_TOKEN_ENV_VAR] !== undefined) {
-      process.env[AWS_SESSION_TOKEN_ENV_VAR] = awsCredentialsAnswers[AWS_SESSION_TOKEN_ENV_VAR]
+    process.env[AWS_ACCESS_KEY_ID_ENV_VAR] = await input(awsAccessKeyIdQuestion)
+    process.env[AWS_SECRET_ACCESS_KEY_ENV_VAR] = await password(awsSecretAccessKeyQuestion)
+
+    const awsSessionToken = await password(awsSessionTokenQuestion)
+    if (awsSessionToken !== undefined) {
+      process.env[AWS_SESSION_TOKEN_ENV_VAR] = awsSessionToken
     }
   } catch (e) {
     if (e instanceof Error) {
@@ -237,8 +194,7 @@ export const requestAWSCredentials = async (): Promise<void> => {
 
 export const requestAWSRegion = async (defaultRegion?: string): Promise<void> => {
   try {
-    const awsRegionAnswer = await inquirer.prompt(awsRegionQuestion(defaultRegion))
-    process.env[AWS_DEFAULT_REGION_ENV_VAR] = awsRegionAnswer[AWS_DEFAULT_REGION_ENV_VAR]
+    process.env[AWS_DEFAULT_REGION_ENV_VAR] = await input(awsRegionQuestion(defaultRegion))
   } catch (e) {
     if (e instanceof Error) {
       throw Error(`Couldn't set AWS region. ${e.message}`)
@@ -251,17 +207,14 @@ export const requestDatadogEnvVars = async (): Promise<void> => {
     const envSite = process.env[CI_SITE_ENV_VAR]
     let selectedDatadogSite = envSite
     if (!isValidDatadogSite(envSite)) {
-      const datadogSiteAnswer = await inquirer.prompt(datadogSiteQuestion)
-      selectedDatadogSite = datadogSiteAnswer[CI_SITE_ENV_VAR]
+      selectedDatadogSite = await select(datadogSiteQuestion)
       process.env[CI_SITE_ENV_VAR] = selectedDatadogSite
     }
 
     if (isMissingAnyDatadogApiKeyEnvVar()) {
-      const datadogApiKeyTypeAnswer = await inquirer.prompt(datadogApiKeyTypeQuestion(selectedDatadogSite!))
-      const datadogApiKeyType = datadogApiKeyTypeAnswer.type
-      const datadogEnvVars = await inquirer.prompt(datadogEnvVarsQuestions(datadogApiKeyType))
-      const selectedDatadogApiKeyEnvVar = datadogApiKeyType.envVar
-      process.env[selectedDatadogApiKeyEnvVar] = datadogEnvVars[selectedDatadogApiKeyEnvVar]
+      const datadogApiKeyType = await select(datadogApiKeyTypeQuestion(selectedDatadogSite!))
+      const datadogEnvVar = await input(datadogEnvVarsQuestions(datadogApiKeyType))
+      process.env[datadogApiKeyType.envVar] = datadogEnvVar
     }
   } catch (e) {
     if (e instanceof Error) {
@@ -272,17 +225,9 @@ export const requestDatadogEnvVars = async (): Promise<void> => {
 
 export const requestEnvServiceVersion = async (): Promise<void> => {
   try {
-    const envQuestionAnswer = await inquirer.prompt(envQuestion)
-    const inputedEnvQuestionAnswer = envQuestionAnswer[ENVIRONMENT_ENV_VAR]
-    process.env[ENVIRONMENT_ENV_VAR] = inputedEnvQuestionAnswer
-
-    const serviceQuestionAnswer = await inquirer.prompt(serviceQuestion)
-    const inputedServiceQuestionAnswer = serviceQuestionAnswer[SERVICE_ENV_VAR]
-    process.env[SERVICE_ENV_VAR] = inputedServiceQuestionAnswer
-
-    const versionQuestionAnswer = await inquirer.prompt(versionQuestion)
-    const inputedVersionQuestionAnswer = versionQuestionAnswer[VERSION_ENV_VAR]
-    process.env[VERSION_ENV_VAR] = inputedVersionQuestionAnswer
+    process.env[ENVIRONMENT_ENV_VAR] = await input(envQuestion)
+    process.env[SERVICE_ENV_VAR] = await input(serviceQuestion)
+    process.env[VERSION_ENV_VAR] = await input(versionQuestion)
   } catch (e) {
     if (e instanceof Error) {
       throw Error(`Couldn't set user defined env, service, and version environment variables. ${e.message}`)
@@ -290,14 +235,12 @@ export const requestEnvServiceVersion = async (): Promise<void> => {
   }
 }
 
-export const requestFunctionSelection = async (functionNames: string[]): Promise<any> => {
+export const requestFunctionSelection = async (functionNames: string[]): Promise<string[]> => {
   try {
-    const selectedFunctionsAnswer: any = await inquirer.prompt(functionSelectionQuestion(functionNames))
-
-    return selectedFunctionsAnswer.functions
+    return await checkbox(functionSelectionQuestion(functionNames))
   } catch (e) {
-    if (e instanceof Error) {
-      throw Error(`Couldn't receive selected functions. ${e.message}`)
-    }
+    const message = e instanceof Error ? e.message : String(e)
+
+    throw Error(`Couldn't receive selected functions. ${message}`)
   }
 }

--- a/packages/plugin-lambda/src/prompt.ts
+++ b/packages/plugin-lambda/src/prompt.ts
@@ -165,7 +165,7 @@ export const datadogEnvVarsQuestions = (datadogApiKeyType: DatadogApiKeyType) =>
 
 export const functionSelectionQuestion = (functionNames: string[]) => ({
   choices: functionNames,
-  message: 'Select the functions to modify (Press <space> to select)',
+  message: 'Select the functions to modify.',
   pageSize: 10,
   validate: (selected: readonly unknown[]) => {
     if (selected.length < 1) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1627,10 +1627,9 @@ __metadata:
     "@datadog/datadog-ci-base": "workspace:*"
     "@google-cloud/logging": "npm:11.2.1"
     "@google-cloud/run": "npm:3.0.0"
+    "@inquirer/prompts": "npm:7.10.1"
     chalk: "npm:3.0.0"
     google-auth-library: "npm:10.2.1"
-    inquirer: "npm:8.2.7"
-    inquirer-checkbox-plus-prompt: "npm:1.4.2"
     ora: "npm:5.4.1"
     upath: "npm:2.0.1"
   languageName: unknown
@@ -1715,15 +1714,13 @@ __metadata:
     "@aws-sdk/credential-providers": "npm:3.1045.0"
     "@aws-sdk/types": "npm:3.973.8"
     "@datadog/datadog-ci-base": "workspace:*"
+    "@inquirer/prompts": "npm:7.10.1"
     "@smithy/property-provider": "npm:2.2.0"
     "@smithy/util-retry": "npm:2.2.0"
     aws-sdk-client-mock: "npm:4.1.0"
     aws-sdk-client-mock-jest: "npm:4.1.0"
     chalk: "npm:3.0.0"
     clipanion: "npm:3.2.1"
-    fuzzy: "npm:0.1.3"
-    inquirer: "npm:8.2.7"
-    inquirer-checkbox-plus-prompt: "npm:1.4.2"
     ora: "npm:5.4.1"
     upath: "npm:2.0.1"
   peerDependencies:
@@ -2584,7 +2581,100 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@inquirer/external-editor@npm:^1.0.0":
+"@inquirer/ansi@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "@inquirer/ansi@npm:1.0.2"
+  checksum: 10/d1496e573a63ee6752bcf3fc93375cdabc55b0d60f0588fe7902282c710b223252ad318ff600ee904e48555634663b53fda517f5b29ce9fbda90bfae18592fbc
+  languageName: node
+  linkType: hard
+
+"@inquirer/checkbox@npm:^4.3.2":
+  version: 4.3.2
+  resolution: "@inquirer/checkbox@npm:4.3.2"
+  dependencies:
+    "@inquirer/ansi": "npm:^1.0.2"
+    "@inquirer/core": "npm:^10.3.2"
+    "@inquirer/figures": "npm:^1.0.15"
+    "@inquirer/type": "npm:^3.0.10"
+    yoctocolors-cjs: "npm:^2.1.3"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10/4ac5dd2679981e23f066c51c605cb1c63ccda9ea6e1ad895e675eb26702aaf6cf961bf5ca3acd832efba5edcf9883b6742002c801673d2b35c123a7fa7db7b23
+  languageName: node
+  linkType: hard
+
+"@inquirer/confirm@npm:^5.1.21":
+  version: 5.1.21
+  resolution: "@inquirer/confirm@npm:5.1.21"
+  dependencies:
+    "@inquirer/core": "npm:^10.3.2"
+    "@inquirer/type": "npm:^3.0.10"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10/a107aa0073965ea510affb9e5b55baf40333503d600970c458c07770cd4e0eee01efc4caba66f0409b0fadc9550d127329622efb543cffcabff3ad0e7f865372
+  languageName: node
+  linkType: hard
+
+"@inquirer/core@npm:^10.3.2":
+  version: 10.3.2
+  resolution: "@inquirer/core@npm:10.3.2"
+  dependencies:
+    "@inquirer/ansi": "npm:^1.0.2"
+    "@inquirer/figures": "npm:^1.0.15"
+    "@inquirer/type": "npm:^3.0.10"
+    cli-width: "npm:^4.1.0"
+    mute-stream: "npm:^2.0.0"
+    signal-exit: "npm:^4.1.0"
+    wrap-ansi: "npm:^6.2.0"
+    yoctocolors-cjs: "npm:^2.1.3"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10/eb434bdf0ae7d904367003c772bcd80cbf679f79c087c99a4949fd7288e9a2f713ec3ea63381b9a001f52389ab56a77fcd88d64d81a03b1195193410ce8971c2
+  languageName: node
+  linkType: hard
+
+"@inquirer/editor@npm:^4.2.23":
+  version: 4.2.23
+  resolution: "@inquirer/editor@npm:4.2.23"
+  dependencies:
+    "@inquirer/core": "npm:^10.3.2"
+    "@inquirer/external-editor": "npm:^1.0.3"
+    "@inquirer/type": "npm:^3.0.10"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10/f91b9aadba6ea28a0f4ea5f075af421e076262aebbd737e1b9779f086fa9d559d064e9942a581544645d1dcf56d6b685e8063fe46677880fbca73f6de4e4e7c5
+  languageName: node
+  linkType: hard
+
+"@inquirer/expand@npm:^4.0.23":
+  version: 4.0.23
+  resolution: "@inquirer/expand@npm:4.0.23"
+  dependencies:
+    "@inquirer/core": "npm:^10.3.2"
+    "@inquirer/type": "npm:^3.0.10"
+    yoctocolors-cjs: "npm:^2.1.3"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10/73ad1d6376e5efe2a452c33494d6d16ee2670c638ae470a795fdff4acb59a8e032e38e141f87b603b6e96320977519b375dac6471d86d5e3087a9c1db40e3111
+  languageName: node
+  linkType: hard
+
+"@inquirer/external-editor@npm:^1.0.0, @inquirer/external-editor@npm:^1.0.3":
   version: 1.0.3
   resolution: "@inquirer/external-editor@npm:1.0.3"
   dependencies:
@@ -2596,6 +2686,145 @@ __metadata:
     "@types/node":
       optional: true
   checksum: 10/c95d7237a885b32031715089f92820525731d4d3c2bd7afdb826307dc296cc2b39e7a644b0bb265441963348cca42e7785feb29c3aaf18fd2b63131769bf6587
+  languageName: node
+  linkType: hard
+
+"@inquirer/figures@npm:^1.0.15":
+  version: 1.0.15
+  resolution: "@inquirer/figures@npm:1.0.15"
+  checksum: 10/3f858807f361ca29f41ec1076bbece4098cc140d86a06159d42c6e3f6e4d9bec9e10871ccfcbbaa367d6a8462b01dff89f2b1b157d9de6e8726bec85533f525c
+  languageName: node
+  linkType: hard
+
+"@inquirer/input@npm:^4.3.1":
+  version: 4.3.1
+  resolution: "@inquirer/input@npm:4.3.1"
+  dependencies:
+    "@inquirer/core": "npm:^10.3.2"
+    "@inquirer/type": "npm:^3.0.10"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10/713aaa4c94263299fbd7adfd65378f788cac1b5047f2b7e1ea349ca669db6c7c91b69ab6e2f6660cdbc28c7f7888c5c77ab4433bd149931597e43976d1ba5f34
+  languageName: node
+  linkType: hard
+
+"@inquirer/number@npm:^3.0.23":
+  version: 3.0.23
+  resolution: "@inquirer/number@npm:3.0.23"
+  dependencies:
+    "@inquirer/core": "npm:^10.3.2"
+    "@inquirer/type": "npm:^3.0.10"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10/50694807b71746e15ed69d100aae3c8014d83c90aa660e8a179fe0db1046f26d727947542f64e24cc8b969a61659cb89fe36208cc2b59c1816382b598e686dd2
+  languageName: node
+  linkType: hard
+
+"@inquirer/password@npm:^4.0.23":
+  version: 4.0.23
+  resolution: "@inquirer/password@npm:4.0.23"
+  dependencies:
+    "@inquirer/ansi": "npm:^1.0.2"
+    "@inquirer/core": "npm:^10.3.2"
+    "@inquirer/type": "npm:^3.0.10"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10/97364970b01c85946a4a50ad876c53ef0c1857a9144e24fad65e5dfa4b4e5dd42564fbcdfa2b49bb049a25d127efbe0882cb18afcdd47b166ebd01c6c4b5e825
+  languageName: node
+  linkType: hard
+
+"@inquirer/prompts@npm:7.10.1":
+  version: 7.10.1
+  resolution: "@inquirer/prompts@npm:7.10.1"
+  dependencies:
+    "@inquirer/checkbox": "npm:^4.3.2"
+    "@inquirer/confirm": "npm:^5.1.21"
+    "@inquirer/editor": "npm:^4.2.23"
+    "@inquirer/expand": "npm:^4.0.23"
+    "@inquirer/input": "npm:^4.3.1"
+    "@inquirer/number": "npm:^3.0.23"
+    "@inquirer/password": "npm:^4.0.23"
+    "@inquirer/rawlist": "npm:^4.1.11"
+    "@inquirer/search": "npm:^3.2.2"
+    "@inquirer/select": "npm:^4.4.2"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10/b3e3386edd255e4e91c7908050674f8a2e69b043883c00feec2f87d697be37bc6e8cd4a360e7e3233a9825ae7ea044a2ac63d5700926d27f9959013d8566f890
+  languageName: node
+  linkType: hard
+
+"@inquirer/rawlist@npm:^4.1.11":
+  version: 4.1.11
+  resolution: "@inquirer/rawlist@npm:4.1.11"
+  dependencies:
+    "@inquirer/core": "npm:^10.3.2"
+    "@inquirer/type": "npm:^3.0.10"
+    yoctocolors-cjs: "npm:^2.1.3"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10/0d8f6484cfc20749190e95eecfb2d034bafb3644ec4907b84b1673646f5dd71730e38e35565ea98dfd240d8851e3cff653edafcc4e0af617054b127b407e3229
+  languageName: node
+  linkType: hard
+
+"@inquirer/search@npm:^3.2.2":
+  version: 3.2.2
+  resolution: "@inquirer/search@npm:3.2.2"
+  dependencies:
+    "@inquirer/core": "npm:^10.3.2"
+    "@inquirer/figures": "npm:^1.0.15"
+    "@inquirer/type": "npm:^3.0.10"
+    yoctocolors-cjs: "npm:^2.1.3"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10/abaed2df7763633ff4414b58d1c87233b69ed3cd2ac77629f0d54b72b8b585dc4806c7a2a8261daba58af5b0a2147e586d079fdc82060b6bcf56b75d3d03f3a7
+  languageName: node
+  linkType: hard
+
+"@inquirer/select@npm:^4.4.2":
+  version: 4.4.2
+  resolution: "@inquirer/select@npm:4.4.2"
+  dependencies:
+    "@inquirer/ansi": "npm:^1.0.2"
+    "@inquirer/core": "npm:^10.3.2"
+    "@inquirer/figures": "npm:^1.0.15"
+    "@inquirer/type": "npm:^3.0.10"
+    yoctocolors-cjs: "npm:^2.1.3"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10/795ec0ac77d575f20bd6a12fb1c040093e62217ac0c80194829a8d3c3d1e09f70ad738e9a9dd6095cc8358fff4e13882209c09bdf8eb0864a86dcabef5b0a6a6
+  languageName: node
+  linkType: hard
+
+"@inquirer/type@npm:^3.0.10":
+  version: 3.0.10
+  resolution: "@inquirer/type@npm:3.0.10"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10/57d113a9db7abc73326491e29bedc88ef362e53779f9f58a1b61225e0be068ce0c54e33cd65f4a13ca46131676fb72c3ef488463c4c9af0aa89680684c55d74c
   languageName: node
   linkType: hard
 
@@ -5564,16 +5793,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chalk@npm:4.1.2, chalk@npm:^4.0.0, chalk@npm:^4.1.0, chalk@npm:^4.1.1, chalk@npm:^4.1.2":
-  version: 4.1.2
-  resolution: "chalk@npm:4.1.2"
-  dependencies:
-    ansi-styles: "npm:^4.1.0"
-    supports-color: "npm:^7.1.0"
-  checksum: 10/cb3f3e594913d63b1814d7ca7c9bafbf895f75fbf93b92991980610dfd7b48500af4e3a5d4e3a8f337990a96b168d7eb84ee55efdce965e2ee8efc20f8c8f139
-  languageName: node
-  linkType: hard
-
 "chalk@npm:^2.4.2":
   version: 2.4.2
   resolution: "chalk@npm:2.4.2"
@@ -5582,6 +5801,16 @@ __metadata:
     escape-string-regexp: "npm:^1.0.5"
     supports-color: "npm:^5.3.0"
   checksum: 10/3d1d103433166f6bfe82ac75724951b33769675252d8417317363ef9d54699b7c3b2d46671b772b893a8e50c3ece70c4b933c73c01e81bc60ea4df9b55afa303
+  languageName: node
+  linkType: hard
+
+"chalk@npm:^4.0.0, chalk@npm:^4.1.0, chalk@npm:^4.1.1, chalk@npm:^4.1.2":
+  version: 4.1.2
+  resolution: "chalk@npm:4.1.2"
+  dependencies:
+    ansi-styles: "npm:^4.1.0"
+    supports-color: "npm:^7.1.0"
+  checksum: 10/cb3f3e594913d63b1814d7ca7c9bafbf895f75fbf93b92991980610dfd7b48500af4e3a5d4e3a8f337990a96b168d7eb84ee55efdce965e2ee8efc20f8c8f139
   languageName: node
   linkType: hard
 
@@ -5661,6 +5890,13 @@ __metadata:
   version: 3.0.0
   resolution: "cli-width@npm:3.0.0"
   checksum: 10/8730848b04fb189666ab037a35888d191c8f05b630b1d770b0b0e4c920b47bb5cc14bddf6b8ffe5bfc66cee97c8211d4d18e756c1ffcc75d7dbe7e1186cd7826
+  languageName: node
+  linkType: hard
+
+"cli-width@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "cli-width@npm:4.1.0"
+  checksum: 10/b58876fbf0310a8a35c79b72ecfcf579b354e18ad04e6b20588724ea2b522799a758507a37dfe132fafaf93a9922cafd9514d9e1598e6b2cd46694853aed099f
   languageName: node
   linkType: hard
 
@@ -7350,13 +7586,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fuzzy@npm:0.1.3":
-  version: 0.1.3
-  resolution: "fuzzy@npm:0.1.3"
-  checksum: 10/3cf399457f3f9832af5d72bdbf354b287d977fca6bd800fb457579a9ccf8d8faa297f70ab7fada0147591e022d817532072ab07f69490b84f5dda96051e8c3ab
-  languageName: node
-  linkType: hard
-
 "gaxios@npm:^6.0.0, gaxios@npm:^6.1.1":
   version: 6.7.0
   resolution: "gaxios@npm:6.7.0"
@@ -7949,22 +8178,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"inquirer-checkbox-plus-prompt@npm:1.4.2":
-  version: 1.4.2
-  resolution: "inquirer-checkbox-plus-prompt@npm:1.4.2"
-  dependencies:
-    chalk: "npm:4.1.2"
-    cli-cursor: "npm:^3.1.0"
-    figures: "npm:^3.0.0"
-    lodash: "npm:^4.17.5"
-    rxjs: "npm:^6.6.7"
-  peerDependencies:
-    inquirer: < 9.x
-  checksum: 10/ab7c8db7b5dfb0d0963b1e8be61b0a3ba0f5994597485db40d49a02f41d7d20ed334c4b393ec549249a1427940106b0d4586668c8e429e19eb7d52dbc2817ec9
-  languageName: node
-  linkType: hard
-
-"inquirer@npm:8.2.7, inquirer@npm:^8.2.7":
+"inquirer@npm:^8.2.7":
   version: 8.2.7
   resolution: "inquirer@npm:8.2.7"
   dependencies:
@@ -9096,7 +9310,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash@npm:^4.17.14, lodash@npm:^4.17.21, lodash@npm:^4.17.5":
+"lodash@npm:^4.17.14, lodash@npm:^4.17.21":
   version: 4.17.23
   resolution: "lodash@npm:4.17.23"
   checksum: 10/82504c88250f58da7a5a4289f57a4f759c44946c005dd232821c7688b5fcfbf4a6268f6a6cdde4b792c91edd2f3b5398c1d2a0998274432cff76def48735e233
@@ -9421,6 +9635,13 @@ __metadata:
   version: 0.0.8
   resolution: "mute-stream@npm:0.0.8"
   checksum: 10/a2d2e79dde87e3424ffc8c334472c7f3d17b072137734ca46e6f221131f1b014201cc593b69a38062e974fb2394d3d1cb4349f80f012bbf8b8ac1b28033e515f
+  languageName: node
+  linkType: hard
+
+"mute-stream@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "mute-stream@npm:2.0.0"
+  checksum: 10/d2e4fd2f5aa342b89b98134a8d899d8ef9b0a6d69274c4af9df46faa2d97aeb1f2ce83d867880d6de63643c52386579b99139801e24e7526c3b9b0a6d1e18d6c
   languageName: node
   linkType: hard
 
@@ -10651,15 +10872,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rxjs@npm:^6.6.7":
-  version: 6.6.7
-  resolution: "rxjs@npm:6.6.7"
-  dependencies:
-    tslib: "npm:^1.9.0"
-  checksum: 10/c8263ebb20da80dd7a91c452b9e96a178331f402344bbb40bc772b56340fcd48d13d1f545a1e3d8e464893008c5e306cc42a1552afe0d562b1a6d4e1e6262b03
-  languageName: node
-  linkType: hard
-
 "rxjs@npm:^7.2.0, rxjs@npm:^7.5.5":
   version: 7.8.1
   resolution: "rxjs@npm:7.8.1"
@@ -10762,7 +10974,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"signal-exit@npm:^4.0.1":
+"signal-exit@npm:^4.0.1, signal-exit@npm:^4.1.0":
   version: 4.1.0
   resolution: "signal-exit@npm:4.1.0"
   checksum: 10/c9fa63bbbd7431066174a48ba2dd9986dfd930c3a8b59de9c29d7b6854ec1c12a80d15310869ea5166d413b99f041bfa3dd80a7947bcd44ea8e6eb3ffeabfa1f
@@ -11605,13 +11817,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tslib@npm:^1.9.0":
-  version: 1.14.1
-  resolution: "tslib@npm:1.14.1"
-  checksum: 10/7dbf34e6f55c6492637adb81b555af5e3b4f9cc6b998fb440dac82d3b42bdc91560a35a5fb75e20e24a076c651438234da6743d139e4feabf0783f3cdfe1dddb
-  languageName: node
-  linkType: hard
-
 "tslib@npm:^2.0.1, tslib@npm:^2.1.0, tslib@npm:^2.2.0, tslib@npm:^2.4.0, tslib@npm:^2.6.2, tslib@npm:^2.8.1":
   version: 2.8.1
   resolution: "tslib@npm:2.8.1"
@@ -12082,7 +12287,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"wrap-ansi@npm:^6.0.1":
+"wrap-ansi@npm:^6.0.1, wrap-ansi@npm:^6.2.0":
   version: 6.2.0
   resolution: "wrap-ansi@npm:6.2.0"
   dependencies:
@@ -12243,6 +12448,13 @@ __metadata:
   version: 0.1.0
   resolution: "yocto-queue@npm:0.1.0"
   checksum: 10/f77b3d8d00310def622123df93d4ee654fc6a0096182af8bd60679ddcdfb3474c56c6c7190817c84a2785648cdee9d721c0154eb45698c62176c322fb46fc700
+  languageName: node
+  linkType: hard
+
+"yoctocolors-cjs@npm:^2.1.3":
+  version: 2.1.3
+  resolution: "yoctocolors-cjs@npm:2.1.3"
+  checksum: 10/b2144b38807673a4254dae06fe1a212729550609e606289c305e45c585b36fab1dbba44fe6cde90db9b28be465ec63f4c2a50867aeec6672f6bc36b6c9a361a0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### What and why?

Replaces `inquirer` v8 with `@inquirer/prompts` v7 in `plugin-lambda` and `plugin-cloud-run`. Also removes `inquirer-checkbox-plus-prompt` and `fuzzy`.

### How?

Direct imports from `@inquirer/prompts` in each plugin -- no shared wrapper needed since `@inquirer/prompts@7.10.1` ships a CJS build that works with the existing TypeScript config. v7 is used over v8 because v8 introduced a dependency on `NoInfer<T>`, which requires TypeScript >=5.4 (this project is on 5.1.6).

### Behavior change

The custom `inquirer-checkbox-plus-prompt`-based checkbox (which let users type to fuzzy-filter the function list) is replaced with the standard `@inquirer/prompts` checkbox, which is scroll-only. `@inquirer/checkbox` v4 has no search support. This is acceptable since function lists are sorted, making scroll navigation reasonable.

| Before | <img width="966" height="204" alt="image" src="https://github.com/user-attachments/assets/46488a76-50aa-497f-b9b7-aa880926e5ee" /> | 
| ------ | ---- |
| After  | <img width="614" height="277" alt="image" src="https://github.com/user-attachments/assets/80b67bf1-a0c8-4ed6-956a-0a70318a7308" /> |




### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)