### PR TITLE
chore: cloud-run e2e telemetry flow validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,6 +188,7 @@ jobs:
           SKIP_CLOUD_RUN_TESTS: ${{ needs.check-cloud-run-changes.outputs.should_run != 'true' || needs.check-version-bump-only.outputs.result == 'true' }}
           GCP_PROJECT_ID: ${{ vars.GCP_PROJECT_ID_E2E }}
           GCP_REGION: ${{ vars.GCP_REGION_E2E }}
+          GCP_CLOUD_RUN_APP_IMAGE_E2E: ${{ vars.GCP_CLOUD_RUN_APP_IMAGE_E2E }}
           AZURE_SUBSCRIPTION_ID: ${{ vars.AZURE_SUBSCRIPTION_ID_E2E }}
           AZURE_RESOURCE_GROUP: ${{ vars.AZURE_RESOURCE_GROUP_E2E }}
           AZURE_CONTAINER_APP_ENV: ${{ vars.AZURE_CONTAINER_APP_ENV_E2E }}
@@ -237,6 +238,7 @@ jobs:
               - 'packages/base/src/helpers/serverless/source-code-integration.ts'
               - 'e2e/cloud-run.test.ts'
               - 'e2e/helpers/cloud-run-verifier.ts'
+              - 'e2e/helpers/cloud-run-telemetry-checker.ts'
               - '.github/workflows/ci.yml'
 
   check-aas-changes:

--- a/e2e/cloud-run.test.ts
+++ b/e2e/cloud-run.test.ts
@@ -54,7 +54,7 @@ describeOrSkip('cloud-run', () => {
         ` --tracing true` +
         ` --no-source-code-integration`,
       {
-        DD_API_KEY: process.env.DD_API_KEY,
+        DD_API_KEY: process.env.DATADOG_API_KEY,
       }
     )
     expect(result.exitCode).toBe(0)

--- a/e2e/cloud-run.test.ts
+++ b/e2e/cloud-run.test.ts
@@ -1,5 +1,6 @@
 import crypto from 'node:crypto'
 
+import {checkTelemetryFlowing} from './helpers/cloud-run-telemetry-checker'
 import {verifyInstrumented, verifyUninstrumented} from './helpers/cloud-run-verifier'
 import {DATADOG_CI_COMMAND, execPromise, execPromiseWithRetries} from './helpers/exec'
 
@@ -17,8 +18,8 @@ describeOrSkip('cloud-run', () => {
         ` --project "${project}"` +
         ` --region "${region}"` +
         ` --platform managed` +
-        ` --image us-docker.pkg.dev/cloudrun/container/hello` +
-        ` --no-allow-unauthenticated` +
+        ` --image ${process.env.GCP_CLOUD_RUN_APP_IMAGE_E2E}` +
+        ` --allow-unauthenticated` +
         ` --min-instances 0` +
         ` --max-instances 1` +
         ` --quiet` +
@@ -50,6 +51,7 @@ describeOrSkip('cloud-run', () => {
         ` --project "${project}"` +
         ` --region "${region}"` +
         ` --service "${serviceName}"` +
+        ` --tracing` +
         ` --no-source-code-integration`,
       {
         DD_API_KEY: process.env.DD_API_KEY,
@@ -58,6 +60,17 @@ describeOrSkip('cloud-run', () => {
     expect(result.exitCode).toBe(0)
 
     verifyInstrumented(serviceName, project, region)
+  }, 600_000)
+
+  it('telemetry flows', async () => {
+    const urlResult = await execPromise(
+      `gcloud run services describe "${serviceName}" --project "${project}" --region "${region}" --format="value(status.url)"`
+    )
+    const serviceUrl = urlResult.stdout.trim()
+
+    await fetch(serviceUrl)
+
+    await checkTelemetryFlowing(serviceName)
   }, 600_000)
 
   it('uninstrument and verify', async () => {

--- a/e2e/cloud-run.test.ts
+++ b/e2e/cloud-run.test.ts
@@ -51,7 +51,7 @@ describeOrSkip('cloud-run', () => {
         ` --project "${project}"` +
         ` --region "${region}"` +
         ` --service "${serviceName}"` +
-        ` --tracing` +
+        ` --tracing true` +
         ` --no-source-code-integration`,
       {
         DD_API_KEY: process.env.DD_API_KEY,

--- a/e2e/helpers/cloud-run-telemetry-checker.ts
+++ b/e2e/helpers/cloud-run-telemetry-checker.ts
@@ -1,0 +1,82 @@
+import {client, v2} from '@datadog/datadog-api-client'
+
+const POLL_INTERVAL_SECONDS = 15
+const MAX_ATTEMPTS = 20
+
+const waitFor = (seconds: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, seconds * 1000))
+
+const pollUntilFound = async (label: string, query: () => Promise<unknown[]>): Promise<void> => {
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+    console.log(`[${label}] attempt ${attempt}/${MAX_ATTEMPTS}`)
+    try {
+      const results = await query()
+      if (results.length > 0) {
+        console.log(`[${label}] found ${results.length} item(s)`)
+
+        return
+      }
+    } catch (error) {
+      console.error(`[${label}] query error:`, error)
+    }
+
+    if (attempt < MAX_ATTEMPTS) {
+      console.log(`[${label}] not found, retrying in ${POLL_INTERVAL_SECONDS}s`)
+      await waitFor(POLL_INTERVAL_SECONDS)
+    }
+  }
+  throw new Error(`[${label}] timed out after ${MAX_ATTEMPTS} attempts (${MAX_ATTEMPTS * POLL_INTERVAL_SECONDS}s)`)
+}
+
+const querySpans = async (configuration: client.Configuration, serviceName: string): Promise<unknown[]> => {
+  const api = new v2.SpansApi(configuration)
+  const now = new Date()
+  const from = new Date(now.getTime() - 15 * 60 * 1000)
+  const response = await api.listSpans({
+    body: {
+      data: {
+        attributes: {
+          filter: {
+            query: `@service:${serviceName}`,
+            from: from.toISOString(),
+            to: now.toISOString(),
+          },
+          page: {limit: 5},
+        },
+        type: 'search_request',
+      },
+    },
+  })
+
+  return response.data ?? []
+}
+
+const queryLogs = async (configuration: client.Configuration, serviceName: string): Promise<unknown[]> => {
+  const api = new v2.LogsApi(configuration)
+  const now = new Date()
+  const from = new Date(now.getTime() - 15 * 60 * 1000)
+  const response = await api.listLogs({
+    body: {
+      filter: {
+        query: `service:${serviceName}`,
+        from: from.toISOString(),
+        to: now.toISOString(),
+      },
+      page: {limit: 5},
+    },
+  })
+
+  return response.data ?? []
+}
+
+export const checkTelemetryFlowing = async (serviceName: string): Promise<void> => {
+  const configuration = client.createConfiguration({
+    authMethods: {
+      apiKeyAuth: process.env.DATADOG_API_KEY,
+      appKeyAuth: process.env.DATADOG_APP_KEY,
+    },
+  })
+  await Promise.all([
+    pollUntilFound('spans', () => querySpans(configuration, serviceName)),
+    pollUntilFound('logs', () => queryLogs(configuration, serviceName)),
+  ])
+}


### PR DESCRIPTION
### What and why?

The Cloud Run e2e tests previously only verified resource shape (sidecar injection, env vars, volume mounts) using the stock `hello` image, which emits no telemetry. This PR extends them to verify that spans and logs from the instrumented app actually reach the Datadog e2e org.

Note, we may want to migrate to `dd-sts` at some point to avoid having api/app keys stored in github

### How?

- Swaps the deploy image to `gcr.io/datadog-serverless-gcp-dev/run-nodejs-sidecar` (a real Node.js app with tracing), controlled via the new `GCP_CLOUD_RUN_APP_IMAGE_E2E` repo variable
- Switches to `--allow-unauthenticated` so the test can hit the service URL without credentials
- Adds `--tracing` to the `instrument` invocation to ensure `DD_TRACE_ENABLED=true`
- Adds a new `telemetry flows` test case (between instrument and uninstrument) that:
  1. Resolves the service URL via `gcloud run services describe`
  2. Hits the endpoint with `fetch` to generate a trace
  3. Polls the DD v2 Spans and Logs APIs in parallel (20 × 15s, 5 min max) until both return results filtered by service name
- Adds `e2e/helpers/cloud-run-telemetry-checker.ts` (mirrors the pattern from `junit-upload-checker.ts`) with explicit `DATADOG_API_KEY`/`DATADOG_APP_KEY` auth -- the e2e org keys already flow in from `DATADOG_API_KEY_E2E`/`DATADOG_APP_KEY_E2E` in CI
- Threads `GCP_CLOUD_RUN_APP_IMAGE_E2E` through CI env and adds the helper file to the cloud-run paths filter

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)