### PR TITLE
[SVLS-9302] separate Cloud Run configuration from command orchestration

### DIFF
--- a/packages/plugin-cloud-run/src/__tests__/uninstrument.test.ts
+++ b/packages/plugin-cloud-run/src/__tests__/uninstrument.test.ts
@@ -261,6 +261,9 @@ describe('UninstrumentCommand', () => {
       }
     })
 
+    const updateAppContainer = (appContainer: IContainer): IContainer =>
+      command.createUninstrumentedServiceConfig({template: {containers: [appContainer]}}).template!.containers![0]
+
     test('removes shared volume mount and DD_ environment variables', () => {
       const appContainer = {
         name: 'main',
@@ -276,7 +279,7 @@ describe('UninstrumentCommand', () => {
         ],
       }
 
-      const result = (command as any).updateAppContainer(appContainer)
+      const result = updateAppContainer(appContainer)
 
       expect(result.volumeMounts).toEqual([{name: 'other-volume', mountPath: '/other'}])
       expect(result.env).toEqual([
@@ -287,7 +290,7 @@ describe('UninstrumentCommand', () => {
 
     test('handles container with undefined env and volumeMounts', () => {
       const appContainer = {name: 'main'}
-      const result = (command as any).updateAppContainer(appContainer)
+      const result = updateAppContainer(appContainer)
 
       expect(result.volumeMounts).toEqual([])
       expect(result.env).toEqual([])
@@ -308,7 +311,7 @@ describe('UninstrumentCommand', () => {
         volumeMounts: [],
       }
 
-      const result = (command as any).updateAppContainer(appContainer)
+      const result = updateAppContainer(appContainer)
 
       expect(result.env).toEqual([
         {name: 'NODE_ENV', value: 'production'},
@@ -329,7 +332,7 @@ describe('UninstrumentCommand', () => {
         volumeMounts: [],
       }
 
-      const result = (command as any).updateAppContainer(appContainer)
+      const result = updateAppContainer(appContainer)
 
       expect(result.env).toEqual([
         {name: 'NODE_ENV', value: 'production'},
@@ -349,7 +352,7 @@ describe('UninstrumentCommand', () => {
         volumeMounts: [],
       }
 
-      const result = (command as any).updateAppContainer(appContainer)
+      const result = updateAppContainer(appContainer)
 
       expect(result.env).toEqual([{name: 'NODE_ENV', value: 'production'}])
     })

--- a/packages/plugin-cloud-run/src/__tests__/uninstrument.test.ts
+++ b/packages/plugin-cloud-run/src/__tests__/uninstrument.test.ts
@@ -12,6 +12,7 @@ import {
 
 import {PluginCommand as UninstrumentCommand} from '../commands/uninstrument'
 import * as cloudRunPromptModule from '../prompt'
+import {uninstrumentServiceConfig} from '../service-config'
 import * as utils from '../utils'
 
 jest.mock('../utils', () => ({
@@ -156,14 +157,16 @@ describe('UninstrumentCommand', () => {
 
   describe('createUninstrumentedServiceConfig', () => {
     let command: UninstrumentCommand
+    let writeStdout: jest.Mock
 
     beforeEach(() => {
       command = new UninstrumentCommand()
+      writeStdout = jest.fn()
       ;(command as any).sidecarName = 'datadog-sidecar'
       ;(command as any).sharedVolumeName = 'shared-volume'
       ;(command as any).envVars = []
       ;(command as any).context = {
-        stdout: {write: jest.fn()},
+        stdout: {write: writeStdout},
         stderr: {write: jest.fn()},
       }
     })
@@ -225,6 +228,8 @@ describe('UninstrumentCommand', () => {
       const result = command.createUninstrumentedServiceConfig(service)
       expect(result.template?.containers).toHaveLength(1)
       expect(result.template?.volumes).toHaveLength(0)
+      expect(writeStdout).toHaveBeenCalledWith(expect.stringContaining("Sidecar container 'datadog-sidecar' not found"))
+      expect(writeStdout).toHaveBeenCalledWith(expect.stringContaining("Shared volume 'shared-volume' not found"))
     })
 
     test('uses custom sidecar and volume names', () => {
@@ -248,21 +253,18 @@ describe('UninstrumentCommand', () => {
     })
   })
 
-  describe('updateAppContainer', () => {
-    let command: UninstrumentCommand
+  describe('application container cleanup', () => {
+    let envVars: string[] | undefined
 
     beforeEach(() => {
-      command = new UninstrumentCommand()
-      ;(command as any).sharedVolumeName = 'shared-volume'
-      ;(command as any).envVars = []
-      ;(command as any).context = {
-        stdout: {write: jest.fn()},
-        stderr: {write: jest.fn()},
-      }
+      envVars = []
     })
 
-    const updateAppContainer = (appContainer: IContainer): IContainer =>
-      command.createUninstrumentedServiceConfig({template: {containers: [appContainer]}}).template!.containers![0]
+    const cleanAppContainer = (appContainer: IContainer): IContainer =>
+      uninstrumentServiceConfig(
+        {template: {containers: [appContainer]}},
+        {sidecarName: 'datadog-sidecar', sharedVolumeName: 'shared-volume', envVars}
+      ).service.template!.containers![0]
 
     test('removes shared volume mount and DD_ environment variables', () => {
       const appContainer = {
@@ -279,7 +281,7 @@ describe('UninstrumentCommand', () => {
         ],
       }
 
-      const result = updateAppContainer(appContainer)
+      const result = cleanAppContainer(appContainer)
 
       expect(result.volumeMounts).toEqual([{name: 'other-volume', mountPath: '/other'}])
       expect(result.env).toEqual([
@@ -289,16 +291,14 @@ describe('UninstrumentCommand', () => {
     })
 
     test('handles container with undefined env and volumeMounts', () => {
-      const appContainer = {name: 'main'}
-      const result = updateAppContainer(appContainer)
+      const result = cleanAppContainer({name: 'main'})
 
       expect(result.volumeMounts).toEqual([])
       expect(result.env).toEqual([])
     })
 
-    test('removes custom environment variables specified via envVars', () => {
-      ;(command as any).envVars = ['CUSTOM_VAR=value1', 'ANOTHER_VAR=value2']
-
+    test('removes configured environment variables', () => {
+      envVars = ['CUSTOM_VAR=value1', 'ANOTHER_VAR=value2']
       const appContainer = {
         name: 'main',
         env: [
@@ -311,17 +311,14 @@ describe('UninstrumentCommand', () => {
         volumeMounts: [],
       }
 
-      const result = updateAppContainer(appContainer)
-
-      expect(result.env).toEqual([
+      expect(cleanAppContainer(appContainer).env).toEqual([
         {name: 'NODE_ENV', value: 'production'},
         {name: 'KEEP_THIS', value: 'keep-me'},
       ])
     })
 
-    test('handles empty envVars array', () => {
-      ;(command as any).envVars = []
-
+    test.each([[], undefined])('handles %p configured environment variables', (configuredEnvVars) => {
+      envVars = configuredEnvVars
       const appContainer = {
         name: 'main',
         env: [
@@ -332,29 +329,10 @@ describe('UninstrumentCommand', () => {
         volumeMounts: [],
       }
 
-      const result = updateAppContainer(appContainer)
-
-      expect(result.env).toEqual([
+      expect(cleanAppContainer(appContainer).env).toEqual([
         {name: 'NODE_ENV', value: 'production'},
         {name: 'CUSTOM_VAR', value: 'custom-value'},
       ])
-    })
-
-    test('handles undefined envVars', () => {
-      ;(command as any).envVars = undefined
-
-      const appContainer = {
-        name: 'main',
-        env: [
-          {name: 'NODE_ENV', value: 'production'},
-          {name: DD_TRACE_ENABLED_ENV_VAR, value: 'true'},
-        ],
-        volumeMounts: [],
-      }
-
-      const result = updateAppContainer(appContainer)
-
-      expect(result.env).toEqual([{name: 'NODE_ENV', value: 'production'}])
     })
   })
 })

--- a/packages/plugin-cloud-run/src/__tests__/uninstrument.test.ts
+++ b/packages/plugin-cloud-run/src/__tests__/uninstrument.test.ts
@@ -232,6 +232,27 @@ describe('UninstrumentCommand', () => {
       expect(writeStdout).toHaveBeenCalledWith(expect.stringContaining("Shared volume 'shared-volume' not found"))
     })
 
+    test.each([[], undefined])('handles %p configured environment variables', (envVars) => {
+      ;(command as any).envVars = envVars
+      const service = {
+        template: {
+          containers: [
+            {
+              name: 'main',
+              env: [
+                {name: DD_TRACE_ENABLED_ENV_VAR, value: 'true'},
+                {name: 'CUSTOM_VAR', value: 'custom-value'},
+              ],
+            },
+          ],
+        },
+      }
+
+      expect(command.createUninstrumentedServiceConfig(service).template?.containers?.[0].env).toEqual([
+        {name: 'CUSTOM_VAR', value: 'custom-value'},
+      ])
+    })
+
     test('uses custom sidecar and volume names', () => {
       ;(command as any).sidecarName = 'custom-sidecar'
       ;(command as any).sharedVolumeName = 'custom-volume'
@@ -254,16 +275,16 @@ describe('UninstrumentCommand', () => {
   })
 
   describe('application container cleanup', () => {
-    let envVars: string[] | undefined
+    let envVarNames: ReadonlySet<string>
 
     beforeEach(() => {
-      envVars = []
+      envVarNames = new Set()
     })
 
     const cleanAppContainer = (appContainer: IContainer): IContainer =>
       uninstrumentServiceConfig(
         {template: {containers: [appContainer]}},
-        {sidecarName: 'datadog-sidecar', sharedVolumeName: 'shared-volume', envVars}
+        {sidecarName: 'datadog-sidecar', sharedVolumeName: 'shared-volume', envVarNames}
       ).service.template!.containers![0]
 
     test('removes shared volume mount and DD_ environment variables', () => {
@@ -298,7 +319,7 @@ describe('UninstrumentCommand', () => {
     })
 
     test('removes configured environment variables', () => {
-      envVars = ['CUSTOM_VAR=value1', 'ANOTHER_VAR=value2']
+      envVarNames = new Set(['CUSTOM_VAR', 'ANOTHER_VAR'])
       const appContainer = {
         name: 'main',
         env: [
@@ -317,22 +338,24 @@ describe('UninstrumentCommand', () => {
       ])
     })
 
-    test.each([[], undefined])('handles %p configured environment variables', (configuredEnvVars) => {
-      envVars = configuredEnvVars
-      const appContainer = {
-        name: 'main',
-        env: [
-          {name: 'NODE_ENV', value: 'production'},
-          {name: DD_TRACE_ENABLED_ENV_VAR, value: 'true'},
-          {name: 'CUSTOM_VAR', value: 'custom-value'},
-        ],
-        volumeMounts: [],
-      }
+    test.each([
+      [false, false],
+      [true, false],
+      [false, true],
+      [true, true],
+    ])('reports sidecar=%s and volume=%s removal independently', (hasSidecar, hasVolume) => {
+      const result = uninstrumentServiceConfig(
+        {
+          template: {
+            containers: [{name: 'main'}, ...(hasSidecar ? [{name: 'datadog-sidecar'}] : [])],
+            volumes: hasVolume ? [{name: 'shared-volume'}] : [],
+          },
+        },
+        {sidecarName: 'datadog-sidecar', sharedVolumeName: 'shared-volume', envVarNames: new Set()}
+      )
 
-      expect(cleanAppContainer(appContainer).env).toEqual([
-        {name: 'NODE_ENV', value: 'production'},
-        {name: 'CUSTOM_VAR', value: 'custom-value'},
-      ])
+      expect(result.sidecarRemoved).toBe(hasSidecar)
+      expect(result.sharedVolumeRemoved).toBe(hasVolume)
     })
   })
 })

--- a/packages/plugin-cloud-run/src/commands/instrument.ts
+++ b/packages/plugin-cloud-run/src/commands/instrument.ts
@@ -226,8 +226,8 @@ export class PluginCommand extends CloudRunInstrumentCommand {
       sharedVolumePath: this.sharedVolumePath,
     })
   }
+
   public getEnvVarsByName(config: ServerlessConfigOptions): Record<string, IEnvVar> {
-    // Get base environment variables
     const envVars = getBaseEnvVars(config)
 
     for (const [name, value] of [

--- a/packages/plugin-cloud-run/src/commands/instrument.ts
+++ b/packages/plugin-cloud-run/src/commands/instrument.ts
@@ -1,4 +1,4 @@
-import type {IContainer, IEnvVar, IService, IServiceTemplate} from '../types'
+import type {IEnvVar, IService} from '../types'
 import type {ServerlessConfigOptions} from '@datadog/datadog-ci-base/helpers/serverless/common'
 
 import {CloudRunInstrumentCommand} from '@datadog/datadog-ci-base/commands/cloud-run/instrument'
@@ -8,26 +8,19 @@ import {newApiKeyValidator} from '@datadog/datadog-ci-base/helpers/apikey'
 import {toBoolean} from '@datadog/datadog-ci-base/helpers/env'
 import {enableFips} from '@datadog/datadog-ci-base/helpers/fips'
 import {renderError, renderSoftWarning} from '@datadog/datadog-ci-base/helpers/renderer'
-import {
-  generateConfigDiff,
-  createInstrumentedTemplate,
-  getBaseEnvVars,
-} from '@datadog/datadog-ci-base/helpers/serverless/common'
+import {generateConfigDiff, getBaseEnvVars} from '@datadog/datadog-ci-base/helpers/serverless/common'
 import {
   DD_LOG_LEVEL_ENV_VAR,
   DD_SOURCE_ENV_VAR,
   DD_TRACE_ENABLED_ENV_VAR,
   EXTRA_TAGS_REG_EXP,
-  HEALTH_PORT_ENV_VAR,
   SERVICE_ENV_VAR,
   CI_SITE_ENV_VAR,
   DD_LLMOBS_AGENTLESS_ENABLED_ENV_VAR,
   DD_LLMOBS_ENABLED_ENV_VAR,
   DD_LLMOBS_ML_APP_ENV_VAR,
-  DEFAULT_HEALTH_CHECK_PORT,
 } from '@datadog/datadog-ci-base/helpers/serverless/constants'
 import {handleSourceCodeIntegration} from '@datadog/datadog-ci-base/helpers/serverless/source-code-integration'
-import {SERVERLESS_CLI_VERSION_TAG_NAME, SERVERLESS_CLI_VERSION_TAG_VALUE} from '@datadog/datadog-ci-base/helpers/tags'
 import {maskString} from '@datadog/datadog-ci-base/helpers/utils'
 import {isValidDatadogSite} from '@datadog/datadog-ci-base/helpers/validation'
 import {ServicesClient} from '@google-cloud/run'
@@ -35,10 +28,8 @@ import chalk from 'chalk'
 
 import {requestGCPProject, requestGCPRegion, requestServiceName, requestSite, requestConfirmation} from '../prompt'
 import {dryRunPrefix, renderAuthenticationInstructions, withSpinner} from '../renderer'
+import {instrumentServiceConfig} from '../service-config'
 import {checkAuthentication, fetchServiceConfigs} from '../utils'
-
-// equivalent to google.cloud.run.v2.EmptyDirVolumeSource.Medium.MEMORY
-const EMPTY_DIR_VOLUME_SOURCE_MEMORY = 1
 
 export class PluginCommand extends CloudRunInstrumentCommand {
   protected fipsConfig = {
@@ -214,45 +205,26 @@ export class PluginCommand extends CloudRunInstrumentCommand {
   }
 
   public createInstrumentedServiceConfig(service: IService, ddService: string): IService {
-    const envVarsByName = this.getEnvVarsByName({
-      service: ddService,
+    return instrumentServiceConfig(service, {
+      ddService,
       environment: this.environment,
       version: this.version,
-      logPath: this.logsPath,
-      extraTags: this.extraTags,
-      envVars: this.envVars,
+      envVarsByName: this.getEnvVarsByName({
+        service: ddService,
+        environment: this.environment,
+        version: this.version,
+        logPath: this.logsPath,
+        extraTags: this.extraTags,
+        envVars: this.envVars,
+      }),
+      healthCheckPort: this.healthCheckPort,
+      sidecarName: this.sidecarName,
+      sidecarImage: this.sidecarImage,
+      sidecarCpus: this.sidecarCpus,
+      sidecarMemory: this.sidecarMemory,
+      sharedVolumeName: this.sharedVolumeName,
+      sharedVolumePath: this.sharedVolumePath,
     })
-    const template: IServiceTemplate = createInstrumentedTemplate(
-      service.template || {},
-      this.buildBaseSidecarContainer(service.template?.containers?.find((c) => c.name === this.sidecarName)),
-      {
-        name: this.sharedVolumeName,
-        mountPath: this.sharedVolumePath,
-        mountOptions: {emptyDir: {medium: EMPTY_DIR_VOLUME_SOURCE_MEMORY}},
-        volumeMountNameKey: 'name',
-      },
-      envVarsByName
-    )
-    // Let GCR generate the next revision name
-    template.revision = undefined
-    // Set unified service tag labels
-    const updatedLabels: Record<string, string> = {
-      ...service.labels,
-      service: ddService,
-      [SERVERLESS_CLI_VERSION_TAG_NAME]: SERVERLESS_CLI_VERSION_TAG_VALUE.replace(/\./g, '_'),
-    }
-    if (!!this.environment) {
-      updatedLabels.env = this.environment
-    }
-    if (!!this.version) {
-      updatedLabels.version = this.version
-    }
-
-    return {
-      ...service,
-      labels: updatedLabels,
-      template,
-    }
   }
   public getEnvVarsByName(config: ServerlessConfigOptions): Record<string, IEnvVar> {
     // Get base environment variables
@@ -277,35 +249,5 @@ export class PluginCommand extends CloudRunInstrumentCommand {
     }
 
     return Object.fromEntries(Object.entries(envVars).map(([name, value]) => [name, {name, value}]))
-  }
-
-  public buildBaseSidecarContainer(existingSidecarContainer: IContainer | undefined): IContainer {
-    // We prioritize in this order: CLI flag, existing setup, default
-    let healthCheckPort = Number(
-      this.healthCheckPort ?? existingSidecarContainer?.env?.find(({name}) => name === HEALTH_PORT_ENV_VAR)?.value
-    )
-    healthCheckPort = Number.isNaN(healthCheckPort) ? DEFAULT_HEALTH_CHECK_PORT : healthCheckPort
-
-    // Create sidecar container with volume mount and environment variables
-    return {
-      ...existingSidecarContainer,
-      name: this.sidecarName,
-      image: this.sidecarImage,
-      startupProbe: {
-        tcpSocket: {
-          port: healthCheckPort,
-        },
-        initialDelaySeconds: 0,
-        periodSeconds: 10,
-        failureThreshold: 3,
-        timeoutSeconds: 1,
-      },
-      resources: {
-        limits: {
-          memory: this.sidecarMemory,
-          cpu: this.sidecarCpus,
-        },
-      },
-    }
   }
 }

--- a/packages/plugin-cloud-run/src/commands/uninstrument.ts
+++ b/packages/plugin-cloud-run/src/commands/uninstrument.ts
@@ -1,17 +1,17 @@
-import type {IContainer, IService, IVolume} from '../types'
+import type {IService} from '../types'
 
 import {CloudRunUninstrumentCommand} from '@datadog/datadog-ci-base/commands/cloud-run/uninstrument'
 import {FIPS_ENV_VAR, FIPS_IGNORE_ERROR_ENV_VAR} from '@datadog/datadog-ci-base/constants'
 import {toBoolean} from '@datadog/datadog-ci-base/helpers/env'
 import {enableFips} from '@datadog/datadog-ci-base/helpers/fips'
 import {renderError, renderSoftWarning} from '@datadog/datadog-ci-base/helpers/renderer'
-import {generateConfigDiff, parseEnvVars} from '@datadog/datadog-ci-base/helpers/serverless/common'
-import {SERVERLESS_CLI_VERSION_TAG_NAME} from '@datadog/datadog-ci-base/helpers/tags'
+import {generateConfigDiff} from '@datadog/datadog-ci-base/helpers/serverless/common'
 import {ServicesClient} from '@google-cloud/run'
 import chalk from 'chalk'
 
 import {requestGCPProject, requestGCPRegion, requestServiceName, requestConfirmation} from '../prompt'
 import {dryRunPrefix, renderAuthenticationInstructions, withSpinner} from '../renderer'
+import {uninstrumentServiceConfig} from '../service-config'
 import {checkAuthentication, fetchServiceConfigs} from '../utils'
 
 export class PluginCommand extends CloudRunUninstrumentCommand {
@@ -139,65 +139,15 @@ export class PluginCommand extends CloudRunUninstrumentCommand {
   }
 
   public createUninstrumentedServiceConfig(service: IService): IService {
-    const template = service.template || {}
-    const containers: IContainer[] = template.containers || []
-    const volumes: IVolume[] = template.volumes || []
-
-    let updatedContainers = containers.filter((c) => c.name !== this.sidecarName)
-    const updatedVolumes = volumes.filter((v) => v.name !== this.sharedVolumeName)
-
-    if (updatedContainers.length === containers.length) {
-      this.context.stdout.write(
-        renderSoftWarning(`Sidecar container '${this.sidecarName}' not found, so no container was removed. Specify the container name with --sidecar-name.
-`)
-      )
+    const result = uninstrumentServiceConfig(service, {
+      sidecarName: this.sidecarName,
+      sharedVolumeName: this.sharedVolumeName,
+      envVars: this.envVars,
+    })
+    for (const warning of result.warnings) {
+      this.context.stdout.write(renderSoftWarning(`${warning}\n`))
     }
 
-    if (updatedVolumes.length === volumes.length) {
-      this.context.stdout.write(
-        renderSoftWarning(`Shared volume '${this.sharedVolumeName}' not found, so no shared volume was removed. Specify the shared volume name with --shared-volume-name.
-`)
-      )
-    }
-
-    updatedContainers = updatedContainers.map((c) => this.updateAppContainer(c))
-
-    const updatedLabels = {...service.labels}
-    delete updatedLabels.service
-    delete updatedLabels.env
-    delete updatedLabels.version
-    delete updatedLabels[SERVERLESS_CLI_VERSION_TAG_NAME]
-
-    return {
-      ...service,
-      labels: updatedLabels,
-      template: {
-        ...template,
-        containers: updatedContainers,
-        volumes: updatedVolumes,
-        // Let GCR generate the next revision name
-        revision: undefined,
-      },
-    }
-  }
-
-  // Remove volume mount and add required env vars
-  private updateAppContainer(appContainer: IContainer) {
-    const existingVolumeMounts = appContainer.volumeMounts || []
-    const updatedVolumeMounts = existingVolumeMounts.filter((v) => v.name !== this.sharedVolumeName)
-
-    const customEnvVars = parseEnvVars(this.envVars)
-
-    const existingEnvVars = appContainer.env || []
-    // Remove env vars beginning with DD_ and custom env vars
-    const updatedEnvVars = existingEnvVars.filter(
-      (v) => v.name && !v.name.startsWith('DD_') && !(v.name in customEnvVars)
-    )
-
-    return {
-      ...appContainer,
-      volumeMounts: updatedVolumeMounts,
-      env: updatedEnvVars,
-    }
+    return result.service
   }
 }

--- a/packages/plugin-cloud-run/src/commands/uninstrument.ts
+++ b/packages/plugin-cloud-run/src/commands/uninstrument.ts
@@ -5,7 +5,7 @@ import {FIPS_ENV_VAR, FIPS_IGNORE_ERROR_ENV_VAR} from '@datadog/datadog-ci-base/
 import {toBoolean} from '@datadog/datadog-ci-base/helpers/env'
 import {enableFips} from '@datadog/datadog-ci-base/helpers/fips'
 import {renderError, renderSoftWarning} from '@datadog/datadog-ci-base/helpers/renderer'
-import {generateConfigDiff} from '@datadog/datadog-ci-base/helpers/serverless/common'
+import {generateConfigDiff, parseEnvVars} from '@datadog/datadog-ci-base/helpers/serverless/common'
 import {ServicesClient} from '@google-cloud/run'
 import chalk from 'chalk'
 
@@ -142,7 +142,7 @@ export class PluginCommand extends CloudRunUninstrumentCommand {
     const result = uninstrumentServiceConfig(service, {
       sidecarName: this.sidecarName,
       sharedVolumeName: this.sharedVolumeName,
-      envVars: this.envVars,
+      envVarNames: new Set(Object.keys(parseEnvVars(this.envVars))),
     })
     if (!result.sidecarRemoved) {
       this.context.stdout.write(

--- a/packages/plugin-cloud-run/src/commands/uninstrument.ts
+++ b/packages/plugin-cloud-run/src/commands/uninstrument.ts
@@ -144,8 +144,19 @@ export class PluginCommand extends CloudRunUninstrumentCommand {
       sharedVolumeName: this.sharedVolumeName,
       envVars: this.envVars,
     })
-    for (const warning of result.warnings) {
-      this.context.stdout.write(renderSoftWarning(`${warning}\n`))
+    if (!result.sidecarRemoved) {
+      this.context.stdout.write(
+        renderSoftWarning(
+          `Sidecar container '${this.sidecarName}' not found, so no container was removed. Specify the container name with --sidecar-name.\n`
+        )
+      )
+    }
+    if (!result.sharedVolumeRemoved) {
+      this.context.stdout.write(
+        renderSoftWarning(
+          `Shared volume '${this.sharedVolumeName}' not found, so no shared volume was removed. Specify the shared volume name with --shared-volume-name.\n`
+        )
+      )
     }
 
     return result.service

--- a/packages/plugin-cloud-run/src/service-config.ts
+++ b/packages/plugin-cloud-run/src/service-config.ts
@@ -4,43 +4,107 @@ import {createInstrumentedTemplate, parseEnvVars} from '@datadog/datadog-ci-base
 import {HEALTH_PORT_ENV_VAR, DEFAULT_HEALTH_CHECK_PORT} from '@datadog/datadog-ci-base/helpers/serverless/constants'
 import {SERVERLESS_CLI_VERSION_TAG_NAME, SERVERLESS_CLI_VERSION_TAG_VALUE} from '@datadog/datadog-ci-base/helpers/tags'
 
-// equivalent to google.cloud.run.v2.EmptyDirVolumeSource.Medium.MEMORY
-const EMPTY_DIR_VOLUME_SOURCE_MEMORY = 1
-
 export interface InstrumentServiceConfigOptions {
-  ddService: string
-  environment: string | undefined
-  version: string | undefined
-  envVarsByName: Record<string, IEnvVar>
-  healthCheckPort: string | undefined
-  sidecarName: string
-  sidecarImage: string
-  sidecarCpus: string
-  sidecarMemory: string
-  sharedVolumeName: string
-  sharedVolumePath: string
+  readonly ddService: string
+  readonly environment: string | undefined
+  readonly version: string | undefined
+  readonly envVarsByName: Readonly<Record<string, IEnvVar>>
+  readonly healthCheckPort: string | undefined
+  readonly sidecarName: string
+  readonly sidecarImage: string
+  readonly sidecarCpus: string
+  readonly sidecarMemory: string
+  readonly sharedVolumeName: string
+  readonly sharedVolumePath: string
 }
 
-export interface UninstrumentServiceConfigOptions {
-  sidecarName: string
-  sharedVolumeName: string
-  envVars: string[] | undefined
+interface UninstrumentServiceConfigOptions {
+  readonly sidecarName: string
+  readonly sharedVolumeName: string
+  readonly envVars: string[] | undefined
 }
 
-export interface UninstrumentServiceConfigResult {
-  service: IService
-  warnings: string[]
+interface UninstrumentServiceConfigResult {
+  readonly service: IService
+  readonly sidecarRemoved: boolean
+  readonly sharedVolumeRemoved: boolean
 }
 
-const buildBaseSidecarContainer = (template: IServiceTemplate, options: InstrumentServiceConfigOptions): IContainer => {
-  const existingSidecarContainer = template.containers?.find((container) => container.name === options.sidecarName)
-  let healthCheckPort = Number(
-    options.healthCheckPort ?? existingSidecarContainer?.env?.find(({name}) => name === HEALTH_PORT_ENV_VAR)?.value
+export const instrumentServiceConfig = (service: IService, options: InstrumentServiceConfigOptions): IService => {
+  const sourceTemplate: IServiceTemplate = service.template || {}
+  const template: IServiceTemplate = {
+    ...createInstrumentedTemplate(
+      sourceTemplate,
+      buildSidecarContainer(sourceTemplate, options),
+      {
+        name: options.sharedVolumeName,
+        mountPath: options.sharedVolumePath,
+        mountOptions: {emptyDir: {medium: MEMORY_VOLUME_MEDIUM}},
+        volumeMountNameKey: 'name',
+      },
+      options.envVarsByName
+    ),
+    revision: undefined,
+  }
+
+  const labels: Record<string, string> = {
+    ...service.labels,
+    [UNIFIED_SERVICE_TAG_LABELS.service]: options.ddService,
+    [SERVERLESS_CLI_VERSION_TAG_NAME]: SERVERLESS_CLI_VERSION_TAG_VALUE.replace(/\./g, '_'),
+  }
+  if (options.environment) {
+    labels[UNIFIED_SERVICE_TAG_LABELS.environment] = options.environment
+  }
+  if (options.version) {
+    labels[UNIFIED_SERVICE_TAG_LABELS.version] = options.version
+  }
+
+  return {...service, labels, template}
+}
+
+export const uninstrumentServiceConfig = (
+  service: IService,
+  options: UninstrumentServiceConfigOptions
+): UninstrumentServiceConfigResult => {
+  const template: IServiceTemplate = service.template || {}
+  const containers: IContainer[] = template.containers || []
+  const volumes: IVolume[] = template.volumes || []
+  const sidecarRemoved = containers.some((container) => container.name === options.sidecarName)
+  const sharedVolumeRemoved = volumes.some((volume) => volume.name === options.sharedVolumeName)
+  const configuredEnvVars = parseEnvVars(options.envVars)
+  const updatedContainers = containers
+    .filter((container) => container.name !== options.sidecarName)
+    .map((container) => removeContainerInstrumentation(container, options.sharedVolumeName, configuredEnvVars))
+  const updatedVolumes = volumes.filter((volume) => volume.name !== options.sharedVolumeName)
+  const labels = Object.fromEntries(
+    Object.entries(service.labels ?? {}).filter(([name]) => !INSTRUMENTATION_LABELS.has(name))
   )
-  healthCheckPort = Number.isNaN(healthCheckPort) ? DEFAULT_HEALTH_CHECK_PORT : healthCheckPort
 
   return {
-    ...existingSidecarContainer,
+    service: {
+      ...service,
+      labels,
+      template: {
+        ...template,
+        containers: updatedContainers,
+        volumes: updatedVolumes,
+        revision: undefined,
+      },
+    },
+    sidecarRemoved,
+    sharedVolumeRemoved,
+  }
+}
+
+const buildSidecarContainer = (template: IServiceTemplate, options: InstrumentServiceConfigOptions): IContainer => {
+  const existingSidecar = template.containers?.find((container) => container.name === options.sidecarName)
+  const parsedHealthCheckPort = Number(
+    options.healthCheckPort ?? existingSidecar?.env?.find(({name}) => name === HEALTH_PORT_ENV_VAR)?.value
+  )
+  const healthCheckPort = Number.isNaN(parsedHealthCheckPort) ? DEFAULT_HEALTH_CHECK_PORT : parsedHealthCheckPort
+
+  return {
+    ...existingSidecar,
     name: options.sidecarName,
     image: options.sidecarImage,
     startupProbe: {
@@ -59,37 +123,7 @@ const buildBaseSidecarContainer = (template: IServiceTemplate, options: Instrume
   }
 }
 
-export const instrumentServiceConfig = (service: IService, options: InstrumentServiceConfigOptions): IService => {
-  const sourceTemplate: IServiceTemplate = service.template || {}
-  const template: IServiceTemplate = createInstrumentedTemplate(
-    sourceTemplate,
-    buildBaseSidecarContainer(sourceTemplate, options),
-    {
-      name: options.sharedVolumeName,
-      mountPath: options.sharedVolumePath,
-      mountOptions: {emptyDir: {medium: EMPTY_DIR_VOLUME_SOURCE_MEMORY}},
-      volumeMountNameKey: 'name',
-    },
-    options.envVarsByName
-  )
-  template.revision = undefined
-
-  const updatedLabels: Record<string, string> = {
-    ...service.labels,
-    service: options.ddService,
-    [SERVERLESS_CLI_VERSION_TAG_NAME]: SERVERLESS_CLI_VERSION_TAG_VALUE.replace(/\./g, '_'),
-  }
-  if (options.environment) {
-    updatedLabels.env = options.environment
-  }
-  if (options.version) {
-    updatedLabels.version = options.version
-  }
-
-  return {...service, labels: updatedLabels, template}
-}
-
-const cleanUninstrumentedContainer = (
+const removeContainerInstrumentation = (
   container: IContainer,
   sharedVolumeName: string,
   configuredEnvVars: Record<string, string>
@@ -101,49 +135,10 @@ const cleanUninstrumentedContainer = (
   ),
 })
 
-export const uninstrumentServiceConfig = (
-  service: IService,
-  options: UninstrumentServiceConfigOptions
-): UninstrumentServiceConfigResult => {
-  const template: IServiceTemplate = service.template || {}
-  const containers: IContainer[] = template.containers || []
-  const volumes: IVolume[] = template.volumes || []
-  const warnings: string[] = []
-
-  if (!containers.some((container) => container.name === options.sidecarName)) {
-    warnings.push(
-      `Sidecar container '${options.sidecarName}' not found, so no container was removed. Specify the container name with --sidecar-name.`
-    )
-  }
-  if (!volumes.some((volume) => volume.name === options.sharedVolumeName)) {
-    warnings.push(
-      `Shared volume '${options.sharedVolumeName}' not found, so no shared volume was removed. Specify the shared volume name with --shared-volume-name.`
-    )
-  }
-
-  const configuredEnvVars = parseEnvVars(options.envVars)
-  const updatedContainers = containers
-    .filter((container) => container.name !== options.sidecarName)
-    .map((container) => cleanUninstrumentedContainer(container, options.sharedVolumeName, configuredEnvVars))
-  const updatedVolumes = volumes.filter((volume) => volume.name !== options.sharedVolumeName)
-
-  const updatedLabels = {...service.labels}
-  delete updatedLabels.service
-  delete updatedLabels.env
-  delete updatedLabels.version
-  delete updatedLabels[SERVERLESS_CLI_VERSION_TAG_NAME]
-
-  return {
-    service: {
-      ...service,
-      labels: updatedLabels,
-      template: {
-        ...template,
-        containers: updatedContainers,
-        volumes: updatedVolumes,
-        revision: undefined,
-      },
-    },
-    warnings,
-  }
-}
+const MEMORY_VOLUME_MEDIUM = 1 as const // google.cloud.run.v2.EmptyDirVolumeSource.Medium.MEMORY
+const UNIFIED_SERVICE_TAG_LABELS = {
+  service: 'service',
+  environment: 'env',
+  version: 'version',
+} as const
+const INSTRUMENTATION_LABELS = new Set([...Object.values(UNIFIED_SERVICE_TAG_LABELS), SERVERLESS_CLI_VERSION_TAG_NAME])

--- a/packages/plugin-cloud-run/src/service-config.ts
+++ b/packages/plugin-cloud-run/src/service-config.ts
@@ -1,0 +1,149 @@
+import type {IContainer, IEnvVar, IService, IServiceTemplate, IVolume} from './types'
+
+import {createInstrumentedTemplate, parseEnvVars} from '@datadog/datadog-ci-base/helpers/serverless/common'
+import {HEALTH_PORT_ENV_VAR, DEFAULT_HEALTH_CHECK_PORT} from '@datadog/datadog-ci-base/helpers/serverless/constants'
+import {SERVERLESS_CLI_VERSION_TAG_NAME, SERVERLESS_CLI_VERSION_TAG_VALUE} from '@datadog/datadog-ci-base/helpers/tags'
+
+// equivalent to google.cloud.run.v2.EmptyDirVolumeSource.Medium.MEMORY
+const EMPTY_DIR_VOLUME_SOURCE_MEMORY = 1
+
+export interface InstrumentServiceConfigOptions {
+  ddService: string
+  environment: string | undefined
+  version: string | undefined
+  envVarsByName: Record<string, IEnvVar>
+  healthCheckPort: string | undefined
+  sidecarName: string
+  sidecarImage: string
+  sidecarCpus: string
+  sidecarMemory: string
+  sharedVolumeName: string
+  sharedVolumePath: string
+}
+
+export interface UninstrumentServiceConfigOptions {
+  sidecarName: string
+  sharedVolumeName: string
+  envVars: string[] | undefined
+}
+
+export interface UninstrumentServiceConfigResult {
+  service: IService
+  warnings: string[]
+}
+
+const buildBaseSidecarContainer = (template: IServiceTemplate, options: InstrumentServiceConfigOptions): IContainer => {
+  const existingSidecarContainer = template.containers?.find((container) => container.name === options.sidecarName)
+  let healthCheckPort = Number(
+    options.healthCheckPort ?? existingSidecarContainer?.env?.find(({name}) => name === HEALTH_PORT_ENV_VAR)?.value
+  )
+  healthCheckPort = Number.isNaN(healthCheckPort) ? DEFAULT_HEALTH_CHECK_PORT : healthCheckPort
+
+  return {
+    ...existingSidecarContainer,
+    name: options.sidecarName,
+    image: options.sidecarImage,
+    startupProbe: {
+      tcpSocket: {port: healthCheckPort},
+      initialDelaySeconds: 0,
+      periodSeconds: 10,
+      failureThreshold: 3,
+      timeoutSeconds: 1,
+    },
+    resources: {
+      limits: {
+        memory: options.sidecarMemory,
+        cpu: options.sidecarCpus,
+      },
+    },
+  }
+}
+
+export const instrumentServiceConfig = (service: IService, options: InstrumentServiceConfigOptions): IService => {
+  const sourceTemplate: IServiceTemplate = service.template || {}
+  const template: IServiceTemplate = createInstrumentedTemplate(
+    sourceTemplate,
+    buildBaseSidecarContainer(sourceTemplate, options),
+    {
+      name: options.sharedVolumeName,
+      mountPath: options.sharedVolumePath,
+      mountOptions: {emptyDir: {medium: EMPTY_DIR_VOLUME_SOURCE_MEMORY}},
+      volumeMountNameKey: 'name',
+    },
+    options.envVarsByName
+  )
+  template.revision = undefined
+
+  const updatedLabels: Record<string, string> = {
+    ...service.labels,
+    service: options.ddService,
+    [SERVERLESS_CLI_VERSION_TAG_NAME]: SERVERLESS_CLI_VERSION_TAG_VALUE.replace(/\./g, '_'),
+  }
+  if (options.environment) {
+    updatedLabels.env = options.environment
+  }
+  if (options.version) {
+    updatedLabels.version = options.version
+  }
+
+  return {...service, labels: updatedLabels, template}
+}
+
+const cleanUninstrumentedContainer = (
+  container: IContainer,
+  sharedVolumeName: string,
+  configuredEnvVars: Record<string, string>
+): IContainer => ({
+  ...container,
+  volumeMounts: (container.volumeMounts || []).filter((volumeMount) => volumeMount.name !== sharedVolumeName),
+  env: (container.env || []).filter(
+    (envVar) => envVar.name && !envVar.name.startsWith('DD_') && !(envVar.name in configuredEnvVars)
+  ),
+})
+
+export const uninstrumentServiceConfig = (
+  service: IService,
+  options: UninstrumentServiceConfigOptions
+): UninstrumentServiceConfigResult => {
+  const template: IServiceTemplate = service.template || {}
+  const containers: IContainer[] = template.containers || []
+  const volumes: IVolume[] = template.volumes || []
+  const warnings: string[] = []
+
+  if (!containers.some((container) => container.name === options.sidecarName)) {
+    warnings.push(
+      `Sidecar container '${options.sidecarName}' not found, so no container was removed. Specify the container name with --sidecar-name.`
+    )
+  }
+  if (!volumes.some((volume) => volume.name === options.sharedVolumeName)) {
+    warnings.push(
+      `Shared volume '${options.sharedVolumeName}' not found, so no shared volume was removed. Specify the shared volume name with --shared-volume-name.`
+    )
+  }
+
+  const configuredEnvVars = parseEnvVars(options.envVars)
+  const updatedContainers = containers
+    .filter((container) => container.name !== options.sidecarName)
+    .map((container) => cleanUninstrumentedContainer(container, options.sharedVolumeName, configuredEnvVars))
+  const updatedVolumes = volumes.filter((volume) => volume.name !== options.sharedVolumeName)
+
+  const updatedLabels = {...service.labels}
+  delete updatedLabels.service
+  delete updatedLabels.env
+  delete updatedLabels.version
+  delete updatedLabels[SERVERLESS_CLI_VERSION_TAG_NAME]
+
+  return {
+    service: {
+      ...service,
+      labels: updatedLabels,
+      template: {
+        ...template,
+        containers: updatedContainers,
+        volumes: updatedVolumes,
+        revision: undefined,
+      },
+    },
+    warnings,
+  }
+}

--- a/packages/plugin-cloud-run/src/service-config.ts
+++ b/packages/plugin-cloud-run/src/service-config.ts
@@ -1,8 +1,16 @@
 import type {IContainer, IEnvVar, IService, IServiceTemplate, IVolume} from './types'
 
-import {createInstrumentedTemplate, parseEnvVars} from '@datadog/datadog-ci-base/helpers/serverless/common'
+import {createInstrumentedTemplate} from '@datadog/datadog-ci-base/helpers/serverless/common'
 import {HEALTH_PORT_ENV_VAR, DEFAULT_HEALTH_CHECK_PORT} from '@datadog/datadog-ci-base/helpers/serverless/constants'
 import {SERVERLESS_CLI_VERSION_TAG_NAME, SERVERLESS_CLI_VERSION_TAG_VALUE} from '@datadog/datadog-ci-base/helpers/tags'
+
+const MEMORY_VOLUME_MEDIUM = 1 as const // google.cloud.run.v2.EmptyDirVolumeSource.Medium.MEMORY
+const UNIFIED_SERVICE_TAG_LABELS = {
+  service: 'service',
+  environment: 'env',
+  version: 'version',
+} as const
+const INSTRUMENTATION_LABELS = new Set([...Object.values(UNIFIED_SERVICE_TAG_LABELS), SERVERLESS_CLI_VERSION_TAG_NAME])
 
 export interface InstrumentServiceConfigOptions {
   readonly ddService: string
@@ -21,7 +29,7 @@ export interface InstrumentServiceConfigOptions {
 interface UninstrumentServiceConfigOptions {
   readonly sidecarName: string
   readonly sharedVolumeName: string
-  readonly envVars: string[] | undefined
+  readonly envVarNames: ReadonlySet<string>
 }
 
 interface UninstrumentServiceConfigResult {
@@ -71,10 +79,9 @@ export const uninstrumentServiceConfig = (
   const volumes: IVolume[] = template.volumes || []
   const sidecarRemoved = containers.some((container) => container.name === options.sidecarName)
   const sharedVolumeRemoved = volumes.some((volume) => volume.name === options.sharedVolumeName)
-  const configuredEnvVars = parseEnvVars(options.envVars)
   const updatedContainers = containers
     .filter((container) => container.name !== options.sidecarName)
-    .map((container) => removeContainerInstrumentation(container, options.sharedVolumeName, configuredEnvVars))
+    .map((container) => removeContainerInstrumentation(container, options.sharedVolumeName, options.envVarNames))
   const updatedVolumes = volumes.filter((volume) => volume.name !== options.sharedVolumeName)
   const labels = Object.fromEntries(
     Object.entries(service.labels ?? {}).filter(([name]) => !INSTRUMENTATION_LABELS.has(name))
@@ -126,19 +133,11 @@ const buildSidecarContainer = (template: IServiceTemplate, options: InstrumentSe
 const removeContainerInstrumentation = (
   container: IContainer,
   sharedVolumeName: string,
-  configuredEnvVars: Record<string, string>
+  envVarNames: ReadonlySet<string>
 ): IContainer => ({
   ...container,
   volumeMounts: (container.volumeMounts || []).filter((volumeMount) => volumeMount.name !== sharedVolumeName),
   env: (container.env || []).filter(
-    (envVar) => envVar.name && !envVar.name.startsWith('DD_') && !(envVar.name in configuredEnvVars)
+    (envVar) => envVar.name && !envVar.name.startsWith('DD_') && !envVarNames.has(envVar.name)
   ),
 })
-
-const MEMORY_VOLUME_MEDIUM = 1 as const // google.cloud.run.v2.EmptyDirVolumeSource.Medium.MEMORY
-const UNIFIED_SERVICE_TAG_LABELS = {
-  service: 'service',
-  environment: 'env',
-  version: 'version',
-} as const
-const INSTRUMENTATION_LABELS = new Set([...Object.values(UNIFIED_SERVICE_TAG_LABELS), SERVERLESS_CLI_VERSION_TAG_NAME])


### PR DESCRIPTION
### What and why?

Separate Cloud Run service mutation from command orchestration without changing instrumentation behavior.

### How?

Pure helpers now build instrumented and uninstrumented service configurations. Commands retain authentication, prompts, API calls, rendering, and warnings.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
