### PR TITLE
v5.20.0

### DIFF
--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-base",
-  "version": "5.19.0",
+  "version": "5.20.0",
   "description": "Base package for Datadog CI",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/datadog-ci/package.json
+++ b/packages/datadog-ci/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci",
-  "version": "5.19.0",
+  "version": "5.20.0",
   "description": "Use Datadog from your CI.",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-aas/package.json
+++ b/packages/plugin-aas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-aas",
-  "version": "5.19.0",
+  "version": "5.20.0",
   "description": "Datadog CI plugin for `aas` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-cloud-run/package.json
+++ b/packages/plugin-cloud-run/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-cloud-run",
-  "version": "5.19.0",
+  "version": "5.20.0",
   "description": "Datadog CI plugin for `cloud-run` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-container-app/package.json
+++ b/packages/plugin-container-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-container-app",
-  "version": "5.19.0",
+  "version": "5.20.0",
   "description": "Datadog CI plugin for `container-app` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-coverage/package.json
+++ b/packages/plugin-coverage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-coverage",
-  "version": "5.19.0",
+  "version": "5.20.0",
   "description": "Datadog CI plugin for `coverage` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-deployment/package.json
+++ b/packages/plugin-deployment/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-deployment",
-  "version": "5.19.0",
+  "version": "5.20.0",
   "description": "Datadog CI plugin for `deployment` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-dora/package.json
+++ b/packages/plugin-dora/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-dora",
-  "version": "5.19.0",
+  "version": "5.20.0",
   "description": "Datadog CI plugin for `dora` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-gate/package.json
+++ b/packages/plugin-gate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-gate",
-  "version": "5.19.0",
+  "version": "5.20.0",
   "description": "Datadog CI plugin for `gate` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-junit/package.json
+++ b/packages/plugin-junit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-junit",
-  "version": "5.19.0",
+  "version": "5.20.0",
   "description": "Datadog CI plugin for `junit` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-lambda/package.json
+++ b/packages/plugin-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-lambda",
-  "version": "5.19.0",
+  "version": "5.20.0",
   "description": "Datadog CI plugin for `lambda` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-sarif/package.json
+++ b/packages/plugin-sarif/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-sarif",
-  "version": "5.19.0",
+  "version": "5.20.0",
   "description": "Datadog CI plugin for `sarif` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-sbom/package.json
+++ b/packages/plugin-sbom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-sbom",
-  "version": "5.19.0",
+  "version": "5.20.0",
   "description": "Datadog CI plugin for `sbom` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-stepfunctions/package.json
+++ b/packages/plugin-stepfunctions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-stepfunctions",
-  "version": "5.19.0",
+  "version": "5.20.0",
   "description": "Datadog CI plugin for `stepfunctions` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-synthetics/package.json
+++ b/packages/plugin-synthetics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-synthetics",
-  "version": "5.19.0",
+  "version": "5.20.0",
   "description": "Datadog CI plugin for `synthetics` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-terraform/package.json
+++ b/packages/plugin-terraform/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-terraform",
-  "version": "5.19.0",
+  "version": "5.20.0",
   "description": "Datadog CI plugin for `terraform` commands",
   "license": "Apache-2.0",
   "keywords": [


### PR DESCRIPTION
<!-- Release notes generated using configuration in .github/release.yml at v5.20.0 -->

## What's Changed
### datadog-ci
* feat(logger): add global `--log-format json` option by @Drarig29 in https://github.com/DataDog/datadog-ci/pull/2372
* chore: fix e2e ERR_STREAM_PREMATURE_CLOSE and flaky ARM Alpine setup by @ava-silver in https://github.com/DataDog/datadog-ci/pull/2378
### Dependencies
* fix(deps): vuln ws (patch → 7.5.11)  by @gh-worker-campaigns-3e9aa4[bot] in https://github.com/DataDog/datadog-ci/pull/2361
* fix(deps): vuln js-yaml (minor → 4.2.0)  by @gh-worker-campaigns-3e9aa4[bot] in https://github.com/DataDog/datadog-ci/pull/2359
* fix(deps): vuln form-data (patch → 4.0.6)  by @gh-worker-campaigns-3e9aa4[bot] in https://github.com/DataDog/datadog-ci/pull/2360
* fix(deps): vuln protobufjs (minor → 7.6.4)  by @gh-worker-campaigns-3e9aa4[bot] in https://github.com/DataDog/datadog-ci/pull/2362
* fix(deps): vuln tar (patch → 7.5.16)  by @gh-worker-campaigns-3e9aa4[bot] in https://github.com/DataDog/datadog-ci/pull/2363
* fix(deps): vuln basic-ftp (minor → 5.3.1)  by @gh-worker-campaigns-3e9aa4[bot] in https://github.com/DataDog/datadog-ci/pull/2382
* fix(deps): vuln undici (minor → 7.28.0)  by @gh-worker-campaigns-3e9aa4[bot] in https://github.com/DataDog/datadog-ci/pull/2383
* fix(deps): vuln flatted (minor → 3.4.2)  by @gh-worker-campaigns-3e9aa4[bot] in https://github.com/DataDog/datadog-ci/pull/2384
### Software Delivery
* feat(trace): add `--no-capture` flag to omit command arguments from reported spans by @eliebleton-manomano in https://github.com/DataDog/datadog-ci/pull/2380
* fix(trace): write diagnostics to stderr so they don't corrupt captured stdout by @eliebleton-manomano in https://github.com/DataDog/datadog-ci/pull/2375
### Serverless
* chore: extract shared e2e telemetry checker by @ava-silver in https://github.com/DataDog/datadog-ci/pull/2369
* [SVLS-7939] Add Lambda E2E tests by @TalUsvyatsky in https://github.com/DataDog/datadog-ci/pull/2333
* make sidecar re-instrument idempotent and enable APM on container-app by @ava-silver in https://github.com/DataDog/datadog-ci/pull/2370
* Add Container App e2e telemetry contract by @ava-silver in https://github.com/DataDog/datadog-ci/pull/2364
* chore: add telemetry checks to AAS web app e2e tests by @ava-silver in https://github.com/DataDog/datadog-ci/pull/2365
* chore: refactor serverless e2e tests by @ava-silver in https://github.com/DataDog/datadog-ci/pull/2371
* chore: Update Lambda layer versions by @gh-worker-engraver-d31c25[bot] in https://github.com/DataDog/datadog-ci/pull/2377
* [SVLS-9256] auto-mark dd env sticky on slot instrumentation by @ava-silver in https://github.com/DataDog/datadog-ci/pull/2340
* [SVLS-9186] add Windows Function App support to aas instrument by @ava-silver in https://github.com/DataDog/datadog-ci/pull/2357
### Chores
* Add id column to endpoints CSV for Reference Tables import by @GabrielAnca in https://github.com/DataDog/datadog-ci/pull/2366
* [SINT-5104] use the latest CI Identities client by @cedricvanrompay-datadog in https://github.com/DataDog/datadog-ci/pull/2373
* chore: fix flaky Windows AAS e2e with a self-contained test app by @ava-silver in https://github.com/DataDog/datadog-ci/pull/2376

## New Contributors
* @cedricvanrompay-datadog made their first contribution in https://github.com/DataDog/datadog-ci/pull/2373
* @eliebleton-manomano made their first contribution in https://github.com/DataDog/datadog-ci/pull/2380

**Full Changelog**: https://github.com/DataDog/datadog-ci/compare/v5.19.0...v5.20.0

[SVLS-7939]: https://datadoghq.atlassian.net/browse/SVLS-7939?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ