### PR TITLE
e2e no plaintext secrets

### DIFF
--- a/e2e/helpers/exec.ts
+++ b/e2e/helpers/exec.ts
@@ -7,8 +7,8 @@ export interface ExecResult {
 }
 
 // In CI the synthetic project installs @datadog/datadog-ci from artifact
-// tarballs, so `yarn datadog-ci` works. Locally, create an e2e/.env.local
-// file with DATADOG_CI_COMMAND='yarn launch' to run from source via tsx.
+// tarballs, so `yarn datadog-ci` works. Locally, set DATADOG_CI_COMMAND='yarn launch'
+// in e2e/.env.local (gitignored) to run from source via tsx.
 export const DATADOG_CI_COMMAND = process.env.DATADOG_CI_COMMAND ?? 'yarn datadog-ci'
 
 export const execPromise = async (command: string, env?: Record<string, string | undefined>): Promise<ExecResult> => {

--- a/e2e/helpers/global-setup.js
+++ b/e2e/helpers/global-setup.js
@@ -1,0 +1,7 @@
+module.exports = function () {
+  if (!process.env.DD_API_KEY && !process.env.DATADOG_API_KEY) {
+    throw new Error(
+      'Missing DD_API_KEY / DATADOG_API_KEY. Run e2e tests via: dd-auth --domain <your-org-domain> -- yarn test:e2e'
+    )
+  }
+}

--- a/e2e/helpers/global-setup.js
+++ b/e2e/helpers/global-setup.js
@@ -1,7 +1,0 @@
-module.exports = function () {
-  if (!process.env.DD_API_KEY && !process.env.DATADOG_API_KEY) {
-    throw new Error(
-      'Missing DD_API_KEY / DATADOG_API_KEY. Run e2e tests via: dd-auth --domain <your-org-domain> -- yarn test:e2e'
-    )
-  }
-}

--- a/jest.config-e2e.js
+++ b/jest.config-e2e.js
@@ -22,10 +22,14 @@ try {
   }
 } catch {}
 
+if (process.argv.some((arg) => arg.includes('jest')) && !process.env.DD_API_KEY && !process.env.DATADOG_API_KEY) {
+  console.error('Missing DD_API_KEY / DATADOG_API_KEY. Run e2e tests via: dd-auth --domain <your-org-domain> -- yarn test:e2e')
+  process.exit(1)
+}
+
 /** @type {import('ts-jest').JestConfigWithTsJest} */
 module.exports = {
   preset: 'ts-jest',
-  globalSetup: './e2e/helpers/global-setup.js',
   transform: {
     '^.+\\.tsx?$': [
       'ts-jest',

--- a/jest.config-e2e.js
+++ b/jest.config-e2e.js
@@ -3,7 +3,9 @@
 
 const {readFileSync} = require('node:fs')
 
-// Load e2e/.env.local if it exists (gitignored, for local overrides)
+// Load e2e/.env.local if it exists (gitignored, for local non-secret overrides like DATADOG_CI_COMMAND)
+// Secrets (DD_API_KEY, DATADOG_API_KEY, DATADOG_APP_KEY) must come from the environment -- use dd-auth:
+//   dd-auth --domain <your-org-domain> -- yarn test:e2e
 try {
   for (const line of readFileSync('e2e/.env.local', 'utf-8').split('\n')) {
     const match = line.match(/^\s*([^#=]+?)\s*=\s*(.*)$/)
@@ -19,6 +21,11 @@ try {
     }
   }
 } catch {}
+
+if (!process.env.DD_API_KEY && !process.env.DATADOG_API_KEY) {
+  console.error('Missing DD_API_KEY / DATADOG_API_KEY. Run e2e tests via: dd-auth --domain <your-org-domain> -- yarn test:e2e')
+  process.exit(1)
+}
 
 /** @type {import('ts-jest').JestConfigWithTsJest} */
 module.exports = {

--- a/jest.config-e2e.js
+++ b/jest.config-e2e.js
@@ -22,14 +22,10 @@ try {
   }
 } catch {}
 
-if (!process.env.DD_API_KEY && !process.env.DATADOG_API_KEY) {
-  console.error('Missing DD_API_KEY / DATADOG_API_KEY. Run e2e tests via: dd-auth --domain <your-org-domain> -- yarn test:e2e')
-  process.exit(1)
-}
-
 /** @type {import('ts-jest').JestConfigWithTsJest} */
 module.exports = {
   preset: 'ts-jest',
+  globalSetup: './e2e/helpers/global-setup.js',
   transform: {
     '^.+\\.tsx?$': [
       'ts-jest',


### PR DESCRIPTION
### What and why?

`e2e/.env.local` was the suggested way to supply secrets locally for e2e tests, which meant real API and app keys living in a plaintext file on disk. This removes that practice and points contributors to `dd-auth` instead.

### How?

- Strips `DD_API_KEY`, `DATADOG_API_KEY`, and `DATADOG_APP_KEY` from `e2e/.env.local` (non-secret config like `DATADOG_CI_COMMAND` and GCP/Azure resource IDs stays)
- Adds a startup guard in `jest.config-e2e.js` that exits immediately with a clear message if no API key is present, rather than failing deep inside a test
- Updates the comment in `e2e/helpers/exec.ts` to no longer imply `.env.local` is for credentials

To run e2e tests locally, use:
```
dd-auth --domain <your-org-domain> -- yarn test:e2e
```

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)