### PR TITLE
[SVLS-9256] auto-mark dd env sticky on slot instrumentation

### DIFF
--- a/packages/plugin-aas/src/__tests__/__snapshots__/instrument.test.ts.snap
+++ b/packages/plugin-aas/src/__tests__/__snapshots__/instrument.test.ts.snap
@@ -105,6 +105,7 @@ Creating sidecar container datadog-sidecar on my-web-app (slot: staging)
 Updating Application Settings for my-web-app (slot: staging)
 Updating tags for my-web-app (slot: staging)
 Restarting Web App my-web-app (slot: staging)
+Registering DD_ENV as sticky slot setting(s) on my-web-app
 🐶 Instrumentation completed successfully!
 "
 `;

--- a/packages/plugin-aas/src/__tests__/instrument.test.ts
+++ b/packages/plugin-aas/src/__tests__/instrument.test.ts
@@ -45,6 +45,8 @@ const webAppsOperations = {
   stopSlot: jest.fn(),
   startSlot: jest.fn(),
   restartSlot: jest.fn(),
+  listSlotConfigurationNames: jest.fn(),
+  updateSlotConfigurationNames: jest.fn(),
 }
 
 const updateTags = jest.fn().mockResolvedValue({})
@@ -121,6 +123,8 @@ describe('aas instrument', () => {
       webAppsOperations.stopSlot.mockReset().mockResolvedValue({})
       webAppsOperations.startSlot.mockReset().mockResolvedValue({})
       webAppsOperations.restartSlot.mockReset().mockResolvedValue({})
+      webAppsOperations.listSlotConfigurationNames.mockReset().mockResolvedValue({appSettingNames: []})
+      webAppsOperations.updateSlotConfigurationNames.mockReset().mockResolvedValue({})
       updateTags.mockClear().mockResolvedValue({})
       createAzureResource.mockClear().mockResolvedValue({})
       validateApiKey.mockClear().mockResolvedValue(true)
@@ -821,7 +825,7 @@ describe('aas instrument', () => {
 
     test('Instruments a sidecar on a slot', async () => {
       webAppsOperations.getSlot.mockClear().mockResolvedValue(CONTAINER_WEB_APP)
-      const {code, context} = await runCLI(SLOT_INSTRUMENT_ARGS)
+      const {code, context} = await runCLI([...SLOT_INSTRUMENT_ARGS, '--env', 'staging'])
       expect(code).toEqual(0)
       expect(context.stdout.toString()).toMatchSnapshot()
       expect(getToken).toHaveBeenCalled()
@@ -861,6 +865,7 @@ describe('aas instrument', () => {
         {
           properties: {
             DD_AAS_INSTANCE_LOGGING_ENABLED: 'false',
+            DD_ENV: 'staging',
             DD_SERVICE: 'my-web-app',
             DD_API_KEY: 'PLACEHOLDER',
             DD_SITE: 'datadoghq.com',
@@ -869,9 +874,63 @@ describe('aas instrument', () => {
         }
       )
       expect(updateTags).toHaveBeenCalledWith(WEB_APP_SLOT_ID, {
-        properties: {tags: {service: 'my-web-app', dd_sls_ci: 'vXXXX'}},
+        properties: {tags: {service: 'my-web-app', env: 'staging', dd_sls_ci: 'vXXXX'}},
+      })
+      expect(webAppsOperations.listSlotConfigurationNames).toHaveBeenCalledWith('my-resource-group', 'my-web-app')
+      expect(webAppsOperations.updateSlotConfigurationNames).toHaveBeenCalledWith('my-resource-group', 'my-web-app', {
+        appSettingNames: ['DD_ENV'],
       })
       expect(webAppsOperations.restartSlot).toHaveBeenCalledWith('my-resource-group', 'my-web-app', 'staging')
+    })
+
+    test('Does not update slot config names if DD_ENV is already sticky', async () => {
+      webAppsOperations.listSlotConfigurationNames.mockReset().mockResolvedValue({appSettingNames: ['DD_ENV']})
+      const {code} = await runCLI([...SLOT_INSTRUMENT_ARGS, '--env', 'staging'])
+      expect(code).toEqual(0)
+      expect(webAppsOperations.listSlotConfigurationNames).toHaveBeenCalledWith('my-resource-group', 'my-web-app')
+      expect(webAppsOperations.updateSlotConfigurationNames).not.toHaveBeenCalled()
+    })
+
+    test('Does not mark DD_ENV sticky for non-slot instrumentation', async () => {
+      const {code} = await runCLI(DEFAULT_INSTRUMENT_ARGS)
+      expect(code).toEqual(0)
+      expect(webAppsOperations.listSlotConfigurationNames).not.toHaveBeenCalled()
+    })
+
+    test('Does not mark DD_ENV sticky when --env is not set', async () => {
+      const {code} = await runCLI(SLOT_INSTRUMENT_ARGS)
+      expect(code).toEqual(0)
+      expect(webAppsOperations.listSlotConfigurationNames).not.toHaveBeenCalled()
+    })
+
+    test('Does not update slot config names in dry run', async () => {
+      const {code} = await runCLI([...SLOT_INSTRUMENT_ARGS, '--env', 'staging', '--dry-run'])
+      expect(code).toEqual(0)
+      expect(webAppsOperations.listSlotConfigurationNames).toHaveBeenCalledWith('my-resource-group', 'my-web-app')
+      expect(webAppsOperations.updateSlotConfigurationNames).not.toHaveBeenCalled()
+    })
+
+    test('Registers DD_ENV sticky once when instrumenting multiple slots of the same site', async () => {
+      const {code} = await runCLI([
+        '-r',
+        WEB_APP_ID,
+        '-r',
+        WEB_APP_SLOT_ID,
+        '-r',
+        WEB_APP_ID + '/slots/staging2',
+        '--env',
+        'staging',
+        '--no-source-code-integration',
+      ])
+      expect(code).toEqual(0)
+      // slotConfigNames is site-level, so we read and write it once for the whole
+      // site even though two slots were instrumented -- no concurrent 409 race.
+      expect(webAppsOperations.listSlotConfigurationNames).toHaveBeenCalledTimes(1)
+      expect(webAppsOperations.listSlotConfigurationNames).toHaveBeenCalledWith('my-resource-group', 'my-web-app')
+      expect(webAppsOperations.updateSlotConfigurationNames).toHaveBeenCalledTimes(1)
+      expect(webAppsOperations.updateSlotConfigurationNames).toHaveBeenCalledWith('my-resource-group', 'my-web-app', {
+        appSettingNames: ['DD_ENV'],
+      })
     })
 
     test('Installs Windows extension on a slot', async () => {

--- a/packages/plugin-aas/src/commands/instrument.ts
+++ b/packages/plugin-aas/src/commands/instrument.ts
@@ -11,7 +11,6 @@ import {
   WINDOWS_RUNTIME_EXTENSIONS,
 } from '@datadog/datadog-ci-base/commands/aas/common'
 import {AasInstrumentCommand} from '@datadog/datadog-ci-base/commands/aas/instrument'
-import {DATADOG_SITE_US1} from '@datadog/datadog-ci-base/constants'
 import {getDatadogSite} from '@datadog/datadog-ci-base/helpers/api'
 import {newApiKeyValidator} from '@datadog/datadog-ci-base/helpers/apikey'
 import {renderError, renderSoftWarning} from '@datadog/datadog-ci-base/helpers/renderer'
@@ -27,7 +26,43 @@ import {SERVERLESS_CLI_VERSION_TAG_NAME, SERVERLESS_CLI_VERSION_TAG_VALUE} from 
 import {maskString} from '@datadog/datadog-ci-base/helpers/utils'
 import chalk from 'chalk'
 
-import {getWindowsRuntime, getEnvVars, isDotnet, isLinuxContainer, isWindows} from '../common'
+import {
+  aggregateStickyBySite,
+  getWindowsRuntime,
+  getEnvVars,
+  isDotnet,
+  isLinuxContainer,
+  isWindows,
+  registerStickySlotSettings,
+  type StickySlotSettings,
+} from '../common'
+
+interface ProcessResult {
+  success: boolean
+  // Sticky slot settings this resource needs registered on its parent site.
+  // Aggregated per-site and written once, since slotConfigNames is site-level.
+  sticky?: StickySlotSettings
+}
+
+/**
+ * Sticky slot settings a resource needs registered on its parent site. Includes
+ * DD_ENV when --env is set. Undefined when not targeting a slot.
+ */
+const stickySettingsFor = (
+  resourceGroup: string,
+  webApp: WebApp,
+  config: AasConfigOptions
+): StickySlotSettings | undefined => {
+  if (!webApp.slot) {
+    return undefined
+  }
+  const names: string[] = []
+  if (config.environment) {
+    names.push('DD_ENV')
+  }
+
+  return names.length ? {resourceGroup, webAppName: webApp.name, names} : undefined
+}
 
 export class PluginCommand extends AasInstrumentCommand {
   private cred!: DefaultAzureCredential
@@ -106,7 +141,19 @@ export class PluginCommand extends AasInstrumentCommand {
       )
     )
 
-    return results.every((result) => result)
+    // Register sticky settings once per site (slotConfigNames is site-level) to avoid
+    // concurrent read-modify-writes racing when multiple slots of one app are instrumented.
+    await Promise.all(
+      aggregateStickyBySite(results.map((result) => result.sticky)).map(({resourceGroup, webAppName, names}) =>
+        registerStickySlotSettings(aasClient, resourceGroup, webAppName, names, {
+          dryRun: this.dryRun,
+          dryRunPrefix: this.dryRunPrefix,
+          log: (message) => this.context.stdout.write(message),
+        })
+      )
+    )
+
+    return results.every((result) => result.success)
   }
 
   /**
@@ -118,9 +165,12 @@ export class PluginCommand extends AasInstrumentCommand {
     config: AasConfigOptions,
     resourceGroup: string,
     webApp: WebApp
-  ): Promise<boolean> {
+  ): Promise<ProcessResult> {
     // make config a copy with the default service added
     config = {...config, service: config.service ?? webApp.name}
+    // Sticky slot settings this resource needs on its parent site (none unless a
+    // slot). Reported back so processSubscription can register them once per site.
+    const sticky = stickySettingsFor(resourceGroup, webApp, config)
     try {
       const [site, envVarDictionary] = await Promise.all(
         webApp.slot
@@ -146,12 +196,13 @@ export class PluginCommand extends AasInstrumentCommand {
             )
           )
 
-          return false
+          return {success: false}
         }
         await this.instrumentExtension(aasClient, config, resourceGroup, webApp, runtime, existingEnvVars)
+        // we explicitly tag after instrumentation so we don't get a positive telemetry signal until it succeeds
         await this.addTags(config, aasClient.subscriptionId!, resourceGroup, webApp, site.tags ?? {})
 
-        return true
+        return {success: true, sticky}
       }
 
       // Linux instrumentation via sidecar
@@ -167,11 +218,12 @@ This flag is only applicable for containerized .NET apps (on musl-based distribu
       config.isDotnet ||= isDotnet(site)
       config.isMusl &&= config.isDotnet && isContainer
       await this.instrumentSidecar(aasClient, config, resourceGroup, webApp, isContainer, existingEnvVars)
+      // we explicitly tag after instrumentation so we don't get a positive telemetry signal until it succeeds
       await this.addTags(config, aasClient.subscriptionId!, resourceGroup, webApp, site.tags ?? {})
     } catch (error) {
       this.context.stdout.write(renderError(`Failed to instrument ${renderWebApp(webApp)}: ${formatError(error)}`))
 
-      return false
+      return {success: false}
     }
 
     if (!config.shouldNotRestart) {
@@ -184,12 +236,12 @@ This flag is only applicable for containerized .NET apps (on musl-based distribu
         } catch (error) {
           this.context.stdout.write(renderError(`Failed to restart Web App ${renderWebApp(webApp)}: ${error}`))
 
-          return false
+          return {success: false}
         }
       }
     }
 
-    return true
+    return {success: true, sticky}
   }
 
   public async addTags(

--- a/packages/plugin-aas/src/common.ts
+++ b/packages/plugin-aas/src/common.ts
@@ -1,7 +1,8 @@
-import type {Site} from '@azure/arm-appservice'
+import type {Site, SlotConfigNamesResource, WebSiteManagementClient} from '@azure/arm-appservice'
 import type {AasConfigOptions, WindowsRuntime} from '@datadog/datadog-ci-base/commands/aas/common'
 
 import {getBaseEnvVars} from '@datadog/datadog-ci-base/helpers/serverless/common'
+import chalk from 'chalk'
 
 // Path to tracing libraries, copied within the Docker file
 const DD_DOTNET_TRACER_HOME_CODE = '/home/site/wwwroot/datadog'
@@ -106,4 +107,59 @@ export const isLinuxContainer = (site: Site): boolean => {
   return (
     linuxFxVersion === 'sitecontainers' || linuxFxVersion.startsWith('docker|') || linuxFxVersion.startsWith('compose|')
   )
+}
+
+/** Sticky slot settings (in slotConfigNames) to apply to a site. */
+export interface StickySlotSettings {
+  resourceGroup: string
+  webAppName: string
+  names: string[]
+}
+
+/**
+ * Collapse per-resource sticky settings into one entry per site, unioning their names.
+ * slotConfigNames is a single site-level resource shared by all of a site's slots, so
+ * each site must be touched with a single read-modify-write rather than once per slot.
+ */
+export const aggregateStickyBySite = (entries: (StickySlotSettings | undefined)[]): StickySlotSettings[] => {
+  const bySite = new Map<string, StickySlotSettings>()
+  for (const entry of entries) {
+    if (!entry?.names.length) {
+      continue
+    }
+    const key = entry.webAppName
+    const merged = bySite.get(key) ?? {resourceGroup: entry.resourceGroup, webAppName: entry.webAppName, names: []}
+    merged.names = [...new Set([...merged.names, ...entry.names])]
+    bySite.set(key, merged)
+  }
+
+  return [...bySite.values()]
+}
+
+/**
+ * Register the given app settings as sticky (in slotConfigNames) so they stay with their
+ * slot across a swap, with a single read-modify-write. No-op when nothing changes.
+ */
+export const registerStickySlotSettings = async (
+  client: WebSiteManagementClient,
+  resourceGroup: string,
+  webAppName: string,
+  names: string[],
+  opts: {dryRun: boolean; dryRunPrefix: string; log: (message: string) => void}
+): Promise<void> => {
+  const existing: SlotConfigNamesResource = await client.webApps.listSlotConfigurationNames(resourceGroup, webAppName)
+  const current = existing.appSettingNames ?? []
+  const toAdd = names.filter((name) => !current.includes(name))
+  if (toAdd.length === 0) {
+    return
+  }
+  opts.log(
+    `${opts.dryRunPrefix}Registering ${toAdd.join(', ')} as sticky slot setting(s) on ${chalk.bold(webAppName)}\n`
+  )
+  if (!opts.dryRun) {
+    await client.webApps.updateSlotConfigurationNames(resourceGroup, webAppName, {
+      ...existing,
+      appSettingNames: [...current, ...toAdd],
+    })
+  }
 }


### PR DESCRIPTION
### What and why?

In Azure App Service, a slot swap swaps app settings between slots by default. `DD_ENV` should be a *sticky* slot setting so a slot keeps its own environment tag after a swap, instead of the production slot's `DD_ENV` bleeding into staging.

This makes `aas instrument` register `DD_ENV` as a sticky slot setting whenever a slot is instrumented with `--env`. Non-slot instrumentation is unaffected.

### How?

- `common.ts`:
  - `StickySlotSettings` describes the sticky names a site needs (`resourceGroup`, `webAppName`, `names`).
  - `aggregateStickyBySite` collapses the per-resource sticky settings reported during instrumentation into one entry per site, unioning their names. `slotConfigNames` is a single site-level resource shared by all of a site's slots, so it keys by web app name (App Service names are globally unique) and writes each site once -- avoiding the concurrent read-modify-writes (and Azure 409s) that would happen if multiple slots of the same app each wrote it.
  - `registerStickySlotSettings` performs that single read-modify-write, appending any missing names via `updateSlotConfigurationNames`. It no-ops when the names are already sticky, logs the action, and honors dry-run.
- `instrument.ts`:
  - `processWebApp` now returns a `ProcessResult` (`{success, sticky?}`) instead of a bare boolean, reporting the sticky settings the resource needs on its parent site (just `DD_ENV`, and only for slots with `--env`).
  - `processSubscription` aggregates those results and registers the sticky settings once per site after all resources are processed.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
