### PR TITLE
deployment correlate-image: include ci_env in request payload

### DIFF
--- a/packages/plugin-deployment/README.md
+++ b/packages/plugin-deployment/README.md
@@ -67,6 +67,8 @@ datadog-ci deployment correlate-image --commit-sha c9c4e93346652f426c91a2c413646
 - `--repository-url` (**required**): Repository URL for the commit SHA being correlated.
 - `--image` (**required**): Image to correlate with the commit SHA.
 
+The command also automatically collects CI environment variables from the CI job that built the image (when run inside a supported CI provider) and includes them in the request so Datadog can attribute the image to the pipeline and job that built it.
+
 ### `gate`
 
 The `gate` command evaluates a Deployment Gate and exits with code 0 if the gate passed or 1 if the gate failed. Refer to the [Deployment Gates documentation][4] for more details.

--- a/packages/plugin-deployment/src/__tests__/correlate-image.test.ts
+++ b/packages/plugin-deployment/src/__tests__/correlate-image.test.ts
@@ -63,6 +63,44 @@ describe('execute', () => {
     expect(output).toContain('"commit_sha": "abcdef"')
     expect(output).toContain('"repository_url": "https://github.com/DataDog/example"')
     expect(output).toContain('"image": "my-image:latest"')
+    expect(output).toContain('"ci_env"')
+  })
+
+  test('valid with dry run includes ci_env from CI environment', async () => {
+    const envVars = {
+      DD_API_KEY: 'fake-api-key',
+      DD_APP_KEY: 'fake-app-key',
+      GITLAB_CI: 'placeholder',
+      CI_PROJECT_URL: 'https://gitlab.com/DataDog/example',
+      CI_COMMIT_SHA: 'abcdef',
+      CI_REPOSITORY_URL: 'https://github.com/DataDog/example',
+      CI_PIPELINE_ID: '1',
+      CI_JOB_ID: '1',
+    }
+    const {context, code} = await runCLI(
+      [
+        '--commit-sha',
+        'abcdef',
+        '--repository-url',
+        'https://github.com/DataDog/example',
+        '--image',
+        'my-image:latest',
+        '--dry-run',
+      ],
+      envVars
+    )
+    expect(code).toBe(0)
+    const output = context.stdout.toString()
+    expect(output).toContain(`"ci_env": {
+      "ci.job.id": "1",
+      "ci.pipeline.id": "1",
+      "ci.provider.name": "gitlab",
+      "git.commit.sha": "abcdef",
+      "git.repository_url": "https://github.com/DataDog/example",
+      "CI_PROJECT_URL": "https://gitlab.com/DataDog/example",
+      "CI_PIPELINE_ID": "1",
+      "CI_JOB_ID": "1"
+    }`)
   })
 
   test('handleError', async () => {

--- a/packages/plugin-deployment/src/commands/correlate-image.ts
+++ b/packages/plugin-deployment/src/commands/correlate-image.ts
@@ -1,7 +1,7 @@
 import {DeploymentCorrelateImageCommand} from '@datadog/datadog-ci-base/commands/deployment/correlate-image'
 import {FIPS_IGNORE_ERROR_ENV_VAR, FIPS_ENV_VAR} from '@datadog/datadog-ci-base/constants'
 import {getDatadogSite} from '@datadog/datadog-ci-base/helpers/api'
-import {getCISpanTags} from '@datadog/datadog-ci-base/helpers/ci'
+import {getCISpanTags, getGithubJobIDFromLogs, getGithubJobNameFromLogs} from '@datadog/datadog-ci-base/helpers/ci'
 import {toBoolean} from '@datadog/datadog-ci-base/helpers/env'
 import {enableFips} from '@datadog/datadog-ci-base/helpers/fips'
 import {Logger, LogLevel} from '@datadog/datadog-ci-base/helpers/logger'
@@ -58,7 +58,9 @@ export class PluginCommand extends DeploymentCorrelateImageCommand {
     const baseAPIURL = `https://${getApiHostForSite(getDatadogSite())}`
     const request = getRequestBuilder({baseUrl: baseAPIURL, apiKey: this.config.apiKey, appKey: this.config.appKey})
 
-    const tags = getCISpanTags() || {}
+    const realGithubJobName = getGithubJobNameFromLogs(this.context)
+    const realGithubJobID = process.env.JOB_CHECK_RUN_ID ?? getGithubJobIDFromLogs(this.context)
+    const tags = getCISpanTags(realGithubJobName, realGithubJobID) || {}
     let envVars: Record<string, string> = {}
     if (tags[CI_ENV_VARS]) {
       envVars = JSON.parse(tags[CI_ENV_VARS])

--- a/packages/plugin-deployment/src/commands/correlate-image.ts
+++ b/packages/plugin-deployment/src/commands/correlate-image.ts
@@ -1,12 +1,14 @@
 import {DeploymentCorrelateImageCommand} from '@datadog/datadog-ci-base/commands/deployment/correlate-image'
 import {FIPS_IGNORE_ERROR_ENV_VAR, FIPS_ENV_VAR} from '@datadog/datadog-ci-base/constants'
 import {getDatadogSite} from '@datadog/datadog-ci-base/helpers/api'
+import {getCISpanTags} from '@datadog/datadog-ci-base/helpers/ci'
 import {toBoolean} from '@datadog/datadog-ci-base/helpers/env'
 import {enableFips} from '@datadog/datadog-ci-base/helpers/fips'
 import {Logger, LogLevel} from '@datadog/datadog-ci-base/helpers/logger'
 import {isRequestError} from '@datadog/datadog-ci-base/helpers/request'
 import {datadogRoute} from '@datadog/datadog-ci-base/helpers/request/datadog-route'
 import {retryRequest} from '@datadog/datadog-ci-base/helpers/retry'
+import {CI_ENV_VARS} from '@datadog/datadog-ci-base/helpers/tags'
 import {getApiHostForSite, getRequestBuilder} from '@datadog/datadog-ci-base/helpers/utils'
 import chalk from 'chalk'
 
@@ -56,12 +58,24 @@ export class PluginCommand extends DeploymentCorrelateImageCommand {
     const baseAPIURL = `https://${getApiHostForSite(getDatadogSite())}`
     const request = getRequestBuilder({baseUrl: baseAPIURL, apiKey: this.config.apiKey, appKey: this.config.appKey})
 
+    const tags = getCISpanTags() || {}
+    let envVars: Record<string, string> = {}
+    if (tags[CI_ENV_VARS]) {
+      envVars = JSON.parse(tags[CI_ENV_VARS])
+      delete tags[CI_ENV_VARS]
+    }
+    const ciEnv: Record<string, string> = {
+      ...tags,
+      ...envVars,
+    }
+
     const correlateEvent = {
       type: 'ci_deployment_correlate_image',
       attributes: {
         commit_sha: this.commitSha,
         repository_url: this.repositoryUrl,
         image: this.image,
+        ci_env: ciEnv,
       },
     }
 

--- a/packages/plugin-deployment/src/commands/correlate.ts
+++ b/packages/plugin-deployment/src/commands/correlate.ts
@@ -1,7 +1,7 @@
 import {DeploymentCorrelateCommand} from '@datadog/datadog-ci-base/commands/deployment/correlate'
 import {FIPS_ENV_VAR, FIPS_IGNORE_ERROR_ENV_VAR} from '@datadog/datadog-ci-base/constants'
 import {getDatadogSite} from '@datadog/datadog-ci-base/helpers/api'
-import {getCISpanTags, getGithubJobIDFromLogs, getGithubJobNameFromLogs} from '@datadog/datadog-ci-base/helpers/ci'
+import {getCISpanTags} from '@datadog/datadog-ci-base/helpers/ci'
 import {toBoolean} from '@datadog/datadog-ci-base/helpers/env'
 import {enableFips} from '@datadog/datadog-ci-base/helpers/fips'
 import {gitRepositoryURL, gitLocalCommitShas, gitCurrentBranch} from '@datadog/datadog-ci-base/helpers/git/get-git-data'
@@ -41,9 +41,7 @@ export class PluginCommand extends DeploymentCorrelateCommand {
     }
     this.cdProviderParam = this.cdProviderParam.toLowerCase()
 
-    const realGithubJobName = getGithubJobNameFromLogs(this.context)
-    const realGithubJobID = process.env.JOB_CHECK_RUN_ID ?? getGithubJobIDFromLogs(this.context)
-    const tags = getCISpanTags(realGithubJobName, realGithubJobID) || {}
+    const tags = getCISpanTags() || {}
 
     if (!this.validateTags(tags)) {
       return 1

--- a/packages/plugin-deployment/src/commands/correlate.ts
+++ b/packages/plugin-deployment/src/commands/correlate.ts
@@ -1,7 +1,7 @@
 import {DeploymentCorrelateCommand} from '@datadog/datadog-ci-base/commands/deployment/correlate'
 import {FIPS_ENV_VAR, FIPS_IGNORE_ERROR_ENV_VAR} from '@datadog/datadog-ci-base/constants'
 import {getDatadogSite} from '@datadog/datadog-ci-base/helpers/api'
-import {getCISpanTags} from '@datadog/datadog-ci-base/helpers/ci'
+import {getCISpanTags, getGithubJobIDFromLogs, getGithubJobNameFromLogs} from '@datadog/datadog-ci-base/helpers/ci'
 import {toBoolean} from '@datadog/datadog-ci-base/helpers/env'
 import {enableFips} from '@datadog/datadog-ci-base/helpers/fips'
 import {gitRepositoryURL, gitLocalCommitShas, gitCurrentBranch} from '@datadog/datadog-ci-base/helpers/git/get-git-data'
@@ -41,7 +41,9 @@ export class PluginCommand extends DeploymentCorrelateCommand {
     }
     this.cdProviderParam = this.cdProviderParam.toLowerCase()
 
-    const tags = getCISpanTags() || {}
+    const realGithubJobName = getGithubJobNameFromLogs(this.context)
+    const realGithubJobID = process.env.JOB_CHECK_RUN_ID ?? getGithubJobIDFromLogs(this.context)
+    const tags = getCISpanTags(realGithubJobName, realGithubJobID) || {}
 
     if (!this.validateTags(tags)) {
       return 1


### PR DESCRIPTION
## What this changes

Two related fixes to the `deployment correlate` and `deployment correlate-image` commands:

1. `correlate-image` now sends a `ci_env` attribute on its request payload, mirroring the sibling `correlate` (GitOps) command. The backend uses it to derive `pipeline_correlation_id` and `job_correlation_id`.
2. Both commands now read the GitHub Actions numeric check run ID from the runner diagnostic log files (via `getGithubJobIDFromLogs`) before building the CI span tags, so `ci.job.id` carries the numeric ID instead of the workflow job name.

## Why

The backend (`/api/v2/ci/deployments/correlate-image` in dd-source) needs `ci_env` to derive CI correlation IDs. Same wire shape as `correlate` so we are not inventing a new format.

For GitHub Actions, the numeric check run ID is not in any standard env var. It only lives in the runner diagnostic log files. The CI visibility commands (`junit upload`, `trace`) already use this approach. Without it, `ci.job.id` ends up being the workflow job name (for example `"build"`), the backend cannot parse that as an int64, and `job_correlation_id` stays empty on every GitHub deployment.

## Example payload

```json
{
  "data": {
    "type": "ci_deployment_correlate_image",
    "attributes": {
      "commit_sha": "abcdef",
      "repository_url": "https://github.com/DataDog/example",
      "image": "my-image:latest",
      "ci_env": {
        "ci.job.id": "29891234567",
        "ci.pipeline.id": "12345",
        "ci.provider.name": "github",
        "GITHUB_SERVER_URL": "https://github.com",
        "GITHUB_REPOSITORY": "DataDog/example",
        "GITHUB_RUN_ID": "12345",
        "GITHUB_RUN_ATTEMPT": "1"
      }
    }
  }
}
```

## Companion backend PRs

- DataDog/dd-source#443772 (writer for `correlate-image` + `ci.job.id` fix)
- DataDog/dd-source#445158 (same `ci.job.id` fix on the existing `correlate` endpoint)
- DataDog/dd-go#238027 (reader on the ArgoCD path)

Safe to ship before the backends land. Older endpoint versions ignore unknown attributes.

## Test plan

- `yarn test packages/plugin-deployment/src/__tests__/correlate-image.test.ts` passes, including new coverage for `ci_env` population.
- `yarn lint` clean.
- Validated end-to-end in staging.