### PR TITLE
Add CI job to upload endpoint catalog CSV to S3

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,6 +1,7 @@
 stages:
   - build
   - release
+  - catalog
 
 build-docker-image:
   stage: build
@@ -30,3 +31,23 @@ publish-docker-image:
     IMG_SOURCES: registry.ddbuild.io/ci/datadog-ci:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}
     IMG_DESTINATIONS: ci:${CI_COMMIT_TAG},ci:latest
     IMG_SIGNING: 'false'
+
+catalog-endpoints:
+  stage: catalog
+  only: ['master']
+  tags: ['runner:docker']
+  image: node:22
+  id_tokens:
+    CI_IDENTITIES_GITLAB_ID_TOKEN:
+      aud: ci-identities
+  variables:
+    CI_IDENTITIES_CLIENT_VERSION: v0.6.4
+  before_script:
+    - apt-get update -qq && apt-get install -y awscli
+    - aws s3 cp "s3://binaries-ddbuild-io-prod/ci-identities/ci-identities-gitlab-job-client/versions/${CI_IDENTITIES_CLIENT_VERSION}/ci-identities-gitlab-job-client-linux-amd64" /usr/local/bin/ci-identities-gitlab-job-client
+    - chmod +x /usr/local/bin/ci-identities-gitlab-job-client
+  script:
+    - yarn install --immutable
+    - yarn catalog-endpoints
+    - ci-identities-gitlab-job-client assume-role
+    - aws s3 cp endpoints.csv s3://dd-datadog-ci/endpoints.csv


### PR DESCRIPTION
Adds a GitLab CI job that runs on every push to master, generates the endpoint catalog CSV via `yarn catalog-endpoints`, and uploads it to the `dd-datadog-ci` S3 bucket using CI Identities for AWS authentication.

The job uses `runner:docker` (legacy EC2 runner) rather than `arch:amd64` (Kubernetes). On Kubernetes, the CI Identities client communicates with the signer via Fabric DNS, which uses Datadog's private PKI — a public image like `node:22` doesn't carry those CA certs and would fail TLS verification. On `runner:docker`, the client uses Vault instead, which uses a publicly trusted cert. The EC2 instance profile (`ci-datadog-ci`, provisioned via `legacy-role: true`) also provides the bootstrap credentials needed to download the CI Identities client binary from S3 before `assume-role` is called.