### PR TITLE
coverage: upload the coverage config and CODEOWNERS as attachments

### DIFF
--- a/packages/base/src/commands/coverage/upload.ts
+++ b/packages/base/src/commands/coverage/upload.ts
@@ -37,6 +37,10 @@ export class CoverageUploadCommand extends BaseCommand {
         'Upload all code coverage report files in current directory with extra verbosity',
         'datadog-ci coverage upload --verbose .',
       ],
+      [
+        'Upload all code coverage report files in current directory with a coverage configuration generated at build time',
+        'datadog-ci coverage upload --coverage-config build/code-coverage.datadog.yml .',
+      ],
     ],
   })
 
@@ -64,6 +68,11 @@ export class CoverageUploadCommand extends BaseCommand {
     description: 'The repository URL to retrieve git metadata from',
   })
   protected basePath = Option.String('--base-path', {description: 'The base path to the coverage report files'})
+
+  protected coverageConfigPath = Option.String('--coverage-config', {
+    description:
+      'The path to the code coverage configuration file to upload. Useful when the configuration is generated during the CI run instead of being committed. The command fails if the file cannot be read. When this option is not set, the configuration is looked up in the committed files and in the working directory.',
+  })
 
   protected ignoredPaths = Option.String('--ignored-paths', {
     description:

--- a/packages/plugin-coverage/README.md
+++ b/packages/plugin-coverage/README.md
@@ -31,6 +31,25 @@ datadog-ci coverage upload --flags type:unit-tests --flags jvm-21 unit-tests/cov
 - `--git-repository-url` is a string specifying the repository URL to retrieve git metadata from. If this is missing, the URL is retrieved from the local git repository.
 - `--disable-file-fixes` (default: `false`): disable the generation and upload of file fixes for code coverage.
 - `--file-fixes-search-path` is a string specifying the root directory used to scan source files for file fixes. By default, the repository root is used. This is useful for monorepos or when coverage reports only cover a subset of the codebase.
+- `--coverage-config` is a string specifying the path to the [code coverage configuration][2] file to upload. Use it when the configuration is generated during the CI run instead of being committed, or when it is not at one of the default locations. If the file cannot be read, the command fails without uploading anything.
+
+#### Code coverage configuration and CODEOWNERS
+
+The command looks for the [code coverage configuration][2] and the `CODEOWNERS` file, and uploads their
+content along with the coverage reports. Both lookups are best-effort: a missing file never fails the
+upload, and the command warns when no coverage configuration is found at all.
+
+Each file is looked up in two places:
+
+1. The files committed at the reported commit — `code-coverage.datadog.yml`, then `code-coverage.datadog.yaml`
+   for the configuration, and `.github/CODEOWNERS`, `CODEOWNERS`, then `docs/CODEOWNERS` for code owners.
+2. The working directory, under the repository root, then `--base-path`, then the current directory.
+
+**The working-directory copy wins**, so a configuration generated at build time is used even when it is
+not committed — which is also what `--coverage-config` is for when the generated file is somewhere else.
+A file that is only committed (for example in a sparse checkout) still applies: it is read from the
+repository instead of being uploaded. Files larger than 1 MiB are not uploaded; only their path and
+SHA are sent.
 
 #### Environment variables
 
@@ -66,5 +85,7 @@ Will upload code coverage report file packages/plugin-coverage/src/__tests__/fix
 Additional helpful documentation, links, and articles:
 
 - [Learn about Datadog Code Coverage][1]
+- [Code Coverage configuration][2]
 
 [1]: https://docs.datadoghq.com/code_coverage/
+[2]: https://docs.datadoghq.com/code_coverage/configuration/

--- a/packages/plugin-coverage/src/__tests__/api-multipart.test.ts
+++ b/packages/plugin-coverage/src/__tests__/api-multipart.test.ts
@@ -1,0 +1,113 @@
+// Asserts the bytes that actually go on the wire, with the real `form-data` and `zlib`.
+// The backend matches the coverage config and CODEOWNERS attachments by *filename*, and the intake
+// rejects a filename that does not match its attachment-name rules, so both are pinned here rather
+// than only asserted through a mocked `form.append`.
+
+import {gunzipSync, gzipSync} from 'zlib'
+
+import type {Payload} from '../interfaces'
+import type {RequestConfig} from '@datadog/datadog-ci-base/helpers/request'
+
+import {CODEOWNERS_ATTACHMENT_FILENAME, COVERAGE_CONFIG_ATTACHMENT_FILENAME, uploadCodeCoverageReport} from '../api'
+
+// The intake validates every attachment name against this (Attachment.NAME_PREDICATE in
+// logs-backend): segments of [a-zA-Z0-9*_+-] separated by dots, so no leading dot.
+const INTAKE_ATTACHMENT_NAME =
+  /^\/?(?:[a-zA-Z0-9*_+-]+(?:\.[a-zA-Z0-9*_-]+)*\/)*(?:[a-zA-Z0-9*_+-]+(?:\.[a-zA-Z0-9*_-]+)*)+$/
+
+const CONFIG_CONTENT = 'schema-version: v1\nignore:\n  - "**/generated/**"\n'
+const CODEOWNERS_CONTENT = '* @DataDog/apm-ci-app\n'
+
+// No report paths, so every part is a buffer and the whole body can be materialized.
+const payloadWithAttachments = (): Payload => ({
+  hostname: 'test-host',
+  format: 'jacoco',
+  spanTags: {},
+  flags: undefined,
+  paths: [],
+  basePath: undefined,
+  prDiff: undefined,
+  commitDiff: undefined,
+  fileFixesCompressed: undefined,
+  coverageConfig: {
+    path: 'code-coverage.datadog.yml',
+    sha: 'a5005d071abcc8cddbaceb06fa80814331a63cb7',
+    gzippedContent: gzipSync(Buffer.from(CONFIG_CONTENT)),
+    size: CONFIG_CONTENT.length,
+  },
+  codeowners: {
+    path: '.github/CODEOWNERS',
+    sha: 'dc2328eaa8c2a1dde843f2e2128c1b3d3c3f566d',
+    gzippedContent: gzipSync(Buffer.from(CODEOWNERS_CONTENT)),
+    size: CODEOWNERS_CONTENT.length,
+  },
+})
+
+const captureRequestBody = async (payload: Payload) => {
+  let captured: RequestConfig | undefined
+  await uploadCodeCoverageReport(async (args) => {
+    captured = args
+
+    return {status: 202} as any
+  })(payload)
+
+  return (captured!.data as {getBuffer: () => Buffer}).getBuffer().toString('binary')
+}
+
+describe('the multipart body sent to the intake', () => {
+  test('names the parts and files exactly as the backend expects', async () => {
+    const body = await captureRequestBody(payloadWithAttachments())
+
+    expect(body).toContain('name="coverage_config"; filename="coverage_config.yml.gz"')
+    expect(body).toContain('name="codeowners"; filename="codeowners.gz"')
+    expect(body).toContain('name="event"; filename="event.json"')
+  })
+
+  test('uses filenames the intake accepts', () => {
+    // a leading dot is the failure mode the report filenames already work around
+    expect(COVERAGE_CONFIG_ATTACHMENT_FILENAME).toMatch(INTAKE_ATTACHMENT_NAME)
+    expect(CODEOWNERS_ATTACHMENT_FILENAME).toMatch(INTAKE_ATTACHMENT_NAME)
+    expect(COVERAGE_CONFIG_ATTACHMENT_FILENAME.startsWith('.')).toBe(false)
+    expect(CODEOWNERS_ATTACHMENT_FILENAME.startsWith('.')).toBe(false)
+  })
+
+  test('sends gzipped content that round-trips to the original file', async () => {
+    const payload = payloadWithAttachments()
+    const body = await captureRequestBody(payload)
+
+    expect(gunzipSync(payload.coverageConfig!.gzippedContent!).toString()).toBe(CONFIG_CONTENT)
+    expect(gunzipSync(payload.codeowners!.gzippedContent!).toString()).toBe(CODEOWNERS_CONTENT)
+    // the gzip magic bytes are present in the body, i.e. the buffer was not stringified
+    expect(body).toContain('\x1f\x8b')
+  })
+
+  test('stays within the intake attachment budget', async () => {
+    const body = await captureRequestBody(payloadWithAttachments())
+    const attachments = body.match(/filename="/g) ?? []
+
+    // event.json plus the two files; event.json does not count towards the intake's limit of 10
+    expect(attachments).toHaveLength(3)
+  })
+
+  test('sends only the event when nothing was resolved', async () => {
+    const body = await captureRequestBody({
+      ...payloadWithAttachments(),
+      coverageConfig: undefined,
+      codeowners: undefined,
+    })
+
+    expect(body).toContain('filename="event.json"')
+    expect(body).not.toContain('coverage_config')
+    expect(body).not.toContain('name="codeowners"')
+  })
+
+  test('carries the path and sha of both files in the event', async () => {
+    const body = await captureRequestBody(payloadWithAttachments())
+    const event = JSON.parse(body.slice(body.indexOf('{'), body.lastIndexOf('}') + 1))
+
+    expect(event['config.path']).toBe('code-coverage.datadog.yml')
+    expect(event['config.sha']).toBe('a5005d071abcc8cddbaceb06fa80814331a63cb7')
+    expect(event['codeowners.path']).toBe('.github/CODEOWNERS')
+    expect(event['codeowners.sha']).toBe('dc2328eaa8c2a1dde843f2e2128c1b3d3c3f566d')
+  })
+})

--- a/packages/plugin-coverage/src/__tests__/api.test.ts
+++ b/packages/plugin-coverage/src/__tests__/api.test.ts
@@ -319,4 +319,123 @@ describe('uploadCodeCoverageReport', () => {
     const eventJson = JSON.parse(eventCall[1])
     expect(eventJson).not.toHaveProperty('file_fixes')
   })
+
+  describe('coverage config and CODEOWNERS attachments', () => {
+    const setUpForm = () => {
+      const fsMock = jest.mocked(fs)
+      const zlibMock = jest.mocked(zlib)
+
+      const mockStream = new PassThrough()
+      fsMock.createReadStream.mockReturnValueOnce(mockStream as unknown as fs.ReadStream)
+      zlibMock.createGzip.mockReturnValueOnce(mockStream as unknown as zlib.Gzip)
+
+      const appendMock = jest.fn()
+      const formMock = {
+        append: appendMock,
+        getHeaders: jest.fn().mockReturnValue({'Content-Type': 'multipart/form-data'}),
+      }
+
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore override constructor
+      FormData.mockImplementation(() => formMock)
+
+      return appendMock
+    }
+
+    const basePayload = {
+      hostname: 'test-host',
+      format: 'jacoco',
+      spanTags: {},
+      flags: undefined,
+      prDiff: undefined,
+      commitDiff: undefined,
+      paths: ['/path/to/report.xml'],
+      basePath: undefined,
+      fileFixesCompressed: undefined,
+    }
+
+    it('sends both attachments with the field names and filenames the backend matches on', async () => {
+      const appendMock = setUpForm()
+      const configContent = Buffer.from('fake-gzipped-config')
+      const codeownersContent = Buffer.from('fake-gzipped-codeowners')
+
+      await uploadCodeCoverageReport(jest.fn().mockResolvedValue({status: 200}))({
+        ...basePayload,
+        coverageConfig: {
+          path: 'code-coverage.datadog.yml',
+          sha: 'config-sha',
+          gzippedContent: configContent,
+          size: 19,
+        },
+        codeowners: {path: '.github/CODEOWNERS', sha: 'codeowners-sha', gzippedContent: codeownersContent, size: 23},
+      })
+
+      const configCall = appendMock.mock.calls.find((call) => call[0] === 'coverage_config')
+      expect(configCall[1]).toEqual(configContent)
+      expect(configCall[2]).toEqual({filename: 'coverage_config.yml.gz'})
+
+      const codeownersCall = appendMock.mock.calls.find((call) => call[0] === 'codeowners')
+      expect(codeownersCall[1]).toEqual(codeownersContent)
+      expect(codeownersCall[2]).toEqual({filename: 'codeowners.gz'})
+
+      // the path/sha tags stay on the event, unchanged in meaning
+      const eventJson = JSON.parse(appendMock.mock.calls.find((call) => call[0] === 'event')[1])
+      expect(eventJson['config.path']).toBe('code-coverage.datadog.yml')
+      expect(eventJson['config.sha']).toBe('config-sha')
+      expect(eventJson['codeowners.path']).toBe('.github/CODEOWNERS')
+      expect(eventJson['codeowners.sha']).toBe('codeowners-sha')
+    })
+
+    it('sends no attachment when only the path and sha are known', async () => {
+      const appendMock = setUpForm()
+
+      await uploadCodeCoverageReport(jest.fn().mockResolvedValue({status: 200}))({
+        ...basePayload,
+        coverageConfig: {path: 'code-coverage.datadog.yml', sha: 'config-sha'},
+        codeowners: {path: '.github/CODEOWNERS', sha: 'codeowners-sha'},
+      })
+
+      expect(appendMock.mock.calls.find((call) => call[0] === 'coverage_config')).toBeUndefined()
+      expect(appendMock.mock.calls.find((call) => call[0] === 'codeowners')).toBeUndefined()
+
+      const eventJson = JSON.parse(appendMock.mock.calls.find((call) => call[0] === 'event')[1])
+      expect(eventJson['config.sha']).toBe('config-sha')
+      expect(eventJson['codeowners.sha']).toBe('codeowners-sha')
+    })
+
+    it('attaches the coverage config independently of CODEOWNERS', async () => {
+      const appendMock = setUpForm()
+
+      await uploadCodeCoverageReport(jest.fn().mockResolvedValue({status: 200}))({
+        ...basePayload,
+        coverageConfig: {
+          path: 'code-coverage.datadog.yml',
+          sha: 'config-sha',
+          gzippedContent: Buffer.from('gz'),
+          size: 2,
+        },
+        codeowners: undefined,
+      })
+
+      expect(appendMock.mock.calls.find((call) => call[0] === 'coverage_config')).toBeDefined()
+      expect(appendMock.mock.calls.find((call) => call[0] === 'codeowners')).toBeUndefined()
+    })
+
+    it('sends no attachment when neither file was resolved', async () => {
+      const appendMock = setUpForm()
+
+      await uploadCodeCoverageReport(jest.fn().mockResolvedValue({status: 200}))({
+        ...basePayload,
+        coverageConfig: undefined,
+        codeowners: undefined,
+      })
+
+      expect(appendMock.mock.calls.find((call) => call[0] === 'coverage_config')).toBeUndefined()
+      expect(appendMock.mock.calls.find((call) => call[0] === 'codeowners')).toBeUndefined()
+
+      const eventJson = JSON.parse(appendMock.mock.calls.find((call) => call[0] === 'event')[1])
+      expect(eventJson).not.toHaveProperty('config.path')
+      expect(eventJson).not.toHaveProperty('codeowners.path')
+    })
+  })
 })

--- a/packages/plugin-coverage/src/__tests__/repo-files.test.ts
+++ b/packages/plugin-coverage/src/__tests__/repo-files.test.ts
@@ -71,14 +71,6 @@ describe('statFileOnDisk', () => {
     expect(statFileOnDisk(makeTempDir())).toBeUndefined()
   })
 
-  test('returns undefined for a dangling symlink', () => {
-    const dir = makeTempDir()
-    const file = upath.join(dir, 'code-coverage.datadog.yml')
-    fs.symlinkSync(upath.join(dir, 'missing-target.yml'), file)
-
-    expect(statFileOnDisk(file)).toBeUndefined()
-  })
-
   test('returns undefined when the file exists but is not readable', () => {
     const dir = makeTempDir()
     const file = upath.join(dir, 'code-coverage.datadog.yml')
@@ -93,6 +85,26 @@ describe('statFileOnDisk', () => {
     } finally {
       accessSync.mockRestore()
     }
+  })
+})
+
+describe('statFileOnDisk with symlinks', () => {
+  test('returns undefined for a dangling symlink', () => {
+    const dir = makeTempDir()
+    const file = upath.join(dir, 'code-coverage.datadog.yml')
+    fs.symlinkSync(upath.join(dir, 'missing-target.yml'), file)
+
+    expect(statFileOnDisk(file)).toBeUndefined()
+  })
+
+  test('follows a symlink to a real file', () => {
+    const dir = makeTempDir()
+    const target = upath.join(dir, 'generated.yml')
+    const file = upath.join(dir, 'code-coverage.datadog.yml')
+    fs.writeFileSync(target, 'schema-version: v1\n')
+    fs.symlinkSync(target, file)
+
+    expect(statFileOnDisk(file)).toMatchObject({absolutePath: file, size: 19})
   })
 })
 

--- a/packages/plugin-coverage/src/__tests__/repo-files.test.ts
+++ b/packages/plugin-coverage/src/__tests__/repo-files.test.ts
@@ -1,0 +1,170 @@
+import {execFileSync} from 'child_process'
+import fs from 'fs'
+import os from 'os'
+
+import upath from 'upath'
+
+import {
+  findFileInSearchRoots,
+  gitBlobSha,
+  statFileOnDisk,
+  toRepositoryRelativePath,
+  MAX_ATTACHED_FILE_SIZE,
+} from '../repo-files'
+
+const makeTempDir = () => upath.normalize(fs.mkdtempSync(upath.join(os.tmpdir(), 'coverage-repo-files-')))
+
+describe('gitBlobSha', () => {
+  test('matches the well-known sha of an empty blob', () => {
+    expect(gitBlobSha(Buffer.alloc(0))).toBe('e69de29bb2d1d6434b8b29ae775ad8c2e48c5391')
+  })
+
+  test('matches the well-known sha of "hello\\n"', () => {
+    // `printf 'hello\n' | git hash-object --stdin`
+    expect(gitBlobSha(Buffer.from('hello\n'))).toBe('ce013625030ba8dba906f756967f9e9ca394464a')
+  })
+
+  test('matches `git hash-object` for the coverage config content', () => {
+    const dir = makeTempDir()
+    const file = upath.join(dir, 'code-coverage.datadog.yml')
+    const content = Buffer.from('schema-version: v1\nignore:\n  - "**/test*"\n')
+    fs.writeFileSync(file, content)
+
+    const expected = execFileSync('git', ['hash-object', file], {encoding: 'utf8'}).trim()
+
+    expect(gitBlobSha(content)).toBe(expected)
+  })
+
+  test('is sensitive to content, including trailing whitespace', () => {
+    expect(gitBlobSha(Buffer.from('a'))).not.toBe(gitBlobSha(Buffer.from('a\n')))
+  })
+
+  test('handles binary content and non-ascii bytes', () => {
+    const content = Buffer.from([0x00, 0xff, 0xc3, 0xa9])
+
+    expect(gitBlobSha(content)).toMatch(/^[0-9a-f]{40}$/)
+  })
+})
+
+describe('statFileOnDisk', () => {
+  test('returns the size and the normalized absolute path', () => {
+    const dir = makeTempDir()
+    const file = upath.join(dir, 'CODEOWNERS')
+    fs.writeFileSync(file, '* @team\n')
+
+    expect(statFileOnDisk(file)).toEqual({path: file, absolutePath: file, size: 8})
+  })
+
+  test('honours the reported path override', () => {
+    const dir = makeTempDir()
+    const file = upath.join(dir, 'CODEOWNERS')
+    fs.writeFileSync(file, '* @team\n')
+
+    expect(statFileOnDisk(file, '.github/CODEOWNERS')).toMatchObject({path: '.github/CODEOWNERS', absolutePath: file})
+  })
+
+  test('returns undefined for a missing file', () => {
+    expect(statFileOnDisk(upath.join(makeTempDir(), 'nope.yml'))).toBeUndefined()
+  })
+
+  test('returns undefined for a directory', () => {
+    expect(statFileOnDisk(makeTempDir())).toBeUndefined()
+  })
+
+  test('returns undefined for a dangling symlink', () => {
+    const dir = makeTempDir()
+    const file = upath.join(dir, 'code-coverage.datadog.yml')
+    fs.symlinkSync(upath.join(dir, 'missing-target.yml'), file)
+
+    expect(statFileOnDisk(file)).toBeUndefined()
+  })
+
+  test('returns undefined when the file exists but is not readable', () => {
+    const dir = makeTempDir()
+    const file = upath.join(dir, 'code-coverage.datadog.yml')
+    fs.writeFileSync(file, 'schema-version: v1\n')
+    // chmod does not restrict root, so the permission failure is simulated instead
+    const accessSync = jest.spyOn(fs, 'accessSync').mockImplementation(() => {
+      throw Object.assign(new Error('EACCES: permission denied'), {code: 'EACCES'})
+    })
+
+    try {
+      expect(statFileOnDisk(file)).toBeUndefined()
+    } finally {
+      accessSync.mockRestore()
+    }
+  })
+})
+
+describe('findFileInSearchRoots', () => {
+  test('returns undefined when no candidate exists in any root', () => {
+    expect(findFileInSearchRoots(['code-coverage.datadog.yml'], [makeTempDir()])).toBeUndefined()
+  })
+
+  test('reports the candidate path, not the absolute one', () => {
+    const dir = makeTempDir()
+    fs.mkdirSync(upath.join(dir, '.github'))
+    fs.writeFileSync(upath.join(dir, '.github/CODEOWNERS'), '* @team\n')
+
+    expect(findFileInSearchRoots(['.github/CODEOWNERS', 'CODEOWNERS'], [dir])).toMatchObject({
+      path: '.github/CODEOWNERS',
+      absolutePath: upath.join(dir, '.github/CODEOWNERS'),
+    })
+  })
+
+  test('prefers earlier roots over earlier candidates', () => {
+    const firstRoot = makeTempDir()
+    const secondRoot = makeTempDir()
+    fs.writeFileSync(upath.join(firstRoot, 'code-coverage.datadog.yaml'), 'schema-version: v1\n')
+    fs.writeFileSync(upath.join(secondRoot, 'code-coverage.datadog.yml'), 'schema-version: v1\n')
+
+    expect(
+      findFileInSearchRoots(['code-coverage.datadog.yml', 'code-coverage.datadog.yaml'], [firstRoot, secondRoot])
+    ).toMatchObject({path: 'code-coverage.datadog.yaml'})
+  })
+
+  test('prefers the first candidate within a single root', () => {
+    const dir = makeTempDir()
+    fs.writeFileSync(upath.join(dir, 'code-coverage.datadog.yml'), 'schema-version: v1\n')
+    fs.writeFileSync(upath.join(dir, 'code-coverage.datadog.yaml'), 'schema-version: v1\n')
+
+    expect(findFileInSearchRoots(['code-coverage.datadog.yml', 'code-coverage.datadog.yaml'], [dir])).toMatchObject({
+      path: 'code-coverage.datadog.yml',
+    })
+  })
+
+  test('skips a root where the candidate is a directory', () => {
+    const firstRoot = makeTempDir()
+    const secondRoot = makeTempDir()
+    fs.mkdirSync(upath.join(firstRoot, 'code-coverage.datadog.yml'))
+    fs.writeFileSync(upath.join(secondRoot, 'code-coverage.datadog.yml'), 'schema-version: v1\n')
+
+    expect(findFileInSearchRoots(['code-coverage.datadog.yml'], [firstRoot, secondRoot])).toMatchObject({
+      absolutePath: upath.join(secondRoot, 'code-coverage.datadog.yml'),
+    })
+  })
+})
+
+describe('toRepositoryRelativePath', () => {
+  test('makes a path inside the repository relative to its root', () => {
+    expect(toRepositoryRelativePath('/repo/build/generated/cc.yml', '/repo')).toBe('build/generated/cc.yml')
+  })
+
+  test('keeps the absolute path when it is outside the repository', () => {
+    expect(toRepositoryRelativePath('/elsewhere/cc.yml', '/repo')).toBe('/elsewhere/cc.yml')
+  })
+
+  test('keeps the absolute path when there is no repository', () => {
+    expect(toRepositoryRelativePath('/elsewhere/cc.yml', undefined)).toBe('/elsewhere/cc.yml')
+  })
+
+  test('keeps the absolute path when it is the repository root itself', () => {
+    expect(toRepositoryRelativePath('/repo', '/repo')).toBe('/repo')
+  })
+})
+
+describe('MAX_ATTACHED_FILE_SIZE', () => {
+  test('is 1 MiB, matching the backend cap', () => {
+    expect(MAX_ATTACHED_FILE_SIZE).toBe(1024 * 1024)
+  })
+})

--- a/packages/plugin-coverage/src/__tests__/upload.test.ts
+++ b/packages/plugin-coverage/src/__tests__/upload.test.ts
@@ -355,7 +355,8 @@ describe('upload', () => {
       command['repositoryRoot'] = '/repo'
       command['basePath'] = '/repo/build'
 
-      expect(command['getSearchRoots']()).toEqual(['/repo', '/repo/build', CWD])
+      // --base-path is resolved, so on Windows it picks up the current drive
+      expect(command['getSearchRoots']()).toEqual(['/repo', upath.resolve('/repo/build'), CWD])
     })
 
     test('falls back to the current directory outside of a git repository', () => {
@@ -379,7 +380,7 @@ describe('upload', () => {
       command['repositoryRoot'] = undefined
       command['basePath'] = 'build/reports'
 
-      expect(command['getSearchRoots']()).toEqual([`${CWD}/build/reports`, CWD])
+      expect(command['getSearchRoots']()).toEqual([upath.resolve('build/reports'), CWD])
     })
   })
 

--- a/packages/plugin-coverage/src/__tests__/upload.test.ts
+++ b/packages/plugin-coverage/src/__tests__/upload.test.ts
@@ -1,15 +1,45 @@
+import {execFileSync} from 'child_process'
+import fs from 'fs'
+import os from 'os'
+import {gunzipSync} from 'zlib'
+
 import type {SpanTags} from '@datadog/datadog-ci-base/helpers/interfaces'
 
 import {createCommand, createMockContext, makeRunCLI} from '@datadog/datadog-ci-base/helpers/__tests__/testing-tools'
 import upath from 'upath'
 
 import {PluginCommand as CoverageUploadCommand} from '../commands/upload'
+import {MAX_ATTACHED_FILE_SIZE, gitBlobSha} from '../repo-files'
 import {jacocoFormat} from '../utils'
 
 jest.mock('@datadog/datadog-ci-base/helpers/id', () => jest.fn())
 
 // Always posix, even on Windows.
 const CWD = upath.normalize(process.cwd())
+
+const CONFIG_CONTENT = 'schema-version: v1\nignore:\n  - "**/test*"\n'
+
+const makeTempDir = () => upath.normalize(fs.mkdtempSync(upath.join(os.tmpdir(), 'coverage-upload-')))
+
+const writeFile = (dir: string, relativePath: string, content: string) => {
+  const absolutePath = upath.join(dir, relativePath)
+  fs.mkdirSync(upath.dirname(absolutePath), {recursive: true})
+  fs.writeFileSync(absolutePath, content)
+
+  return absolutePath
+}
+
+// A command whose only search root is `root`, with git either absent or returning `blobSha`.
+const commandWithSearchRoot = (root: string | undefined, blobSha?: string) => {
+  const context = createMockContext()
+  const command = createCommand(CoverageUploadCommand, context as any)
+  command['repositoryRoot'] = root
+  if (blobSha !== undefined) {
+    command['git'] = {revparse: jest.fn().mockResolvedValue(blobSha)} as any
+  }
+
+  return {command, output: () => context.stdout.toString()}
+}
 
 describe('upload', () => {
   describe('getApiHelper', () => {
@@ -293,6 +323,416 @@ describe('upload', () => {
       expect(revparse).toHaveBeenNthCalledWith(1, ['deadbeef:code-coverage.datadog.yml'])
       expect(revparse).toHaveBeenNthCalledWith(2, ['deadbeef:code-coverage.datadog.yaml'])
     })
+
+    test('swallows the lookup error at debug level by default', async () => {
+      const context = createMockContext()
+      const command = createCommand(CoverageUploadCommand, context as any)
+      command['git'] = {revparse: jest.fn().mockRejectedValue(new Error('does not exist'))} as any
+
+      const result = await command['getRepoFile'](['code-coverage.datadog.yml'], 'deadbeef')
+
+      expect(result).toBeUndefined()
+      expect(context.stdout.toString()).not.toContain('does not exist')
+    })
+
+    test('warns about the lookup error when the file was explicitly requested', async () => {
+      const context = createMockContext()
+      const command = createCommand(CoverageUploadCommand, context as any)
+      command['git'] = {revparse: jest.fn().mockRejectedValue(new Error('does not exist'))} as any
+
+      const result = await command['getRepoFile'](['build/cc.yml'], 'deadbeef', {explicit: true})
+
+      expect(result).toBeUndefined()
+      expect(context.stdout.toString()).toContain(
+        'Error while trying to get repo file build/cc.yml details at deadbeef'
+      )
+    })
+  })
+
+  describe('getSearchRoots', () => {
+    test('searches the repository root, then --base-path, then the current directory', () => {
+      const command = createCommand(CoverageUploadCommand)
+      command['repositoryRoot'] = '/repo'
+      command['basePath'] = '/repo/build'
+
+      expect(command['getSearchRoots']()).toEqual(['/repo', '/repo/build', CWD])
+    })
+
+    test('falls back to the current directory outside of a git repository', () => {
+      const command = createCommand(CoverageUploadCommand)
+      command['repositoryRoot'] = undefined
+      command['basePath'] = undefined
+
+      expect(command['getSearchRoots']()).toEqual([CWD])
+    })
+
+    test('deduplicates roots', () => {
+      const command = createCommand(CoverageUploadCommand)
+      command['repositoryRoot'] = CWD
+      command['basePath'] = '.'
+
+      expect(command['getSearchRoots']()).toEqual([CWD])
+    })
+
+    test('resolves a relative --base-path against the current directory', () => {
+      const command = createCommand(CoverageUploadCommand)
+      command['repositoryRoot'] = undefined
+      command['basePath'] = 'build/reports'
+
+      expect(command['getSearchRoots']()).toEqual([`${CWD}/build/reports`, CWD])
+    })
+  })
+
+  describe('resolveRepoFile', () => {
+    test('attaches the file found on disk, with a content-derived blob sha', async () => {
+      const root = makeTempDir()
+      const absolutePath = writeFile(root, 'code-coverage.datadog.yml', CONFIG_CONTENT)
+      const {command} = commandWithSearchRoot(root)
+
+      const result = await command['resolveRepoFile']('the config', ['code-coverage.datadog.yml'], 'deadbeef')
+
+      expect(result?.path).toBe('code-coverage.datadog.yml')
+      expect(result?.sha).toBe(execFileSync('git', ['hash-object', absolutePath], {encoding: 'utf8'}).trim())
+      expect(result?.size).toBe(CONFIG_CONTENT.length)
+      expect(gunzipSync(result!.gzippedContent!).toString()).toBe(CONFIG_CONTENT)
+    })
+
+    test('prefers the on-disk content over the committed blob', async () => {
+      const root = makeTempDir()
+      writeFile(root, 'code-coverage.datadog.yml', CONFIG_CONTENT)
+      const {command} = commandWithSearchRoot(root, 'committed-blob-sha')
+
+      const result = await command['resolveRepoFile']('the config', ['code-coverage.datadog.yml'], 'deadbeef')
+
+      expect(result?.sha).toBe(gitBlobSha(Buffer.from(CONFIG_CONTENT)))
+      expect(result?.sha).not.toBe('committed-blob-sha')
+      expect(result?.gzippedContent).toBeDefined()
+    })
+
+    test('reports the same sha as the git lookup when the on-disk file is the committed one', async () => {
+      const root = makeTempDir()
+      const absolutePath = writeFile(root, 'code-coverage.datadog.yml', CONFIG_CONTENT)
+      const committedSha = execFileSync('git', ['hash-object', absolutePath], {encoding: 'utf8'}).trim()
+      const {command} = commandWithSearchRoot(root, committedSha)
+
+      const result = await command['resolveRepoFile']('the config', ['code-coverage.datadog.yml'], 'deadbeef')
+
+      expect(result?.sha).toBe(committedSha)
+    })
+
+    test('keeps the git-derived path and sha when the file is not in the working directory', async () => {
+      const {command} = commandWithSearchRoot(makeTempDir(), 'committed-blob-sha')
+
+      const result = await command['resolveRepoFile']('the config', ['code-coverage.datadog.yml'], 'deadbeef')
+
+      expect(result).toEqual({path: 'code-coverage.datadog.yml', sha: 'committed-blob-sha'})
+      expect(result?.gzippedContent).toBeUndefined()
+    })
+
+    test('returns undefined when the file is neither committed nor on disk', async () => {
+      const {command} = commandWithSearchRoot(makeTempDir())
+
+      expect(await command['resolveRepoFile']('the config', ['code-coverage.datadog.yml'], 'deadbeef')).toBeUndefined()
+    })
+
+    test('does not attach a file over the size cap, and keeps the git-derived path and sha', async () => {
+      const root = makeTempDir()
+      writeFile(root, 'CODEOWNERS', 'x'.repeat(MAX_ATTACHED_FILE_SIZE + 1))
+      const {command, output} = commandWithSearchRoot(root, 'committed-blob-sha')
+
+      const result = await command['resolveRepoFile']('the CODEOWNERS file', ['CODEOWNERS'], 'deadbeef')
+
+      expect(result).toEqual({path: 'CODEOWNERS', sha: 'committed-blob-sha'})
+      expect(output()).toContain('Not uploading the content of the CODEOWNERS file')
+      expect(output()).toContain(`exceeds the ${MAX_ATTACHED_FILE_SIZE} bytes limit`)
+    })
+
+    test('attaches a file exactly at the size cap', async () => {
+      const root = makeTempDir()
+      writeFile(root, 'CODEOWNERS', 'x'.repeat(MAX_ATTACHED_FILE_SIZE))
+      const {command} = commandWithSearchRoot(root)
+
+      const result = await command['resolveRepoFile']('the CODEOWNERS file', ['CODEOWNERS'], 'deadbeef')
+
+      expect(result?.size).toBe(MAX_ATTACHED_FILE_SIZE)
+      expect(result?.gzippedContent).toBeDefined()
+    })
+
+    test('returns undefined when an oversized file is not committed either', async () => {
+      const root = makeTempDir()
+      writeFile(root, 'CODEOWNERS', 'x'.repeat(MAX_ATTACHED_FILE_SIZE + 1))
+      const {command} = commandWithSearchRoot(root)
+
+      expect(await command['resolveRepoFile']('the CODEOWNERS file', ['CODEOWNERS'], 'deadbeef')).toBeUndefined()
+    })
+
+    test('finds CODEOWNERS in its alternative locations', async () => {
+      const root = makeTempDir()
+      writeFile(root, 'docs/CODEOWNERS', '* @team\n')
+      const {command} = commandWithSearchRoot(root)
+
+      const result = await command['resolveRepoFile'](
+        'the CODEOWNERS file',
+        ['.github/CODEOWNERS', 'CODEOWNERS', 'docs/CODEOWNERS'],
+        'deadbeef'
+      )
+
+      expect(result?.path).toBe('docs/CODEOWNERS')
+      expect(gunzipSync(result!.gzippedContent!).toString()).toBe('* @team\n')
+    })
+
+    test('works without git, computing the sha from the working-directory content', async () => {
+      const root = makeTempDir()
+      writeFile(root, 'code-coverage.datadog.yml', CONFIG_CONTENT)
+      const {command} = commandWithSearchRoot(root)
+      command['git'] = undefined
+
+      const result = await command['resolveRepoFile']('the config', ['code-coverage.datadog.yml'], undefined)
+
+      expect(result?.sha).toBe(gitBlobSha(Buffer.from(CONFIG_CONTENT)))
+    })
+
+    test('logs what it attached and what it did not', async () => {
+      const root = makeTempDir()
+      writeFile(root, 'code-coverage.datadog.yml', CONFIG_CONTENT)
+      const {command, output} = commandWithSearchRoot(root)
+
+      await command['resolveRepoFile']('the code coverage configuration', ['code-coverage.datadog.yml'], undefined)
+
+      expect(output()).toContain('Uploading the code coverage configuration code-coverage.datadog.yml')
+      expect(output()).toContain(`${CONFIG_CONTENT.length} bytes`)
+    })
+
+    test('logs that only the path is sent when the file is only committed', async () => {
+      const {command, output} = commandWithSearchRoot(makeTempDir(), 'committed-blob-sha')
+
+      await command['resolveRepoFile']('the code coverage configuration', ['code-coverage.datadog.yml'], 'deadbeef')
+
+      expect(output()).toContain('Not uploading the content of the code coverage configuration')
+      expect(output()).toContain('it will be read from the repository instead')
+    })
+
+    test('does not claim the file is missing from the working directory when it is only oversized', async () => {
+      const root = makeTempDir()
+      writeFile(root, 'CODEOWNERS', 'x'.repeat(MAX_ATTACHED_FILE_SIZE + 1))
+      const {command, output} = commandWithSearchRoot(root, 'committed-blob-sha')
+
+      await command['resolveRepoFile']('the CODEOWNERS file', ['CODEOWNERS'], 'deadbeef')
+
+      expect(output()).not.toContain('not in the working directory')
+    })
+  })
+
+  describe('resolveCoverageConfig', () => {
+    test('warns when no configuration is found anywhere', async () => {
+      const {command, output} = commandWithSearchRoot(makeTempDir())
+
+      expect(await command['resolveCoverageConfig']('deadbeef')).toBeUndefined()
+      expect(output()).toContain('No code coverage configuration found')
+      expect(output()).toContain('in the files committed at deadbeef')
+      expect(output()).toContain('the organization-level configuration will be used')
+      expect(output()).toContain('--coverage-config')
+    })
+
+    test('does not warn when a configuration is found', async () => {
+      const root = makeTempDir()
+      writeFile(root, 'code-coverage.datadog.yaml', CONFIG_CONTENT)
+      const {command, output} = commandWithSearchRoot(root)
+
+      expect((await command['resolveCoverageConfig']('deadbeef'))?.path).toBe('code-coverage.datadog.yaml')
+      expect(output()).not.toContain('No code coverage configuration found')
+    })
+
+    test('mentions the searched directories when there is no commit', async () => {
+      const root = makeTempDir()
+      const {command, output} = commandWithSearchRoot(root)
+
+      expect(await command['resolveCoverageConfig'](undefined)).toBeUndefined()
+      expect(output()).toContain(root)
+      expect(output()).not.toContain('in the files committed at')
+    })
+
+    test('uses the file resolved from --coverage-config without searching', async () => {
+      const {command} = commandWithSearchRoot(makeTempDir(), 'committed-blob-sha')
+      command['coverageConfigPath'] = 'build/cc.yml'
+      command['explicitCoverageConfig'] = {path: 'build/cc.yml', sha: 'explicit-sha', gzippedContent: Buffer.from('gz')}
+
+      const result = await command['resolveCoverageConfig']('deadbeef')
+
+      expect(result).toEqual({path: 'build/cc.yml', sha: 'explicit-sha', gzippedContent: Buffer.from('gz')})
+      expect(command['git']!.revparse).not.toHaveBeenCalled()
+    })
+
+    test('falls back to the committed blob of the explicit path when the file is too large', async () => {
+      const root = makeTempDir()
+      const {command} = commandWithSearchRoot(root, 'committed-blob-sha')
+      command['coverageConfigPath'] = upath.join(root, 'build/cc.yml')
+      command['explicitCoverageConfig'] = undefined
+
+      const result = await command['resolveCoverageConfig']('deadbeef')
+
+      expect(result).toEqual({path: 'build/cc.yml', sha: 'committed-blob-sha'})
+      expect(command['git']!.revparse).toHaveBeenCalledWith(['deadbeef:build/cc.yml'])
+    })
+  })
+
+  describe('readCoverageConfigFile', () => {
+    test('reads the file, attaches it, and reports a repository-relative path', () => {
+      const root = makeTempDir()
+      const absolutePath = writeFile(root, 'build/generated/cc.yml', CONFIG_CONTENT)
+      const {command} = commandWithSearchRoot(root)
+
+      const result = command['readCoverageConfigFile'](absolutePath)
+
+      expect(result?.path).toBe('build/generated/cc.yml')
+      expect(result?.sha).toBe(gitBlobSha(Buffer.from(CONFIG_CONTENT)))
+      expect(gunzipSync(result!.gzippedContent!).toString()).toBe(CONFIG_CONTENT)
+    })
+
+    test('keeps the absolute path when the file is outside the repository', () => {
+      const root = makeTempDir()
+      const absolutePath = writeFile(makeTempDir(), 'cc.yml', CONFIG_CONTENT)
+      const {command} = commandWithSearchRoot(root)
+
+      expect(command['readCoverageConfigFile'](absolutePath)?.path).toBe(absolutePath)
+    })
+
+    test('resolves a relative path against the current directory', () => {
+      const {command} = commandWithSearchRoot(CWD)
+
+      const result = command['readCoverageConfigFile']('src/__tests__/fixtures/jacoco-report.xml')
+
+      expect(result?.path).toBe('src/__tests__/fixtures/jacoco-report.xml')
+    })
+
+    test('throws when the file does not exist', () => {
+      const {command} = commandWithSearchRoot(makeTempDir())
+
+      expect(() => command['readCoverageConfigFile']('does/not/exist.yml')).toThrow('no readable file at')
+    })
+
+    test('throws when the path is a directory', () => {
+      const root = makeTempDir()
+      const {command} = commandWithSearchRoot(root)
+
+      expect(() => command['readCoverageConfigFile'](root)).toThrow('no readable file at')
+    })
+
+    test('does not attach a file over the size cap, and warns', () => {
+      const root = makeTempDir()
+      const absolutePath = writeFile(root, 'build/cc.yml', 'x'.repeat(MAX_ATTACHED_FILE_SIZE + 1))
+      const {command, output} = commandWithSearchRoot(root)
+
+      expect(command['readCoverageConfigFile'](absolutePath)).toBeUndefined()
+      expect(output()).toContain('Not uploading the content of the code coverage configuration')
+      expect(output()).toContain('build/cc.yml')
+    })
+  })
+
+  describe('generatePayloads', () => {
+    const setUpForBudget = (
+      reportCount: number,
+      resolved: {
+        coverageConfig?: boolean
+        codeowners?: boolean
+        prDiff?: boolean
+        commitDiff?: boolean
+        fileFixes?: boolean
+      }
+    ) => {
+      const command = createCommand(CoverageUploadCommand)
+      const paths = Array.from({length: reportCount}, (_, i) => `report-${i}.xml`)
+
+      jest.spyOn(command as any, 'getMatchingCoverageReportFilesByFormat').mockReturnValue({jacoco: paths})
+      jest
+        .spyOn(command as any, 'resolveCoverageConfig')
+        .mockResolvedValue(
+          resolved.coverageConfig ? {path: 'cc.yml', sha: 'sha', gzippedContent: Buffer.from('gz')} : undefined
+        )
+      jest
+        .spyOn(command as any, 'resolveRepoFile')
+        .mockResolvedValue(
+          resolved.codeowners ? {path: 'CODEOWNERS', sha: 'sha', gzippedContent: Buffer.from('gz')} : undefined
+        )
+      jest.spyOn(command as any, 'getPrDiff').mockResolvedValue(resolved.prDiff ? {files: {}} : undefined)
+      jest.spyOn(command as any, 'getCommitDiff').mockResolvedValue(resolved.commitDiff ? {files: {}} : undefined)
+      jest.spyOn(command as any, 'getFileFixes').mockResolvedValue(resolved.fileFixes ? {'a.go': {}} : undefined)
+
+      return command
+    }
+
+    test('reserves nothing when only reports are uploaded', async () => {
+      const command = setUpForBudget(10, {})
+
+      const payloads = await command['generatePayloads']({} as SpanTags)
+
+      expect(payloads).toHaveLength(1)
+      expect(payloads[0].paths).toHaveLength(10)
+    })
+
+    test('reserves one slot per attachment that is actually sent', async () => {
+      const command = setUpForBudget(10, {coverageConfig: true, codeowners: true, prDiff: true})
+
+      const payloads = await command['generatePayloads']({} as SpanTags)
+
+      // 10 - 3 reserved = 7 reports per request
+      expect(payloads).toHaveLength(2)
+      expect(payloads[0].paths).toHaveLength(7)
+      expect(payloads[1].paths).toHaveLength(3)
+    })
+
+    test('reserves five slots when every optional attachment is present', async () => {
+      const command = setUpForBudget(11, {
+        coverageConfig: true,
+        codeowners: true,
+        prDiff: true,
+        commitDiff: true,
+        fileFixes: true,
+      })
+
+      const payloads = await command['generatePayloads']({} as SpanTags)
+
+      expect(payloads).toHaveLength(3)
+      expect(payloads.map((payload) => payload.paths.length)).toEqual([5, 5, 1])
+    })
+
+    test('does not reserve a slot for a file that has no attached content', async () => {
+      const command = setUpForBudget(9, {})
+      jest.spyOn(command as any, 'resolveCoverageConfig').mockResolvedValue({path: 'cc.yml', sha: 'committed-sha'})
+      jest.spyOn(command as any, 'resolveRepoFile').mockResolvedValue({path: 'CODEOWNERS', sha: 'committed-sha'})
+
+      const payloads = await command['generatePayloads']({} as SpanTags)
+
+      expect(payloads).toHaveLength(1)
+      expect(payloads[0].paths).toHaveLength(9)
+    })
+
+    test('uploads every report even when the reserved slots take most of the budget', async () => {
+      const command = setUpForBudget(3, {
+        coverageConfig: true,
+        codeowners: true,
+        prDiff: true,
+        commitDiff: true,
+        fileFixes: true,
+      })
+
+      const payloads = await command['generatePayloads']({} as SpanTags)
+
+      expect(payloads.every((payload) => payload.paths.length >= 1)).toBe(true)
+      expect(payloads.flatMap((payload) => payload.paths)).toHaveLength(3)
+    })
+
+    test('carries the resolved files on every chunk', async () => {
+      const command = setUpForBudget(20, {coverageConfig: true, codeowners: true})
+
+      const payloads = await command['generatePayloads']({} as SpanTags)
+
+      expect(payloads.length).toBeGreaterThan(1)
+      for (const payload of payloads) {
+        expect(payload.coverageConfig?.gzippedContent).toBeDefined()
+        expect(payload.codeowners?.gzippedContent).toBeDefined()
+      }
+    })
   })
 
   describe('getFlags', () => {
@@ -396,6 +836,80 @@ describe('execute', () => {
     const output = context.stdout.toString()
     expect(output).toContain('type:unit-tests')
     expect(output).toContain('jvm-21')
+  })
+
+  describe('--coverage-config', () => {
+    const runCLIWithConfig = (configPath: string) =>
+      makeRunCLI(CoverageUploadCommand, ['coverage', 'upload', '--dry-run', '--coverage-config', configPath])([
+        'src/__tests__/fixtures/jacoco-report.xml',
+      ])
+
+    test('fails without uploading anything when the file is missing', async () => {
+      const {context, code} = await runCLIWithConfig('does/not/exist.yml')
+
+      expect(code).toBe(1)
+      expect(context.stderr.toString()).toContain('Could not read the code coverage configuration file')
+      expect(context.stderr.toString()).toContain('does/not/exist.yml')
+      // nothing was uploaded, not even git metadata
+      expect(context.stdout.toString()).not.toContain('Syncing git metadata')
+      expect(context.stdout.toString()).not.toContain('Starting upload')
+    })
+
+    test('fails when the path is a directory', async () => {
+      const {context, code} = await runCLIWithConfig('src/__tests__/fixtures')
+
+      expect(code).toBe(1)
+      expect(context.stderr.toString()).toContain('Could not read the code coverage configuration file')
+    })
+
+    test('fails when the file cannot be read', async () => {
+      // a dangling symlink is unreadable for every user, unlike a chmod that root ignores
+      const dir = makeTempDir()
+      const configPath = upath.join(dir, 'code-coverage.datadog.yml')
+      fs.symlinkSync(upath.join(dir, 'generated-later.yml'), configPath)
+
+      const {context, code} = await runCLIWithConfig(configPath)
+
+      expect(code).toBe(1)
+      expect(context.stderr.toString()).toContain('Could not read the code coverage configuration file')
+      expect(context.stdout.toString()).not.toContain('Starting upload')
+    })
+
+    test('attaches the file and reports it in dry-run mode', async () => {
+      const configPath = writeFile(makeTempDir(), 'generated-config.yml', CONFIG_CONTENT)
+
+      const {context, code} = await runCLIWithConfig(configPath)
+      const output = context.stdout.toString()
+
+      expect(code).toBe(0)
+      expect(output).toContain('[DRYRUN] Uploading the code coverage configuration')
+      expect(output).toContain(`${CONFIG_CONTENT.length} bytes`)
+      expect(output).toContain(gitBlobSha(Buffer.from(CONFIG_CONTENT)))
+      expect(output).toContain('Uploaded 1 files')
+    })
+  })
+
+  test('reports the CODEOWNERS file it would attach in dry-run mode', async () => {
+    // this repository has a .github/CODEOWNERS, so the working-directory lookup finds it
+    const {context, code} = await makeRunCLI(CoverageUploadCommand, ['coverage', 'upload', '--dry-run'])([
+      'src/__tests__/fixtures/jacoco-report.xml',
+    ])
+    const output = context.stdout.toString()
+
+    expect(code).toBe(0)
+    expect(output).toContain('[DRYRUN] Uploading the CODEOWNERS file .github/CODEOWNERS')
+  })
+
+  test('warns when no coverage configuration can be resolved', async () => {
+    // this repository has no code-coverage.datadog.yml
+    const {context, code} = await makeRunCLI(CoverageUploadCommand, ['coverage', 'upload', '--dry-run'])([
+      'src/__tests__/fixtures/jacoco-report.xml',
+    ])
+    const output = context.stdout.toString()
+
+    expect(code).toBe(0)
+    expect(output).toContain('No code coverage configuration found')
+    expect(output).toContain('the organization-level configuration will be used')
   })
 })
 

--- a/packages/plugin-coverage/src/__tests__/upload.test.ts
+++ b/packages/plugin-coverage/src/__tests__/upload.test.ts
@@ -734,6 +734,143 @@ describe('upload', () => {
         expect(payload.codeowners?.gzippedContent).toBeDefined()
       }
     })
+
+    // A 400 from the intake is in `errorCodesStopUpload`, so an off-by-one here aborts the whole
+    // upload. Assert the invariant over every combination of the optional attachments.
+    test('never lets the total non-event part count exceed the intake limit', async () => {
+      const optional = ['coverageConfig', 'codeowners', 'prDiff', 'commitDiff', 'fileFixes'] as const
+
+      const combinations = optional.reduce<Record<string, boolean>[]>(
+        (acc, key) =>
+          acc.flatMap((combination) => [
+            {...combination, [key]: false},
+            {...combination, [key]: true},
+          ]),
+        [{}]
+      )
+      expect(combinations).toHaveLength(32)
+
+      for (const resolved of combinations) {
+        const command = setUpForBudget(25, resolved)
+
+        const payloads = await command['generatePayloads']({} as SpanTags)
+        const reserved = optional.filter((key) => resolved[key]).length
+
+        expect(payloads.length).toBeGreaterThan(0)
+        for (const payload of payloads) {
+          expect(payload.paths.length + reserved).toBeLessThanOrEqual(10)
+        }
+        // and nothing is dropped
+        expect(payloads.flatMap((payload) => payload.paths)).toHaveLength(25)
+      }
+    })
+  })
+
+  describe('chunkReports', () => {
+    const commandWithReportSizes = (sizes: Record<string, number>) => {
+      const context = createMockContext()
+      const command = createCommand(CoverageUploadCommand, context as any)
+      jest.spyOn(command as any, 'getReportSize').mockImplementation((path) => sizes[path as string] ?? 0)
+
+      return {command, output: () => context.stdout.toString()}
+    }
+
+    test('chunks on count when the reports are small', () => {
+      const {command} = commandWithReportSizes({})
+
+      const chunks = command['chunkReports'](['a', 'b', 'c', 'd', 'e'], 2, 1000)
+
+      expect(chunks).toEqual([['a', 'b'], ['c', 'd'], ['e']])
+    })
+
+    test('starts a new request before the total size would exceed the cap', () => {
+      const {command} = commandWithReportSizes({a: 600, b: 600, c: 600})
+
+      const chunks = command['chunkReports'](['a', 'b', 'c'], 10, 1000)
+
+      expect(chunks).toEqual([['a'], ['b'], ['c']])
+    })
+
+    test('fills a request up to the size cap', () => {
+      const {command} = commandWithReportSizes({a: 400, b: 400, c: 400, d: 400})
+
+      const chunks = command['chunkReports'](['a', 'b', 'c', 'd'], 10, 1000)
+
+      expect(chunks).toEqual([
+        ['a', 'b'],
+        ['c', 'd'],
+      ])
+    })
+
+    test('allows a chunk exactly at the size cap', () => {
+      const {command} = commandWithReportSizes({a: 500, b: 500})
+
+      expect(command['chunkReports'](['a', 'b'], 10, 1000)).toEqual([['a', 'b']])
+    })
+
+    test('applies whichever of the two limits binds first', () => {
+      const {command} = commandWithReportSizes({a: 100, b: 100, c: 900, d: 200})
+
+      // a+b hits the count limit, then c+d would be 1100 bytes so the size limit splits them
+      expect(command['chunkReports'](['a', 'b', 'c', 'd'], 2, 1000)).toEqual([['a', 'b'], ['c'], ['d']])
+    })
+
+    test('still uploads a single report that is larger than the cap, and warns', () => {
+      const {command, output} = commandWithReportSizes({big: 5000, small: 10})
+
+      const chunks = command['chunkReports'](['big', 'small'], 10, 1000)
+
+      expect(chunks).toEqual([['big'], ['small']])
+      expect(output()).toContain('The coverage report [big] is 5000 bytes')
+      expect(output()).toContain('exceeds the 1000 bytes the intake accepts per request')
+    })
+
+    test('does not warn about a report that fits', () => {
+      const {command, output} = commandWithReportSizes({a: 10})
+
+      command['chunkReports'](['a'], 10, 1000)
+
+      expect(output()).not.toContain('exceeds')
+    })
+
+    test('returns no chunks for no reports', () => {
+      const {command} = commandWithReportSizes({})
+
+      expect(command['chunkReports']([], 10, 1000)).toEqual([])
+    })
+
+    test('reserves budget for the other attachments, so a full report set is split by size', async () => {
+      // 4 reports of 20 MiB with the 48 MiB request cap => 2 per request
+      const command = createCommand(CoverageUploadCommand)
+      const paths = ['r1', 'r2', 'r3', 'r4']
+      jest.spyOn(command as any, 'getMatchingCoverageReportFilesByFormat').mockReturnValue({jacoco: paths})
+      jest.spyOn(command as any, 'getReportSize').mockReturnValue(20 * 1024 * 1024)
+      jest.spyOn(command as any, 'resolveCoverageConfig').mockResolvedValue(undefined)
+      jest.spyOn(command as any, 'resolveRepoFile').mockResolvedValue(undefined)
+      jest.spyOn(command as any, 'getPrDiff').mockResolvedValue(undefined)
+      jest.spyOn(command as any, 'getCommitDiff').mockResolvedValue(undefined)
+      jest.spyOn(command as any, 'getFileFixes').mockResolvedValue(undefined)
+
+      const payloads = await command['generatePayloads']({} as SpanTags)
+
+      expect(payloads.map((payload) => payload.paths.length)).toEqual([2, 2])
+    })
+  })
+
+  describe('getReportSize', () => {
+    test('returns the size on disk', () => {
+      const root = makeTempDir()
+      const absolutePath = writeFile(root, 'report.xml', 'x'.repeat(123))
+      const command = createCommand(CoverageUploadCommand)
+
+      expect(command['getReportSize'](absolutePath)).toBe(123)
+    })
+
+    test('returns zero for a path that cannot be stat-ed, rather than throwing', () => {
+      const command = createCommand(CoverageUploadCommand)
+
+      expect(command['getReportSize'](upath.join(makeTempDir(), 'missing.xml'))).toBe(0)
+    })
   })
 
   describe('getFlags', () => {

--- a/packages/plugin-coverage/src/api.ts
+++ b/packages/plugin-coverage/src/api.ts
@@ -13,6 +13,11 @@ import FormData from 'form-data'
 export const intakeUrl = getIntakeUrl('ci-intake')
 export const apiUrl = getApiUrl()
 
+// The backend looks these attachments up by filename, so they must not change.
+// Filenames must not start with a dot: the intake rejects those (see `getReportFilename`).
+export const COVERAGE_CONFIG_ATTACHMENT_FILENAME = 'coverage_config.yml.gz'
+export const CODEOWNERS_ATTACHMENT_FILENAME = 'codeowners.gz'
+
 export const uploadCodeCoverageReport =
   (request: (args: RequestConfig) => Promise<RequestResponse>) => async (payload: Payload) => {
     const form = new FormData()
@@ -53,6 +58,18 @@ export const uploadCodeCoverageReport =
     if (payload.fileFixesCompressed) {
       form.append('file_fixes', payload.fileFixesCompressed, {
         filename: 'file_fixes.json.gz',
+      })
+    }
+
+    if (payload.coverageConfig?.gzippedContent) {
+      form.append('coverage_config', payload.coverageConfig.gzippedContent, {
+        filename: COVERAGE_CONFIG_ATTACHMENT_FILENAME,
+      })
+    }
+
+    if (payload.codeowners?.gzippedContent) {
+      form.append('codeowners', payload.codeowners.gzippedContent, {
+        filename: CODEOWNERS_ATTACHMENT_FILENAME,
       })
     }
 

--- a/packages/plugin-coverage/src/commands/upload.ts
+++ b/packages/plugin-coverage/src/commands/upload.ts
@@ -50,6 +50,7 @@ import {
   renderFailedUpload,
   renderInvalidFile,
   renderNoCoverageConfigFound,
+  renderOversizedReport,
   renderOversizedRepoFile,
   renderRepoFileNotAttached,
   renderRetriedUpload,
@@ -77,6 +78,12 @@ const errorCodesStopUpload = [400, 403]
 // multipart part named `event` is excluded from the count by the intake decoder.
 const MAX_ATTACHMENTS_PER_REQUEST = 10
 
+// The same intake rejects a request body over 50 MiB with a 413. A 413 is not in
+// `errorCodesStopUpload`, so it is retried and then skipped: reports would go missing from a run that
+// still reports success. Chunk on total size as well as on count, keeping a margin for `event.json`,
+// the multipart framing and the difference between a report's size on disk and gzipped.
+const MAX_REQUEST_SIZE = 48 * 1024 * 1024
+
 const COVERAGE_CONFIG_LABEL = 'the code coverage configuration'
 
 const CODEOWNERS_LABEL = 'the CODEOWNERS file'
@@ -84,6 +91,8 @@ const CODEOWNERS_LABEL = 'the CODEOWNERS file'
 // The head SHA the payload carries on the wire (api.ts spreads `...payload.spanTags`,
 // so this matches what the splitter reads as `coalesce(HeadSHA, SHA)`).
 const getReportedCommitSha = (spanTags: SpanTags): string | undefined => spanTags[GIT_HEAD_SHA] || spanTags[GIT_SHA]
+
+const serializedSize = (value: unknown): number => (value === undefined ? 0 : Buffer.byteLength(JSON.stringify(value)))
 
 // The SHA is computed from the content that is attached, not from the committed blob, so that it
 // stays the git blob SHA-1 of whatever the backend ends up reading.
@@ -253,15 +262,24 @@ export class PluginCommand extends CoverageUploadCommand {
     const maxReportsPerRequest = Math.max(1, MAX_ATTACHMENTS_PER_REQUEST - reservedAttachments)
     this.logger.debug(`Uploading at most ${maxReportsPerRequest} coverage report(s) per request`)
 
+    // The diffs are gzipped per request in `api.ts`, so their uncompressed size is used here: over-
+    // estimating the reserved bytes only ever produces smaller chunks, never a request over the cap.
+    const reservedBytes =
+      serializedSize(prDiff) +
+      serializedSize(commitDiff) +
+      (fileFixesCompressed?.length ?? 0) +
+      (coverageConfig?.gzippedContent?.length ?? 0) +
+      (codeowners?.gzippedContent?.length ?? 0)
+    const maxReportBytesPerRequest = Math.max(1, MAX_REQUEST_SIZE - reservedBytes)
+    this.logger.debug(`Uploading at most ${maxReportBytesPerRequest} coverage report byte(s) per request`)
+
     let payloads: Payload[] = []
     if (Object.keys(reports).length) {
-      payloads = Object.entries(reports).flatMap(([format, paths]) => {
-        const numChunks = Math.ceil(paths.length / maxReportsPerRequest)
-
-        return Array.from({length: numChunks}, (_, i) => ({
+      payloads = Object.entries(reports).flatMap(([format, paths]) =>
+        this.chunkReports(paths, maxReportsPerRequest, maxReportBytesPerRequest).map((chunk) => ({
           format,
           basePath: this.basePath,
-          paths: paths.slice(i * maxReportsPerRequest, (i + 1) * maxReportsPerRequest),
+          paths: chunk,
           spanTags,
           flags,
           hostname: os.hostname(),
@@ -271,10 +289,56 @@ export class PluginCommand extends CoverageUploadCommand {
           codeowners,
           fileFixesCompressed,
         }))
-      })
+      )
     }
 
     return payloads
+  }
+
+  /**
+   * Groups report paths into requests that respect both the intake's attachment count limit and its
+   * total request size limit. A report larger than `maxBytes` on its own still gets its own request:
+   * splitting a single report is not possible, so the alternative would be dropping it.
+   */
+  private chunkReports(paths: string[], maxReports: number, maxBytes: number): string[][] {
+    const chunks: string[][] = []
+    let current: string[] = []
+    let currentBytes = 0
+
+    for (const path of paths) {
+      const size = this.getReportSize(path)
+
+      if (current.length > 0 && (current.length >= maxReports || currentBytes + size > maxBytes)) {
+        chunks.push(current)
+        current = []
+        currentBytes = 0
+      }
+
+      if (current.length === 0 && size > maxBytes) {
+        this.logger.warn(renderOversizedReport(path, size, maxBytes))
+      }
+
+      current.push(path)
+      currentBytes += size
+    }
+
+    if (current.length > 0) {
+      chunks.push(current)
+    }
+
+    return chunks
+  }
+
+  private getReportSize(path: string): number {
+    try {
+      return fs.statSync(path).size
+    } catch (e) {
+      // The upload of this path will fail later with a clearer error; do not let sizing be the thing
+      // that breaks, and do not let an unknown size silently consume the whole budget.
+      this.logger.debug(`Error while trying to size the coverage report ${path}: ${e}`)
+
+      return 0
+    }
   }
 
   private async getFileFixes(): Promise<FileFixes | undefined> {

--- a/packages/plugin-coverage/src/commands/upload.ts
+++ b/packages/plugin-coverage/src/commands/upload.ts
@@ -1,3 +1,4 @@
+import fs from 'fs'
 import os from 'os'
 import {gzipSync} from 'zlib'
 
@@ -41,32 +42,57 @@ import upath from 'upath'
 import {apiConstructor, apiUrl, intakeUrl} from '../api'
 import {generateFileFixes} from '../file-fixes'
 import {
+  renderAttachedRepoFile,
   renderCommandInfo,
+  renderCoverageConfigReadError,
   renderDryRunUpload,
   renderFailedGitDBSync,
   renderFailedUpload,
   renderInvalidFile,
+  renderNoCoverageConfigFound,
+  renderOversizedRepoFile,
+  renderRepoFileNotAttached,
   renderRetriedUpload,
   renderSuccessfulGitDBSync,
   renderSuccessfulUpload,
   renderSuccessfulUploadCommand,
   renderUpload,
 } from '../renderer'
+import {
+  CODEOWNERS_PATHS,
+  COVERAGE_CONFIG_PATHS,
+  MAX_ATTACHED_FILE_SIZE,
+  findFileInSearchRoots,
+  gitBlobSha,
+  statFileOnDisk,
+  toRepositoryRelativePath,
+} from '../repo-files'
 import {coverageFormats, detectFormat, isCoverageFormat, toCoverageFormat, validateCoverageReport} from '../utils'
 
 const TRACE_ID_HTTP_HEADER = 'x-datadog-trace-id'
 const PARENT_ID_HTTP_HEADER = 'x-datadog-parent-id'
 const errorCodesStopUpload = [400, 403]
 
-const MAX_REPORTS_PER_REQUEST = 7 // backend supports 10 attachments, to keep the logic simple we subtract 3: for PR diff, commit diff, and file fixes
+// The intake accepts 10 attachments per `cicovreprt` request. `event.json` is not one of them: the
+// multipart part named `event` is excluded from the count by the intake decoder.
+const MAX_ATTACHMENTS_PER_REQUEST = 10
 
-const COVERAGE_CONFIG_PATHS = ['code-coverage.datadog.yml', 'code-coverage.datadog.yaml']
+const COVERAGE_CONFIG_LABEL = 'the code coverage configuration'
 
-const CODEOWNERS_PATHS = ['.github/CODEOWNERS', 'CODEOWNERS', 'docs/CODEOWNERS']
+const CODEOWNERS_LABEL = 'the CODEOWNERS file'
 
 // The head SHA the payload carries on the wire (api.ts spreads `...payload.spanTags`,
 // so this matches what the splitter reads as `coalesce(HeadSHA, SHA)`).
 const getReportedCommitSha = (spanTags: SpanTags): string | undefined => spanTags[GIT_HEAD_SHA] || spanTags[GIT_SHA]
+
+// The SHA is computed from the content that is attached, not from the committed blob, so that it
+// stays the git blob SHA-1 of whatever the backend ends up reading.
+const toAttachedFile = (path: string, content: Buffer): RepoFile => ({
+  path,
+  sha: gitBlobSha(content),
+  gzippedContent: gzipSync(content),
+  size: content.length,
+})
 
 export class PluginCommand extends CoverageUploadCommand {
   private config = {
@@ -77,6 +103,11 @@ export class PluginCommand extends CoverageUploadCommand {
   }
 
   private git: simpleGit.SimpleGit | undefined = undefined
+
+  private repositoryRoot: string | undefined = undefined
+
+  // Set when --coverage-config points at a file that could be read and is small enough to attach.
+  private explicitCoverageConfig: RepoFile | undefined = undefined
 
   public async execute() {
     enableFips(this.fips || this.config.fips, this.fipsIgnoreError || this.config.fipsIgnoreError)
@@ -102,6 +133,19 @@ export class PluginCommand extends CoverageUploadCommand {
 
     if (isGitRepository) {
       this.git = await newSimpleGit()
+      this.repositoryRoot = await this.getRepositoryRoot()
+    }
+
+    // Resolved before anything is uploaded: an explicitly requested configuration that cannot be
+    // read is a user error, and the command must fail instead of silently uploading without it.
+    if (this.coverageConfigPath) {
+      try {
+        this.explicitCoverageConfig = this.readCoverageConfigFile(this.coverageConfigPath)
+      } catch (e) {
+        this.context.stderr.write(renderCoverageConfigReadError(this.coverageConfigPath, (e as Error).message))
+
+        return 1
+      }
     }
 
     if (!this.skipGitMetadataUpload) {
@@ -185,8 +229,8 @@ export class PluginCommand extends CoverageUploadCommand {
     const flags = this.getFlags()
 
     const reportedCommit = getReportedCommitSha(spanTags)
-    const coverageConfig = await this.getRepoFile(COVERAGE_CONFIG_PATHS, reportedCommit)
-    const codeowners = await this.getRepoFile(CODEOWNERS_PATHS, reportedCommit)
+    const coverageConfig = await this.resolveCoverageConfig(reportedCommit)
+    const codeowners = await this.resolveRepoFile(CODEOWNERS_LABEL, CODEOWNERS_PATHS, reportedCommit)
     const commitDiff = await this.getCommitDiff(spanTags)
     const prDiff = await this.getPrDiff(spanTags)
     const fileFixes = await this.getFileFixes()
@@ -197,15 +241,27 @@ export class PluginCommand extends CoverageUploadCommand {
     }
     const reports = this.getMatchingCoverageReportFilesByFormat()
 
+    // Every chunk carries the same non-report attachments, so the report budget is what is left of
+    // the intake's per-request attachment limit once those are accounted for.
+    const reservedAttachments = [
+      prDiff,
+      commitDiff,
+      fileFixesCompressed,
+      coverageConfig?.gzippedContent,
+      codeowners?.gzippedContent,
+    ].filter((attachment) => attachment !== undefined).length
+    const maxReportsPerRequest = Math.max(1, MAX_ATTACHMENTS_PER_REQUEST - reservedAttachments)
+    this.logger.debug(`Uploading at most ${maxReportsPerRequest} coverage report(s) per request`)
+
     let payloads: Payload[] = []
     if (Object.keys(reports).length) {
       payloads = Object.entries(reports).flatMap(([format, paths]) => {
-        const numChunks = Math.ceil(paths.length / MAX_REPORTS_PER_REQUEST)
+        const numChunks = Math.ceil(paths.length / maxReportsPerRequest)
 
         return Array.from({length: numChunks}, (_, i) => ({
           format,
           basePath: this.basePath,
-          paths: paths.slice(i * MAX_REPORTS_PER_REQUEST, (i + 1) * MAX_REPORTS_PER_REQUEST),
+          paths: paths.slice(i * maxReportsPerRequest, (i + 1) * maxReportsPerRequest),
           spanTags,
           flags,
           hostname: os.hostname(),
@@ -240,7 +296,11 @@ export class PluginCommand extends CoverageUploadCommand {
     }
   }
 
-  private async getRepoFile(possiblePaths: string[], ref: string | undefined): Promise<RepoFile | undefined> {
+  private async getRepoFile(
+    possiblePaths: string[],
+    ref: string | undefined,
+    opts: {explicit?: boolean} = {}
+  ): Promise<RepoFile | undefined> {
     if (!this.git || !ref) {
       return undefined
     }
@@ -252,11 +312,144 @@ export class PluginCommand extends CoverageUploadCommand {
           return {path, sha}
         }
       } catch (e) {
-        this.logger.debug(`Error while trying to get repo file ${path} details at ${ref}: ${e}`)
+        const message = `Error while trying to get repo file ${path} details at ${ref}: ${e}`
+        // A file the user explicitly asked for must not fail silently.
+        if (opts.explicit) {
+          this.logger.warn(message)
+        } else {
+          this.logger.debug(message)
+        }
       }
     }
 
     return undefined
+  }
+
+  private async resolveCoverageConfig(reportedCommit: string | undefined): Promise<RepoFile | undefined> {
+    if (!this.coverageConfigPath) {
+      const resolved = await this.resolveRepoFile(COVERAGE_CONFIG_LABEL, COVERAGE_CONFIG_PATHS, reportedCommit)
+      if (!resolved) {
+        this.logger.warn(renderNoCoverageConfigFound(reportedCommit, this.getSearchRoots()))
+      }
+
+      return resolved
+    }
+
+    if (this.explicitCoverageConfig) {
+      this.reportResolvedRepoFile(COVERAGE_CONFIG_LABEL, this.explicitCoverageConfig)
+
+      return this.explicitCoverageConfig
+    }
+
+    // The explicit configuration exists but is too large to attach (execute() would have failed
+    // otherwise): keep the path and take the SHA from the committed copy of that same file, if any.
+    const reportedPath = toRepositoryRelativePath(upath.resolve(this.coverageConfigPath), this.repositoryRoot)
+    const fromGit = await this.getRepoFile([reportedPath], reportedCommit, {explicit: true})
+    this.reportResolvedRepoFile(COVERAGE_CONFIG_LABEL, fromGit)
+
+    return fromGit
+  }
+
+  /**
+   * Best-effort resolution of a repository file: it is looked up both in the files committed at
+   * `reportedCommit` and in the working directory. The working-directory copy wins when both exist,
+   * because a file regenerated at build time is what the user wants to be used. Never throws.
+   */
+  private async resolveRepoFile(
+    label: string,
+    candidates: string[],
+    reportedCommit: string | undefined
+  ): Promise<RepoFile | undefined> {
+    const fromGit = await this.getRepoFile(candidates, reportedCommit)
+
+    const onDisk = findFileInSearchRoots(candidates, this.getSearchRoots())
+    if (!onDisk) {
+      this.reportResolvedRepoFile(label, fromGit)
+
+      return fromGit
+    }
+
+    if (onDisk.size > MAX_ATTACHED_FILE_SIZE) {
+      // the warning already says that only the path and SHA are sent, so do not report twice
+      this.logger.warn(renderOversizedRepoFile(label, onDisk, MAX_ATTACHED_FILE_SIZE))
+
+      return fromGit
+    }
+
+    let resolved: RepoFile | undefined
+    try {
+      resolved = toAttachedFile(onDisk.path, fs.readFileSync(onDisk.absolutePath))
+    } catch (e) {
+      this.logger.warn(`Could not read ${label} from ${onDisk.absolutePath}: ${e}`)
+      resolved = fromGit
+    }
+    this.reportResolvedRepoFile(label, resolved)
+
+    return resolved
+  }
+
+  /**
+   * Reads the file given by `--coverage-config`. Throws when it cannot be read: the caller turns that
+   * into a non-zero exit code. Returns `undefined` when the file is readable but too large to attach.
+   */
+  private readCoverageConfigFile(configPath: string): RepoFile | undefined {
+    const absolutePath = upath.resolve(configPath)
+
+    const onDisk = statFileOnDisk(absolutePath)
+    if (!onDisk) {
+      throw new Error(`no readable file at ${absolutePath}`)
+    }
+
+    const reportedPath = toRepositoryRelativePath(absolutePath, this.repositoryRoot)
+    if (onDisk.size > MAX_ATTACHED_FILE_SIZE) {
+      const oversized = {...onDisk, path: reportedPath}
+      this.logger.warn(renderOversizedRepoFile(COVERAGE_CONFIG_LABEL, oversized, MAX_ATTACHED_FILE_SIZE))
+
+      return undefined
+    }
+
+    return toAttachedFile(reportedPath, fs.readFileSync(absolutePath))
+  }
+
+  private reportResolvedRepoFile(label: string, file: RepoFile | undefined) {
+    if (!file) {
+      return
+    }
+
+    if (file.gzippedContent) {
+      this.logger.info(renderAttachedRepoFile(this.dryRun, label, file))
+    } else {
+      this.logger.info(renderRepoFileNotAttached(label, file))
+    }
+  }
+
+  /**
+   * Directories searched for the coverage configuration and CODEOWNERS, in priority order.
+   */
+  private getSearchRoots(): string[] {
+    const roots = [
+      ...(this.repositoryRoot ? [this.repositoryRoot] : []),
+      ...(this.basePath ? [upath.resolve(this.basePath)] : []),
+      upath.normalize(process.cwd()),
+    ]
+
+    return [...new Set(roots)]
+  }
+
+  private async getRepositoryRoot(): Promise<string | undefined> {
+    if (!this.git) {
+      return undefined
+    }
+
+    try {
+      const root = (await this.git.revparse(['--show-toplevel'])).trim()
+
+      return root ? upath.normalize(root) : undefined
+    } catch (e) {
+      this.logger.debug(`Error while trying to get the repository root: ${e}`)
+
+      return undefined
+    }
   }
 
   private async getPrDiff(spanTags: SpanTags): Promise<DiffData | undefined> {

--- a/packages/plugin-coverage/src/interfaces.ts
+++ b/packages/plugin-coverage/src/interfaces.ts
@@ -21,6 +21,11 @@ export interface Payload {
 export interface RepoFile {
   path: string
   sha: string
+  // Gzipped file content, only set when the content could be read and is attached to the request.
+  // When absent, the backend reads the content from the committed blob at `path`/`sha` instead.
+  gzippedContent?: Buffer
+  // Uncompressed size of the attached content, for reporting purposes.
+  size?: number
 }
 
 export interface APIHelper {

--- a/packages/plugin-coverage/src/renderer.ts
+++ b/packages/plugin-coverage/src/renderer.ts
@@ -1,4 +1,4 @@
-import type {Payload} from './interfaces'
+import type {Payload, RepoFile} from './interfaces'
 import type {SpanTags} from '@datadog/datadog-ci-base/helpers/interfaces'
 
 import chalk from 'chalk'
@@ -99,4 +99,41 @@ export const renderSuccessfulGitDBSync = (dryRun: boolean, elapsed: number) => {
 
 export const renderFailedGitDBSync = (err: any) => {
   return chalk.red.bold(`${ICONS.FAILED} Could not sync git metadata: ${err}\n`)
+}
+
+export const renderCoverageConfigReadError = (path: string, errorMessage: string) => {
+  return chalk.red(
+    `${ICONS.FAILED} Could not read the code coverage configuration file [${chalk.bold.dim(
+      path
+    )}] given by --coverage-config: ${errorMessage}\n`
+  )
+}
+
+export const renderNoCoverageConfigFound = (commit: string | undefined, searchRoots: string[]) => {
+  const searchedIn = [
+    ...(commit ? [`in the files committed at ${commit}`] : []),
+    ...(searchRoots.length ? [`on disk in ${searchRoots.join(', ')}`] : []),
+  ].join(' and ')
+
+  return chalk.yellow(
+    `${ICONS.WARNING} No code coverage configuration found (looked ${searchedIn}); the organization-level configuration will be used. Pass --coverage-config <path> to upload a configuration that is not committed.`
+  )
+}
+
+export const renderOversizedRepoFile = (label: string, file: {path: string; size: number}, maxSize: number) => {
+  return chalk.yellow(
+    `${ICONS.WARNING} Not uploading the content of ${label} [${chalk.bold.dim(file.path)}]: it is ${
+      file.size
+    } bytes, which exceeds the ${maxSize} bytes limit. Only its path and SHA are sent.`
+  )
+}
+
+export const renderAttachedRepoFile = (dryRun: boolean, label: string, file: RepoFile) => {
+  return chalk.green(
+    `${dryRun ? '[DRYRUN] ' : ''}Uploading ${label} ${file.path} (${file.size ?? 0} bytes, sha ${file.sha})`
+  )
+}
+
+export const renderRepoFileNotAttached = (label: string, file: RepoFile) => {
+  return `Not uploading the content of ${label} ${file.path} (sha ${file.sha}): the file is not in the working directory, so it will be read from the repository instead.`
 }

--- a/packages/plugin-coverage/src/renderer.ts
+++ b/packages/plugin-coverage/src/renderer.ts
@@ -128,6 +128,12 @@ export const renderOversizedRepoFile = (label: string, file: {path: string; size
   )
 }
 
+export const renderOversizedReport = (path: string, size: number, maxSize: number) => {
+  return chalk.yellow(
+    `${ICONS.WARNING} The coverage report [${chalk.bold.dim(path)}] is ${size} bytes, which on its own exceeds the ${maxSize} bytes the intake accepts per request. It is uploaded anyway, but the request may be rejected.`
+  )
+}
+
 export const renderAttachedRepoFile = (dryRun: boolean, label: string, file: RepoFile) => {
   return chalk.green(
     `${dryRun ? '[DRYRUN] ' : ''}Uploading ${label} ${file.path} (${file.size ?? 0} bytes, sha ${file.sha})`

--- a/packages/plugin-coverage/src/repo-files.ts
+++ b/packages/plugin-coverage/src/repo-files.ts
@@ -1,0 +1,92 @@
+// Discovery of the repository files that are uploaded alongside coverage reports: the code coverage
+// configuration (`code-coverage.datadog.yml`) and `CODEOWNERS`.
+//
+// Both are looked up in the committed tree (path + git blob SHA only) and in the working directory.
+// A file found in the working directory is attached to the upload, which is what makes a
+// configuration generated during the CI run usable.
+
+import {createHash} from 'crypto'
+import fs from 'fs'
+
+import upath from 'upath'
+
+export const COVERAGE_CONFIG_PATHS = ['code-coverage.datadog.yml', 'code-coverage.datadog.yaml']
+
+export const CODEOWNERS_PATHS = ['.github/CODEOWNERS', 'CODEOWNERS', 'docs/CODEOWNERS']
+
+// Files larger than this are not attached: the backend keeps them in reducer state and in blob
+// storage, and CODEOWNERS files in large monorepos can grow arbitrarily.
+export const MAX_ATTACHED_FILE_SIZE = 1024 * 1024
+
+export interface FileOnDisk {
+  // Path reported to the backend: repository-relative whenever the file is inside the repository.
+  path: string
+  absolutePath: string
+  size: number
+}
+
+/**
+ * Computes the git blob SHA-1 of the given content: `sha1("blob " + byteLength + "\0" + content)`.
+ * Matches `git hash-object`, so a file read from disk and the same file read from the committed tree
+ * produce the same SHA, and the backend content cache stays content-addressed.
+ */
+export const gitBlobSha = (content: Buffer): string =>
+  createHash('sha1').update(`blob ${content.length}\0`).update(content).digest('hex')
+
+/**
+ * Returns the first of `candidates` that exists as a readable file under any of `searchRoots`.
+ * Roots are tried in order first, so the repository root wins over the current directory.
+ */
+export const findFileInSearchRoots = (candidates: string[], searchRoots: string[]): FileOnDisk | undefined => {
+  for (const root of searchRoots) {
+    for (const candidate of candidates) {
+      const found = statFileOnDisk(upath.resolve(root, candidate), candidate)
+      if (found) {
+        return found
+      }
+    }
+  }
+
+  return undefined
+}
+
+/**
+ * Stats a single file, returning `undefined` when it does not exist, is not a regular file, or is
+ * not readable. `reportedPath` overrides the path sent to the backend, which is repository-relative.
+ */
+export const statFileOnDisk = (absolutePath: string, reportedPath?: string): FileOnDisk | undefined => {
+  try {
+    const stats = fs.statSync(absolutePath)
+    if (!stats.isFile()) {
+      return undefined
+    }
+    fs.accessSync(absolutePath, fs.constants.R_OK)
+
+    return {
+      path: reportedPath ?? upath.normalize(absolutePath),
+      absolutePath: upath.normalize(absolutePath),
+      size: stats.size,
+    }
+  } catch {
+    return undefined
+  }
+}
+
+/**
+ * Makes `absolutePath` relative to `repositoryRoot` when it is inside it, so that `config.path` and
+ * `codeowners.path` stay repository-relative like the git-derived ones. Falls back to the
+ * normalized absolute path for files outside of the repository.
+ */
+export const toRepositoryRelativePath = (absolutePath: string, repositoryRoot: string | undefined): string => {
+  const normalized = upath.normalize(absolutePath)
+  if (!repositoryRoot) {
+    return normalized
+  }
+
+  const relative = upath.relative(upath.normalize(repositoryRoot), normalized)
+  if (!relative || relative.startsWith('../') || upath.isAbsolute(relative)) {
+    return normalized
+  }
+
+  return relative
+}


### PR DESCRIPTION
Fixes #2414

The issue offered three options and asked which was preferred. **This implements all three:** option 1 (fall back to the working directory), option 2 (an explicit `--coverage-config <path>` flag), and option 3 (warn when no config is resolved, and promote the swallowed `logger.debug`). It also goes one step further than any of them: the file's **content** is uploaded as an attachment, so the backend can apply a config that was never committed — options 1 and 2 alone would still have left the backend re-reading the file from the committed tree by path and SHA, which is the actual reason a generated config is ignored today. Thanks to @swarajrao for a very well-researched report; it made this straightforward to act on.

`coverage upload` resolves `code-coverage.datadog.yml` and `CODEOWNERS` through git only (`git rev-parse <ref>:<path>`), so a config generated during the CI run is silently ignored — the lookup error is swallowed into `logger.debug`, and at default verbosity nothing in the output says the config was not applied. This is the CLI half of "coverage config + CODEOWNERS as EVP attachments"; the backend services read the attachments in separate PRs.

### What changed

**Both files are now looked up in the committed tree *and* in the working directory**, and their content is uploaded as EVP attachments alongside the coverage reports whenever it can be read:

| form field | filename |
|---|---|
| `coverage_config` | `coverage_config.yml.gz` |
| `codeowners` | `codeowners.gz` |

The on-disk copy wins over the committed blob — regenerating the config at build time is exactly the use case in the issue. When content is attached, `config.sha` / `codeowners.sha` become the **git blob SHA-1 of the attached bytes** (`sha1("blob " + len + "\0" + content)`), so the value still matches `git hash-object` and the backend's content-addressed cache keeps working whether the file was committed or generated. Search roots for the working-directory lookup, in order: the git repository root, `--base-path`, then the current directory.

Files over **1 MiB uncompressed** are not attached (CODEOWNERS in a large monorepo can be arbitrarily big); the command warns and falls back to today's git-derived path and SHA. No new event tags, no schema change.

**New `--coverage-config <path>` flag** for a config that is generated, or lives outside the default locations. An explicitly requested file that cannot be read is a user error: the command writes a clear message to stderr and **exits non-zero before uploading anything**, git metadata included. Without the flag, discovery of both files stays best-effort and never fails the upload.

**The warnings the issue asks for.** When no config is resolved at all:

```
⚠️ No code coverage configuration found (looked in the files committed at <sha> and on disk in <dirs>);
   the organization-level configuration will be used. Pass --coverage-config <path> to upload a
   configuration that is not committed.
```

and the swallowed `logger.debug` in the git lookup is promoted to `logger.warn` when the file was explicitly requested. What was resolved is now reported at `info`, so the silence the issue complains about is gone:

```
Uploading the code coverage configuration code-coverage.datadog.yml (49 bytes, sha a5005d07...)
Uploading the CODEOWNERS file .github/CODEOWNERS (22 bytes, sha dc2328ea...)
```

`--dry-run` prefixes those with `[DRYRUN]`, so it reports which files would be attached.

**The attachment budget is computed instead of hardcoded.** `MAX_REPORTS_PER_REQUEST = 7` ("backend supports 10 attachments, to keep the logic simple we subtract 3") is replaced by:

```ts
reserved = [prDiff, commitDiff, fileFixes, coverageConfig, codeowners].filter(present).length
maxReportsPerRequest = Math.max(1, MAX_ATTACHMENTS_PER_REQUEST - reserved)
```

All five are resolved before chunking, so the budget is exact rather than an unconditional -3. I verified the real limit against the intake source rather than trusting the comment: `cicovreprt` is configured with `max-attachment-count: 10` and `max-content-size: 50MiB`, and **`event.json` does not count towards the limit** — the public path uses `V2MultiPartMessageDecoder`, which excludes the part named `event` before counting. Exceeding the count returns HTTP 400, which is in `errorCodesStopUpload`, so an over-budget request aborts the whole upload; getting this right matters.

**Chunking now respects the request size limit too.** The same intake rejects a body over 50 MiB with a 413 — and 413 is *not* in `errorCodesStopUpload`, so it is retried and then skipped, dropping that chunk's reports from a run that still prints `Uploaded N files`. Since this change makes requests carry more attachments than before, it also makes chunking size-aware: the budget is what remains of 48 MiB (50 MiB less a margin for `event.json` and the multipart framing) after the diffs, file fixes, config and CODEOWNERS. Report sizes come from disk, so they over-estimate the gzipped bytes actually sent — over-estimating only ever produces smaller chunks, never an oversized request. A single report larger than the budget still gets its own request, and warns. Verified on four 22 MB jacoco reports: previously one request of 88 MB, now two of 44 MB.

### Tests

216 unit tests in `packages/plugin-coverage` (was 152), covering: blob-SHA computation (asserted against `git hash-object`, including empty and binary content), search-root and candidate precedence, on-disk-wins, git-only fallback, the size cap at and just over the boundary, unreadable/missing/directory/dangling-symlink explicit paths, the oversized-explicit fallback to the git lookup, non-git operation, the `debug`→`warn` promotion, every branch of the budget computation, and the two new multipart parts. The count invariant is asserted over the **full cross-product** of the five optional attachments (32 combinations): every chunk satisfies `reports + reserved <= 10` and no report is dropped — an off-by-one there would 400, which aborts the whole upload. `api-multipart.test.ts` encodes a real multipart body rather than mocking `form-data`, pinning `name="coverage_config"; filename="coverage_config.yml.gz"` and `name="codeowners"; filename="codeowners.gz"` as they appear on the wire, since the backend matches on the filename.

Also exercised by hand in a throwaway repo: committed-and-identical (SHA equals `git hash-object`, no behaviour change), modified-on-disk, untracked-generated, missing explicit path (exit 1, nothing uploaded), a 1.32 MB CODEOWNERS, and 12 reports + config + CODEOWNERS in a non-git directory chunking into 8 + 4 — exactly 10 attachments per request.

`yarn lint`, `yarn tsc:build` and `yarn test packages/plugin-coverage` are clean.

### Note

The docs at [Code Coverage Configuration](https://docs.datadoghq.com/code_coverage/configuration/) still say to create the file "in the root of your repository" without mentioning the committed-only constraint (issue item 2). The plugin README is updated here; the public docs live in another repo and need a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
