### PR TITLE
[SVLS-9307] language injection specifications

### DIFF
--- a/packages/base/src/helpers/serverless/__tests__/ssi/env.test.ts
+++ b/packages/base/src/helpers/serverless/__tests__/ssi/env.test.ts
@@ -15,18 +15,18 @@ describe('environment fragment merging', () => {
     name: 'NODE_OPTIONS',
     value: '--require /datadog-lib/node_modules/dd-trace/init.js',
     separator: ' ',
-    direction: 'append',
+    mode: 'append',
   }
   const prependFragment: EnvFragment = {
     name: 'RUBYOPT',
     value: '-r/datadog-lib/auto_inject',
     separator: ' ',
-    direction: 'prepend',
+    mode: 'prepend',
   }
   const scalarFragment: EnvFragment = {
     name: 'CORECLR_ENABLE_PROFILING',
     value: '1',
-    direction: 'set-if-absent',
+    mode: 'set-if-absent',
   }
 
   test.each([
@@ -39,7 +39,7 @@ describe('environment fragment merging', () => {
     {fragment: scalarFragment, current: undefined, merged: '1'},
     {fragment: scalarFragment, current: '', merged: '1'},
     {fragment: scalarFragment, current: '1', merged: '1'},
-  ])('merges $fragment.direction fragments', ({fragment, current, merged}) => {
+  ])('merges $fragment.mode fragments', ({fragment, current, merged}) => {
     expect(mergeEnvFragment(current, fragment)).toBe(merged)
   })
 
@@ -48,11 +48,11 @@ describe('environment fragment merging', () => {
     {fragment: prependFragment, current: `${prependFragment.value} -w`},
     {fragment: appendFragment, current: `${appendFragment.value} --inspect ${appendFragment.value}`},
     {fragment: prependFragment, current: `${prependFragment.value} -w ${prependFragment.value}`},
-  ])('deduplicates exact $fragment.direction fragments', ({fragment, current}) => {
+  ])('deduplicates exact $fragment.mode fragments', ({fragment, current}) => {
     const merged = mergeEnvFragment(current, fragment)
     expect(merged.split(fragment.value)).toHaveLength(2)
-    expect(merged.startsWith(fragment.value)).toBe(fragment.direction === 'prepend')
-    expect(merged.endsWith(fragment.value)).toBe(fragment.direction === 'append')
+    expect(merged.startsWith(fragment.value)).toBe(fragment.mode === 'prepend')
+    expect(merged.endsWith(fragment.value)).toBe(fragment.mode === 'append')
   })
 
   test.each([
@@ -62,7 +62,7 @@ describe('environment fragment merging', () => {
     {fragment: scalarFragment, current: '1', present: true},
     {fragment: scalarFragment, current: '0', present: false},
     {fragment: scalarFragment, current: undefined, present: false},
-  ])('detects exact $fragment.direction fragments', ({fragment, current, present}) => {
+  ])('detects exact $fragment.mode fragments', ({fragment, current, present}) => {
     expect(hasEnvFragment(current, fragment)).toBe(present)
   })
 
@@ -76,11 +76,17 @@ describe('environment fragment merging', () => {
     {fragment: appendFragment, current: '--inspect'},
     {fragment: prependFragment, current: '-w'},
     {
-      fragment: {name: 'PYTHONPATH', value: '/datadog-lib', separator: ':', direction: 'append'} as EnvFragment,
+      fragment: {name: 'PYTHONPATH', value: '/datadog-lib', separator: ':', mode: 'append'} as EnvFragment,
       current: '/app:/vendor',
     },
     {
-      fragment: {name: 'PHP_INI_SCAN_DIR', value: ':/datadog-lib/linux-gnu/loader', direction: 'append'} as EnvFragment,
+      fragment: {
+        name: 'PHP_INI_SCAN_DIR',
+        value: '/datadog-lib/linux-gnu/loader',
+        separator: ':',
+        mode: 'append',
+        preserveLeadingEmpty: true,
+      } as EnvFragment,
       current: '/etc/php/conf.d',
     },
   ])('merge then remove restores $current for $fragment.name', ({fragment, current}) => {
@@ -90,13 +96,16 @@ describe('environment fragment merging', () => {
   test('deduplicates and exactly removes PHP config from the middle of a path list', () => {
     const fragment: EnvFragment = {
       name: 'PHP_INI_SCAN_DIR',
-      value: ':/datadog-lib/linux-gnu/loader',
-      direction: 'append',
+      value: '/datadog-lib/linux-gnu/loader',
+      separator: ':',
+      mode: 'append',
+      preserveLeadingEmpty: true,
     }
-    const current = `/etc/php${fragment.value}:/custom/php${fragment.value}`
-    expect(mergeEnvFragment(current, fragment)).toBe(`/etc/php:/custom/php${fragment.value}`)
-    expect(removeEnvFragment(`/etc/php${fragment.value}:/custom/php`, fragment)).toBe('/etc/php:/custom/php')
-    expect(removeEnvFragment(`/etc/php${fragment.value}.backup`, fragment)).toBe(`/etc/php${fragment.value}.backup`)
+    const current = `/etc/php:${fragment.value}:/custom/php:${fragment.value}`
+    expect(mergeEnvFragment(undefined, fragment)).toBe(`:${fragment.value}`)
+    expect(mergeEnvFragment(current, fragment)).toBe(`/etc/php:/custom/php:${fragment.value}`)
+    expect(removeEnvFragment(`/etc/php:${fragment.value}:/custom/php`, fragment)).toBe('/etc/php:/custom/php')
+    expect(removeEnvFragment(`/etc/php:${fragment.value}.backup`, fragment)).toBe(`/etc/php:${fragment.value}.backup`)
   })
 
   test('preserves pre-existing separator formatting', () => {
@@ -118,7 +127,7 @@ describe('environment fragment merging', () => {
     name: 'LD_PRELOAD',
     value: '/datadog-lib/continuousprofiler/Datadog.Linux.ApiWrapper.x64.so',
     separator: ' ',
-    direction: 'prepend',
+    mode: 'prepend',
     maxLength: 1024,
   }
 
@@ -143,23 +152,6 @@ describe('environment fragment merging', () => {
   test('treats an empty current value as absent during removal', () => {
     expect(removeEnvFragment('', appendFragment)).toBeUndefined()
     expect(removeEnvFragment('', scalarFragment)).toBeUndefined()
-  })
-
-  test.each(['line\nbreak', 'nul\0value'])('rejects malformed current value %p', (current) => {
-    expect(() => hasEnvFragment(current, appendFragment)).toThrow('Existing value')
-    expect(() => mergeEnvFragment(current, appendFragment)).toThrow('Existing value')
-    expect(() => removeEnvFragment(current, appendFragment)).toThrow('Existing value')
-  })
-
-  test.each([
-    {...appendFragment, name: ''},
-    {...appendFragment, value: ''},
-    {...appendFragment, value: 'line\nbreak'},
-    {...appendFragment, maxLength: 0},
-    {...scalarFragment, separator: ' ' as const},
-  ])('rejects malformed fragment %#', (fragment) => {
-    expect(() => hasEnvFragment(undefined, fragment)).toThrow()
-    expect(() => mergeEnvFragment(undefined, fragment)).toThrow()
   })
 })
 

--- a/packages/base/src/helpers/serverless/__tests__/ssi/env.test.ts
+++ b/packages/base/src/helpers/serverless/__tests__/ssi/env.test.ts
@@ -108,6 +108,34 @@ describe('environment fragment merging', () => {
     expect(removeEnvFragment(`/etc/php:${fragment.value}.backup`, fragment)).toBe(`/etc/php:${fragment.value}.backup`)
   })
 
+  const pythonPathFragment: EnvFragment = {
+    name: 'PYTHONPATH',
+    value: '/datadog-lib',
+    separator: ':',
+    mode: 'append',
+  }
+
+  test.each([
+    {
+      fragment: prependFragment,
+      current: `-w ${prependFragment.value} ${prependFragment.value}`,
+      removed: '-w',
+      merged: `${prependFragment.value} -w`,
+    },
+    {
+      fragment: pythonPathFragment,
+      current: `${pythonPathFragment.value}:${pythonPathFragment.value}:/custom`,
+      removed: '/custom',
+      merged: `/custom:${pythonPathFragment.value}`,
+    },
+  ])(
+    'removes adjacent $fragment.mode fragments without leaving a separator',
+    ({fragment, current, removed, merged}) => {
+      expect(removeEnvFragment(current, fragment)).toBe(removed)
+      expect(mergeEnvFragment(current, fragment)).toBe(merged)
+    }
+  )
+
   test('preserves pre-existing separator formatting', () => {
     const current = '--inspect  --trace-warnings '
     const merged = mergeEnvFragment(current, appendFragment)
@@ -166,6 +194,7 @@ describe('injection mode tag', () => {
     {current: `env:prod,${tag}`, merged: `${tag},env:prod`},
     {current: `env:prod,${tag},team:serverless`, merged: `${tag},env:prod,team:serverless`},
     {current: `${tag},env:prod,${tag}`, merged: `${tag},env:prod`},
+    {current: `env:prod,${tag},${tag}`, merged: `${tag},env:prod`},
   ])('merges exactly once into $current', ({current, merged}) => {
     expect(mergeInjectionModeTag(current)).toBe(merged)
     expect(mergeInjectionModeTag(merged)).toBe(merged)
@@ -187,6 +216,7 @@ describe('injection mode tag', () => {
     {current: `${tag},env:prod`, removed: 'env:prod'},
     {current: `env:prod,${tag}`, removed: 'env:prod'},
     {current: `env:prod,${tag},team:serverless`, removed: 'env:prod,team:serverless'},
+    {current: `env:prod,${tag},${tag}`, removed: 'env:prod'},
   ])('removes only the exact tag from $current', ({current, removed}) => {
     expect(removeInjectionModeTag(current)).toBe(removed)
   })

--- a/packages/base/src/helpers/serverless/__tests__/ssi/env.test.ts
+++ b/packages/base/src/helpers/serverless/__tests__/ssi/env.test.ts
@@ -1,0 +1,207 @@
+import {
+  EnvFragmentConflictError,
+  SINGLE_LANGUAGE_INJECTION_MODE_TAG,
+  hasEnvFragment,
+  hasInjectionModeTag,
+  mergeEnvFragment,
+  mergeInjectionModeTag,
+  removeEnvFragment,
+  removeInjectionModeTag,
+  type EnvFragment,
+} from '@datadog/datadog-ci-base/helpers/serverless/ssi/env'
+
+describe('environment fragment merging', () => {
+  const appendFragment: EnvFragment = {
+    name: 'NODE_OPTIONS',
+    value: '--require /datadog-lib/node_modules/dd-trace/init.js',
+    separator: ' ',
+    direction: 'append',
+  }
+  const prependFragment: EnvFragment = {
+    name: 'RUBYOPT',
+    value: '-r/datadog-lib/auto_inject',
+    separator: ' ',
+    direction: 'prepend',
+  }
+  const scalarFragment: EnvFragment = {
+    name: 'CORECLR_ENABLE_PROFILING',
+    value: '1',
+    direction: 'set-if-absent',
+  }
+
+  test.each([
+    {fragment: appendFragment, current: undefined, merged: appendFragment.value},
+    {fragment: appendFragment, current: '', merged: appendFragment.value},
+    {fragment: appendFragment, current: '--inspect', merged: `--inspect ${appendFragment.value}`},
+    {fragment: prependFragment, current: undefined, merged: prependFragment.value},
+    {fragment: prependFragment, current: '', merged: prependFragment.value},
+    {fragment: prependFragment, current: '-w', merged: `${prependFragment.value} -w`},
+    {fragment: scalarFragment, current: undefined, merged: '1'},
+    {fragment: scalarFragment, current: '', merged: '1'},
+    {fragment: scalarFragment, current: '1', merged: '1'},
+  ])('merges $fragment.direction fragments', ({fragment, current, merged}) => {
+    expect(mergeEnvFragment(current, fragment)).toBe(merged)
+  })
+
+  test.each([
+    {fragment: appendFragment, current: `--inspect ${appendFragment.value}`},
+    {fragment: prependFragment, current: `${prependFragment.value} -w`},
+    {fragment: appendFragment, current: `${appendFragment.value} --inspect ${appendFragment.value}`},
+    {fragment: prependFragment, current: `${prependFragment.value} -w ${prependFragment.value}`},
+  ])('deduplicates exact $fragment.direction fragments', ({fragment, current}) => {
+    const merged = mergeEnvFragment(current, fragment)
+    expect(merged.split(fragment.value)).toHaveLength(2)
+    expect(merged.startsWith(fragment.value)).toBe(fragment.direction === 'prepend')
+    expect(merged.endsWith(fragment.value)).toBe(fragment.direction === 'append')
+  })
+
+  test.each([
+    {fragment: appendFragment, current: appendFragment.value, present: true},
+    {fragment: appendFragment, current: `${appendFragment.value}.backup`, present: false},
+    {fragment: prependFragment, current: `${prependFragment.value} -w`, present: true},
+    {fragment: scalarFragment, current: '1', present: true},
+    {fragment: scalarFragment, current: '0', present: false},
+    {fragment: scalarFragment, current: undefined, present: false},
+  ])('detects exact $fragment.direction fragments', ({fragment, current, present}) => {
+    expect(hasEnvFragment(current, fragment)).toBe(present)
+  })
+
+  test('does not match similarly named substrings', () => {
+    const similar = `${appendFragment.value}.backup`
+    expect(mergeEnvFragment(similar, appendFragment)).toBe(`${similar} ${appendFragment.value}`)
+    expect(removeEnvFragment(similar, appendFragment)).toBe(similar)
+  })
+
+  test.each([
+    {fragment: appendFragment, current: '--inspect'},
+    {fragment: prependFragment, current: '-w'},
+    {
+      fragment: {name: 'PYTHONPATH', value: '/datadog-lib', separator: ':', direction: 'append'} as EnvFragment,
+      current: '/app:/vendor',
+    },
+    {
+      fragment: {name: 'PHP_INI_SCAN_DIR', value: ':/datadog-lib/linux-gnu/loader', direction: 'append'} as EnvFragment,
+      current: '/etc/php/conf.d',
+    },
+  ])('merge then remove restores $current for $fragment.name', ({fragment, current}) => {
+    expect(removeEnvFragment(mergeEnvFragment(current, fragment), fragment)).toBe(current)
+  })
+
+  test('deduplicates and exactly removes PHP config from the middle of a path list', () => {
+    const fragment: EnvFragment = {
+      name: 'PHP_INI_SCAN_DIR',
+      value: ':/datadog-lib/linux-gnu/loader',
+      direction: 'append',
+    }
+    const current = `/etc/php${fragment.value}:/custom/php${fragment.value}`
+    expect(mergeEnvFragment(current, fragment)).toBe(`/etc/php:/custom/php${fragment.value}`)
+    expect(removeEnvFragment(`/etc/php${fragment.value}:/custom/php`, fragment)).toBe('/etc/php:/custom/php')
+    expect(removeEnvFragment(`/etc/php${fragment.value}.backup`, fragment)).toBe(`/etc/php${fragment.value}.backup`)
+  })
+
+  test('preserves pre-existing separator formatting', () => {
+    const current = '--inspect  --trace-warnings '
+    const merged = mergeEnvFragment(current, appendFragment)
+    expect(merged).toBe(`${current} ${appendFragment.value}`)
+    expect(removeEnvFragment(merged, appendFragment)).toBe(current)
+  })
+
+  test('preserves a changed owned scalar during removal', () => {
+    expect(removeEnvFragment('0', scalarFragment)).toBe('0')
+  })
+
+  test('reports a scalar conflict instead of overwriting it', () => {
+    expect(() => mergeEnvFragment('0', scalarFragment)).toThrow(EnvFragmentConflictError)
+  })
+
+  const dotnetPreloadFragment: EnvFragment = {
+    name: 'LD_PRELOAD',
+    value: '/datadog-lib/continuousprofiler/Datadog.Linux.ApiWrapper.x64.so',
+    separator: ' ',
+    direction: 'prepend',
+    maxLength: 1024,
+  }
+
+  test('enforces the .NET LD_PRELOAD byte limit after prepending', () => {
+    const fragment = dotnetPreloadFragment
+    expect(mergeEnvFragment('x'.repeat(1024 - Buffer.byteLength(fragment.value) - 1), fragment)).toHaveLength(1024)
+    expect(() => mergeEnvFragment('x'.repeat(1024 - Buffer.byteLength(fragment.value)), fragment)).toThrow(
+      '1024-byte limit'
+    )
+  })
+
+  test.each([undefined, 'libother.so', '/datadog-lib/continuousprofiler/Datadog.Linux.ApiWrapper.x64.so'])(
+    'prepends and deduplicates the .NET wrapper for %p',
+    (current) => {
+      const fragment = dotnetPreloadFragment
+      const merged = mergeEnvFragment(current, fragment)
+      expect(merged.startsWith(fragment.value)).toBe(true)
+      expect(merged.split(fragment.value)).toHaveLength(2)
+    }
+  )
+
+  test('treats an empty current value as absent during removal', () => {
+    expect(removeEnvFragment('', appendFragment)).toBeUndefined()
+    expect(removeEnvFragment('', scalarFragment)).toBeUndefined()
+  })
+
+  test.each(['line\nbreak', 'nul\0value'])('rejects malformed current value %p', (current) => {
+    expect(() => hasEnvFragment(current, appendFragment)).toThrow('Existing value')
+    expect(() => mergeEnvFragment(current, appendFragment)).toThrow('Existing value')
+    expect(() => removeEnvFragment(current, appendFragment)).toThrow('Existing value')
+  })
+
+  test.each([
+    {...appendFragment, name: ''},
+    {...appendFragment, value: ''},
+    {...appendFragment, value: 'line\nbreak'},
+    {...appendFragment, maxLength: 0},
+    {...scalarFragment, separator: ' ' as const},
+  ])('rejects malformed fragment %#', (fragment) => {
+    expect(() => hasEnvFragment(undefined, fragment)).toThrow()
+    expect(() => mergeEnvFragment(undefined, fragment)).toThrow()
+  })
+})
+
+describe('injection mode tag', () => {
+  const tag = SINGLE_LANGUAGE_INJECTION_MODE_TAG
+
+  test.each([
+    {current: undefined, merged: tag},
+    {current: 'env:prod', merged: `${tag},env:prod`},
+    {current: tag, merged: tag},
+    {current: `${tag},env:prod`, merged: `${tag},env:prod`},
+    {current: `env:prod,${tag}`, merged: `${tag},env:prod`},
+    {current: `env:prod,${tag},team:serverless`, merged: `${tag},env:prod,team:serverless`},
+    {current: `${tag},env:prod,${tag}`, merged: `${tag},env:prod`},
+  ])('merges exactly once into $current', ({current, merged}) => {
+    expect(mergeInjectionModeTag(current)).toBe(merged)
+    expect(mergeInjectionModeTag(merged)).toBe(merged)
+  })
+
+  test.each([
+    {current: undefined, present: false},
+    {current: tag, present: true},
+    {current: `${tag},env:prod`, present: true},
+    {current: `env:prod,${tag}`, present: true},
+    {current: `${tag}-other`, present: false},
+  ])('detects the exact tag in $current', ({current, present}) => {
+    expect(hasInjectionModeTag(current)).toBe(present)
+  })
+
+  test.each([
+    {current: undefined, removed: undefined},
+    {current: tag, removed: undefined},
+    {current: `${tag},env:prod`, removed: 'env:prod'},
+    {current: `env:prod,${tag}`, removed: 'env:prod'},
+    {current: `env:prod,${tag},team:serverless`, removed: 'env:prod,team:serverless'},
+  ])('removes only the exact tag from $current', ({current, removed}) => {
+    expect(removeInjectionModeTag(current)).toBe(removed)
+  })
+
+  test('preserves similarly named and whitespace-prefixed tags', () => {
+    const current = `${tag}-other, ${tag},env:prod`
+    expect(removeInjectionModeTag(current)).toBe(current)
+    expect(mergeInjectionModeTag(current)).toBe(`${tag},${current}`)
+  })
+})

--- a/packages/base/src/helpers/serverless/__tests__/ssi/injection-spec.test.ts
+++ b/packages/base/src/helpers/serverless/__tests__/ssi/injection-spec.test.ts
@@ -1,0 +1,200 @@
+import type {CanonicalTracerLanguage, ServerlessLanguage} from '@datadog/datadog-ci-base/helpers/serverless/ssi/tracer'
+
+import {mergeEnvFragment} from '@datadog/datadog-ci-base/helpers/serverless/ssi/env'
+import {
+  getSingleLanguageInjectionSpec,
+  type ServerlessLibc,
+} from '@datadog/datadog-ci-base/helpers/serverless/ssi/injection-spec'
+
+const languageCases: {
+  language: ServerlessLanguage
+  canonical: CanonicalTracerLanguage
+  repository: string
+}[] = [
+  {language: 'java', canonical: 'java', repository: 'dd-trace-java'},
+  {language: 'nodejs', canonical: 'js', repository: 'dd-trace-js'},
+  {language: 'csharp', canonical: 'dotnet', repository: 'dd-trace-dotnet'},
+  {language: 'python', canonical: 'python', repository: 'dd-trace-py'},
+  {language: 'ruby', canonical: 'ruby', repository: 'dd-trace-rb'},
+  {language: 'php', canonical: 'php', repository: 'dd-trace-php'},
+]
+
+const getSpec = (language: ServerlessLanguage, libc: ServerlessLibc = 'glibc') =>
+  getSingleLanguageInjectionSpec({
+    language,
+    libc,
+    registry: 'gcr.io/datadoghq',
+    version: 'latest',
+  })
+
+describe('injection specification metadata and root', () => {
+  test.each(languageCases)(
+    'returns image and repository metadata for $language',
+    ({language, canonical, repository}) => {
+      const spec = getSpec(language)
+      expect(spec).toMatchObject({
+        language,
+        canonicalLanguage: canonical,
+        repository,
+        image: `gcr.io/datadoghq/dd-lib-${canonical}-init:latest`,
+      })
+    }
+  )
+
+  test('uses a configurable normalized tracer root', () => {
+    const spec = getSingleLanguageInjectionSpec({
+      language: 'java',
+      libc: 'glibc',
+      registry: 'public.ecr.aws/datadog',
+      version: 'v1',
+      root: '/opt/datadog/',
+    })
+    expect(spec.requiredFiles).toEqual([['/opt/datadog/dd-java-agent.jar']])
+    expect(spec.env[0].value).toContain('/opt/datadog/dd-java-agent.jar')
+  })
+
+  test('supports the filesystem root without producing double slashes', () => {
+    const spec = getSingleLanguageInjectionSpec({
+      language: 'python',
+      libc: 'glibc',
+      registry: 'gcr.io/datadoghq',
+      version: 'latest',
+      root: '/',
+    })
+    expect(spec.requiredFiles).toEqual([['/sitecustomize.py']])
+    expect(spec.env[0].value).toBe('/')
+  })
+
+  test.each(['', 'relative', '/path with-space', '/opt/../datadog', '/opt//datadog'])(
+    'rejects malformed root %p',
+    (root) => {
+      expect(() =>
+        getSingleLanguageInjectionSpec({
+          language: 'java',
+          libc: 'glibc',
+          registry: 'gcr.io/datadoghq',
+          version: 'latest',
+          root,
+        })
+      ).toThrow('Tracer root')
+    }
+  )
+})
+
+describe('language injection specifications', () => {
+  test('keeps Java options runtime-agnostic when the runtime version is unknown', () => {
+    const spec = getSpec('java', 'musl')
+    expect(spec.requiredFiles).toEqual([['/datadog-lib/dd-java-agent.jar']])
+    expect(spec.env).toEqual([
+      {
+        name: 'JAVA_TOOL_OPTIONS',
+        value: '-javaagent:/datadog-lib/dd-java-agent.jar -XX:+IgnoreUnrecognizedVMOptions',
+        separator: ' ',
+        direction: 'append',
+      },
+    ])
+    expect(spec.env[0].value).not.toContain('enable-native-access')
+  })
+
+  test.each(['glibc', 'musl'] as const)('Node package self-selects for %s', (libc) => {
+    const spec = getSpec('nodejs', libc)
+    expect(spec.requiredFiles).toEqual([['/datadog-lib/node_modules/dd-trace/init.js']])
+    expect(spec.env).toEqual([
+      {
+        name: 'NODE_OPTIONS',
+        value: '--require /datadog-lib/node_modules/dd-trace/init.js',
+        separator: ' ',
+        direction: 'append',
+      },
+    ])
+  })
+
+  test.each(['glibc', 'musl'] as const)('Python package self-selects for %s', (libc) => {
+    const spec = getSpec('python', libc)
+    expect(spec.requiredFiles).toEqual([['/datadog-lib/sitecustomize.py']])
+    expect(spec.env).toEqual([
+      {
+        name: 'PYTHONPATH',
+        value: '/datadog-lib',
+        separator: ':',
+        direction: 'append',
+      },
+    ])
+  })
+
+  test('requires the Ruby bootstrap referenced by RUBYOPT', () => {
+    const spec = getSpec('ruby')
+    expect(spec.requiredFiles).toEqual([['/datadog-lib/auto_inject.rb']])
+    expect(spec.env).toEqual([
+      {
+        name: 'RUBYOPT',
+        value: '-r/datadog-lib/auto_inject',
+        separator: ' ',
+        direction: 'prepend',
+      },
+    ])
+  })
+
+  test('rejects Ruby on musl', () => {
+    expect(() => getSpec('ruby', 'musl')).toThrow('does not support musl')
+  })
+
+  test.each([
+    {libc: 'glibc' as const, platform: 'linux-gnu'},
+    {libc: 'musl' as const, platform: 'linux-musl'},
+  ])('selects PHP $platform files and config for $libc', ({libc, platform}) => {
+    const spec = getSpec('php', libc)
+    const loader = `/datadog-lib/${platform}/loader`
+    expect(spec.requiredFiles).toEqual([[`${loader}/dd_library_loader.ini`], [`${loader}/dd_library_loader.so`]])
+    expect(spec.env).toEqual([
+      {name: 'PHP_INI_SCAN_DIR', value: `:${loader}`, direction: 'append'},
+      {name: 'DD_LOADER_PACKAGE_PATH', value: '/datadog-lib', direction: 'set-if-absent'},
+    ])
+    expect(mergeEnvFragment(undefined, spec.env[0])).toBe(`:${loader}`)
+    expect(mergeEnvFragment('/etc/php/conf.d', spec.env[0])).toBe(`/etc/php/conf.d:${loader}`)
+  })
+
+  test.each(['2.56.0', 'v2.60.1'])('rejects pinned .NET 2.x layouts that require architecture', (version) => {
+    expect(() =>
+      getSingleLanguageInjectionSpec({
+        language: 'csharp',
+        libc: 'glibc',
+        registry: 'gcr.io/datadoghq',
+        version,
+      })
+    ).toThrow('versions before 3.0 require architecture-specific package paths')
+  })
+
+  test.each(['glibc', 'musl'] as const)('uses the current universal .NET package paths for %s', (libc) => {
+    const spec = getSpec('csharp', libc)
+    expect(spec.requiredFiles).toEqual([
+      ['/datadog-lib/Datadog.Trace.ClrProfiler.Native.so'],
+      ['/datadog-lib/continuousprofiler/Datadog.Linux.ApiWrapper.x64.so'],
+    ])
+    expect(spec.env).toEqual([
+      {name: 'CORECLR_ENABLE_PROFILING', value: '1', direction: 'set-if-absent'},
+      {
+        name: 'CORECLR_PROFILER',
+        value: '{846F5F1C-F9AE-4B07-969E-05C26BC060D8}',
+        direction: 'set-if-absent',
+      },
+      {
+        name: 'CORECLR_PROFILER_PATH',
+        value: '/datadog-lib/Datadog.Trace.ClrProfiler.Native.so',
+        direction: 'set-if-absent',
+      },
+      {name: 'DD_DOTNET_TRACER_HOME', value: '/datadog-lib', direction: 'set-if-absent'},
+      {
+        name: 'LD_PRELOAD',
+        value: '/datadog-lib/continuousprofiler/Datadog.Linux.ApiWrapper.x64.so',
+        separator: ' ',
+        direction: 'prepend',
+        maxLength: 1024,
+      },
+    ])
+  })
+
+  test('rejects an invalid libc at runtime', () => {
+    expect(() => getSpec('java', 'uclibc' as ServerlessLibc)).toThrow('Unsupported libc')
+  })
+})

--- a/packages/base/src/helpers/serverless/__tests__/ssi/injection-spec.test.ts
+++ b/packages/base/src/helpers/serverless/__tests__/ssi/injection-spec.test.ts
@@ -1,5 +1,9 @@
 import {mergeEnvFragment} from '@datadog/datadog-ci-base/helpers/serverless/ssi/env'
-import {getLanguageInjectionSpec, type Libc} from '@datadog/datadog-ci-base/helpers/serverless/ssi/injection-spec'
+import {
+  getLanguageCompatibilityError,
+  getLanguageInjectionSpec,
+  type Libc,
+} from '@datadog/datadog-ci-base/helpers/serverless/ssi/injection-spec'
 import {LANGUAGE_METADATA, type Language} from '@datadog/datadog-ci-base/helpers/serverless/ssi/tracer'
 
 const languages = Object.keys(LANGUAGE_METADATA) as Language[]
@@ -42,21 +46,6 @@ describe('injection specification metadata and root', () => {
     expect(spec.artifacts).toEqual([['/sitecustomize.py']])
     expect(spec.env[0].value).toBe('/')
   })
-
-  test.each(['', 'relative', '/path with-space', '/opt/../datadog', '/opt//datadog'])(
-    'rejects unsafe root %p',
-    (root) => {
-      expect(() =>
-        getLanguageInjectionSpec({
-          language: 'java',
-          libc: 'glibc',
-          registry: 'gcr.io/datadoghq',
-          version: 'latest',
-          root,
-        })
-      ).toThrow('Tracer root')
-    }
-  )
 })
 
 describe('language injection specifications', () => {
@@ -113,8 +102,10 @@ describe('language injection specifications', () => {
     ])
   })
 
-  test('rejects Ruby on musl', () => {
-    expect(() => getSpec('ruby', 'musl')).toThrow('does not support musl')
+  test('reports Ruby on musl as incompatible', () => {
+    expect(getLanguageCompatibilityError({language: 'ruby', libc: 'musl', version: 'latest'})).toContain(
+      'does not support musl'
+    )
   })
 
   test.each([
@@ -138,15 +129,10 @@ describe('language injection specifications', () => {
     expect(mergeEnvFragment('/etc/php/conf.d', spec.env[0])).toBe(`/etc/php/conf.d:${loader}`)
   })
 
-  test.each(['2.56.0', 'v2.60.1'])('rejects pinned .NET 2.x layouts that require architecture', (version) => {
-    expect(() =>
-      getLanguageInjectionSpec({
-        language: 'csharp',
-        libc: 'glibc',
-        registry: 'gcr.io/datadoghq',
-        version,
-      })
-    ).toThrow('versions before 3.0 require architecture-specific package paths')
+  test.each(['2.56.0', 'v2.60.1'])('reports .NET 2.x layouts as incompatible', (version) => {
+    expect(getLanguageCompatibilityError({language: 'csharp', libc: 'glibc', version})).toContain(
+      'versions before 3.0 require architecture-specific package paths'
+    )
   })
 
   test.each(['glibc', 'musl'] as const)('uses the current universal .NET package paths for %s', (libc) => {
@@ -178,8 +164,8 @@ describe('language injection specifications', () => {
     ])
   })
 
-  test('rejects unsupported user input', () => {
-    expect(() => getSpec('go' as Language)).toThrow('Unsupported language')
-    expect(() => getSpec('java', 'uclibc' as Libc)).toThrow('Unsupported libc')
+  test('accepts compatible language options', () => {
+    expect(getLanguageCompatibilityError({language: 'java', libc: 'musl', version: 'latest'})).toBeUndefined()
+    expect(getLanguageCompatibilityError({language: 'csharp', libc: 'glibc', version: '3.0.0'})).toBeUndefined()
   })
 })

--- a/packages/base/src/helpers/serverless/__tests__/ssi/injection-spec.test.ts
+++ b/packages/base/src/helpers/serverless/__tests__/ssi/injection-spec.test.ts
@@ -1,26 +1,11 @@
-import type {CanonicalTracerLanguage, ServerlessLanguage} from '@datadog/datadog-ci-base/helpers/serverless/ssi/tracer'
-
 import {mergeEnvFragment} from '@datadog/datadog-ci-base/helpers/serverless/ssi/env'
-import {
-  getSingleLanguageInjectionSpec,
-  type ServerlessLibc,
-} from '@datadog/datadog-ci-base/helpers/serverless/ssi/injection-spec'
+import {getLanguageInjectionSpec, type Libc} from '@datadog/datadog-ci-base/helpers/serverless/ssi/injection-spec'
+import {LANGUAGE_METADATA, type Language} from '@datadog/datadog-ci-base/helpers/serverless/ssi/tracer'
 
-const languageCases: {
-  language: ServerlessLanguage
-  canonical: CanonicalTracerLanguage
-  repository: string
-}[] = [
-  {language: 'java', canonical: 'java', repository: 'dd-trace-java'},
-  {language: 'nodejs', canonical: 'js', repository: 'dd-trace-js'},
-  {language: 'csharp', canonical: 'dotnet', repository: 'dd-trace-dotnet'},
-  {language: 'python', canonical: 'python', repository: 'dd-trace-py'},
-  {language: 'ruby', canonical: 'ruby', repository: 'dd-trace-rb'},
-  {language: 'php', canonical: 'php', repository: 'dd-trace-php'},
-]
+const languages = Object.keys(LANGUAGE_METADATA) as Language[]
 
-const getSpec = (language: ServerlessLanguage, libc: ServerlessLibc = 'glibc') =>
-  getSingleLanguageInjectionSpec({
+const getSpec = (language: Language, libc: Libc = 'glibc') =>
+  getLanguageInjectionSpec({
     language,
     libc,
     registry: 'gcr.io/datadoghq',
@@ -28,48 +13,41 @@ const getSpec = (language: ServerlessLanguage, libc: ServerlessLibc = 'glibc') =
   })
 
 describe('injection specification metadata and root', () => {
-  test.each(languageCases)(
-    'returns image and repository metadata for $language',
-    ({language, canonical, repository}) => {
-      const spec = getSpec(language)
-      expect(spec).toMatchObject({
-        language,
-        canonicalLanguage: canonical,
-        repository,
-        image: `gcr.io/datadoghq/dd-lib-${canonical}-init:latest`,
-      })
-    }
-  )
+  test.each(languages)('returns the %s tracer image', (language) => {
+    expect(getSpec(language).image).toBe(
+      `gcr.io/datadoghq/dd-lib-${LANGUAGE_METADATA[language].tracerLanguage}-init:latest`
+    )
+  })
 
   test('uses a configurable normalized tracer root', () => {
-    const spec = getSingleLanguageInjectionSpec({
+    const spec = getLanguageInjectionSpec({
       language: 'java',
       libc: 'glibc',
       registry: 'public.ecr.aws/datadog',
       version: 'v1',
       root: '/opt/datadog/',
     })
-    expect(spec.requiredFiles).toEqual([['/opt/datadog/dd-java-agent.jar']])
+    expect(spec.artifacts).toEqual([['/opt/datadog/dd-java-agent.jar']])
     expect(spec.env[0].value).toContain('/opt/datadog/dd-java-agent.jar')
   })
 
   test('supports the filesystem root without producing double slashes', () => {
-    const spec = getSingleLanguageInjectionSpec({
+    const spec = getLanguageInjectionSpec({
       language: 'python',
       libc: 'glibc',
       registry: 'gcr.io/datadoghq',
       version: 'latest',
       root: '/',
     })
-    expect(spec.requiredFiles).toEqual([['/sitecustomize.py']])
+    expect(spec.artifacts).toEqual([['/sitecustomize.py']])
     expect(spec.env[0].value).toBe('/')
   })
 
   test.each(['', 'relative', '/path with-space', '/opt/../datadog', '/opt//datadog'])(
-    'rejects malformed root %p',
+    'rejects unsafe root %p',
     (root) => {
       expect(() =>
-        getSingleLanguageInjectionSpec({
+        getLanguageInjectionSpec({
           language: 'java',
           libc: 'glibc',
           registry: 'gcr.io/datadoghq',
@@ -84,13 +62,13 @@ describe('injection specification metadata and root', () => {
 describe('language injection specifications', () => {
   test('keeps Java options runtime-agnostic when the runtime version is unknown', () => {
     const spec = getSpec('java', 'musl')
-    expect(spec.requiredFiles).toEqual([['/datadog-lib/dd-java-agent.jar']])
+    expect(spec.artifacts).toEqual([['/datadog-lib/dd-java-agent.jar']])
     expect(spec.env).toEqual([
       {
         name: 'JAVA_TOOL_OPTIONS',
         value: '-javaagent:/datadog-lib/dd-java-agent.jar -XX:+IgnoreUnrecognizedVMOptions',
         separator: ' ',
-        direction: 'append',
+        mode: 'append',
       },
     ])
     expect(spec.env[0].value).not.toContain('enable-native-access')
@@ -98,39 +76,39 @@ describe('language injection specifications', () => {
 
   test.each(['glibc', 'musl'] as const)('Node package self-selects for %s', (libc) => {
     const spec = getSpec('nodejs', libc)
-    expect(spec.requiredFiles).toEqual([['/datadog-lib/node_modules/dd-trace/init.js']])
+    expect(spec.artifacts).toEqual([['/datadog-lib/node_modules/dd-trace/init.js']])
     expect(spec.env).toEqual([
       {
         name: 'NODE_OPTIONS',
         value: '--require /datadog-lib/node_modules/dd-trace/init.js',
         separator: ' ',
-        direction: 'append',
+        mode: 'append',
       },
     ])
   })
 
   test.each(['glibc', 'musl'] as const)('Python package self-selects for %s', (libc) => {
     const spec = getSpec('python', libc)
-    expect(spec.requiredFiles).toEqual([['/datadog-lib/sitecustomize.py']])
+    expect(spec.artifacts).toEqual([['/datadog-lib/sitecustomize.py']])
     expect(spec.env).toEqual([
       {
         name: 'PYTHONPATH',
         value: '/datadog-lib',
         separator: ':',
-        direction: 'append',
+        mode: 'append',
       },
     ])
   })
 
   test('requires the Ruby bootstrap referenced by RUBYOPT', () => {
     const spec = getSpec('ruby')
-    expect(spec.requiredFiles).toEqual([['/datadog-lib/auto_inject.rb']])
+    expect(spec.artifacts).toEqual([['/datadog-lib/auto_inject.rb']])
     expect(spec.env).toEqual([
       {
         name: 'RUBYOPT',
         value: '-r/datadog-lib/auto_inject',
         separator: ' ',
-        direction: 'prepend',
+        mode: 'prepend',
       },
     ])
   })
@@ -145,10 +123,16 @@ describe('language injection specifications', () => {
   ])('selects PHP $platform files and config for $libc', ({libc, platform}) => {
     const spec = getSpec('php', libc)
     const loader = `/datadog-lib/${platform}/loader`
-    expect(spec.requiredFiles).toEqual([[`${loader}/dd_library_loader.ini`], [`${loader}/dd_library_loader.so`]])
+    expect(spec.artifacts).toEqual([[`${loader}/dd_library_loader.ini`], [`${loader}/dd_library_loader.so`]])
     expect(spec.env).toEqual([
-      {name: 'PHP_INI_SCAN_DIR', value: `:${loader}`, direction: 'append'},
-      {name: 'DD_LOADER_PACKAGE_PATH', value: '/datadog-lib', direction: 'set-if-absent'},
+      {
+        name: 'PHP_INI_SCAN_DIR',
+        value: loader,
+        separator: ':',
+        mode: 'append',
+        preserveLeadingEmpty: true,
+      },
+      {name: 'DD_LOADER_PACKAGE_PATH', value: '/datadog-lib', mode: 'set-if-absent'},
     ])
     expect(mergeEnvFragment(undefined, spec.env[0])).toBe(`:${loader}`)
     expect(mergeEnvFragment('/etc/php/conf.d', spec.env[0])).toBe(`/etc/php/conf.d:${loader}`)
@@ -156,7 +140,7 @@ describe('language injection specifications', () => {
 
   test.each(['2.56.0', 'v2.60.1'])('rejects pinned .NET 2.x layouts that require architecture', (version) => {
     expect(() =>
-      getSingleLanguageInjectionSpec({
+      getLanguageInjectionSpec({
         language: 'csharp',
         libc: 'glibc',
         registry: 'gcr.io/datadoghq',
@@ -167,34 +151,35 @@ describe('language injection specifications', () => {
 
   test.each(['glibc', 'musl'] as const)('uses the current universal .NET package paths for %s', (libc) => {
     const spec = getSpec('csharp', libc)
-    expect(spec.requiredFiles).toEqual([
+    expect(spec.artifacts).toEqual([
       ['/datadog-lib/Datadog.Trace.ClrProfiler.Native.so'],
       ['/datadog-lib/continuousprofiler/Datadog.Linux.ApiWrapper.x64.so'],
     ])
     expect(spec.env).toEqual([
-      {name: 'CORECLR_ENABLE_PROFILING', value: '1', direction: 'set-if-absent'},
+      {name: 'CORECLR_ENABLE_PROFILING', value: '1', mode: 'set-if-absent'},
       {
         name: 'CORECLR_PROFILER',
         value: '{846F5F1C-F9AE-4B07-969E-05C26BC060D8}',
-        direction: 'set-if-absent',
+        mode: 'set-if-absent',
       },
       {
         name: 'CORECLR_PROFILER_PATH',
         value: '/datadog-lib/Datadog.Trace.ClrProfiler.Native.so',
-        direction: 'set-if-absent',
+        mode: 'set-if-absent',
       },
-      {name: 'DD_DOTNET_TRACER_HOME', value: '/datadog-lib', direction: 'set-if-absent'},
+      {name: 'DD_DOTNET_TRACER_HOME', value: '/datadog-lib', mode: 'set-if-absent'},
       {
         name: 'LD_PRELOAD',
         value: '/datadog-lib/continuousprofiler/Datadog.Linux.ApiWrapper.x64.so',
         separator: ' ',
-        direction: 'prepend',
+        mode: 'prepend',
         maxLength: 1024,
       },
     ])
   })
 
-  test('rejects an invalid libc at runtime', () => {
-    expect(() => getSpec('java', 'uclibc' as ServerlessLibc)).toThrow('Unsupported libc')
+  test('rejects unsupported user input', () => {
+    expect(() => getSpec('go' as Language)).toThrow('Unsupported language')
+    expect(() => getSpec('java', 'uclibc' as Libc)).toThrow('Unsupported libc')
   })
 })

--- a/packages/base/src/helpers/serverless/ssi/env.ts
+++ b/packages/base/src/helpers/serverless/ssi/env.ts
@@ -1,47 +1,101 @@
 export const SINGLE_LANGUAGE_INJECTION_MODE_TAG = '_dd.injection.mode:serverless-single-lang'
 
-export type EnvMergeDirection = 'append' | 'prepend' | 'set-if-absent'
-export type EnvSeparator = ' ' | ':' | ','
-
-export interface EnvFragment {
+type EnvFragmentBase = {
   name: string
   value: string
-  separator?: EnvSeparator
-  direction: EnvMergeDirection
   maxLength?: number
 }
+
+type EnvSeparator = ' ' | ':' | ','
+
+type AppendedEnvFragment = EnvFragmentBase &
+  (
+    | {mode: 'append'; separator?: EnvSeparator; preserveLeadingEmpty?: never}
+    | {mode: 'append'; separator: EnvSeparator; preserveLeadingEmpty: true}
+  )
+
+type PositionedEnvFragment =
+  | AppendedEnvFragment
+  | (EnvFragmentBase & {mode: 'prepend'; separator?: EnvSeparator; preserveLeadingEmpty?: never})
+
+type ScalarEnvFragment = EnvFragmentBase & {
+  mode: 'set-if-absent'
+  separator?: never
+  preserveLeadingEmpty?: never
+}
+
+export type EnvFragment = PositionedEnvFragment | ScalarEnvFragment
+
+export const hasEnvFragment = (currentValue: string | undefined, fragment: EnvFragment): boolean => {
+  if (currentValue === undefined) {
+    return false
+  }
+
+  return fragment.mode === 'set-if-absent'
+    ? currentValue === fragment.value
+    : findRanges(currentValue, fragment).length > 0
+}
+
+export const mergeEnvFragment = (currentValue: string | undefined, fragment: EnvFragment): string => {
+  if (fragment.mode === 'set-if-absent') {
+    if (currentValue && currentValue !== fragment.value) {
+      throw new EnvFragmentConflictError(fragment.name, currentValue, fragment.value)
+    }
+    const value = currentValue || fragment.value
+    assertWithinMaxLength(value, fragment)
+
+    return value
+  }
+
+  const remaining = currentValue === undefined ? undefined : removeExactFragment(currentValue, fragment)
+  let result: string
+  if (!remaining) {
+    result = `${fragment.preserveLeadingEmpty ? fragment.separator : ''}${fragment.value}`
+  } else if (fragment.mode === 'append') {
+    result = `${remaining}${fragment.separator ?? ''}${fragment.value}`
+  } else {
+    result = `${fragment.value}${fragment.separator ?? ''}${remaining}`
+  }
+  assertWithinMaxLength(result, fragment)
+
+  return result
+}
+
+/**
+ * Removes only the exact fragment. Callers must track whether it existed before merging and remove only fragments
+ * they own.
+ */
+export const removeEnvFragment = (currentValue: string | undefined, fragment: EnvFragment): string | undefined => {
+  if (!currentValue) {
+    return undefined
+  }
+  if (fragment.mode === 'set-if-absent') {
+    return currentValue === fragment.value ? undefined : currentValue
+  }
+
+  return removeExactFragment(currentValue, fragment) || undefined
+}
+
+const INJECTION_MODE_TAG_FRAGMENT: EnvFragment = {
+  name: 'DD_TAGS',
+  value: SINGLE_LANGUAGE_INJECTION_MODE_TAG,
+  separator: ',',
+  mode: 'prepend',
+}
+
+export const hasInjectionModeTag = (currentTags: string | undefined): boolean =>
+  hasEnvFragment(currentTags, INJECTION_MODE_TAG_FRAGMENT)
+
+export const mergeInjectionModeTag = (currentTags: string | undefined): string =>
+  mergeEnvFragment(currentTags, INJECTION_MODE_TAG_FRAGMENT)
+
+export const removeInjectionModeTag = (currentTags: string | undefined): string | undefined =>
+  removeEnvFragment(currentTags, INJECTION_MODE_TAG_FRAGMENT)
 
 export class EnvFragmentConflictError extends Error {
   constructor(name: string, currentValue: string, requiredValue: string) {
     super(`${name} is already set to ${JSON.stringify(currentValue)}; expected ${JSON.stringify(requiredValue)}`)
     this.name = 'EnvFragmentConflictError'
-  }
-}
-
-const ENV_NAME_REG_EXP = /^[A-Za-z_][A-Za-z0-9_]*$/
-
-const validateStringValue = (value: string, description: string): void => {
-  if (typeof value !== 'string' || !value || /[\0\r\n]/.test(value)) {
-    throw new Error(`${description} must be a non-empty single-line string`)
-  }
-}
-
-const validateCurrentValue = (value: string | undefined, name: string): void => {
-  if (value !== undefined && (typeof value !== 'string' || /[\0\r\n]/.test(value))) {
-    throw new Error(`Existing value for ${name} must be a single-line string`)
-  }
-}
-
-const validateFragment = (fragment: EnvFragment): void => {
-  if (!ENV_NAME_REG_EXP.test(fragment.name)) {
-    throw new Error(`Invalid environment variable name: ${JSON.stringify(fragment.name)}`)
-  }
-  validateStringValue(fragment.value, `Fragment for ${fragment.name}`)
-  if (fragment.direction === 'set-if-absent' && fragment.separator !== undefined) {
-    throw new Error(`set-if-absent fragment ${fragment.name} cannot have a separator`)
-  }
-  if (fragment.maxLength !== undefined && (!Number.isInteger(fragment.maxLength) || fragment.maxLength <= 0)) {
-    throw new Error(`maxLength for ${fragment.name} must be a positive integer`)
   }
 }
 
@@ -51,30 +105,13 @@ const assertWithinMaxLength = (value: string, fragment: EnvFragment): void => {
   }
 }
 
-const findExactFragmentRanges = (currentValue: string, fragment: EnvFragment): [number, number][] => {
-  const separator = fragment.separator
+const findRanges = (currentValue: string, fragment: PositionedEnvFragment): [number, number][] => {
+  const {separator} = fragment
   if (separator === undefined) {
-    if (fragment.direction === 'append' && fragment.value.startsWith(':')) {
-      const colonDelimitedRanges: [number, number][] = []
-      let searchOffset = 0
-      while (searchOffset <= currentValue.length - fragment.value.length) {
-        const index = currentValue.indexOf(fragment.value, searchOffset)
-        if (index === -1) {
-          break
-        }
-        const end = index + fragment.value.length
-        if (end === currentValue.length || currentValue[end] === ':') {
-          colonDelimitedRanges.push([index, end])
-        }
-        searchOffset = end
-      }
-
-      return colonDelimitedRanges
-    }
-    if (fragment.direction === 'append' && currentValue.endsWith(fragment.value)) {
+    if (fragment.mode === 'append' && currentValue.endsWith(fragment.value)) {
       return [[currentValue.length - fragment.value.length, currentValue.length]]
     }
-    if (fragment.direction === 'prepend' && currentValue.startsWith(fragment.value)) {
+    if (fragment.mode === 'prepend' && currentValue.startsWith(fragment.value)) {
       return [[0, fragment.value.length]]
     }
 
@@ -89,9 +126,9 @@ const findExactFragmentRanges = (currentValue: string, fragment: EnvFragment): [
       break
     }
     const end = index + fragment.value.length
-    const hasStartBoundary = index === 0 || currentValue[index - 1] === separator
-    const hasEndBoundary = end === currentValue.length || currentValue[end] === separator
-    if (hasStartBoundary && hasEndBoundary) {
+    const startsAtBoundary = index === 0 || currentValue[index - 1] === separator
+    const endsAtBoundary = end === currentValue.length || currentValue[end] === separator
+    if (startsAtBoundary && endsAtBoundary) {
       ranges.push([index, end])
     }
     start = end
@@ -100,24 +137,23 @@ const findExactFragmentRanges = (currentValue: string, fragment: EnvFragment): [
   return ranges
 }
 
-const removeRanges = (currentValue: string, fragment: EnvFragment, ranges: [number, number][]): string => {
-  const separator = fragment.separator
-  const expandedRanges = ranges.map(([start, end]): [number, number] => {
-    if (separator === undefined) {
+const removeExactFragment = (currentValue: string, fragment: PositionedEnvFragment): string => {
+  const ranges = findRanges(currentValue, fragment).map(([start, end]): [number, number] => {
+    if (fragment.separator === undefined) {
       return [start, end]
     }
-    if (fragment.direction === 'append') {
-      if (start > 0 && currentValue[start - 1] === separator) {
+    if (fragment.mode === 'append') {
+      if (start > 0 && currentValue[start - 1] === fragment.separator) {
         return [start - 1, end]
       }
-      if (end < currentValue.length && currentValue[end] === separator) {
+      if (end < currentValue.length && currentValue[end] === fragment.separator) {
         return [start, end + 1]
       }
-    } else if (fragment.direction === 'prepend') {
-      if (end < currentValue.length && currentValue[end] === separator) {
+    } else {
+      if (end < currentValue.length && currentValue[end] === fragment.separator) {
         return [start, end + 1]
       }
-      if (start > 0 && currentValue[start - 1] === separator) {
+      if (start > 0 && currentValue[start - 1] === fragment.separator) {
         return [start - 1, end]
       }
     }
@@ -125,103 +161,22 @@ const removeRanges = (currentValue: string, fragment: EnvFragment, ranges: [numb
     return [start, end]
   })
 
-  const mergedRanges: [number, number][] = []
-  for (const range of expandedRanges) {
-    const previous = mergedRanges.at(-1)
+  const merged: [number, number][] = []
+  for (const range of ranges) {
+    const previous = merged.at(-1)
     if (previous && range[0] <= previous[1]) {
       previous[1] = Math.max(previous[1], range[1])
     } else {
-      mergedRanges.push([...range])
+      merged.push([...range])
     }
   }
 
   let result = ''
   let offset = 0
-  for (const [start, end] of mergedRanges) {
+  for (const [start, end] of merged) {
     result += currentValue.slice(offset, start)
     offset = end
   }
 
   return result + currentValue.slice(offset)
 }
-
-const removeExactFragments = (currentValue: string, fragment: EnvFragment): string => {
-  return removeRanges(currentValue, fragment, findExactFragmentRanges(currentValue, fragment))
-}
-
-export const hasEnvFragment = (currentValue: string | undefined, fragment: EnvFragment): boolean => {
-  validateFragment(fragment)
-  validateCurrentValue(currentValue, fragment.name)
-  if (currentValue === undefined) {
-    return false
-  }
-
-  return fragment.direction === 'set-if-absent'
-    ? currentValue === fragment.value
-    : findExactFragmentRanges(currentValue, fragment).length > 0
-}
-
-export const mergeEnvFragment = (currentValue: string | undefined, fragment: EnvFragment): string => {
-  validateFragment(fragment)
-  validateCurrentValue(currentValue, fragment.name)
-
-  if (fragment.direction === 'set-if-absent') {
-    if (currentValue && currentValue !== fragment.value) {
-      throw new EnvFragmentConflictError(fragment.name, currentValue, fragment.value)
-    }
-    const scalarValue = currentValue || fragment.value
-    assertWithinMaxLength(scalarValue, fragment)
-
-    return scalarValue
-  }
-
-  const valueWithoutFragment = currentValue === undefined ? undefined : removeExactFragments(currentValue, fragment)
-  let result: string
-  if (!valueWithoutFragment) {
-    result = fragment.value
-  } else if (fragment.direction === 'append') {
-    result = `${valueWithoutFragment}${fragment.separator ?? ''}${fragment.value}`
-  } else {
-    result = `${fragment.value}${fragment.separator ?? ''}${valueWithoutFragment}`
-  }
-  assertWithinMaxLength(result, fragment)
-
-  return result
-}
-
-/**
- * Removes exact values described by the fragment only. Callers must track whether a matching value pre-existed
- * before merging and call this helper only for values they own.
- */
-export const removeEnvFragment = (currentValue: string | undefined, fragment: EnvFragment): string | undefined => {
-  validateFragment(fragment)
-  validateCurrentValue(currentValue, fragment.name)
-  if (!currentValue) {
-    return undefined
-  }
-  if (fragment.direction === 'set-if-absent') {
-    return currentValue === fragment.value ? undefined : currentValue
-  }
-
-  return removeExactFragments(currentValue, fragment) || undefined
-}
-
-const INJECTION_MODE_TAG_FRAGMENT: EnvFragment = {
-  name: 'DD_TAGS',
-  value: SINGLE_LANGUAGE_INJECTION_MODE_TAG,
-  separator: ',',
-  direction: 'prepend',
-}
-
-export const hasInjectionModeTag = (currentTags: string | undefined): boolean =>
-  hasEnvFragment(currentTags, INJECTION_MODE_TAG_FRAGMENT)
-
-export const mergeInjectionModeTag = (currentTags: string | undefined): string =>
-  mergeEnvFragment(currentTags, INJECTION_MODE_TAG_FRAGMENT)
-
-/**
- * Removes the exact Single-Language injection mode tag only. Callers must track whether the tag pre-existed
- * before merging and call this helper only for a tag they own.
- */
-export const removeInjectionModeTag = (currentTags: string | undefined): string | undefined =>
-  removeEnvFragment(currentTags, INJECTION_MODE_TAG_FRAGMENT)

--- a/packages/base/src/helpers/serverless/ssi/env.ts
+++ b/packages/base/src/helpers/serverless/ssi/env.ts
@@ -24,8 +24,24 @@ type ScalarEnvFragment = EnvFragmentBase & {
   preserveLeadingEmpty?: never
 }
 
+/**
+ * An environment value owned by instrumentation. `mode` controls placement, `separator` defines exact entry
+ * boundaries, and `maxLength` limits the merged value in bytes. `preserveLeadingEmpty` retains the default entry in
+ * path lists such as `PHP_INI_SCAN_DIR`.
+ */
 export type EnvFragment = PositionedEnvFragment | ScalarEnvFragment
 
+/**
+ * Checks whether an environment variable contains the exact owned fragment.
+ *
+ * @example
+ * hasEnvFragment('--inspect --require /datadog-lib/node_modules/dd-trace/init.js', {
+ *   name: 'NODE_OPTIONS',
+ *   value: '--require /datadog-lib/node_modules/dd-trace/init.js',
+ *   separator: ' ',
+ *   mode: 'append',
+ * }) // true
+ */
 export const hasEnvFragment = (currentValue: string | undefined, fragment: EnvFragment): boolean => {
   if (currentValue === undefined) {
     return false
@@ -36,6 +52,26 @@ export const hasEnvFragment = (currentValue: string | undefined, fragment: EnvFr
     : findRanges(currentValue, fragment).length > 0
 }
 
+/**
+ * Adds an owned fragment once in its configured position.
+ *
+ * @example
+ * mergeEnvFragment('--inspect', {
+ *   name: 'NODE_OPTIONS',
+ *   value: '--require /datadog-lib/node_modules/dd-trace/init.js',
+ *   separator: ' ',
+ *   mode: 'append',
+ * }) // '--inspect --require /datadog-lib/node_modules/dd-trace/init.js'
+ *
+ * @example
+ * mergeEnvFragment(undefined, {
+ *   name: 'PHP_INI_SCAN_DIR',
+ *   value: '/datadog-lib/linux-gnu/loader',
+ *   separator: ':',
+ *   mode: 'append',
+ *   preserveLeadingEmpty: true,
+ * }) // ':/datadog-lib/linux-gnu/loader'
+ */
 export const mergeEnvFragment = (currentValue: string | undefined, fragment: EnvFragment): string => {
   if (fragment.mode === 'set-if-absent') {
     if (currentValue && currentValue !== fragment.value) {
@@ -48,22 +84,22 @@ export const mergeEnvFragment = (currentValue: string | undefined, fragment: Env
   }
 
   const remaining = currentValue === undefined ? undefined : removeExactFragment(currentValue, fragment)
-  let result: string
-  if (!remaining) {
-    result = `${fragment.preserveLeadingEmpty ? fragment.separator : ''}${fragment.value}`
-  } else if (fragment.mode === 'append') {
-    result = `${remaining}${fragment.separator ?? ''}${fragment.value}`
-  } else {
-    result = `${fragment.value}${fragment.separator ?? ''}${remaining}`
-  }
+  const result = mergePositionedFragment(remaining, fragment)
   assertWithinMaxLength(result, fragment)
 
   return result
 }
 
 /**
- * Removes only the exact fragment. Callers must track whether it existed before merging and remove only fragments
- * they own.
+ * Removes an exact fragment. Only remove fragments owned by the caller.
+ *
+ * @example
+ * removeEnvFragment('--inspect --require /datadog-lib/node_modules/dd-trace/init.js', {
+ *   name: 'NODE_OPTIONS',
+ *   value: '--require /datadog-lib/node_modules/dd-trace/init.js',
+ *   separator: ' ',
+ *   mode: 'append',
+ * }) // '--inspect'
  */
 export const removeEnvFragment = (currentValue: string | undefined, fragment: EnvFragment): string | undefined => {
   if (!currentValue) {
@@ -105,7 +141,24 @@ const assertWithinMaxLength = (value: string, fragment: EnvFragment): void => {
   }
 }
 
-const findRanges = (currentValue: string, fragment: PositionedEnvFragment): [number, number][] => {
+const mergePositionedFragment = (currentValue: string | undefined, fragment: PositionedEnvFragment): string => {
+  if (!currentValue) {
+    return `${fragment.preserveLeadingEmpty ? fragment.separator : ''}${fragment.value}`
+  }
+
+  switch (fragment.mode) {
+    case 'append':
+      return `${currentValue}${fragment.separator ?? ''}${fragment.value}`
+    case 'prepend':
+      return `${fragment.value}${fragment.separator ?? ''}${currentValue}`
+  }
+}
+
+type Range = readonly [start: number, end: number]
+
+const escapeRegExp = (value: string): string => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+
+const findRanges = (currentValue: string, fragment: PositionedEnvFragment): Range[] => {
   const {separator} = fragment
   if (separator === undefined) {
     if (fragment.mode === 'append' && currentValue.endsWith(fragment.value)) {
@@ -118,65 +171,57 @@ const findRanges = (currentValue: string, fragment: PositionedEnvFragment): [num
     return []
   }
 
-  const ranges: [number, number][] = []
-  let start = 0
-  while (start <= currentValue.length - fragment.value.length) {
-    const index = currentValue.indexOf(fragment.value, start)
-    if (index === -1) {
-      break
-    }
-    const end = index + fragment.value.length
-    const startsAtBoundary = index === 0 || currentValue[index - 1] === separator
-    const endsAtBoundary = end === currentValue.length || currentValue[end] === separator
-    if (startsAtBoundary && endsAtBoundary) {
-      ranges.push([index, end])
-    }
-    start = end
-  }
+  const pattern = new RegExp(`(^|${escapeRegExp(separator)})(${escapeRegExp(fragment.value)})(?=${separator}|$)`, 'g')
 
-  return ranges
+  return [...currentValue.matchAll(pattern)].map((match): Range => {
+    const start = match.index! + match[1].length
+
+    return [start, start + fragment.value.length]
+  })
 }
 
-const removeExactFragment = (currentValue: string, fragment: PositionedEnvFragment): string => {
-  const ranges = findRanges(currentValue, fragment).map(([start, end]): [number, number] => {
-    if (fragment.separator === undefined) {
-      return [start, end]
-    }
-    if (fragment.mode === 'append') {
-      if (start > 0 && currentValue[start - 1] === fragment.separator) {
-        return [start - 1, end]
-      }
-      if (end < currentValue.length && currentValue[end] === fragment.separator) {
-        return [start, end + 1]
-      }
-    } else {
-      if (end < currentValue.length && currentValue[end] === fragment.separator) {
-        return [start, end + 1]
-      }
-      if (start > 0 && currentValue[start - 1] === fragment.separator) {
-        return [start - 1, end]
-      }
-    }
-
+const expandRange = (currentValue: string, fragment: PositionedEnvFragment, [start, end]: Range): Range => {
+  const {separator} = fragment
+  if (separator === undefined) {
     return [start, end]
-  })
+  }
 
-  const merged: [number, number][] = []
-  for (const range of ranges) {
-    const previous = merged.at(-1)
-    if (previous && range[0] <= previous[1]) {
-      previous[1] = Math.max(previous[1], range[1])
-    } else {
-      merged.push([...range])
+  const canRemoveBefore = start > 0 && currentValue[start - 1] === separator
+  const canRemoveAfter = end < currentValue.length && currentValue[end] === separator
+
+  if (fragment.mode === 'append') {
+    if (canRemoveBefore) {
+      return [start - 1, end]
+    }
+    if (canRemoveAfter) {
+      return [start, end + 1]
+    }
+  } else {
+    if (canRemoveAfter) {
+      return [start, end + 1]
+    }
+    if (canRemoveBefore) {
+      return [start - 1, end]
     }
   }
 
-  let result = ''
-  let offset = 0
-  for (const [start, end] of merged) {
-    result += currentValue.slice(offset, start)
-    offset = end
-  }
+  return [start, end]
+}
 
-  return result + currentValue.slice(offset)
+const mergeRanges = (ranges: Range[]): Range[] =>
+  ranges.reduce<Range[]>((merged, range) => {
+    const previous = merged.at(-1)
+
+    return previous && range[0] <= previous[1]
+      ? [...merged.slice(0, -1), [previous[0], Math.max(previous[1], range[1])]]
+      : [...merged, range]
+  }, [])
+
+const removeExactFragment = (currentValue: string, fragment: PositionedEnvFragment): string => {
+  const ranges = mergeRanges(
+    findRanges(currentValue, fragment).map((range) => expandRange(currentValue, fragment, range))
+  )
+  const parts = ranges.map(([start], index) => currentValue.slice(index === 0 ? 0 : ranges[index - 1][1], start))
+
+  return [...parts, currentValue.slice(ranges.at(-1)?.[1] ?? 0)].join('')
 }

--- a/packages/base/src/helpers/serverless/ssi/env.ts
+++ b/packages/base/src/helpers/serverless/ssi/env.ts
@@ -208,19 +208,18 @@ const expandRange = (currentValue: string, fragment: PositionedEnvFragment, [sta
   return [start, end]
 }
 
-const mergeRanges = (ranges: Range[]): Range[] =>
+const mergeRanges = (ranges: Range[], maxGap = 0): Range[] =>
   ranges.reduce<Range[]>((merged, range) => {
     const previous = merged.at(-1)
 
-    return previous && range[0] <= previous[1]
+    return previous && range[0] <= previous[1] + maxGap
       ? [...merged.slice(0, -1), [previous[0], Math.max(previous[1], range[1])]]
       : [...merged, range]
   }, [])
 
 const removeExactFragment = (currentValue: string, fragment: PositionedEnvFragment): string => {
-  const ranges = mergeRanges(
-    findRanges(currentValue, fragment).map((range) => expandRange(currentValue, fragment, range))
-  )
+  const fragmentRuns = mergeRanges(findRanges(currentValue, fragment), fragment.separator?.length)
+  const ranges = mergeRanges(fragmentRuns.map((range) => expandRange(currentValue, fragment, range)))
   const parts = ranges.map(([start], index) => currentValue.slice(index === 0 ? 0 : ranges[index - 1][1], start))
 
   return [...parts, currentValue.slice(ranges.at(-1)?.[1] ?? 0)].join('')

--- a/packages/base/src/helpers/serverless/ssi/env.ts
+++ b/packages/base/src/helpers/serverless/ssi/env.ts
@@ -1,0 +1,227 @@
+export const SINGLE_LANGUAGE_INJECTION_MODE_TAG = '_dd.injection.mode:serverless-single-lang'
+
+export type EnvMergeDirection = 'append' | 'prepend' | 'set-if-absent'
+export type EnvSeparator = ' ' | ':' | ','
+
+export interface EnvFragment {
+  name: string
+  value: string
+  separator?: EnvSeparator
+  direction: EnvMergeDirection
+  maxLength?: number
+}
+
+export class EnvFragmentConflictError extends Error {
+  constructor(name: string, currentValue: string, requiredValue: string) {
+    super(`${name} is already set to ${JSON.stringify(currentValue)}; expected ${JSON.stringify(requiredValue)}`)
+    this.name = 'EnvFragmentConflictError'
+  }
+}
+
+const ENV_NAME_REG_EXP = /^[A-Za-z_][A-Za-z0-9_]*$/
+
+const validateStringValue = (value: string, description: string): void => {
+  if (typeof value !== 'string' || !value || /[\0\r\n]/.test(value)) {
+    throw new Error(`${description} must be a non-empty single-line string`)
+  }
+}
+
+const validateCurrentValue = (value: string | undefined, name: string): void => {
+  if (value !== undefined && (typeof value !== 'string' || /[\0\r\n]/.test(value))) {
+    throw new Error(`Existing value for ${name} must be a single-line string`)
+  }
+}
+
+const validateFragment = (fragment: EnvFragment): void => {
+  if (!ENV_NAME_REG_EXP.test(fragment.name)) {
+    throw new Error(`Invalid environment variable name: ${JSON.stringify(fragment.name)}`)
+  }
+  validateStringValue(fragment.value, `Fragment for ${fragment.name}`)
+  if (fragment.direction === 'set-if-absent' && fragment.separator !== undefined) {
+    throw new Error(`set-if-absent fragment ${fragment.name} cannot have a separator`)
+  }
+  if (fragment.maxLength !== undefined && (!Number.isInteger(fragment.maxLength) || fragment.maxLength <= 0)) {
+    throw new Error(`maxLength for ${fragment.name} must be a positive integer`)
+  }
+}
+
+const assertWithinMaxLength = (value: string, fragment: EnvFragment): void => {
+  if (fragment.maxLength !== undefined && Buffer.byteLength(value) > fragment.maxLength) {
+    throw new Error(`${fragment.name} exceeds its ${fragment.maxLength}-byte limit`)
+  }
+}
+
+const findExactFragmentRanges = (currentValue: string, fragment: EnvFragment): [number, number][] => {
+  const separator = fragment.separator
+  if (separator === undefined) {
+    if (fragment.direction === 'append' && fragment.value.startsWith(':')) {
+      const colonDelimitedRanges: [number, number][] = []
+      let searchOffset = 0
+      while (searchOffset <= currentValue.length - fragment.value.length) {
+        const index = currentValue.indexOf(fragment.value, searchOffset)
+        if (index === -1) {
+          break
+        }
+        const end = index + fragment.value.length
+        if (end === currentValue.length || currentValue[end] === ':') {
+          colonDelimitedRanges.push([index, end])
+        }
+        searchOffset = end
+      }
+
+      return colonDelimitedRanges
+    }
+    if (fragment.direction === 'append' && currentValue.endsWith(fragment.value)) {
+      return [[currentValue.length - fragment.value.length, currentValue.length]]
+    }
+    if (fragment.direction === 'prepend' && currentValue.startsWith(fragment.value)) {
+      return [[0, fragment.value.length]]
+    }
+
+    return []
+  }
+
+  const ranges: [number, number][] = []
+  let start = 0
+  while (start <= currentValue.length - fragment.value.length) {
+    const index = currentValue.indexOf(fragment.value, start)
+    if (index === -1) {
+      break
+    }
+    const end = index + fragment.value.length
+    const hasStartBoundary = index === 0 || currentValue[index - 1] === separator
+    const hasEndBoundary = end === currentValue.length || currentValue[end] === separator
+    if (hasStartBoundary && hasEndBoundary) {
+      ranges.push([index, end])
+    }
+    start = end
+  }
+
+  return ranges
+}
+
+const removeRanges = (currentValue: string, fragment: EnvFragment, ranges: [number, number][]): string => {
+  const separator = fragment.separator
+  const expandedRanges = ranges.map(([start, end]): [number, number] => {
+    if (separator === undefined) {
+      return [start, end]
+    }
+    if (fragment.direction === 'append') {
+      if (start > 0 && currentValue[start - 1] === separator) {
+        return [start - 1, end]
+      }
+      if (end < currentValue.length && currentValue[end] === separator) {
+        return [start, end + 1]
+      }
+    } else if (fragment.direction === 'prepend') {
+      if (end < currentValue.length && currentValue[end] === separator) {
+        return [start, end + 1]
+      }
+      if (start > 0 && currentValue[start - 1] === separator) {
+        return [start - 1, end]
+      }
+    }
+
+    return [start, end]
+  })
+
+  const mergedRanges: [number, number][] = []
+  for (const range of expandedRanges) {
+    const previous = mergedRanges.at(-1)
+    if (previous && range[0] <= previous[1]) {
+      previous[1] = Math.max(previous[1], range[1])
+    } else {
+      mergedRanges.push([...range])
+    }
+  }
+
+  let result = ''
+  let offset = 0
+  for (const [start, end] of mergedRanges) {
+    result += currentValue.slice(offset, start)
+    offset = end
+  }
+
+  return result + currentValue.slice(offset)
+}
+
+const removeExactFragments = (currentValue: string, fragment: EnvFragment): string => {
+  return removeRanges(currentValue, fragment, findExactFragmentRanges(currentValue, fragment))
+}
+
+export const hasEnvFragment = (currentValue: string | undefined, fragment: EnvFragment): boolean => {
+  validateFragment(fragment)
+  validateCurrentValue(currentValue, fragment.name)
+  if (currentValue === undefined) {
+    return false
+  }
+
+  return fragment.direction === 'set-if-absent'
+    ? currentValue === fragment.value
+    : findExactFragmentRanges(currentValue, fragment).length > 0
+}
+
+export const mergeEnvFragment = (currentValue: string | undefined, fragment: EnvFragment): string => {
+  validateFragment(fragment)
+  validateCurrentValue(currentValue, fragment.name)
+
+  if (fragment.direction === 'set-if-absent') {
+    if (currentValue && currentValue !== fragment.value) {
+      throw new EnvFragmentConflictError(fragment.name, currentValue, fragment.value)
+    }
+    const scalarValue = currentValue || fragment.value
+    assertWithinMaxLength(scalarValue, fragment)
+
+    return scalarValue
+  }
+
+  const valueWithoutFragment = currentValue === undefined ? undefined : removeExactFragments(currentValue, fragment)
+  let result: string
+  if (!valueWithoutFragment) {
+    result = fragment.value
+  } else if (fragment.direction === 'append') {
+    result = `${valueWithoutFragment}${fragment.separator ?? ''}${fragment.value}`
+  } else {
+    result = `${fragment.value}${fragment.separator ?? ''}${valueWithoutFragment}`
+  }
+  assertWithinMaxLength(result, fragment)
+
+  return result
+}
+
+/**
+ * Removes exact values described by the fragment only. Callers must track whether a matching value pre-existed
+ * before merging and call this helper only for values they own.
+ */
+export const removeEnvFragment = (currentValue: string | undefined, fragment: EnvFragment): string | undefined => {
+  validateFragment(fragment)
+  validateCurrentValue(currentValue, fragment.name)
+  if (!currentValue) {
+    return undefined
+  }
+  if (fragment.direction === 'set-if-absent') {
+    return currentValue === fragment.value ? undefined : currentValue
+  }
+
+  return removeExactFragments(currentValue, fragment) || undefined
+}
+
+const INJECTION_MODE_TAG_FRAGMENT: EnvFragment = {
+  name: 'DD_TAGS',
+  value: SINGLE_LANGUAGE_INJECTION_MODE_TAG,
+  separator: ',',
+  direction: 'prepend',
+}
+
+export const hasInjectionModeTag = (currentTags: string | undefined): boolean =>
+  hasEnvFragment(currentTags, INJECTION_MODE_TAG_FRAGMENT)
+
+export const mergeInjectionModeTag = (currentTags: string | undefined): string =>
+  mergeEnvFragment(currentTags, INJECTION_MODE_TAG_FRAGMENT)
+
+/**
+ * Removes the exact Single-Language injection mode tag only. Callers must track whether the tag pre-existed
+ * before merging and call this helper only for a tag they own.
+ */
+export const removeInjectionModeTag = (currentTags: string | undefined): string | undefined =>
+  removeEnvFragment(currentTags, INJECTION_MODE_TAG_FRAGMENT)

--- a/packages/base/src/helpers/serverless/ssi/injection-spec.ts
+++ b/packages/base/src/helpers/serverless/ssi/injection-spec.ts
@@ -1,0 +1,200 @@
+import type {EnvFragment} from './env'
+
+import {
+  LANGUAGE_METADATA,
+  buildSingleLanguageTracerImage,
+  type CanonicalTracerLanguage,
+  type ServerlessLanguage,
+  type SingleLanguageTracerRegistry,
+} from './tracer'
+
+export const DEFAULT_SINGLE_LANGUAGE_TRACER_ROOT = '/datadog-lib'
+
+export type ServerlessLibc = 'glibc' | 'musl'
+
+/** Each entry is a set of alternative paths. At least one path in every entry must exist. */
+export type RequiredFileAlternatives = readonly [string, ...string[]]
+
+export interface SingleLanguageInjectionSpec {
+  language: ServerlessLanguage
+  canonicalLanguage: CanonicalTracerLanguage
+  repository: string
+  image: string
+  requiredFiles: RequiredFileAlternatives[]
+  env: EnvFragment[]
+}
+
+export interface SingleLanguageInjectionOptions {
+  language: ServerlessLanguage
+  registry: SingleLanguageTracerRegistry
+  version: string
+  libc: ServerlessLibc
+  root?: string
+}
+
+const LIBC_VALUES: readonly ServerlessLibc[] = ['glibc', 'musl']
+
+const validateStringValue = (value: string, description: string): void => {
+  if (typeof value !== 'string' || !value || /[\0\r\n]/.test(value)) {
+    throw new Error(`${description} must be a non-empty single-line string`)
+  }
+}
+
+const normalizeRoot = (root: string): string => {
+  validateStringValue(root, 'Tracer root')
+  if (
+    !root.startsWith('/') ||
+    /\s/.test(root) ||
+    (root !== '/' && root.includes('//')) ||
+    root.split('/').some((part) => part === '.' || part === '..')
+  ) {
+    throw new Error(
+      `Tracer root must be an absolute path without whitespace or relative segments: ${JSON.stringify(root)}`
+    )
+  }
+
+  return root === '/' ? root : root.replace(/\/+$/, '')
+}
+
+const pathInRoot = (root: string, path: string): string => `${root === '/' ? '' : root}/${path}`
+
+const getRuntimeVersionAgnosticJavaEnv = (root: string): EnvFragment[] => [
+  {
+    name: 'JAVA_TOOL_OPTIONS',
+    value: `-javaagent:${pathInRoot(root, 'dd-java-agent.jar')} -XX:+IgnoreUnrecognizedVMOptions`,
+    separator: ' ',
+    direction: 'append',
+  },
+]
+
+const assertArchitectureNeutralDotnetLayout = (language: ServerlessLanguage, version: string): void => {
+  if (language !== 'csharp') {
+    return
+  }
+
+  const pinnedMajor = version.match(/^v?(\d+)(?:\.|$)/)?.[1]
+  if (pinnedMajor !== undefined && Number(pinnedMajor) < 3) {
+    throw new Error(
+      `Unsupported .NET tracer version ${JSON.stringify(version)}: versions before 3.0 require architecture-specific package paths`
+    )
+  }
+}
+
+const getDotnetEnv = (root: string): EnvFragment[] => [
+  {name: 'CORECLR_ENABLE_PROFILING', value: '1', direction: 'set-if-absent'},
+  {
+    name: 'CORECLR_PROFILER',
+    value: '{846F5F1C-F9AE-4B07-969E-05C26BC060D8}',
+    direction: 'set-if-absent',
+  },
+  {
+    name: 'CORECLR_PROFILER_PATH',
+    value: pathInRoot(root, 'Datadog.Trace.ClrProfiler.Native.so'),
+    direction: 'set-if-absent',
+  },
+  {name: 'DD_DOTNET_TRACER_HOME', value: root, direction: 'set-if-absent'},
+  {
+    name: 'LD_PRELOAD',
+    value: pathInRoot(root, 'continuousprofiler/Datadog.Linux.ApiWrapper.x64.so'),
+    separator: ' ',
+    direction: 'prepend',
+    maxLength: 1024,
+  },
+]
+
+const getLanguageFilesAndEnv = (
+  language: ServerlessLanguage,
+  libc: ServerlessLibc,
+  root: string
+): Pick<SingleLanguageInjectionSpec, 'requiredFiles' | 'env'> => {
+  switch (language) {
+    case 'java':
+      return {
+        requiredFiles: [[pathInRoot(root, 'dd-java-agent.jar')]],
+        env: getRuntimeVersionAgnosticJavaEnv(root),
+      }
+    case 'nodejs':
+      return {
+        requiredFiles: [[pathInRoot(root, 'node_modules/dd-trace/init.js')]],
+        env: [
+          {
+            name: 'NODE_OPTIONS',
+            value: `--require ${pathInRoot(root, 'node_modules/dd-trace/init.js')}`,
+            separator: ' ',
+            direction: 'append',
+          },
+        ],
+      }
+    case 'csharp':
+      return {
+        requiredFiles: [
+          [pathInRoot(root, 'Datadog.Trace.ClrProfiler.Native.so')],
+          [pathInRoot(root, 'continuousprofiler/Datadog.Linux.ApiWrapper.x64.so')],
+        ],
+        env: getDotnetEnv(root),
+      }
+    case 'python':
+      return {
+        requiredFiles: [[pathInRoot(root, 'sitecustomize.py')]],
+        env: [
+          {
+            name: 'PYTHONPATH',
+            value: root,
+            separator: ':',
+            direction: 'append',
+          },
+        ],
+      }
+    case 'ruby':
+      return {
+        requiredFiles: [[pathInRoot(root, 'auto_inject.rb')]],
+        env: [
+          {
+            name: 'RUBYOPT',
+            value: `-r${pathInRoot(root, 'auto_inject')}`,
+            separator: ' ',
+            direction: 'prepend',
+          },
+        ],
+      }
+    case 'php': {
+      const loaderRoot = pathInRoot(root, `linux-${libc === 'glibc' ? 'gnu' : 'musl'}/loader`)
+
+      return {
+        requiredFiles: [[`${loaderRoot}/dd_library_loader.ini`], [`${loaderRoot}/dd_library_loader.so`]],
+        env: [
+          {name: 'PHP_INI_SCAN_DIR', value: `:${loaderRoot}`, direction: 'append'},
+          {name: 'DD_LOADER_PACKAGE_PATH', value: root, direction: 'set-if-absent'},
+        ],
+      }
+    }
+  }
+}
+
+export const getSingleLanguageInjectionSpec = (
+  options: SingleLanguageInjectionOptions
+): SingleLanguageInjectionSpec => {
+  const metadata = LANGUAGE_METADATA[options.language]
+  if (!metadata) {
+    throw new Error(`Unsupported serverless language: ${String(options.language)}`)
+  }
+  if (!LIBC_VALUES.includes(options.libc)) {
+    throw new Error(`Unsupported libc: ${String(options.libc)}`)
+  }
+  if (options.language === 'ruby' && options.libc === 'musl') {
+    throw new Error('Ruby Single-Language SSI does not support musl')
+  }
+
+  const root = normalizeRoot(options.root ?? DEFAULT_SINGLE_LANGUAGE_TRACER_ROOT)
+  const image = buildSingleLanguageTracerImage(options.registry, metadata.canonicalLanguage, options.version)
+  assertArchitectureNeutralDotnetLayout(options.language, options.version)
+  const languageSpec = getLanguageFilesAndEnv(options.language, options.libc, root)
+
+  return {
+    language: options.language,
+    canonicalLanguage: metadata.canonicalLanguage,
+    repository: metadata.repository,
+    image,
+    ...languageSpec,
+  }
+}

--- a/packages/base/src/helpers/serverless/ssi/injection-spec.ts
+++ b/packages/base/src/helpers/serverless/ssi/injection-spec.ts
@@ -43,98 +43,109 @@ export const getLanguageInjectionSpec = (options: LanguageInjectionOptions): Lan
   const root = options.root ?? DEFAULT_TRACER_ROOT
   const image = buildSingleLanguageTracerImage(options.registry, options.language, options.version)
 
-  return {image, ...LANGUAGE_SPECS[options.language](root, options.libc)}
+  return {image, ...LANGUAGE_CONFIG[options.language].getSpec(root, options.libc)}
 }
 
 /** Returns a domain compatibility error after individual CLI arguments have been validated. */
-export const getLanguageCompatibilityError = (options: LanguageCompatibilityOptions): string | undefined => {
-  if (options.language === 'ruby' && options.libc === 'musl') {
-    return 'Ruby Single-Language SSI does not support musl'
-  }
-  if (options.language !== 'csharp') {
-    return undefined
-  }
+export const getLanguageCompatibilityError = (options: LanguageCompatibilityOptions): string | undefined =>
+  LANGUAGE_CONFIG[options.language].getCompatibilityError?.(options)
 
-  const pinnedMajor = options.version.match(/^v?(\d+)(?:\.|$)/)?.[1]
-
-  return pinnedMajor !== undefined && Number(pinnedMajor) < 3
-    ? `Unsupported .NET tracer version ${JSON.stringify(options.version)}: versions before 3.0 require architecture-specific package paths`
-    : undefined
+type LanguageConfig = {
+  getSpec: (root: string, libc: Libc) => Pick<LanguageInjectionSpec, 'artifacts' | 'env'>
+  getCompatibilityError?: (options: Omit<LanguageCompatibilityOptions, 'language'>) => string | undefined
 }
 
-type SpecFactory = (root: string, libc: Libc) => Pick<LanguageInjectionSpec, 'artifacts' | 'env'>
-
-const LANGUAGE_SPECS = {
-  java: (root) => ({
-    artifacts: [[path.posix.join(root, 'dd-java-agent.jar')]],
-    env: [
-      {
-        name: 'JAVA_TOOL_OPTIONS',
-        value: `-javaagent:${path.posix.join(root, 'dd-java-agent.jar')} -XX:+IgnoreUnrecognizedVMOptions`,
-        separator: ' ',
-        mode: 'append',
-      },
-    ],
-  }),
-  nodejs: (root) => ({
-    artifacts: [[path.posix.join(root, 'node_modules/dd-trace/init.js')]],
-    env: [
-      {
-        name: 'NODE_OPTIONS',
-        value: `--require ${path.posix.join(root, 'node_modules/dd-trace/init.js')}`,
-        separator: ' ',
-        mode: 'append',
-      },
-    ],
-  }),
-  csharp: (root) => ({
-    artifacts: [
-      [path.posix.join(root, 'Datadog.Trace.ClrProfiler.Native.so')],
-      [path.posix.join(root, 'continuousprofiler/Datadog.Linux.ApiWrapper.x64.so')],
-    ],
-    env: getDotnetEnv(root),
-  }),
-  python: (root) => ({
-    artifacts: [[path.posix.join(root, 'sitecustomize.py')]],
-    env: [
-      {
-        name: 'PYTHONPATH',
-        value: root,
-        separator: ':',
-        mode: 'append',
-      },
-    ],
-  }),
-  ruby: (root) => ({
-    artifacts: [[path.posix.join(root, 'auto_inject.rb')]],
-    env: [
-      {
-        name: 'RUBYOPT',
-        value: `-r${path.posix.join(root, 'auto_inject')}`,
-        separator: ' ',
-        mode: 'prepend',
-      },
-    ],
-  }),
-  php: (root, libc) => {
-    const platform = libc === 'glibc' ? 'linux-gnu' : 'linux-musl'
-    const loader = path.posix.join(root, `${platform}/loader`)
-
-    return {
-      artifacts: [[`${loader}/dd_library_loader.ini`], [`${loader}/dd_library_loader.so`]],
+const LANGUAGE_CONFIG: Record<Language, LanguageConfig> = {
+  java: {
+    getSpec: (root) => ({
+      artifacts: [[path.posix.join(root, 'dd-java-agent.jar')]],
       env: [
         {
-          name: 'PHP_INI_SCAN_DIR',
-          value: loader,
+          name: 'JAVA_TOOL_OPTIONS',
+          value: `-javaagent:${path.posix.join(root, 'dd-java-agent.jar')} -XX:+IgnoreUnrecognizedVMOptions`,
+          separator: ' ',
+          mode: 'append',
+        },
+      ],
+    }),
+  },
+  nodejs: {
+    getSpec: (root) => ({
+      artifacts: [[path.posix.join(root, 'node_modules/dd-trace/init.js')]],
+      env: [
+        {
+          name: 'NODE_OPTIONS',
+          value: `--require ${path.posix.join(root, 'node_modules/dd-trace/init.js')}`,
+          separator: ' ',
+          mode: 'append',
+        },
+      ],
+    }),
+  },
+  csharp: {
+    getSpec: (root) => ({
+      artifacts: [
+        [path.posix.join(root, 'Datadog.Trace.ClrProfiler.Native.so')],
+        [path.posix.join(root, 'continuousprofiler/Datadog.Linux.ApiWrapper.x64.so')],
+      ],
+      env: getDotnetEnv(root),
+    }),
+    getCompatibilityError: ({version}) => {
+      const pinnedMajor = version.match(/^v?(\d+)(?:\.|$)/)?.[1]
+
+      return pinnedMajor !== undefined && Number(pinnedMajor) < 3
+        ? `Unsupported .NET tracer version ${JSON.stringify(version)}: versions before 3.0 require architecture-specific package paths`
+        : undefined
+    },
+  },
+  python: {
+    getSpec: (root) => ({
+      artifacts: [[path.posix.join(root, 'sitecustomize.py')]],
+      env: [
+        {
+          name: 'PYTHONPATH',
+          value: root,
           separator: ':',
           mode: 'append',
-          preserveLeadingEmpty: true,
         },
-        {name: 'DD_LOADER_PACKAGE_PATH', value: root, mode: 'set-if-absent'},
       ],
-    }
+    }),
   },
-} satisfies Record<Language, SpecFactory>
+  ruby: {
+    getSpec: (root) => ({
+      artifacts: [[path.posix.join(root, 'auto_inject.rb')]],
+      env: [
+        {
+          name: 'RUBYOPT',
+          value: `-r${path.posix.join(root, 'auto_inject')}`,
+          separator: ' ',
+          mode: 'prepend',
+        },
+      ],
+    }),
+    getCompatibilityError: ({libc}) => (libc === 'musl' ? 'Ruby Single-Language SSI does not support musl' : undefined),
+  },
+  php: {
+    getSpec: (root, libc) => {
+      const platform = libc === 'glibc' ? 'linux-gnu' : 'linux-musl'
+      const loader = path.posix.join(root, `${platform}/loader`)
+
+      return {
+        artifacts: [[`${loader}/dd_library_loader.ini`], [`${loader}/dd_library_loader.so`]],
+        env: [
+          {
+            name: 'PHP_INI_SCAN_DIR',
+            value: loader,
+            separator: ':',
+            mode: 'append',
+            preserveLeadingEmpty: true,
+          },
+          {name: 'DD_LOADER_PACKAGE_PATH', value: root, mode: 'set-if-absent'},
+        ],
+      }
+    },
+  },
+}
 
 const getDotnetEnv = (root: string): EnvFragment[] => [
   {name: 'CORECLR_ENABLE_PROFILING', value: '1', mode: 'set-if-absent'},

--- a/packages/base/src/helpers/serverless/ssi/injection-spec.ts
+++ b/packages/base/src/helpers/serverless/ssi/injection-spec.ts
@@ -1,50 +1,137 @@
 import type {EnvFragment} from './env'
 
-import {
-  LANGUAGE_METADATA,
-  buildSingleLanguageTracerImage,
-  type CanonicalTracerLanguage,
-  type ServerlessLanguage,
-  type SingleLanguageTracerRegistry,
-} from './tracer'
+import {buildSingleLanguageTracerImage, type Language, type SingleLanguageTracerRegistry} from './tracer'
 
-export const DEFAULT_SINGLE_LANGUAGE_TRACER_ROOT = '/datadog-lib'
+export const DEFAULT_TRACER_ROOT = '/datadog-lib'
+export const LIBCS = ['glibc', 'musl'] as const
 
-export type ServerlessLibc = 'glibc' | 'musl'
+export type Libc = (typeof LIBCS)[number]
 
-/** Each entry is a set of alternative paths. At least one path in every entry must exist. */
-export type RequiredFileAlternatives = readonly [string, ...string[]]
+/** Alternative paths for one required artifact; at least one must exist. */
+export type RequiredArtifact = readonly [string, ...string[]]
 
-export interface SingleLanguageInjectionSpec {
-  language: ServerlessLanguage
-  canonicalLanguage: CanonicalTracerLanguage
-  repository: string
-  image: string
-  requiredFiles: RequiredFileAlternatives[]
-  env: EnvFragment[]
+export interface LanguageInjectionSpec {
+  readonly image: string
+  readonly artifacts: readonly RequiredArtifact[]
+  readonly env: readonly EnvFragment[]
 }
 
-export interface SingleLanguageInjectionOptions {
-  language: ServerlessLanguage
-  registry: SingleLanguageTracerRegistry
-  version: string
-  libc: ServerlessLibc
-  root?: string
+export interface LanguageInjectionOptions {
+  readonly language: Language
+  readonly registry: SingleLanguageTracerRegistry
+  readonly version: string
+  readonly libc: Libc
+  readonly root?: string
 }
 
-const LIBC_VALUES: readonly ServerlessLibc[] = ['glibc', 'musl']
-
-const validateStringValue = (value: string, description: string): void => {
-  if (typeof value !== 'string' || !value || /[\0\r\n]/.test(value)) {
-    throw new Error(`${description} must be a non-empty single-line string`)
+/**
+ * Builds the image, required artifacts, and environment for one tracer.
+ *
+ * @example
+ * getLanguageInjectionSpec({
+ *   language: 'nodejs',
+ *   registry: 'gcr.io/datadoghq',
+ *   version: 'latest',
+ *   libc: 'glibc',
+ * })
+ */
+export const getLanguageInjectionSpec = (options: LanguageInjectionOptions): LanguageInjectionSpec => {
+  const buildSpec = LANGUAGE_SPECS[options.language]
+  if (!buildSpec) {
+    throw new Error(`Unsupported language: ${String(options.language)}`)
   }
+  if (!LIBCS.includes(options.libc)) {
+    throw new Error(`Unsupported libc: ${String(options.libc)}`)
+  }
+  if (options.language === 'ruby' && options.libc === 'musl') {
+    throw new Error('Ruby Single-Language SSI does not support musl')
+  }
+
+  const root = normalizeRoot(options.root ?? DEFAULT_TRACER_ROOT)
+  const image = buildSingleLanguageTracerImage(options.registry, options.language, options.version)
+  assertDotnetLayout(options.language, options.version)
+
+  return {image, ...buildSpec(root, options.libc)}
 }
+
+type SpecFactory = (root: string, libc: Libc) => Pick<LanguageInjectionSpec, 'artifacts' | 'env'>
+
+const LANGUAGE_SPECS = {
+  java: (root) => ({
+    artifacts: [[inRoot(root, 'dd-java-agent.jar')]],
+    env: [
+      {
+        name: 'JAVA_TOOL_OPTIONS',
+        value: `-javaagent:${inRoot(root, 'dd-java-agent.jar')} -XX:+IgnoreUnrecognizedVMOptions`,
+        separator: ' ',
+        mode: 'append',
+      },
+    ],
+  }),
+  nodejs: (root) => ({
+    artifacts: [[inRoot(root, 'node_modules/dd-trace/init.js')]],
+    env: [
+      {
+        name: 'NODE_OPTIONS',
+        value: `--require ${inRoot(root, 'node_modules/dd-trace/init.js')}`,
+        separator: ' ',
+        mode: 'append',
+      },
+    ],
+  }),
+  csharp: (root) => ({
+    artifacts: [
+      [inRoot(root, 'Datadog.Trace.ClrProfiler.Native.so')],
+      [inRoot(root, 'continuousprofiler/Datadog.Linux.ApiWrapper.x64.so')],
+    ],
+    env: getDotnetEnv(root),
+  }),
+  python: (root) => ({
+    artifacts: [[inRoot(root, 'sitecustomize.py')]],
+    env: [
+      {
+        name: 'PYTHONPATH',
+        value: root,
+        separator: ':',
+        mode: 'append',
+      },
+    ],
+  }),
+  ruby: (root) => ({
+    artifacts: [[inRoot(root, 'auto_inject.rb')]],
+    env: [
+      {
+        name: 'RUBYOPT',
+        value: `-r${inRoot(root, 'auto_inject')}`,
+        separator: ' ',
+        mode: 'prepend',
+      },
+    ],
+  }),
+  php: (root, libc) => {
+    const platform = libc === 'glibc' ? 'linux-gnu' : 'linux-musl'
+    const loader = inRoot(root, `${platform}/loader`)
+
+    return {
+      artifacts: [[`${loader}/dd_library_loader.ini`], [`${loader}/dd_library_loader.so`]],
+      env: [
+        {
+          name: 'PHP_INI_SCAN_DIR',
+          value: loader,
+          separator: ':',
+          mode: 'append',
+          preserveLeadingEmpty: true,
+        },
+        {name: 'DD_LOADER_PACKAGE_PATH', value: root, mode: 'set-if-absent'},
+      ],
+    }
+  },
+} satisfies Record<Language, SpecFactory>
 
 const normalizeRoot = (root: string): string => {
-  validateStringValue(root, 'Tracer root')
   if (
     !root.startsWith('/') ||
-    /\s/.test(root) ||
+    /[\s\0]/.test(root) ||
     (root !== '/' && root.includes('//')) ||
     root.split('/').some((part) => part === '.' || part === '..')
   ) {
@@ -56,18 +143,9 @@ const normalizeRoot = (root: string): string => {
   return root === '/' ? root : root.replace(/\/+$/, '')
 }
 
-const pathInRoot = (root: string, path: string): string => `${root === '/' ? '' : root}/${path}`
+const inRoot = (root: string, path: string): string => `${root === '/' ? '' : root}/${path}`
 
-const getRuntimeVersionAgnosticJavaEnv = (root: string): EnvFragment[] => [
-  {
-    name: 'JAVA_TOOL_OPTIONS',
-    value: `-javaagent:${pathInRoot(root, 'dd-java-agent.jar')} -XX:+IgnoreUnrecognizedVMOptions`,
-    separator: ' ',
-    direction: 'append',
-  },
-]
-
-const assertArchitectureNeutralDotnetLayout = (language: ServerlessLanguage, version: string): void => {
+const assertDotnetLayout = (language: Language, version: string): void => {
   if (language !== 'csharp') {
     return
   }
@@ -81,120 +159,23 @@ const assertArchitectureNeutralDotnetLayout = (language: ServerlessLanguage, ver
 }
 
 const getDotnetEnv = (root: string): EnvFragment[] => [
-  {name: 'CORECLR_ENABLE_PROFILING', value: '1', direction: 'set-if-absent'},
+  {name: 'CORECLR_ENABLE_PROFILING', value: '1', mode: 'set-if-absent'},
   {
     name: 'CORECLR_PROFILER',
     value: '{846F5F1C-F9AE-4B07-969E-05C26BC060D8}',
-    direction: 'set-if-absent',
+    mode: 'set-if-absent',
   },
   {
     name: 'CORECLR_PROFILER_PATH',
-    value: pathInRoot(root, 'Datadog.Trace.ClrProfiler.Native.so'),
-    direction: 'set-if-absent',
+    value: inRoot(root, 'Datadog.Trace.ClrProfiler.Native.so'),
+    mode: 'set-if-absent',
   },
-  {name: 'DD_DOTNET_TRACER_HOME', value: root, direction: 'set-if-absent'},
+  {name: 'DD_DOTNET_TRACER_HOME', value: root, mode: 'set-if-absent'},
   {
     name: 'LD_PRELOAD',
-    value: pathInRoot(root, 'continuousprofiler/Datadog.Linux.ApiWrapper.x64.so'),
+    value: inRoot(root, 'continuousprofiler/Datadog.Linux.ApiWrapper.x64.so'),
     separator: ' ',
-    direction: 'prepend',
+    mode: 'prepend',
     maxLength: 1024,
   },
 ]
-
-const getLanguageFilesAndEnv = (
-  language: ServerlessLanguage,
-  libc: ServerlessLibc,
-  root: string
-): Pick<SingleLanguageInjectionSpec, 'requiredFiles' | 'env'> => {
-  switch (language) {
-    case 'java':
-      return {
-        requiredFiles: [[pathInRoot(root, 'dd-java-agent.jar')]],
-        env: getRuntimeVersionAgnosticJavaEnv(root),
-      }
-    case 'nodejs':
-      return {
-        requiredFiles: [[pathInRoot(root, 'node_modules/dd-trace/init.js')]],
-        env: [
-          {
-            name: 'NODE_OPTIONS',
-            value: `--require ${pathInRoot(root, 'node_modules/dd-trace/init.js')}`,
-            separator: ' ',
-            direction: 'append',
-          },
-        ],
-      }
-    case 'csharp':
-      return {
-        requiredFiles: [
-          [pathInRoot(root, 'Datadog.Trace.ClrProfiler.Native.so')],
-          [pathInRoot(root, 'continuousprofiler/Datadog.Linux.ApiWrapper.x64.so')],
-        ],
-        env: getDotnetEnv(root),
-      }
-    case 'python':
-      return {
-        requiredFiles: [[pathInRoot(root, 'sitecustomize.py')]],
-        env: [
-          {
-            name: 'PYTHONPATH',
-            value: root,
-            separator: ':',
-            direction: 'append',
-          },
-        ],
-      }
-    case 'ruby':
-      return {
-        requiredFiles: [[pathInRoot(root, 'auto_inject.rb')]],
-        env: [
-          {
-            name: 'RUBYOPT',
-            value: `-r${pathInRoot(root, 'auto_inject')}`,
-            separator: ' ',
-            direction: 'prepend',
-          },
-        ],
-      }
-    case 'php': {
-      const loaderRoot = pathInRoot(root, `linux-${libc === 'glibc' ? 'gnu' : 'musl'}/loader`)
-
-      return {
-        requiredFiles: [[`${loaderRoot}/dd_library_loader.ini`], [`${loaderRoot}/dd_library_loader.so`]],
-        env: [
-          {name: 'PHP_INI_SCAN_DIR', value: `:${loaderRoot}`, direction: 'append'},
-          {name: 'DD_LOADER_PACKAGE_PATH', value: root, direction: 'set-if-absent'},
-        ],
-      }
-    }
-  }
-}
-
-export const getSingleLanguageInjectionSpec = (
-  options: SingleLanguageInjectionOptions
-): SingleLanguageInjectionSpec => {
-  const metadata = LANGUAGE_METADATA[options.language]
-  if (!metadata) {
-    throw new Error(`Unsupported serverless language: ${String(options.language)}`)
-  }
-  if (!LIBC_VALUES.includes(options.libc)) {
-    throw new Error(`Unsupported libc: ${String(options.libc)}`)
-  }
-  if (options.language === 'ruby' && options.libc === 'musl') {
-    throw new Error('Ruby Single-Language SSI does not support musl')
-  }
-
-  const root = normalizeRoot(options.root ?? DEFAULT_SINGLE_LANGUAGE_TRACER_ROOT)
-  const image = buildSingleLanguageTracerImage(options.registry, metadata.canonicalLanguage, options.version)
-  assertArchitectureNeutralDotnetLayout(options.language, options.version)
-  const languageSpec = getLanguageFilesAndEnv(options.language, options.libc, root)
-
-  return {
-    language: options.language,
-    canonicalLanguage: metadata.canonicalLanguage,
-    repository: metadata.repository,
-    image,
-    ...languageSpec,
-  }
-}

--- a/packages/base/src/helpers/serverless/ssi/injection-spec.ts
+++ b/packages/base/src/helpers/serverless/ssi/injection-spec.ts
@@ -1,3 +1,5 @@
+import path from 'node:path'
+
 import type {EnvFragment} from './env'
 
 import {buildSingleLanguageTracerImage, type Language, type SingleLanguageTracerRegistry} from './tracer'
@@ -24,6 +26,8 @@ export interface LanguageInjectionOptions {
   readonly root?: string
 }
 
+export type LanguageCompatibilityOptions = Pick<LanguageInjectionOptions, 'language' | 'libc' | 'version'>
+
 /**
  * Builds the image, required artifacts, and environment for one tracer.
  *
@@ -36,44 +40,48 @@ export interface LanguageInjectionOptions {
  * })
  */
 export const getLanguageInjectionSpec = (options: LanguageInjectionOptions): LanguageInjectionSpec => {
-  const buildSpec = LANGUAGE_SPECS[options.language]
-  if (!buildSpec) {
-    throw new Error(`Unsupported language: ${String(options.language)}`)
-  }
-  if (!LIBCS.includes(options.libc)) {
-    throw new Error(`Unsupported libc: ${String(options.libc)}`)
-  }
-  if (options.language === 'ruby' && options.libc === 'musl') {
-    throw new Error('Ruby Single-Language SSI does not support musl')
-  }
-
-  const root = normalizeRoot(options.root ?? DEFAULT_TRACER_ROOT)
+  const root = options.root ?? DEFAULT_TRACER_ROOT
   const image = buildSingleLanguageTracerImage(options.registry, options.language, options.version)
-  assertDotnetLayout(options.language, options.version)
 
-  return {image, ...buildSpec(root, options.libc)}
+  return {image, ...LANGUAGE_SPECS[options.language](root, options.libc)}
+}
+
+/** Returns a domain compatibility error after individual CLI arguments have been validated. */
+export const getLanguageCompatibilityError = (options: LanguageCompatibilityOptions): string | undefined => {
+  if (options.language === 'ruby' && options.libc === 'musl') {
+    return 'Ruby Single-Language SSI does not support musl'
+  }
+  if (options.language !== 'csharp') {
+    return undefined
+  }
+
+  const pinnedMajor = options.version.match(/^v?(\d+)(?:\.|$)/)?.[1]
+
+  return pinnedMajor !== undefined && Number(pinnedMajor) < 3
+    ? `Unsupported .NET tracer version ${JSON.stringify(options.version)}: versions before 3.0 require architecture-specific package paths`
+    : undefined
 }
 
 type SpecFactory = (root: string, libc: Libc) => Pick<LanguageInjectionSpec, 'artifacts' | 'env'>
 
 const LANGUAGE_SPECS = {
   java: (root) => ({
-    artifacts: [[inRoot(root, 'dd-java-agent.jar')]],
+    artifacts: [[path.posix.join(root, 'dd-java-agent.jar')]],
     env: [
       {
         name: 'JAVA_TOOL_OPTIONS',
-        value: `-javaagent:${inRoot(root, 'dd-java-agent.jar')} -XX:+IgnoreUnrecognizedVMOptions`,
+        value: `-javaagent:${path.posix.join(root, 'dd-java-agent.jar')} -XX:+IgnoreUnrecognizedVMOptions`,
         separator: ' ',
         mode: 'append',
       },
     ],
   }),
   nodejs: (root) => ({
-    artifacts: [[inRoot(root, 'node_modules/dd-trace/init.js')]],
+    artifacts: [[path.posix.join(root, 'node_modules/dd-trace/init.js')]],
     env: [
       {
         name: 'NODE_OPTIONS',
-        value: `--require ${inRoot(root, 'node_modules/dd-trace/init.js')}`,
+        value: `--require ${path.posix.join(root, 'node_modules/dd-trace/init.js')}`,
         separator: ' ',
         mode: 'append',
       },
@@ -81,13 +89,13 @@ const LANGUAGE_SPECS = {
   }),
   csharp: (root) => ({
     artifacts: [
-      [inRoot(root, 'Datadog.Trace.ClrProfiler.Native.so')],
-      [inRoot(root, 'continuousprofiler/Datadog.Linux.ApiWrapper.x64.so')],
+      [path.posix.join(root, 'Datadog.Trace.ClrProfiler.Native.so')],
+      [path.posix.join(root, 'continuousprofiler/Datadog.Linux.ApiWrapper.x64.so')],
     ],
     env: getDotnetEnv(root),
   }),
   python: (root) => ({
-    artifacts: [[inRoot(root, 'sitecustomize.py')]],
+    artifacts: [[path.posix.join(root, 'sitecustomize.py')]],
     env: [
       {
         name: 'PYTHONPATH',
@@ -98,11 +106,11 @@ const LANGUAGE_SPECS = {
     ],
   }),
   ruby: (root) => ({
-    artifacts: [[inRoot(root, 'auto_inject.rb')]],
+    artifacts: [[path.posix.join(root, 'auto_inject.rb')]],
     env: [
       {
         name: 'RUBYOPT',
-        value: `-r${inRoot(root, 'auto_inject')}`,
+        value: `-r${path.posix.join(root, 'auto_inject')}`,
         separator: ' ',
         mode: 'prepend',
       },
@@ -110,7 +118,7 @@ const LANGUAGE_SPECS = {
   }),
   php: (root, libc) => {
     const platform = libc === 'glibc' ? 'linux-gnu' : 'linux-musl'
-    const loader = inRoot(root, `${platform}/loader`)
+    const loader = path.posix.join(root, `${platform}/loader`)
 
     return {
       artifacts: [[`${loader}/dd_library_loader.ini`], [`${loader}/dd_library_loader.so`]],
@@ -128,36 +136,6 @@ const LANGUAGE_SPECS = {
   },
 } satisfies Record<Language, SpecFactory>
 
-const normalizeRoot = (root: string): string => {
-  if (
-    !root.startsWith('/') ||
-    /[\s\0]/.test(root) ||
-    (root !== '/' && root.includes('//')) ||
-    root.split('/').some((part) => part === '.' || part === '..')
-  ) {
-    throw new Error(
-      `Tracer root must be an absolute path without whitespace or relative segments: ${JSON.stringify(root)}`
-    )
-  }
-
-  return root === '/' ? root : root.replace(/\/+$/, '')
-}
-
-const inRoot = (root: string, path: string): string => `${root === '/' ? '' : root}/${path}`
-
-const assertDotnetLayout = (language: Language, version: string): void => {
-  if (language !== 'csharp') {
-    return
-  }
-
-  const pinnedMajor = version.match(/^v?(\d+)(?:\.|$)/)?.[1]
-  if (pinnedMajor !== undefined && Number(pinnedMajor) < 3) {
-    throw new Error(
-      `Unsupported .NET tracer version ${JSON.stringify(version)}: versions before 3.0 require architecture-specific package paths`
-    )
-  }
-}
-
 const getDotnetEnv = (root: string): EnvFragment[] => [
   {name: 'CORECLR_ENABLE_PROFILING', value: '1', mode: 'set-if-absent'},
   {
@@ -167,13 +145,13 @@ const getDotnetEnv = (root: string): EnvFragment[] => [
   },
   {
     name: 'CORECLR_PROFILER_PATH',
-    value: inRoot(root, 'Datadog.Trace.ClrProfiler.Native.so'),
+    value: path.posix.join(root, 'Datadog.Trace.ClrProfiler.Native.so'),
     mode: 'set-if-absent',
   },
   {name: 'DD_DOTNET_TRACER_HOME', value: root, mode: 'set-if-absent'},
   {
     name: 'LD_PRELOAD',
-    value: inRoot(root, 'continuousprofiler/Datadog.Linux.ApiWrapper.x64.so'),
+    value: path.posix.join(root, 'continuousprofiler/Datadog.Linux.ApiWrapper.x64.so'),
     separator: ' ',
     mode: 'prepend',
     maxLength: 1024,


### PR DESCRIPTION
### What and why?

Add a shared, pure specification for injecting each supported serverless tracer. This keeps tracer image construction, required files, and environment configuration consistent across runtimes.

### How?

The specification builds runtime-specific artifact paths and environment fragments for Java, Node.js, Python, Ruby, PHP, and .NET, with configurable roots and libc-aware PHP layouts. It also exposes compatibility errors for unsupported Ruby/musl and older .NET tracer combinations, using POSIX paths for Linux container files.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
