### PR TITLE
docs(trace): surface the `trace span` subcommand

### DIFF
--- a/packages/base/src/commands/span/README.md
+++ b/packages/base/src/commands/span/README.md
@@ -15,8 +15,8 @@ datadog-ci trace span --name "Say Hello" --duration 800 --tags responded-hello-t
 ```
 
 - `--name` is a human-readable name for the reported span.
-- `--start-time` the span start time in milliseconds since the unix epoch.
-- `--end-time` the span end time in milliseconds since the unix epoch.
+- `--start-time` the span start time in milliseconds since the unix epoch (UTC).
+- `--end-time` the span end time in milliseconds since the unix epoch (UTC).
 - `--duration` is the duration of the span in milliseconds. If duration is provided instead of `--start-time` and `--end-time`, the span end time is the current time when executing this command. This method is less precise than using start and end times since launching the datadog-ci process requires some time.
 - `--tags` is an array of key-value pairs with the format `key:value`. These tags are added to the custom span.
     The resulting dictionary is merged with the contents of the `DD_TAGS` environment variable. If a `key` appears both in `--tags` and `DD_TAGS`, the value in `DD_TAGS` takes precedence.

--- a/packages/base/src/commands/trace/README.md
+++ b/packages/base/src/commands/trace/README.md
@@ -14,6 +14,8 @@ For example:
 datadog-ci trace --name "Say Hello" -- echo "Hello World"
 ```
 
+> To report a standalone span with a name and a duration (or start/end time) instead of wrapping a command, use the [`trace span`](../span) subcommand.
+
 - The positional arguments are the command which will be launched and traced.
 - `--name` (default: same as <command>) is a human-friendly name for the reported span.
 - `--tags` is an array of key-value pairs with the format `key:value`. These tags are added to the custom span.

--- a/packages/datadog-ci/README.md
+++ b/packages/datadog-ci/README.md
@@ -219,7 +219,7 @@ The following `<scope>` and `<command>` values are available.
 <sub>**README:** [📚](/packages/base/src/commands/trace) | **Documentation:** [🔗](https://docs.datadoghq.com/continuous_integration/pipelines/custom_commands/)</sub>
 
 - Add custom commands to a CI Visibility pipeline in Datadog.
-- `span` ([README](/packages/base/src/commands/span)): Report a standalone custom span (with a name and a duration or start/end time) to a CI Visibility pipeline in Datadog, without wrapping a command.
+- `span` ([📚](/packages/base/src/commands/span)): Report a custom span to a CI Visibility pipeline in Datadog without wrapping a command.
 
 #### `unity-symbols`
 

--- a/packages/datadog-ci/README.md
+++ b/packages/datadog-ci/README.md
@@ -219,6 +219,7 @@ The following `<scope>` and `<command>` values are available.
 <sub>**README:** [📚](/packages/base/src/commands/trace) | **Documentation:** [🔗](https://docs.datadoghq.com/continuous_integration/pipelines/custom_commands/)</sub>
 
 - Add custom commands to a CI Visibility pipeline in Datadog.
+- `span` ([README](/packages/base/src/commands/span)): Report a standalone custom span (with a name and a duration or start/end time) to a CI Visibility pipeline in Datadog, without wrapping a command.
 
 #### `unity-symbols`
 


### PR DESCRIPTION
## What & why

The `trace span` subcommand — report a *standalone* custom span with a name and a duration (or start/end time), without wrapping a command — ships today and has its own [README](/packages/base/src/commands/span/README.md), and it's covered on the [official docs page](https://docs.datadoghq.com/continuous_integration/pipelines/custom_commands/). But it isn't discoverable from the repo's front-door README: the `trace` section only describes the command-wrapping form (`trace ... -- <cmd>`) and never mentions or links `span`. It's easy to forget the subcommand exists.

## Changes

- Root README: list `span` under the `trace` section, linking to its README.
- `trace` README: add a one-line cross-reference to the `trace span` subcommand.
- `span` README: spell out that `--start-time` / `--end-time` epoch milliseconds are UTC (they're serialized via `toISOString()`), so there's no timezone ambiguity for readers.

Docs only — no code or behavior change.

## Note on parameters

I checked the full option surface (`--name`, `--duration`, `--start-time`, `--end-time`, `--tags`, `--measures`, `--dry-run`) — all already documented in the span README. The only inherited-but-undocumented flags are `--fips` / `--fips-ignore-error`, but no command README in the repo documents those, so I left them out to stay consistent rather than diverge here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

-- Claudelie