### PR TITLE
Add config file support to deployment gate command

### DIFF
--- a/packages/base/src/commands/deployment/gate.ts
+++ b/packages/base/src/commands/deployment/gate.ts
@@ -75,8 +75,8 @@ export class DeploymentGateCommand extends BaseCommand {
     description:
       'When true, the script will consider the gate as failed when timeout is reached or unexpected errors occur calling the Datadog APIs',
   })
-  protected configFilePath = Option.String('--config-file', {
-    description: 'Path to a JSON file containing gate configuration',
+  protected configFilePath = Option.String('--config', {
+    description: 'Path to the configuration file',
     validator: t.isString(),
   })
   // monitorsQueryVariable is hidden because it's not available yet

--- a/packages/base/src/commands/deployment/gate.ts
+++ b/packages/base/src/commands/deployment/gate.ts
@@ -26,6 +26,10 @@ export class DeploymentGateCommand extends BaseCommand {
         'datadog-ci deployment gate --service payments-backend --env prod',
       ],
       [
+        'Evaluate a gate with inline rule definitions',
+        'datadog-ci deployment gate --service payments-backend --env prod --version 1.2.3 --config-file ./gate-config.json',
+      ],
+      [
         'Evaluate a deployment gate with custom timeout',
         'datadog-ci deployment gate --service payments-backend --env prod --timeout 7200',
       ],
@@ -70,6 +74,10 @@ export class DeploymentGateCommand extends BaseCommand {
   protected failOnError = Option.Boolean('--fail-on-error', false, {
     description:
       'When true, the script will consider the gate as failed when timeout is reached or unexpected errors occur calling the Datadog APIs',
+  })
+  protected configFilePath = Option.String('--config-file', {
+    description: 'Path to a JSON file containing gate configuration',
+    validator: t.isString(),
   })
   // monitorsQueryVariable is hidden because it's not available yet
   protected monitorsQueryVariable = Option.String('--monitors-query-variable', '', {

--- a/packages/base/src/commands/deployment/gate.ts
+++ b/packages/base/src/commands/deployment/gate.ts
@@ -27,7 +27,7 @@ export class DeploymentGateCommand extends BaseCommand {
       ],
       [
         'Evaluate a gate with inline rule definitions',
-        'datadog-ci deployment gate --service payments-backend --env prod --version 1.2.3 --config-file ./gate-config.json',
+        'datadog-ci deployment gate --service payments-backend --env prod --version 1.2.3 --config ./gate-config.json',
       ],
       [
         'Evaluate a deployment gate with custom timeout',

--- a/packages/plugin-deployment/README.md
+++ b/packages/plugin-deployment/README.md
@@ -88,7 +88,7 @@ datadog-ci deployment gate --service payments-backend --env prod
 - `--identifier` (default: `default`): Deployment Gate identifier. For example, `pre`.
 - `--version` (**required** if your gate has faulty deployment detection rules): Version that is being deployed. For example, `v1.0.3`.
 - `--apm-primary-tag`: APM primary tag (only for gates with faulty deployment detection rules). For example, `region:us-central-1`.
-- `--config-file`: Path to a JSON file containing gate configuration. When provided, rules are evaluated inline without requiring a pre-created gate in Datadog.
+- `--config`: Path to the configuration file. Use this file to define inline rules without requiring a pre-created gate in Datadog.
 - `--timeout` (default: 10800 = 3 hours): Maximum time to wait for the script execution in seconds. For example, `3600`.
 - `--fail-on-error` (default: `false`): When false, the script will consider the gate as passed and exit with code 0 when timeout is reached or unexpected errors occur. Otherwise it will consider the gate failed and exit with code 1.
 

--- a/packages/plugin-deployment/README.md
+++ b/packages/plugin-deployment/README.md
@@ -74,7 +74,7 @@ The command also automatically collects CI environment variables from the CI job
 The `gate` command evaluates a Deployment Gate and exits with code 0 if the gate passed or 1 if the gate failed. Refer to the [Deployment Gates documentation][4] for more details.
 
 ```bash
-datadog-ci deployment gate --service --env [--identifier] [--version] [--apm-primary-tag] [--timeout] [--fail-on-error]
+datadog-ci deployment gate --service --env [--identifier] [--version] [--apm-primary-tag] [--config-file] [--timeout] [--fail-on-error]
 ```
 
 For example:
@@ -88,6 +88,7 @@ datadog-ci deployment gate --service payments-backend --env prod
 - `--identifier` (default: `default`): Deployment Gate identifier. For example, `pre`.
 - `--version` (**required** if your gate has faulty deployment detection rules): Version that is being deployed. For example, `v1.0.3`.
 - `--apm-primary-tag`: APM primary tag (only for gates with faulty deployment detection rules). For example, `region:us-central-1`.
+- `--config-file`: Path to a JSON file containing gate configuration. When provided, rules are evaluated inline without requiring a pre-created gate in Datadog.
 - `--timeout` (default: 10800 = 3 hours): Maximum time to wait for the script execution in seconds. For example, `3600`.
 - `--fail-on-error` (default: `false`): When false, the script will consider the gate as passed and exit with code 0 when timeout is reached or unexpected errors occur. Otherwise it will consider the gate failed and exit with code 1.
 

--- a/packages/plugin-deployment/README.md
+++ b/packages/plugin-deployment/README.md
@@ -74,7 +74,7 @@ The command also automatically collects CI environment variables from the CI job
 The `gate` command evaluates a Deployment Gate and exits with code 0 if the gate passed or 1 if the gate failed. Refer to the [Deployment Gates documentation][4] for more details.
 
 ```bash
-datadog-ci deployment gate --service --env [--identifier] [--version] [--apm-primary-tag] [--config-file] [--timeout] [--fail-on-error]
+datadog-ci deployment gate --service --env [--identifier] [--version] [--apm-primary-tag] [--config] [--timeout] [--fail-on-error]
 ```
 
 For example:
@@ -88,11 +88,29 @@ datadog-ci deployment gate --service payments-backend --env prod
 - `--identifier` (default: `default`): Deployment Gate identifier. For example, `pre`.
 - `--version` (**required** if your gate has faulty deployment detection rules): Version that is being deployed. For example, `v1.0.3`.
 - `--apm-primary-tag`: APM primary tag (only for gates with faulty deployment detection rules). For example, `region:us-central-1`.
-- `--config`: Path to the configuration file. Use this file to define inline rules without requiring a pre-created gate in Datadog.
+- `--config`: Path to a JSON file containing gate configuration. Use this to define inline rules without requiring a pre-created gate in Datadog. Refer to the [setup documentation][5] for more details.
 - `--timeout` (default: 10800 = 3 hours): Maximum time to wait for the script execution in seconds. For example, `3600`.
 - `--fail-on-error` (default: `false`): When false, the script will consider the gate as passed and exit with code 0 when timeout is reached or unexpected errors occur. Otherwise it will consider the gate failed and exit with code 1.
 
 The command will exit with status 0 when the gate passes and status 1 otherwise.
+
+Example configuration file:
+
+```json
+{
+  "dryRun": false,
+  "rules": [
+    {
+      "type": "monitor",
+      "name": "error rate monitors",
+      "options": {
+        "query": "service:payments-backend env:prod",
+        "duration": 300
+      }
+    }
+  ]
+}
+```
 
 ### Environment variables
 
@@ -111,3 +129,4 @@ Additional helpful documentation, links, and articles:
 [2]: https://docs.datadoghq.com/continuous_delivery/
 [3]: https://docs.datadoghq.com/continuous_delivery/deployments/argocd#correlate-deployments-with-ci-pipelines
 [4]: https://docs.datadoghq.com/deployment_gates/
+[5]: https://docs.datadoghq.com/deployment_gates/setup

--- a/packages/plugin-deployment/README.md
+++ b/packages/plugin-deployment/README.md
@@ -129,4 +129,4 @@ Additional helpful documentation, links, and articles:
 [2]: https://docs.datadoghq.com/continuous_delivery/
 [3]: https://docs.datadoghq.com/continuous_delivery/deployments/argocd#correlate-deployments-with-ci-pipelines
 [4]: https://docs.datadoghq.com/deployment_gates/
-[5]: https://docs.datadoghq.com/deployment_gates/setup
+[5]: https://docs.datadoghq.com/api/latest/deployment-gates/trigger-a-deployment-gate-evaluation/

--- a/packages/plugin-deployment/README.md
+++ b/packages/plugin-deployment/README.md
@@ -129,4 +129,4 @@ Additional helpful documentation, links, and articles:
 [2]: https://docs.datadoghq.com/continuous_delivery/
 [3]: https://docs.datadoghq.com/continuous_delivery/deployments/argocd#correlate-deployments-with-ci-pipelines
 [4]: https://docs.datadoghq.com/deployment_gates/
-[5]: https://docs.datadoghq.com/api/latest/deployment-gates/trigger-a-deployment-gate-evaluation/
+[5]: https://docs.datadoghq.com/api/latest/deployment-gates/trigger-a-deployment-gate-evaluation

--- a/packages/plugin-deployment/src/__tests__/__snapshots__/gate.test.ts.snap
+++ b/packages/plugin-deployment/src/__tests__/__snapshots__/gate.test.ts.snap
@@ -9,6 +9,7 @@ exports[`gate execute evaluation errors on gate evaluation request should fail w
 
 Requesting gate evaluation...
 Request failed with error: 400 Bad Request
+invalid configuration: invalid rule at index 0: invalid rule type: moniyor
 Deployment gate evaluation failed due to a non-retryable error: Request failed with status code 400
 ❌ Request failed with client error, exiting with status 1
 "

--- a/packages/plugin-deployment/src/__tests__/fixtures/config-empty-rules.json
+++ b/packages/plugin-deployment/src/__tests__/fixtures/config-empty-rules.json
@@ -1,0 +1,4 @@
+{
+  "dry_run": false,
+  "rules": []
+}

--- a/packages/plugin-deployment/src/__tests__/fixtures/config-empty-rules.json
+++ b/packages/plugin-deployment/src/__tests__/fixtures/config-empty-rules.json
@@ -1,4 +1,4 @@
 {
-  "dry_run": false,
+  "dryRun": false,
   "rules": []
 }

--- a/packages/plugin-deployment/src/__tests__/fixtures/config-invalid-json.json
+++ b/packages/plugin-deployment/src/__tests__/fixtures/config-invalid-json.json
@@ -1,0 +1,1 @@
+{ invalid json

--- a/packages/plugin-deployment/src/__tests__/fixtures/config-valid.json
+++ b/packages/plugin-deployment/src/__tests__/fixtures/config-valid.json
@@ -1,5 +1,5 @@
 {
-  "dry_run": false,
+  "dryRun": false,
   "rules": [
     {
       "type": "monitor",

--- a/packages/plugin-deployment/src/__tests__/fixtures/config-valid.json
+++ b/packages/plugin-deployment/src/__tests__/fixtures/config-valid.json
@@ -1,0 +1,23 @@
+{
+  "dry_run": false,
+  "rules": [
+    {
+      "type": "monitor",
+      "name": "error rate monitors",
+      "dry_run": false,
+      "options": {
+        "query": "service:transaction-backend env:production",
+        "duration": 300
+      }
+    },
+    {
+      "type": "faulty_deployment_detection",
+      "name": "apm faulty deployment",
+      "dry_run": false,
+      "options": {
+        "duration": 900,
+        "excluded_resources": ["GET /healthcheck"]
+      }
+    }
+  ]
+}

--- a/packages/plugin-deployment/src/__tests__/fixtures/config-valid.json
+++ b/packages/plugin-deployment/src/__tests__/fixtures/config-valid.json
@@ -4,7 +4,7 @@
     {
       "type": "monitor",
       "name": "error rate monitors",
-      "dry_run": false,
+      "dryRun": false,
       "options": {
         "query": "service:transaction-backend env:production",
         "duration": 300
@@ -13,7 +13,7 @@
     {
       "type": "faulty_deployment_detection",
       "name": "apm faulty deployment",
-      "dry_run": false,
+      "dryRun": false,
       "options": {
         "duration": 900,
         "excluded_resources": ["GET /healthcheck"]

--- a/packages/plugin-deployment/src/__tests__/gate.test.ts
+++ b/packages/plugin-deployment/src/__tests__/gate.test.ts
@@ -649,11 +649,11 @@ describe('gate', () => {
       })
     })
 
-    test('should include configuration when gateConfiguration is set', () => {
+    test('should include configuration when configuration is set', () => {
       const command = createCommand(DeploymentGateCommand)
       command['service'] = 'test-service'
       command['env'] = 'prod'
-      command['gateConfiguration'] = {
+      command['configuration'] = {
         dryRun: false,
         rules: [
           {type: 'monitor', name: 'error rate check', dryRun: false, options: {query: 'service:foo', duration: 300}},

--- a/packages/plugin-deployment/src/__tests__/gate.test.ts
+++ b/packages/plugin-deployment/src/__tests__/gate.test.ts
@@ -102,7 +102,7 @@ describe('gate', () => {
           'test-service',
           '--env',
           'prod',
-          '--config-file',
+          '--config',
           '/nonexistent/path/gate-config.json',
         ])
         expect(code).toBe(1)
@@ -115,7 +115,7 @@ describe('gate', () => {
           'test-service',
           '--env',
           'prod',
-          '--config-file',
+          '--config',
           `${fixturesPath}/config-invalid-json.json`,
         ])
         expect(code).toBe(1)
@@ -128,7 +128,7 @@ describe('gate', () => {
           'test-service',
           '--env',
           'prod',
-          '--config-file',
+          '--config',
           `${fixturesPath}/config-empty-rules.json`,
         ])
         expect(code).toBe(1)
@@ -219,7 +219,7 @@ describe('gate', () => {
           'test-service',
           '--env',
           'prod',
-          '--config-file',
+          '--config',
           `${fixturesPath}/config-valid.json`,
         ])
 
@@ -228,7 +228,7 @@ describe('gate', () => {
           service: 'test-service',
           env: 'prod',
           configuration: {
-            dry_run: false,
+            dryRun: false,
             rules: [
               {
                 type: 'monitor',
@@ -654,7 +654,7 @@ describe('gate', () => {
       command['service'] = 'test-service'
       command['env'] = 'prod'
       command['gateConfiguration'] = {
-        dry_run: false,
+        dryRun: false,
         rules: [{type: 'monitor', name: 'error rate check', options: {query: 'service:foo', duration: 300}}],
       }
 
@@ -663,7 +663,7 @@ describe('gate', () => {
         service: 'test-service',
         env: 'prod',
         configuration: {
-          dry_run: false,
+          dryRun: false,
           rules: [{type: 'monitor', name: 'error rate check', options: {query: 'service:foo', duration: 300}}],
         },
       })

--- a/packages/plugin-deployment/src/__tests__/gate.test.ts
+++ b/packages/plugin-deployment/src/__tests__/gate.test.ts
@@ -233,13 +233,13 @@ describe('gate', () => {
               {
                 type: 'monitor',
                 name: 'error rate monitors',
-                dry_run: false,
+                dryRun: false,
                 options: {query: 'service:transaction-backend env:production', duration: 300},
               },
               {
                 type: 'faulty_deployment_detection',
                 name: 'apm faulty deployment',
-                dry_run: false,
+                dryRun: false,
                 options: {duration: 900, excluded_resources: ['GET /healthcheck']},
               },
             ],
@@ -655,7 +655,9 @@ describe('gate', () => {
       command['env'] = 'prod'
       command['gateConfiguration'] = {
         dryRun: false,
-        rules: [{type: 'monitor', name: 'error rate check', options: {query: 'service:foo', duration: 300}}],
+        rules: [
+          {type: 'monitor', name: 'error rate check', dryRun: false, options: {query: 'service:foo', duration: 300}},
+        ],
       }
 
       const request = command['buildEvaluationRequest']()
@@ -664,7 +666,9 @@ describe('gate', () => {
         env: 'prod',
         configuration: {
           dryRun: false,
-          rules: [{type: 'monitor', name: 'error rate check', options: {query: 'service:foo', duration: 300}}],
+          rules: [
+            {type: 'monitor', name: 'error rate check', dryRun: false, options: {query: 'service:foo', duration: 300}},
+          ],
         },
       })
     })

--- a/packages/plugin-deployment/src/__tests__/gate.test.ts
+++ b/packages/plugin-deployment/src/__tests__/gate.test.ts
@@ -295,6 +295,15 @@ describe('gate', () => {
             response: {
               status: 400,
               statusText: 'Bad Request',
+              data: {
+                errors: [
+                  {
+                    status: '400',
+                    title: 'Bad Request',
+                    detail: 'invalid configuration: invalid rule at index 0: invalid rule type: moniyor',
+                  },
+                ],
+              },
             },
           })
           const mockApi = {

--- a/packages/plugin-deployment/src/__tests__/gate.test.ts
+++ b/packages/plugin-deployment/src/__tests__/gate.test.ts
@@ -3,6 +3,8 @@ import {createCommand, makeRunCLI} from '@datadog/datadog-ci-base/helpers/__test
 import * as apiModule from '../api'
 import {PluginCommand as DeploymentGateCommand} from '../commands/gate'
 
+const fixturesPath = `${__dirname}/fixtures`
+
 const buildEvaluationRequestResponse = (evaluationId: string) => ({
   data: {
     data: {
@@ -93,6 +95,45 @@ describe('gate', () => {
         expect(code).toBe(1)
         expect(context.stdout.toString()).toContain('Invalid --timeout value. Must be a positive integer.')
       })
+
+      test('should fail if config file does not exist', async () => {
+        const {context, code} = await runCLI([
+          '--service',
+          'test-service',
+          '--env',
+          'prod',
+          '--config-file',
+          '/nonexistent/path/gate-config.json',
+        ])
+        expect(code).toBe(1)
+        expect(context.stdout.toString()).toContain('Config file not found')
+      })
+
+      test('should fail if config file contains invalid JSON', async () => {
+        const {context, code} = await runCLI([
+          '--service',
+          'test-service',
+          '--env',
+          'prod',
+          '--config-file',
+          `${fixturesPath}/config-invalid-json.json`,
+        ])
+        expect(code).toBe(1)
+        expect(context.stdout.toString()).toContain('Failed to parse config file as JSON')
+      })
+
+      test('should fail if config file has empty rules array', async () => {
+        const {context, code} = await runCLI([
+          '--service',
+          'test-service',
+          '--env',
+          'prod',
+          '--config-file',
+          `${fixturesPath}/config-empty-rules.json`,
+        ])
+        expect(code).toBe(1)
+        expect(context.stdout.toString()).toContain('Config file must contain a non-empty')
+      })
     })
 
     describe('successful evaluation', () => {
@@ -164,6 +205,46 @@ describe('gate', () => {
         expect(mockApi.requestGateEvaluation).toHaveBeenCalledWith({service: 'test-service', env: 'prod'})
         expect(mockApi.getGateEvaluationResult).toHaveBeenCalledTimes(1)
         expect(mockApi.getGateEvaluationResult).toHaveBeenCalledWith('test-evaluation-id')
+      })
+
+      test('should pass configuration to the API when config file is provided', async () => {
+        const mockApi = {
+          requestGateEvaluation: jest.fn().mockResolvedValue(buildEvaluationRequestResponse('test-evaluation-id')),
+          getGateEvaluationResult: jest.fn().mockResolvedValue(buildGateEvaluationResultResponse('pass')),
+        }
+        jest.spyOn(apiModule, 'apiConstructor').mockReturnValue(mockApi)
+
+        const {code} = await runCLI([
+          '--service',
+          'test-service',
+          '--env',
+          'prod',
+          '--config-file',
+          `${fixturesPath}/config-valid.json`,
+        ])
+
+        expect(code).toBe(0)
+        expect(mockApi.requestGateEvaluation).toHaveBeenCalledWith({
+          service: 'test-service',
+          env: 'prod',
+          configuration: {
+            dry_run: false,
+            rules: [
+              {
+                type: 'monitor',
+                name: 'error rate monitors',
+                dry_run: false,
+                options: {query: 'service:transaction-backend env:production', duration: 300},
+              },
+              {
+                type: 'faulty_deployment_detection',
+                name: 'apm faulty deployment',
+                dry_run: false,
+                options: {duration: 900, excluded_resources: ['GET /healthcheck']},
+              },
+            ],
+          },
+        })
       })
 
       test('should succeed when requests fail but succeed on retry', async () => {
@@ -565,6 +646,26 @@ describe('gate', () => {
         version: '1.2.3',
         apm_primary_tag: 'team:backend',
         monitors_query_variable: 'test-monitors-query-variable',
+      })
+    })
+
+    test('should include configuration when gateConfiguration is set', () => {
+      const command = createCommand(DeploymentGateCommand)
+      command['service'] = 'test-service'
+      command['env'] = 'prod'
+      command['gateConfiguration'] = {
+        dry_run: false,
+        rules: [{type: 'monitor', name: 'error rate check', options: {query: 'service:foo', duration: 300}}],
+      }
+
+      const request = command['buildEvaluationRequest']()
+      expect(request).toEqual({
+        service: 'test-service',
+        env: 'prod',
+        configuration: {
+          dry_run: false,
+          rules: [{type: 'monitor', name: 'error rate check', options: {query: 'service:foo', duration: 300}}],
+        },
       })
     })
   })

--- a/packages/plugin-deployment/src/api.ts
+++ b/packages/plugin-deployment/src/api.ts
@@ -24,6 +24,7 @@ const requestGateEvaluation =
           ...(evaluationRequest.monitors_query_variable && {
             monitors_query_variable: evaluationRequest.monitors_query_variable,
           }),
+          ...(evaluationRequest.configuration && {configuration: evaluationRequest.configuration}),
         },
       },
     }

--- a/packages/plugin-deployment/src/api.ts
+++ b/packages/plugin-deployment/src/api.ts
@@ -1,5 +1,6 @@
 import type {
   APIHelper,
+  Configuration,
   GateEvaluationRequest,
   GateEvaluationRequestResponse,
   GateEvaluationStatusResponse,
@@ -8,6 +9,16 @@ import type {RequestConfig, RequestResponse} from '@datadog/datadog-ci-base/help
 
 import {datadogRoute} from '@datadog/datadog-ci-base/helpers/request/datadog-route'
 import {getRequestBuilder} from '@datadog/datadog-ci-base/helpers/utils'
+
+const toApiConfiguration = (config: Configuration) => ({
+  ...(config.dryRun !== undefined && {dry_run: config.dryRun}),
+  rules: config.rules.map((rule) => ({
+    type: rule.type,
+    name: rule.name,
+    ...(rule.dryRun !== undefined && {dry_run: rule.dryRun}),
+    ...(rule.options && {options: rule.options}),
+  })),
+})
 
 const requestGateEvaluation =
   (request: (args: RequestConfig) => Promise<RequestResponse<GateEvaluationRequestResponse>>) =>
@@ -24,7 +35,7 @@ const requestGateEvaluation =
           ...(evaluationRequest.monitors_query_variable && {
             monitors_query_variable: evaluationRequest.monitors_query_variable,
           }),
-          ...(evaluationRequest.configuration && {configuration: evaluationRequest.configuration}),
+          ...(evaluationRequest.configuration && {configuration: toApiConfiguration(evaluationRequest.configuration)}),
         },
       },
     }

--- a/packages/plugin-deployment/src/commands/gate.ts
+++ b/packages/plugin-deployment/src/commands/gate.ts
@@ -175,18 +175,14 @@ export class PluginCommand extends DeploymentGateCommand {
     try {
       parsedConfig = JSON.parse(fs.readFileSync(configFilePath, 'utf-8'))
     } catch {
-      this.logger.error(
-        chalk.red(`${ICONS.FAILED} Failed to parse config file as JSON: ${chalk.bold(configFilePath)}`)
-      )
+      this.logger.error(chalk.red(`${ICONS.FAILED} Failed to parse config file as JSON: ${chalk.bold(configFilePath)}`))
 
       return undefined
     }
 
     const config = parsedConfig as Configuration
     if (!Array.isArray(config.rules) || config.rules.length === 0) {
-      this.logger.error(
-        chalk.red(`${ICONS.FAILED} Config file must contain a non-empty ${chalk.bold('rules')} array`)
-      )
+      this.logger.error(chalk.red(`${ICONS.FAILED} Config file must contain a non-empty ${chalk.bold('rules')} array`))
 
       return undefined
     }

--- a/packages/plugin-deployment/src/commands/gate.ts
+++ b/packages/plugin-deployment/src/commands/gate.ts
@@ -1,4 +1,6 @@
-import type {APIHelper, GateEvaluationRequest, GateEvaluationStatusResponse} from '../interfaces'
+import fs from 'fs'
+
+import type {APIHelper, Configuration, GateEvaluationRequest, GateEvaluationStatusResponse} from '../interfaces'
 
 import {DeploymentGateCommand} from '@datadog/datadog-ci-base/commands/deployment/gate'
 import {FIPS_ENV_VAR, FIPS_IGNORE_ERROR_ENV_VAR} from '@datadog/datadog-ci-base/constants'
@@ -28,6 +30,7 @@ export class PluginCommand extends DeploymentGateCommand {
   private evaluationRequestTimeout = 60000 // 1 minute
   private pollingInterval = 15000 // 15 seconds
   private startTime: number = Date.now()
+  private gateConfiguration: Configuration | undefined
 
   public async execute() {
     enableFips(this.fips || this.config.fips, this.fipsIgnoreError || this.config.fipsIgnoreError)
@@ -74,6 +77,15 @@ export class PluginCommand extends DeploymentGateCommand {
       return 1
     }
 
+    if (this.configFilePath) {
+      const config = this.loadGateConfiguration(this.configFilePath)
+      if (!config) {
+        return 1
+      }
+
+      this.gateConfiguration = config
+    }
+
     this.logger.info('Starting deployment gate evaluation with parameters:')
     this.logger.info(`\tService: ${this.service}`)
     this.logger.info(`\tEnvironment: ${this.env}`)
@@ -85,6 +97,9 @@ export class PluginCommand extends DeploymentGateCommand {
     }
     if (this.apmPrimaryTag) {
       this.logger.info(`\tAPM Primary Tag: ${this.apmPrimaryTag}`)
+    }
+    if (this.gateConfiguration) {
+      this.logger.info(`\tGate configuration: ${this.gateConfiguration.rules.length} rules`)
     }
     this.logger.info(`\tTimeout: ${timeoutSeconds} seconds`)
     this.logger.info(`\tFail on error: ${this.failOnError ? 'true' : 'false'}\n`)
@@ -142,7 +157,41 @@ export class PluginCommand extends DeploymentGateCommand {
       request.monitors_query_variable = this.monitorsQueryVariable
     }
 
+    if (this.gateConfiguration) {
+      request.configuration = this.gateConfiguration
+    }
+
     return request
+  }
+
+  private loadGateConfiguration(configFilePath: string): Configuration | undefined {
+    if (!fs.existsSync(configFilePath)) {
+      this.logger.error(chalk.red(`${ICONS.FAILED} Config file not found: ${chalk.bold(configFilePath)}`))
+
+      return undefined
+    }
+
+    let parsedConfig: unknown
+    try {
+      parsedConfig = JSON.parse(fs.readFileSync(configFilePath, 'utf-8'))
+    } catch {
+      this.logger.error(
+        chalk.red(`${ICONS.FAILED} Failed to parse config file as JSON: ${chalk.bold(configFilePath)}`)
+      )
+
+      return undefined
+    }
+
+    const config = parsedConfig as Configuration
+    if (!Array.isArray(config.rules) || config.rules.length === 0) {
+      this.logger.error(
+        chalk.red(`${ICONS.FAILED} Config file must contain a non-empty ${chalk.bold('rules')} array`)
+      )
+
+      return undefined
+    }
+
+    return config
   }
 
   private async requestGateEvaluation(

--- a/packages/plugin-deployment/src/commands/gate.ts
+++ b/packages/plugin-deployment/src/commands/gate.ts
@@ -30,7 +30,7 @@ export class PluginCommand extends DeploymentGateCommand {
   private evaluationRequestTimeout = 60000 // 1 minute
   private pollingInterval = 15000 // 15 seconds
   private startTime: number = Date.now()
-  private gateConfiguration: Configuration | undefined
+  private configuration: Configuration | undefined
 
   public async execute() {
     enableFips(this.fips || this.config.fips, this.fipsIgnoreError || this.config.fipsIgnoreError)
@@ -83,7 +83,7 @@ export class PluginCommand extends DeploymentGateCommand {
         return 1
       }
 
-      this.gateConfiguration = config
+      this.configuration = config
     }
 
     this.logger.info('Starting deployment gate evaluation with parameters:')
@@ -98,8 +98,8 @@ export class PluginCommand extends DeploymentGateCommand {
     if (this.apmPrimaryTag) {
       this.logger.info(`\tAPM Primary Tag: ${this.apmPrimaryTag}`)
     }
-    if (this.gateConfiguration) {
-      this.logger.info(`\tGate configuration: ${this.gateConfiguration.rules.length} rules`)
+    if (this.configuration) {
+      this.logger.info(`\tGate configuration: ${this.configuration.rules.length} rules`)
     }
     this.logger.info(`\tTimeout: ${timeoutSeconds} seconds`)
     this.logger.info(`\tFail on error: ${this.failOnError ? 'true' : 'false'}\n`)
@@ -157,8 +157,8 @@ export class PluginCommand extends DeploymentGateCommand {
       request.monitors_query_variable = this.monitorsQueryVariable
     }
 
-    if (this.gateConfiguration) {
-      request.configuration = this.gateConfiguration
+    if (this.configuration) {
+      request.configuration = this.configuration
     }
 
     return request

--- a/packages/plugin-deployment/src/commands/gate.ts
+++ b/packages/plugin-deployment/src/commands/gate.ts
@@ -207,6 +207,10 @@ export class PluginCommand extends DeploymentGateCommand {
       } catch (error) {
         if (isRequestError(error) && error.response?.status) {
           this.logger.error(`Request failed with error: ${error.response.status} ${error.response.statusText}`)
+          const details: string[] = error.response.data?.errors?.map((e: {detail?: string}) => e.detail).filter(Boolean)
+          if (details?.length) {
+            details.forEach((detail) => this.logger.error(detail))
+          }
         } else {
           const errorMessage = error instanceof Error ? error.message : String(error)
           this.logger.error(`Could not start gate evaluation with unknown error: ${errorMessage}`)

--- a/packages/plugin-deployment/src/interfaces.ts
+++ b/packages/plugin-deployment/src/interfaces.ts
@@ -8,7 +8,7 @@ export interface Rule {
 }
 
 export interface Configuration {
-  dry_run?: boolean
+  dryRun?: boolean
   rules: Rule[]
 }
 

--- a/packages/plugin-deployment/src/interfaces.ts
+++ b/packages/plugin-deployment/src/interfaces.ts
@@ -1,5 +1,17 @@
 import type {RequestResponse} from '@datadog/datadog-ci-base/helpers/request'
 
+export interface Rule {
+  type: string
+  name: string
+  dry_run?: boolean
+  options?: Record<string, unknown>
+}
+
+export interface Configuration {
+  dry_run?: boolean
+  rules: Rule[]
+}
+
 export interface GateEvaluationRequest {
   service: string
   env: string
@@ -7,6 +19,7 @@ export interface GateEvaluationRequest {
   version?: string
   apm_primary_tag?: string
   monitors_query_variable?: string
+  configuration?: Configuration
 }
 
 export interface GateEvaluationRequestResponse {

--- a/packages/plugin-deployment/src/interfaces.ts
+++ b/packages/plugin-deployment/src/interfaces.ts
@@ -3,7 +3,7 @@ import type {RequestResponse} from '@datadog/datadog-ci-base/helpers/request'
 export interface Rule {
   type: string
   name: string
-  dry_run?: boolean
+  dryRun?: boolean
   options?: Record<string, unknown>
 }
 


### PR DESCRIPTION
The deployment gate command only supports pre-created gates, where rules must be configured in Datadog ahead of time. This PR adds a `--config-file` option that accepts a path to a JSON file containing inline rule definitions, allowing gates to be evaluated without requiring any prior setup in Datadog.

Passing configuration via a JSON file is the standard pattern in this CLI for structured input (used by synthetics, SBOM, and others) — it avoids shell escaping of complex nested objects and keeps deployment config readable alongside the code.

When provided, the parsed configuration is included in the evaluation request. The command validates that the file exists, is valid JSON, and contains a non-empty `rules` array before proceeding.