### PR TITLE
[K9VULN-15920] Warn when env tag is passed to sbom upload

### DIFF
--- a/packages/plugin-sbom/src/commands/upload.ts
+++ b/packages/plugin-sbom/src/commands/upload.ts
@@ -96,10 +96,10 @@ export class PluginCommand extends SbomUploadCommand {
     const service = 'datadog-ci'
 
     if (this.env !== 'ci') {
-      this.context.stderr.write(renderEnvFlagDeprecationWarning())
+      this.context.stdout.write(renderEnvFlagDeprecationWarning())
     }
 
-    const environment = this.env
+    const environment = 'ci'
 
     if (!this.basePath || !this.basePath.length) {
       this.context.stderr.write('Missing basePath\n')

--- a/packages/plugin-sbom/src/commands/upload.ts
+++ b/packages/plugin-sbom/src/commands/upload.ts
@@ -22,6 +22,7 @@ import {getApiHelper} from '../api'
 import {generatePayload} from '../payload'
 import {
   renderDuplicateUpload,
+  renderEnvFlagDeprecationWarning,
   renderFailedUpload,
   renderInvalidFile,
   renderInvalidPayload,
@@ -93,6 +94,10 @@ export class PluginCommand extends SbomUploadCommand {
     }
 
     const service = 'datadog-ci'
+
+    if (this.env !== 'ci') {
+      this.context.stderr.write(renderEnvFlagDeprecationWarning())
+    }
 
     const environment = this.env
 

--- a/packages/plugin-sbom/src/renderer.ts
+++ b/packages/plugin-sbom/src/renderer.ts
@@ -106,6 +106,11 @@ export const renderSuccessfulCommand = (duration: number) => {
   return fullStr
 }
 
+export const renderEnvFlagDeprecationWarning = (): string =>
+  chalk.yellow(
+    `${ICONS.WARNING} The --env flag is not used for SBOM uploads and will be ignored. The environment is automatically set to "ci".\n`
+  )
+
 export const renderPayloadWarning = (dependencies: Dependency[]): string => {
   let ret = ''
 


### PR DESCRIPTION
### What and why?

The `--env` flag is ignored server-side for non-SCI SBOM uploads (env is always normalized to `"ci"`). This adds a client-side warning so users know the flag has no effect rather than silently ignoring it.

### How?

- `packages/plugin-sbom/src/renderer.ts` — added `renderEnvFlagDeprecationWarning()` that prints a yellow warning to stderr
- `packages/plugin-sbom/src/commands/upload.ts` — calls the warning when `--env` is set to anything other than the default `"ci"`