### PR TITLE
Add id column to endpoints CSV for Reference Tables import

### DIFF
--- a/bin/catalog-endpoints.ts
+++ b/bin/catalog-endpoints.ts
@@ -158,7 +158,10 @@ const main = () => {
     return s !== 0 ? s : a.route.localeCompare(b.route)
   })
 
-  const csv = ['scope,route,method', ...rows.map(({scope, route, method}) => `${scope},${route},${method}`)].join('\n')
+  const csv = [
+    'resource_name,scope,route,method',
+    ...rows.map(({scope, route, method}) => `${method} ${route},${scope},${route},${method}`),
+  ].join('\n')
 
   const outPath = path.join(ROOT, 'endpoints.csv')
   fs.writeFileSync(outPath, csv + '\n')


### PR DESCRIPTION
The endpoints CSV is imported into the Reference Tables product in Datadog, which requires a primary key column. Since none of the existing columns (`scope`, `route`, `method`) are unique on their own, a new `resource_name` column is added as the first column with value `{method} {route}` (e.g. `GET /api/v2/synthetics/tests`).