### PR TITLE
[SVLS-9302] define Cloud Run SSI configuration

### DIFF
--- a/packages/base/src/commands/cloud-run/constants.ts
+++ b/packages/base/src/commands/cloud-run/constants.ts
@@ -1,5 +1,9 @@
 import {ENVIRONMENT_ENV_VAR, SERVICE_ENV_VAR, SITE_ENV_VAR} from '../../helpers/serverless/constants'
 
+export const DEFAULT_TRACER_REGISTRY = 'gcr.io/datadoghq'
+export const DEFAULT_TRACER_VERSION = 'latest'
+export const DEFAULT_TRACER_LIBC = 'glibc'
+
 export const SKIP_MASKING_CLOUDRUN_ENV_VARS = new Set([
   SITE_ENV_VAR,
   SERVICE_ENV_VAR,

--- a/packages/base/src/helpers/serverless/__tests__/ssi/injection-spec.test.ts
+++ b/packages/base/src/helpers/serverless/__tests__/ssi/injection-spec.test.ts
@@ -1,6 +1,6 @@
 import {mergeEnvFragment} from '@datadog/datadog-ci-base/helpers/serverless/ssi/env'
 import {
-  getLanguageCompatibilityError,
+  getLanguageCompatibilityErrors,
   getLanguageInjectionSpec,
   type Libc,
 } from '@datadog/datadog-ci-base/helpers/serverless/ssi/injection-spec'
@@ -103,9 +103,9 @@ describe('language injection specifications', () => {
   })
 
   test('reports Ruby on musl as incompatible', () => {
-    expect(getLanguageCompatibilityError({language: 'ruby', libc: 'musl', version: 'latest'})).toContain(
-      'does not support musl'
-    )
+    expect(getLanguageCompatibilityErrors({language: 'ruby', libc: 'musl', version: 'latest'})).toEqual([
+      expect.stringContaining('does not support musl'),
+    ])
   })
 
   test.each([
@@ -130,9 +130,9 @@ describe('language injection specifications', () => {
   })
 
   test.each(['2.56.0', 'v2.60.1'])('reports .NET 2.x layouts as incompatible', (version) => {
-    expect(getLanguageCompatibilityError({language: 'csharp', libc: 'glibc', version})).toContain(
-      'versions before 3.0 require architecture-specific package paths'
-    )
+    expect(getLanguageCompatibilityErrors({language: 'csharp', libc: 'glibc', version})).toEqual([
+      expect.stringContaining('versions before 3.0 require architecture-specific package paths'),
+    ])
   })
 
   test.each(['glibc', 'musl'] as const)('uses the current universal .NET package paths for %s', (libc) => {
@@ -165,7 +165,7 @@ describe('language injection specifications', () => {
   })
 
   test('accepts compatible language options', () => {
-    expect(getLanguageCompatibilityError({language: 'java', libc: 'musl', version: 'latest'})).toBeUndefined()
-    expect(getLanguageCompatibilityError({language: 'csharp', libc: 'glibc', version: '3.0.0'})).toBeUndefined()
+    expect(getLanguageCompatibilityErrors({language: 'java', libc: 'musl', version: 'latest'})).toEqual([])
+    expect(getLanguageCompatibilityErrors({language: 'csharp', libc: 'glibc', version: '3.0.0'})).toEqual([])
   })
 })

--- a/packages/base/src/helpers/serverless/ssi/constants.ts
+++ b/packages/base/src/helpers/serverless/ssi/constants.ts
@@ -1,4 +1,15 @@
 export const TRACER_COPY_CONTAINER_NAME = 'datadog-tracer-copy'
+export const SSI_APP_CONTAINER_NAME = 'datadog-app'
 export const TRACER_VOLUME_NAME = 'datadog-tracer'
 export const TRACER_MOUNT_PATH = '/datadog-lib'
 export const TRACER_READINESS_PORT = 18999
+
+export const DEFAULT_TRACER_REGISTRY = 'gcr.io/datadoghq'
+export const DEFAULT_TRACER_VERSION = 'latest'
+export const DEFAULT_TRACER_LIBC = 'glibc'
+
+export const DEFAULT_TRACER_VOLUME_SIZE = '768Mi'
+export const DEFAULT_TRACER_SIDECAR_MEMORY = '1Gi'
+
+export const SSI_ADOPTION_LABEL_NAME = 'dd_sls_injection_mode'
+export const SSI_ADOPTION_LABEL_VALUE = 'single_language'

--- a/packages/base/src/helpers/serverless/ssi/constants.ts
+++ b/packages/base/src/helpers/serverless/ssi/constants.ts
@@ -1,15 +1,4 @@
 export const TRACER_COPY_CONTAINER_NAME = 'datadog-tracer-copy'
-export const SSI_APP_CONTAINER_NAME = 'datadog-app'
 export const TRACER_VOLUME_NAME = 'datadog-tracer'
 export const TRACER_MOUNT_PATH = '/datadog-lib'
 export const TRACER_READINESS_PORT = 18999
-
-export const DEFAULT_TRACER_REGISTRY = 'gcr.io/datadoghq'
-export const DEFAULT_TRACER_VERSION = 'latest'
-export const DEFAULT_TRACER_LIBC = 'glibc'
-
-export const DEFAULT_TRACER_VOLUME_SIZE = '768Mi'
-export const DEFAULT_TRACER_SIDECAR_MEMORY = '1Gi'
-
-export const SSI_ADOPTION_LABEL_NAME = 'dd_sls_injection_mode'
-export const SSI_ADOPTION_LABEL_VALUE = 'single_language'

--- a/packages/base/src/helpers/serverless/ssi/injection-spec.ts
+++ b/packages/base/src/helpers/serverless/ssi/injection-spec.ts
@@ -46,13 +46,13 @@ export const getLanguageInjectionSpec = (options: LanguageInjectionOptions): Lan
   return {image, ...LANGUAGE_CONFIG[options.language].getSpec(root, options.libc)}
 }
 
-/** Returns a domain compatibility error after individual CLI arguments have been validated. */
-export const getLanguageCompatibilityError = (options: LanguageCompatibilityOptions): string | undefined =>
-  LANGUAGE_CONFIG[options.language].getCompatibilityError?.(options)
+/** Returns domain compatibility errors after individual CLI arguments have been validated. */
+export const getLanguageCompatibilityErrors = (options: LanguageCompatibilityOptions): readonly string[] =>
+  LANGUAGE_CONFIG[options.language].getCompatibilityErrors?.(options) ?? []
 
 type LanguageConfig = {
   getSpec: (root: string, libc: Libc) => Pick<LanguageInjectionSpec, 'artifacts' | 'env'>
-  getCompatibilityError?: (options: Omit<LanguageCompatibilityOptions, 'language'>) => string | undefined
+  getCompatibilityErrors?: (options: Omit<LanguageCompatibilityOptions, 'language'>) => readonly string[]
 }
 
 const LANGUAGE_CONFIG: Record<Language, LanguageConfig> = {
@@ -90,12 +90,14 @@ const LANGUAGE_CONFIG: Record<Language, LanguageConfig> = {
       ],
       env: getDotnetEnv(root),
     }),
-    getCompatibilityError: ({version}) => {
+    getCompatibilityErrors: ({version}) => {
       const pinnedMajor = version.match(/^v?(\d+)(?:\.|$)/)?.[1]
 
       return pinnedMajor !== undefined && Number(pinnedMajor) < 3
-        ? `Unsupported .NET tracer version ${JSON.stringify(version)}: versions before 3.0 require architecture-specific package paths`
-        : undefined
+        ? [
+            `Unsupported .NET tracer version ${JSON.stringify(version)}: versions before 3.0 require architecture-specific package paths`,
+          ]
+        : []
     },
   },
   python: {
@@ -123,7 +125,7 @@ const LANGUAGE_CONFIG: Record<Language, LanguageConfig> = {
         },
       ],
     }),
-    getCompatibilityError: ({libc}) => (libc === 'musl' ? 'Ruby Single-Language SSI does not support musl' : undefined),
+    getCompatibilityErrors: ({libc}) => (libc === 'musl' ? ['Ruby Single-Language SSI does not support musl'] : []),
   },
   php: {
     getSpec: (root, libc) => {

--- a/packages/plugin-cloud-run/src/__tests__/ssi.test.ts
+++ b/packages/plugin-cloud-run/src/__tests__/ssi.test.ts
@@ -3,8 +3,7 @@ import type {Language} from '@datadog/datadog-ci-base/helpers/serverless/ssi/tra
 
 import {resolveSsiConfig, selectIngressContainer, SsiConfigError, type SsiOptions} from '../ssi'
 
-const baseFlags: SsiOptions = {
-  apmEnabled: false,
+const defaultOptions: SsiOptions = {
   language: undefined,
   tracing: undefined,
   tracerVersion: 'latest',
@@ -14,34 +13,35 @@ const baseFlags: SsiOptions = {
   tracerSidecarMemory: '1Gi',
 }
 
-const errorsFor = (overrides: Partial<SsiOptions>) => {
-  const result = resolveSsiConfig({...baseFlags, ...overrides})
+const getErrors = (overrides: Partial<SsiOptions>) => {
+  const result = resolveSsiConfig({...defaultOptions, ...overrides})
 
   return result.kind === 'errors' ? result.errors.join('\n') : ''
 }
 
 describe('resolveSsiConfig', () => {
-  test('is disabled when APM is not requested', () => {
-    expect(resolveSsiConfig({...baseFlags, language: 'nodejs'})).toEqual({kind: 'disabled', warnings: []})
-    expect(errorsFor({tracerVersion: '1.2.3', tracerLibc: 'musl'})).toContain('--tracer-version, --tracer-libc')
+  test.each<[string, SsiOptions['tracing']]>([
+    ['unset', undefined],
+    ['manual', 'manual'],
+    ['disabled', 'disabled'],
+  ])('does not inject when tracing is %s', (_description, tracing) => {
+    expect(resolveSsiConfig({...defaultOptions, tracing, language: 'nodejs'})).toEqual({
+      kind: 'no-injection',
+      warnings: [],
+    })
+  })
+
+  test('requires injection for tracer flags', () => {
+    expect(getErrors({tracerVersion: '1.2.3', tracerLibc: 'musl'})).toContain('--tracer-version, --tracer-libc')
   })
 
   test.each([
-    [{apmEnabled: true}, '--language'],
-    [{apmEnabled: true, language: 'nodejs', tracing: 'false'}, 'disabled tracing'],
-    [{apmEnabled: true, language: 'nodejs', tracing: 'FALSE'}, 'disabled tracing'],
-    [{apmEnabled: true, language: 'nodejs', tracing: '0'}, 'disabled tracing'],
-    [{apmEnabled: true, language: 'ruby', tracerLibc: 'musl'}, 'musl'],
-    [{apmEnabled: true, language: 'csharp', tracerVersion: '2.51.0'}, '2.51.0'],
+    [{tracing: 'inject'}, '--language'],
+    [{tracing: 'inject', language: 'go'}, 'dd-trace-go'],
+    [{tracing: 'inject', language: 'ruby', tracerLibc: 'musl'}, 'musl'],
+    [{tracing: 'inject', language: 'csharp', tracerVersion: '2.51.0'}, '2.51.0'],
   ] satisfies [Partial<SsiOptions>, string][])('rejects incompatible options %#', (options, message) => {
-    expect(errorsFor(options)).toContain(message)
-  })
-
-  test('uses agent-only mode for Go and rejects tracer image flags', () => {
-    const result = resolveSsiConfig({...baseFlags, apmEnabled: true, language: 'go'})
-    expect(result.kind).toBe('agent-only')
-    expect(result.warnings.join('\n')).toContain('dd-trace-go')
-    expect(errorsFor({apmEnabled: true, language: 'go', tracerVersion: '1.2.3'})).toContain('--tracer-version')
+    expect(getErrors(options)).toContain(message)
   })
 
   test.each<[Language, string]>([
@@ -52,7 +52,7 @@ describe('resolveSsiConfig', () => {
     ['ruby', 'ruby'],
     ['php', 'php'],
   ])('resolves the %s tracer image', (language, tracerLanguage) => {
-    const result = resolveSsiConfig({...baseFlags, apmEnabled: true, language})
+    const result = resolveSsiConfig({...defaultOptions, tracing: 'inject', language})
     expect(result.kind).toBe('single-language')
     expect(result.kind === 'single-language' && result.spec.image).toBe(
       `gcr.io/datadoghq/dd-lib-${tracerLanguage}-init:latest`
@@ -60,7 +60,7 @@ describe('resolveSsiConfig', () => {
   })
 
   test('emits the Java warning', () => {
-    expect(resolveSsiConfig({...baseFlags, apmEnabled: true, language: 'java'}).warnings.join('\n')).toContain(
+    expect(resolveSsiConfig({...defaultOptions, tracing: 'inject', language: 'java'}).warnings.join('\n')).toContain(
       'Java 24+'
     )
   })

--- a/packages/plugin-cloud-run/src/__tests__/ssi.test.ts
+++ b/packages/plugin-cloud-run/src/__tests__/ssi.test.ts
@@ -1,0 +1,127 @@
+import type {IContainer} from '../types'
+
+import {
+  cloudRunQuantityToBytes,
+  selectIngressContainer,
+  SsiValidationError,
+  validateCloudRunQuantity,
+  validateSsiFlags,
+} from '../ssi'
+const baseFlags = {
+  apmEnabled: false,
+  language: undefined as string | undefined,
+  tracing: undefined as string | undefined,
+  tracerVersion: 'latest',
+  tracerRegistry: 'gcr.io/datadoghq',
+  libc: 'glibc',
+  tracerVolumeSize: '768Mi',
+  tracerSidecarMemory: '1Gi',
+}
+
+const errorsFor = (overrides: Partial<typeof baseFlags>) => {
+  const result = validateSsiFlags({...baseFlags, ...overrides})
+
+  return result.kind === 'errors' ? result.errors.join('\n') : ''
+}
+
+describe('Cloud Run quantities', () => {
+  test.each([
+    ['512Mi', 512 * 1024 ** 2],
+    ['1Gi', 1024 ** 3],
+    ['0.5Gi', 0.5 * 1024 ** 3],
+    ['256', 256],
+  ])('parses %s', (value, bytes) => {
+    expect(cloudRunQuantityToBytes(value)).toBe(bytes)
+    expect(validateCloudRunQuantity(value, '--size')).toBe('')
+  })
+
+  test.each(['0', '0Mi', 'abc', '-1Gi', '1 Gi'])('rejects %s', (value) => {
+    expect(cloudRunQuantityToBytes(value)).toBeUndefined()
+    expect(validateCloudRunQuantity(value, '--size')).toContain('--size')
+  })
+})
+
+describe('validateSsiFlags', () => {
+  test('is disabled when APM is not requested', () => {
+    expect(validateSsiFlags({...baseFlags, language: 'nodejs'})).toEqual({kind: 'disabled', warnings: []})
+    expect(errorsFor({tracerVersion: '1.2.3', libc: 'musl'})).toContain('--tracer-version, --libc')
+  })
+
+  test.each([
+    [{apmEnabled: true}, '--language'],
+    [{apmEnabled: true, language: 'rust'}, 'rust'],
+    [{apmEnabled: true, language: 'nodejs', tracing: 'false'}, '--tracing false'],
+    [{apmEnabled: true, language: 'ruby', libc: 'musl'}, 'musl'],
+    [{apmEnabled: true, language: 'csharp', tracerVersion: '2.51.0'}, '2.51.0'],
+    [{apmEnabled: true, language: 'nodejs', tracerRegistry: 'example.com'}, 'example.com'],
+    [{apmEnabled: true, language: 'nodejs', tracerVersion: 'v1/../evil'}, 'Invalid tracer version'],
+  ])('rejects invalid options %#', (options, message) => {
+    expect(errorsFor(options)).toContain(message)
+  })
+
+  test('uses agent-only mode for Go and rejects tracer image flags', () => {
+    const result = validateSsiFlags({...baseFlags, apmEnabled: true, language: 'go'})
+    expect(result.kind).toBe('go-agent-only')
+    expect(result.warnings.join('\n')).toContain('dd-trace-go')
+    expect(errorsFor({apmEnabled: true, language: 'go', tracerVersion: '1.2.3'})).toContain('--tracer-version')
+  })
+
+  test.each([
+    ['java', 'java'],
+    ['nodejs', 'js'],
+    ['csharp', 'dotnet'],
+    ['python', 'python'],
+    ['ruby', 'ruby'],
+    ['php', 'php'],
+  ])('resolves the %s tracer image', (language, canonical) => {
+    const result = validateSsiFlags({...baseFlags, apmEnabled: true, language})
+    expect(result.kind).toBe('single-language')
+    expect(result.kind === 'single-language' && result.spec.image).toBe(
+      `gcr.io/datadoghq/dd-lib-${canonical}-init:latest`
+    )
+  })
+
+  test('validates volume sizing and emits the Java warning', () => {
+    expect(errorsFor({apmEnabled: true, language: 'nodejs', tracerVolumeSize: 'bad'})).toContain('positive')
+    expect(
+      errorsFor({apmEnabled: true, language: 'nodejs', tracerVolumeSize: '1Gi', tracerSidecarMemory: '1000M'})
+    ).toContain('cannot be smaller')
+    expect(validateSsiFlags({...baseFlags, apmEnabled: true, language: 'java'}).warnings.join('\n')).toContain(
+      'Java 24+'
+    )
+  })
+})
+
+describe('selectIngressContainer', () => {
+  const reserved = new Set(['datadog-sidecar', 'datadog-tracer-copy'])
+
+  test('selects the sole application port and ignores reserved and probe ports', () => {
+    const containers: IContainer[] = [
+      {name: 'worker', startupProbe: {tcpSocket: {port: 9000}}},
+      {name: 'app', ports: [{containerPort: 8080}]},
+      {name: 'datadog-sidecar', ports: [{containerPort: 8126}]},
+    ]
+    expect(selectIngressContainer(containers, reserved).name).toBe('app')
+  })
+
+  test('selects an unnamed ingress or the sole portless candidate', () => {
+    expect(selectIngressContainer([{name: '', ports: [{containerPort: 8080}]}, {name: 'worker'}], reserved).name).toBe(
+      ''
+    )
+    expect(selectIngressContainer([{name: 'app'}, {name: 'datadog-sidecar'}], reserved).name).toBe('app')
+  })
+
+  test('rejects missing and ambiguous ingress containers', () => {
+    expect(() => selectIngressContainer([{name: 'datadog-sidecar'}], reserved)).toThrow(SsiValidationError)
+    expect(() =>
+      selectIngressContainer(
+        [
+          {name: 'app', ports: [{containerPort: 8080}]},
+          {name: 'admin', ports: [{containerPort: 9090}]},
+        ],
+        reserved
+      )
+    ).toThrow(/app, admin/)
+    expect(() => selectIngressContainer([{name: 'app'}, {name: 'worker'}], reserved)).toThrow(/app, worker/)
+  })
+})

--- a/packages/plugin-cloud-run/src/__tests__/ssi.test.ts
+++ b/packages/plugin-cloud-run/src/__tests__/ssi.test.ts
@@ -9,8 +9,6 @@ const defaultOptions: SsiOptions = {
   tracerVersion: 'latest',
   tracerRegistry: 'gcr.io/datadoghq',
   tracerLibc: 'glibc',
-  tracerVolumeSize: '768Mi',
-  tracerSidecarMemory: '1Gi',
 }
 
 const getErrors = (overrides: Partial<SsiOptions>) => {

--- a/packages/plugin-cloud-run/src/__tests__/ssi.test.ts
+++ b/packages/plugin-cloud-run/src/__tests__/ssi.test.ts
@@ -9,7 +9,7 @@ const baseFlags: SsiOptions = {
   tracing: undefined,
   tracerVersion: 'latest',
   tracerRegistry: 'gcr.io/datadoghq',
-  libc: 'glibc',
+  tracerLibc: 'glibc',
   tracerVolumeSize: '768Mi',
   tracerSidecarMemory: '1Gi',
 }
@@ -23,7 +23,7 @@ const errorsFor = (overrides: Partial<SsiOptions>) => {
 describe('resolveSsiConfig', () => {
   test('is disabled when APM is not requested', () => {
     expect(resolveSsiConfig({...baseFlags, language: 'nodejs'})).toEqual({kind: 'disabled', warnings: []})
-    expect(errorsFor({tracerVersion: '1.2.3', libc: 'musl'})).toContain('--tracer-version, --libc')
+    expect(errorsFor({tracerVersion: '1.2.3', tracerLibc: 'musl'})).toContain('--tracer-version, --tracer-libc')
   })
 
   test.each([
@@ -31,7 +31,7 @@ describe('resolveSsiConfig', () => {
     [{apmEnabled: true, language: 'nodejs', tracing: 'false'}, 'disabled tracing'],
     [{apmEnabled: true, language: 'nodejs', tracing: 'FALSE'}, 'disabled tracing'],
     [{apmEnabled: true, language: 'nodejs', tracing: '0'}, 'disabled tracing'],
-    [{apmEnabled: true, language: 'ruby', libc: 'musl'}, 'musl'],
+    [{apmEnabled: true, language: 'ruby', tracerLibc: 'musl'}, 'musl'],
     [{apmEnabled: true, language: 'csharp', tracerVersion: '2.51.0'}, '2.51.0'],
   ] satisfies [Partial<SsiOptions>, string][])('rejects incompatible options %#', (options, message) => {
     expect(errorsFor(options)).toContain(message)

--- a/packages/plugin-cloud-run/src/__tests__/ssi.test.ts
+++ b/packages/plugin-cloud-run/src/__tests__/ssi.test.ts
@@ -1,16 +1,12 @@
 import type {IContainer} from '../types'
+import type {Language} from '@datadog/datadog-ci-base/helpers/serverless/ssi/tracer'
 
-import {
-  cloudRunQuantityToBytes,
-  selectIngressContainer,
-  SsiValidationError,
-  validateCloudRunQuantity,
-  validateSsiFlags,
-} from '../ssi'
-const baseFlags = {
+import {resolveSsiConfig, selectIngressContainer, SsiConfigError, type SsiOptions} from '../ssi'
+
+const baseFlags: SsiOptions = {
   apmEnabled: false,
-  language: undefined as string | undefined,
-  tracing: undefined as string | undefined,
+  language: undefined,
+  tracing: undefined,
   tracerVersion: 'latest',
   tracerRegistry: 'gcr.io/datadoghq',
   libc: 'glibc',
@@ -18,75 +14,53 @@ const baseFlags = {
   tracerSidecarMemory: '1Gi',
 }
 
-const errorsFor = (overrides: Partial<typeof baseFlags>) => {
-  const result = validateSsiFlags({...baseFlags, ...overrides})
+const errorsFor = (overrides: Partial<SsiOptions>) => {
+  const result = resolveSsiConfig({...baseFlags, ...overrides})
 
   return result.kind === 'errors' ? result.errors.join('\n') : ''
 }
 
-describe('Cloud Run quantities', () => {
-  test.each([
-    ['512Mi', 512 * 1024 ** 2],
-    ['1Gi', 1024 ** 3],
-    ['0.5Gi', 0.5 * 1024 ** 3],
-    ['256', 256],
-  ])('parses %s', (value, bytes) => {
-    expect(cloudRunQuantityToBytes(value)).toBe(bytes)
-    expect(validateCloudRunQuantity(value, '--size')).toBe('')
-  })
-
-  test.each(['0', '0Mi', 'abc', '-1Gi', '1 Gi'])('rejects %s', (value) => {
-    expect(cloudRunQuantityToBytes(value)).toBeUndefined()
-    expect(validateCloudRunQuantity(value, '--size')).toContain('--size')
-  })
-})
-
-describe('validateSsiFlags', () => {
+describe('resolveSsiConfig', () => {
   test('is disabled when APM is not requested', () => {
-    expect(validateSsiFlags({...baseFlags, language: 'nodejs'})).toEqual({kind: 'disabled', warnings: []})
+    expect(resolveSsiConfig({...baseFlags, language: 'nodejs'})).toEqual({kind: 'disabled', warnings: []})
     expect(errorsFor({tracerVersion: '1.2.3', libc: 'musl'})).toContain('--tracer-version, --libc')
   })
 
   test.each([
     [{apmEnabled: true}, '--language'],
-    [{apmEnabled: true, language: 'rust'}, 'rust'],
-    [{apmEnabled: true, language: 'nodejs', tracing: 'false'}, '--tracing false'],
+    [{apmEnabled: true, language: 'nodejs', tracing: 'false'}, 'disabled tracing'],
+    [{apmEnabled: true, language: 'nodejs', tracing: 'FALSE'}, 'disabled tracing'],
+    [{apmEnabled: true, language: 'nodejs', tracing: '0'}, 'disabled tracing'],
     [{apmEnabled: true, language: 'ruby', libc: 'musl'}, 'musl'],
     [{apmEnabled: true, language: 'csharp', tracerVersion: '2.51.0'}, '2.51.0'],
-    [{apmEnabled: true, language: 'nodejs', tracerRegistry: 'example.com'}, 'example.com'],
-    [{apmEnabled: true, language: 'nodejs', tracerVersion: 'v1/../evil'}, 'Invalid tracer version'],
-  ])('rejects invalid options %#', (options, message) => {
+  ] satisfies [Partial<SsiOptions>, string][])('rejects incompatible options %#', (options, message) => {
     expect(errorsFor(options)).toContain(message)
   })
 
   test('uses agent-only mode for Go and rejects tracer image flags', () => {
-    const result = validateSsiFlags({...baseFlags, apmEnabled: true, language: 'go'})
-    expect(result.kind).toBe('go-agent-only')
+    const result = resolveSsiConfig({...baseFlags, apmEnabled: true, language: 'go'})
+    expect(result.kind).toBe('agent-only')
     expect(result.warnings.join('\n')).toContain('dd-trace-go')
     expect(errorsFor({apmEnabled: true, language: 'go', tracerVersion: '1.2.3'})).toContain('--tracer-version')
   })
 
-  test.each([
+  test.each<[Language, string]>([
     ['java', 'java'],
     ['nodejs', 'js'],
     ['csharp', 'dotnet'],
     ['python', 'python'],
     ['ruby', 'ruby'],
     ['php', 'php'],
-  ])('resolves the %s tracer image', (language, canonical) => {
-    const result = validateSsiFlags({...baseFlags, apmEnabled: true, language})
+  ])('resolves the %s tracer image', (language, tracerLanguage) => {
+    const result = resolveSsiConfig({...baseFlags, apmEnabled: true, language})
     expect(result.kind).toBe('single-language')
     expect(result.kind === 'single-language' && result.spec.image).toBe(
-      `gcr.io/datadoghq/dd-lib-${canonical}-init:latest`
+      `gcr.io/datadoghq/dd-lib-${tracerLanguage}-init:latest`
     )
   })
 
-  test('validates volume sizing and emits the Java warning', () => {
-    expect(errorsFor({apmEnabled: true, language: 'nodejs', tracerVolumeSize: 'bad'})).toContain('positive')
-    expect(
-      errorsFor({apmEnabled: true, language: 'nodejs', tracerVolumeSize: '1Gi', tracerSidecarMemory: '1000M'})
-    ).toContain('cannot be smaller')
-    expect(validateSsiFlags({...baseFlags, apmEnabled: true, language: 'java'}).warnings.join('\n')).toContain(
+  test('emits the Java warning', () => {
+    expect(resolveSsiConfig({...baseFlags, apmEnabled: true, language: 'java'}).warnings.join('\n')).toContain(
       'Java 24+'
     )
   })
@@ -112,7 +86,7 @@ describe('selectIngressContainer', () => {
   })
 
   test('rejects missing and ambiguous ingress containers', () => {
-    expect(() => selectIngressContainer([{name: 'datadog-sidecar'}], reserved)).toThrow(SsiValidationError)
+    expect(() => selectIngressContainer([{name: 'datadog-sidecar'}], reserved)).toThrow(SsiConfigError)
     expect(() =>
       selectIngressContainer(
         [

--- a/packages/plugin-cloud-run/src/__tests__/ssi.test.ts
+++ b/packages/plugin-cloud-run/src/__tests__/ssi.test.ts
@@ -1,7 +1,7 @@
 import type {IContainer} from '../types'
 import type {Language} from '@datadog/datadog-ci-base/helpers/serverless/ssi/tracer'
 
-import {resolveSsiConfig, selectIngressContainer, SsiConfigError, type SsiOptions} from '../ssi'
+import {resolveSsiConfig, selectMainContainer, SsiConfigError, type SsiOptions} from '../ssi'
 
 const defaultOptions: SsiOptions = {
   language: undefined,
@@ -64,7 +64,7 @@ describe('resolveSsiConfig', () => {
   })
 })
 
-describe('selectIngressContainer', () => {
+describe('selectMainContainer', () => {
   const reserved = new Set(['datadog-sidecar', 'datadog-tracer-copy'])
 
   test('selects the sole application port and ignores reserved and probe ports', () => {
@@ -73,20 +73,18 @@ describe('selectIngressContainer', () => {
       {name: 'app', ports: [{containerPort: 8080}]},
       {name: 'datadog-sidecar', ports: [{containerPort: 8126}]},
     ]
-    expect(selectIngressContainer(containers, reserved).name).toBe('app')
+    expect(selectMainContainer(containers, reserved).name).toBe('app')
   })
 
-  test('selects an unnamed ingress or the sole portless candidate', () => {
-    expect(selectIngressContainer([{name: '', ports: [{containerPort: 8080}]}, {name: 'worker'}], reserved).name).toBe(
-      ''
-    )
-    expect(selectIngressContainer([{name: 'app'}, {name: 'datadog-sidecar'}], reserved).name).toBe('app')
+  test('selects an unnamed main container or the sole portless candidate', () => {
+    expect(selectMainContainer([{name: '', ports: [{containerPort: 8080}]}, {name: 'worker'}], reserved).name).toBe('')
+    expect(selectMainContainer([{name: 'app'}, {name: 'datadog-sidecar'}], reserved).name).toBe('app')
   })
 
-  test('rejects missing and ambiguous ingress containers', () => {
-    expect(() => selectIngressContainer([{name: 'datadog-sidecar'}], reserved)).toThrow(SsiConfigError)
+  test('rejects missing and ambiguous main containers', () => {
+    expect(() => selectMainContainer([{name: 'datadog-sidecar'}], reserved)).toThrow(SsiConfigError)
     expect(() =>
-      selectIngressContainer(
+      selectMainContainer(
         [
           {name: 'app', ports: [{containerPort: 8080}]},
           {name: 'admin', ports: [{containerPort: 9090}]},
@@ -94,6 +92,6 @@ describe('selectIngressContainer', () => {
         reserved
       )
     ).toThrow(/app, admin/)
-    expect(() => selectIngressContainer([{name: 'app'}, {name: 'worker'}], reserved)).toThrow(/app, worker/)
+    expect(() => selectMainContainer([{name: 'app'}, {name: 'worker'}], reserved)).toThrow(/app, worker/)
   })
 })

--- a/packages/plugin-cloud-run/src/ssi.ts
+++ b/packages/plugin-cloud-run/src/ssi.ts
@@ -9,7 +9,7 @@ import {
 } from '@datadog/datadog-ci-base/commands/cloud-run/constants'
 import {TRACER_MOUNT_PATH} from '@datadog/datadog-ci-base/helpers/serverless/ssi/constants'
 import {
-  getLanguageCompatibilityError,
+  getLanguageCompatibilityErrors,
   getLanguageInjectionSpec,
 } from '@datadog/datadog-ci-base/helpers/serverless/ssi/injection-spec'
 import {LANGUAGE_METADATA} from '@datadog/datadog-ci-base/helpers/serverless/ssi/tracer'
@@ -77,12 +77,11 @@ export const resolveSsiConfig = (options: SsiOptions): SsiConfigResult => {
     }
   }
 
-  const compatibilityError = getLanguageCompatibilityError({
+  const errors = getLanguageCompatibilityErrors({
     language: options.language,
     libc: options.tracerLibc,
     version: options.tracerVersion,
   })
-  const errors = compatibilityError === undefined ? [] : [compatibilityError]
   if (errors.length > 0) {
     return {kind: 'errors', errors, warnings: []}
   }

--- a/packages/plugin-cloud-run/src/ssi.ts
+++ b/packages/plugin-cloud-run/src/ssi.ts
@@ -1,10 +1,8 @@
 import type {IContainer} from './types'
-import type {
-  ServerlessLibc,
-  SingleLanguageInjectionSpec,
-} from '@datadog/datadog-ci-base/helpers/serverless/ssi/injection-spec'
-import type {ServerlessLanguage} from '@datadog/datadog-ci-base/helpers/serverless/ssi/tracer'
+import type {LanguageInjectionSpec, Libc} from '@datadog/datadog-ci-base/helpers/serverless/ssi/injection-spec'
+import type {Language, SingleLanguageTracerRegistry} from '@datadog/datadog-ci-base/helpers/serverless/ssi/tracer'
 
+import {toBoolean} from '@datadog/datadog-ci-base/helpers/env'
 import {
   DEFAULT_TRACER_LIBC,
   DEFAULT_TRACER_REGISTRY,
@@ -13,230 +11,140 @@ import {
   DEFAULT_TRACER_VOLUME_SIZE,
   TRACER_MOUNT_PATH,
 } from '@datadog/datadog-ci-base/helpers/serverless/ssi/constants'
-import {getSingleLanguageInjectionSpec} from '@datadog/datadog-ci-base/helpers/serverless/ssi/injection-spec'
-import {SINGLE_LANGUAGE_TRACER_REGISTRIES} from '@datadog/datadog-ci-base/helpers/serverless/ssi/tracer'
+import {
+  getLanguageCompatibilityError,
+  getLanguageInjectionSpec,
+} from '@datadog/datadog-ci-base/helpers/serverless/ssi/injection-spec'
+import {LANGUAGE_METADATA} from '@datadog/datadog-ci-base/helpers/serverless/ssi/tracer'
 
-/** Languages accepted by `--language` today. `go` is accepted for APM as an agent-only mode. */
-export const CLOUD_RUN_LANGUAGES = ['nodejs', 'python', 'go', 'java', 'csharp', 'ruby', 'php'] as const
-export const SINGLE_LANGUAGE_VALUES: readonly ServerlessLanguage[] = [
-  'java',
-  'nodejs',
-  'csharp',
-  'python',
-  'ruby',
-  'php',
-]
+export const TRACER_INJECTION_LANGUAGES: readonly Language[] = Object.keys(LANGUAGE_METADATA) as Language[]
+export const CLOUD_RUN_LANGUAGES = [...TRACER_INJECTION_LANGUAGES, 'go'] as const
 
-export class SsiValidationError extends Error {
-  constructor(message: string) {
-    super(message)
-    this.name = 'SsiValidationError'
-  }
-}
+export type CloudRunLanguage = (typeof CLOUD_RUN_LANGUAGES)[number]
 
-export interface SsiFlagOptions {
+export interface SsiOptions {
   apmEnabled: boolean
-  language: string | undefined
+  language: CloudRunLanguage | undefined
   tracing: string | undefined
   tracerVersion: string
-  tracerRegistry: string
-  libc: string
+  tracerRegistry: SingleLanguageTracerRegistry
+  libc: Libc
   tracerVolumeSize: string
   tracerSidecarMemory: string
 }
 
-export type SsiFlagValidation =
-  | {kind: 'errors'; errors: string[]; warnings: string[]}
-  | {kind: 'disabled'; warnings: string[]}
-  | {kind: 'go-agent-only'; warnings: string[]}
+export type SsiConfigResult =
+  | {kind: 'errors'; errors: readonly string[]; warnings: readonly string[]}
+  | {kind: 'disabled'; warnings: readonly string[]}
+  | {kind: 'agent-only'; warnings: readonly string[]}
   | {
       kind: 'single-language'
-      warnings: string[]
-      language: ServerlessLanguage
-      libc: ServerlessLibc
-      spec: SingleLanguageInjectionSpec
+      warnings: readonly string[]
+      language: Language
+      libc: Libc
+      spec: LanguageInjectionSpec
       tracerVolumeSize: string
       tracerSidecarMemory: string
     }
 
-const CLOUD_RUN_QUANTITY_REG_EXP = /^(\d+(?:\.\d+)?)(m|Ki|Mi|Gi|Ti|k|M|G|T)?$/
-const CLOUD_RUN_QUANTITY_MULTIPLIERS: Record<string, number> = {
-  '': 1,
-  m: 0.001,
-  Ki: 1024,
-  Mi: 1024 ** 2,
-  Gi: 1024 ** 3,
-  Ti: 1024 ** 4,
-  k: 1000,
-  M: 1000 ** 2,
-  G: 1000 ** 3,
-  T: 1000 ** 4,
-}
-
-export const cloudRunQuantityToBytes = (value: string): number | undefined => {
-  const match = typeof value === 'string' ? value.trim().match(CLOUD_RUN_QUANTITY_REG_EXP) : undefined
-  if (!match) {
-    return undefined
-  }
-  const quantity = Number(match[1]) * CLOUD_RUN_QUANTITY_MULTIPLIERS[match[2] ?? '']
-
-  return Number.isFinite(quantity) && quantity > 0 ? quantity : undefined
-}
-
-export const validateCloudRunQuantity = (value: string, flag: string): string => {
-  if (cloudRunQuantityToBytes(value) === undefined) {
-    return `${flag} must be a positive Cloud Run quantity such as 768Mi or 1Gi, got ${JSON.stringify(value)}.`
-  }
-
-  return ''
-}
-
-const nonDefaultTracerFlags = (options: SsiFlagOptions): string[] => {
-  const nonDefault: string[] = []
-  if (options.tracerVersion !== DEFAULT_TRACER_VERSION) {
-    nonDefault.push('--tracer-version')
-  }
-  if (options.tracerRegistry !== DEFAULT_TRACER_REGISTRY) {
-    nonDefault.push('--tracer-registry')
-  }
-  if (options.libc !== DEFAULT_TRACER_LIBC) {
-    nonDefault.push('--libc')
-  }
-  if (options.tracerVolumeSize !== DEFAULT_TRACER_VOLUME_SIZE) {
-    nonDefault.push('--tracer-volume-size')
-  }
-  if (options.tracerSidecarMemory !== DEFAULT_TRACER_SIDECAR_MEMORY) {
-    nonDefault.push('--tracer-sidecar-memory')
-  }
-
-  return nonDefault
-}
-
-export const validateSsiFlags = (options: SsiFlagOptions): SsiFlagValidation => {
-  const errors: string[] = []
-  const warnings: string[] = []
-
+/** Resolves SSI inputs to a mode or validation errors. */
+export const resolveSsiConfig = (options: SsiOptions): SsiConfigResult => {
   if (!options.apmEnabled) {
-    const ignored = nonDefaultTracerFlags(options)
-    if (ignored.length > 0) {
-      errors.push(
-        `${ignored.join(
+    const ignored = customTracerFlags(options)
+
+    return ignored.length > 0
+      ? {
+          kind: 'errors',
+          errors: [
+            `${ignored.join(
+              ', '
+            )} only applies when --apm-enabled is set. Add --apm-enabled, or remove these flags to avoid silently changing nothing.`,
+          ],
+          warnings: [],
+        }
+      : {kind: 'disabled', warnings: []}
+  }
+
+  const tracingErrors =
+    toBoolean(options.tracing) === false
+      ? ['--apm-enabled cannot be combined with disabled tracing. Remove one of the two flags.']
+      : []
+
+  if (options.language === undefined) {
+    return {
+      kind: 'errors',
+      errors: [
+        ...tracingErrors,
+        `--apm-enabled requires --language. Multi-Language instrumentation is not supported yet. Supported Single-Language values are: ${TRACER_INJECTION_LANGUAGES.join(
           ', '
-        )} only applies when --apm-enabled is set. Add --apm-enabled, or remove these flags to avoid silently changing nothing.`
-      )
-    }
-
-    return errors.length > 0 ? {kind: 'errors', errors, warnings} : {kind: 'disabled', warnings}
-  }
-
-  if (options.tracing === 'false') {
-    errors.push('--apm-enabled cannot be combined with --tracing false. Remove one of the two flags.')
-  }
-
-  const language = options.language
-  if (!language) {
-    errors.push(
-      `--apm-enabled requires --language. Multi-Language instrumentation is not supported yet (SVLS-9316). Supported Single-Language values are: ${SINGLE_LANGUAGE_VALUES.join(
-        ', '
-      )}, plus "go" for agent-only tracing.`
-    )
-
-    return {kind: 'errors', errors, warnings}
-  }
-
-  if (!(CLOUD_RUN_LANGUAGES as readonly string[]).includes(language)) {
-    errors.push(
-      `Unsupported --language value ${JSON.stringify(language)}. Possible values: ${CLOUD_RUN_LANGUAGES.join(', ')}.`
-    )
-
-    return {kind: 'errors', errors, warnings}
-  }
-
-  if (language === 'go') {
-    const ignored = nonDefaultTracerFlags(options)
-    if (ignored.length > 0) {
-      errors.push(
-        `${ignored.join(', ')} cannot be used with --language go because Go does not use an SSI tracer image. Remove these flags.`
-      )
-    }
-    warnings.push(
-      'Go does not support automatic tracer injection. Datadog is setting DD_TRACE_ENABLED=true so the Datadog Agent sidecar can collect traces, but no tracer is installed. Instrument your Go application with dd-trace-go and redeploy your image to get traces.'
-    )
-
-    return errors.length > 0 ? {kind: 'errors', errors, warnings} : {kind: 'go-agent-only', warnings}
-  }
-
-  for (const [flag, value] of [
-    ['--tracer-volume-size', options.tracerVolumeSize],
-    ['--tracer-sidecar-memory', options.tracerSidecarMemory],
-  ] as const) {
-    const error = validateCloudRunQuantity(value, flag)
-    if (error) {
-      errors.push(error)
+        )}, plus "go" for agent-only tracing.`,
+      ],
+      warnings: [],
     }
   }
 
-  if (!(SINGLE_LANGUAGE_TRACER_REGISTRIES as readonly string[]).includes(options.tracerRegistry)) {
-    errors.push(
-      `Unsupported --tracer-registry ${JSON.stringify(
-        options.tracerRegistry
-      )}. Possible values: ${SINGLE_LANGUAGE_TRACER_REGISTRIES.join(', ')}.`
-    )
+  if (options.language === 'go') {
+    const ignored = customTracerFlags(options)
+    const goErrors = [
+      ...tracingErrors,
+      ...(ignored.length > 0
+        ? [
+            `${ignored.join(', ')} cannot be used with --language go because Go does not use an SSI tracer image. Remove these flags.`,
+          ]
+        : []),
+    ]
+    const goWarnings = [
+      'Go does not support automatic tracer injection. Datadog is setting DD_TRACE_ENABLED=true so the Datadog Agent sidecar can collect traces, but no tracer is installed. Instrument your Go application with dd-trace-go and redeploy your image to get traces.',
+    ]
+
+    return goErrors.length > 0
+      ? {kind: 'errors', errors: goErrors, warnings: goWarnings}
+      : {kind: 'agent-only', warnings: goWarnings}
   }
 
-  if (options.libc !== 'glibc' && options.libc !== 'musl') {
-    errors.push(`Unsupported --libc ${JSON.stringify(options.libc)}. Possible values: glibc, musl.`)
-  }
-
-  const volumeBytes = cloudRunQuantityToBytes(options.tracerVolumeSize)
-  const sidecarMemoryBytes = cloudRunQuantityToBytes(options.tracerSidecarMemory)
-  if (volumeBytes !== undefined && sidecarMemoryBytes !== undefined && sidecarMemoryBytes < volumeBytes) {
-    errors.push(
-      `--tracer-sidecar-memory (${options.tracerSidecarMemory}) cannot be smaller than --tracer-volume-size (${options.tracerVolumeSize}) because the Memory volume is charged to the tracer copy sidecar.`
-    )
-  }
-
+  const compatibilityError = getLanguageCompatibilityError({
+    language: options.language,
+    libc: options.libc,
+    version: options.tracerVersion,
+  })
+  const errors = [...tracingErrors, ...(compatibilityError === undefined ? [] : [compatibilityError])]
   if (errors.length > 0) {
-    return {kind: 'errors', errors, warnings}
+    return {kind: 'errors', errors, warnings: []}
   }
 
-  let spec: SingleLanguageInjectionSpec
-  try {
-    spec = getSingleLanguageInjectionSpec({
-      language: language as ServerlessLanguage,
-      registry: options.tracerRegistry as (typeof SINGLE_LANGUAGE_TRACER_REGISTRIES)[number],
-      version: options.tracerVersion,
-      libc: options.libc as ServerlessLibc,
-      root: TRACER_MOUNT_PATH,
-    })
-  } catch (error) {
-    return {kind: 'errors', errors: [error instanceof Error ? error.message : String(error)], warnings}
-  }
-
-  if (language === 'java') {
-    warnings.push(
-      'This release supports Java 8 through Java 23. Java 24+ applications require an additional JVM flag that datadog-ci cannot set safely without knowing your runtime version.'
-    )
-  }
+  const spec = getLanguageInjectionSpec({
+    language: options.language,
+    registry: options.tracerRegistry,
+    version: options.tracerVersion,
+    libc: options.libc,
+    root: TRACER_MOUNT_PATH,
+  })
+  const warnings =
+    options.language === 'java'
+      ? [
+          'This release supports Java 8 through Java 23. Java 24+ applications require an additional JVM flag that datadog-ci cannot set safely without knowing your runtime version.',
+        ]
+      : []
 
   return {
     kind: 'single-language',
     warnings,
-    language: language as ServerlessLanguage,
-    libc: options.libc as ServerlessLibc,
+    language: options.language,
+    libc: options.libc,
     spec,
     tracerVolumeSize: options.tracerVolumeSize,
     tracerSidecarMemory: options.tracerSidecarMemory,
   }
 }
 
+/** Selects the ingress application container or rejects an ambiguous layout. */
 export const selectIngressContainer = (
   containers: readonly IContainer[],
   reservedNames: ReadonlySet<string>
 ): IContainer => {
   const candidates = containers.filter((container) => !container.name || !reservedNames.has(container.name))
   if (candidates.length === 0) {
-    throw new SsiValidationError('No application container was found to instrument.')
+    throw new SsiConfigError('No application container was found to instrument.')
   }
 
   const withPorts = candidates.filter((container) => (container.ports ?? []).length > 0)
@@ -244,7 +152,7 @@ export const selectIngressContainer = (
     return withPorts[0]
   }
   if (withPorts.length > 1) {
-    throw new SsiValidationError(
+    throw new SsiConfigError(
       `Multiple containers declare ports, so the ingress container is ambiguous: ${withPorts
         .map((container) => container.name || '<unnamed>')
         .join(', ')}. Cloud Run allows exactly one ingress container.`
@@ -254,9 +162,25 @@ export const selectIngressContainer = (
     return candidates[0]
   }
 
-  throw new SsiValidationError(
+  throw new SsiConfigError(
     `No container declares ports, so the ingress container is ambiguous: ${candidates
       .map((container) => container.name || '<unnamed>')
       .join(', ')}. Declare a container port on your ingress container.`
   )
 }
+
+export class SsiConfigError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'SsiConfigError'
+  }
+}
+
+const customTracerFlags = (options: SsiOptions): string[] =>
+  [
+    options.tracerVersion !== DEFAULT_TRACER_VERSION ? '--tracer-version' : undefined,
+    options.tracerRegistry !== DEFAULT_TRACER_REGISTRY ? '--tracer-registry' : undefined,
+    options.libc !== DEFAULT_TRACER_LIBC ? '--libc' : undefined,
+    options.tracerVolumeSize !== DEFAULT_TRACER_VOLUME_SIZE ? '--tracer-volume-size' : undefined,
+    options.tracerSidecarMemory !== DEFAULT_TRACER_SIDECAR_MEMORY ? '--tracer-sidecar-memory' : undefined,
+  ].filter((flag): flag is string => flag !== undefined)

--- a/packages/plugin-cloud-run/src/ssi.ts
+++ b/packages/plugin-cloud-run/src/ssi.ts
@@ -110,8 +110,8 @@ export const resolveSsiConfig = (options: SsiOptions): SsiConfigResult => {
   }
 }
 
-/** Selects the ingress application container or rejects an ambiguous layout. */
-export const selectIngressContainer = (
+/** Selects the main application container or rejects an ambiguous layout. */
+export const selectMainContainer = (
   containers: readonly IContainer[],
   reservedNames: ReadonlySet<string>
 ): IContainer => {
@@ -126,9 +126,9 @@ export const selectIngressContainer = (
   }
   if (withPorts.length > 1) {
     throw new SsiConfigError(
-      `Multiple containers declare ports, so the ingress container is ambiguous: ${withPorts
+      `Multiple containers declare ports, so the main container is ambiguous: ${withPorts
         .map((container) => container.name || '<unnamed>')
-        .join(', ')}. Cloud Run allows exactly one ingress container.`
+        .join(', ')}. Cloud Run allows exactly one main container.`
     )
   }
   if (candidates.length === 1) {
@@ -136,9 +136,9 @@ export const selectIngressContainer = (
   }
 
   throw new SsiConfigError(
-    `No container declares ports, so the ingress container is ambiguous: ${candidates
+    `No container declares ports, so the main container is ambiguous: ${candidates
       .map((container) => container.name || '<unnamed>')
-      .join(', ')}. Declare a container port on your ingress container.`
+      .join(', ')}. Declare a container port on your main container.`
   )
 }
 

--- a/packages/plugin-cloud-run/src/ssi.ts
+++ b/packages/plugin-cloud-run/src/ssi.ts
@@ -5,11 +5,9 @@ import type {Language, SingleLanguageTracerRegistry} from '@datadog/datadog-ci-b
 import {
   DEFAULT_TRACER_LIBC,
   DEFAULT_TRACER_REGISTRY,
-  DEFAULT_TRACER_SIDECAR_MEMORY,
   DEFAULT_TRACER_VERSION,
-  DEFAULT_TRACER_VOLUME_SIZE,
-  TRACER_MOUNT_PATH,
-} from '@datadog/datadog-ci-base/helpers/serverless/ssi/constants'
+} from '@datadog/datadog-ci-base/commands/cloud-run/constants'
+import {TRACER_MOUNT_PATH} from '@datadog/datadog-ci-base/helpers/serverless/ssi/constants'
 import {
   getLanguageCompatibilityError,
   getLanguageInjectionSpec,
@@ -30,8 +28,6 @@ export interface SsiOptions {
   tracerVersion: string
   tracerRegistry: SingleLanguageTracerRegistry
   tracerLibc: Libc
-  tracerVolumeSize: string
-  tracerSidecarMemory: string
 }
 
 export type SsiConfigResult = (
@@ -42,8 +38,6 @@ export type SsiConfigResult = (
       language: Language
       libc: Libc
       spec: LanguageInjectionSpec
-      tracerVolumeSize: string
-      tracerSidecarMemory: string
     }
 ) & {warnings: readonly string[]}
 
@@ -113,8 +107,6 @@ export const resolveSsiConfig = (options: SsiOptions): SsiConfigResult => {
     language: options.language,
     libc: options.tracerLibc,
     spec,
-    tracerVolumeSize: options.tracerVolumeSize,
-    tracerSidecarMemory: options.tracerSidecarMemory,
   }
 }
 
@@ -163,6 +155,4 @@ const nonDefaultTracerFlags = (options: SsiOptions): string[] =>
     options.tracerVersion !== DEFAULT_TRACER_VERSION ? '--tracer-version' : undefined,
     options.tracerRegistry !== DEFAULT_TRACER_REGISTRY ? '--tracer-registry' : undefined,
     options.tracerLibc !== DEFAULT_TRACER_LIBC ? '--tracer-libc' : undefined,
-    options.tracerVolumeSize !== DEFAULT_TRACER_VOLUME_SIZE ? '--tracer-volume-size' : undefined,
-    options.tracerSidecarMemory !== DEFAULT_TRACER_SIDECAR_MEMORY ? '--tracer-sidecar-memory' : undefined,
   ].filter((flag): flag is string => flag !== undefined)

--- a/packages/plugin-cloud-run/src/ssi.ts
+++ b/packages/plugin-cloud-run/src/ssi.ts
@@ -2,7 +2,6 @@ import type {IContainer} from './types'
 import type {LanguageInjectionSpec, Libc} from '@datadog/datadog-ci-base/helpers/serverless/ssi/injection-spec'
 import type {Language, SingleLanguageTracerRegistry} from '@datadog/datadog-ci-base/helpers/serverless/ssi/tracer'
 
-import {toBoolean} from '@datadog/datadog-ci-base/helpers/env'
 import {
   DEFAULT_TRACER_LIBC,
   DEFAULT_TRACER_REGISTRY,
@@ -22,10 +21,12 @@ export const CLOUD_RUN_LANGUAGES = [...TRACER_INJECTION_LANGUAGES, 'go'] as cons
 
 export type CloudRunLanguage = (typeof CLOUD_RUN_LANGUAGES)[number]
 
+export const NORMALIZED_TRACING_MODES = ['manual', 'disabled', 'inject'] as const
+export type TracingMode = (typeof NORMALIZED_TRACING_MODES)[number]
+
 export interface SsiOptions {
-  apmEnabled: boolean
   language: CloudRunLanguage | undefined
-  tracing: string | undefined
+  tracing: TracingMode | undefined
   tracerVersion: string
   tracerRegistry: SingleLanguageTracerRegistry
   tracerLibc: Libc
@@ -35,7 +36,7 @@ export interface SsiOptions {
 
 export type SsiConfigResult = (
   | {kind: 'errors'; errors: readonly string[]}
-  | {kind: 'disabled' | 'agent-only'}
+  | {kind: 'no-injection'}
   | {
       kind: 'single-language'
       language: Language
@@ -48,57 +49,38 @@ export type SsiConfigResult = (
 
 /** Resolves SSI inputs to a mode or validation errors. */
 export const resolveSsiConfig = (options: SsiOptions): SsiConfigResult => {
-  if (!options.apmEnabled) {
+  if (options.tracing !== 'inject') {
     const unusedFlags = nonDefaultTracerFlags(options)
 
     return unusedFlags.length > 0
       ? {
           kind: 'errors',
-          errors: [
-            `${unusedFlags.join(
-              ', '
-            )} only applies when --apm-enabled is set. Add --apm-enabled, or remove these flags to avoid silently changing nothing.`,
-          ],
+          errors: [`${unusedFlags.join(', ')} only applies with --tracing inject.`],
           warnings: [],
         }
-      : {kind: 'disabled', warnings: []}
+      : {kind: 'no-injection', warnings: []}
   }
-
-  const tracingErrors =
-    toBoolean(options.tracing) === false
-      ? ['--apm-enabled cannot be combined with disabled tracing. Remove one of the two flags.']
-      : []
 
   if (options.language === undefined) {
     return {
       kind: 'errors',
       errors: [
-        ...tracingErrors,
-        `--apm-enabled requires --language. Multi-Language instrumentation is not supported yet. Supported Single-Language values are: ${TRACER_INJECTION_LANGUAGES.join(
+        `--tracing inject requires --language until automatic multi-language injection is supported. Possible values: ${TRACER_INJECTION_LANGUAGES.join(
           ', '
-        )}, plus "go" for agent-only tracing.`,
+        )}.`,
       ],
       warnings: [],
     }
   }
 
   if (options.language === 'go') {
-    const unsupportedFlags = nonDefaultTracerFlags(options)
-    const goErrors = [
-      ...tracingErrors,
-      ...(unsupportedFlags.length > 0
-        ? [
-            `${unsupportedFlags.join(', ')} cannot be used with --language go because Go does not use an SSI tracer image. Remove these flags.`,
-          ]
-        : []),
-    ]
-    const goWarnings = [
-      'Go does not support automatic tracer injection. Datadog is setting DD_TRACE_ENABLED=true so the Datadog Agent sidecar can collect traces, but no tracer is installed. Instrument your Go application with dd-trace-go and redeploy your image to get traces.',
-    ]
-
-    return goErrors.length > 0
-      ? {kind: 'errors', errors: goErrors, warnings: goWarnings}
-      : {kind: 'agent-only', warnings: goWarnings}
+    return {
+      kind: 'errors',
+      errors: [
+        'Go does not support tracer injection. Instrument the application with dd-trace-go and use --tracing manual.',
+      ],
+      warnings: [],
+    }
   }
 
   const compatibilityError = getLanguageCompatibilityError({
@@ -106,7 +88,7 @@ export const resolveSsiConfig = (options: SsiOptions): SsiConfigResult => {
     libc: options.tracerLibc,
     version: options.tracerVersion,
   })
-  const errors = [...tracingErrors, ...(compatibilityError === undefined ? [] : [compatibilityError])]
+  const errors = compatibilityError === undefined ? [] : [compatibilityError]
   if (errors.length > 0) {
     return {kind: 'errors', errors, warnings: []}
   }

--- a/packages/plugin-cloud-run/src/ssi.ts
+++ b/packages/plugin-cloud-run/src/ssi.ts
@@ -1,0 +1,262 @@
+import type {IContainer} from './types'
+import type {
+  ServerlessLibc,
+  SingleLanguageInjectionSpec,
+} from '@datadog/datadog-ci-base/helpers/serverless/ssi/injection-spec'
+import type {ServerlessLanguage} from '@datadog/datadog-ci-base/helpers/serverless/ssi/tracer'
+
+import {
+  DEFAULT_TRACER_LIBC,
+  DEFAULT_TRACER_REGISTRY,
+  DEFAULT_TRACER_SIDECAR_MEMORY,
+  DEFAULT_TRACER_VERSION,
+  DEFAULT_TRACER_VOLUME_SIZE,
+  TRACER_MOUNT_PATH,
+} from '@datadog/datadog-ci-base/helpers/serverless/ssi/constants'
+import {getSingleLanguageInjectionSpec} from '@datadog/datadog-ci-base/helpers/serverless/ssi/injection-spec'
+import {SINGLE_LANGUAGE_TRACER_REGISTRIES} from '@datadog/datadog-ci-base/helpers/serverless/ssi/tracer'
+
+/** Languages accepted by `--language` today. `go` is accepted for APM as an agent-only mode. */
+export const CLOUD_RUN_LANGUAGES = ['nodejs', 'python', 'go', 'java', 'csharp', 'ruby', 'php'] as const
+export const SINGLE_LANGUAGE_VALUES: readonly ServerlessLanguage[] = [
+  'java',
+  'nodejs',
+  'csharp',
+  'python',
+  'ruby',
+  'php',
+]
+
+export class SsiValidationError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'SsiValidationError'
+  }
+}
+
+export interface SsiFlagOptions {
+  apmEnabled: boolean
+  language: string | undefined
+  tracing: string | undefined
+  tracerVersion: string
+  tracerRegistry: string
+  libc: string
+  tracerVolumeSize: string
+  tracerSidecarMemory: string
+}
+
+export type SsiFlagValidation =
+  | {kind: 'errors'; errors: string[]; warnings: string[]}
+  | {kind: 'disabled'; warnings: string[]}
+  | {kind: 'go-agent-only'; warnings: string[]}
+  | {
+      kind: 'single-language'
+      warnings: string[]
+      language: ServerlessLanguage
+      libc: ServerlessLibc
+      spec: SingleLanguageInjectionSpec
+      tracerVolumeSize: string
+      tracerSidecarMemory: string
+    }
+
+const CLOUD_RUN_QUANTITY_REG_EXP = /^(\d+(?:\.\d+)?)(m|Ki|Mi|Gi|Ti|k|M|G|T)?$/
+const CLOUD_RUN_QUANTITY_MULTIPLIERS: Record<string, number> = {
+  '': 1,
+  m: 0.001,
+  Ki: 1024,
+  Mi: 1024 ** 2,
+  Gi: 1024 ** 3,
+  Ti: 1024 ** 4,
+  k: 1000,
+  M: 1000 ** 2,
+  G: 1000 ** 3,
+  T: 1000 ** 4,
+}
+
+export const cloudRunQuantityToBytes = (value: string): number | undefined => {
+  const match = typeof value === 'string' ? value.trim().match(CLOUD_RUN_QUANTITY_REG_EXP) : undefined
+  if (!match) {
+    return undefined
+  }
+  const quantity = Number(match[1]) * CLOUD_RUN_QUANTITY_MULTIPLIERS[match[2] ?? '']
+
+  return Number.isFinite(quantity) && quantity > 0 ? quantity : undefined
+}
+
+export const validateCloudRunQuantity = (value: string, flag: string): string => {
+  if (cloudRunQuantityToBytes(value) === undefined) {
+    return `${flag} must be a positive Cloud Run quantity such as 768Mi or 1Gi, got ${JSON.stringify(value)}.`
+  }
+
+  return ''
+}
+
+const nonDefaultTracerFlags = (options: SsiFlagOptions): string[] => {
+  const nonDefault: string[] = []
+  if (options.tracerVersion !== DEFAULT_TRACER_VERSION) {
+    nonDefault.push('--tracer-version')
+  }
+  if (options.tracerRegistry !== DEFAULT_TRACER_REGISTRY) {
+    nonDefault.push('--tracer-registry')
+  }
+  if (options.libc !== DEFAULT_TRACER_LIBC) {
+    nonDefault.push('--libc')
+  }
+  if (options.tracerVolumeSize !== DEFAULT_TRACER_VOLUME_SIZE) {
+    nonDefault.push('--tracer-volume-size')
+  }
+  if (options.tracerSidecarMemory !== DEFAULT_TRACER_SIDECAR_MEMORY) {
+    nonDefault.push('--tracer-sidecar-memory')
+  }
+
+  return nonDefault
+}
+
+export const validateSsiFlags = (options: SsiFlagOptions): SsiFlagValidation => {
+  const errors: string[] = []
+  const warnings: string[] = []
+
+  if (!options.apmEnabled) {
+    const ignored = nonDefaultTracerFlags(options)
+    if (ignored.length > 0) {
+      errors.push(
+        `${ignored.join(
+          ', '
+        )} only applies when --apm-enabled is set. Add --apm-enabled, or remove these flags to avoid silently changing nothing.`
+      )
+    }
+
+    return errors.length > 0 ? {kind: 'errors', errors, warnings} : {kind: 'disabled', warnings}
+  }
+
+  if (options.tracing === 'false') {
+    errors.push('--apm-enabled cannot be combined with --tracing false. Remove one of the two flags.')
+  }
+
+  const language = options.language
+  if (!language) {
+    errors.push(
+      `--apm-enabled requires --language. Multi-Language instrumentation is not supported yet (SVLS-9316). Supported Single-Language values are: ${SINGLE_LANGUAGE_VALUES.join(
+        ', '
+      )}, plus "go" for agent-only tracing.`
+    )
+
+    return {kind: 'errors', errors, warnings}
+  }
+
+  if (!(CLOUD_RUN_LANGUAGES as readonly string[]).includes(language)) {
+    errors.push(
+      `Unsupported --language value ${JSON.stringify(language)}. Possible values: ${CLOUD_RUN_LANGUAGES.join(', ')}.`
+    )
+
+    return {kind: 'errors', errors, warnings}
+  }
+
+  if (language === 'go') {
+    const ignored = nonDefaultTracerFlags(options)
+    if (ignored.length > 0) {
+      errors.push(
+        `${ignored.join(', ')} cannot be used with --language go because Go does not use an SSI tracer image. Remove these flags.`
+      )
+    }
+    warnings.push(
+      'Go does not support automatic tracer injection. Datadog is setting DD_TRACE_ENABLED=true so the Datadog Agent sidecar can collect traces, but no tracer is installed. Instrument your Go application with dd-trace-go and redeploy your image to get traces.'
+    )
+
+    return errors.length > 0 ? {kind: 'errors', errors, warnings} : {kind: 'go-agent-only', warnings}
+  }
+
+  for (const [flag, value] of [
+    ['--tracer-volume-size', options.tracerVolumeSize],
+    ['--tracer-sidecar-memory', options.tracerSidecarMemory],
+  ] as const) {
+    const error = validateCloudRunQuantity(value, flag)
+    if (error) {
+      errors.push(error)
+    }
+  }
+
+  if (!(SINGLE_LANGUAGE_TRACER_REGISTRIES as readonly string[]).includes(options.tracerRegistry)) {
+    errors.push(
+      `Unsupported --tracer-registry ${JSON.stringify(
+        options.tracerRegistry
+      )}. Possible values: ${SINGLE_LANGUAGE_TRACER_REGISTRIES.join(', ')}.`
+    )
+  }
+
+  if (options.libc !== 'glibc' && options.libc !== 'musl') {
+    errors.push(`Unsupported --libc ${JSON.stringify(options.libc)}. Possible values: glibc, musl.`)
+  }
+
+  const volumeBytes = cloudRunQuantityToBytes(options.tracerVolumeSize)
+  const sidecarMemoryBytes = cloudRunQuantityToBytes(options.tracerSidecarMemory)
+  if (volumeBytes !== undefined && sidecarMemoryBytes !== undefined && sidecarMemoryBytes < volumeBytes) {
+    errors.push(
+      `--tracer-sidecar-memory (${options.tracerSidecarMemory}) cannot be smaller than --tracer-volume-size (${options.tracerVolumeSize}) because the Memory volume is charged to the tracer copy sidecar.`
+    )
+  }
+
+  if (errors.length > 0) {
+    return {kind: 'errors', errors, warnings}
+  }
+
+  let spec: SingleLanguageInjectionSpec
+  try {
+    spec = getSingleLanguageInjectionSpec({
+      language: language as ServerlessLanguage,
+      registry: options.tracerRegistry as (typeof SINGLE_LANGUAGE_TRACER_REGISTRIES)[number],
+      version: options.tracerVersion,
+      libc: options.libc as ServerlessLibc,
+      root: TRACER_MOUNT_PATH,
+    })
+  } catch (error) {
+    return {kind: 'errors', errors: [error instanceof Error ? error.message : String(error)], warnings}
+  }
+
+  if (language === 'java') {
+    warnings.push(
+      'This release supports Java 8 through Java 23. Java 24+ applications require an additional JVM flag that datadog-ci cannot set safely without knowing your runtime version.'
+    )
+  }
+
+  return {
+    kind: 'single-language',
+    warnings,
+    language: language as ServerlessLanguage,
+    libc: options.libc as ServerlessLibc,
+    spec,
+    tracerVolumeSize: options.tracerVolumeSize,
+    tracerSidecarMemory: options.tracerSidecarMemory,
+  }
+}
+
+export const selectIngressContainer = (
+  containers: readonly IContainer[],
+  reservedNames: ReadonlySet<string>
+): IContainer => {
+  const candidates = containers.filter((container) => !container.name || !reservedNames.has(container.name))
+  if (candidates.length === 0) {
+    throw new SsiValidationError('No application container was found to instrument.')
+  }
+
+  const withPorts = candidates.filter((container) => (container.ports ?? []).length > 0)
+  if (withPorts.length === 1) {
+    return withPorts[0]
+  }
+  if (withPorts.length > 1) {
+    throw new SsiValidationError(
+      `Multiple containers declare ports, so the ingress container is ambiguous: ${withPorts
+        .map((container) => container.name || '<unnamed>')
+        .join(', ')}. Cloud Run allows exactly one ingress container.`
+    )
+  }
+  if (candidates.length === 1) {
+    return candidates[0]
+  }
+
+  throw new SsiValidationError(
+    `No container declares ports, so the ingress container is ambiguous: ${candidates
+      .map((container) => container.name || '<unnamed>')
+      .join(', ')}. Declare a container port on your ingress container.`
+  )
+}

--- a/packages/plugin-cloud-run/src/ssi.ts
+++ b/packages/plugin-cloud-run/src/ssi.ts
@@ -28,35 +28,34 @@ export interface SsiOptions {
   tracing: string | undefined
   tracerVersion: string
   tracerRegistry: SingleLanguageTracerRegistry
-  libc: Libc
+  tracerLibc: Libc
   tracerVolumeSize: string
   tracerSidecarMemory: string
 }
 
-export type SsiConfigResult =
-  | {kind: 'errors'; errors: readonly string[]; warnings: readonly string[]}
-  | {kind: 'disabled'; warnings: readonly string[]}
-  | {kind: 'agent-only'; warnings: readonly string[]}
+export type SsiConfigResult = (
+  | {kind: 'errors'; errors: readonly string[]}
+  | {kind: 'disabled' | 'agent-only'}
   | {
       kind: 'single-language'
-      warnings: readonly string[]
       language: Language
       libc: Libc
       spec: LanguageInjectionSpec
       tracerVolumeSize: string
       tracerSidecarMemory: string
     }
+) & {warnings: readonly string[]}
 
 /** Resolves SSI inputs to a mode or validation errors. */
 export const resolveSsiConfig = (options: SsiOptions): SsiConfigResult => {
   if (!options.apmEnabled) {
-    const ignored = customTracerFlags(options)
+    const unusedFlags = nonDefaultTracerFlags(options)
 
-    return ignored.length > 0
+    return unusedFlags.length > 0
       ? {
           kind: 'errors',
           errors: [
-            `${ignored.join(
+            `${unusedFlags.join(
               ', '
             )} only applies when --apm-enabled is set. Add --apm-enabled, or remove these flags to avoid silently changing nothing.`,
           ],
@@ -84,12 +83,12 @@ export const resolveSsiConfig = (options: SsiOptions): SsiConfigResult => {
   }
 
   if (options.language === 'go') {
-    const ignored = customTracerFlags(options)
+    const unsupportedFlags = nonDefaultTracerFlags(options)
     const goErrors = [
       ...tracingErrors,
-      ...(ignored.length > 0
+      ...(unsupportedFlags.length > 0
         ? [
-            `${ignored.join(', ')} cannot be used with --language go because Go does not use an SSI tracer image. Remove these flags.`,
+            `${unsupportedFlags.join(', ')} cannot be used with --language go because Go does not use an SSI tracer image. Remove these flags.`,
           ]
         : []),
     ]
@@ -104,7 +103,7 @@ export const resolveSsiConfig = (options: SsiOptions): SsiConfigResult => {
 
   const compatibilityError = getLanguageCompatibilityError({
     language: options.language,
-    libc: options.libc,
+    libc: options.tracerLibc,
     version: options.tracerVersion,
   })
   const errors = [...tracingErrors, ...(compatibilityError === undefined ? [] : [compatibilityError])]
@@ -116,7 +115,7 @@ export const resolveSsiConfig = (options: SsiOptions): SsiConfigResult => {
     language: options.language,
     registry: options.tracerRegistry,
     version: options.tracerVersion,
-    libc: options.libc,
+    libc: options.tracerLibc,
     root: TRACER_MOUNT_PATH,
   })
   const warnings =
@@ -130,7 +129,7 @@ export const resolveSsiConfig = (options: SsiOptions): SsiConfigResult => {
     kind: 'single-language',
     warnings,
     language: options.language,
-    libc: options.libc,
+    libc: options.tracerLibc,
     spec,
     tracerVolumeSize: options.tracerVolumeSize,
     tracerSidecarMemory: options.tracerSidecarMemory,
@@ -176,11 +175,12 @@ export class SsiConfigError extends Error {
   }
 }
 
-const customTracerFlags = (options: SsiOptions): string[] =>
+/** Returns tracer flags whose values differ from their defaults. */
+const nonDefaultTracerFlags = (options: SsiOptions): string[] =>
   [
     options.tracerVersion !== DEFAULT_TRACER_VERSION ? '--tracer-version' : undefined,
     options.tracerRegistry !== DEFAULT_TRACER_REGISTRY ? '--tracer-registry' : undefined,
-    options.libc !== DEFAULT_TRACER_LIBC ? '--libc' : undefined,
+    options.tracerLibc !== DEFAULT_TRACER_LIBC ? '--tracer-libc' : undefined,
     options.tracerVolumeSize !== DEFAULT_TRACER_VOLUME_SIZE ? '--tracer-volume-size' : undefined,
     options.tracerSidecarMemory !== DEFAULT_TRACER_SIDECAR_MEMORY ? '--tracer-sidecar-memory' : undefined,
   ].filter((flag): flag is string => flag !== undefined)


### PR DESCRIPTION
### What and why?

Define Cloud Run's Single-Language SSI policy before wiring it into the command. The design extends the existing `--tracing` and `--language` controls instead of adding an overlapping APM flag.

### How?

A pure resolver turns normalized tracing modes into either no injection, a language-specific tracer specification, or customer-facing compatibility errors. The PR also selects an unambiguous ingress container and keeps tracer defaults scoped to Cloud Run.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
