### PR TITLE
chore: add script to catalog DD routes per scope

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,6 +103,8 @@ packages/datadog-ci/src/commands/react-native/__tests__/fixtures/with-sources-co
 # Jest cache directories
 .jest-cache/
 
+endpoints.csv
+
 # Standalone binary built locally
 datadog-ci_linux-x64
 datadog-ci_linux-arm64

--- a/bin/catalog-endpoints.ts
+++ b/bin/catalog-endpoints.ts
@@ -10,8 +10,6 @@ const SKIP_HELPERS = new Set([
   path.join(ROOT, 'packages/base/src/helpers/upload.ts'),
 ])
 
-const FLARE_HELPER = path.join(ROOT, 'packages/base/src/helpers/serverless/flare.ts')
-
 type Row = {scope: string; route: string; method: string}
 
 const collectTsFiles = (dir: string): string[] => {
@@ -43,7 +41,7 @@ const extractRoutes = (filePath: string): {route: string; method: string}[] => {
   const results: {route: string; method: string}[] = []
 
   const routeRegex = /datadogRoute\('([^']+)'/g
-  const methodRegex = /method:\s*(?:'(GET|POST|PUT|DELETE|PATCH)'|METHOD_(GET|POST|PUT|DELETE|PATCH))/i
+  const methodRegex = /method:\s*(?:'(GET|POST|PUT|DELETE|PATCH)')/
 
   let match: RegExpExecArray | undefined
   while ((match = routeRegex.exec(content) ?? undefined) !== undefined) {
@@ -63,7 +61,7 @@ const extractRoutes = (filePath: string): {route: string; method: string}[] => {
     for (const i of searchLines) {
       const m = methodRegex.exec(lines[i])
       if (m) {
-        method = (m[1] ?? m[2]).toUpperCase()
+        method = m[1].toUpperCase()
         break
       }
     }
@@ -101,12 +99,15 @@ const collectScopeEntries = (): Map<string, string[]> => {
   return scopes
 }
 
-const findFlareScopeImporters = (scopes: Map<string, string[]>): Set<string> => {
+// For a helper file, find all scopes that import it
+const findHelperImporters = (scopes: Map<string, string[]>, helperFile: string): Set<string> => {
   const importers = new Set<string>()
+  const srcDir = path.join(ROOT, 'packages/base/src')
+  const relPath = path.relative(srcDir, helperFile).replace(/\.ts$/, '').replace(/\\/g, '/')
   for (const [scope, files] of scopes) {
     for (const f of files) {
       const content = fs.readFileSync(f, 'utf8')
-      if (content.includes('helpers/serverless/flare')) {
+      if (content.includes(relPath)) {
         importers.add(scope)
         break
       }
@@ -118,53 +119,50 @@ const findFlareScopeImporters = (scopes: Map<string, string[]>): Set<string> => 
 
 const main = () => {
   const scopes = collectScopeEntries()
+  const rowMap = new Map<string, Row>()
 
-  // Determine which scopes import the shared flare helper
-  const flareImporters = findFlareScopeImporters(scopes)
-  const flareRoutes = extractRoutes(FLARE_HELPER)
-
-  const rows: Row[] = []
+  const addRow = (scope: string, route: string, method: string) => {
+    rowMap.set(`${scope}|${route}|${method}`, {scope, route, method})
+  }
 
   for (const [scope, files] of scopes) {
     for (const f of files) {
       for (const {route, method} of extractRoutes(f)) {
-        rows.push({scope, route, method})
-      }
-    }
-    // Attribute flare routes to any scope that imports the helper
-    if (flareImporters.has(scope)) {
-      for (const {route, method} of flareRoutes) {
-        rows.push({scope, route, method})
+        addRow(scope, route, method)
       }
     }
   }
 
-  // Deduplicate
-  const seen = new Set<string>()
-  const unique = rows.filter(({scope, route, method}) => {
-    const key = `${scope}|${route}|${method}`
-    if (seen.has(key)) {
-      return false
+  // Attribute shared helper routes to all scopes that import them
+  const helpersDir = path.join(ROOT, 'packages/base/src/helpers')
+  for (const helperFile of collectTsFiles(helpersDir)) {
+    if (SKIP_HELPERS.has(helperFile)) {
+      continue
     }
-    seen.add(key)
-
-    return true
-  })
+    const helperRoutes = extractRoutes(helperFile)
+    if (helperRoutes.length === 0) {
+      continue
+    }
+    const importers = findHelperImporters(scopes, helperFile)
+    for (const scope of importers) {
+      for (const {route, method} of helperRoutes) {
+        addRow(scope, route, method)
+      }
+    }
+  }
 
   // Sort by scope then route
-  unique.sort((a, b) => {
+  const rows = [...rowMap.values()].sort((a, b) => {
     const s = a.scope.localeCompare(b.scope)
 
     return s !== 0 ? s : a.route.localeCompare(b.route)
   })
 
-  const csv = ['scope,route,method', ...unique.map(({scope, route, method}) => `${scope},${route},${method}`)].join(
-    '\n'
-  )
+  const csv = ['scope,route,method', ...rows.map(({scope, route, method}) => `${scope},${route},${method}`)].join('\n')
 
   const outPath = path.join(ROOT, 'endpoints.csv')
   fs.writeFileSync(outPath, csv + '\n')
-  console.log(`Wrote ${unique.length} rows to ${outPath}`)
+  console.log(`Wrote ${rows.length} rows to ${outPath}`)
 }
 
 main()

--- a/bin/catalog-endpoints.ts
+++ b/bin/catalog-endpoints.ts
@@ -1,0 +1,170 @@
+import fs from 'fs'
+// eslint-disable-next-line no-restricted-imports
+import path from 'path'
+
+const ROOT = path.resolve(__dirname, '..')
+
+// Files too cross-cutting to attribute to a single scope
+const SKIP_HELPERS = new Set([
+  path.join(ROOT, 'packages/base/src/helpers/apikey.ts'),
+  path.join(ROOT, 'packages/base/src/helpers/upload.ts'),
+])
+
+const FLARE_HELPER = path.join(ROOT, 'packages/base/src/helpers/serverless/flare.ts')
+
+type Row = {scope: string; route: string; method: string}
+
+const collectTsFiles = (dir: string): string[] => {
+  if (!fs.existsSync(dir)) {
+    return []
+  }
+  const results: string[] = []
+  for (const entry of fs.readdirSync(dir, {withFileTypes: true})) {
+    if (entry.name === '__tests__') {
+      continue
+    }
+    const full = path.join(dir, entry.name)
+    if (entry.isDirectory()) {
+      results.push(...collectTsFiles(full))
+    } else if (entry.isFile() && entry.name.endsWith('.ts')) {
+      results.push(full)
+    }
+  }
+
+  return results
+}
+
+const extractRoutes = (filePath: string): {route: string; method: string}[] => {
+  if (SKIP_HELPERS.has(filePath)) {
+    return []
+  }
+  const content = fs.readFileSync(filePath, 'utf8')
+  const lines = content.split('\n')
+  const results: {route: string; method: string}[] = []
+
+  const routeRegex = /datadogRoute\('([^']+)'/g
+  const methodRegex = /method:\s*(?:'(GET|POST|PUT|DELETE|PATCH)'|METHOD_(GET|POST|PUT|DELETE|PATCH))/i
+
+  let match: RegExpExecArray | undefined
+  while ((match = routeRegex.exec(content) ?? undefined) !== undefined) {
+    const route = match[1]
+    // Determine line number of this match (0-indexed)
+    const before = content.slice(0, match.index)
+    const lineIndex = before.split('\n').length - 1
+
+    // Look up to 5 lines back and 2 lines forward for method
+    let method = 'GET'
+    const startLine = Math.max(0, lineIndex - 5)
+    const endLine = Math.min(lines.length - 1, lineIndex + 2)
+    const searchLines = [
+      ...Array.from({length: lineIndex - startLine + 1}, (_, k) => lineIndex - k),
+      ...Array.from({length: endLine - lineIndex}, (_, k) => lineIndex + k + 1),
+    ]
+    for (const i of searchLines) {
+      const m = methodRegex.exec(lines[i])
+      if (m) {
+        method = (m[1] ?? m[2]).toUpperCase()
+        break
+      }
+    }
+
+    results.push({route, method})
+  }
+
+  return results
+}
+
+const collectScopeEntries = (): Map<string, string[]> => {
+  const scopes = new Map<string, string[]>()
+
+  // Plugin packages: packages/plugin-<scope>/src/**/*.ts
+  const packagesDir = path.join(ROOT, 'packages')
+  for (const entry of fs.readdirSync(packagesDir, {withFileTypes: true})) {
+    if (entry.isDirectory() && entry.name.startsWith('plugin-')) {
+      const scope = entry.name.slice('plugin-'.length)
+      const files = collectTsFiles(path.join(packagesDir, entry.name, 'src'))
+      scopes.set(scope, files)
+    }
+  }
+
+  // Base command scopes: packages/base/src/commands/<scope>/
+  const commandsDir = path.join(ROOT, 'packages/base/src/commands')
+  for (const entry of fs.readdirSync(commandsDir, {withFileTypes: true})) {
+    if (entry.isDirectory()) {
+      const scope = entry.name
+      const files = collectTsFiles(path.join(commandsDir, scope))
+      const existing = scopes.get(scope) ?? []
+      scopes.set(scope, [...existing, ...files])
+    }
+  }
+
+  return scopes
+}
+
+const findFlareScopeImporters = (scopes: Map<string, string[]>): Set<string> => {
+  const importers = new Set<string>()
+  for (const [scope, files] of scopes) {
+    for (const f of files) {
+      const content = fs.readFileSync(f, 'utf8')
+      if (content.includes('helpers/serverless/flare')) {
+        importers.add(scope)
+        break
+      }
+    }
+  }
+
+  return importers
+}
+
+const main = () => {
+  const scopes = collectScopeEntries()
+
+  // Determine which scopes import the shared flare helper
+  const flareImporters = findFlareScopeImporters(scopes)
+  const flareRoutes = extractRoutes(FLARE_HELPER)
+
+  const rows: Row[] = []
+
+  for (const [scope, files] of scopes) {
+    for (const f of files) {
+      for (const {route, method} of extractRoutes(f)) {
+        rows.push({scope, route, method})
+      }
+    }
+    // Attribute flare routes to any scope that imports the helper
+    if (flareImporters.has(scope)) {
+      for (const {route, method} of flareRoutes) {
+        rows.push({scope, route, method})
+      }
+    }
+  }
+
+  // Deduplicate
+  const seen = new Set<string>()
+  const unique = rows.filter(({scope, route, method}) => {
+    const key = `${scope}|${route}|${method}`
+    if (seen.has(key)) {
+      return false
+    }
+    seen.add(key)
+
+    return true
+  })
+
+  // Sort by scope then route
+  unique.sort((a, b) => {
+    const s = a.scope.localeCompare(b.scope)
+
+    return s !== 0 ? s : a.route.localeCompare(b.route)
+  })
+
+  const csv = ['scope,route,method', ...unique.map(({scope, route, method}) => `${scope},${route},${method}`)].join(
+    '\n'
+  )
+
+  const outPath = path.join(ROOT, 'endpoints.csv')
+  fs.writeFileSync(outPath, csv + '\n')
+  console.log(`Wrote ${unique.length} rows to ${outPath}`)
+}
+
+main()

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "build": "yarn tsc:build",
     "bundle:npm": "cd packages/datadog-ci && node ../../scripts/tsdown-cli-npm.mjs",
     "bundle:sea": "cd packages/datadog-ci && node ../../scripts/tsdown-cli-sea.mjs",
+    "catalog-endpoints": "tsx --conditions=development bin/catalog-endpoints.ts",
     "check-licenses": "node bin/check-licenses.js",
     "check-npm-packages": "bin/check-npm-packages.sh",
     "clean": "rimraf --glob .eslintcache .jest-cache 'packages/*/{dist,tsconfig.tsbuildinfo}'",


### PR DESCRIPTION
### What and why?

Adds `bin/catalog-endpoints.ts` -- a dev script that statically analyzes the codebase and produces `endpoints.csv`: a mapping of CLI scopes to the Datadog API routes they call, with HTTP methods. This supports SEAL (Smart Edge Audit Logs) passive observability -- CI will upload the CSV to S3 to keep a reference table current so audit log data can be enriched with CLI command context.

Right now uses a grep-based approach, but we could switch to an AST parsing approach or something else in the future if we want more capability

Example output:
```csv
scope,route,method
cloud-run,/api/ui/support/serverless/flare,POST
coverage,/api/v2/cicovreprt,POST
deployment,/api/v2/ci/deployments/correlate,POST
deployment,/api/v2/ci/deployments/correlate-image,POST
deployment,/api/v2/deployments/gates/evaluation,POST
deployment,/api/v2/deployments/gates/evaluation/:evaluationId,GET
dora,/api/v2/dora/deployment,POST
dsyms,/api/v2/srcmap,GET
elf-symbols,/api/v2/srcmap,GET
flutter-symbols,/api/v2/srcmap,GET
gate,/api/v2/quality-gates/evaluate,POST
git-metadata,/api/v2/git/repository/packfile,GET
git-metadata,/api/v2/git/repository/search_commits,GET
git-metadata,/api/v2/srcmap,GET
junit,/api/v2/cireport,POST
lambda,/api/ui/support/serverless/flare,POST
measure,/api/v2/ci/pipeline/metrics,POST
pe-symbols,/api/v2/srcmap,GET
react-native,/api/v2/srcmap,GET
sarif,/api/v2/cicodescan,POST
sbom,/api/v2/static-analysis-sca/dependencies,POST
sourcemaps,/api/v2/srcmap,GET
synthetics,/synthetics/ci/batch/:batchId,GET
synthetics,/synthetics/ci/tunnel,GET
synthetics,/synthetics/mobile/applications/:applicationId/multipart-presigned-urls,POST
synthetics,/synthetics/mobile/applications/:applicationId/multipart-upload-complete,POST
synthetics,/synthetics/mobile/applications/validation-job-status/:jobId,GET
synthetics,/synthetics/settings,GET
synthetics,/synthetics/tests/:testId,GET
synthetics,/synthetics/tests/:testId,PUT
synthetics,/synthetics/tests/:testId/version_history/:version?only_check_existence=true,GET
synthetics,/synthetics/tests/:testType/:testId,GET
synthetics,/synthetics/tests/poll_results,GET
synthetics,/synthetics/tests/search,GET
synthetics,/synthetics/tests/trigger/ci,POST
tag,/api/v2/ci/pipeline/tags,POST
terraform,/api/v2/ciiac,POST
trace,/api/intake/ci/custom_spans,POST
unity-symbols,/api/v2/srcmap,GET
```

### How?

- Globs `packages/plugin-*/src` and `packages/base/src/commands/*/` to collect scopes and their source files
- Extracts `datadogRoute('...')` calls via regex; resolves HTTP method by scanning up to 5 lines before / 2 lines after each call for `method: 'VERB'` (handles lowercase, `METHOD_POST`-style constants; defaults to `GET`)
- Handles `helpers/serverless/flare.ts` as a special case -- greps which scopes import it and attributes its routes to each importer (`lambda`, `cloud-run`)
- Skips `helpers/apikey.ts` (`/api/v1/validate`) and `helpers/upload.ts` (`/v1/input`) as they're too cross-cutting
- Deduplicates rows and writes `endpoints.csv` at the repo root (gitignored)

Run with `yarn catalog-endpoints`.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)