### PR TITLE
[RUM-16533] Allow JS sourcemaps upload without a version (--global-release, --exclude)

### DIFF
--- a/packages/base/src/commands/sourcemaps/README.md
+++ b/packages/base/src/commands/sourcemaps/README.md
@@ -32,7 +32,7 @@ The folder structure should match the structure of the served static files.
 
 * `--service` (required) should be set as the name of the service you're uploading sourcemaps for, and Datadog will use this service name to find the corresponding sourcemaps based on the `service` tag set on the RUM SDK.
 
-* `--release-version` (required) is similar and will be used to match the `version` tag set on the RUM SDK.
+* `--release-version` (required, unless uploading a global release) is similar and will be used to match the `version` tag set on the RUM SDK. See [Global (version-less) sourcemaps](#global-version-less-sourcemaps) to upload without a version.
 
 * `--minified-path-prefix` (required) should be a prefix common to all your JS source files, depending on the URL they are served from. The prefix can be a full URL or an absolute path.
 Example: if you're uploading `dist/file.js` to `https://example.com/static/file.js`, you can use `datadog-ci sourcemaps upload ./dist --minified-path-prefix https://example.com/static/` or `datadog-ci sourcemaps upload ./dist --minified-path-prefix /static/`.
@@ -47,6 +47,28 @@ In addition, some optional parameters are available:
 * `--project-path` (default: empty): the path of the project where the sourcemaps were built. This will be stripped off from sources paths referenced in the sourcemap so they can be properly matched against tracked files paths. See details in the [dedicated section](#setting-the-project-path).
 * `--repository-url` (default: empty): overrides the repository remote with a custom URL, for example, https://github.com/my-company/my-project. Can also be set via the `DD_GIT_REPOSITORY_URL` environment variable.
 * `--commit-sha` (default: empty): overrides the git commit SHA. Can also be set via the `DD_GIT_COMMIT_SHA` environment variable.
+* `--global-release` (default: false): uploads the sourcemaps without a version (see [Global (version-less) sourcemaps](#global-version-less-sourcemaps)). Cannot be combined with `--release-version`.
+* `--exclude` (default: empty): a glob expression, relative to the upload directory, of files to ignore. Matching files are not uploaded, which lets you upload them separately in another invocation (see [Global (version-less) sourcemaps](#global-version-less-sourcemaps)).
+
+### Global (version-less) sourcemaps
+
+Some applications (for example, micro-frontends, see [#829](https://github.com/DataDog/datadog-ci/issues/829)) cannot tie their sourcemaps to a single RUM `version`. When file names are content-hashed and therefore unique across builds, you can upload sourcemaps that are matched regardless of the `version` tag reported by the RUM SDK.
+
+To do so, either omit `--release-version` or pass `--global-release` explicitly:
+
+```bash
+datadog-ci sourcemaps upload ./build --service my-service --minified-path-prefix https://static.datadog.com --global-release
+```
+
+If a build mixes content-hashed file names with fixed ones (such as `main.js`), use `--exclude` to skip the fixed files from the global upload, then upload them separately with a `--release-version`:
+
+```bash
+# Upload the content-hashed files as a global release, skipping main.js
+datadog-ci sourcemaps upload ./build --service my-service --minified-path-prefix https://static.datadog.com --global-release --exclude "**/main.js"
+
+# Upload the non-hashed files with a version
+datadog-ci sourcemaps upload ./build/main.js.map --service my-service --minified-path-prefix https://static.datadog.com --release-version 1.234
+```
 
 ### Link errors with your source code
 

--- a/packages/base/src/commands/sourcemaps/__tests__/fixtures/exclude-legacy/keep.min.js
+++ b/packages/base/src/commands/sourcemaps/__tests__/fixtures/exclude-legacy/keep.min.js
@@ -1,0 +1,1 @@
+/* keep, no sourceMappingURL */

--- a/packages/base/src/commands/sourcemaps/__tests__/fixtures/exclude-legacy/keep.min.js.map
+++ b/packages/base/src/commands/sourcemaps/__tests__/fixtures/exclude-legacy/keep.min.js.map
@@ -1,0 +1,3 @@
+{
+    "sources": ["webpack:///./src/commands/sourcemaps/__tests__/git.test.ts"]
+}

--- a/packages/base/src/commands/sourcemaps/__tests__/fixtures/exclude-legacy/skip.min.js
+++ b/packages/base/src/commands/sourcemaps/__tests__/fixtures/exclude-legacy/skip.min.js
@@ -1,0 +1,1 @@
+/* skip, no sourceMappingURL */

--- a/packages/base/src/commands/sourcemaps/__tests__/fixtures/exclude-legacy/skip.min.js.map
+++ b/packages/base/src/commands/sourcemaps/__tests__/fixtures/exclude-legacy/skip.min.js.map
@@ -1,0 +1,3 @@
+{
+    "sources": ["webpack:///./src/commands/sourcemaps/__tests__/git.test.ts"]
+}

--- a/packages/base/src/commands/sourcemaps/__tests__/fixtures/exclude/keep.min.js
+++ b/packages/base/src/commands/sourcemaps/__tests__/fixtures/exclude/keep.min.js
@@ -1,0 +1,3 @@
+/* minified bundle */
+var a=1;console.log(a);
+//# sourceMappingURL=keep.min.js.map

--- a/packages/base/src/commands/sourcemaps/__tests__/fixtures/exclude/keep.min.js.map
+++ b/packages/base/src/commands/sourcemaps/__tests__/fixtures/exclude/keep.min.js.map
@@ -1,0 +1,3 @@
+{
+    "sources": ["webpack:///./src/commands/sourcemaps/__tests__/git.test.ts"]
+}

--- a/packages/base/src/commands/sourcemaps/__tests__/fixtures/exclude/skip.min.js
+++ b/packages/base/src/commands/sourcemaps/__tests__/fixtures/exclude/skip.min.js
@@ -1,0 +1,3 @@
+/* minified bundle */
+var b=2;console.log(b);
+//# sourceMappingURL=skip.min.js.map

--- a/packages/base/src/commands/sourcemaps/__tests__/fixtures/exclude/skip.min.js.map
+++ b/packages/base/src/commands/sourcemaps/__tests__/fixtures/exclude/skip.min.js.map
@@ -1,0 +1,3 @@
+{
+    "sources": ["webpack:///./src/commands/sourcemaps/__tests__/git.test.ts"]
+}

--- a/packages/base/src/commands/sourcemaps/__tests__/upload.test.ts
+++ b/packages/base/src/commands/sourcemaps/__tests__/upload.test.ts
@@ -380,6 +380,67 @@ describe('execute', () => {
   })
 })
 
+describe('execute global release', () => {
+  const runCLI = makeRunCLI(SourcemapsUploadCommand, [
+    'sourcemaps',
+    'upload',
+    '--service',
+    'test-service',
+    '--minified-path-prefix',
+    'https://static.com/js',
+    '--dry-run',
+  ])
+
+  test('--global-release uploads with the sentinel version', async () => {
+    const {context, code} = await runCLI(['./src/commands/sourcemaps/__tests__/fixtures/basic', '--global-release'])
+    expect(code).toBe(0)
+    expect(context.stdout.toString()).toContain('Version: __GLOBAL__ (global release)')
+  })
+
+  test('omitting --release-version uploads with the sentinel version', async () => {
+    const {context, code} = await runCLI(['./src/commands/sourcemaps/__tests__/fixtures/basic'])
+    expect(code).toBe(0)
+    expect(context.stdout.toString()).toContain('Version: __GLOBAL__ (global release)')
+  })
+
+  test('--release-version combined with --global-release is rejected', async () => {
+    const {context, code} = await runCLI([
+      './src/commands/sourcemaps/__tests__/fixtures/basic',
+      '--global-release',
+      '--release-version',
+      '1234',
+    ])
+    expect(code).toBe(1)
+    expect(context.stderr.toString()).toContain('Cannot use both --release-version and --global-release')
+  })
+})
+
+describe('execute with --exclude', () => {
+  const runCLI = makeRunCLI(SourcemapsUploadCommand, [
+    'sourcemaps',
+    'upload',
+    '--release-version',
+    '1234',
+    '--service',
+    'test-service',
+    '--minified-path-prefix',
+    'https://static.com/js',
+    '--dry-run',
+  ])
+
+  test('skips files matching the exclude glob', async () => {
+    const {context, code} = await runCLI([
+      './src/commands/sourcemaps/__tests__/fixtures/exclude',
+      '--exclude',
+      '**/skip.min.js',
+    ])
+    const output = context.stdout.toString()
+    expect(code).toBe(0)
+    expect(output).toContain('keep.min.js')
+    expect(output).not.toContain('skip.min.js')
+  })
+})
+
 interface ExpectedOutput {
   basePath: string
   concurrency: number

--- a/packages/base/src/commands/sourcemaps/__tests__/upload.test.ts
+++ b/packages/base/src/commands/sourcemaps/__tests__/upload.test.ts
@@ -439,6 +439,20 @@ describe('execute with --exclude', () => {
     expect(output).toContain('keep.min.js')
     expect(output).not.toContain('skip.min.js')
   })
+
+  // The legacy discovery path globs *.js.map directly (no sourceMappingURL comment),
+  // so the exclude must still be matched against the minified file it resolves to.
+  test('skips files matching the exclude glob in the legacy path', async () => {
+    const {context, code} = await runCLI([
+      './src/commands/sourcemaps/__tests__/fixtures/exclude-legacy',
+      '--exclude',
+      '**/skip.min.js',
+    ])
+    const output = context.stdout.toString()
+    expect(code).toBe(0)
+    expect(output).toContain('keep.min.js')
+    expect(output).not.toContain('skip.min.js')
+  })
 })
 
 interface ExpectedOutput {

--- a/packages/base/src/commands/sourcemaps/renderer.ts
+++ b/packages/base/src/commands/sourcemaps/renderer.ts
@@ -113,7 +113,8 @@ export const renderCommandInfo = (
   releaseVersion: string,
   service: string,
   poolLimit: number,
-  dryRun: boolean
+  dryRun: boolean,
+  globalRelease: boolean
 ) => {
   let fullStr = ''
   if (dryRun) {
@@ -128,9 +129,12 @@ export const renderCommandInfo = (
   )
   fullStr += minifiedPathPrefixStr
 
+  const versionStr = globalRelease
+    ? `${chalk.green('Version:')} ${chalk.cyan(releaseVersion)} ${chalk.dim('(global release)')}`
+    : `${chalk.green('Version:')} ${chalk.cyan(releaseVersion)}`
   const serviceVersionProjectPathStr =
     [
-      `${chalk.green('Version:')} ${chalk.cyan(releaseVersion)}`,
+      versionStr,
       `${chalk.green('Service:')} ${chalk.cyan(service)}`,
       `${chalk.green('Project path:')} ${projectPath !== undefined ? chalk.cyan(projectPath) : chalk.dim('<empty>')}`,
     ].join(' · ') + '\n\n'

--- a/packages/base/src/commands/sourcemaps/upload.ts
+++ b/packages/base/src/commands/sourcemaps/upload.ts
@@ -237,7 +237,7 @@ export class SourcemapsUploadCommand extends BaseCommand {
   // Looks for the sourcemaps and minified files on disk and returns
   // the associated payloads.
   private getMatchingSourcemapFiles = async (): Promise<Sourcemap[]> => {
-    const jsFiles = globSync(buildPath(this.basePath, '**/*.js'), {ignore: this.getExcludePattern()})
+    const jsFiles = globSync(buildPath(this.basePath, '**/*.js'))
 
     const sourcemaps = (
       await doWithMaxConcurrency(this.maxConcurrency, jsFiles, async (minifiedFilePath) => {
@@ -283,7 +283,7 @@ export class SourcemapsUploadCommand extends BaseCommand {
   // Looks for the sourcemaps and minified files on disk and returns
   // the associated payloads.
   private getLegacyMatchingSourcemapFiles = async (): Promise<Sourcemap[]> => {
-    const sourcemapFiles = globSync(buildPath(this.basePath, '**/*js.map'), {ignore: this.getExcludePattern()})
+    const sourcemapFiles = globSync(buildPath(this.basePath, '**/*js.map'))
 
     return Promise.all(
       sourcemapFiles.map(async (sourcemapPath) => {
@@ -295,10 +295,15 @@ export class SourcemapsUploadCommand extends BaseCommand {
     )
   }
 
-  // Builds the glob pattern of files to ignore, resolving the user-provided --exclude
-  // expression relative to the base path so it can be matched against collected file paths.
-  private getExcludePattern(): string | undefined {
-    return this.exclude ? buildPath(this.basePath, this.exclude) : undefined
+  // Resolves the user-provided --exclude glob (relative to the base path) to the set of
+  // minified file paths to skip, so they can be uploaded separately in another invocation.
+  // Matching is done on the minified file regardless of how the sourcemap was discovered.
+  private getExcludedMinifiedFiles(): Set<string> {
+    if (!this.exclude) {
+      return new Set()
+    }
+
+    return new Set(globSync(buildPath(this.basePath, this.exclude)))
   }
 
   private getMinifiedURLAndRelativePath(minifiedFilePath: string): [string, string] {
@@ -308,7 +313,10 @@ export class SourcemapsUploadCommand extends BaseCommand {
   }
 
   private getPayloadsToUpload = async (useGit: boolean): Promise<Sourcemap[]> => {
-    const payloads = await this.getMatchingSourcemapFiles()
+    const excludedMinifiedFiles = this.getExcludedMinifiedFiles()
+    const payloads = (await this.getMatchingSourcemapFiles()).filter(
+      (sourcemap) => !excludedMinifiedFiles.has(sourcemap.minifiedFilePath)
+    )
     if (!useGit) {
       return payloads
     }

--- a/packages/base/src/commands/sourcemaps/upload.ts
+++ b/packages/base/src/commands/sourcemaps/upload.ts
@@ -49,6 +49,10 @@ import {
 import {getMinifiedFilePath, readLastLine} from './utils'
 import {InvalidPayload, validatePayload} from './validation'
 
+// Sentinel version sent for version-less uploads. The backend recognizes this value
+// and stores the sourcemaps so they can be matched regardless of the RUM `version` tag.
+export const GLOBAL_VERSION = '__GLOBAL__'
+
 export class SourcemapsUploadCommand extends BaseCommand {
   public static paths = [['sourcemaps', 'upload']]
 
@@ -68,6 +72,10 @@ export class SourcemapsUploadCommand extends BaseCommand {
         'Upload all sourcemaps in /home/users/ci with 50 concurrent uploads',
         'datadog-ci sourcemaps upload /home/users/ci --service my-service --minified-path-prefix https://static.datadog.com --release-version 1.234 --max-concurrency 50',
       ],
+      [
+        'Upload version-less (global) sourcemaps, excluding non-hashed files',
+        'datadog-ci sourcemaps upload . --service my-service --minified-path-prefix https://static.datadog.com --global-release --exclude "**/main.js"',
+      ],
     ],
   })
 
@@ -75,6 +83,8 @@ export class SourcemapsUploadCommand extends BaseCommand {
   private disableGit = Option.Boolean('--disable-git')
   private quiet = Option.Boolean('--quiet', false)
   private dryRun = Option.Boolean('--dry-run', false)
+  private exclude = Option.String('--exclude')
+  private globalRelease = Option.Boolean('--global-release', false)
   private maxConcurrency = Option.String('--max-concurrency', '20', {validator: validation.isInteger()})
   private minifiedPathPrefix = Option.String('--minified-path-prefix')
   private projectPath = Option.String('--project-path')
@@ -100,10 +110,17 @@ export class SourcemapsUploadCommand extends BaseCommand {
   public async execute() {
     enableFips(this.fips || this.config.fips, this.fipsIgnoreError || this.config.fipsIgnoreError)
 
-    if (!this.releaseVersion) {
-      this.context.stderr.write('Missing release version\n')
+    if (this.releaseVersion && this.globalRelease) {
+      this.context.stderr.write('Cannot use both --release-version and --global-release\n')
 
       return 1
+    }
+
+    // A version-less upload (either --global-release or no --release-version) is sent with a
+    // sentinel version that the backend recognizes as a global release.
+    const isGlobalRelease = this.globalRelease || !this.releaseVersion
+    if (!this.releaseVersion) {
+      this.releaseVersion = GLOBAL_VERSION
     }
 
     if (!this.service) {
@@ -134,7 +151,8 @@ export class SourcemapsUploadCommand extends BaseCommand {
         this.releaseVersion,
         this.service,
         this.maxConcurrency,
-        this.dryRun
+        this.dryRun,
+        isGlobalRelease
       )
     )
     const metricsLogger = getMetricsLogger({
@@ -219,7 +237,7 @@ export class SourcemapsUploadCommand extends BaseCommand {
   // Looks for the sourcemaps and minified files on disk and returns
   // the associated payloads.
   private getMatchingSourcemapFiles = async (): Promise<Sourcemap[]> => {
-    const jsFiles = globSync(buildPath(this.basePath, '**/*.js'))
+    const jsFiles = globSync(buildPath(this.basePath, '**/*.js'), {ignore: this.getExcludePattern()})
 
     const sourcemaps = (
       await doWithMaxConcurrency(this.maxConcurrency, jsFiles, async (minifiedFilePath) => {
@@ -265,7 +283,7 @@ export class SourcemapsUploadCommand extends BaseCommand {
   // Looks for the sourcemaps and minified files on disk and returns
   // the associated payloads.
   private getLegacyMatchingSourcemapFiles = async (): Promise<Sourcemap[]> => {
-    const sourcemapFiles = globSync(buildPath(this.basePath, '**/*js.map'))
+    const sourcemapFiles = globSync(buildPath(this.basePath, '**/*js.map'), {ignore: this.getExcludePattern()})
 
     return Promise.all(
       sourcemapFiles.map(async (sourcemapPath) => {
@@ -275,6 +293,12 @@ export class SourcemapsUploadCommand extends BaseCommand {
         return new Sourcemap(minifiedFilePath, minifiedURL, sourcemapPath, relativePath, this.minifiedPathPrefix)
       })
     )
+  }
+
+  // Builds the glob pattern of files to ignore, resolving the user-provided --exclude
+  // expression relative to the base path so it can be matched against collected file paths.
+  private getExcludePattern(): string | undefined {
+    return this.exclude ? buildPath(this.basePath, this.exclude) : undefined
   }
 
   private getMinifiedURLAndRelativePath(minifiedFilePath: string): [string, string] {


### PR DESCRIPTION
### What and why?

Jira: [RUM-16533](https://datadoghq.atlassian.net/browse/RUM-16533) · GitHub: [#829](https://github.com/DataDog/datadog-ci/issues/829)

Micro-frontend apps and modern bundlers (content-hashed filenames) can't tie their sourcemaps to a single RUM `version`: each micro frontend releases independently, and per-version uploads duplicate huge numbers of files. Today `sourcemaps upload` **requires** `--release-version`, which makes this impossible.

This PR lets customers upload **version-less** sourcemaps that the backend matches regardless of the RUM `version` tag, plus an `--exclude` flag so builds mixing hashed and fixed filenames can be uploaded in separate invocations.

### How?

- **`--global-release`** (or simply omitting `--release-version`): sends a `__GLOBAL__` sentinel version that the backend recognizes as a global release. Passing both `--release-version` and `--global-release` is rejected. The command output shows `Version: __GLOBAL__ (global release)`.
- **`--exclude=<glob>`**: a glob (relative to the upload directory) of files to ignore. Resolved once to the set of minified files and applied as a filter on each collected sourcemap's minified file path, so exclusion behaves identically whether a sourcemap is discovered via a `sourceMappingURL` comment or the legacy `*.js.map` glob.
- README and command usage examples updated.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)

[RUM-16533]: https://datadoghq.atlassian.net/browse/RUM-16533?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ