### PR TITLE
fix(aas): honor HTTP_PROXY/HTTPS_PROXY during API key validation

### DIFF
--- a/packages/base/src/helpers/__tests__/apikey.test.ts
+++ b/packages/base/src/helpers/__tests__/apikey.test.ts
@@ -1,0 +1,65 @@
+import {EnvHttpProxyAgent} from 'undici'
+
+import {newApiKeyValidator} from '../apikey'
+import * as request from '../request'
+
+describe('newApiKeyValidator', () => {
+  describe('validateApiKey', () => {
+    test('uses the environment proxy dispatcher', async () => {
+      const httpRequestSpy = jest.spyOn(request, 'httpRequest').mockResolvedValue({
+        config: {},
+        data: {valid: true},
+        headers: {},
+        status: 200,
+        statusText: 'OK',
+      })
+
+      const validator = newApiKeyValidator({
+        apiKey: 'api-key',
+        datadogSite: 'datadoghq.com',
+      })
+
+      await expect(validator.validateApiKey()).resolves.toBe(true)
+
+      expect(httpRequestSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          baseURL: 'https://api.datadoghq.com',
+          dispatcher: expect.any(EnvHttpProxyAgent),
+        })
+      )
+
+      httpRequestSpy.mockRestore()
+    })
+
+    test('returns false for a 403 response', async () => {
+      jest.spyOn(request, 'httpRequest').mockRejectedValue(
+        Object.assign(
+          new request.RequestError('Forbidden', {}, {data: undefined, status: 403, statusText: 'Forbidden'}),
+          {
+            isRequestError: true,
+          }
+        )
+      )
+
+      const validator = newApiKeyValidator({apiKey: 'api-key', datadogSite: 'datadoghq.com'})
+      await expect(validator.validateApiKey()).resolves.toBe(false)
+
+      jest.restoreAllMocks()
+    })
+
+    test('rethrows non-403 errors (e.g. network/proxy failure)', async () => {
+      const networkError = new request.RequestError('read ECONNRESET', {})
+      jest.spyOn(request, 'httpRequest').mockRejectedValue(networkError)
+
+      const validator = newApiKeyValidator({apiKey: 'api-key', datadogSite: 'datadoghq.com'})
+      await expect(validator.validateApiKey()).rejects.toThrow('read ECONNRESET')
+
+      jest.restoreAllMocks()
+    })
+
+    test('returns false for an empty API key', async () => {
+      const validator = newApiKeyValidator({apiKey: '', datadogSite: 'datadoghq.com'})
+      await expect(validator.validateApiKey()).resolves.toBe(false)
+    })
+  })
+})

--- a/packages/base/src/helpers/apikey.ts
+++ b/packages/base/src/helpers/apikey.ts
@@ -3,7 +3,7 @@ import type {BufferedMetricsLogger} from 'datadog-metrics'
 import chalk from 'chalk'
 
 import {InvalidConfigurationError} from './errors'
-import {httpRequest, isRequestError} from './request'
+import {getProxyDispatcher, httpRequest, isRequestError} from './request'
 import {datadogRoute} from './request/datadog-route'
 
 /** ApiKeyValidator is an helper interface to interpret Datadog error responses and possibly check the
@@ -77,6 +77,7 @@ class ApiKeyValidatorImplem {
         method: 'GET',
         baseURL: `https://api.${this.datadogSite}`,
         url: datadogRoute('/api/v1/validate'),
+        dispatcher: getProxyDispatcher(),
       })
 
       return response.data.valid

--- a/packages/base/src/helpers/request.ts
+++ b/packages/base/src/helpers/request.ts
@@ -49,7 +49,7 @@ export const isRequestError = (error: unknown): error is RequestError =>
 
 const dispatcherCache = new Map<string, ProxyAgent>()
 
-export const getProxyDispatcher = (proxyUrl: string): EnvHttpProxyAgent | ProxyAgent => {
+export const getProxyDispatcher = (proxyUrl = ''): EnvHttpProxyAgent | ProxyAgent => {
   // EnvHttpProxyAgent reads env vars at construction, so never cache it
   if (!proxyUrl) {
     return new EnvHttpProxyAgent()

--- a/packages/plugin-aas/src/__tests__/instrument.test.ts
+++ b/packages/plugin-aas/src/__tests__/instrument.test.ts
@@ -286,6 +286,20 @@ describe('aas instrument', () => {
       expect(webAppsOperations.restart).not.toHaveBeenCalled()
     })
 
+    test('Fails with network error message when API key validation throws (e.g. proxy/ECONNRESET)', async () => {
+      const networkError = Object.assign(new Error('read ECONNRESET'), {code: 'ECONNRESET'})
+      validateApiKey.mockClear().mockRejectedValue(networkError)
+
+      const {code, context} = await runCLI(DEFAULT_INSTRUMENT_ARGS)
+      expect(code).toEqual(1)
+      const output = context.stdout.toString()
+      expect(output).toContain('network error')
+      expect(output).toContain('HTTP_PROXY')
+      expect(output).not.toContain('Ensure you copied the value and not the Key ID')
+      expect(getToken).not.toHaveBeenCalled()
+      expect(webAppsOperations.get).not.toHaveBeenCalled()
+    })
+
     test('Warns and exits if Web App is Windows but runtime cannot be detected', async () => {
       webAppsOperations.get.mockClear().mockResolvedValue({...CONTAINER_WEB_APP, kind: 'app,windows'})
       const {code, context} = await runCLI(DEFAULT_INSTRUMENT_ARGS)

--- a/packages/plugin-aas/src/commands/instrument.ts
+++ b/packages/plugin-aas/src/commands/instrument.ts
@@ -75,7 +75,7 @@ export class PluginCommand extends AasInstrumentCommand {
         renderSoftWarning(
           `Could not validate the API Key stored in the environment variable ${chalk.bold('DD_API_KEY')}: ${maskString(
             process.env.DD_API_KEY ?? ''
-          )}\nA network error occurred while contacting the Datadog API. If you are behind a corporate proxy, ensure ${chalk.bold('HTTP_PROXY')} and ${chalk.bold('HTTPS_PROXY')} are set correctly.\nError: ${e}`
+          )}\nA network error occurred while validating your Datadog API key. If you are using a proxy, ensure ${chalk.bold('HTTP_PROXY')} and ${chalk.bold('HTTPS_PROXY')} are set.\nError: ${e}`
         )
       )
 

--- a/packages/plugin-aas/src/commands/instrument.ts
+++ b/packages/plugin-aas/src/commands/instrument.ts
@@ -64,15 +64,24 @@ export class PluginCommand extends AasInstrumentCommand {
       return 1
     }
 
+    let isApiKeyValid: boolean
     try {
-      const isApiKeyValid = await newApiKeyValidator({
+      isApiKeyValid = await newApiKeyValidator({
         apiKey: process.env.DD_API_KEY,
         datadogSite: getDatadogSite(),
       }).validateApiKey()
-      if (!isApiKeyValid) {
-        throw Error()
-      }
     } catch (e) {
+      this.context.stdout.write(
+        renderSoftWarning(
+          `Could not validate the API Key stored in the environment variable ${chalk.bold('DD_API_KEY')}: ${maskString(
+            process.env.DD_API_KEY ?? ''
+          )}\nA network error occurred while contacting the Datadog API. If you are behind a corporate proxy, ensure ${chalk.bold('HTTP_PROXY')} and ${chalk.bold('HTTPS_PROXY')} are set correctly.\nError: ${e}`
+        )
+      )
+
+      return 1
+    }
+    if (!isApiKeyValid) {
       this.context.stdout.write(
         renderSoftWarning(
           `Invalid API Key stored in the environment variable ${chalk.bold('DD_API_KEY')}: ${maskString(


### PR DESCRIPTION
## Summary

- **Root cause:** `validateApiKey()` in `packages/base/src/helpers/apikey.ts` called `httpRequest` without a `dispatcher`, so undici's `fetch` ignored `HTTP_PROXY`/`HTTPS_PROXY`. Behind a corporate proxy this caused an `ECONNRESET`, which was then caught by a blanket catch in `instrument.ts` and mislabeled as "Invalid API Key".
- **Fix:** Pass `getProxyDispatcher('')` (which returns an `EnvHttpProxyAgent` reading proxy env vars) into the `validateApiKey` `httpRequest` call — the same pattern already used by `getRequestBuilder` elsewhere in the codebase.
- **Better error message:** Split the `instrument.ts` catch block so a network/proxy failure reports a clear "network error" message with a hint to check `HTTP_PROXY`/`HTTPS_PROXY`, instead of the misleading "Invalid API Key" message.

Fixes: [SLES-2940](https://datadoghq.atlassian.net/browse/SLES-2940)

## Test plan

- [ ] `yarn build` — clean
- [ ] `yarn test packages/plugin-aas/src/__tests__/instrument.test.ts` — passes, including new test for the network-error path
- [ ] Manual: `HTTP_PROXY=http://localhost:9 DD_API_KEY=<valid> DD_SITE=datadoghq.com yarn launch aas instrument --resource-id ...` → shows "network error" (proxy used, localhost:9 not listening)
- [ ] Manual: `DD_API_KEY=<valid> DD_SITE=datadoghq.com yarn launch aas instrument --resource-id ...` → passes API key validation, proceeds to Azure auth (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SLES-2940]: https://datadoghq.atlassian.net/browse/SLES-2940?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ