### PR TITLE
[SVLS-9302] add Cloud Run SSI environment handlers

### DIFF
--- a/packages/base/src/commands/cloud-run/constants.ts
+++ b/packages/base/src/commands/cloud-run/constants.ts
@@ -1,8 +1,8 @@
 import {ENVIRONMENT_ENV_VAR, SERVICE_ENV_VAR, SITE_ENV_VAR} from '../../helpers/serverless/constants'
 
-export const DEFAULT_TRACER_REGISTRY = 'gcr.io/datadoghq'
-export const DEFAULT_TRACER_VERSION = 'latest'
-export const DEFAULT_TRACER_LIBC = 'glibc'
+export const DEFAULT_TRACER_REGISTRY = 'gcr.io/datadoghq' as const
+export const DEFAULT_TRACER_VERSION = 'latest' as const
+export const DEFAULT_TRACER_LIBC = 'glibc' as const
 
 export const SKIP_MASKING_CLOUDRUN_ENV_VARS = new Set([
   SITE_ENV_VAR,

--- a/packages/plugin-cloud-run/src/__tests__/ssi.test.ts
+++ b/packages/plugin-cloud-run/src/__tests__/ssi.test.ts
@@ -1,7 +1,13 @@
-import type {IContainer} from '../types'
+import type {IContainer, IEnvVar} from '../types'
 import type {Language} from '@datadog/datadog-ci-base/helpers/serverless/ssi/tracer'
+import type {ServerlessLibc} from '@datadog/datadog-ci-base/helpers/serverless/ssi/injection-spec'
+import type {ServerlessLanguage} from '@datadog/datadog-ci-base/helpers/serverless/ssi/tracer'
+import {SINGLE_LANGUAGE_INJECTION_MODE_TAG} from '@datadog/datadog-ci-base/helpers/serverless/ssi/env'
+import {getSingleLanguageInjectionSpec} from '@datadog/datadog-ci-base/helpers/serverless/ssi/injection-spec'
 
-import {resolveSsiConfig, selectMainContainer, SsiConfigError, type SsiOptions} from '../ssi'
+import {resolveSsiConfig,
+  mergeNativeInjectionEnv,
+  removeKnownNativeInjectionEnv, selectMainContainer, SsiConfigError, type SsiOptions} from '../ssi'
 
 const defaultOptions: SsiOptions = {
   language: undefined,
@@ -10,6 +16,17 @@ const defaultOptions: SsiOptions = {
   tracerRegistry: 'gcr.io/datadoghq',
   tracerLibc: 'glibc',
 }
+
+const getSpec = (language: ServerlessLanguage, libc: ServerlessLibc = 'glibc') =>
+  getSingleLanguageInjectionSpec({
+    language,
+    registry: 'gcr.io/datadoghq',
+    version: 'latest',
+    libc,
+    root: '/datadog-lib',
+  })
+
+const nodeSpec = getSpec('nodejs')
 
 const getErrors = (overrides: Partial<SsiOptions>) => {
   const result = resolveSsiConfig({...defaultOptions, ...overrides})
@@ -61,6 +78,88 @@ describe('resolveSsiConfig', () => {
     expect(resolveSsiConfig({...defaultOptions, tracing: 'inject', language: 'java'}).warnings.join('\n')).toContain(
       'Java 24+'
     )
+  })
+})
+
+describe('native injection environment', () => {
+  test('extends existing values and adds the injection tag once', () => {
+    const existing: IEnvVar[] = [
+      {name: 'NODE_OPTIONS', value: '--max-old-space-size=512'},
+      {name: 'DD_TAGS', value: 'team:backend'},
+    ]
+
+    const first = mergeNativeInjectionEnv(existing, nodeSpec)
+    expect(first).toEqual([
+      {name: 'NODE_OPTIONS', value: '--max-old-space-size=512 --require /datadog-lib/node_modules/dd-trace/init.js'},
+      {name: 'DD_TAGS', value: `${SINGLE_LANGUAGE_INJECTION_MODE_TAG},team:backend`},
+    ])
+    expect(mergeNativeInjectionEnv(first, nodeSpec)).toEqual(first)
+  })
+
+  test.each(['NODE_OPTIONS', 'DD_TAGS'])('rejects a value-source target for %s', (name) => {
+    expect(() => mergeNativeInjectionEnv([{name, valueSource: {secretKeyRef: {secret: 'secret'}}}], nodeSpec)).toThrow(
+      SsiValidationError
+    )
+  })
+
+  test.each(['NODE_OPTIONS', 'DD_TAGS'])('rejects a duplicate target for %s', (name) => {
+    expect(() =>
+      mergeNativeInjectionEnv(
+        [
+          {name, value: 'first'},
+          {name, value: 'second'},
+        ],
+        nodeSpec
+      )
+    ).toThrow(/more than once/)
+  })
+
+  test.each([
+    ['java', 'glibc'],
+    ['java', 'musl'],
+    ['nodejs', 'glibc'],
+    ['nodejs', 'musl'],
+    ['csharp', 'glibc'],
+    ['csharp', 'musl'],
+    ['python', 'glibc'],
+    ['python', 'musl'],
+    ['ruby', 'glibc'],
+    ['php', 'glibc'],
+    ['php', 'musl'],
+  ] as [ServerlessLanguage, ServerlessLibc][])('removes every exact known %s/%s fragment', (language, libc) => {
+    const injected = mergeNativeInjectionEnv(
+      [
+        {name: 'CUSTOM', value: 'keep'},
+        {name: 'DD_TAGS', value: 'team:backend'},
+      ],
+      getSpec(language, libc)
+    )
+
+    expect(removeKnownNativeInjectionEnv(injected)).toEqual([
+      {name: 'CUSTOM', value: 'keep'},
+      {name: 'DD_TAGS', value: 'team:backend'},
+    ])
+  })
+
+  test('supports markerless cross-language replacement', () => {
+    const markerlessJava = mergeNativeInjectionEnv([{name: 'CUSTOM', value: 'keep'}], getSpec('java')).filter(
+      (variable) => variable.name !== 'DD_TAGS'
+    )
+    const replaced = mergeNativeInjectionEnv(removeKnownNativeInjectionEnv(markerlessJava), nodeSpec)
+
+    expect(replaced).toEqual([
+      {name: 'CUSTOM', value: 'keep'},
+      {name: 'NODE_OPTIONS', value: '--require /datadog-lib/node_modules/dd-trace/init.js'},
+      {name: 'DD_TAGS', value: SINGLE_LANGUAGE_INJECTION_MODE_TAG},
+    ])
+  })
+
+  test('removes both known PHP libc paths while preserving other scan directories', () => {
+    const glibc = getSpec('php', 'glibc').env[0].value
+    const musl = getSpec('php', 'musl').env[0].value
+    expect(
+      removeKnownNativeInjectionEnv([{name: 'PHP_INI_SCAN_DIR', value: `/etc/php${glibc}${musl}:/custom/php`}])
+    ).toEqual([{name: 'PHP_INI_SCAN_DIR', value: '/etc/php:/custom/php'}])
   })
 })
 

--- a/packages/plugin-cloud-run/src/__tests__/ssi.test.ts
+++ b/packages/plugin-cloud-run/src/__tests__/ssi.test.ts
@@ -1,13 +1,24 @@
 import type {IContainer, IEnvVar} from '../types'
+import type {Libc} from '@datadog/datadog-ci-base/helpers/serverless/ssi/injection-spec'
 import type {Language} from '@datadog/datadog-ci-base/helpers/serverless/ssi/tracer'
-import type {ServerlessLibc} from '@datadog/datadog-ci-base/helpers/serverless/ssi/injection-spec'
-import type {ServerlessLanguage} from '@datadog/datadog-ci-base/helpers/serverless/ssi/tracer'
-import {SINGLE_LANGUAGE_INJECTION_MODE_TAG} from '@datadog/datadog-ci-base/helpers/serverless/ssi/env'
-import {getSingleLanguageInjectionSpec} from '@datadog/datadog-ci-base/helpers/serverless/ssi/injection-spec'
 
-import {resolveSsiConfig,
-  mergeNativeInjectionEnv,
-  removeKnownNativeInjectionEnv, selectMainContainer, SsiConfigError, type SsiOptions} from '../ssi'
+import {TRACER_MOUNT_PATH} from '@datadog/datadog-ci-base/helpers/serverless/ssi/constants'
+import {SINGLE_LANGUAGE_INJECTION_MODE_TAG} from '@datadog/datadog-ci-base/helpers/serverless/ssi/env'
+import {
+  LIBCS,
+  getLanguageCompatibilityError,
+  getLanguageInjectionSpec,
+} from '@datadog/datadog-ci-base/helpers/serverless/ssi/injection-spec'
+
+import {
+  TRACER_INJECTION_LANGUAGES,
+  mergeLanguageInjectionEnv,
+  removeLanguageInjectionEnv,
+  resolveSsiConfig,
+  selectMainContainer,
+  SsiConfigError,
+  type SsiOptions,
+} from '../ssi'
 
 const defaultOptions: SsiOptions = {
   language: undefined,
@@ -17,16 +28,21 @@ const defaultOptions: SsiOptions = {
   tracerLibc: 'glibc',
 }
 
-const getSpec = (language: ServerlessLanguage, libc: ServerlessLibc = 'glibc') =>
-  getSingleLanguageInjectionSpec({
+const getSpec = (language: Language, libc: Libc = defaultOptions.tracerLibc) =>
+  getLanguageInjectionSpec({
     language,
-    registry: 'gcr.io/datadoghq',
-    version: 'latest',
+    registry: defaultOptions.tracerRegistry,
+    version: defaultOptions.tracerVersion,
     libc,
-    root: '/datadog-lib',
+    root: TRACER_MOUNT_PATH,
   })
 
 const nodeSpec = getSpec('nodejs')
+const supportedLanguageVariants = TRACER_INJECTION_LANGUAGES.flatMap((language) =>
+  LIBCS.filter(
+    (libc) => getLanguageCompatibilityError({language, libc, version: defaultOptions.tracerVersion}) === undefined
+  ).map((libc) => [language, libc] as const)
+)
 
 const getErrors = (overrides: Partial<SsiOptions>) => {
   const result = resolveSsiConfig({...defaultOptions, ...overrides})
@@ -81,30 +97,30 @@ describe('resolveSsiConfig', () => {
   })
 })
 
-describe('native injection environment', () => {
+describe('language injection environment', () => {
   test('extends existing values and adds the injection tag once', () => {
     const existing: IEnvVar[] = [
       {name: 'NODE_OPTIONS', value: '--max-old-space-size=512'},
       {name: 'DD_TAGS', value: 'team:backend'},
     ]
 
-    const first = mergeNativeInjectionEnv(existing, nodeSpec)
+    const first = mergeLanguageInjectionEnv(existing, nodeSpec)
     expect(first).toEqual([
       {name: 'NODE_OPTIONS', value: '--max-old-space-size=512 --require /datadog-lib/node_modules/dd-trace/init.js'},
       {name: 'DD_TAGS', value: `${SINGLE_LANGUAGE_INJECTION_MODE_TAG},team:backend`},
     ])
-    expect(mergeNativeInjectionEnv(first, nodeSpec)).toEqual(first)
+    expect(mergeLanguageInjectionEnv(first, nodeSpec)).toEqual(first)
   })
 
   test.each(['NODE_OPTIONS', 'DD_TAGS'])('rejects a value-source target for %s', (name) => {
-    expect(() => mergeNativeInjectionEnv([{name, valueSource: {secretKeyRef: {secret: 'secret'}}}], nodeSpec)).toThrow(
-      SsiValidationError
-    )
+    expect(() =>
+      mergeLanguageInjectionEnv([{name, valueSource: {secretKeyRef: {secret: 'secret'}}}], nodeSpec)
+    ).toThrow(SsiConfigError)
   })
 
   test.each(['NODE_OPTIONS', 'DD_TAGS'])('rejects a duplicate target for %s', (name) => {
     expect(() =>
-      mergeNativeInjectionEnv(
+      mergeLanguageInjectionEnv(
         [
           {name, value: 'first'},
           {name, value: 'second'},
@@ -114,20 +130,14 @@ describe('native injection environment', () => {
     ).toThrow(/more than once/)
   })
 
-  test.each([
-    ['java', 'glibc'],
-    ['java', 'musl'],
-    ['nodejs', 'glibc'],
-    ['nodejs', 'musl'],
-    ['csharp', 'glibc'],
-    ['csharp', 'musl'],
-    ['python', 'glibc'],
-    ['python', 'musl'],
-    ['ruby', 'glibc'],
-    ['php', 'glibc'],
-    ['php', 'musl'],
-  ] as [ServerlessLanguage, ServerlessLibc][])('removes every exact known %s/%s fragment', (language, libc) => {
-    const injected = mergeNativeInjectionEnv(
+  test('rejects a conflicting scalar value', () => {
+    expect(() =>
+      mergeLanguageInjectionEnv([{name: 'CORECLR_ENABLE_PROFILING', value: '0'}], getSpec('csharp'))
+    ).toThrow(SsiConfigError)
+  })
+
+  test.each(supportedLanguageVariants)('removes the %s/%s tracer environment', (language, libc) => {
+    const injected = mergeLanguageInjectionEnv(
       [
         {name: 'CUSTOM', value: 'keep'},
         {name: 'DD_TAGS', value: 'team:backend'},
@@ -135,17 +145,17 @@ describe('native injection environment', () => {
       getSpec(language, libc)
     )
 
-    expect(removeKnownNativeInjectionEnv(injected)).toEqual([
+    expect(removeLanguageInjectionEnv(injected)).toEqual([
       {name: 'CUSTOM', value: 'keep'},
       {name: 'DD_TAGS', value: 'team:backend'},
     ])
   })
 
-  test('supports markerless cross-language replacement', () => {
-    const markerlessJava = mergeNativeInjectionEnv([{name: 'CUSTOM', value: 'keep'}], getSpec('java')).filter(
+  test('replaces another language when the injection tag is missing', () => {
+    const markerlessJava = mergeLanguageInjectionEnv([{name: 'CUSTOM', value: 'keep'}], getSpec('java')).filter(
       (variable) => variable.name !== 'DD_TAGS'
     )
-    const replaced = mergeNativeInjectionEnv(removeKnownNativeInjectionEnv(markerlessJava), nodeSpec)
+    const replaced = mergeLanguageInjectionEnv(removeLanguageInjectionEnv(markerlessJava), nodeSpec)
 
     expect(replaced).toEqual([
       {name: 'CUSTOM', value: 'keep'},
@@ -154,11 +164,20 @@ describe('native injection environment', () => {
     ])
   })
 
+  test('preserves value-source and empty environment variables during removal', () => {
+    const env: IEnvVar[] = [
+      {name: 'NODE_OPTIONS', valueSource: {secretKeyRef: {secret: 'node-options'}}},
+      {name: 'DD_TAGS', value: ''},
+    ]
+
+    expect(removeLanguageInjectionEnv(env)).toEqual(env)
+  })
+
   test('removes both known PHP libc paths while preserving other scan directories', () => {
     const glibc = getSpec('php', 'glibc').env[0].value
     const musl = getSpec('php', 'musl').env[0].value
     expect(
-      removeKnownNativeInjectionEnv([{name: 'PHP_INI_SCAN_DIR', value: `/etc/php${glibc}${musl}:/custom/php`}])
+      removeLanguageInjectionEnv([{name: 'PHP_INI_SCAN_DIR', value: `/etc/php:${glibc}:${musl}:/custom/php`}])
     ).toEqual([{name: 'PHP_INI_SCAN_DIR', value: '/etc/php:/custom/php'}])
   })
 })

--- a/packages/plugin-cloud-run/src/__tests__/ssi.test.ts
+++ b/packages/plugin-cloud-run/src/__tests__/ssi.test.ts
@@ -6,7 +6,7 @@ import {TRACER_MOUNT_PATH} from '@datadog/datadog-ci-base/helpers/serverless/ssi
 import {SINGLE_LANGUAGE_INJECTION_MODE_TAG} from '@datadog/datadog-ci-base/helpers/serverless/ssi/env'
 import {
   LIBCS,
-  getLanguageCompatibilityError,
+  getLanguageCompatibilityErrors,
   getLanguageInjectionSpec,
 } from '@datadog/datadog-ci-base/helpers/serverless/ssi/injection-spec'
 
@@ -40,7 +40,7 @@ const getSpec = (language: Language, libc: Libc = defaultOptions.tracerLibc) =>
 const nodeSpec = getSpec('nodejs')
 const supportedLanguageVariants = TRACER_INJECTION_LANGUAGES.flatMap((language) =>
   LIBCS.filter(
-    (libc) => getLanguageCompatibilityError({language, libc, version: defaultOptions.tracerVersion}) === undefined
+    (libc) => getLanguageCompatibilityErrors({language, libc, version: defaultOptions.tracerVersion}).length === 0
   ).map((libc) => [language, libc] as const)
 )
 

--- a/packages/plugin-cloud-run/src/ssi.ts
+++ b/packages/plugin-cloud-run/src/ssi.ts
@@ -192,12 +192,12 @@ const assertLanguageInjectionEnvCanBeMerged = (env: readonly IEnvVar[], spec: La
     const matching = env.filter((variable) => variable.name === name)
     if (matching.length > 1) {
       throw new SsiConfigError(
-        `${name} appears more than once on the ingress container, so Datadog cannot safely modify it. Remove the duplicate before retrying.`
+        `${name} appears more than once on the main container, so Datadog cannot safely modify it. Remove the duplicate before retrying.`
       )
     }
     if (matching[0]?.valueSource) {
       throw new SsiConfigError(
-        `${name} on the ingress container is populated from a secret reference, which Datadog cannot safely extend. Set it to a literal value or remove it before instrumenting.`
+        `${name} on the main container is populated from a secret reference, which Datadog cannot safely extend. Set it to a literal value or remove it before instrumenting.`
       )
     }
   }

--- a/packages/plugin-cloud-run/src/ssi.ts
+++ b/packages/plugin-cloud-run/src/ssi.ts
@@ -221,7 +221,7 @@ const mergeLanguageEnvFragment = (currentValue: string | undefined, fragment: En
 
 const LANGUAGE_ENV_FRAGMENTS: readonly EnvFragment[] = TRACER_INJECTION_LANGUAGES.flatMap((language) =>
   LIBCS.filter(
-    (libc) => getLanguageCompatibilityError({language, libc, version: DEFAULT_TRACER_VERSION}) === undefined
+    (libc) => getLanguageCompatibilityErrors({language, libc, version: DEFAULT_TRACER_VERSION}).length === 0
   ).flatMap(
     (libc) =>
       getLanguageInjectionSpec({

--- a/packages/plugin-cloud-run/src/ssi.ts
+++ b/packages/plugin-cloud-run/src/ssi.ts
@@ -1,13 +1,20 @@
-import type {IContainer} from './types'
+import type {IContainer, IEnvVar} from './types'
+import type {EnvFragment} from '@datadog/datadog-ci-base/helpers/serverless/ssi/env'
 import type {LanguageInjectionSpec, Libc} from '@datadog/datadog-ci-base/helpers/serverless/ssi/injection-spec'
 import type {Language, SingleLanguageTracerRegistry} from '@datadog/datadog-ci-base/helpers/serverless/ssi/tracer'
-
+import {DD_TAGS_ENV_VAR} from '@datadog/datadog-ci-base/helpers/serverless/constants'
 import {
   DEFAULT_TRACER_LIBC,
   DEFAULT_TRACER_REGISTRY,
   DEFAULT_TRACER_VERSION,
 } from '@datadog/datadog-ci-base/commands/cloud-run/constants'
 import {TRACER_MOUNT_PATH} from '@datadog/datadog-ci-base/helpers/serverless/ssi/constants'
+import {
+  mergeEnvFragment,
+  mergeInjectionModeTag,
+  removeEnvFragment,
+  removeInjectionModeTag,
+} from '@datadog/datadog-ci-base/helpers/serverless/ssi/env'
 import {
   getLanguageCompatibilityErrors,
   getLanguageInjectionSpec,
@@ -139,6 +146,123 @@ export const selectMainContainer = (
       .map((container) => container.name || '<unnamed>')
       .join(', ')}. Declare a container port on your main container.`
   )
+}
+
+const findEnv = (env: readonly IEnvVar[], name: string): IEnvVar | undefined =>
+  env.find((variable) => variable.name === name)
+
+const assertUniqueTargetEnvNames = (env: readonly IEnvVar[], targetNames: ReadonlySet<string>): void => {
+  for (const name of targetNames) {
+    if (env.filter((variable) => variable.name === name).length > 1) {
+      throw new SsiValidationError(
+        `${name} appears more than once on the ingress container, so Datadog cannot safely modify it. Remove the duplicate before retrying.`
+      )
+    }
+  }
+}
+
+const assertNoValueSource = (existing: IEnvVar | undefined, name: string): void => {
+  if (existing?.valueSource) {
+    throw new SsiValidationError(
+      `${name} on the ingress container is populated from a secret reference, which Datadog cannot safely extend. Set it to a literal value or remove it before instrumenting.`
+    )
+  }
+}
+
+export const assertNativeInjectionEnvCanBeMerged = (
+  existingEnv: readonly IEnvVar[] | null | undefined,
+  spec: SingleLanguageInjectionSpec
+): void => {
+  const env = existingEnv ?? []
+  const targetNames = new Set([...spec.env.map((fragment) => fragment.name), DD_TAGS_ENV_VAR])
+  assertUniqueTargetEnvNames(env, targetNames)
+  for (const name of targetNames) {
+    assertNoValueSource(findEnv(env, name), name)
+  }
+}
+
+const upsertEnv = (env: IEnvVar[], name: string, value: string): IEnvVar[] => {
+  const index = env.findIndex((variable) => variable.name === name)
+  if (index === -1) {
+    return [...env, {name, value}]
+  }
+  const updated = [...env]
+  updated[index] = {...updated[index], value}
+
+  return updated
+}
+
+export const mergeNativeInjectionEnv = (
+  existingEnv: readonly IEnvVar[] | null | undefined,
+  spec: SingleLanguageInjectionSpec
+): IEnvVar[] => {
+  let env: IEnvVar[] = [...(existingEnv ?? [])]
+  assertNativeInjectionEnvCanBeMerged(env, spec)
+
+  for (const fragment of spec.env) {
+    const existing = findEnv(env, fragment.name)
+    env = upsertEnv(env, fragment.name, mergeEnvFragment(existing?.value ?? undefined, fragment))
+  }
+
+  const existingTags = findEnv(env, DD_TAGS_ENV_VAR)
+  env = upsertEnv(env, DD_TAGS_ENV_VAR, mergeInjectionModeTag(existingTags?.value ?? undefined))
+
+  return env
+}
+
+const KNOWN_NATIVE_FRAGMENTS: readonly EnvFragment[] = (() => {
+  const fragments = new Map<string, EnvFragment>()
+  for (const language of SINGLE_LANGUAGE_VALUES) {
+    for (const libc of ['glibc', 'musl'] as const) {
+      if (language === 'ruby' && libc === 'musl') {
+        continue
+      }
+      const spec = getSingleLanguageInjectionSpec({
+        language,
+        libc,
+        registry: DEFAULT_TRACER_REGISTRY,
+        version: DEFAULT_TRACER_VERSION,
+        root: TRACER_MOUNT_PATH,
+      })
+      for (const fragment of spec.env) {
+        fragments.set(JSON.stringify(fragment), fragment)
+      }
+    }
+  }
+
+  return [...fragments.values()]
+})()
+
+const KNOWN_NATIVE_FRAGMENTS_BY_NAME = new Map<string, EnvFragment[]>()
+for (const fragment of KNOWN_NATIVE_FRAGMENTS) {
+  const fragments = KNOWN_NATIVE_FRAGMENTS_BY_NAME.get(fragment.name) ?? []
+  fragments.push(fragment)
+  KNOWN_NATIVE_FRAGMENTS_BY_NAME.set(fragment.name, fragments)
+}
+
+/** Removes every exact native SSI fragment and the injection-mode tag, regardless of selected language or libc. */
+export const removeKnownNativeInjectionEnv = (existingEnv: readonly IEnvVar[] | null | undefined): IEnvVar[] => {
+  const cleaned: IEnvVar[] = []
+  for (const variable of existingEnv ?? []) {
+    if (!variable.name || variable.valueSource || typeof variable.value !== 'string' || variable.value === '') {
+      cleaned.push(variable)
+      continue
+    }
+
+    let value: string | undefined = variable.value
+    if (variable.name === DD_TAGS_ENV_VAR) {
+      value = removeInjectionModeTag(value)
+    }
+    for (const fragment of KNOWN_NATIVE_FRAGMENTS_BY_NAME.get(variable.name) ?? []) {
+      value = removeEnvFragment(value, fragment)
+    }
+
+    if (value !== undefined) {
+      cleaned.push(value === variable.value ? variable : {...variable, value})
+    }
+  }
+
+  return cleaned
 }
 
 export class SsiConfigError extends Error {

--- a/packages/plugin-cloud-run/src/ssi.ts
+++ b/packages/plugin-cloud-run/src/ssi.ts
@@ -2,12 +2,13 @@ import type {IContainer, IEnvVar} from './types'
 import type {EnvFragment} from '@datadog/datadog-ci-base/helpers/serverless/ssi/env'
 import type {LanguageInjectionSpec, Libc} from '@datadog/datadog-ci-base/helpers/serverless/ssi/injection-spec'
 import type {Language, SingleLanguageTracerRegistry} from '@datadog/datadog-ci-base/helpers/serverless/ssi/tracer'
-import {DD_TAGS_ENV_VAR} from '@datadog/datadog-ci-base/helpers/serverless/constants'
+
 import {
   DEFAULT_TRACER_LIBC,
   DEFAULT_TRACER_REGISTRY,
   DEFAULT_TRACER_VERSION,
 } from '@datadog/datadog-ci-base/commands/cloud-run/constants'
+import {DD_TAGS_ENV_VAR} from '@datadog/datadog-ci-base/helpers/serverless/constants'
 import {TRACER_MOUNT_PATH} from '@datadog/datadog-ci-base/helpers/serverless/ssi/constants'
 import {
   mergeEnvFragment,
@@ -16,6 +17,7 @@ import {
   removeInjectionModeTag,
 } from '@datadog/datadog-ci-base/helpers/serverless/ssi/env'
 import {
+  LIBCS,
   getLanguageCompatibilityErrors,
   getLanguageInjectionSpec,
 } from '@datadog/datadog-ci-base/helpers/serverless/ssi/injection-spec'
@@ -148,129 +150,89 @@ export const selectMainContainer = (
   )
 }
 
+export const mergeLanguageInjectionEnv = (
+  existingEnv: readonly IEnvVar[] | null | undefined,
+  spec: LanguageInjectionSpec
+): IEnvVar[] => {
+  const env = existingEnv ?? []
+  assertLanguageInjectionEnvCanBeMerged(env, spec)
+  const merged = spec.env.reduce<IEnvVar[]>(
+    (current, fragment) => {
+      const existing = findEnv(current, fragment.name)
+
+      return upsertEnv(current, fragment.name, mergeLanguageEnvFragment(existing?.value ?? undefined, fragment))
+    },
+    [...env]
+  )
+  const existingTags = findEnv(merged, DD_TAGS_ENV_VAR)
+
+  return upsertEnv(merged, DD_TAGS_ENV_VAR, mergeInjectionModeTag(existingTags?.value ?? undefined))
+}
+
+/** Removes exact tracer fragments for every supported language so replacing a tracer cannot leave stale settings. */
+export const removeLanguageInjectionEnv = (existingEnv: readonly IEnvVar[] | null | undefined): IEnvVar[] =>
+  (existingEnv ?? []).flatMap((variable) => {
+    if (!variable.name || variable.valueSource || !variable.value) {
+      return [variable]
+    }
+
+    const fragments = LANGUAGE_ENV_FRAGMENTS.filter((fragment) => fragment.name === variable.name)
+    const withoutTag = variable.name === DD_TAGS_ENV_VAR ? removeInjectionModeTag(variable.value) : variable.value
+    const value = fragments.reduce<string | undefined>(removeEnvFragment, withoutTag)
+
+    return value === undefined ? [] : [value === variable.value ? variable : {...variable, value}]
+  })
+
 const findEnv = (env: readonly IEnvVar[], name: string): IEnvVar | undefined =>
   env.find((variable) => variable.name === name)
 
-const assertUniqueTargetEnvNames = (env: readonly IEnvVar[], targetNames: ReadonlySet<string>): void => {
+const assertLanguageInjectionEnvCanBeMerged = (env: readonly IEnvVar[], spec: LanguageInjectionSpec): void => {
+  const targetNames = new Set([...spec.env.map((fragment) => fragment.name), DD_TAGS_ENV_VAR])
   for (const name of targetNames) {
-    if (env.filter((variable) => variable.name === name).length > 1) {
-      throw new SsiValidationError(
+    const matching = env.filter((variable) => variable.name === name)
+    if (matching.length > 1) {
+      throw new SsiConfigError(
         `${name} appears more than once on the ingress container, so Datadog cannot safely modify it. Remove the duplicate before retrying.`
+      )
+    }
+    if (matching[0]?.valueSource) {
+      throw new SsiConfigError(
+        `${name} on the ingress container is populated from a secret reference, which Datadog cannot safely extend. Set it to a literal value or remove it before instrumenting.`
       )
     }
   }
 }
 
-const assertNoValueSource = (existing: IEnvVar | undefined, name: string): void => {
-  if (existing?.valueSource) {
-    throw new SsiValidationError(
-      `${name} on the ingress container is populated from a secret reference, which Datadog cannot safely extend. Set it to a literal value or remove it before instrumenting.`
-    )
-  }
-}
-
-export const assertNativeInjectionEnvCanBeMerged = (
-  existingEnv: readonly IEnvVar[] | null | undefined,
-  spec: SingleLanguageInjectionSpec
-): void => {
-  const env = existingEnv ?? []
-  const targetNames = new Set([...spec.env.map((fragment) => fragment.name), DD_TAGS_ENV_VAR])
-  assertUniqueTargetEnvNames(env, targetNames)
-  for (const name of targetNames) {
-    assertNoValueSource(findEnv(env, name), name)
-  }
-}
-
-const upsertEnv = (env: IEnvVar[], name: string, value: string): IEnvVar[] => {
+const upsertEnv = (env: readonly IEnvVar[], name: string, value: string): IEnvVar[] => {
   const index = env.findIndex((variable) => variable.name === name)
-  if (index === -1) {
-    return [...env, {name, value}]
-  }
-  const updated = [...env]
-  updated[index] = {...updated[index], value}
 
-  return updated
+  return index === -1
+    ? [...env, {name, value}]
+    : env.map((variable, variableIndex) => (variableIndex === index ? {...variable, value} : variable))
 }
 
-export const mergeNativeInjectionEnv = (
-  existingEnv: readonly IEnvVar[] | null | undefined,
-  spec: SingleLanguageInjectionSpec
-): IEnvVar[] => {
-  let env: IEnvVar[] = [...(existingEnv ?? [])]
-  assertNativeInjectionEnvCanBeMerged(env, spec)
-
-  for (const fragment of spec.env) {
-    const existing = findEnv(env, fragment.name)
-    env = upsertEnv(env, fragment.name, mergeEnvFragment(existing?.value ?? undefined, fragment))
+const mergeLanguageEnvFragment = (currentValue: string | undefined, fragment: EnvFragment): string => {
+  try {
+    return mergeEnvFragment(currentValue, fragment)
+  } catch (error) {
+    throw new SsiConfigError(error instanceof Error ? error.message : String(error))
   }
-
-  const existingTags = findEnv(env, DD_TAGS_ENV_VAR)
-  env = upsertEnv(env, DD_TAGS_ENV_VAR, mergeInjectionModeTag(existingTags?.value ?? undefined))
-
-  return env
 }
 
-const KNOWN_NATIVE_FRAGMENTS: readonly EnvFragment[] = (() => {
-  const fragments = new Map<string, EnvFragment>()
-  for (const language of SINGLE_LANGUAGE_VALUES) {
-    for (const libc of ['glibc', 'musl'] as const) {
-      if (language === 'ruby' && libc === 'musl') {
-        continue
-      }
-      const spec = getSingleLanguageInjectionSpec({
+const LANGUAGE_ENV_FRAGMENTS: readonly EnvFragment[] = TRACER_INJECTION_LANGUAGES.flatMap((language) =>
+  LIBCS.filter(
+    (libc) => getLanguageCompatibilityError({language, libc, version: DEFAULT_TRACER_VERSION}) === undefined
+  ).flatMap(
+    (libc) =>
+      getLanguageInjectionSpec({
         language,
         libc,
         registry: DEFAULT_TRACER_REGISTRY,
         version: DEFAULT_TRACER_VERSION,
         root: TRACER_MOUNT_PATH,
-      })
-      for (const fragment of spec.env) {
-        fragments.set(JSON.stringify(fragment), fragment)
-      }
-    }
-  }
-
-  return [...fragments.values()]
-})()
-
-const KNOWN_NATIVE_FRAGMENTS_BY_NAME = new Map<string, EnvFragment[]>()
-for (const fragment of KNOWN_NATIVE_FRAGMENTS) {
-  const fragments = KNOWN_NATIVE_FRAGMENTS_BY_NAME.get(fragment.name) ?? []
-  fragments.push(fragment)
-  KNOWN_NATIVE_FRAGMENTS_BY_NAME.set(fragment.name, fragments)
-}
-
-/** Removes every exact native SSI fragment and the injection-mode tag, regardless of selected language or libc. */
-export const removeKnownNativeInjectionEnv = (existingEnv: readonly IEnvVar[] | null | undefined): IEnvVar[] => {
-  const cleaned: IEnvVar[] = []
-  for (const variable of existingEnv ?? []) {
-    if (!variable.name || variable.valueSource || typeof variable.value !== 'string' || variable.value === '') {
-      cleaned.push(variable)
-      continue
-    }
-
-    let value: string | undefined = variable.value
-    if (variable.name === DD_TAGS_ENV_VAR) {
-      value = removeInjectionModeTag(value)
-    }
-    for (const fragment of KNOWN_NATIVE_FRAGMENTS_BY_NAME.get(variable.name) ?? []) {
-      value = removeEnvFragment(value, fragment)
-    }
-
-    if (value !== undefined) {
-      cleaned.push(value === variable.value ? variable : {...variable, value})
-    }
-  }
-
-  return cleaned
-}
-
-export class SsiConfigError extends Error {
-  constructor(message: string) {
-    super(message)
-    this.name = 'SsiConfigError'
-  }
-}
+      }).env
+  )
+)
 
 /** Returns tracer flags whose values differ from their defaults. */
 const nonDefaultTracerFlags = (options: SsiOptions): string[] =>
@@ -279,3 +241,10 @@ const nonDefaultTracerFlags = (options: SsiOptions): string[] =>
     options.tracerRegistry !== DEFAULT_TRACER_REGISTRY ? '--tracer-registry' : undefined,
     options.tracerLibc !== DEFAULT_TRACER_LIBC ? '--tracer-libc' : undefined,
   ].filter((flag): flag is string => flag !== undefined)
+
+export class SsiConfigError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'SsiConfigError'
+  }
+}


### PR DESCRIPTION
### What and why?

Add safe Cloud Run environment handling for Single-Language tracer injection and cleanup.

### How?

Merge typed language injection fragments idempotently, reject ambiguous or secret-backed targets, and remove exact tracer fragments across supported language and libc combinations. Keep tracer defaults literal-typed for downstream option types.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
