### PR TITLE
Use v2 API for deployment gate command

### DIFF
--- a/packages/base/src/helpers/request/datadog-route.ts
+++ b/packages/base/src/helpers/request/datadog-route.ts
@@ -6,8 +6,6 @@
 export const DATADOG_ROUTE_PATHS = [
   '/api/intake/ci/custom_spans',
   '/api/ui/support/serverless/flare',
-  '/api/unstable/deployments/gates/evaluation',
-  '/api/unstable/deployments/gates/evaluation/:evaluationId',
   '/api/v1/validate',
   '/api/v2/ci/deployments/correlate-image',
   '/api/v2/ci/deployments/correlate',
@@ -17,6 +15,8 @@ export const DATADOG_ROUTE_PATHS = [
   '/api/v2/cicovreprt',
   '/api/v2/ciiac',
   '/api/v2/cireport',
+  '/api/v2/deployments/gates/evaluation',
+  '/api/v2/deployments/gates/evaluation/:evaluationId',
   '/api/v2/dora/deployment',
   '/api/v2/git/repository/packfile',
   '/api/v2/git/repository/search_commits',

--- a/packages/plugin-deployment/src/api.ts
+++ b/packages/plugin-deployment/src/api.ts
@@ -34,7 +34,7 @@ const requestGateEvaluation =
         'Content-Type': 'application/json',
       },
       method: 'POST',
-      url: datadogRoute('/api/unstable/deployments/gates/evaluation'),
+      url: datadogRoute('/api/v2/deployments/gates/evaluation'),
     })
   }
 
@@ -43,7 +43,7 @@ const getGateEvaluationResult =
   async (evaluationId: string) => {
     return request({
       method: 'GET',
-      url: datadogRoute('/api/unstable/deployments/gates/evaluation/:evaluationId', {evaluationId}),
+      url: datadogRoute('/api/v2/deployments/gates/evaluation/:evaluationId', {evaluationId}),
     })
   }
 


### PR DESCRIPTION
The deployment gates API now exposes a v2 endpoint. This PR makes the deployment gate command target the stable `/api/v2` route instead of `/api/unstable`, which will be deprecated in the future.