### PR TITLE
tags: support array-valued tag values

### DIFF
--- a/packages/base/src/helpers/__tests__/tags-fixtures/tags-with-arrays.json
+++ b/packages/base/src/helpers/__tests__/tags-fixtures/tags-with-arrays.json
@@ -1,0 +1,6 @@
+{
+  "team": ["backend", "platform"],
+  "single": "value",
+  "numeric_array": [1, 2, 3],
+  "mixed_array": ["a", 1, true]
+}

--- a/packages/base/src/helpers/__tests__/tags.test.ts
+++ b/packages/base/src/helpers/__tests__/tags.test.ts
@@ -61,6 +61,30 @@ describe('parseTags', () => {
   test('should not include invalid key:value pairs', () => {
     expect(parseTags(['key1:value1', 'key2:value2', 'invalidkeyvalue'])).toEqual({key1: 'value1', key2: 'value2'})
   })
+
+  test('normalizes bracket-form array values to canonical JSON', () => {
+    expect(parseTags(['team:[backend,platform]'])).toEqual({team: '["backend","platform"]'})
+  })
+
+  test('normalizes JSON-array values to canonical JSON', () => {
+    expect(parseTags(['team:["backend","platform"]'])).toEqual({team: '["backend","platform"]'})
+  })
+
+  test('preserves quoted commas inside JSON-array elements', () => {
+    expect(parseTags(['names:["Smith, John","Doe, Jane"]'])).toEqual({names: '["Smith, John","Doe, Jane"]'})
+  })
+
+  test('trims whitespace inside legacy bracket-form elements', () => {
+    expect(parseTags(['team:[ backend , platform ]'])).toEqual({team: '["backend","platform"]'})
+  })
+
+  test('passes scalar values through unchanged', () => {
+    expect(parseTags(['team:backend', 'env:prod'])).toEqual({team: 'backend', env: 'prod'})
+  })
+
+  test('does not treat values without brackets as arrays', () => {
+    expect(parseTags(['note:hello, world'])).toEqual({note: 'hello, world'})
+  })
 })
 
 describe('parseTagsFile', () => {
@@ -90,6 +114,18 @@ describe('parseTagsFile', () => {
     expect(valid).toBe(true)
     expect(tags).toEqual({bar: 'world'})
     expect(context.stdout.toString()).toContain("[WARN] tag 'foo' had nested fields which will be ignored")
+  })
+
+  test('array values are JSON-encoded', () => {
+    const context = createMockContext()
+    const [tags, valid] = parseTagsFile(context, `${fixturesPath}/tags-with-arrays.json`)
+    expect(valid).toBe(true)
+    expect(tags).toEqual({
+      team: '["backend","platform"]',
+      single: 'value',
+      numeric_array: '[1,2,3]',
+      mixed_array: '["a",1,true]',
+    })
   })
 
   test('empty file path', () => {

--- a/packages/base/src/helpers/tags.ts
+++ b/packages/base/src/helpers/tags.ts
@@ -69,12 +69,47 @@ const parseNumericTag = (numericTag: string | undefined): number | undefined => 
 }
 
 /**
+ * If `value` looks like a bracketed array (e.g. `[a,b,c]` or `["a","b"]`),
+ * normalize it to a canonical JSON-array string. Otherwise return it unchanged.
+ *
+ * The CI Visibility API accepts tags as Record<string,string>; sending arrays
+ * as JSON-encoded strings lets the server promote them back to multi-value
+ * facets without a wire-format change.
+ */
+const canonicalizeArrayValue = (value: string): string => {
+  const trimmed = value.trim()
+  if (trimmed.length < 2 || trimmed[0] !== '[' || trimmed[trimmed.length - 1] !== ']') {
+    return value
+  }
+  try {
+    const parsed = JSON.parse(trimmed) as unknown
+    if (Array.isArray(parsed)) {
+      return JSON.stringify(parsed)
+    }
+  } catch {
+    // Not valid JSON. Fall through to legacy bracket parsing for inputs like
+    // `[a,b,c]` (no element quotes).
+  }
+  const inner = trimmed.slice(1, -1).trim()
+  if (inner === '') {
+    return value
+  }
+  const elements = inner.split(',').map((s) => s.trim())
+
+  return JSON.stringify(elements)
+}
+
+/**
  * Receives an array of the form ['key:value', 'key2:value2']
- * and returns an object of the form {key: 'value', key2: 'value2'}
+ * and returns an object of the form {key: 'value', key2: 'value2'}.
+ *
+ * Bracketed values (`key:[a,b,c]` or `key:["a","b"]`) are normalized to a
+ * canonical JSON-array string so the server can deserialize them as a
+ * multi-value attribute.
  */
 export const parseTags = (tags: string[]): Record<string, string> => {
   try {
-    return tags.reduce((acc, keyValuePair) => {
+    return tags.reduce<Record<string, string>>((acc, keyValuePair) => {
       if (!keyValuePair.includes(':')) {
         return acc
       }
@@ -85,7 +120,7 @@ export const parseTags = (tags: string[]): Record<string, string> => {
 
       return {
         ...acc,
-        [key]: value,
+        [key]: canonicalizeArrayValue(value),
       }
     }, {})
   } catch (e) {
@@ -129,10 +164,16 @@ export const parseMetrics = (tags: string[]) => {
  * Receives a filepath to a JSON file that contains tags in the form of:
  * {
  *  "key": "value",
- *  "key2": "value2"
+ *  "key2": "value2",
+ *  "key3": ["a", "b", "c"]
  * }
- * and returns a record of the form {key: 'value', key2: 'value2'}
- * Numbers are converted to strings and nested objects are ignored.
+ * and returns a record of the form
+ * {key: 'value', key2: 'value2', key3: '["a","b","c"]'}.
+ *
+ * Array values are JSON-encoded so they travel through the API as strings
+ * but get promoted to multi-value facets by the server. Numbers are
+ * converted to strings and nested objects are ignored.
+ *
  * @param context - the context of the CLI, used to write to stdout and stderr
  * @param tagsFile - the path to the JSON file
  */
@@ -149,23 +190,26 @@ export const parseTagsFile = (
     return [{}, false]
   }
 
-  let tags: Record<string, string>
+  let raw: Record<string, unknown>
   try {
-    tags = JSON.parse(fileContent) as Record<string, string>
+    raw = JSON.parse(fileContent) as Record<string, unknown>
   } catch (error) {
     context.stderr.write(`${chalk.red.bold('[ERROR]')} could not parse JSON file '${tagsFile}': ${error}\n`)
 
     return [{}, false]
   }
 
-  // We want to ensure that all tags are strings
-  for (const key in tags) {
-    if (typeof tags[key] === 'object') {
+  const tags: Record<string, string> = {}
+  for (const [key, value] of Object.entries(raw)) {
+    if (Array.isArray(value)) {
+      tags[key] = JSON.stringify(value)
+    } else if (value && typeof value === 'object') {
       context.stdout.write(`${chalk.yellow.bold('[WARN]')} tag '${key}' had nested fields which will be ignored\n`)
-      delete tags[key]
-    } else if (typeof tags[key] !== 'string') {
+    } else if (typeof value === 'string') {
+      tags[key] = value
+    } else {
       context.stdout.write(`${chalk.yellow.bold('[WARN]')} tag '${key}' was not a string, converting to string\n`)
-      tags[key] = String(tags[key])
+      tags[key] = String(value)
     }
   }
 


### PR DESCRIPTION
## Summary

Allow `datadog-ci tag` users to attach array-valued custom tags to their CI Visibility pipelines/jobs/stages/steps so values render as multi-value facets in the UI. Two input forms are supported:

- **CLI bracket syntax**: `--tags team:[backend,platform]` and JSON-array form `--tags 'team:["backend","platform"]'`
- **`--tags-file` JSON arrays**: `{"team": ["backend", "platform"]}`

Both forms normalize to a canonical JSON-array string (e.g. `["backend","platform"]`) before being POSTed. The wire format and request shape are unchanged (still `tags: Record<string, string>`); the server promotes the JSON-encoded array back to a multi-value attribute when the per-org feature flag is enabled.

## Server-side companion

dd-go PR: https://github.com/DataDog/dd-go/pull/239160 (per-org feature flag `ci_app_array_custom_tags`)

## Design

Full plan: https://datadoghq.atlassian.net/wiki/spaces/SDCICD/pages/6778323684/Array-valued+custom+tags+for+CI+Visibility+Implementation+Plan

## Test plan

- [x] `yarn workspace @datadog/datadog-ci-base build` — passes
- [x] `yarn workspace @datadog/datadog-ci-base lint` — passes
- [x] `jest packages/base/src/helpers/__tests__/tags.test.ts` — 31 tests pass, including 7 new cases covering bracket form, JSON form, quoted commas inside elements, legacy whitespace handling, file-form arrays, and scalar pass-through.
- [ ] End-to-end staging validation: deploy server PR, enable `ci_app_array_custom_tags` for the test org, run `datadog-ci tag --tags 'team:[backend,platform]'` and confirm `@custom.team:backend` / `@custom.team:platform` filter the event in CI Visibility.

## Behavior compatibility notes

- A value that today happens to look like `[FOO]` will now be sent as a JSON-encoded single-element array `["FOO"]`. Customers without the feature flag enabled on the server side keep their existing behavior (stored as the raw string). Customers with the flag enabled would see their attribute flip to multi-value — same trade-off as on the server PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)