### PR TITLE
Improve git metadata API error messages

### DIFF
--- a/packages/base/src/commands/git-metadata/__tests__/gitdb.test.ts
+++ b/packages/base/src/commands/git-metadata/__tests__/gitdb.test.ts
@@ -1412,6 +1412,85 @@ describe('gitdb', () => {
     mocks.expectCalls()
   })
 
+  test('includes response details when the search commits response is invalid', async () => {
+    const mocks = new MockAll({
+      getConfig: [
+        {
+          input: 'clone.defaultRemoteName',
+          output: defaultRemoteNameNotConfigured,
+        },
+      ],
+      fetch: [],
+      getRemotes: [
+        {
+          input: undefined,
+          output: [{name: 'origin', refs: {push: 'https://github.com/DataDog/datadog-ci'}}],
+        },
+      ],
+      log: [
+        {
+          input: ['-n 1000', '--since="1 month ago"'],
+          output: {
+            all: [
+              {
+                hash: '87ce64f636853fbebc05edfcefe9cccc28a7968b',
+              },
+              {
+                hash: 'cc424c261da5e261b76d982d5d361a023556e2aa',
+              },
+            ],
+          },
+        },
+      ],
+      raw: [],
+      revparse: [],
+      version: [],
+      execSync: [],
+      httpRequest: [
+        {
+          input: {
+            url: '/api/v2/git/repository/search_commits',
+            data: {
+              meta: {
+                repository_url: 'https://github.com/DataDog/datadog-ci',
+              },
+              data: [
+                {
+                  id: '87ce64f636853fbebc05edfcefe9cccc28a7968b',
+                  type: 'commit',
+                },
+                {
+                  id: 'cc424c261da5e261b76d982d5d361a023556e2aa',
+                  type: 'commit',
+                },
+              ],
+            },
+          },
+          output: {
+            config: {},
+            data: {
+              errors: [
+                {
+                  status: '504',
+                  title: 'Gateway Timeout',
+                },
+              ],
+            },
+            headers: {},
+            status: 504,
+            statusText: 'Gateway Timeout',
+          },
+        },
+      ],
+    })
+    const upload = uploadToGitDB(logger, request, mocks.simpleGit as any, false)
+    await expect(upload).rejects.toThrow(
+      'Invalid API response from search_commits (status 504 Gateway Timeout): ' +
+        '{"errors":[{"status":"504","title":"Gateway Timeout"}]}'
+    )
+    mocks.expectCalls()
+  })
+
   test('all commits are known, no packfile upload', async () => {
     const mocks = new MockAll({
       getConfig: [

--- a/packages/base/src/commands/git-metadata/__tests__/gitdb.test.ts
+++ b/packages/base/src/commands/git-metadata/__tests__/gitdb.test.ts
@@ -16,7 +16,7 @@ import {Logger, LogLevel} from '../../../helpers/logger'
 import * as requestModule from '../../../helpers/request'
 import {getRequestBuilder} from '../../../helpers/utils'
 
-import {uploadToGitDB} from '../gitdb'
+import {uploadPackfile, uploadToGitDB} from '../gitdb'
 
 describe('gitdb', () => {
   const tmpdir = upath.join(os.tmpdir(), 'random')
@@ -1233,7 +1233,8 @@ describe('gitdb', () => {
     mocks.expectCalls()
   })
 
-  test('fails after 3 http requests', async () => {
+  test('includes the endpoint when the search commits request times out after retries', async () => {
+    const searchCommitsError = new requestModule.RequestError('The operation was aborted due to timeout', {})
     const mocks = new MockAll({
       getConfig: [
         {
@@ -1287,7 +1288,7 @@ describe('gitdb', () => {
               ],
             },
           },
-          output: new Error('http error'),
+          output: searchCommitsError,
         },
         {
           input: {
@@ -1308,7 +1309,7 @@ describe('gitdb', () => {
               ],
             },
           },
-          output: new Error('http error'),
+          output: searchCommitsError,
         },
         {
           input: {
@@ -1329,13 +1330,47 @@ describe('gitdb', () => {
               ],
             },
           },
-          output: new Error('http error'),
+          output: searchCommitsError,
         },
       ],
     })
     const upload = uploadToGitDB(logger, request, mocks.simpleGit as any, false)
-    await expect(upload).rejects.toThrow('http error')
+    await expect(upload).rejects.toThrow('search_commits request failed: The operation was aborted due to timeout')
     mocks.expectCalls()
+  })
+
+  test('includes response details when a packfile request fails', async () => {
+    const httpRequest = jest.mocked(requestModule.httpRequest)
+    httpRequest.mockRejectedValue(
+      new requestModule.RequestError(
+        'Request failed with status code 400',
+        {},
+        {
+          data: {
+            errors: [
+              {
+                status: '400',
+                title: 'Bad Request',
+              },
+            ],
+          },
+          status: 400,
+          statusText: 'Bad Request',
+        }
+      )
+    )
+
+    const upload = uploadPackfile(
+      logger,
+      request,
+      'https://github.com/DataDog/datadog-ci',
+      '87ce64f636853fbebc05edfcefe9cccc28a7968b',
+      temporaryPackFile
+    )
+    await expect(upload).rejects.toThrow(
+      'packfile request failed (status 400 Bad Request): ' + '{"errors":[{"status":"400","title":"Bad Request"}]}'
+    )
+    expect(httpRequest).toHaveBeenCalledTimes(1)
   })
 
   test('fail immediately if returned format is incorrect', async () => {
@@ -1471,22 +1506,20 @@ describe('gitdb', () => {
             data: {
               errors: [
                 {
-                  status: '504',
-                  title: 'Gateway Timeout',
+                  title: 'Unexpected response',
                 },
               ],
             },
             headers: {},
-            status: 504,
-            statusText: 'Gateway Timeout',
+            status: 200,
+            statusText: 'OK',
           },
         },
       ],
     })
     const upload = uploadToGitDB(logger, request, mocks.simpleGit as any, false)
     await expect(upload).rejects.toThrow(
-      'Invalid API response from search_commits (status 504 Gateway Timeout): ' +
-        '{"errors":[{"status":"504","title":"Gateway Timeout"}]}'
+      'Invalid API response from search_commits (status 200 OK): ' + '{"errors":[{"title":"Unexpected response"}]}'
     )
     mocks.expectCalls()
   })

--- a/packages/base/src/commands/git-metadata/gitdb.ts
+++ b/packages/base/src/commands/git-metadata/gitdb.ts
@@ -12,6 +12,7 @@ import upath from 'upath'
 import {getDefaultRemoteName, gitRemote as getRepoURL} from '../../helpers/git/get-git-data'
 import type {RequestBuilder} from '../../helpers/interfaces'
 import type {Logger} from '../../helpers/logger'
+import {isRequestError} from '../../helpers/request'
 import type {RequestResponse} from '../../helpers/request'
 import {datadogRoute} from '../../helpers/request/datadog-route'
 import {retryRequest} from '../../helpers/retry'
@@ -23,6 +24,21 @@ const API_TIMEOUT = 15000
 const MAX_HISTORY = {
   maxCommits: 1000,
   oldestCommits: '1 month ago',
+}
+
+const formatResponseData = (data: unknown) => (typeof data === 'string' ? data : JSON.stringify(data))
+
+const formatRequestError = (reqName: string, error: unknown) => {
+  if (!isRequestError(error)) {
+    return `${reqName} request failed: ${String(error)}`
+  }
+  if (!error.response) {
+    return `${reqName} request failed: ${error.message}`
+  }
+
+  const status = [error.response.status, error.response.statusText].filter(Boolean).join(' ')
+
+  return `${reqName} request failed (status ${status}): ${formatResponseData(error.response.data)}`
 }
 
 const getCommitsToInclude = async (
@@ -248,8 +264,7 @@ const getKnownCommits = async (log: Logger, request: RequestBuilder, repoURL: st
   const commits = response.data as SearchCommitResponse
   if (!commits || commits.data === undefined) {
     const status = [response.status, response.statusText].filter(Boolean).join(' ')
-    const body = typeof response.data === 'string' ? response.data : JSON.stringify(response.data)
-    throw new Error(`Invalid API response from search_commits (status ${status}): ${body}`)
+    throw new Error(`Invalid API response from search_commits (status ${status}): ${formatResponseData(response.data)}`)
   }
 
   return commits.data.map((c) => {
@@ -383,15 +398,17 @@ export const uploadPackfile = async (
 
 // runRequest will run the passed request, with retries of retriable errors + logging of any retry attempt.
 const runRequest = async <T>(log: Logger, reqName: string, request: () => Promise<RequestResponse<T>>) => {
-  return retryRequest(request, {
-    retries: 2,
-    onRetry: (e, attempt) => {
-      let errorMessage = `${e}`
-      const maybeHttpError = e as any
-      if (maybeHttpError.response && maybeHttpError.response.statusText) {
-        errorMessage = `${maybeHttpError.message} (${maybeHttpError.response.statusText})`
-      }
-      log.warn(`[attempt ${attempt}] Retrying ${reqName} request: ${errorMessage}`)
-    },
-  })
+  try {
+    return await retryRequest(request, {
+      retries: 2,
+      onRetry: (error, attempt) => {
+        log.warn(`[attempt ${attempt}] ${formatRequestError(reqName, error)}; retrying`)
+      },
+    })
+  } catch (error) {
+    if (isRequestError(error)) {
+      error.message = formatRequestError(reqName, error)
+    }
+    throw error
+  }
 }

--- a/packages/base/src/commands/git-metadata/gitdb.ts
+++ b/packages/base/src/commands/git-metadata/gitdb.ts
@@ -247,7 +247,9 @@ const getKnownCommits = async (log: Logger, request: RequestBuilder, repoURL: st
   )
   const commits = response.data as SearchCommitResponse
   if (!commits || commits.data === undefined) {
-    throw new Error(`Invalid API response: ${response}`)
+    const status = [response.status, response.statusText].filter(Boolean).join(' ')
+    const body = typeof response.data === 'string' ? response.data : JSON.stringify(response.data)
+    throw new Error(`Invalid API response from search_commits (status ${status}): ${body}`)
   }
 
   return commits.data.map((c) => {


### PR DESCRIPTION
### What and why?

Git metadata upload failures can surface generic errors that omit the failing endpoint and useful backend details. For example, an unexpected `/search_commits` response was rendered as `Invalid API response: [object Object]`, while request timeouts and `/packfile` failures also lacked consistent context.

### How?

Format errors at the shared GitDB request boundary used by both `/search_commits` and `/packfile`:

- Include the endpoint name for request failures and client-side timeouts.
- Include the HTTP status, status text, and serialized response body when a response is available.
- Include the same details in retry warnings and final errors.
- Keep malformed successful `/search_commits` responses as a separate validation error.
- Omit request configuration and headers so API credentials cannot appear in logs.

Add regression coverage for a retried `/search_commits` timeout, a `/packfile` HTTP error response, and a malformed successful `/search_commits` response.

Validated with:

- `yarn build`
- `yarn lint`
- `yarn test packages/base/src/commands/git-metadata/__tests__/gitdb.test.ts --runInBand --watchman=false`

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
