### PR TITLE
[SVLS-9307] tracer metadata foundation

### DIFF
--- a/packages/base/src/helpers/serverless/__tests__/ssi/tracer.test.ts
+++ b/packages/base/src/helpers/serverless/__tests__/ssi/tracer.test.ts
@@ -29,11 +29,14 @@ describe('language and image metadata', () => {
     )
   })
 
-  test('rejects an unsupported language at runtime', () => {
-    expect(() => buildSingleLanguageTracerImage('gcr.io/datadoghq', 'go' as Language, 'latest')).toThrow(
-      'Unsupported language'
-    )
-  })
+  test.each(['go', 'toString', 'constructor', '__proto__'])(
+    'rejects unsupported language %p at runtime',
+    (language) => {
+      expect(() => buildSingleLanguageTracerImage('gcr.io/datadoghq', language as Language, 'latest')).toThrow(
+        'Unsupported language'
+      )
+    }
+  )
 
   test.each(['docker.io/datadog', 'gcr.io/datadoghq/', '', ' public.ecr.aws/datadog'])(
     'rejects registry %p',

--- a/packages/base/src/helpers/serverless/__tests__/ssi/tracer.test.ts
+++ b/packages/base/src/helpers/serverless/__tests__/ssi/tracer.test.ts
@@ -1,0 +1,62 @@
+import {
+  SINGLE_LANGUAGE_TRACER_REGISTRIES,
+  buildSingleLanguageTracerImage,
+  normalizeServerlessLanguage,
+  type CanonicalTracerLanguage,
+  type ServerlessLanguage,
+  type SingleLanguageTracerRegistry,
+} from '@datadog/datadog-ci-base/helpers/serverless/ssi/tracer'
+
+const languageCases: {
+  language: ServerlessLanguage
+  canonical: CanonicalTracerLanguage
+}[] = [
+  {language: 'java', canonical: 'java'},
+  {language: 'nodejs', canonical: 'js'},
+  {language: 'csharp', canonical: 'dotnet'},
+  {language: 'python', canonical: 'python'},
+  {language: 'ruby', canonical: 'ruby'},
+  {language: 'php', canonical: 'php'},
+]
+
+describe('language and image metadata', () => {
+  test.each(languageCases)('normalizes $language to $canonical', ({language, canonical}) => {
+    expect(normalizeServerlessLanguage(language)).toBe(canonical)
+  })
+
+  test('rejects an unsupported language at runtime', () => {
+    expect(() => normalizeServerlessLanguage('go' as ServerlessLanguage)).toThrow('Unsupported serverless language')
+  })
+
+  test.each(
+    SINGLE_LANGUAGE_TRACER_REGISTRIES.flatMap((registry) => languageCases.map(({canonical}) => ({registry, canonical})))
+  )('builds the $registry $canonical image', ({registry, canonical}) => {
+    expect(buildSingleLanguageTracerImage(registry, canonical, '1.2.3')).toBe(
+      `${registry}/dd-lib-${canonical}-init:1.2.3`
+    )
+  })
+
+  test.each(['docker.io/datadog', 'gcr.io/datadoghq/', '', ' public.ecr.aws/datadog'])(
+    'rejects registry %p',
+    (registry) => {
+      expect(() => buildSingleLanguageTracerImage(registry as SingleLanguageTracerRegistry, 'java', 'latest')).toThrow(
+        'Unsupported tracer registry'
+      )
+    }
+  )
+
+  test.each(['', ' ', '/', '1/2', 'latest:debug', '.latest', `a${'b'.repeat(128)}`, undefined])(
+    'rejects malformed version %p',
+    (version) => {
+      expect(() => buildSingleLanguageTracerImage('gcr.io/datadoghq', 'java', version as string)).toThrow(
+        'Invalid tracer version'
+      )
+    }
+  )
+
+  test('rejects an unsupported canonical language at runtime', () => {
+    expect(() =>
+      buildSingleLanguageTracerImage('gcr.io/datadoghq', 'nodejs' as CanonicalTracerLanguage, 'latest')
+    ).toThrow('Unsupported canonical tracer language')
+  })
+})

--- a/packages/base/src/helpers/serverless/__tests__/ssi/tracer.test.ts
+++ b/packages/base/src/helpers/serverless/__tests__/ssi/tracer.test.ts
@@ -1,38 +1,37 @@
 import {
   SINGLE_LANGUAGE_TRACER_REGISTRIES,
   buildSingleLanguageTracerImage,
-  normalizeServerlessLanguage,
-  type CanonicalTracerLanguage,
-  type ServerlessLanguage,
+  type Language,
   type SingleLanguageTracerRegistry,
+  type TracerLanguage,
 } from '@datadog/datadog-ci-base/helpers/serverless/ssi/tracer'
 
 const languageCases: {
-  language: ServerlessLanguage
-  canonical: CanonicalTracerLanguage
+  language: Language
+  tracerLanguage: TracerLanguage
 }[] = [
-  {language: 'java', canonical: 'java'},
-  {language: 'nodejs', canonical: 'js'},
-  {language: 'csharp', canonical: 'dotnet'},
-  {language: 'python', canonical: 'python'},
-  {language: 'ruby', canonical: 'ruby'},
-  {language: 'php', canonical: 'php'},
+  {language: 'java', tracerLanguage: 'java'},
+  {language: 'nodejs', tracerLanguage: 'js'},
+  {language: 'csharp', tracerLanguage: 'dotnet'},
+  {language: 'python', tracerLanguage: 'python'},
+  {language: 'ruby', tracerLanguage: 'ruby'},
+  {language: 'php', tracerLanguage: 'php'},
 ]
 
 describe('language and image metadata', () => {
-  test.each(languageCases)('normalizes $language to $canonical', ({language, canonical}) => {
-    expect(normalizeServerlessLanguage(language)).toBe(canonical)
+  test.each(
+    SINGLE_LANGUAGE_TRACER_REGISTRIES.flatMap((registry) =>
+      languageCases.map(({language, tracerLanguage}) => ({registry, language, tracerLanguage}))
+    )
+  )('builds the $registry $tracerLanguage image for $language', ({registry, language, tracerLanguage}) => {
+    expect(buildSingleLanguageTracerImage(registry, language, '1.2.3')).toBe(
+      `${registry}/dd-lib-${tracerLanguage}-init:1.2.3`
+    )
   })
 
   test('rejects an unsupported language at runtime', () => {
-    expect(() => normalizeServerlessLanguage('go' as ServerlessLanguage)).toThrow('Unsupported serverless language')
-  })
-
-  test.each(
-    SINGLE_LANGUAGE_TRACER_REGISTRIES.flatMap((registry) => languageCases.map(({canonical}) => ({registry, canonical})))
-  )('builds the $registry $canonical image', ({registry, canonical}) => {
-    expect(buildSingleLanguageTracerImage(registry, canonical, '1.2.3')).toBe(
-      `${registry}/dd-lib-${canonical}-init:1.2.3`
+    expect(() => buildSingleLanguageTracerImage('gcr.io/datadoghq', 'go' as Language, 'latest')).toThrow(
+      'Unsupported language'
     )
   })
 
@@ -53,10 +52,4 @@ describe('language and image metadata', () => {
       )
     }
   )
-
-  test('rejects an unsupported canonical language at runtime', () => {
-    expect(() =>
-      buildSingleLanguageTracerImage('gcr.io/datadoghq', 'nodejs' as CanonicalTracerLanguage, 'latest')
-    ).toThrow('Unsupported canonical tracer language')
-  })
 })

--- a/packages/base/src/helpers/serverless/ssi/tracer.ts
+++ b/packages/base/src/helpers/serverless/ssi/tracer.ts
@@ -1,0 +1,53 @@
+export const SINGLE_LANGUAGE_TRACER_REGISTRIES = [
+  'gcr.io/datadoghq',
+  'public.ecr.aws/datadog',
+  'datadoghq.azurecr.io',
+] as const
+
+export type SingleLanguageTracerRegistry = (typeof SINGLE_LANGUAGE_TRACER_REGISTRIES)[number]
+export type ServerlessLanguage = 'java' | 'nodejs' | 'csharp' | 'python' | 'ruby' | 'php'
+export type CanonicalTracerLanguage = 'java' | 'js' | 'dotnet' | 'python' | 'ruby' | 'php'
+
+export interface LanguageMetadata {
+  canonicalLanguage: CanonicalTracerLanguage
+  repository: string
+}
+
+export const LANGUAGE_METADATA: Record<ServerlessLanguage, LanguageMetadata> = {
+  java: {canonicalLanguage: 'java', repository: 'dd-trace-java'},
+  nodejs: {canonicalLanguage: 'js', repository: 'dd-trace-js'},
+  csharp: {canonicalLanguage: 'dotnet', repository: 'dd-trace-dotnet'},
+  python: {canonicalLanguage: 'python', repository: 'dd-trace-py'},
+  ruby: {canonicalLanguage: 'ruby', repository: 'dd-trace-rb'},
+  php: {canonicalLanguage: 'php', repository: 'dd-trace-php'},
+}
+
+const CANONICAL_TRACER_LANGUAGES: readonly CanonicalTracerLanguage[] = ['java', 'js', 'dotnet', 'python', 'ruby', 'php']
+const IMAGE_TAG_REG_EXP = /^[\w][\w.-]{0,127}$/
+
+export const normalizeServerlessLanguage = (language: ServerlessLanguage): CanonicalTracerLanguage => {
+  const metadata = LANGUAGE_METADATA[language]
+  if (!metadata) {
+    throw new Error(`Unsupported serverless language: ${String(language)}`)
+  }
+
+  return metadata.canonicalLanguage
+}
+
+export const buildSingleLanguageTracerImage = (
+  registry: SingleLanguageTracerRegistry,
+  canonicalLanguage: CanonicalTracerLanguage,
+  version: string
+): string => {
+  if (!(SINGLE_LANGUAGE_TRACER_REGISTRIES as readonly string[]).includes(registry)) {
+    throw new Error(`Unsupported tracer registry: ${String(registry)}`)
+  }
+  if (!CANONICAL_TRACER_LANGUAGES.includes(canonicalLanguage)) {
+    throw new Error(`Unsupported canonical tracer language: ${String(canonicalLanguage)}`)
+  }
+  if (typeof version !== 'string' || !IMAGE_TAG_REG_EXP.test(version)) {
+    throw new Error(`Invalid tracer version: ${JSON.stringify(version)}`)
+  }
+
+  return `${registry}/dd-lib-${canonicalLanguage}-init:${version}`
+}

--- a/packages/base/src/helpers/serverless/ssi/tracer.ts
+++ b/packages/base/src/helpers/serverless/ssi/tracer.ts
@@ -28,10 +28,10 @@ export const buildSingleLanguageTracerImage = (
   if (!(SINGLE_LANGUAGE_TRACER_REGISTRIES as readonly string[]).includes(registry)) {
     throw new Error(`Unsupported tracer registry: ${String(registry)}`)
   }
-  const metadata = LANGUAGE_METADATA[language]
-  if (!metadata) {
+  if (!Object.prototype.hasOwnProperty.call(LANGUAGE_METADATA, language)) {
     throw new Error(`Unsupported language: ${String(language)}`)
   }
+  const metadata = LANGUAGE_METADATA[language]
   if (typeof version !== 'string' || !IMAGE_TAG_REG_EXP.test(version)) {
     throw new Error(`Invalid tracer version: ${JSON.stringify(version)}`)
   }

--- a/packages/base/src/helpers/serverless/ssi/tracer.ts
+++ b/packages/base/src/helpers/serverless/ssi/tracer.ts
@@ -5,49 +5,36 @@ export const SINGLE_LANGUAGE_TRACER_REGISTRIES = [
 ] as const
 
 export type SingleLanguageTracerRegistry = (typeof SINGLE_LANGUAGE_TRACER_REGISTRIES)[number]
-export type ServerlessLanguage = 'java' | 'nodejs' | 'csharp' | 'python' | 'ruby' | 'php'
-export type CanonicalTracerLanguage = 'java' | 'js' | 'dotnet' | 'python' | 'ruby' | 'php'
 
-export interface LanguageMetadata {
-  canonicalLanguage: CanonicalTracerLanguage
-  repository: string
-}
+export const LANGUAGE_METADATA = {
+  java: {tracerLanguage: 'java', repository: 'dd-trace-java'},
+  nodejs: {tracerLanguage: 'js', repository: 'dd-trace-js'},
+  csharp: {tracerLanguage: 'dotnet', repository: 'dd-trace-dotnet'},
+  python: {tracerLanguage: 'python', repository: 'dd-trace-py'},
+  ruby: {tracerLanguage: 'ruby', repository: 'dd-trace-rb'},
+  php: {tracerLanguage: 'php', repository: 'dd-trace-php'},
+} as const
 
-export const LANGUAGE_METADATA: Record<ServerlessLanguage, LanguageMetadata> = {
-  java: {canonicalLanguage: 'java', repository: 'dd-trace-java'},
-  nodejs: {canonicalLanguage: 'js', repository: 'dd-trace-js'},
-  csharp: {canonicalLanguage: 'dotnet', repository: 'dd-trace-dotnet'},
-  python: {canonicalLanguage: 'python', repository: 'dd-trace-py'},
-  ruby: {canonicalLanguage: 'ruby', repository: 'dd-trace-rb'},
-  php: {canonicalLanguage: 'php', repository: 'dd-trace-php'},
-}
+export type Language = keyof typeof LANGUAGE_METADATA
+export type TracerLanguage = (typeof LANGUAGE_METADATA)[Language]['tracerLanguage']
 
-const CANONICAL_TRACER_LANGUAGES: readonly CanonicalTracerLanguage[] = ['java', 'js', 'dotnet', 'python', 'ruby', 'php']
 const IMAGE_TAG_REG_EXP = /^[\w][\w.-]{0,127}$/
-
-export const normalizeServerlessLanguage = (language: ServerlessLanguage): CanonicalTracerLanguage => {
-  const metadata = LANGUAGE_METADATA[language]
-  if (!metadata) {
-    throw new Error(`Unsupported serverless language: ${String(language)}`)
-  }
-
-  return metadata.canonicalLanguage
-}
 
 export const buildSingleLanguageTracerImage = (
   registry: SingleLanguageTracerRegistry,
-  canonicalLanguage: CanonicalTracerLanguage,
+  language: Language,
   version: string
 ): string => {
   if (!(SINGLE_LANGUAGE_TRACER_REGISTRIES as readonly string[]).includes(registry)) {
     throw new Error(`Unsupported tracer registry: ${String(registry)}`)
   }
-  if (!CANONICAL_TRACER_LANGUAGES.includes(canonicalLanguage)) {
-    throw new Error(`Unsupported canonical tracer language: ${String(canonicalLanguage)}`)
+  const metadata = LANGUAGE_METADATA[language]
+  if (!metadata) {
+    throw new Error(`Unsupported language: ${String(language)}`)
   }
   if (typeof version !== 'string' || !IMAGE_TAG_REG_EXP.test(version)) {
     throw new Error(`Invalid tracer version: ${JSON.stringify(version)}`)
   }
 
-  return `${registry}/dd-lib-${canonicalLanguage}-init:${version}`
+  return `${registry}/dd-lib-${metadata.tracerLanguage}-init:${version}`
 }


### PR DESCRIPTION
### What and why?

Add a shared source of truth for Single-Language SSI language and tracer-image metadata, preventing runtime language names, tracer identifiers, and image references from drifting apart.

### How?

A language metadata map derives the public language types and drives image construction. Image references reject unsupported languages, registries, and malformed tags.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
