### PR TITLE
[NO TICKET] Add SHA-based id column to endpoints CSV for unique primary key

### DIFF
--- a/bin/catalog-endpoints.ts
+++ b/bin/catalog-endpoints.ts
@@ -1,3 +1,4 @@
+import {createHash} from 'crypto'
 import fs from 'fs'
 // eslint-disable-next-line no-restricted-imports
 import path from 'path'
@@ -159,8 +160,12 @@ const main = () => {
   })
 
   const csv = [
-    'resource_name,scope,route,method',
-    ...rows.map(({scope, route, method}) => `${method} ${route},${scope},${route},${method}`),
+    'id,resource_name,scope,route,method',
+    ...rows.map(({scope, route, method}) => {
+      const id = createHash('sha256').update(`${method},${route},${scope}`).digest('hex').slice(0, 16)
+
+      return `${id},${method} ${route},${scope},${route},${method}`
+    }),
   ].join('\n')
 
   const outPath = path.join(ROOT, 'endpoints.csv')

--- a/bin/catalog-endpoints.ts
+++ b/bin/catalog-endpoints.ts
@@ -118,6 +118,16 @@ const findHelperImporters = (scopes: Map<string, string[]>, helperFile: string):
   return importers
 }
 
+const buildCsv = (rows: Row[]): string =>
+  [
+    'id,resource_name,scope,route,method',
+    ...rows.map(({scope, route, method}) => {
+      const id = createHash('sha256').update(`${method},${route},${scope}`).digest('hex').slice(0, 16)
+
+      return `${id},${method} ${route},${scope},${route},${method}`
+    }),
+  ].join('\n')
+
 const main = () => {
   const scopes = collectScopeEntries()
   const rowMap = new Map<string, Row>()
@@ -159,17 +169,8 @@ const main = () => {
     return s !== 0 ? s : a.route.localeCompare(b.route)
   })
 
-  const csv = [
-    'id,resource_name,scope,route,method',
-    ...rows.map(({scope, route, method}) => {
-      const id = createHash('sha256').update(`${method},${route},${scope}`).digest('hex').slice(0, 16)
-
-      return `${id},${method} ${route},${scope},${route},${method}`
-    }),
-  ].join('\n')
-
   const outPath = path.join(ROOT, 'endpoints.csv')
-  fs.writeFileSync(outPath, csv + '\n')
+  fs.writeFileSync(outPath, buildCsv(rows) + '\n')
   console.log(`Wrote ${rows.length} rows to ${outPath}`)
 }
 


### PR DESCRIPTION
The `resource_name` column (e.g. `GET /api/v1/tests`) is not guaranteed to be unique since multiple scopes can call the same endpoint. This adds an `id` column as the first column, computed as the first 16 hex characters of the SHA-256 of `{method},{route},{scope}`, giving a stable unique key suitable for use as a Reference Tables primary key.