### PR TITLE
Download CI Identities client to project dir

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -57,8 +57,9 @@ catalog-endpoints-upload:
   variables:
     CI_IDENTITIES_CLIENT_VERSION: v0.6.4
   before_script:
-    - aws s3 cp "s3://binaries-ddbuild-io-prod/ci-identities/ci-identities-gitlab-job-client/versions/${CI_IDENTITIES_CLIENT_VERSION}/ci-identities-gitlab-job-client-linux-amd64" /usr/local/bin/ci-identities-gitlab-job-client
-    - chmod +x /usr/local/bin/ci-identities-gitlab-job-client
+    - aws s3 cp "s3://binaries-ddbuild-io-prod/ci-identities/ci-identities-gitlab-job-client/versions/${CI_IDENTITIES_CLIENT_VERSION}/ci-identities-gitlab-job-client-linux-amd64" "${CI_PROJECT_DIR}/ci-identities-gitlab-job-client"
+    - chmod +x "${CI_PROJECT_DIR}/ci-identities-gitlab-job-client"
+    - export PATH="${CI_PROJECT_DIR}:${PATH}"
   script:
     - ci-identities-gitlab-job-client assume-role
     - aws s3 cp endpoints.csv s3://dd-datadog-ci/endpoints.csv

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -59,7 +59,6 @@ catalog-endpoints-upload:
   before_script:
     - aws s3 cp "s3://binaries-ddbuild-io-prod/ci-identities/ci-identities-gitlab-job-client/versions/${CI_IDENTITIES_CLIENT_VERSION}/ci-identities-gitlab-job-client-linux-amd64" "${CI_PROJECT_DIR}/ci-identities-gitlab-job-client"
     - chmod +x "${CI_PROJECT_DIR}/ci-identities-gitlab-job-client"
-    - export PATH="${CI_PROJECT_DIR}:${PATH}"
   script:
-    - ci-identities-gitlab-job-client assume-role
+    - "${CI_PROJECT_DIR}/ci-identities-gitlab-job-client" assume-role
     - aws s3 cp endpoints.csv s3://dd-datadog-ci/endpoints.csv


### PR DESCRIPTION
Kubernetes containers don't have write access to `/usr/local/bin/`, causing a permission denied error when downloading the CI Identities client binary. Downloading to `$CI_PROJECT_DIR` instead and adding it to `$PATH`.