### PR TITLE
[dev] Make `yarn launch` prefer local plugin source code

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,6 +34,14 @@ yarn install
 yarn launch <scope> <command> ...
 ```
 
+`yarn launch` runs the CLI from TypeScript source with the `development` condition. It is the right command for
+day-to-day development because changes in `packages/base/src`, `packages/datadog-ci/src`, and plugin `src` files are
+picked up without rebuilding.
+
+`yarn launch:dist` runs the packaged CLI bundle from `packages/datadog-ci/dist/bundle.js`. Build it first with
+`yarn bundle:npm`. When testing changes to separately installable plugins, rebuild the plugin bundle too, for example
+with `yarn workspace @datadog/datadog-ci-plugin-lambda prepack`.
+
 ### Framework and libraries used
 
 - [clipanion](https://github.com/arcanis/clipanion): CLI library to handle the different commands.

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "knip:strict": "knip --include dependencies --no-config-hints --strict",
     "launch": "tsx --conditions=development packages/datadog-ci/src/cli.ts",
     "launch:debug": "tsx --conditions=development --inspect-brk packages/datadog-ci/src/cli.ts",
-    "launch:dist": "tsx packages/datadog-ci/dist/cli.js",
+    "launch:dist": "node packages/datadog-ci/dist/bundle.js",
     "lint": "yarn lint:all $@ || (echo \"\nYou can fix this by running ==> yarn format <==\n\" && false)",
     "lint:all": "eslint --cache --quiet '**/*.ts'",
     "lint:ci": "yarn lint:all -f @microsoft/sarif -o 'sarif-datadog-ci.sarif'",

--- a/packages/base/src/helpers/__tests__/plugin.test.ts
+++ b/packages/base/src/helpers/__tests__/plugin.test.ts
@@ -21,6 +21,21 @@ jest.mock('../message-box')
 jest.mock('../../version', () => ({
   cliVersion: '1.0.0',
 }))
+
+const mockBundledPluginExecute = jest.fn()
+
+jest.mock('@datadog/datadog-ci-plugin-synthetics', () => ({
+  commands: {
+    'run-tests': {
+      PluginCommand: class {
+        public execute() {
+          return mockBundledPluginExecute()
+        }
+      },
+    },
+  },
+}))
+
 jest.mock('@datadog/datadog-ci-base/package.json', () => ({
   peerDependencies: {
     '@datadog/datadog-ci-plugin-test': '1.0.0',
@@ -95,6 +110,17 @@ describe('executePluginCommand', () => {
     const command = createCommand(SyntheticsRunTestsCommand)
     const result = await executePluginCommand(command)
     expect(result).toBe(0)
+  })
+
+  test('prefers command submodule over self-contained plugin bundle', async () => {
+    mockBundledPluginExecute.mockResolvedValue(42)
+    jest.spyOn(SyntheticsRunTestsPluginCommand, 'execute').mockResolvedValue(0)
+
+    const command = createCommand(SyntheticsRunTestsCommand)
+    const result = await executePluginCommand(command)
+
+    expect(result).toBe(0)
+    expect(mockBundledPluginExecute).not.toHaveBeenCalled()
   })
 
   test('injects plugin identity into the user agent context during execution', async () => {

--- a/packages/base/src/helpers/__tests__/plugin.test.ts
+++ b/packages/base/src/helpers/__tests__/plugin.test.ts
@@ -9,6 +9,7 @@ import {
   installPlugin,
   listAllPlugins,
   executePluginCommand,
+  normalizePluginSubmodule,
   VERSION_OVERRIDE_REGEX,
 } from '../plugin'
 import {getUserAgent} from '../user-agent'
@@ -153,6 +154,22 @@ describe('executePluginCommand', () => {
     ).toHaveLength(1)
 
     consoleLogSpy.mockRestore()
+  })
+})
+
+describe('normalizePluginSubmodule', () => {
+  class PluginCommand {}
+
+  test('keeps ESM submodule shape', () => {
+    const submodule = {PluginCommand}
+
+    expect(normalizePluginSubmodule(submodule)).toBe(submodule)
+  })
+
+  test('unwraps CJS default export shape', () => {
+    const submodule = {PluginCommand}
+
+    expect(normalizePluginSubmodule({default: submodule})).toBe(submodule)
   })
 })
 

--- a/packages/base/src/helpers/plugin.ts
+++ b/packages/base/src/helpers/plugin.ts
@@ -64,6 +64,21 @@ export const executePluginCommand = async <T extends Command>(instance: T): Prom
   }
 }
 
+export const normalizePluginSubmodule = (submodule: unknown): PluginSubModule => {
+  if (isPluginSubmodule(submodule)) {
+    return submodule
+  }
+
+  if (typeof submodule === 'object' && submodule && 'default' in submodule) {
+    const defaultExport = submodule.default
+    if (isPluginSubmodule(defaultExport)) {
+      return defaultExport
+    }
+  }
+
+  return submodule as PluginSubModule
+}
+
 export const listAllPlugins = (): string[] => {
   return Object.keys(peerDependencies)
 }
@@ -346,7 +361,7 @@ const importPluginSubmodule = async (scope: string, command: string): Promise<Pl
     const submodulePath = url.pathToFileURL(resolvedSubmodulePath).href
     debug('Importing submodule:', submodulePath)
 
-    return (await import(submodulePath)) as PluginSubModule
+    return normalizePluginSubmodule(await import(submodulePath))
   }
 
   const pluginPackage = `@datadog/datadog-ci-plugin-${scope}`
@@ -388,6 +403,15 @@ const patchModulePaths = (preferredPath?: string) => {
 
 const isValidScope = (scope: string): boolean => {
   return scopeToPackageName(scope) in peerDependencies
+}
+
+const isPluginSubmodule = (submodule: unknown): submodule is PluginSubModule => {
+  return (
+    typeof submodule === 'object' &&
+    !!submodule &&
+    'PluginCommand' in submodule &&
+    typeof submodule.PluginCommand === 'function'
+  )
 }
 
 /**

--- a/packages/base/src/helpers/plugin.ts
+++ b/packages/base/src/helpers/plugin.ts
@@ -328,9 +328,30 @@ const importPluginSubmodule = async (scope: string, command: string): Promise<Pl
   patchModulePaths()
   await handlePluginAutoInstall(scope)
 
+  // 2. Development/default submodule export.
+  // `yarn launch` passes `--conditions=development`, so this resolves to local source files.
+  // Published CLI/plugin usage resolves the same export to the dist command wrapper.
+  const submoduleName = `@datadog/datadog-ci-plugin-${scope}/commands/${command}`
+  debug('Resolving submodule:', submoduleName)
+  let submoduleResolveError: unknown
+  let resolvedSubmodulePath: string | undefined
+  try {
+    resolvedSubmodulePath = require.resolve(submoduleName)
+  } catch (error) {
+    debug(`Could not require.resolve() the ${submoduleName} submodule: ${error}`)
+    submoduleResolveError = error
+  }
+
+  if (resolvedSubmodulePath) {
+    const submodulePath = url.pathToFileURL(resolvedSubmodulePath).href
+    debug('Importing submodule:', submodulePath)
+
+    return (await import(submodulePath)) as PluginSubModule
+  }
+
   const pluginPackage = `@datadog/datadog-ci-plugin-${scope}`
 
-  // 2. Self-contained plugin bundle (published vendored bundles)
+  // 3. Self-contained plugin bundle fallback (published vendored bundles without submodule exports)
   try {
     const bundle = require(pluginPackage)
     const submodule = bundle.commands?.[command]
@@ -340,23 +361,10 @@ const importPluginSubmodule = async (scope: string, command: string): Promise<Pl
       return submodule as PluginSubModule
     }
   } catch (error) {
-    debug('Plugin bundle load failed, trying submodule path:', error)
+    debug('Plugin bundle load failed:', error)
   }
 
-  // 3. Development mode: load individual command submodule.
-  const submoduleName = `@datadog/datadog-ci-plugin-${scope}/commands/${command}`
-  debug('Resolving submodule:', submoduleName)
-  let submodulePath = submoduleName
-  try {
-    const resolvedPath = require.resolve(submoduleName)
-    const absolutePath = url.pathToFileURL(resolvedPath).href
-    submodulePath = absolutePath
-  } catch (error) {
-    debug(`Could not require.resolve() the ${submoduleName} submodule: ${error}`)
-  }
-  debug('Importing submodule:', submodulePath)
-
-  return (await import(submodulePath)) as PluginSubModule
+  throw submoduleResolveError
 }
 
 export const scopeToPackageName = (scope: string): string => {


### PR DESCRIPTION
### What and why?

`yarn launch` should execute plugin command source when running with the development condition. After the bundling migration, plugin resolution tried the package root bundle before the command submodule, so local source changes could be bypassed when a stale `dist/bundle.js` existed.

`yarn launch:dist` should exercise the packaged CLI bundle instead of TypeScript-compiled `dist/cli.js`, so it now runs `packages/datadog-ci/dist/bundle.js` directly.

### How?

Prefer `@datadog/datadog-ci-plugin-<scope>/commands/<command>` before the self-contained package bundle in the plugin loader. The submodule export resolves to `src` under `--conditions=development` and to `dist` in normal/package usage. Keep the root bundle as a fallback for bundled/plugin packages without submodule exports.

Normalize dynamic imports of CommonJS command wrappers so packaged `dist/commands/*` wrappers expose `PluginCommand` consistently during bundled/e2e execution.

Documented the difference between `yarn launch` and `yarn launch:dist` in `CONTRIBUTING.md`, including the bundle build commands needed for dist-mode testing.

Added regression tests that verify command submodules win over self-contained bundles and that CommonJS default-export wrapper shapes are unwrapped.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)