### PR TITLE
[SVLS-9186] add Windows Function App support to aas instrument

### DIFF
--- a/packages/plugin-aas/src/__tests__/common.test.ts
+++ b/packages/plugin-aas/src/__tests__/common.test.ts
@@ -1,7 +1,11 @@
 import type {Site} from '@azure/arm-appservice'
-import type {AasConfigOptions} from '@datadog/datadog-ci-base/commands/aas/common'
+import type {AasConfigOptions, WebApp} from '@datadog/datadog-ci-base/commands/aas/common'
 
 import {getWindowsRuntime, getEnvVars, isDotnet, isLinuxContainer, isWindows} from '../common'
+
+const WEB_APP: WebApp = {name: 'my-web-app'}
+const NON_CONTAINER_SITE: Site = {kind: 'app,linux', location: 'East US', siteConfig: {}}
+const CONTAINER_SITE: Site = {kind: 'app,linux', location: 'East US', siteConfig: {linuxFxVersion: 'sitecontainers'}}
 
 const DEFAULT_CONFIG: AasConfigOptions = {
   subscriptionId: '00000000-0000-0000-0000-000000000000',
@@ -36,7 +40,7 @@ describe('aas common', () => {
     })
 
     test('returns required env vars with default DD_SITE', () => {
-      const envVars = getEnvVars(DEFAULT_CONFIG, false)
+      const envVars = getEnvVars(DEFAULT_CONFIG, NON_CONTAINER_SITE, WEB_APP)
       expect(envVars).toEqual({
         DD_API_KEY: 'test-api-key',
         DD_SITE: 'datadoghq.com',
@@ -51,7 +55,7 @@ describe('aas common', () => {
         ...DEFAULT_CONFIG,
         isInstanceLoggingEnabled: true,
       }
-      const envVars = getEnvVars(config, false)
+      const envVars = getEnvVars(config, NON_CONTAINER_SITE, WEB_APP)
       expect(envVars.DD_SITE).toEqual('datadoghq.eu')
       expect(envVars.DD_AAS_INSTANCE_LOGGING_ENABLED).toEqual('true')
     })
@@ -61,7 +65,7 @@ describe('aas common', () => {
         ...DEFAULT_CONFIG,
         service: 'my-service',
       }
-      const envVars = getEnvVars(config, false)
+      const envVars = getEnvVars(config, NON_CONTAINER_SITE, WEB_APP)
       expect(envVars.DD_SERVICE).toEqual('my-service')
     })
 
@@ -71,7 +75,7 @@ describe('aas common', () => {
         isInstanceLoggingEnabled: false,
         environment: 'prod',
       }
-      const envVars = getEnvVars(config, false)
+      const envVars = getEnvVars(config, NON_CONTAINER_SITE, WEB_APP)
       expect(envVars.DD_ENV).toEqual('prod')
     })
 
@@ -81,7 +85,7 @@ describe('aas common', () => {
         isInstanceLoggingEnabled: false,
         logPath: '/tmp/logs',
       }
-      const envVars = getEnvVars(config, false)
+      const envVars = getEnvVars(config, NON_CONTAINER_SITE, WEB_APP)
       expect(envVars.DD_SERVERLESS_LOG_PATH).toEqual('/tmp/logs')
     })
 
@@ -93,7 +97,7 @@ describe('aas common', () => {
         environment: 'dev',
         logPath: '/var/log',
       }
-      const envVars = getEnvVars(config, false)
+      const envVars = getEnvVars(config, NON_CONTAINER_SITE, WEB_APP)
       expect(envVars).toMatchObject({
         DD_SERVICE: 'svc',
         DD_ENV: 'dev',
@@ -152,7 +156,7 @@ describe('aas common', () => {
     })
 
     test('includes .NET specific env vars when isDotnet is true', () => {
-      const envVars = getEnvVars({...DEFAULT_CONFIG, isDotnet: true}, false)
+      const envVars = getEnvVars({...DEFAULT_CONFIG, isDotnet: true}, NON_CONTAINER_SITE, WEB_APP)
       expect(envVars).toMatchObject({
         DD_DOTNET_TRACER_HOME: '/home/site/wwwroot/datadog',
         DD_TRACE_LOG_DIRECTORY: '/home/LogFiles/dotnet',
@@ -171,7 +175,7 @@ describe('aas common', () => {
         logPath: '/dotnet/logs',
         isInstanceLoggingEnabled: true,
       }
-      const envVars = getEnvVars(config, false)
+      const envVars = getEnvVars(config, NON_CONTAINER_SITE, WEB_APP)
       expect(envVars).toMatchObject({
         DD_SERVICE: 'svc',
         DD_ENV: 'qa',
@@ -195,7 +199,7 @@ describe('aas common', () => {
         logPath: '/dotnet/logs',
         isInstanceLoggingEnabled: true,
       }
-      const envVars = getEnvVars(config, false)
+      const envVars = getEnvVars(config, NON_CONTAINER_SITE, WEB_APP)
       expect(envVars).toMatchObject({
         DD_SERVICE: 'svc',
         DD_ENV: 'qa',
@@ -218,7 +222,7 @@ describe('aas common', () => {
         logPath: '/dotnet/logs',
         isInstanceLoggingEnabled: true,
       }
-      const envVars = getEnvVars(config, true)
+      const envVars = getEnvVars(config, CONTAINER_SITE, WEB_APP)
       expect(envVars).toMatchObject({
         DD_SERVICE: 'svc',
         DD_ENV: 'qa',
@@ -242,7 +246,7 @@ describe('aas common', () => {
         logPath: '/dotnet/logs',
         isInstanceLoggingEnabled: true,
       }
-      const envVars = getEnvVars(config, true)
+      const envVars = getEnvVars(config, CONTAINER_SITE, WEB_APP)
       expect(envVars).toMatchObject({
         DD_SERVICE: 'svc',
         DD_ENV: 'qa',
@@ -261,12 +265,12 @@ describe('aas common', () => {
         ...DEFAULT_CONFIG,
         extraTags: 'custom:tag,another:value',
       }
-      const envVars = getEnvVars(config, false)
+      const envVars = getEnvVars(config, NON_CONTAINER_SITE, WEB_APP)
       expect(envVars.DD_TAGS).toEqual('custom:tag,another:value')
     })
 
     test('does not include DD_TAGS when extraTags is not provided', () => {
-      const envVars = getEnvVars(DEFAULT_CONFIG, false)
+      const envVars = getEnvVars(DEFAULT_CONFIG, NON_CONTAINER_SITE, WEB_APP)
       expect(envVars.DD_TAGS).toBeUndefined()
     })
   })

--- a/packages/plugin-aas/src/__tests__/common.ts
+++ b/packages/plugin-aas/src/__tests__/common.ts
@@ -111,6 +111,33 @@ export const WINDOWS_JAVA_WEB_APP: Site = {
   },
 }
 
+export const WINDOWS_DOTNET_FUNCTION_APP: Site = {
+  ...WINDOWS_DOTNET_WEB_APP,
+  kind: 'functionapp',
+}
+
+export const WINDOWS_NODE_FUNCTION_APP: Site = {
+  ...WINDOWS_NODE_WEB_APP,
+  kind: 'functionapp',
+}
+
+// Windows .NET Function App on a Consumption plan (sku 'Dynamic'); the .NET extension can't
+// attach its profiler there, so instrumentation is rejected.
+export const WINDOWS_DOTNET_FUNCTION_APP_CONSUMPTION: Site = {
+  ...WINDOWS_DOTNET_FUNCTION_APP,
+  sku: 'Dynamic',
+}
+
+export const WINDOWS_JAVA_FUNCTION_APP: Site = {
+  ...WINDOWS_JAVA_WEB_APP,
+  kind: 'functionapp',
+}
+
+export const LINUX_FUNCTION_APP: Site = {
+  ...CONTAINER_WEB_APP,
+  kind: 'functionapp,linux',
+}
+
 export const DEFAULT_ARGS = [
   '-s',
   '00000000-0000-0000-0000-000000000000',

--- a/packages/plugin-aas/src/__tests__/instrument.test.ts
+++ b/packages/plugin-aas/src/__tests__/instrument.test.ts
@@ -68,9 +68,14 @@ import {PluginCommand as InstrumentCommand} from '../commands/instrument'
 import {
   CONTAINER_WEB_APP,
   LINUX_CODE_WEB_APP,
+  LINUX_FUNCTION_APP,
   WINDOWS_DOTNET_WEB_APP,
+  WINDOWS_DOTNET_FUNCTION_APP,
+  WINDOWS_DOTNET_FUNCTION_APP_CONSUMPTION,
   WINDOWS_NODE_WEB_APP,
+  WINDOWS_NODE_FUNCTION_APP,
   WINDOWS_JAVA_WEB_APP,
+  WINDOWS_JAVA_FUNCTION_APP,
   DEFAULT_INSTRUMENT_ARGS,
   DEFAULT_CONFIG,
   WEB_APP_ID,
@@ -805,6 +810,113 @@ describe('aas instrument', () => {
       expect(context.stdout.toString()).toMatchSnapshot()
     })
 
+    test('Installs .NET extension on Windows Function App (no slot)', async () => {
+      webAppsOperations.get.mockClear().mockResolvedValue(WINDOWS_DOTNET_FUNCTION_APP)
+      const {code} = await runCLI(DEFAULT_INSTRUMENT_ARGS)
+      expect(code).toEqual(0)
+
+      expect(webAppsOperations.get).toHaveBeenCalledWith('my-resource-group', 'my-web-app')
+      expect(webAppsOperations.stop).toHaveBeenCalledTimes(1)
+      expect(createAzureResource).toHaveBeenCalledWith(
+        `${WEB_APP_ID}/siteextensions/Datadog.AzureAppServices.DotNet`,
+        '2024-11-01',
+        expect.any(Object)
+      )
+      expect(webAppsOperations.start).toHaveBeenCalledTimes(1)
+      expect(webAppsOperations.listSlotConfigurationNames).not.toHaveBeenCalled()
+      expect(webAppsOperations.updateSlotConfigurationNames).not.toHaveBeenCalled()
+    })
+
+    test('Installs .NET extension on Windows Function App with slot (sticky prereqs applied)', async () => {
+      webAppsOperations.getSlot.mockClear().mockResolvedValue(WINDOWS_DOTNET_FUNCTION_APP)
+      const {code} = await runCLI(SLOT_INSTRUMENT_ARGS)
+      expect(code).toEqual(0)
+
+      expect(webAppsOperations.getSlot).toHaveBeenCalledWith('my-resource-group', 'my-web-app', 'staging')
+      expect(webAppsOperations.listSlotConfigurationNames).toHaveBeenCalledWith('my-resource-group', 'my-web-app')
+      expect(webAppsOperations.updateSlotConfigurationNames).toHaveBeenCalledWith(
+        'my-resource-group',
+        'my-web-app',
+        expect.objectContaining({
+          appSettingNames: expect.arrayContaining(['WEBSITE_PRIVATE_EXTENSIONS']),
+        })
+      )
+      expect(webAppsOperations.updateApplicationSettingsSlot).toHaveBeenCalledWith(
+        'my-resource-group',
+        'my-web-app',
+        'staging',
+        expect.objectContaining({
+          properties: expect.objectContaining({WEBSITE_PRIVATE_EXTENSIONS: '0'}),
+        })
+      )
+      expect(webAppsOperations.stopSlot).toHaveBeenCalledWith('my-resource-group', 'my-web-app', 'staging')
+      expect(createAzureResource).toHaveBeenCalledWith(
+        `${WEB_APP_SLOT_ID}/siteextensions/Datadog.AzureAppServices.DotNet`,
+        '2024-11-01',
+        expect.any(Object)
+      )
+      expect(webAppsOperations.startSlot).toHaveBeenCalledWith('my-resource-group', 'my-web-app', 'staging')
+
+      // WEBSITE_PRIVATE_EXTENSIONS=0 must be written to the slot before the extension install so the
+      // Functions runtime releases its SiteExtensions locks beforehand (see datadog-aas-extension#457)
+      expect(webAppsOperations.updateApplicationSettingsSlot.mock.invocationCallOrder[0]).toBeLessThan(
+        createAzureResource.mock.invocationCallOrder[0]
+      )
+    })
+
+    test('Registers DD_ENV and WEBSITE_PRIVATE_EXTENSIONS sticky together on a Function App slot with --env', async () => {
+      webAppsOperations.getSlot.mockClear().mockResolvedValue(WINDOWS_DOTNET_FUNCTION_APP)
+      const {code} = await runCLI([...SLOT_INSTRUMENT_ARGS, '--env', 'staging'])
+      expect(code).toEqual(0)
+
+      // Both names must be registered in a single read-modify-write to avoid one clobbering the other
+      expect(webAppsOperations.updateSlotConfigurationNames).toHaveBeenCalledTimes(1)
+      expect(webAppsOperations.updateSlotConfigurationNames).toHaveBeenCalledWith(
+        'my-resource-group',
+        'my-web-app',
+        expect.objectContaining({
+          appSettingNames: expect.arrayContaining(['WEBSITE_PRIVATE_EXTENSIONS', 'DD_ENV']),
+        })
+      )
+    })
+
+    test('Rejects Windows Node.js Function App with error', async () => {
+      webAppsOperations.get.mockClear().mockResolvedValue(WINDOWS_NODE_FUNCTION_APP)
+      const {code, context} = await runCLI(DEFAULT_INSTRUMENT_ARGS)
+      expect(code).toEqual(1)
+      expect(context.stdout.toString()).toContain('https://docs.datadoghq.com/serverless/azure_functions')
+      expect(createAzureResource).not.toHaveBeenCalled()
+      expect(webAppsOperations.stop).not.toHaveBeenCalled()
+    })
+
+    test('Rejects Windows Java Function App with error', async () => {
+      webAppsOperations.get.mockClear().mockResolvedValue(WINDOWS_JAVA_FUNCTION_APP)
+      const {code, context} = await runCLI(DEFAULT_INSTRUMENT_ARGS)
+      expect(code).toEqual(1)
+      expect(context.stdout.toString()).toContain('https://docs.datadoghq.com/serverless/azure_functions')
+      expect(createAzureResource).not.toHaveBeenCalled()
+      expect(webAppsOperations.stop).not.toHaveBeenCalled()
+    })
+
+    test('Rejects Linux Function App with error', async () => {
+      webAppsOperations.get.mockClear().mockResolvedValue(LINUX_FUNCTION_APP)
+      const {code, context} = await runCLI(DEFAULT_INSTRUMENT_ARGS)
+      expect(code).toEqual(1)
+      expect(context.stdout.toString()).toContain('https://docs.datadoghq.com/serverless/azure_functions')
+      expect(webAppsOperations.createOrUpdateSiteContainer).not.toHaveBeenCalled()
+      expect(webAppsOperations.stop).not.toHaveBeenCalled()
+    })
+
+    test('Rejects Windows .NET Function App on a Consumption plan with error', async () => {
+      webAppsOperations.get.mockClear().mockResolvedValue(WINDOWS_DOTNET_FUNCTION_APP_CONSUMPTION)
+      const {code, context} = await runCLI(DEFAULT_INSTRUMENT_ARGS)
+      expect(code).toEqual(1)
+      expect(context.stdout.toString()).toContain('Dedicated (App Service) or Premium plan')
+      expect(context.stdout.toString()).toContain('https://docs.datadoghq.com/serverless/azure_functions')
+      expect(createAzureResource).not.toHaveBeenCalled()
+      expect(webAppsOperations.stop).not.toHaveBeenCalled()
+    })
+
     test('Validates windows runtime parameter', async () => {
       const {code, context} = await runCLI([...DEFAULT_INSTRUMENT_ARGS, '--windows-runtime', 'invalid'])
       expect(code).toEqual(1)
@@ -1009,7 +1121,14 @@ describe('aas instrument', () => {
     })
 
     test('creates sidecar if not present and updates app settings', async () => {
-      await command.instrumentSidecar(client, DEFAULT_CONFIG_WITH_DEFAULT_SERVICE, 'rg', {name: 'app'}, false, {})
+      await command.instrumentSidecar(
+        client,
+        DEFAULT_CONFIG_WITH_DEFAULT_SERVICE,
+        'rg',
+        {name: 'app'},
+        {},
+        LINUX_CODE_WEB_APP
+      )
 
       expect(webAppsOperations.createOrUpdateSiteContainer).toHaveBeenCalledWith('rg', 'app', 'datadog-sidecar', {
         image: 'index.docker.io/datadog/serverless-init:latest',
@@ -1039,8 +1158,8 @@ describe('aas instrument', () => {
         {...DEFAULT_CONFIG_WITH_DEFAULT_SERVICE, isDotnet: true},
         'rg',
         {name: 'app'},
-        false,
-        {}
+        {},
+        LINUX_CODE_WEB_APP
       )
 
       expect(webAppsOperations.createOrUpdateSiteContainer).toHaveBeenCalledWith('rg', 'app', 'datadog-sidecar', {
@@ -1081,8 +1200,8 @@ describe('aas instrument', () => {
         {...DEFAULT_CONFIG_WITH_DEFAULT_SERVICE, isDotnet: true, isMusl: true},
         'rg',
         {name: 'app'},
-        false,
-        {}
+        {},
+        LINUX_CODE_WEB_APP
       )
 
       expect(webAppsOperations.createOrUpdateSiteContainer).toHaveBeenCalledWith('rg', 'app', 'datadog-sidecar', {
@@ -1134,7 +1253,14 @@ describe('aas instrument', () => {
       webAppsOperations.createOrUpdateSiteContainer.mockResolvedValue({})
       webAppsOperations.updateApplicationSettings.mockResolvedValue({})
 
-      await command.instrumentSidecar(client, DEFAULT_CONFIG_WITH_DEFAULT_SERVICE, 'rg', {name: 'app'}, false, {})
+      await command.instrumentSidecar(
+        client,
+        DEFAULT_CONFIG_WITH_DEFAULT_SERVICE,
+        'rg',
+        {name: 'app'},
+        {},
+        LINUX_CODE_WEB_APP
+      )
 
       expect(webAppsOperations.createOrUpdateSiteContainer).toHaveBeenCalled()
       expect(webAppsOperations.updateApplicationSettings).toHaveBeenCalled()
@@ -1168,8 +1294,8 @@ describe('aas instrument', () => {
         DEFAULT_CONFIG_WITH_DEFAULT_SERVICE,
         'rg',
         {name: 'app'},
-        false,
-        existingEnvVars
+        existingEnvVars,
+        LINUX_CODE_WEB_APP
       )
       expect(webAppsOperations.createOrUpdateSiteContainer).not.toHaveBeenCalled()
       expect(webAppsOperations.updateApplicationSettings).not.toHaveBeenCalled()
@@ -1180,7 +1306,14 @@ describe('aas instrument', () => {
       command.dryRun = true
       webAppsOperations.listSiteContainers.mockReturnValue(asyncIterable())
 
-      await command.instrumentSidecar(client, DEFAULT_CONFIG_WITH_DEFAULT_SERVICE, 'rg', {name: 'app'}, false, {})
+      await command.instrumentSidecar(
+        client,
+        DEFAULT_CONFIG_WITH_DEFAULT_SERVICE,
+        'rg',
+        {name: 'app'},
+        {},
+        LINUX_CODE_WEB_APP
+      )
 
       expect(webAppsOperations.createOrUpdateSiteContainer).not.toHaveBeenCalled()
       expect(webAppsOperations.updateApplicationSettings).not.toHaveBeenCalled()
@@ -1201,8 +1334,8 @@ describe('aas instrument', () => {
         DEFAULT_CONFIG_WITH_DEFAULT_SERVICE,
         'rg',
         {name: 'app'},
-        false,
-        existingEnvVars
+        existingEnvVars,
+        LINUX_CODE_WEB_APP
       )
 
       expect(webAppsOperations.updateApplicationSettings).not.toHaveBeenCalled()

--- a/packages/plugin-aas/src/__tests__/uninstrument.test.ts
+++ b/packages/plugin-aas/src/__tests__/uninstrument.test.ts
@@ -26,6 +26,8 @@ const webAppsOperations = {
   listApplicationSettingsSlot: jest.fn(),
   updateApplicationSettingsSlot: jest.fn(),
   listSiteExtensionsSlot: jest.fn(),
+  listSlotConfigurationNames: jest.fn(),
+  updateSlotConfigurationNames: jest.fn(),
 }
 
 const updateTags = jest.fn().mockResolvedValue({})
@@ -45,6 +47,7 @@ import {PluginCommand as UninstrumentCommand} from '../commands/uninstrument'
 import {
   CONTAINER_WEB_APP,
   WINDOWS_DOTNET_WEB_APP,
+  WINDOWS_DOTNET_FUNCTION_APP,
   WINDOWS_NODE_WEB_APP,
   WINDOWS_JAVA_WEB_APP,
   DEFAULT_ARGS,
@@ -92,6 +95,8 @@ describe('aas instrument', () => {
       webAppsOperations.listApplicationSettingsSlot.mockReset().mockResolvedValue({properties: {}})
       webAppsOperations.updateApplicationSettingsSlot.mockReset().mockResolvedValue(undefined)
       webAppsOperations.listSiteExtensionsSlot.mockReset().mockReturnValue(asyncIterable())
+      webAppsOperations.listSlotConfigurationNames.mockReset().mockResolvedValue({appSettingNames: []})
+      webAppsOperations.updateSlotConfigurationNames.mockReset().mockResolvedValue({})
       updateTags.mockClear().mockResolvedValue({})
       deleteAzureResource.mockClear().mockResolvedValue({})
     })
@@ -628,6 +633,79 @@ describe('aas instrument', () => {
           }),
         })
       )
+    })
+
+    test('Removes WEBSITE_PRIVATE_EXTENSIONS setting and sticky entry from a Function App slot', async () => {
+      webAppsOperations.getSlot.mockClear().mockResolvedValue({
+        ...WINDOWS_DOTNET_FUNCTION_APP,
+        tags: {service: WINDOWS_DOTNET_FUNCTION_APP.name},
+      })
+      webAppsOperations.getConfigurationSlot.mockClear().mockResolvedValue(WINDOWS_DOTNET_FUNCTION_APP.siteConfig)
+      webAppsOperations.listSiteExtensionsSlot
+        .mockClear()
+        .mockReturnValue(asyncIterable({name: 'my-web-app/Datadog.AzureAppServices.DotNet'}))
+      webAppsOperations.listApplicationSettingsSlot.mockClear().mockResolvedValue({
+        properties: {WEBSITE_PRIVATE_EXTENSIONS: '0', DD_API_KEY: 'test-key', hello: 'world'},
+      })
+      // DD_ENV is left sticky on purpose; only WEBSITE_PRIVATE_EXTENSIONS is our teardown concern
+      webAppsOperations.listSlotConfigurationNames
+        .mockClear()
+        .mockResolvedValue({appSettingNames: ['WEBSITE_PRIVATE_EXTENSIONS', 'DD_ENV']})
+
+      const {code} = await runCLI(SLOT_ARGS)
+      expect(code).toEqual(0)
+
+      // WEBSITE_PRIVATE_EXTENSIONS (and DD settings) removed from app settings, user settings kept
+      expect(webAppsOperations.updateApplicationSettingsSlot).toHaveBeenCalledWith(
+        'my-resource-group',
+        'my-web-app',
+        'staging',
+        {properties: {hello: 'world'}}
+      )
+      // sticky entry removed for WEBSITE_PRIVATE_EXTENSIONS, DD_ENV left in place
+      expect(webAppsOperations.listSlotConfigurationNames).toHaveBeenCalledWith('my-resource-group', 'my-web-app')
+      expect(webAppsOperations.updateSlotConfigurationNames).toHaveBeenCalledWith('my-resource-group', 'my-web-app', {
+        appSettingNames: ['DD_ENV'],
+      })
+    })
+
+    test('Does not touch slot config names when uninstrumenting a non-Function-App slot', async () => {
+      webAppsOperations.getSlot.mockClear().mockResolvedValue({
+        ...WINDOWS_DOTNET_WEB_APP,
+        tags: {service: WINDOWS_DOTNET_WEB_APP.name},
+      })
+      webAppsOperations.getConfigurationSlot.mockClear().mockResolvedValue(WINDOWS_DOTNET_WEB_APP.siteConfig)
+      webAppsOperations.listSiteExtensionsSlot
+        .mockClear()
+        .mockReturnValue(asyncIterable({name: 'my-web-app/Datadog.AzureAppServices.DotNet'}))
+
+      const {code} = await runCLI(SLOT_ARGS)
+      expect(code).toEqual(0)
+      expect(webAppsOperations.listSlotConfigurationNames).not.toHaveBeenCalled()
+      expect(webAppsOperations.updateSlotConfigurationNames).not.toHaveBeenCalled()
+    })
+
+    test('Removes WEBSITE_PRIVATE_EXTENSIONS sticky once across multiple Function App slots', async () => {
+      webAppsOperations.getSlot.mockClear().mockResolvedValue({
+        ...WINDOWS_DOTNET_FUNCTION_APP,
+        tags: {service: WINDOWS_DOTNET_FUNCTION_APP.name},
+      })
+      webAppsOperations.getConfigurationSlot.mockClear().mockResolvedValue(WINDOWS_DOTNET_FUNCTION_APP.siteConfig)
+      webAppsOperations.listSiteExtensionsSlot
+        .mockClear()
+        .mockReturnValue(asyncIterable({name: 'my-web-app/Datadog.AzureAppServices.DotNet'}))
+      webAppsOperations.listSlotConfigurationNames
+        .mockClear()
+        .mockResolvedValue({appSettingNames: ['WEBSITE_PRIVATE_EXTENSIONS']})
+
+      const {code} = await runCLI(['-r', WEB_APP_SLOT_ID, '-r', WEB_APP_ID + '/slots/staging2'])
+      expect(code).toEqual(0)
+      // site-level resource touched once, not once per slot
+      expect(webAppsOperations.listSlotConfigurationNames).toHaveBeenCalledTimes(1)
+      expect(webAppsOperations.updateSlotConfigurationNames).toHaveBeenCalledTimes(1)
+      expect(webAppsOperations.updateSlotConfigurationNames).toHaveBeenCalledWith('my-resource-group', 'my-web-app', {
+        appSettingNames: [],
+      })
     })
   })
 })

--- a/packages/plugin-aas/src/commands/instrument.ts
+++ b/packages/plugin-aas/src/commands/instrument.ts
@@ -1,4 +1,4 @@
-import type {SiteContainer, StringDictionary} from '@azure/arm-appservice'
+import type {Site, SiteContainer, StringDictionary} from '@azure/arm-appservice'
 import type {AasConfigOptions, WebApp, WindowsRuntime} from '@datadog/datadog-ci-base/commands/aas/common'
 
 import {WebSiteManagementClient} from '@azure/arm-appservice'
@@ -30,39 +30,24 @@ import {
   aggregateStickyBySite,
   getWindowsRuntime,
   getEnvVars,
+  isConsumptionPlan,
   isDotnet,
+  isFunctionApp,
   isLinuxContainer,
   isWindows,
-  registerStickySlotSettings,
-  type StickySlotSettings,
+  mutateStickySlotSettings,
+  stickySlotSettings,
+  WEBSITE_PRIVATE_EXTENSIONS,
+  type ProcessResult,
+  AZURE_FUNCTIONS_DOCS_URL,
+  AZURE_WINDOWS_FUNCTIONS_DOCS_URL,
 } from '../common'
 
-interface ProcessResult {
-  success: boolean
-  // Sticky slot settings this resource needs registered on its parent site.
-  // Aggregated per-site and written once, since slotConfigNames is site-level.
-  sticky?: StickySlotSettings
-}
-
-/**
- * Sticky slot settings a resource needs registered on its parent site. Includes
- * DD_ENV when --env is set. Undefined when not targeting a slot.
- */
-const stickySettingsFor = (
-  resourceGroup: string,
-  webApp: WebApp,
-  config: AasConfigOptions
-): StickySlotSettings | undefined => {
-  if (!webApp.slot) {
-    return undefined
-  }
-  const names: string[] = []
-  if (config.environment) {
-    names.push('DD_ENV')
-  }
-
-  return names.length ? {resourceGroup, webAppName: webApp.name, names} : undefined
-}
+// Pin DD_ENV (set via --env) plus any extra names sticky to the slot.
+const stickyNames = (config: AasConfigOptions, additional: string[] = []): string[] => [
+  ...additional,
+  ...(config.environment ? ['DD_ENV'] : []),
+]
 
 export class PluginCommand extends AasInstrumentCommand {
   private cred!: DefaultAzureCredential
@@ -145,7 +130,7 @@ export class PluginCommand extends AasInstrumentCommand {
     // concurrent read-modify-writes racing when multiple slots of one app are instrumented.
     await Promise.all(
       aggregateStickyBySite(results.map((result) => result.sticky)).map(({resourceGroup, webAppName, names}) =>
-        registerStickySlotSettings(aasClient, resourceGroup, webAppName, names, {
+        mutateStickySlotSettings(aasClient, resourceGroup, webAppName, names, 'add', {
           dryRun: this.dryRun,
           dryRunPrefix: this.dryRunPrefix,
           log: (message) => this.context.stdout.write(message),
@@ -168,9 +153,7 @@ export class PluginCommand extends AasInstrumentCommand {
   ): Promise<ProcessResult> {
     // make config a copy with the default service added
     config = {...config, service: config.service ?? webApp.name}
-    // Sticky slot settings this resource needs on its parent site (none unless a
-    // slot). Reported back so processSubscription can register them once per site.
-    const sticky = stickySettingsFor(resourceGroup, webApp, config)
+    const sticky = stickySlotSettings(resourceGroup, webApp, stickyNames(config))
     try {
       const [site, envVarDictionary] = await Promise.all(
         webApp.slot
@@ -186,9 +169,48 @@ export class PluginCommand extends AasInstrumentCommand {
       const existingEnvVars = envVarDictionary.properties ?? {}
 
       // Determine instrumentation method based on platform
+      if (isFunctionApp(site) && !isWindows(site)) {
+        this.context.stdout.write(
+          renderError(`Linux Function Apps are not supported by this command. See ${AZURE_FUNCTIONS_DOCS_URL}`)
+        )
+
+        return {success: false}
+      }
+
       if (isWindows(site)) {
         // Windows instrumentation via extension
         const runtime = config.windowsRuntime ?? getWindowsRuntime(site, existingEnvVars)
+
+        if (isFunctionApp(site)) {
+          if (isConsumptionPlan(site)) {
+            this.context.stdout.write(
+              renderError(
+                `Windows Function Apps require a Dedicated (App Service) or Premium plan. See ${AZURE_WINDOWS_FUNCTIONS_DOCS_URL}`
+              )
+            )
+
+            return {success: false}
+          }
+          if (runtime !== 'dotnet') {
+            this.context.stdout.write(
+              renderError(
+                `Windows Function Apps with the ${runtime ?? 'unknown'} runtime are not supported by this command. See ${AZURE_FUNCTIONS_DOCS_URL}`
+              )
+            )
+
+            return {success: false}
+          }
+          // Slots need WEBSITE_PRIVATE_EXTENSIONS=0 pinned sticky so it survives a swap.
+          await this.instrumentExtension(aasClient, config, resourceGroup, webApp, 'dotnet', existingEnvVars, site)
+          // tag only after instrumentation succeeds (avoids false telemetry)
+          await this.addTags(config, aasClient.subscriptionId!, resourceGroup, webApp, site.tags ?? {})
+
+          return {
+            success: true,
+            sticky: stickySlotSettings(resourceGroup, webApp, stickyNames(config, [WEBSITE_PRIVATE_EXTENSIONS])),
+          }
+        }
+
         if (!runtime) {
           this.context.stdout.write(
             renderSoftWarning(
@@ -198,8 +220,8 @@ export class PluginCommand extends AasInstrumentCommand {
 
           return {success: false}
         }
-        await this.instrumentExtension(aasClient, config, resourceGroup, webApp, runtime, existingEnvVars)
-        // we explicitly tag after instrumentation so we don't get a positive telemetry signal until it succeeds
+        await this.instrumentExtension(aasClient, config, resourceGroup, webApp, runtime, existingEnvVars, site)
+        // tag only after instrumentation succeeds (avoids false telemetry)
         await this.addTags(config, aasClient.subscriptionId!, resourceGroup, webApp, site.tags ?? {})
 
         return {success: true, sticky}
@@ -217,8 +239,8 @@ This flag is only applicable for containerized .NET apps (on musl-based distribu
       }
       config.isDotnet ||= isDotnet(site)
       config.isMusl &&= config.isDotnet && isContainer
-      await this.instrumentSidecar(aasClient, config, resourceGroup, webApp, isContainer, existingEnvVars)
-      // we explicitly tag after instrumentation so we don't get a positive telemetry signal until it succeeds
+      await this.instrumentSidecar(aasClient, config, resourceGroup, webApp, existingEnvVars, site)
+      // tag only after instrumentation succeeds (avoids false telemetry)
       await this.addTags(config, aasClient.subscriptionId!, resourceGroup, webApp, site.tags ?? {})
     } catch (error) {
       this.context.stdout.write(renderError(`Failed to instrument ${renderWebApp(webApp)}: ${formatError(error)}`))
@@ -285,7 +307,8 @@ This flag is only applicable for containerized .NET apps (on musl-based distribu
     resourceGroup: string,
     webApp: WebApp,
     runtime: WindowsRuntime,
-    existingEnvVars: Record<string, string>
+    existingEnvVars: Record<string, string>,
+    site: Site
   ) {
     const extensionId = WINDOWS_RUNTIME_EXTENSIONS[runtime]
 
@@ -298,7 +321,7 @@ This flag is only applicable for containerized .NET apps (on musl-based distribu
     const extensionInstalled = existingExtensions.some(
       (ext) => ext.name && getExtensionId(ext.name).toLowerCase() === extensionId.toLowerCase()
     )
-    const envVars = getEnvVars(config, false)
+    const envVars = getEnvVars(config, site, webApp)
 
     if (extensionInstalled) {
       this.context.stdout.write(
@@ -309,7 +332,8 @@ This flag is only applicable for containerized .NET apps (on musl-based distribu
       return
     }
 
-    const envVarsPromise = this.updateEnvVars(client, resourceGroup, webApp, existingEnvVars, envVars)
+    // Apply app settings before installing the extension (commits WEBSITE_PRIVATE_EXTENSIONS=0 for slots).
+    await this.updateEnvVars(client, resourceGroup, webApp, existingEnvVars, envVars)
 
     this.context.stdout.write(`${this.dryRunPrefix}Stopping Web App ${renderWebApp(webApp)}\n`)
     if (!this.dryRun) {
@@ -329,7 +353,6 @@ This flag is only applicable for containerized .NET apps (on musl-based distribu
         {}
       )
     }
-    await envVarsPromise
 
     this.context.stdout.write(`${this.dryRunPrefix}Starting Web App ${renderWebApp(webApp)}\n`)
     if (!this.dryRun) {
@@ -344,8 +367,8 @@ This flag is only applicable for containerized .NET apps (on musl-based distribu
     config: AasConfigOptions,
     resourceGroup: string,
     webApp: WebApp,
-    isContainer: boolean,
-    existingEnvVars: Record<string, string>
+    existingEnvVars: Record<string, string>,
+    site: Site
   ) {
     const siteContainers = await collectAsyncIterator(
       webApp.slot
@@ -353,7 +376,7 @@ This flag is only applicable for containerized .NET apps (on musl-based distribu
         : client.webApps.listSiteContainers(resourceGroup, webApp.name)
     )
     const sidecarContainer = siteContainers.find((c) => c.name === SIDECAR_CONTAINER_NAME)
-    const envVars = getEnvVars(config, isContainer)
+    const envVars = getEnvVars(config, site, webApp)
     // We need to ensure that the sidecar container is configured correctly, which means checking the image, target port,
     // and environment variables. The sidecar environment variables must have matching names and values, as the sidecar
     // env values point to env keys in the main App Settings. (essentially env var forwarding)

--- a/packages/plugin-aas/src/commands/uninstrument.ts
+++ b/packages/plugin-aas/src/commands/uninstrument.ts
@@ -13,7 +13,17 @@ import {SIDECAR_CONTAINER_NAME} from '@datadog/datadog-ci-base/helpers/serverles
 import {SERVERLESS_CLI_VERSION_TAG_NAME} from '@datadog/datadog-ci-base/helpers/tags'
 import chalk from 'chalk'
 
-import {AAS_DD_SETTING_NAMES, isDotnet, isWindows} from '../common'
+import {
+  AAS_DD_SETTING_NAMES,
+  aggregateStickyBySite,
+  isDotnet,
+  isWindows,
+  isWindowsFunctionApp,
+  mutateStickySlotSettings,
+  stickySlotSettings,
+  WEBSITE_PRIVATE_EXTENSIONS,
+  type ProcessResult,
+} from '../common'
 
 export class PluginCommand extends AasUninstrumentCommand {
   private cred!: DefaultAzureCredential
@@ -63,7 +73,19 @@ export class PluginCommand extends AasUninstrumentCommand {
       )
     )
 
-    return results.every((result) => result)
+    // Remove sticky settings once per site (slotConfigNames is site-level) to avoid concurrent
+    // read-modify-writes racing when multiple slots of one app are uninstrumented.
+    await Promise.all(
+      aggregateStickyBySite(results.map((result) => result.sticky)).map(({resourceGroup, webAppName, names}) =>
+        mutateStickySlotSettings(client, resourceGroup, webAppName, names, 'remove', {
+          dryRun: this.dryRun,
+          dryRunPrefix: this.dryRunPrefix,
+          log: (message) => this.context.stdout.write(message),
+        })
+      )
+    )
+
+    return results.every((result) => result.success)
   }
 
   /**
@@ -75,7 +97,7 @@ export class PluginCommand extends AasUninstrumentCommand {
     config: AasConfigOptions,
     resourceGroup: string,
     webApp: WebApp
-  ): Promise<boolean> {
+  ): Promise<ProcessResult> {
     try {
       const [site, siteConfig] = await Promise.all(
         webApp.slot
@@ -90,13 +112,18 @@ export class PluginCommand extends AasUninstrumentCommand {
       )
       // patch in the site config which is the real source of truth
       site.siteConfig = siteConfig
+      // Undo WEBSITE_PRIVATE_EXTENSIONS set during instrumentation: remove the app setting here,
+      // unregister it sticky below. (DD_ENV is intentionally left sticky.)
+      const removePrivateExtensions = isWindowsFunctionApp(site) && !!webApp.slot
+      const extraSettings = removePrivateExtensions ? [WEBSITE_PRIVATE_EXTENSIONS] : []
       // Determine uninstrumentation method based on platform
       if (isWindows(site)) {
         await this.uninstrumentExtension(
           client,
           {...config, service: config.service ?? webApp.name},
           resourceGroup,
-          webApp
+          webApp,
+          extraSettings
         )
       } else {
         // Linux uninstrumentation via sidecar
@@ -108,20 +135,26 @@ export class PluginCommand extends AasUninstrumentCommand {
         )
       }
       await this.removeTags(client.subscriptionId!, resourceGroup, webApp, site.tags ?? {})
+
+      return {
+        success: true,
+        sticky: removePrivateExtensions
+          ? stickySlotSettings(resourceGroup, webApp, [WEBSITE_PRIVATE_EXTENSIONS])
+          : undefined,
+      }
     } catch (error) {
       this.context.stdout.write(renderError(`Failed to uninstrument ${chalk.bold(webApp)}: ${formatError(error)}`))
 
-      return false
+      return {success: false}
     }
-
-    return true
   }
 
   public async uninstrumentExtension(
     client: WebSiteManagementClient,
     config: AasConfigOptions,
     resourceGroup: string,
-    webApp: WebApp
+    webApp: WebApp,
+    additionalSettings: string[] = []
   ) {
     // List all currently installed extensions
     const existingExtensions = await collectAsyncIterator(
@@ -163,7 +196,7 @@ export class PluginCommand extends AasUninstrumentCommand {
     }
 
     // Updaing the environment variables will trigger a restart
-    await this.removeEnvVars(config, webApp, client, resourceGroup)
+    await this.removeEnvVars(config, webApp, client, resourceGroup, additionalSettings)
   }
 
   public async uninstrumentSidecar(
@@ -187,9 +220,14 @@ export class PluginCommand extends AasUninstrumentCommand {
     config: AasConfigOptions,
     webApp: WebApp,
     client: WebSiteManagementClient,
-    resourceGroup: string
+    resourceGroup: string,
+    additionalSettings: string[] = []
   ) {
-    const configuredSettings = new Set([...AAS_DD_SETTING_NAMES, ...Object.keys(parseEnvVars(config.envVars))])
+    const configuredSettings = new Set([
+      ...AAS_DD_SETTING_NAMES,
+      ...Object.keys(parseEnvVars(config.envVars)),
+      ...additionalSettings,
+    ])
     this.context.stdout.write(`${this.dryRunPrefix}Checking Application Settings on ${renderWebApp(webApp)}\n`)
     const currentEnvVars = (
       await (webApp.slot

--- a/packages/plugin-aas/src/common.ts
+++ b/packages/plugin-aas/src/common.ts
@@ -1,5 +1,5 @@
 import type {Site, SlotConfigNamesResource, WebSiteManagementClient} from '@azure/arm-appservice'
-import type {AasConfigOptions, WindowsRuntime} from '@datadog/datadog-ci-base/commands/aas/common'
+import type {AasConfigOptions, WebApp, WindowsRuntime} from '@datadog/datadog-ci-base/commands/aas/common'
 
 import {getBaseEnvVars} from '@datadog/datadog-ci-base/helpers/serverless/common'
 import chalk from 'chalk'
@@ -34,6 +34,10 @@ export const AAS_DD_SETTING_NAMES = [
   'WEBSITES_ENABLE_APP_SERVICE_STORAGE',
 ] as const
 
+// Disabling private site extensions releases the Functions runtime's locks on the SiteExtensions
+// directory before the extension install (datadog-aas-extension#457).
+export const WEBSITE_PRIVATE_EXTENSIONS = 'WEBSITE_PRIVATE_EXTENSIONS'
+
 /**
  * Detects the runtime of a Windows-based Web App
  * @param site The web app or slot
@@ -57,12 +61,17 @@ export const getWindowsRuntime = (site: Site, envVars: Record<string, string>): 
   return undefined
 }
 
-export const getEnvVars = (config: AasConfigOptions, isContainer: boolean): Record<string, string> => {
+export const getEnvVars = (config: AasConfigOptions, site: Site, webApp: WebApp): Record<string, string> => {
+  const isContainer = isLinuxContainer(site)
+  // Function App slots need private extensions disabled before the extension install.
+  const includePrivateExtensions = isWindowsFunctionApp(site) && !!webApp.slot
+
   // Get base environment variables
   let envVars = getBaseEnvVars(config)
   envVars = {
     WEBSITES_ENABLE_APP_SERVICE_STORAGE: 'true',
     DD_AAS_INSTANCE_LOGGING_ENABLED: (config.isInstanceLoggingEnabled ?? false).toString(),
+    ...(includePrivateExtensions ? {[WEBSITE_PRIVATE_EXTENSIONS]: '0'} : {}),
     ...envVars,
   }
 
@@ -82,6 +91,13 @@ export const getEnvVars = (config: AasConfigOptions, isContainer: boolean): Reco
   return envVars
 }
 
+export const AZURE_FUNCTIONS_DOCS_URL = 'https://docs.datadoghq.com/serverless/azure_functions'
+export const AZURE_WINDOWS_FUNCTIONS_DOCS_URL = 'https://docs.datadoghq.com/serverless/azure_functions/dotnet_extension'
+
+export const isFunctionApp = (site: Site): boolean => {
+  return !!site.kind?.includes('functionapp')
+}
+
 export const isWindows = (site: Site): boolean => {
   if (!site.kind) {
     // search for windowsFxVersion in siteConfig if there is no kind
@@ -97,6 +113,15 @@ export const isDotnet = (site: Site): boolean => {
     (!!site.siteConfig?.windowsFxVersion && site.siteConfig.windowsFxVersion.toLowerCase().startsWith('dotnet'))
   )
 }
+
+export const isWindowsFunctionApp = (site: Site): boolean => isWindows(site) && isFunctionApp(site)
+
+// The .NET site extension only injects its profiler on Dedicated (App Service) and Elastic
+// Premium plans. On Consumption / Flex Consumption the extension installs but the profiler is
+// never attached to the worker, so no telemetry flows. site.sku carries the plan tier name.
+const UNSUPPORTED_FUNCTION_APP_SKUS = ['Dynamic', 'FlexConsumption']
+export const isConsumptionPlan = (site: Site): boolean =>
+  !!site.sku && UNSUPPORTED_FUNCTION_APP_SKUS.some((sku) => sku.toLowerCase() === site.sku!.toLowerCase())
 
 export const isLinuxContainer = (site: Site): boolean => {
   if (!site.siteConfig?.linuxFxVersion) {
@@ -116,6 +141,20 @@ export interface StickySlotSettings {
   names: string[]
 }
 
+export interface ProcessResult {
+  success: boolean
+  // Sticky settings to add/remove on the parent site, aggregated and written once per site.
+  sticky?: StickySlotSettings
+}
+
+/** Build a sticky-settings entry, or undefined when this isn't a slot or there's nothing to pin. */
+export const stickySlotSettings = (
+  resourceGroup: string,
+  webApp: WebApp,
+  names: string[]
+): StickySlotSettings | undefined =>
+  webApp.slot && names.length ? {resourceGroup, webAppName: webApp.name, names} : undefined
+
 /**
  * Collapse per-resource sticky settings into one entry per site, unioning their names.
  * slotConfigNames is a single site-level resource shared by all of a site's slots, so
@@ -127,6 +166,7 @@ export const aggregateStickyBySite = (entries: (StickySlotSettings | undefined)[
     if (!entry?.names.length) {
       continue
     }
+    // Web App names are globally unique, so the name alone identifies the site.
     const key = entry.webAppName
     const merged = bySite.get(key) ?? {resourceGroup: entry.resourceGroup, webAppName: entry.webAppName, names: []}
     merged.names = [...new Set([...merged.names, ...entry.names])]
@@ -137,29 +177,30 @@ export const aggregateStickyBySite = (entries: (StickySlotSettings | undefined)[
 }
 
 /**
- * Register the given app settings as sticky (in slotConfigNames) so they stay with their
- * slot across a swap, with a single read-modify-write. No-op when nothing changes.
+ * Add or remove sticky slot settings on a site's slotConfigNames with a single
+ * read-modify-write. No-op when nothing changes.
  */
-export const registerStickySlotSettings = async (
+export const mutateStickySlotSettings = async (
   client: WebSiteManagementClient,
   resourceGroup: string,
   webAppName: string,
   names: string[],
+  mode: 'add' | 'remove',
   opts: {dryRun: boolean; dryRunPrefix: string; log: (message: string) => void}
 ): Promise<void> => {
   const existing: SlotConfigNamesResource = await client.webApps.listSlotConfigurationNames(resourceGroup, webAppName)
   const current = existing.appSettingNames ?? []
-  const toAdd = names.filter((name) => !current.includes(name))
-  if (toAdd.length === 0) {
+  const changed = mode === 'add' ? names.filter((n) => !current.includes(n)) : names.filter((n) => current.includes(n))
+  if (changed.length === 0) {
     return
   }
+  const appSettingNames = mode === 'add' ? [...current, ...changed] : current.filter((n) => !changed.includes(n))
   opts.log(
-    `${opts.dryRunPrefix}Registering ${toAdd.join(', ')} as sticky slot setting(s) on ${chalk.bold(webAppName)}\n`
+    mode === 'add'
+      ? `${opts.dryRunPrefix}Registering ${changed.join(', ')} as sticky slot setting(s) on ${chalk.bold(webAppName)}\n`
+      : `${opts.dryRunPrefix}Removing sticky slot setting(s) ${changed.join(', ')} from ${chalk.bold(webAppName)}\n`
   )
   if (!opts.dryRun) {
-    await client.webApps.updateSlotConfigurationNames(resourceGroup, webAppName, {
-      ...existing,
-      appSettingNames: [...current, ...toAdd],
-    })
+    await client.webApps.updateSlotConfigurationNames(resourceGroup, webAppName, {...existing, appSettingNames})
   }
 }


### PR DESCRIPTION
### What and why?

`aas instrument` treated every site like a Web App, so Function Apps fell through the platform checks and got the wrong handling. This adds first-class Function App support:

- **Windows .NET Function Apps** install the same site extension as Windows Web Apps. On a deployment slot there's a wrinkle from [datadog-aas-extension#457](https://github.com/DataDog/datadog-aas-extension/pull/457): the Functions runtime holds file locks on the `SiteExtensions` directory, so Kudu's `MoveDirectory` step fails intermittently during the install. Setting `WEBSITE_PRIVATE_EXTENSIONS=0` makes the runtime release those locks. It is committed *before* the install and registered as a sticky slot setting so it doesn't follow a swap into production.
- **Windows Function Apps on Node or Java** aren't supported via the extension -- the command exits with an error pointing to the [Azure Functions docs](https://docs.datadoghq.com/serverless/azure_functions).
- **Windows Function Apps on a Consumption / Flex Consumption plan** aren't supported -- the [extension requires a Dedicated (App Service) or Premium plan](https://docs.datadoghq.com/serverless/azure_functions/dotnet_extension/), so the command exits with the same redirect rather than installing an extension that will never produce telemetry.
- **Linux Function Apps** aren't supported -- the command exits with the same redirect instead of silently falling through to the sidecar path.

Web App behavior is unchanged. Builds on the sticky-slot helpers from the parent PR.

### How?

- `common.ts`:
  - Adds `isFunctionApp`, `isWindowsFunctionApp`, `isConsumptionPlan`, the `WEBSITE_PRIVATE_EXTENSIONS` constant, and `AZURE_FUNCTIONS_DOCS_URL`.
  - `isConsumptionPlan` reads `site.sku` (the plan tier name, e.g. `Dynamic` for Consumption, `FlexConsumption` for Flex Consumption) off the site object the command already fetches -- no extra API call.
  - `getEnvVars(config, site, webApp)` derives containerization from the site and injects `WEBSITE_PRIVATE_EXTENSIONS=0` for Windows Function App slots, so the lock-release setting is part of the settings written before the install.
  - Generalizes the parent PR's `registerStickySlotSettings` into `mutateStickySlotSettings(..., mode: 'add' | 'remove', ...)`, so the same single-read-modify-write path both registers settings (instrument) and unregisters them (uninstrument).
  - Moves the shared `ProcessResult` type and a `stickySlotSettings` helper here so both commands use them.
- `instrument.ts`:
  - Rejects Linux Function Apps before the Windows branch. Inside the Windows Function App branch, rejects Consumption/Flex Consumption plans and non-.NET runtimes with the redirect.
  - `instrumentExtension`/`instrumentSidecar` take the resolved `site` and write app settings **before** the extension install (previously the write was dispatched and only awaited afterward). This gives the lock-release setting the ordering it needs.
  - On a .NET Function App slot, pins `WEBSITE_PRIVATE_EXTENSIONS` sticky alongside `DD_ENV`.
- `uninstrument.ts`:
  - Returns `ProcessResult` and, on a Windows Function App slot, removes the `WEBSITE_PRIVATE_EXTENSIONS` app setting and unregisters it sticky (`mutateStickySlotSettings` in `remove` mode, aggregated once per site). `DD_ENV` is intentionally left sticky.

### Testing

Validated end-to-end against a live Windows .NET (isolated) Function App on a Dedicated (App Service) plan: deployed an HTTP-triggered function, ran `aas instrument --windows-runtime dotnet`, drove traffic, and confirmed traces in Datadog.

While doing this I also confirmed the plan requirement empirically: on a **Consumption** plan the extension installs but never injects the profiler (`CORECLR_*` env vars are absent from the worker), so no traces flow -- which is why the command now rejects Consumption/Flex Consumption up front. On the Dedicated plan, traces flowed with `WEBSITE_USE_PLACEHOLDER_DOTNETISOLATED` left at its default, so no extra placeholder configuration is needed.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
