### PR TITLE
Fix YAML syntax in catalog-endpoints-upload script

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -60,5 +60,5 @@ catalog-endpoints-upload:
     - aws s3 cp "s3://binaries-ddbuild-io-prod/ci-identities/ci-identities-gitlab-job-client/versions/${CI_IDENTITIES_CLIENT_VERSION}/ci-identities-gitlab-job-client-linux-amd64" "${CI_PROJECT_DIR}/ci-identities-gitlab-job-client"
     - chmod +x "${CI_PROJECT_DIR}/ci-identities-gitlab-job-client"
   script:
-    - "${CI_PROJECT_DIR}/ci-identities-gitlab-job-client" assume-role
+    - ${CI_PROJECT_DIR}/ci-identities-gitlab-job-client assume-role
     - aws s3 cp endpoints.csv s3://dd-datadog-ci/endpoints.csv


### PR DESCRIPTION
`"${CI_PROJECT_DIR}/..." assume-role` is invalid YAML — a double-quoted scalar followed by unquoted content. Removing the quotes around the path fixes the pipeline config error.