### PR TITLE
fix(ci): find GitHub diagnostic logs at the runner home _diag

### DIFF
--- a/packages/base/src/helpers/__tests__/ci.test.ts
+++ b/packages/base/src/helpers/__tests__/ci.test.ts
@@ -683,9 +683,6 @@ describe('getGithubJobDisplayNameFromLogs', () => {
   })
 
   test('should find the job display name at <runnerRoot>/_diag derived from RUNNER_TEMP', () => {
-    // Self-hosted runner installed directly under /home/runner, so diagnostic logs
-    // live at /home/runner/_diag (not under an actions-runner/ subdir). The dir is
-    // only reachable via the RUNNER_TEMP-derived <runnerRoot>/_diag candidate.
     process.env.RUNNER_TEMP = '/home/runner/_work/_temp'
     const targetDir = '/home/runner/_diag'
     const logContent = sampleLogContent(sampleJobDisplayName)
@@ -698,6 +695,51 @@ describe('getGithubJobDisplayNameFromLogs', () => {
     expect(jobName).toBe(sampleJobDisplayName)
     expect(mockedFs.readdirSync).toHaveBeenCalledWith(targetDir, {withFileTypes: true})
     expect(mockedFs.readFileSync).toHaveBeenCalledWith(`${targetDir}/${sampleLogFileName}`, 'utf-8')
+  })
+
+  test('should find the job display name at /home/runner/_diag when RUNNER_TEMP resolves to root', () => {
+    process.env.RUNNER_TEMP = '/__w/_temp'
+    const targetDir = '/home/runner/_diag'
+    const logContent = sampleLogContent(sampleJobDisplayName)
+
+    mockReaddirSync(targetDir, sampleLogFileName)
+    jest.spyOn(fs, 'readFileSync').mockReturnValue(logContent)
+
+    const jobName = getGithubJobNameFromLogs(createMockContext() as BaseContext)
+
+    expect(jobName).toBe(sampleJobDisplayName)
+    expect(mockedFs.readdirSync).toHaveBeenCalledWith(targetDir, {withFileTypes: true})
+  })
+
+  test('should find the job display name at $HOME/_diag on a non-standard runner home', () => {
+    process.env.HOME = '/custom/runner-home'
+    const targetDir = '/custom/runner-home/_diag'
+    const logContent = sampleLogContent(sampleJobDisplayName)
+
+    mockReaddirSync(targetDir, sampleLogFileName)
+    jest.spyOn(fs, 'readFileSync').mockReturnValue(logContent)
+
+    const jobName = getGithubJobNameFromLogs(createMockContext() as BaseContext)
+
+    expect(jobName).toBe(sampleJobDisplayName)
+    expect(mockedFs.readdirSync).toHaveBeenCalledWith(targetDir, {withFileTypes: true})
+  })
+
+  test('should read a duplicated candidate directory only once', () => {
+    process.env.RUNNER_TEMP = '/home/runner/_work/_temp'
+    process.env.HOME = '/home/runner'
+
+    jest.spyOn(fs, 'readdirSync').mockImplementation((pathToRead) => {
+      if (String(pathToRead) === '/home/runner/_diag') {
+        return []
+      }
+      throw getNotFoundFsError()
+    })
+
+    getGithubJobNameFromLogs(createMockContext() as BaseContext)
+
+    const reads = mockedFs.readdirSync.mock.calls.filter((call) => String(call[0]) === '/home/runner/_diag')
+    expect(reads).toHaveLength(1)
   })
 
   test('should find and return the job display name windows (SaaS)', () => {

--- a/packages/base/src/helpers/__tests__/ci.test.ts
+++ b/packages/base/src/helpers/__tests__/ci.test.ts
@@ -682,6 +682,24 @@ describe('getGithubJobDisplayNameFromLogs', () => {
     expect(mockedFs.readFileSync).toHaveBeenCalledWith(`${targetDir}/${sampleLogFileName}`, 'utf-8')
   })
 
+  test('should find the job display name at <runnerRoot>/_diag derived from RUNNER_TEMP', () => {
+    // Self-hosted runner installed directly under /home/runner, so diagnostic logs
+    // live at /home/runner/_diag (not under an actions-runner/ subdir). The dir is
+    // only reachable via the RUNNER_TEMP-derived <runnerRoot>/_diag candidate.
+    process.env.RUNNER_TEMP = '/home/runner/_work/_temp'
+    const targetDir = '/home/runner/_diag'
+    const logContent = sampleLogContent(sampleJobDisplayName)
+
+    mockReaddirSync(targetDir, sampleLogFileName)
+    jest.spyOn(fs, 'readFileSync').mockReturnValue(logContent)
+
+    const jobName = getGithubJobNameFromLogs(createMockContext() as BaseContext)
+
+    expect(jobName).toBe(sampleJobDisplayName)
+    expect(mockedFs.readdirSync).toHaveBeenCalledWith(targetDir, {withFileTypes: true})
+    expect(mockedFs.readFileSync).toHaveBeenCalledWith(`${targetDir}/${sampleLogFileName}`, 'utf-8')
+  })
+
   test('should find and return the job display name windows (SaaS)', () => {
     process.env.RUNNER_OS = 'Windows'
     const targetDir = HOSTED_SAAS_DIAG_DIR_WIN

--- a/packages/base/src/helpers/ci.ts
+++ b/packages/base/src/helpers/ci.ts
@@ -147,6 +147,7 @@ export const parseLevels = (input: string | undefined): {levels: CILevel[]; erro
 }
 
 export const githubWellKnownDiagnosticDirsUnix = [
+  '/home/runner/_diag',
   '/home/runner/actions-runner/_diag', // for self-hosted
   '/opt/actions-runner/_diag', // self-hosted in some cases
 ]
@@ -212,6 +213,12 @@ const getGithubDiagnosticDirsFromEnv = (): string[] => {
     dirs.push(`${runnerRoot}/actions-runner/*/_diag`)
     dirs.push(`${runnerRoot}/actions-runner/*/*/_diag`)
     dirs.push(upath.join(runnerRoot, 'actions-runner', '_diag'))
+  }
+
+  const home = process.env.HOME
+  if (home) {
+    dirs.push(upath.join(home, '_diag'))
+    dirs.push(upath.join(home, 'actions-runner', '_diag'))
   }
 
   return uniq(dirs.filter(Boolean))


### PR DESCRIPTION
Covers GitHub Actions runners that keep diagnostic logs directly under the runner home — `/home/runner/_diag/Worker_*.log` — rather than under an `actions-runner/` subdirectory.

- Adds `/home/runner/_diag` to the static `githubWellKnownDiagnosticDirsUnix`.
- Derives `<HOME>/_diag` and `<HOME>/actions-runner/_diag` in `getGithubDiagnosticDirsFromEnv`.
