### PR TITLE
Add package bugs metadata

### DIFF
--- a/.syncpackrc.json
+++ b/.syncpackrc.json
@@ -7,6 +7,7 @@
     "license",
     "keywords",
     "homepage",
+    "bugs",
     "repository",
     "engines",
     "bin",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,5 @@
 {
   "name": "datadog-ci-monorepo",
-  "bugs": {
-    "url": "https://github.com/DataDog/datadog-ci/issues"
-  },
   "scripts": {
     "build": "yarn tsc:build",
     "bundle:npm": "cd packages/datadog-ci && node ../../scripts/tsdown-cli-npm.mjs",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,8 @@
 {
   "name": "datadog-ci-monorepo",
+  "bugs": {
+    "url": "https://github.com/DataDog/datadog-ci/issues"
+  },
   "scripts": {
     "build": "yarn tsc:build",
     "bundle:npm": "cd packages/datadog-ci && node ../../scripts/tsdown-cli-npm.mjs",

--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -8,6 +8,9 @@
     "datadog-ci"
   ],
   "homepage": "https://github.com/DataDog/datadog-ci/tree/master/packages/base",
+  "bugs": {
+    "url": "https://github.com/DataDog/datadog-ci/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/DataDog/datadog-ci.git",

--- a/packages/datadog-ci/package.json
+++ b/packages/datadog-ci/package.json
@@ -8,6 +8,9 @@
     "datadog-ci"
   ],
   "homepage": "https://github.com/DataDog/datadog-ci",
+  "bugs": {
+    "url": "https://github.com/DataDog/datadog-ci/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/DataDog/datadog-ci.git",

--- a/packages/plugin-aas/package.json
+++ b/packages/plugin-aas/package.json
@@ -9,6 +9,9 @@
     "plugin"
   ],
   "homepage": "https://github.com/DataDog/datadog-ci/tree/master/packages/plugin-aas",
+  "bugs": {
+    "url": "https://github.com/DataDog/datadog-ci/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/DataDog/datadog-ci.git",

--- a/packages/plugin-cloud-run/package.json
+++ b/packages/plugin-cloud-run/package.json
@@ -9,6 +9,9 @@
     "plugin"
   ],
   "homepage": "https://github.com/DataDog/datadog-ci/tree/master/packages/plugin-cloud-run",
+  "bugs": {
+    "url": "https://github.com/DataDog/datadog-ci/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/DataDog/datadog-ci.git",

--- a/packages/plugin-container-app/package.json
+++ b/packages/plugin-container-app/package.json
@@ -9,6 +9,9 @@
     "plugin"
   ],
   "homepage": "https://github.com/DataDog/datadog-ci/tree/master/packages/plugin-container-app",
+  "bugs": {
+    "url": "https://github.com/DataDog/datadog-ci/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/DataDog/datadog-ci.git",

--- a/packages/plugin-coverage/package.json
+++ b/packages/plugin-coverage/package.json
@@ -9,6 +9,9 @@
     "plugin"
   ],
   "homepage": "https://github.com/DataDog/datadog-ci/tree/master/packages/plugin-coverage",
+  "bugs": {
+    "url": "https://github.com/DataDog/datadog-ci/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/DataDog/datadog-ci.git",

--- a/packages/plugin-deployment/package.json
+++ b/packages/plugin-deployment/package.json
@@ -9,6 +9,9 @@
     "plugin"
   ],
   "homepage": "https://github.com/DataDog/datadog-ci/tree/master/packages/plugin-deployment",
+  "bugs": {
+    "url": "https://github.com/DataDog/datadog-ci/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/DataDog/datadog-ci.git",

--- a/packages/plugin-dora/package.json
+++ b/packages/plugin-dora/package.json
@@ -9,6 +9,9 @@
     "plugin"
   ],
   "homepage": "https://github.com/DataDog/datadog-ci/tree/master/packages/plugin-dora",
+  "bugs": {
+    "url": "https://github.com/DataDog/datadog-ci/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/DataDog/datadog-ci.git",

--- a/packages/plugin-gate/package.json
+++ b/packages/plugin-gate/package.json
@@ -9,6 +9,9 @@
     "plugin"
   ],
   "homepage": "https://github.com/DataDog/datadog-ci/tree/master/packages/plugin-gate",
+  "bugs": {
+    "url": "https://github.com/DataDog/datadog-ci/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/DataDog/datadog-ci.git",

--- a/packages/plugin-junit/package.json
+++ b/packages/plugin-junit/package.json
@@ -9,6 +9,9 @@
     "plugin"
   ],
   "homepage": "https://github.com/DataDog/datadog-ci/tree/master/packages/plugin-junit",
+  "bugs": {
+    "url": "https://github.com/DataDog/datadog-ci/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/DataDog/datadog-ci.git",

--- a/packages/plugin-lambda/package.json
+++ b/packages/plugin-lambda/package.json
@@ -9,6 +9,9 @@
     "plugin"
   ],
   "homepage": "https://github.com/DataDog/datadog-ci/tree/master/packages/plugin-lambda",
+  "bugs": {
+    "url": "https://github.com/DataDog/datadog-ci/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/DataDog/datadog-ci.git",

--- a/packages/plugin-sarif/package.json
+++ b/packages/plugin-sarif/package.json
@@ -9,6 +9,9 @@
     "plugin"
   ],
   "homepage": "https://github.com/DataDog/datadog-ci/tree/master/packages/plugin-sarif",
+  "bugs": {
+    "url": "https://github.com/DataDog/datadog-ci/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/DataDog/datadog-ci.git",

--- a/packages/plugin-sbom/package.json
+++ b/packages/plugin-sbom/package.json
@@ -9,6 +9,9 @@
     "plugin"
   ],
   "homepage": "https://github.com/DataDog/datadog-ci/tree/master/packages/plugin-sbom",
+  "bugs": {
+    "url": "https://github.com/DataDog/datadog-ci/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/DataDog/datadog-ci.git",

--- a/packages/plugin-stepfunctions/package.json
+++ b/packages/plugin-stepfunctions/package.json
@@ -9,6 +9,9 @@
     "plugin"
   ],
   "homepage": "https://github.com/DataDog/datadog-ci/tree/master/packages/plugin-stepfunctions",
+  "bugs": {
+    "url": "https://github.com/DataDog/datadog-ci/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/DataDog/datadog-ci.git",

--- a/packages/plugin-synthetics/package.json
+++ b/packages/plugin-synthetics/package.json
@@ -9,6 +9,9 @@
     "plugin"
   ],
   "homepage": "https://github.com/DataDog/datadog-ci/tree/master/packages/plugin-synthetics",
+  "bugs": {
+    "url": "https://github.com/DataDog/datadog-ci/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/DataDog/datadog-ci.git",

--- a/packages/plugin-terraform/package.json
+++ b/packages/plugin-terraform/package.json
@@ -11,6 +11,9 @@
     "terraform"
   ],
   "homepage": "https://github.com/DataDog/datadog-ci/tree/master/packages/plugin-terraform",
+  "bugs": {
+    "url": "https://github.com/DataDog/datadog-ci/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/DataDog/datadog-ci.git",


### PR DESCRIPTION
## Summary
- add the package-level `bugs.url` metadata for `@datadog/datadog-ci`

## Validation
- `node -e "const p=require('./packages/datadog-ci/package.json'); if (p.bugs?.url !== 'https://github.com/DataDog/datadog-ci/issues') { console.error(p.bugs); process.exit(1) } console.log(JSON.stringify({name:p.name, version:p.version, bugs:p.bugs, repository:p.repository}, null, 2))"`
- `git diff --check`
- `npm view @datadog/datadog-ci@5.18.0 name version repository homepage bugs --json` confirms the published package currently has no `bugs` field
