### PR TITLE
Split catalog-endpoints CI job into generate and upload

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -50,7 +50,7 @@ catalog-endpoints-upload:
   only: ['master']
   needs: ['catalog-endpoints-generate']
   tags: ['arch:amd64']
-  image: registry.ddbuild.io/images/aws-cli:2.28.10
+  image: registry.ddbuild.io/images/aws-cli:2.33.12
   id_tokens:
     CI_IDENTITIES_GITLAB_ID_TOKEN:
       aud: ci-identities

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -32,22 +32,33 @@ publish-docker-image:
     IMG_DESTINATIONS: ci:${CI_COMMIT_TAG},ci:latest
     IMG_SIGNING: 'false'
 
-catalog-endpoints:
+catalog-endpoints-generate:
   stage: catalog
   only: ['master']
-  tags: ['runner:docker']
+  tags: ['arch:amd64']
   image: node:22
+  script:
+    - yarn install --immutable
+    - yarn catalog-endpoints
+  artifacts:
+    paths:
+      - endpoints.csv
+    expire_in: 1 hour
+
+catalog-endpoints-upload:
+  stage: catalog
+  only: ['master']
+  needs: ['catalog-endpoints-generate']
+  tags: ['arch:amd64']
+  image: registry.ddbuild.io/images/aws-cli:2.28.10
   id_tokens:
     CI_IDENTITIES_GITLAB_ID_TOKEN:
       aud: ci-identities
   variables:
     CI_IDENTITIES_CLIENT_VERSION: v0.6.4
   before_script:
-    - apt-get update -qq && apt-get install -y awscli
     - aws s3 cp "s3://binaries-ddbuild-io-prod/ci-identities/ci-identities-gitlab-job-client/versions/${CI_IDENTITIES_CLIENT_VERSION}/ci-identities-gitlab-job-client-linux-amd64" /usr/local/bin/ci-identities-gitlab-job-client
     - chmod +x /usr/local/bin/ci-identities-gitlab-job-client
   script:
-    - yarn install --immutable
-    - yarn catalog-endpoints
     - ci-identities-gitlab-job-client assume-role
     - aws s3 cp endpoints.csv s3://dd-datadog-ci/endpoints.csv


### PR DESCRIPTION
The previous single-job approach used `runner:docker` (legacy EC2 runner) because `node:22` lacks Datadog's private CA certs needed for the CI Identities Fabric DNS path on Kubernetes runners. However, `runner:docker` is not available on protected branches, causing the job to get stuck.

The job is now split into two:

- **catalog-endpoints-generate** runs `yarn catalog-endpoints` on `node:22` with no CI Identities involved, and passes `endpoints.csv` as a GitLab artifact.
- **catalog-endpoints-upload** picks up the artifact and uploads it to S3 using the internal `registry.ddbuild.io/images/aws-cli` image, which already has Datadog CA certs and AWS CLI. Both jobs run on `arch:amd64`.