### PR TITLE
chore: fix tag command

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -4,7 +4,7 @@ To release a new version of `datadog-ci`:
 
 1. Create a new branch for the version upgrade.
 2. Run `yarn version:all <major|minor|patch>`.
-3. Commit the change `vX.X.X` and tag it with `git tag vX.X.X`.
+3. Commit the change `vX.X.X` and tag it with `git tag -m vX.X.X vX.X.X`.
    - You may refer to [Semantic Versioning](https://semver.org/#summary) to determine what level to increment.
 4. Push the branch along with the tag using `git push --tags`, and create a PR.
    - Find and open the workflow run corresponding to your tag [in this list](https://github.com/DataDog/datadog-ci/actions/workflows/publish-release.yml).


### PR DESCRIPTION
### What and why?

With the changes in git signing across datadog, the default behavior of the command is now to require a message for the tag (which is a signed annotated tag) -- this updates the docs to match so the message is inlined

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)