### PR TITLE
[RUM-16940] add `--debug-id` upload mode for web sourcemaps

### DIFF
--- a/packages/base/src/commands/sourcemaps/__tests__/debugId.test.ts
+++ b/packages/base/src/commands/sourcemaps/__tests__/debugId.test.ts
@@ -1,24 +1,26 @@
 import fs from 'fs'
 
-import type {CommandContext} from '@datadog/datadog-ci-base'
-
-import {createMockContext} from '@datadog/datadog-ci-base/helpers/__tests__/testing-tools'
-
-import {extractDebugId} from '../debugId'
+import {addDebugIdToPayloads, extractDebugId} from '../debugId'
+import {Sourcemap} from '../interfaces'
 
 const DEBUG_ID = '2f1d7f52-4e1b-4f7c-8c0d-2f4a5f6d8e91'
 
-const mockFileContent = (content: string) => {
-  jest.spyOn(fs, 'readFileSync').mockReturnValueOnce(content)
+const makeSourcemap = (minifiedFilePath: string) =>
+  new Sourcemap(minifiedFilePath, `https://static.com/${minifiedFilePath}`, `${minifiedFilePath}.map`, minifiedFilePath)
+
+// Mocks fs.readFileSync to return the given content keyed by minified file path.
+const mockFilesByPath = (contentByPath: Record<string, string>) => {
+  jest.spyOn(fs, 'readFileSync').mockImplementation((path: unknown) => {
+    const content = contentByPath[path as string]
+    if (content === undefined) {
+      throw new Error(`ENOENT: ${String(path)}`)
+    }
+
+    return content
+  })
 }
 
 describe('extractDebugId', () => {
-  let context: CommandContext
-
-  beforeEach(() => {
-    context = createMockContext() as CommandContext
-  })
-
   afterEach(() => {
     jest.restoreAllMocks()
   })
@@ -34,25 +36,49 @@ describe('extractDebugId', () => {
       [`var x=1;({"ddDebugId":"${DEBUG_ID}"});var y=2;`],
       [`var x=1;\n{"ddDebugId": "${DEBUG_ID}"}\nvar y=2;`],
     ])('%s', (content: string) => {
-      mockFileContent(content)
-      expect(extractDebugId('bundle.js', context)).toBe(DEBUG_ID)
-      expect(context.stderr.toString()).toBe('')
+      jest.spyOn(fs, 'readFileSync').mockReturnValueOnce(content)
+      expect(extractDebugId('bundle.js')).toBe(DEBUG_ID)
     })
   })
 
   describe('missing or unreadable', () => {
-    test('returns undefined and writes to stderr when snippet is absent', () => {
-      mockFileContent('var x = 1; console.log("hello");')
-      expect(extractDebugId('bundle.js', context)).toBeUndefined()
-      expect(context.stderr.toString()).toContain('Debug ID not found')
+    test('returns undefined when snippet is absent', () => {
+      jest.spyOn(fs, 'readFileSync').mockReturnValueOnce('var x = 1; console.log("hello");')
+      expect(extractDebugId('bundle.js')).toBeUndefined()
     })
 
-    test('returns undefined and writes to stderr when file cannot be read', () => {
+    test('returns undefined when file cannot be read', () => {
       jest.spyOn(fs, 'readFileSync').mockImplementationOnce(() => {
         throw new Error('ENOENT: no such file or directory')
       })
-      expect(extractDebugId('nonexistent.js', context)).toBeUndefined()
-      expect(context.stderr.toString()).toContain('Cannot extract Debug ID')
+      expect(extractDebugId('nonexistent.js')).toBeUndefined()
     })
+  })
+})
+
+describe('addDebugIdToPayloads', () => {
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  test('stores each debug ID on its payload and returns true when any is found', () => {
+    mockFilesByPath({
+      'a.min.js': `{"ddDebugId":"${DEBUG_ID}"}`,
+      'b.min.js': 'var x = 1;',
+    })
+    const withId = makeSourcemap('a.min.js')
+    const withoutId = makeSourcemap('b.min.js')
+
+    expect(addDebugIdToPayloads([withId, withoutId])).toBe(true)
+    expect(withId.debugId).toBe(DEBUG_ID)
+    expect(withoutId.debugId).toBeUndefined()
+  })
+
+  test('returns false when no payload has a debug ID', () => {
+    mockFilesByPath({'a.min.js': 'var x = 1;', 'b.min.js': 'var y = 2;'})
+    const payloads = [makeSourcemap('a.min.js'), makeSourcemap('b.min.js')]
+
+    expect(addDebugIdToPayloads(payloads)).toBe(false)
+    expect(payloads.every((p) => p.debugId === undefined)).toBe(true)
   })
 })

--- a/packages/base/src/commands/sourcemaps/__tests__/debugId.test.ts
+++ b/packages/base/src/commands/sourcemaps/__tests__/debugId.test.ts
@@ -1,0 +1,58 @@
+import fs from 'fs'
+
+import type {CommandContext} from '@datadog/datadog-ci-base'
+
+import {createMockContext} from '@datadog/datadog-ci-base/helpers/__tests__/testing-tools'
+
+import {extractDebugId} from '../debugId'
+
+const DEBUG_ID = '2f1d7f52-4e1b-4f7c-8c0d-2f4a5f6d8e91'
+
+const mockFileContent = (content: string) => {
+  jest.spyOn(fs, 'readFileSync').mockReturnValueOnce(content)
+}
+
+describe('extractDebugId', () => {
+  let context: CommandContext
+
+  beforeEach(() => {
+    context = createMockContext() as CommandContext
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  describe('snippet formats', () => {
+    test.each([
+      [`{"ddDebugId":"${DEBUG_ID}"}`],
+      [`{"ddDebugId": "${DEBUG_ID}"}`],
+      [`{"ddDebugId" : "${DEBUG_ID}"}`],
+      [`{"ddDebugId"   :   "${DEBUG_ID}"}`],
+      [`{"ddDebugId"\t:\t"${DEBUG_ID}"}`],
+      [`{'ddDebugId': '${DEBUG_ID}'}`],
+      [`var x=1;({"ddDebugId":"${DEBUG_ID}"});var y=2;`],
+      [`var x=1;\n{"ddDebugId": "${DEBUG_ID}"}\nvar y=2;`],
+    ])('%s', (content: string) => {
+      mockFileContent(content)
+      expect(extractDebugId('bundle.js', context)).toBe(DEBUG_ID)
+      expect(context.stderr.toString()).toBe('')
+    })
+  })
+
+  describe('missing or unreadable', () => {
+    test('returns undefined and writes to stderr when snippet is absent', () => {
+      mockFileContent('var x = 1; console.log("hello");')
+      expect(extractDebugId('bundle.js', context)).toBeUndefined()
+      expect(context.stderr.toString()).toContain('Debug ID not found')
+    })
+
+    test('returns undefined and writes to stderr when file cannot be read', () => {
+      jest.spyOn(fs, 'readFileSync').mockImplementationOnce(() => {
+        throw new Error('ENOENT: no such file or directory')
+      })
+      expect(extractDebugId('nonexistent.js', context)).toBeUndefined()
+      expect(context.stderr.toString()).toContain('Cannot extract Debug ID')
+    })
+  })
+})

--- a/packages/base/src/commands/sourcemaps/__tests__/fixtures/bundle-with-debug-id/common.min.js
+++ b/packages/base/src/commands/sourcemaps/__tests__/fixtures/bundle-with-debug-id/common.min.js
@@ -1,0 +1,2 @@
+(function(c,n){try{if(typeof window==='undefined')return;var w=window,m=w[n]=w[n]||{},s=new Error().stack;s&&(m[s]=c)}catch(e){}})({"ddDebugId":"2f1d7f52-4e1b-4f7c-8c0d-2f4a5f6d8e91"},"DD_SOURCE_CODE_CONTEXT");
+//# sourceMappingURL=common.min.js.map

--- a/packages/base/src/commands/sourcemaps/__tests__/fixtures/bundle-with-debug-id/common.min.js.map
+++ b/packages/base/src/commands/sourcemaps/__tests__/fixtures/bundle-with-debug-id/common.min.js.map
@@ -1,0 +1,1 @@
+{"version":3,"sources":["common.js"],"mappings":""}

--- a/packages/base/src/commands/sourcemaps/__tests__/fixtures/bundle-with-partial-debug-id/a.min.js
+++ b/packages/base/src/commands/sourcemaps/__tests__/fixtures/bundle-with-partial-debug-id/a.min.js
@@ -1,0 +1,2 @@
+(function(c,n){try{if(typeof window==='undefined')return;var w=window,m=w[n]=w[n]||{},s=new Error().stack;s&&(m[s]=c)}catch(e){}})({"ddDebugId":"2f1d7f52-4e1b-4f7c-8c0d-2f4a5f6d8e91"},"DD_SOURCE_CODE_CONTEXT");
+//# sourceMappingURL=a.min.js.map

--- a/packages/base/src/commands/sourcemaps/__tests__/fixtures/bundle-with-partial-debug-id/a.min.js.map
+++ b/packages/base/src/commands/sourcemaps/__tests__/fixtures/bundle-with-partial-debug-id/a.min.js.map
@@ -1,0 +1,1 @@
+{"version":3,"sources":["a.js"],"mappings":""}

--- a/packages/base/src/commands/sourcemaps/__tests__/fixtures/bundle-with-partial-debug-id/b.min.js
+++ b/packages/base/src/commands/sourcemaps/__tests__/fixtures/bundle-with-partial-debug-id/b.min.js
@@ -1,0 +1,2 @@
+var x = 1; console.log("hello");
+//# sourceMappingURL=b.min.js.map

--- a/packages/base/src/commands/sourcemaps/__tests__/fixtures/bundle-with-partial-debug-id/b.min.js.map
+++ b/packages/base/src/commands/sourcemaps/__tests__/fixtures/bundle-with-partial-debug-id/b.min.js.map
@@ -1,0 +1,1 @@
+{"version":3,"sources":["b.js"],"mappings":""}

--- a/packages/base/src/commands/sourcemaps/__tests__/upload.test.ts
+++ b/packages/base/src/commands/sourcemaps/__tests__/upload.test.ts
@@ -121,15 +121,23 @@ describe('upload', () => {
       expect(command.context.stderr.toString()).toBe('')
     })
 
-    test('returns false when --debug-id is combined with service/version/path options', () => {
+    test('returns false when --debug-id is combined with service/version/minified-path-prefix options', () => {
       const command = createCommand(SourcemapsUploadCommand)
       command['debugId'] = true
       command['service'] = 'my-service'
       command['releaseVersion'] = '1.0.0'
-      command['projectPath'] = 'src'
+      command['minifiedPathPrefix'] = 'https://static.example.com/js'
       expect(command['validateOptions']()).toBe(false)
       const stderr = command.context.stderr.toString()
-      expect(stderr).toContain('--service, --release-version, --project-path cannot be used with --debug-id')
+      expect(stderr).toContain('--service, --release-version, --minified-path-prefix cannot be used with --debug-id')
+    })
+
+    test('returns true when --debug-id is combined with --project-path', () => {
+      const command = createCommand(SourcemapsUploadCommand)
+      command['debugId'] = true
+      command['projectPath'] = 'src'
+      expect(command['validateOptions']()).toBe(true)
+      expect(command.context.stderr.toString()).toBe('')
     })
 
     test('returns false when release version is missing', () => {
@@ -293,14 +301,7 @@ describe('execute', () => {
     '--dry-run',
   ])
 
-  const runCLIWithDebugId = makeRunCLI(SourcemapsUploadCommand, [
-    'sourcemaps',
-    'upload',
-    '--debug-id',
-    '--minified-path-prefix',
-    'https://static.com/js',
-    '--dry-run',
-  ])
+  const runCLIWithDebugId = makeRunCLI(SourcemapsUploadCommand, ['sourcemaps', 'upload', '--debug-id', '--dry-run'])
 
   test('debug id', async () => {
     const {context, code} = await runCLIWithDebugId([
@@ -308,7 +309,7 @@ describe('execute', () => {
     ])
     expect(code).toBe(0)
     expect(context.stdout.toString()).toContain(
-      '[DRYRUN] Uploading sourcemap src/commands/sourcemaps/__tests__/fixtures/bundle-with-debug-id/common.min.js.map for JS file available at https://static.com/js/common.min.js (debug ID: 2f1d7f52-4e1b-4f7c-8c0d-2f4a5f6d8e91)'
+      '[DRYRUN] Uploading sourcemap src/commands/sourcemaps/__tests__/fixtures/bundle-with-debug-id/common.min.js.map for JS file available at common.min.js (debug ID: 2f1d7f52-4e1b-4f7c-8c0d-2f4a5f6d8e91)'
     )
   })
 

--- a/packages/base/src/commands/sourcemaps/__tests__/upload.test.ts
+++ b/packages/base/src/commands/sourcemaps/__tests__/upload.test.ts
@@ -1,13 +1,109 @@
+import type {CommandContext} from '@datadog/datadog-ci-base'
+import type {MultipartStringValue} from '@datadog/datadog-ci-base/helpers/upload'
+
 import chalk from 'chalk'
 import upath from 'upath'
 
-import {createCommand, makeRunCLI} from '@datadog/datadog-ci-base/helpers/__tests__/testing-tools'
+import {createCommand, createMockContext, makeRunCLI} from '@datadog/datadog-ci-base/helpers/__tests__/testing-tools'
 
 import {Sourcemap} from '../interfaces'
 import {SourcemapsUploadCommand} from '../upload'
 
 // Always posix, even on Windows.
 const CWD = upath.normalize(process.cwd())
+
+describe('Sourcemap.asMultipartPayload', () => {
+  describe('extractDebugId', () => {
+    test('includes debug_id in event metadata when bundle contains _ddDebugIds snippet', () => {
+      const sourcemap = new Sourcemap(
+        'src/commands/sourcemaps/__tests__/fixtures/bundle-with-debug-id/common.min.js',
+        'https://static.example.com/common.min.js',
+        'src/commands/sourcemaps/__tests__/fixtures/bundle-with-debug-id/common.min.js.map',
+        'common.min.js',
+        'https://static.example.com'
+      )
+      const context = createMockContext() as CommandContext
+
+      const payload = sourcemap.asMultipartPayload({
+        cliVersion: '1.0.0',
+        debugId: true,
+        context,
+      })
+      const event = payload.content.get('event') as MultipartStringValue
+      const eventValue = JSON.parse(event['value']) as {debug_id: string}
+
+      expect(eventValue['debug_id']).toBe('2f1d7f52-4e1b-4f7c-8c0d-2f4a5f6d8e91')
+    })
+
+    test('omits debug_id and writes to stderr when bundle has no snippet', () => {
+      const sourcemap = new Sourcemap(
+        'src/commands/sourcemaps/__tests__/fixtures/basic/common.min.js',
+        'https://static.example.com/common.min.js',
+        'src/commands/sourcemaps/__tests__/fixtures/basic/common.min.js.map',
+        'common.min.js',
+        'https://static.example.com'
+      )
+      const context = createMockContext() as CommandContext
+
+      const payload = sourcemap.asMultipartPayload({
+        cliVersion: '1.0.0',
+        debugId: true,
+        context,
+      })
+      const event = payload.content.get('event') as MultipartStringValue
+      const eventValue = JSON.parse(event['value']) as Record<string, unknown>
+
+      expect(eventValue['debug_id']).toBeUndefined()
+      expect(context.stderr.toString()).toContain('Debug ID not found')
+    })
+
+    test('omits debug_id and writes to stderr when bundle file cannot be read', () => {
+      const sourcemap = new Sourcemap(
+        'nonexistent/path/bundle.js',
+        'https://static.example.com/bundle.js',
+        'src/commands/sourcemaps/__tests__/fixtures/basic/common.min.js.map',
+        'bundle.js',
+        'https://static.example.com'
+      )
+      const context = createMockContext() as CommandContext
+
+      const payload = sourcemap.asMultipartPayload({
+        cliVersion: '1.0.0',
+        debugId: true,
+        context,
+      })
+      const event = payload.content.get('event') as MultipartStringValue
+      const eventValue = JSON.parse(event['value']) as Record<string, unknown>
+
+      expect(eventValue['debug_id']).toBeUndefined()
+      expect(context.stderr.toString()).toContain('Cannot extract Debug ID')
+    })
+
+    test('omits debug_id without error when --debug-id flag is not set', () => {
+      const sourcemap = new Sourcemap(
+        'src/commands/sourcemaps/__tests__/fixtures/bundle-with-debug-id/common.min.js',
+        'https://static.example.com/common.min.js',
+        'src/commands/sourcemaps/__tests__/fixtures/bundle-with-debug-id/common.min.js.map',
+        'common.min.js',
+        'https://static.example.com'
+      )
+      const context = createMockContext() as CommandContext
+
+      const payload = sourcemap.asMultipartPayload({
+        cliVersion: '1.0.0',
+        service: 'my-service',
+        version: '1.2.3',
+        debugId: false,
+        context,
+      })
+      const event = payload.content.get('event') as MultipartStringValue
+      const eventValue = JSON.parse(event['value']) as Record<string, unknown>
+
+      expect(eventValue['debug_id']).toBeUndefined()
+      expect(context.stderr.toString()).toBe('')
+    })
+  })
+})
 
 describe('upload', () => {
   describe('getMinifiedURL', () => {

--- a/packages/base/src/commands/sourcemaps/__tests__/upload.test.ts
+++ b/packages/base/src/commands/sourcemaps/__tests__/upload.test.ts
@@ -301,6 +301,25 @@ describe('execute', () => {
     )
   })
 
+  test('debug id missing in all files aborts with exit 1', async () => {
+    const {context, code} = await runCLIWithDebugId(['./src/commands/sourcemaps/__tests__/fixtures/basic'])
+    expect(code).toBe(1)
+    expect(context.stderr.toString()).toContain('No debug ID found in any minified file')
+    expect(context.stdout.toString()).not.toContain('[DRYRUN] Uploading sourcemap')
+  })
+
+  test('debug id missing in some files skips only those files', async () => {
+    const {context, code} = await runCLIWithDebugId([
+      './src/commands/sourcemaps/__tests__/fixtures/bundle-with-partial-debug-id',
+    ])
+    expect(code).toBe(0)
+    const stdout = context.stdout.toString()
+    expect(stdout).toContain('[DRYRUN] Uploading sourcemap')
+    expect(stdout).toContain('a.min.js.map')
+    expect(stdout).toContain('because no debug ID was found')
+    expect(stdout).toContain('b.min.js.map')
+  })
+
   test('relative path with double dots', async () => {
     const {context, code} = await runCLI(['./src/commands/sourcemaps/__tests__/doesnotexist/../fixtures/basic'])
     const output = context.stdout.toString().split('\n')

--- a/packages/base/src/commands/sourcemaps/__tests__/upload.test.ts
+++ b/packages/base/src/commands/sourcemaps/__tests__/upload.test.ts
@@ -121,6 +121,17 @@ describe('upload', () => {
       expect(command.context.stderr.toString()).toBe('')
     })
 
+    test('returns false when --debug-id is combined with service/version/path options', () => {
+      const command = createCommand(SourcemapsUploadCommand)
+      command['debugId'] = true
+      command['service'] = 'my-service'
+      command['releaseVersion'] = '1.0.0'
+      command['projectPath'] = 'src'
+      expect(command['validateOptions']()).toBe(false)
+      const stderr = command.context.stderr.toString()
+      expect(stderr).toContain('--service, --release-version, --project-path cannot be used with --debug-id')
+    })
+
     test('returns false when release version is missing', () => {
       const command = createCommand(SourcemapsUploadCommand)
       expect(command['validateOptions']()).toBe(false)

--- a/packages/base/src/commands/sourcemaps/__tests__/upload.test.ts
+++ b/packages/base/src/commands/sourcemaps/__tests__/upload.test.ts
@@ -320,6 +320,12 @@ describe('execute', () => {
     expect(context.stdout.toString()).not.toContain('[DRYRUN] Uploading sourcemap')
   })
 
+  test('debug id with no sourcemaps found succeeds with exit 0', async () => {
+    const {context, code} = await runCLIWithDebugId(['./src/commands/sourcemaps/__tests__/fixtures/doesnotexist'])
+    expect(code).toBe(0)
+    expect(context.stderr.toString()).not.toContain('No debug ID found')
+  })
+
   test('debug id missing in some files skips only those files', async () => {
     const {context, code} = await runCLIWithDebugId([
       './src/commands/sourcemaps/__tests__/fixtures/bundle-with-partial-debug-id',

--- a/packages/base/src/commands/sourcemaps/__tests__/upload.test.ts
+++ b/packages/base/src/commands/sourcemaps/__tests__/upload.test.ts
@@ -1,109 +1,13 @@
-import type {CommandContext} from '@datadog/datadog-ci-base'
-import type {MultipartStringValue} from '@datadog/datadog-ci-base/helpers/upload'
-
 import chalk from 'chalk'
 import upath from 'upath'
 
-import {createCommand, createMockContext, makeRunCLI} from '@datadog/datadog-ci-base/helpers/__tests__/testing-tools'
+import {createCommand, makeRunCLI} from '@datadog/datadog-ci-base/helpers/__tests__/testing-tools'
 
 import {Sourcemap} from '../interfaces'
 import {SourcemapsUploadCommand} from '../upload'
 
 // Always posix, even on Windows.
 const CWD = upath.normalize(process.cwd())
-
-describe('Sourcemap.asMultipartPayload', () => {
-  describe('extractDebugId', () => {
-    test('includes debug_id in event metadata when bundle contains _ddDebugIds snippet', () => {
-      const sourcemap = new Sourcemap(
-        'src/commands/sourcemaps/__tests__/fixtures/bundle-with-debug-id/common.min.js',
-        'https://static.example.com/common.min.js',
-        'src/commands/sourcemaps/__tests__/fixtures/bundle-with-debug-id/common.min.js.map',
-        'common.min.js',
-        'https://static.example.com'
-      )
-      const context = createMockContext() as CommandContext
-
-      const payload = sourcemap.asMultipartPayload({
-        cliVersion: '1.0.0',
-        debugId: true,
-        context,
-      })
-      const event = payload.content.get('event') as MultipartStringValue
-      const eventValue = JSON.parse(event['value']) as {debug_id: string}
-
-      expect(eventValue['debug_id']).toBe('2f1d7f52-4e1b-4f7c-8c0d-2f4a5f6d8e91')
-    })
-
-    test('omits debug_id and writes to stderr when bundle has no snippet', () => {
-      const sourcemap = new Sourcemap(
-        'src/commands/sourcemaps/__tests__/fixtures/basic/common.min.js',
-        'https://static.example.com/common.min.js',
-        'src/commands/sourcemaps/__tests__/fixtures/basic/common.min.js.map',
-        'common.min.js',
-        'https://static.example.com'
-      )
-      const context = createMockContext() as CommandContext
-
-      const payload = sourcemap.asMultipartPayload({
-        cliVersion: '1.0.0',
-        debugId: true,
-        context,
-      })
-      const event = payload.content.get('event') as MultipartStringValue
-      const eventValue = JSON.parse(event['value']) as Record<string, unknown>
-
-      expect(eventValue['debug_id']).toBeUndefined()
-      expect(context.stderr.toString()).toContain('Debug ID not found')
-    })
-
-    test('omits debug_id and writes to stderr when bundle file cannot be read', () => {
-      const sourcemap = new Sourcemap(
-        'nonexistent/path/bundle.js',
-        'https://static.example.com/bundle.js',
-        'src/commands/sourcemaps/__tests__/fixtures/basic/common.min.js.map',
-        'bundle.js',
-        'https://static.example.com'
-      )
-      const context = createMockContext() as CommandContext
-
-      const payload = sourcemap.asMultipartPayload({
-        cliVersion: '1.0.0',
-        debugId: true,
-        context,
-      })
-      const event = payload.content.get('event') as MultipartStringValue
-      const eventValue = JSON.parse(event['value']) as Record<string, unknown>
-
-      expect(eventValue['debug_id']).toBeUndefined()
-      expect(context.stderr.toString()).toContain('Cannot extract Debug ID')
-    })
-
-    test('omits debug_id without error when --debug-id flag is not set', () => {
-      const sourcemap = new Sourcemap(
-        'src/commands/sourcemaps/__tests__/fixtures/bundle-with-debug-id/common.min.js',
-        'https://static.example.com/common.min.js',
-        'src/commands/sourcemaps/__tests__/fixtures/bundle-with-debug-id/common.min.js.map',
-        'common.min.js',
-        'https://static.example.com'
-      )
-      const context = createMockContext() as CommandContext
-
-      const payload = sourcemap.asMultipartPayload({
-        cliVersion: '1.0.0',
-        service: 'my-service',
-        version: '1.2.3',
-        debugId: false,
-        context,
-      })
-      const event = payload.content.get('event') as MultipartStringValue
-      const eventValue = JSON.parse(event['value']) as Record<string, unknown>
-
-      expect(eventValue['debug_id']).toBeUndefined()
-      expect(context.stderr.toString()).toBe('')
-    })
-  })
-})
 
 describe('upload', () => {
   describe('getMinifiedURL', () => {
@@ -206,6 +110,54 @@ describe('upload', () => {
       command['minifiedPathPrefix'] = 'info: undesired log line\nhttps://example.com/static/js/'
 
       expect(command['isMinifiedPathPrefixValid']()).toBe(false)
+    })
+  })
+
+  describe('validateOptions', () => {
+    test('returns true when --debug-id is set (skips all other checks)', () => {
+      const command = createCommand(SourcemapsUploadCommand)
+      command['debugId'] = true
+      expect(command['validateOptions']()).toBe(true)
+      expect(command.context.stderr.toString()).toBe('')
+    })
+
+    test('returns false when release version is missing', () => {
+      const command = createCommand(SourcemapsUploadCommand)
+      expect(command['validateOptions']()).toBe(false)
+      expect(command.context.stderr.toString()).toContain('Missing release version')
+    })
+
+    test('returns false when service is missing', () => {
+      const command = createCommand(SourcemapsUploadCommand)
+      command['releaseVersion'] = '1.0.0'
+      expect(command['validateOptions']()).toBe(false)
+      expect(command.context.stderr.toString()).toContain('Missing service')
+    })
+
+    test('returns false when minified path prefix is missing', () => {
+      const command = createCommand(SourcemapsUploadCommand)
+      command['releaseVersion'] = '1.0.0'
+      command['service'] = 'my-service'
+      expect(command['validateOptions']()).toBe(false)
+      expect(command.context.stderr.toString()).toContain('Missing minified path prefix')
+    })
+
+    test('returns false when minified path prefix is invalid', () => {
+      const command = createCommand(SourcemapsUploadCommand)
+      command['releaseVersion'] = '1.0.0'
+      command['service'] = 'my-service'
+      command['minifiedPathPrefix'] = 'not-a-valid-prefix'
+      expect(command['validateOptions']()).toBe(false)
+      expect(command.context.stdout.toString()).toContain('prefix')
+    })
+
+    test('returns true when all required options are valid', () => {
+      const command = createCommand(SourcemapsUploadCommand)
+      command['releaseVersion'] = '1.0.0'
+      command['service'] = 'my-service'
+      command['minifiedPathPrefix'] = 'https://static.example.com/js'
+      expect(command['validateOptions']()).toBe(true)
+      expect(command.context.stderr.toString()).toBe('')
     })
   })
 
@@ -329,6 +281,25 @@ describe('execute', () => {
     'https://static.com/js',
     '--dry-run',
   ])
+
+  const runCLIWithDebugId = makeRunCLI(SourcemapsUploadCommand, [
+    'sourcemaps',
+    'upload',
+    '--debug-id',
+    '--minified-path-prefix',
+    'https://static.com/js',
+    '--dry-run',
+  ])
+
+  test('debug id', async () => {
+    const {context, code} = await runCLIWithDebugId([
+      './src/commands/sourcemaps/__tests__/fixtures/bundle-with-debug-id',
+    ])
+    expect(code).toBe(0)
+    expect(context.stdout.toString()).toContain(
+      '[DRYRUN] Uploading sourcemap src/commands/sourcemaps/__tests__/fixtures/bundle-with-debug-id/common.min.js.map for JS file available at https://static.com/js/common.min.js (debug ID: 2f1d7f52-4e1b-4f7c-8c0d-2f4a5f6d8e91)'
+    )
+  })
 
   test('relative path with double dots', async () => {
     const {context, code} = await runCLI(['./src/commands/sourcemaps/__tests__/doesnotexist/../fixtures/basic'])

--- a/packages/base/src/commands/sourcemaps/debugId.ts
+++ b/packages/base/src/commands/sourcemaps/debugId.ts
@@ -1,21 +1,32 @@
 import fs from 'fs'
 
-import type {CommandContext} from '@datadog/datadog-ci-base'
+import type {Sourcemap} from './interfaces'
 
 const DD_DEBUG_ID_REGEX = /["']ddDebugId["']\s*:\s*["']([^"']+)["']/
 
-export const extractDebugId = (filePath: string, context: CommandContext): string | undefined => {
+export const extractDebugId = (filePath: string): string | undefined => {
   try {
     const source = fs.readFileSync(filePath, 'utf-8')
-    const match = source.match(DD_DEBUG_ID_REGEX)
-    if (match) {
-      return match[1]
+
+    return source.match(DD_DEBUG_ID_REGEX)?.[1]
+  } catch {
+    // Unreadable file: treated as having no debug ID.
+    return undefined
+  }
+}
+
+/**
+ * Adds the debug ID extracted from each payload's minified file onto the
+ * payload. Returns true if at least one payload has a debug ID.
+ */
+export const addDebugIdToPayloads = (payloads: Sourcemap[]): boolean => {
+  let hasAnyDebugId = false
+  for (const payload of payloads) {
+    payload.debugId = extractDebugId(payload.minifiedFilePath)
+    if (payload.debugId !== undefined) {
+      hasAnyDebugId = true
     }
-    context.stderr.write(`Debug ID not found in ${filePath}\n`)
-  } catch (err) {
-    const errorMsg = err instanceof Error ? err.message : String(err)
-    context.stderr.write(`Cannot extract Debug ID from ${filePath}: ${errorMsg}\n`)
   }
 
-  return undefined
+  return hasAnyDebugId
 }

--- a/packages/base/src/commands/sourcemaps/debugId.ts
+++ b/packages/base/src/commands/sourcemaps/debugId.ts
@@ -1,0 +1,21 @@
+import fs from 'fs'
+
+import type {CommandContext} from '@datadog/datadog-ci-base'
+
+const DD_DEBUG_ID_REGEX = /["']ddDebugId["']\s*:\s*["']([^"']+)["']/
+
+export const extractDebugId = (filePath: string, context: CommandContext): string | undefined => {
+  try {
+    const source = fs.readFileSync(filePath, 'utf-8')
+    const match = source.match(DD_DEBUG_ID_REGEX)
+    if (match) {
+      return match[1]
+    }
+    context.stderr.write(`Debug ID not found in ${filePath}\n`)
+  } catch (err) {
+    const errorMsg = err instanceof Error ? err.message : String(err)
+    context.stderr.write(`Cannot extract Debug ID from ${filePath}: ${errorMsg}\n`)
+  }
+
+  return undefined
+}

--- a/packages/base/src/commands/sourcemaps/debugId.ts
+++ b/packages/base/src/commands/sourcemaps/debugId.ts
@@ -2,7 +2,8 @@ import fs from 'fs'
 
 import type {Sourcemap} from './interfaces'
 
-const DD_DEBUG_ID_REGEX = /["']ddDebugId["']\s*:\s*["']([^"']+)["']/
+const DD_DEBUG_ID_REGEX =
+  /["']ddDebugId["']\s*:\s*["']([a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})["']/
 
 export const extractDebugId = (filePath: string): string | undefined => {
   try {

--- a/packages/base/src/commands/sourcemaps/interfaces.ts
+++ b/packages/base/src/commands/sourcemaps/interfaces.ts
@@ -2,6 +2,7 @@ import type {CommandContext} from '@datadog/datadog-ci-base'
 import type {MultipartPayload, MultipartValue} from '@datadog/datadog-ci-base/helpers/upload'
 
 export class Sourcemap {
+  public debugId?: string
   public gitData?: GitData
   public minifiedFilePath: string
   public minifiedPathPrefix?: string
@@ -49,13 +50,7 @@ export class Sourcemap {
     }
   }
 
-  private getMetadataPayload({
-    cliVersion,
-    service,
-    version,
-    projectPath,
-    debugId,
-  }: SourcemapUploadOptions): MultipartValue {
+  private getMetadataPayload({cliVersion, service, version, projectPath}: SourcemapUploadOptions): MultipartValue {
     const metadata: {[k: string]: any} = {
       cli_version: cliVersion,
       project_path: projectPath,
@@ -63,7 +58,7 @@ export class Sourcemap {
       service,
       version,
       minified_url: this.minifiedUrl,
-      debug_id: debugId,
+      debug_id: this.debugId,
     }
 
     if (this.gitData !== undefined) {
@@ -85,7 +80,6 @@ export class Sourcemap {
 export interface SourcemapUploadOptions {
   cliVersion: string
   context: CommandContext
-  debugId?: string
   projectPath?: string
   service?: string
   version?: string

--- a/packages/base/src/commands/sourcemaps/interfaces.ts
+++ b/packages/base/src/commands/sourcemaps/interfaces.ts
@@ -1,5 +1,3 @@
-import fs from 'fs'
-
 import type {CommandContext} from '@datadog/datadog-ci-base'
 import type {MultipartPayload, MultipartValue} from '@datadog/datadog-ci-base/helpers/upload'
 
@@ -51,42 +49,21 @@ export class Sourcemap {
     }
   }
 
-  private extractDebugId(context: CommandContext): string | undefined {
-    try {
-      const source = fs.readFileSync(this.minifiedFilePath, 'utf-8')
-      const match = source.match(/"ddDebugId":"([^"]+)"/)
-      if (match) {
-        return match[1]
-      }
-      context.stderr.write(`Debug ID not found in ${this.minifiedFilePath}\n`)
-    } catch (err) {
-      const errorMsg = err instanceof Error ? err.message : String(err)
-      context.stderr.write(`Cannot extract Debug ID from ${this.minifiedFilePath}: ${errorMsg}\n`)
-    }
-
-    return undefined
-  }
-
   private getMetadataPayload({
     cliVersion,
     service,
     version,
     projectPath,
     debugId,
-    context,
   }: SourcemapUploadOptions): MultipartValue {
     const metadata: {[k: string]: any} = {
       cli_version: cliVersion,
       project_path: projectPath,
       type: 'js_sourcemap',
-    }
-
-    if (debugId) {
-      metadata.debug_id = this.extractDebugId(context)
-    } else {
-      metadata.service = service
-      metadata.version = version
-      metadata.minified_url = this.minifiedUrl
+      service,
+      version,
+      minified_url: this.minifiedUrl,
+      debug_id: debugId,
     }
 
     if (this.gitData !== undefined) {
@@ -108,7 +85,7 @@ export class Sourcemap {
 export interface SourcemapUploadOptions {
   cliVersion: string
   context: CommandContext
-  debugId: boolean
+  debugId?: string
   projectPath?: string
   service?: string
   version?: string

--- a/packages/base/src/commands/sourcemaps/interfaces.ts
+++ b/packages/base/src/commands/sourcemaps/interfaces.ts
@@ -1,3 +1,6 @@
+import fs from 'fs'
+
+import type {CommandContext} from '@datadog/datadog-ci-base'
 import type {MultipartPayload, MultipartValue} from '@datadog/datadog-ci-base/helpers/upload'
 
 export class Sourcemap {
@@ -26,14 +29,9 @@ export class Sourcemap {
     this.gitData = gitData
   }
 
-  public asMultipartPayload(
-    cliVersion: string,
-    service: string,
-    version: string,
-    projectPath: string
-  ): MultipartPayload {
+  public asMultipartPayload(options: SourcemapUploadOptions): MultipartPayload {
     const content = new Map<string, MultipartValue>([
-      ['event', this.getMetadataPayload(cliVersion, service, version, projectPath)],
+      ['event', this.getMetadataPayload(options)],
       ['source_map', {type: 'file', path: this.sourcemapPath, options: {filename: 'source_map'}}],
       ['minified_file', {type: 'file', path: this.minifiedFilePath, options: {filename: 'minified_file'}}],
     ])
@@ -53,20 +51,44 @@ export class Sourcemap {
     }
   }
 
-  private getMetadataPayload(
-    cliVersion: string,
-    service: string,
-    version: string,
-    projectPath: string
-  ): MultipartValue {
+  private extractDebugId(context: CommandContext): string | undefined {
+    try {
+      const source = fs.readFileSync(this.minifiedFilePath, 'utf-8')
+      const match = source.match(/"ddDebugId":"([^"]+)"/)
+      if (match) {
+        return match[1]
+      }
+      context.stderr.write(`Debug ID not found in ${this.minifiedFilePath}\n`)
+    } catch (err) {
+      const errorMsg = err instanceof Error ? err.message : String(err)
+      context.stderr.write(`Cannot extract Debug ID from ${this.minifiedFilePath}: ${errorMsg}\n`)
+    }
+
+    return undefined
+  }
+
+  private getMetadataPayload({
+    cliVersion,
+    service,
+    version,
+    projectPath,
+    debugId,
+    context,
+  }: SourcemapUploadOptions): MultipartValue {
     const metadata: {[k: string]: any} = {
       cli_version: cliVersion,
-      minified_url: this.minifiedUrl,
       project_path: projectPath,
-      service,
       type: 'js_sourcemap',
-      version,
     }
+
+    if (debugId) {
+      metadata.debug_id = this.extractDebugId(context)
+    } else {
+      metadata.service = service
+      metadata.version = version
+      metadata.minified_url = this.minifiedUrl
+    }
+
     if (this.gitData !== undefined) {
       metadata.git_repository_url = this.gitData.gitRepositoryURL
       metadata.git_commit_sha = this.gitData.gitCommitSha
@@ -81,6 +103,15 @@ export class Sourcemap {
       value: JSON.stringify(metadata),
     }
   }
+}
+
+export interface SourcemapUploadOptions {
+  cliVersion: string
+  context: CommandContext
+  debugId: boolean
+  projectPath?: string
+  service?: string
+  version?: string
 }
 
 export interface GitData {

--- a/packages/base/src/commands/sourcemaps/renderer.ts
+++ b/packages/base/src/commands/sourcemaps/renderer.ts
@@ -140,5 +140,8 @@ export const renderCommandInfo = (
   return fullStr
 }
 
-export const renderUpload = (sourcemap: Sourcemap): string =>
-  `Uploading sourcemap ${sourcemap.sourcemapPath} for JS file available at ${sourcemap.minifiedUrl}\n`
+export const renderUpload = (sourcemap: Sourcemap, debugId?: string): string => {
+  const debugIdSuffix = debugId ? ` (debug ID: ${debugId})` : ''
+
+  return `Uploading sourcemap ${sourcemap.sourcemapPath} for JS file available at ${sourcemap.minifiedUrl}${debugIdSuffix}\n`
+}

--- a/packages/base/src/commands/sourcemaps/renderer.ts
+++ b/packages/base/src/commands/sourcemaps/renderer.ts
@@ -108,10 +108,11 @@ export const renderSuccessfulCommand = (statuses: UploadStatus[], duration: numb
 
 export const renderCommandInfo = (
   basePath: string,
-  minifiedPathPrefix: string,
+  minifiedPathPrefix: string | undefined,
   projectPath: string | undefined,
-  releaseVersion: string,
-  service: string,
+  releaseVersion: string | undefined,
+  service: string | undefined,
+  debugId: boolean,
   poolLimit: number,
   dryRun: boolean
 ) => {
@@ -119,22 +120,22 @@ export const renderCommandInfo = (
   if (dryRun) {
     fullStr += chalk.yellow(`${ICONS.WARNING} DRY-RUN MODE ENABLED. WILL NOT UPLOAD SOURCEMAPS\n`)
   }
-  const startStr = chalk.green(`Starting upload with concurrency ${poolLimit}. \n`)
-  fullStr += startStr
-  const basePathStr = chalk.green(`Will look for sourcemaps in ${basePath}\n`)
-  fullStr += basePathStr
-  const minifiedPathPrefixStr = chalk.green(
-    `Will match JS files for errors on files starting with ${minifiedPathPrefix}\n`
-  )
-  fullStr += minifiedPathPrefixStr
+  fullStr += chalk.green(`Starting upload with concurrency ${poolLimit}. \n`)
+  fullStr += chalk.green(`Will look for sourcemaps in ${basePath}\n`)
 
-  const serviceVersionProjectPathStr =
-    [
-      `${chalk.green('Version:')} ${chalk.cyan(releaseVersion)}`,
-      `${chalk.green('Service:')} ${chalk.cyan(service)}`,
-      `${chalk.green('Project path:')} ${projectPath !== undefined ? chalk.cyan(projectPath) : chalk.dim('<empty>')}`,
-    ].join(' · ') + '\n\n'
-  fullStr += serviceVersionProjectPathStr
+  if (minifiedPathPrefix) {
+    fullStr += chalk.green(`Will match JS files for errors on files starting with ${minifiedPathPrefix}\n`)
+  }
+
+  const metaParts = []
+  if (!debugId) {
+    metaParts.push(`${chalk.green('Version:')} ${chalk.cyan(releaseVersion)}`)
+    metaParts.push(`${chalk.green('Service:')} ${chalk.cyan(service)}`)
+  }
+  metaParts.push(
+    `${chalk.green('Project path:')} ${projectPath !== undefined ? chalk.cyan(projectPath) : chalk.dim('<empty>')}`
+  )
+  fullStr += metaParts.join(' · ') + '\n\n'
 
   return fullStr
 }

--- a/packages/base/src/commands/sourcemaps/renderer.ts
+++ b/packages/base/src/commands/sourcemaps/renderer.ts
@@ -38,6 +38,8 @@ export const renderFailedUpload = (sourcemap: Sourcemap, errorMessage: string) =
   return chalk.red(`${ICONS.FAILED} Failed upload sourcemap for ${sourcemapPathBold}: ${errorMessage}\n`)
 }
 
+export const renderNoDebugIdFound = () => 'No debug ID found in any minified file. Aborting upload.\n'
+
 export const renderRetriedUpload = (payload: Sourcemap, errorMessage: string, attempt: number) => {
   const sourcemapPathBold = `[${chalk.bold.dim(payload.sourcemapPath)}]`
 
@@ -140,8 +142,8 @@ export const renderCommandInfo = (
   return fullStr
 }
 
-export const renderUpload = (sourcemap: Sourcemap, debugId?: string): string => {
-  const debugIdSuffix = debugId ? ` (debug ID: ${debugId})` : ''
+export const renderUpload = (sourcemap: Sourcemap): string => {
+  const debugIdSuffix = sourcemap.debugId ? ` (debug ID: ${sourcemap.debugId})` : ''
 
   return `Uploading sourcemap ${sourcemap.sourcemapPath} for JS file available at ${sourcemap.minifiedUrl}${debugIdSuffix}\n`
 }

--- a/packages/base/src/commands/sourcemaps/upload.ts
+++ b/packages/base/src/commands/sourcemaps/upload.ts
@@ -32,6 +32,7 @@ import {getRequestBuilder, buildPath} from '@datadog/datadog-ci-base/helpers/uti
 import * as validation from '@datadog/datadog-ci-base/helpers/validation'
 import {cliVersion} from '@datadog/datadog-ci-base/version'
 
+import {extractDebugId} from './debugId'
 import {Sourcemap} from './interfaces'
 import {
   renderCommandInfo,
@@ -101,9 +102,8 @@ export class SourcemapsUploadCommand extends BaseCommand {
   public async execute() {
     enableFips(this.fips || this.config.fips, this.fipsIgnoreError || this.config.fipsIgnoreError)
 
-    const validationError = this.validateOptions()
-    if (validationError) {
-      return validationError
+    if (!this.validateOptions()) {
+      return 1
     }
 
     // Normalizing the basePath to resolve .. and .
@@ -368,34 +368,36 @@ export class SourcemapsUploadCommand extends BaseCommand {
     })
   }
 
-  private validateOptions(): 1 | undefined {
+  private validateOptions(): boolean {
     if (this.debugId) {
-      return undefined
+      return true
     }
 
     if (!this.releaseVersion) {
       this.context.stderr.write('Missing release version\n')
 
-      return 1
+      return false
     }
 
     if (!this.service) {
       this.context.stderr.write('Missing service\n')
 
-      return 1
+      return false
     }
 
     if (!this.minifiedPathPrefix) {
       this.context.stderr.write('Missing minified path prefix\n')
 
-      return 1
+      return false
     }
 
     if (!this.isMinifiedPathPrefixValid()) {
       this.context.stdout.write(renderInvalidPrefix)
 
-      return 1
+      return false
     }
+
+    return true
   }
 
   private isMinifiedPathPrefixValid(): boolean {
@@ -439,16 +441,17 @@ export class SourcemapsUploadCommand extends BaseCommand {
         return UploadStatus.Skipped
       }
 
+      const debugId = this.debugId ? extractDebugId(sourcemap.minifiedFilePath, this.context) : undefined
       const payload = sourcemap.asMultipartPayload({
         cliVersion: this.cliVersion,
         service: this.service,
         version: this.releaseVersion,
         projectPath: this.projectPath,
-        debugId: this.debugId,
+        debugId,
         context: this.context,
       })
       if (this.dryRun) {
-        this.context.stdout.write(`[DRYRUN] ${renderUpload(sourcemap)}`)
+        this.context.stdout.write(`[DRYRUN] ${renderUpload(sourcemap, debugId)}`)
 
         return UploadStatus.Success
       }
@@ -467,7 +470,7 @@ export class SourcemapsUploadCommand extends BaseCommand {
           if (this.quiet) {
             return
           }
-          this.context.stdout.write(renderUpload(sourcemap))
+          this.context.stdout.write(renderUpload(sourcemap, debugId))
         },
         retries: 5,
         useGzip: true,

--- a/packages/base/src/commands/sourcemaps/upload.ts
+++ b/packages/base/src/commands/sourcemaps/upload.ts
@@ -388,8 +388,8 @@ export class SourcemapsUploadCommand extends BaseCommand {
         conflicting.push('--release-version')
       }
 
-      if (this.projectPath !== undefined) {
-        conflicting.push('--project-path')
+      if (this.minifiedPathPrefix !== undefined) {
+        conflicting.push('--minified-path-prefix')
       }
 
       if (conflicting.length > 0) {

--- a/packages/base/src/commands/sourcemaps/upload.ts
+++ b/packages/base/src/commands/sourcemaps/upload.ts
@@ -378,6 +378,28 @@ export class SourcemapsUploadCommand extends BaseCommand {
 
   private validateOptions(): boolean {
     if (this.debugId) {
+      const conflicting: string[] = []
+
+      if (this.service !== undefined) {
+        conflicting.push('--service')
+      }
+
+      if (this.releaseVersion !== undefined) {
+        conflicting.push('--release-version')
+      }
+
+      if (this.projectPath !== undefined) {
+        conflicting.push('--project-path')
+      }
+
+      if (conflicting.length > 0) {
+        this.context.stderr.write(
+          `${conflicting.join(', ')} cannot be used with --debug-id. Sourcemaps are matched by debug ID in this mode.\n`
+        )
+
+        return false
+      }
+
       return true
     }
 

--- a/packages/base/src/commands/sourcemaps/upload.ts
+++ b/packages/base/src/commands/sourcemaps/upload.ts
@@ -32,7 +32,7 @@ import {getRequestBuilder, buildPath} from '@datadog/datadog-ci-base/helpers/uti
 import * as validation from '@datadog/datadog-ci-base/helpers/validation'
 import {cliVersion} from '@datadog/datadog-ci-base/version'
 
-import {extractDebugId} from './debugId'
+import {addDebugIdToPayloads} from './debugId'
 import {Sourcemap} from './interfaces'
 import {
   renderCommandInfo,
@@ -42,6 +42,7 @@ import {
   renderGitDataNotAttachedWarning,
   renderGitWarning,
   renderInvalidPrefix,
+  renderNoDebugIdFound,
   renderRetriedUpload,
   renderSourcesNotFoundWarning,
   renderSuccessfulCommand,
@@ -138,6 +139,13 @@ export class SourcemapsUploadCommand extends BaseCommand {
     const useGit = this.disableGit === undefined || !this.disableGit
     const initialTime = Date.now()
     const payloads = await this.getPayloadsToUpload(useGit)
+
+    if (this.debugId && !addDebugIdToPayloads(payloads)) {
+      this.context.stderr.write(renderNoDebugIdFound())
+
+      return 1
+    }
+
     const requestBuilder = this.getRequestBuilder()
     const uploadMultipart = this.upload(requestBuilder, metricsLogger, apiKeyValidator)
     try {
@@ -423,7 +431,7 @@ export class SourcemapsUploadCommand extends BaseCommand {
   ): (sourcemap: Sourcemap) => Promise<UploadStatus> {
     return async (sourcemap: Sourcemap) => {
       try {
-        validatePayload(sourcemap, this.context.stdout)
+        validatePayload(sourcemap, this.context.stdout, this.debugId)
       } catch (error) {
         if (error instanceof InvalidPayload) {
           this.context.stdout.write(renderFailedUpload(sourcemap, error.message))
@@ -441,17 +449,15 @@ export class SourcemapsUploadCommand extends BaseCommand {
         return UploadStatus.Skipped
       }
 
-      const debugId = this.debugId ? extractDebugId(sourcemap.minifiedFilePath, this.context) : undefined
       const payload = sourcemap.asMultipartPayload({
         cliVersion: this.cliVersion,
         service: this.service,
         version: this.releaseVersion,
         projectPath: this.projectPath,
-        debugId,
         context: this.context,
       })
       if (this.dryRun) {
-        this.context.stdout.write(`[DRYRUN] ${renderUpload(sourcemap, debugId)}`)
+        this.context.stdout.write(`[DRYRUN] ${renderUpload(sourcemap)}`)
 
         return UploadStatus.Success
       }
@@ -470,7 +476,7 @@ export class SourcemapsUploadCommand extends BaseCommand {
           if (this.quiet) {
             return
           }
-          this.context.stdout.write(renderUpload(sourcemap, debugId))
+          this.context.stdout.write(renderUpload(sourcemap))
         },
         retries: 5,
         useGzip: true,

--- a/packages/base/src/commands/sourcemaps/upload.ts
+++ b/packages/base/src/commands/sourcemaps/upload.ts
@@ -140,7 +140,7 @@ export class SourcemapsUploadCommand extends BaseCommand {
     const initialTime = Date.now()
     const payloads = await this.getPayloadsToUpload(useGit)
 
-    if (this.debugId && !addDebugIdToPayloads(payloads)) {
+    if (this.debugId && payloads.length > 0 && !addDebugIdToPayloads(payloads)) {
       this.context.stderr.write(renderNoDebugIdFound())
 
       return 1

--- a/packages/base/src/commands/sourcemaps/upload.ts
+++ b/packages/base/src/commands/sourcemaps/upload.ts
@@ -81,6 +81,7 @@ export class SourcemapsUploadCommand extends BaseCommand {
   private releaseVersion = Option.String('--release-version')
   private repositoryURL = Option.String('--repository-url')
   private commitSha = Option.String('--commit-sha')
+  private debugId = Option.Boolean('--debug-id', false)
   private service = Option.String('--service')
 
   private cliVersion = cliVersion
@@ -100,28 +101,9 @@ export class SourcemapsUploadCommand extends BaseCommand {
   public async execute() {
     enableFips(this.fips || this.config.fips, this.fipsIgnoreError || this.config.fipsIgnoreError)
 
-    if (!this.releaseVersion) {
-      this.context.stderr.write('Missing release version\n')
-
-      return 1
-    }
-
-    if (!this.service) {
-      this.context.stderr.write('Missing service\n')
-
-      return 1
-    }
-
-    if (!this.minifiedPathPrefix) {
-      this.context.stderr.write('Missing minified path prefix\n')
-
-      return 1
-    }
-
-    if (!this.isMinifiedPathPrefixValid()) {
-      this.context.stdout.write(renderInvalidPrefix)
-
-      return 1
+    const validationError = this.validateOptions()
+    if (validationError) {
+      return validationError
     }
 
     // Normalizing the basePath to resolve .. and .
@@ -133,13 +115,19 @@ export class SourcemapsUploadCommand extends BaseCommand {
         this.projectPath,
         this.releaseVersion,
         this.service,
+        this.debugId,
         this.maxConcurrency,
         this.dryRun
       )
     )
+    const loggerTags = [`cli_version:${this.cliVersion}`]
+    if (!this.debugId) {
+      loggerTags.push(`version:${this.releaseVersion}`)
+      loggerTags.push(`service:${this.service}`)
+    }
     const metricsLogger = getMetricsLogger({
       datadogSite: getDatadogSiteFromEnv(),
-      defaultTags: [`version:${this.releaseVersion}`, `service:${this.service}`, `cli_version:${this.cliVersion}`],
+      defaultTags: loggerTags,
       prefix: 'datadog.ci.sourcemaps.',
     })
     const apiKeyValidator = newApiKeyValidator({
@@ -280,7 +268,7 @@ export class SourcemapsUploadCommand extends BaseCommand {
   private getMinifiedURLAndRelativePath(minifiedFilePath: string): [string, string] {
     const relativePath = upath.relative(this.basePath, minifiedFilePath)
 
-    return [buildPath(this.minifiedPathPrefix!, relativePath), relativePath]
+    return [buildPath(this.minifiedPathPrefix ?? '', relativePath), relativePath]
   }
 
   private getPayloadsToUpload = async (useGit: boolean): Promise<Sourcemap[]> => {
@@ -380,6 +368,36 @@ export class SourcemapsUploadCommand extends BaseCommand {
     })
   }
 
+  private validateOptions(): 1 | undefined {
+    if (this.debugId) {
+      return undefined
+    }
+
+    if (!this.releaseVersion) {
+      this.context.stderr.write('Missing release version\n')
+
+      return 1
+    }
+
+    if (!this.service) {
+      this.context.stderr.write('Missing service\n')
+
+      return 1
+    }
+
+    if (!this.minifiedPathPrefix) {
+      this.context.stderr.write('Missing minified path prefix\n')
+
+      return 1
+    }
+
+    if (!this.isMinifiedPathPrefixValid()) {
+      this.context.stdout.write(renderInvalidPrefix)
+
+      return 1
+    }
+  }
+
   private isMinifiedPathPrefixValid(): boolean {
     let host
     try {
@@ -421,12 +439,14 @@ export class SourcemapsUploadCommand extends BaseCommand {
         return UploadStatus.Skipped
       }
 
-      const payload = sourcemap.asMultipartPayload(
-        this.cliVersion,
-        this.service!,
-        this.releaseVersion!,
-        this.projectPath ?? ''
-      )
+      const payload = sourcemap.asMultipartPayload({
+        cliVersion: this.cliVersion,
+        service: this.service,
+        version: this.releaseVersion,
+        projectPath: this.projectPath,
+        debugId: this.debugId,
+        context: this.context,
+      })
       if (this.dryRun) {
         this.context.stdout.write(`[DRYRUN] ${renderUpload(sourcemap)}`)
 

--- a/packages/base/src/commands/sourcemaps/validation.ts
+++ b/packages/base/src/commands/sourcemaps/validation.ts
@@ -15,7 +15,7 @@ export class InvalidPayload extends Error {
   }
 }
 
-export const validatePayload = (sourcemap: Sourcemap, stdout: Writable) => {
+export const validatePayload = (sourcemap: Sourcemap, stdout: Writable, debugIdRequired = false) => {
   // Check existence of sourcemap file
   const sourcemapCheck = checkFile(sourcemap.sourcemapPath)
   if (!sourcemapCheck.exists) {
@@ -37,6 +37,14 @@ export const validatePayload = (sourcemap: Sourcemap, stdout: Writable) => {
     throw new InvalidPayload(
       'empty_js',
       `Skipping sourcemap (${sourcemap.sourcemapPath}) due to ${sourcemap.minifiedFilePath} being empty`
+    )
+  }
+
+  // Check for a debug ID when uploading in debug-ID mode.
+  if (debugIdRequired && sourcemap.debugId === undefined) {
+    throw new InvalidPayload(
+      'missing_debug_id',
+      `Skipping sourcemap ${sourcemap.sourcemapPath} because no debug ID was found in ${sourcemap.minifiedFilePath}`
     )
   }
 


### PR DESCRIPTION
## Context

When an error spans multiple micro-frontends, unminification breaks because all frames are resolved using the top frame’s (service, version).

This PR adds support for `debug_id` sourcemaps by extracting the `debug_id` (a [TC39 proposal](https://github.com/tc39/ecma426/blob/main/proposals/debug-id.md)￼) from the source file and including it in the upload metadata. This enables the backend to resolve sourcemaps per frame using debug_id instead of a shared (service, version).

## What this PR does

Adds a `--debug-id` flag to `sourcemaps upload`. When set:

- `--service`, `--release-version`, and `--minified-path-prefix` are **forbidden** when --debug-id is present
- The CLI reads the `debug_id` from the bundle's `ddDebugId` runtime snippet (injected by the build plugin)
- The upload event metadata includes `debug_id` instead of `service`/`version`/`minified_url`

## Test plan

- [ ] `yarn build`
- [ ] `yarn test packages/base/src/commands/sourcemaps`
- [ ] Manual: `yarn launch sourcemaps upload <path> --debug-id  --dry-run`
- [ ] Manual: `yarn launch sourcemaps upload <path>` — validates and rejects missing flags