### PR TITLE
chore: fix e2e ERR_STREAM_PREMATURE_CLOSE and flaky ARM Alpine setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -694,6 +694,16 @@ jobs:
     runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      # setup-alpine downloads apk.static with a single 10s-timeout curl, and the gitlab mirror
+      # is unreliable from arm64 runners. Pre-fetch it with retries into the path setup-alpine
+      # caches ($RUNNER_TEMP/apk); the action then skips its own flaky download.
+      - name: Pre-fetch aarch64 apk.static (work around flaky gitlab mirror)
+        run: |
+          mkdir -p "$RUNNER_TEMP"
+          curl -4 -fsSL --retry 5 --retry-all-errors --retry-delay 5 --connect-timeout 30 --max-time 180 \
+            -o "$RUNNER_TEMP/apk" \
+            https://gitlab.alpinelinux.org/api/v4/projects/5/packages/generic/v2.14.10/aarch64/apk.static
+          echo "e471d35aa221d031abe9b6288aede12a8e9f1a398954e5a2e1d1bce1727b4ef4  $RUNNER_TEMP/apk" | sha256sum -c
       - name: Setup Alpine
         uses: jirutka/setup-alpine@ae3b3ddba35054804fc4a3507b519fa7e8152050 # v1.4.1
         with:

--- a/e2e/helpers/api-client.ts
+++ b/e2e/helpers/api-client.ts
@@ -1,0 +1,7 @@
+import {client} from '@datadog/datadog-api-client'
+
+// The api-client defaults to cross-fetch (node-fetch v2), which intermittently throws
+// ERR_STREAM_PREMATURE_CLOSE against the Datadog API on some platforms (notably Alpine/musl).
+// Node's native fetch (undici) handles connection close gracefully, so route the client through it.
+export const createE2EConfiguration = (authMethods?: client.AuthMethodsConfiguration): client.Configuration =>
+  client.createConfiguration({fetch: globalThis.fetch, ...(authMethods ? {authMethods} : {})})

--- a/e2e/helpers/junit-upload-checker.ts
+++ b/e2e/helpers/junit-upload-checker.ts
@@ -1,4 +1,6 @@
-import {client, v2} from '@datadog/datadog-api-client'
+import {v2} from '@datadog/datadog-api-client'
+
+import {createE2EConfiguration} from './api-client'
 
 const CHECK_INTERVAL_SECONDS = 10
 const MAX_NUM_ATTEMPTS = 10
@@ -17,7 +19,7 @@ const waitFor = (waitSeconds: number): Promise<void> => {
 export const checkJunitUpload = async (options: CheckJunitUploadOptions): Promise<void> => {
   const {service, commitSha, testLevel, extraFilter} = options
 
-  const configuration = client.createConfiguration()
+  const configuration = createE2EConfiguration()
   const apiInstance = new v2.CIVisibilityTestsApi(configuration)
 
   const baseFilterQuery = `@test.service:${service} @git.commit.sha:${commitSha}`

--- a/e2e/serverless/helpers/telemetry-checker.ts
+++ b/e2e/serverless/helpers/telemetry-checker.ts
@@ -1,4 +1,8 @@
-import {client, v2} from '@datadog/datadog-api-client'
+import type {client} from '@datadog/datadog-api-client'
+
+import {v2} from '@datadog/datadog-api-client'
+
+import {createE2EConfiguration} from '../../helpers/api-client'
 
 const POLL_INTERVAL_SECONDS = 15
 const MAX_ATTEMPTS = 20
@@ -99,11 +103,9 @@ export const checkTelemetryFlowing = async (
   // assert traces only.
   {checkLogs = true}: {checkLogs?: boolean} = {}
 ): Promise<void> => {
-  const configuration = client.createConfiguration({
-    authMethods: {
-      apiKeyAuth: process.env.DATADOG_API_KEY,
-      appKeyAuth: process.env.DATADOG_APP_KEY,
-    },
+  const configuration = createE2EConfiguration({
+    apiKeyAuth: process.env.DATADOG_API_KEY,
+    appKeyAuth: process.env.DATADOG_APP_KEY,
   })
   const checks = [pollUntilFound('spans', () => querySpans(configuration, identity))]
   if (checkLogs) {


### PR DESCRIPTION
### What and why?

Two CI failures on the Alpine and serverless e2e jobs, both pre-existing on `master` and unrelated to feature work:

1. **`ERR_STREAM_PREMATURE_CLOSE` on every Datadog API call from the e2e checkers.** The `@datadog/datadog-api-client` defaults to `cross-fetch` (node-fetch v2), which intermittently aborts the response stream against the Datadog API on some platforms (notably Alpine/musl). It is not tied to a single Node major -- it reproduced on Node 22.23 and 24.17 in Alpine, while the glibc ubuntu jobs on Node 22.19 stayed green.
2. **Flaky `Test standalone binary in ARM Alpine` setup.** `jirutka/setup-alpine` downloads the aarch64 `apk.static` with a single 10s-timeout `curl` from the gitlab mirror, which is unreliable from arm64 runners (`curl: (28) Failed to connect ... Timeout`).

### How?

1. Route the e2e api-client through Node's native `fetch` (undici), which handles connection close gracefully. Added a `createE2EConfiguration()` helper that passes `fetch: globalThis.fetch` as a top-level config param (the client overwrites `httpApi.fetch` with `conf.fetch` during `createConfiguration`, so setting it on the instance is ignored). Wired into `junit-upload-checker.ts` and `telemetry-checker.ts`.
2. Pre-fetch the aarch64 `apk.static` with retries into the path setup-alpine caches (`$RUNNER_TEMP/apk`) before the Setup Alpine step. The action verifies the cached file's sha256 and skips its own flaky download.

Verified in CI: `Test standalone binary in Alpine` and the `End-to-end test the package` matrix now pass with the fetch fix.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)