### PR TITLE
Use internal Node.js mirror image for catalog-endpoints-generate

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -52,6 +52,8 @@ catalog-endpoints-upload:
   stage: catalog
   rules:
     - if: $CI_COMMIT_BRANCH == "master"
+    - when: manual
+      allow_failure: true
   needs: ['catalog-endpoints-generate']
   tags: ['arch:amd64']
   image: registry.ddbuild.io/images/aws-cli:2.33.12

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -36,7 +36,7 @@ catalog-endpoints-generate:
   stage: catalog
   only: ['master']
   tags: ['arch:amd64']
-  image: node:22
+  image: registry.ddbuild.io/images/mirror/node:22
   script:
     - yarn install --immutable
     - yarn catalog-endpoints

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -34,10 +34,7 @@ publish-docker-image:
 
 catalog-endpoints-generate:
   stage: catalog
-  rules:
-    - if: $CI_COMMIT_BRANCH == "master"
-    - when: manual
-      allow_failure: true
+  only: ['master']
   tags: ['arch:amd64']
   image: registry.ddbuild.io/images/mirror/node:22
   script:
@@ -50,10 +47,7 @@ catalog-endpoints-generate:
 
 catalog-endpoints-upload:
   stage: catalog
-  rules:
-    - if: $CI_COMMIT_BRANCH == "master"
-    - when: manual
-      allow_failure: true
+  only: ['master']
   needs: ['catalog-endpoints-generate']
   tags: ['arch:amd64']
   image: registry.ddbuild.io/images/aws-cli:2.33.12

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -34,7 +34,10 @@ publish-docker-image:
 
 catalog-endpoints-generate:
   stage: catalog
-  only: ['master']
+  rules:
+    - if: $CI_COMMIT_BRANCH == "master"
+    - when: manual
+      allow_failure: true
   tags: ['arch:amd64']
   image: registry.ddbuild.io/images/mirror/node:22
   script:
@@ -47,7 +50,8 @@ catalog-endpoints-generate:
 
 catalog-endpoints-upload:
   stage: catalog
-  only: ['master']
+  rules:
+    - if: $CI_COMMIT_BRANCH == "master"
   needs: ['catalog-endpoints-generate']
   tags: ['arch:amd64']
   image: registry.ddbuild.io/images/aws-cli:2.33.12


### PR DESCRIPTION
`node:22` from Docker Hub is blocked by the `third-party-registry` ValidatingAdmissionPolicy on Kubernetes runners. Switching to `registry.ddbuild.io/images/mirror/node:22`, which is on the approved registries list.