### PR TITLE
Release v5.19.0

### DIFF
--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-base",
-  "version": "5.18.0",
+  "version": "5.19.0",
   "description": "Base package for Datadog CI",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/datadog-ci/package.json
+++ b/packages/datadog-ci/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci",
-  "version": "5.18.0",
+  "version": "5.19.0",
   "description": "Use Datadog from your CI.",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-aas/package.json
+++ b/packages/plugin-aas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-aas",
-  "version": "5.18.0",
+  "version": "5.19.0",
   "description": "Datadog CI plugin for `aas` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-cloud-run/package.json
+++ b/packages/plugin-cloud-run/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-cloud-run",
-  "version": "5.18.0",
+  "version": "5.19.0",
   "description": "Datadog CI plugin for `cloud-run` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-container-app/package.json
+++ b/packages/plugin-container-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-container-app",
-  "version": "5.18.0",
+  "version": "5.19.0",
   "description": "Datadog CI plugin for `container-app` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-coverage/package.json
+++ b/packages/plugin-coverage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-coverage",
-  "version": "5.18.0",
+  "version": "5.19.0",
   "description": "Datadog CI plugin for `coverage` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-deployment/package.json
+++ b/packages/plugin-deployment/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-deployment",
-  "version": "5.18.0",
+  "version": "5.19.0",
   "description": "Datadog CI plugin for `deployment` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-dora/package.json
+++ b/packages/plugin-dora/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-dora",
-  "version": "5.18.0",
+  "version": "5.19.0",
   "description": "Datadog CI plugin for `dora` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-gate/package.json
+++ b/packages/plugin-gate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-gate",
-  "version": "5.18.0",
+  "version": "5.19.0",
   "description": "Datadog CI plugin for `gate` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-junit/package.json
+++ b/packages/plugin-junit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-junit",
-  "version": "5.18.0",
+  "version": "5.19.0",
   "description": "Datadog CI plugin for `junit` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-lambda/package.json
+++ b/packages/plugin-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-lambda",
-  "version": "5.18.0",
+  "version": "5.19.0",
   "description": "Datadog CI plugin for `lambda` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-sarif/package.json
+++ b/packages/plugin-sarif/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-sarif",
-  "version": "5.18.0",
+  "version": "5.19.0",
   "description": "Datadog CI plugin for `sarif` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-sbom/package.json
+++ b/packages/plugin-sbom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-sbom",
-  "version": "5.18.0",
+  "version": "5.19.0",
   "description": "Datadog CI plugin for `sbom` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-stepfunctions/package.json
+++ b/packages/plugin-stepfunctions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-stepfunctions",
-  "version": "5.18.0",
+  "version": "5.19.0",
   "description": "Datadog CI plugin for `stepfunctions` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-synthetics/package.json
+++ b/packages/plugin-synthetics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-synthetics",
-  "version": "5.18.0",
+  "version": "5.19.0",
   "description": "Datadog CI plugin for `synthetics` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-terraform/package.json
+++ b/packages/plugin-terraform/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-terraform",
-  "version": "5.18.0",
+  "version": "5.19.0",
   "description": "Datadog CI plugin for `terraform` commands",
   "license": "Apache-2.0",
   "keywords": [


### PR DESCRIPTION
<!-- Release notes generated using configuration in .github/release.yml at v5.19.0 -->

## What's Changed
### datadog-ci
* chore: skip serverless e2e on version-bump-only release commits by @ava-silver in https://github.com/DataDog/datadog-ci/pull/2335
* chore: add script to catalog DD routes per scope by @ava-silver in https://github.com/DataDog/datadog-ci/pull/2343
* feat(logger): add `jsonOutput` to internal logger by @tsushanth in https://github.com/DataDog/datadog-ci/pull/2347
### Software Delivery
* Add config file support to deployment gate command by @GabrielAnca in https://github.com/DataDog/datadog-ci/pull/2339
### Serverless
* chore: Update Lambda layer versions by @gh-worker-engraver-d31c25[bot] in https://github.com/DataDog/datadog-ci/pull/2345
* chore: cloud-run e2e telemetry flow validation by @ava-silver in https://github.com/DataDog/datadog-ci/pull/2341
* chore: unified e2e resource naming and tagging by @ava-silver in https://github.com/DataDog/datadog-ci/pull/2358
### Static Analysis
* [K9VULN-15920] Warn when env tag is passed to sbom upload by @divyav-datadog in https://github.com/DataDog/datadog-ci/pull/2344
### Chores
* Add CI job to upload endpoint catalog CSV to S3 by @GabrielAnca in https://github.com/DataDog/datadog-ci/pull/2346
* Split catalog-endpoints CI job into generate and upload by @GabrielAnca in https://github.com/DataDog/datadog-ci/pull/2351
* Use internal Node.js mirror image for catalog-endpoints-generate by @GabrielAnca in https://github.com/DataDog/datadog-ci/pull/2352
* Add package bugs metadata by @pesoszpesosz in https://github.com/DataDog/datadog-ci/pull/2348
* Download CI Identities client to project dir by @GabrielAnca in https://github.com/DataDog/datadog-ci/pull/2353
* Fix YAML syntax in catalog-endpoints-upload script by @GabrielAnca in https://github.com/DataDog/datadog-ci/pull/2354
* e2e no plaintext secrets by @ava-silver in https://github.com/DataDog/datadog-ci/pull/2349
* Add YAML linting to CI by @GabrielAnca in https://github.com/DataDog/datadog-ci/pull/2355

## New Contributors
* @divyav-datadog made their first contribution in https://github.com/DataDog/datadog-ci/pull/2344
* @tsushanth made their first contribution in https://github.com/DataDog/datadog-ci/pull/2347
* @pesoszpesosz made their first contribution in https://github.com/DataDog/datadog-ci/pull/2348

**Full Changelog**: https://github.com/DataDog/datadog-ci/compare/v5.18.0...v5.19.0

[K9VULN-15920]: https://datadoghq.atlassian.net/browse/K9VULN-15920?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ