### PR TITLE
chore: bump dd-octo-sts-action to v1.0.4 for node24

### DIFF
--- a/.github/workflows/issue-labeler.yml
+++ b/.github/workflows/issue-labeler.yml
@@ -10,7 +10,7 @@ jobs:
     permissions:
       id-token: write # To federate tokens
     steps:
-      - uses: DataDog/dd-octo-sts-action@acaa02eee7e3bb0839e4272dacb37b8f3b58ba80 # v1.0.3
+      - uses: DataDog/dd-octo-sts-action@96a25462dbcb10ebf0bfd6e2ccc917d2ab235b9a # v1.0.4
         id: octo-sts
         with:
           scope: DataDog/datadog-ci

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -15,7 +15,7 @@ jobs:
     outputs:
       release-id: ${{ steps.draft-release.outputs.result }}
     steps:
-      - uses: DataDog/dd-octo-sts-action@acaa02eee7e3bb0839e4272dacb37b8f3b58ba80 # v1.0.3
+      - uses: DataDog/dd-octo-sts-action@96a25462dbcb10ebf0bfd6e2ccc917d2ab235b9a # v1.0.4
         id: octo-sts
         with:
           scope: DataDog/datadog-ci
@@ -52,7 +52,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: create-draft-release
     steps:
-      - uses: DataDog/dd-octo-sts-action@acaa02eee7e3bb0839e4272dacb37b8f3b58ba80 # v1.0.3
+      - uses: DataDog/dd-octo-sts-action@96a25462dbcb10ebf0bfd6e2ccc917d2ab235b9a # v1.0.4
         id: octo-sts
         with:
           scope: DataDog/datadog-ci
@@ -98,7 +98,7 @@ jobs:
     runs-on: ubuntu-24.04-arm
     needs: create-draft-release
     steps:
-      - uses: DataDog/dd-octo-sts-action@acaa02eee7e3bb0839e4272dacb37b8f3b58ba80 # v1.0.3
+      - uses: DataDog/dd-octo-sts-action@96a25462dbcb10ebf0bfd6e2ccc917d2ab235b9a # v1.0.4
         id: octo-sts
         with:
           scope: DataDog/datadog-ci
@@ -146,7 +146,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: create-draft-release
     steps:
-      - uses: DataDog/dd-octo-sts-action@acaa02eee7e3bb0839e4272dacb37b8f3b58ba80 # v1.0.3
+      - uses: DataDog/dd-octo-sts-action@96a25462dbcb10ebf0bfd6e2ccc917d2ab235b9a # v1.0.4
         id: octo-sts
         with:
           scope: DataDog/datadog-ci
@@ -204,7 +204,7 @@ jobs:
     runs-on: ubuntu-24.04-arm
     needs: create-draft-release
     steps:
-      - uses: DataDog/dd-octo-sts-action@acaa02eee7e3bb0839e4272dacb37b8f3b58ba80 # v1.0.3
+      - uses: DataDog/dd-octo-sts-action@96a25462dbcb10ebf0bfd6e2ccc917d2ab235b9a # v1.0.4
         id: octo-sts
         with:
           scope: DataDog/datadog-ci
@@ -260,7 +260,7 @@ jobs:
     runs-on: windows-latest
     needs: create-draft-release
     steps:
-      - uses: DataDog/dd-octo-sts-action@acaa02eee7e3bb0839e4272dacb37b8f3b58ba80 # v1.0.3
+      - uses: DataDog/dd-octo-sts-action@96a25462dbcb10ebf0bfd6e2ccc917d2ab235b9a # v1.0.4
         id: octo-sts
         with:
           scope: DataDog/datadog-ci
@@ -309,7 +309,7 @@ jobs:
     runs-on: macos-latest-large
     needs: create-draft-release
     steps:
-      - uses: DataDog/dd-octo-sts-action@acaa02eee7e3bb0839e4272dacb37b8f3b58ba80 # v1.0.3
+      - uses: DataDog/dd-octo-sts-action@96a25462dbcb10ebf0bfd6e2ccc917d2ab235b9a # v1.0.4
         id: octo-sts
         with:
           scope: DataDog/datadog-ci
@@ -355,7 +355,7 @@ jobs:
     runs-on: macos-latest
     needs: create-draft-release
     steps:
-      - uses: DataDog/dd-octo-sts-action@acaa02eee7e3bb0839e4272dacb37b8f3b58ba80 # v1.0.3
+      - uses: DataDog/dd-octo-sts-action@96a25462dbcb10ebf0bfd6e2ccc917d2ab235b9a # v1.0.4
         id: octo-sts
         with:
           scope: DataDog/datadog-ci
@@ -410,7 +410,7 @@ jobs:
       - build-binary-macos
       - build-binary-macos-arm
     steps:
-      - uses: DataDog/dd-octo-sts-action@acaa02eee7e3bb0839e4272dacb37b8f3b58ba80 # v1.0.3
+      - uses: DataDog/dd-octo-sts-action@96a25462dbcb10ebf0bfd6e2ccc917d2ab235b9a # v1.0.4
         id: octo-sts
         with:
           scope: DataDog/datadog-ci
@@ -497,7 +497,7 @@ jobs:
           - synthetics-test-automation-bitrise-step-upload-application
           - synthetics-batch-smoke-tester
     steps:
-      - uses: DataDog/dd-octo-sts-action@acaa02eee7e3bb0839e4272dacb37b8f3b58ba80 # v1.0.3
+      - uses: DataDog/dd-octo-sts-action@96a25462dbcb10ebf0bfd6e2ccc917d2ab235b9a # v1.0.4
         id: octo-sts
         with:
           scope: DataDog/${{ matrix.integration-repo }}


### PR DESCRIPTION
### What and why?

Bumps `DataDog/dd-octo-sts-action` from v1.0.3 to v1.0.4 across `publish-release.yml` and `issue-labeler.yml`. v1.0.3 runs on Node.js 20, which GitHub Actions runners now force onto Node.js 24 with a deprecation warning; v1.0.4 ships a `node24` runtime.

### How?

Updated all 11 pinned SHAs to the v1.0.4 commit.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)