### PR TITLE
fix: add missing metadata fields to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,5 +93,8 @@
   },
   "workspaces": [
     "packages/*"
-  ]
+  ],
+  "bugs": {
+    "url": "https://github.com/DataDog/datadog-ci/issues"
+  }
 }


### PR DESCRIPTION
Adds missing `bugs` metadata to `package.json`.

Fixes npm tooling unable to resolve package metadata.