### PR TITLE
fix(trace): write diagnostics to stderr so they don't corrupt captured stdout

### DIFF
--- a/packages/base/src/__tests__/version.test.ts
+++ b/packages/base/src/__tests__/version.test.ts
@@ -38,4 +38,21 @@ describe('printVersion', () => {
       process.argv = original
     }
   })
+
+  it.each(['1', 'true', 'TRUE'])('does not print when DD_CI_SKIP_VERSION_BANNER is %p', (value) => {
+    const original = process.env.DD_CI_SKIP_VERSION_BANNER
+    process.env.DD_CI_SKIP_VERSION_BANNER = value
+
+    try {
+      const {lines, logger} = collect(false)
+      printVersion(logger)
+      expect(lines).toHaveLength(0)
+    } finally {
+      if (original === undefined) {
+        delete process.env.DD_CI_SKIP_VERSION_BANNER
+      } else {
+        process.env.DD_CI_SKIP_VERSION_BANNER = original
+      }
+    }
+  })
 })

--- a/packages/base/src/commands/span/__tests__/span.test.ts
+++ b/packages/base/src/commands/span/__tests__/span.test.ts
@@ -30,8 +30,12 @@ describe('span', () => {
 
     test('no-name', async () => {
       const env = {GITLAB_CI: '1'}
-      const {code} = await runCLI(['--duration', '10000'], env)
+      const {context, code} = await runCLI(['--duration', '10000'], env)
       expect(code).toBe(1)
+      // Validation errors are diagnostics: they belong on stderr, not stdout (which must stay
+      // clean for `$(datadog-ci trace span ...)` captures).
+      expect(context.stderr.toString()).toContain('The span name must be provided.')
+      expect(context.stdout.toString()).toBe('')
     })
 
     test('no-time-info', async () => {

--- a/packages/base/src/commands/span/span.ts
+++ b/packages/base/src/commands/span/span.ts
@@ -45,7 +45,7 @@ export class SpanCommand extends CustomSpanCommand {
     this.tryEnableFips()
 
     if (!this.name) {
-      this.context.stdout.write(`The span name must be provided.\n`)
+      this.context.stderr.write(`The span name must be provided.\n`)
 
       return 1
     }
@@ -55,7 +55,7 @@ export class SpanCommand extends CustomSpanCommand {
       (!this.startTimeInMs && this.endTimeInMs) ||
       (this.durationInMs && (this.startTimeInMs || this.endTimeInMs))
     ) {
-      this.context.stdout.write(`Either duration or start and end time must be provided.\n`)
+      this.context.stderr.write(`Either duration or start and end time must be provided.\n`)
 
       return 1
     }
@@ -65,13 +65,13 @@ export class SpanCommand extends CustomSpanCommand {
     }
 
     if (!this.durationInMs) {
-      this.context.stdout.write(`The span duration must be provided or start-time and end-time.\n`)
+      this.context.stderr.write(`The span duration must be provided or start-time and end-time.\n`)
 
       return 1
     }
 
     if (this.durationInMs < 0) {
-      this.context.stdout.write(`The span duration must be positive / end time must be after start time.\n`)
+      this.context.stderr.write(`The span duration must be positive / end time must be after start time.\n`)
 
       return 1
     }

--- a/packages/base/src/commands/trace/__tests__/trace.test.ts
+++ b/packages/base/src/commands/trace/__tests__/trace.test.ts
@@ -15,7 +15,19 @@ describe('trace', () => {
 
     process.env = {...getEnvVarPlaceholders(), ...extraEnv}
     const context = createMockContext({env: process.env})
-    context.stderr = new PassThrough()
+    // `trace` pipes the child's stderr into `context.stderr` (`childProcess.stderr.pipe(...)`),
+    // which needs a real stream — the mock context's stderr isn't one. Use a PassThrough, but
+    // wrap `write` so we can still synchronously assert on what the command emits to stderr.
+    const stderr = new PassThrough()
+    let stderrData = ''
+    const originalWrite = stderr.write.bind(stderr)
+    stderr.write = ((chunk: any, ...rest: any[]) => {
+      stderrData += chunk.toString()
+
+      return originalWrite(chunk, ...rest)
+    }) as typeof stderr.write
+    ;(stderr as any).toString = () => stderrData
+    context.stderr = stderr
     const code = await cli.run(['trace', '--dry-run', ...extraArgs, '--', 'echo'], context)
 
     return {context, code}
@@ -42,6 +54,19 @@ describe('trace', () => {
       process.env = {}
       const {code} = await runCLI(['--no-fail'])
       expect(code).toBe(0)
+    })
+
+    test('should write the --no-fail note to stderr, not stdout', async () => {
+      // Regression: `trace` inherits the wrapped child's stdout, so any diagnostic the command
+      // writes to its own stdout leaks into `VAR=$(datadog-ci trace -- cmd)` captures and can
+      // corrupt captured values (e.g. secrets). Diagnostics must go to stderr.
+      process.env = {}
+      const {context, code} = await runCLI(['--no-fail'])
+      expect(code).toBe(0)
+      // This is the assertion that catches the bug: the old `console.log` never reached stderr.
+      expect(context.stderr.toString()).toContain('note: Not failing since --no-fail provided')
+      // Guards against a future `context.stdout.write` leak (the old `console.log` bypassed this mock).
+      expect(context.stdout.toString()).toBe('')
     })
   })
 

--- a/packages/base/src/commands/trace/helper.ts
+++ b/packages/base/src/commands/trace/helper.ts
@@ -57,7 +57,7 @@ export abstract class CustomSpanCommand extends BaseCommand {
   ): Promise<number> {
     const provider = getCIProvider()
     if (!SUPPORTED_PROVIDERS.includes(provider)) {
-      this.context.stdout.write(
+      this.context.stderr.write(
         `Unsupported CI provider "${provider}". Supported providers are: ${SUPPORTED_PROVIDERS.join(', ')}\n`
       )
 
@@ -100,7 +100,7 @@ export abstract class CustomSpanCommand extends BaseCommand {
 
   private getApiHelper(): APIHelper {
     if (!this.config.apiKey) {
-      this.context.stdout.write(
+      this.context.stderr.write(
         `Neither ${chalk.red.bold('DATADOG_API_KEY')} nor ${chalk.red.bold('DD_API_KEY')} is in your environment.\n`
       )
       throw new Error('API key is missing')

--- a/packages/base/src/commands/trace/test-utils.ts
+++ b/packages/base/src/commands/trace/test-utils.ts
@@ -24,7 +24,7 @@ export const makeCIProviderTests = (runCLI: RunCLIType, runCLIArgs: string[]) =>
       process.env = {}
       const {context, code} = await runCLI(runCLIArgs)
       expect(code).toBe(1)
-      expect(context.stdout.toString()).toContain('Unsupported CI provider "unknown"')
+      expect(context.stderr.toString()).toContain('Unsupported CI provider "unknown"')
     })
 
     test('should detect the circleci environment', async () => {

--- a/packages/base/src/commands/trace/trace.ts
+++ b/packages/base/src/commands/trace/trace.ts
@@ -55,7 +55,10 @@ export class TraceCommand extends CustomSpanCommand {
       stdio: ['inherit', 'inherit', 'pipe'],
     })
     const chunks: Buffer[] = []
-    childProcess.stderr.pipe(this.context.stderr)
+    // `{end: false}`: don't end `context.stderr` when the child closes, so the post-child
+    // `--no-fail` diagnostic below can still be written without a "write after end" error
+    // on regular Writable streams (`process.stderr` tolerates it, but others don't).
+    childProcess.stderr.pipe(this.context.stderr, {end: false})
     const stderrCatcher: Promise<string> = new Promise((resolve, reject) => {
       childProcess.stderr.on('data', (chunk) => chunks.push(Buffer.from(chunk)))
       childProcess.stderr.on('error', (err) => reject(err))
@@ -85,7 +88,7 @@ export class TraceCommand extends CustomSpanCommand {
 
     if (res !== 0) {
       if (this.noFail) {
-        console.log('note: Not failing since --no-fail provided')
+        this.context.stderr.write('note: Not failing since --no-fail provided\n')
 
         return exitCode
       }

--- a/packages/base/src/constants.ts
+++ b/packages/base/src/constants.ts
@@ -24,6 +24,9 @@ export const FIPS_IGNORE_ERROR_ENV_VAR = 'DATADOG_FIPS_IGNORE_ERROR'
 
 export const LOG_FORMAT_ENV_VAR = 'DD_LOG_FORMAT'
 
+// When set to `1`/`true`, suppresses the `datadog-ci v<version>` banner entirely.
+export const SKIP_VERSION_BANNER_ENV_VAR = 'DD_CI_SKIP_VERSION_BANNER'
+
 export const CONTENT_TYPE_HEADER = 'Content-Type'
 export const CONTENT_TYPE_VALUE_PROTOBUF = 'application/x-protobuf'
 export const CONTENT_TYPE_VALUE_JSON = 'application/json'

--- a/packages/base/src/version.ts
+++ b/packages/base/src/version.ts
@@ -4,13 +4,23 @@ import chalk from 'chalk'
 
 import {version} from '@datadog/datadog-ci-base/package.json'
 
+import {SKIP_VERSION_BANNER_ENV_VAR} from './constants'
+import {toBoolean} from './helpers/env'
+
 export const cliVersion = version
 
 /**
  * Logs the version in all commands, except version commands. Routed through the
  * logger so it respects `--log-format` (a JSON line in JSON mode, dim text otherwise).
+ *
+ * Suppressed entirely when `DD_CI_SKIP_VERSION_BANNER` is `1`/`true`, for callers
+ * that find the per-invocation banner too noisy.
  */
 export const printVersion = (logger: Logger) => {
+  if (toBoolean(process.env[SKIP_VERSION_BANNER_ENV_VAR])) {
+    return
+  }
+
   const lastArg = process.argv.at(-1)
   const skipVersion = lastArg === '--version' || lastArg === 'version' || lastArg === '--help'
   if (skipVersion) {

--- a/packages/datadog-ci/README.md
+++ b/packages/datadog-ci/README.md
@@ -270,6 +270,12 @@ Ignore Node.js errors if FIPS cannot be enabled on the host system.
 - ENV variable: `DATADOG_FIPS_IGNORE_ERROR=true`
 - CLI param: `--fips-ignore-error`
 
+### Version banner
+
+Every invocation prints a `datadog-ci v<version>` banner to `stderr`. To silence it — for example to keep CI logs quiet when the CLI runs many times — set:
+
+- ENV variable: `DD_CI_SKIP_VERSION_BANNER=true`
+
 
 ## More ways to install the CLI
 

--- a/packages/datadog-ci/src/__tests__/version-banner.test.ts
+++ b/packages/datadog-ci/src/__tests__/version-banner.test.ts
@@ -1,0 +1,77 @@
+import {spawnSync} from 'child_process'
+
+import {cliVersion} from '../cli'
+
+// Integration-style guard for the bug class this addresses: the auto version banner
+// must never land on stdout, or it corrupts captured/piped output like
+// `VAR=$(datadog-ci trace -- cmd)`. The banner is emitted in cli.ts under
+// `require.main === module`, which in-process `cli.run()` tests don't exercise — so we
+// spawn the real entry point and read stdout/stderr as separate streams (no shell, to
+// avoid redirection quirks like zsh MULTIOS duplicating a stream).
+
+// Derived from `__dirname` (handles both path separators) to avoid a `path`/`upath` import.
+const REPO_ROOT = __dirname.replace(/[\\/]packages[\\/]datadog-ci[\\/]src[\\/]__tests__$/, '')
+const CLI_ENTRY = 'packages/datadog-ci/src/cli.ts' // resolved relative to REPO_ROOT (the spawn cwd)
+const TSX_CLI = require.resolve('tsx/cli')
+
+const BANNER = /datadog-ci v\d/
+
+const runCli = (args: string[], extraEnv: Record<string, string> = {}) => {
+  const result = spawnSync(process.execPath, [TSX_CLI, '--conditions=development', CLI_ENTRY, ...args], {
+    cwd: REPO_ROOT,
+    encoding: 'utf8',
+    env: {...process.env, ...extraEnv},
+    timeout: 60_000,
+  })
+  if (result.error) {
+    throw result.error
+  }
+
+  return {stdout: result.stdout, stderr: result.stderr, status: result.status}
+}
+
+describe('version banner (cli entry point)', () => {
+  // tsx cold-starts on each spawn, so give these more room than the 5s default.
+  jest.setTimeout(120_000)
+
+  test('writes the auto banner to stderr, never stdout', () => {
+    // `trace --dry-run` parses into a real command (BaseCommand path) and bails offline
+    // at the CI-provider check, so no network is needed.
+    const {stdout, stderr} = runCli(['trace', '--dry-run', '--', 'echo', 'hi'])
+
+    expect(stderr).toMatch(BANNER)
+    // The assertion that guards the bug: the banner must stay out of captured stdout.
+    expect(stdout).not.toMatch(BANNER)
+  })
+
+  test('mirrors --log-format json: banner is a JSON line on stderr, still not on stdout', () => {
+    const {stdout, stderr} = runCli(['trace', '--dry-run', '--log-format', 'json', '--', 'echo', 'hi'])
+
+    expect(stderr).toContain(JSON.stringify({level: 'info', message: `datadog-ci v${cliVersion}`}))
+    expect(stdout).not.toMatch(BANNER)
+  })
+
+  test('keeps stdout clean even on a command-line parse error', () => {
+    // Parse errors fall back to a default logger; the banner must still avoid stdout.
+    const {stdout, stderr} = runCli(['this-command-does-not-exist'])
+
+    expect(stderr).toMatch(BANNER)
+    expect(stdout).not.toMatch(BANNER)
+  })
+
+  test.each(['version', '--version'])('prints the version to stdout for %p without the auto banner', (arg) => {
+    // `printVersion` skips these, so clipanion's builtin is the only thing that prints the
+    // version — to stdout. Guards against the auto banner double-printing on stderr.
+    const {stdout, stderr} = runCli([arg])
+
+    expect(stdout).toContain(cliVersion)
+    expect(stderr).not.toMatch(BANNER)
+  })
+
+  test('DD_CI_SKIP_VERSION_BANNER suppresses the banner on both streams', () => {
+    const {stdout, stderr} = runCli(['this-command-does-not-exist'], {DD_CI_SKIP_VERSION_BANNER: '1'})
+
+    expect(stdout).not.toMatch(BANNER)
+    expect(stderr).not.toMatch(BANNER)
+  })
+})

--- a/packages/datadog-ci/src/cli.ts
+++ b/packages/datadog-ci/src/cli.ts
@@ -78,10 +78,11 @@ if (require.main === module) {
     // Parse error: defer to cli.run below for clipanion's error rendering.
   }
 
-  // Route the banner through the resolved command's logger so it respects `--log-format`.
-  // Builtin commands (e.g. --help) and command line parse errors fall back to a default text logger.
-  const versionLogger =
-    command instanceof BaseCommand ? command.logger : new Logger((s) => context.stdout.write(s), LogLevel.INFO)
+  // Write the banner to stderr so it never corrupts captured stdout (e.g. `VAR=$(datadog-ci ...)`),
+  // while mirroring the resolved command's `--log-format` so it stays a JSON line in JSON mode.
+  // Builtin commands (e.g. --help) and command line parse errors fall back to text format.
+  const jsonOutput = command instanceof BaseCommand ? command.logger.isJsonOutput() : false
+  const versionLogger = new Logger((s) => context.stderr.write(s), LogLevel.INFO, {jsonOutput})
 
   printVersion(versionLogger)
 

--- a/standalone-e2e/standalone-smoke.test.ts
+++ b/standalone-e2e/standalone-smoke.test.ts
@@ -154,7 +154,8 @@ describe('standalone binary', () => {
       expect(result).toStrictEqual({
         exitCode: 0,
         stdout: expect.stringContaining('All plugins are already baked into the standalone binary.') as string,
-        stderr: '',
+        // The version banner is written to stderr on every non-`version`/`--help` invocation.
+        stderr: `datadog-ci v${version}`,
       })
     })
   })


### PR DESCRIPTION
### What and why?

`datadog-ci trace -- <cmd>` runs the wrapped command with `stdio: ['inherit', 'inherit', 'pipe']`, so the child's stdout **is** fd 1 and its bytes are captured verbatim by `VAR=$(datadog-ci trace -- cmd)`. But `trace` also wrote some of its **own** diagnostics to fd 1 (`console.log` / `context.stdout.write`), so those lines got mixed into the capture.

When the wrapped command emits a secret — e.g. `TOKEN=$(… vault write -field=token …)` — the captured value gains a newline + diagnostic text and is rejected downstream (`configured Vault token contains non-printable characters`). It is intermittent and load-correlated: the `--no-fail` note only fires when the span report fails (e.g. under intake throttling).

These diagnostics belong on **stderr**, consistent with the adjacent error paths in the same files that already use `this.context.stderr.write`. The `datadog-ci v<version>` banner has the same problem — it's printed to stdout on every invocation, so it can corrupt the same captures — and on top of that it's noisy in CI where the CLI runs many times.

Resolves #2381.

### How?

Route three trace diagnostics from stdout → stderr:

- the `--no-fail` note (`trace.ts`) — was `console.log`, now `this.context.stderr.write` (with the trailing `\n` that `console.log` implied)
- the unsupported-CI-provider message (`helper.ts`, shared `CustomSpanCommand`)
- the missing-API-key message (`helper.ts`, shared `CustomSpanCommand`)

The `helper.ts` changes also harden the `span` command, which shares the `CustomSpanCommand` base. No change to stdio inheritance, the `childProcess.stderr` pipe, or the span/reporting logic.

Also route the **version banner** to stderr (`cli.ts`), mirroring the resolved command's `--log-format` so it stays a JSON line in JSON mode; builtin commands and parse errors fall back to text format. And add **`DD_CI_SKIP_VERSION_BANNER`** (`1`/`true`) to suppress the banner entirely, following the existing `DD_CI_`-prefixed toggle convention (e.g. `DD_CI_BYPASS_SITE_VALIDATION`).

Adds regression tests: the `--no-fail` note lands on stderr (not stdout), the shared CI-provider assertion is updated to match, and the banner is suppressed when `DD_CI_SKIP_VERSION_BANNER` is `1`/`true`.

**Judgment call left out (happy to add if preferred):** the `--dry-run` payload write in `helper.ts` is also capturable, but moving it would change `span --dry-run | jq` behaviour and is lower risk (only under `--dry-run`), so it's left on stdout.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
