### PR TITLE
[SVLS-9302] target cloud run app containers

### DIFF
--- a/packages/base/src/helpers/serverless/__tests__/common.test.ts
+++ b/packages/base/src/helpers/serverless/__tests__/common.test.ts
@@ -233,4 +233,60 @@ describe('createInstrumentedTemplate', () => {
     expect(sidecar).toBeDefined()
     expect((sidecar as {resources?: {ephemeralStorage?: string}}).resources?.ephemeralStorage).toBe('2Gi')
   })
+
+  describe('app container selection', () => {
+    const template = {
+      containers: [
+        {name: 'ingress', env: [{name: 'NODE_ENV', value: 'production'}], volumeMounts: []},
+        {name: 'worker', env: [{name: 'WORKER', value: 'yes'}], volumeMounts: []},
+      ],
+      volumes: [],
+    } as unknown as Parameters<typeof createInstrumentedTemplate>[0]
+    const baseSidecar = {
+      name: 'datadog-sidecar',
+      image: 'gcr.io/datadoghq/serverless-init:latest',
+      env: [],
+      volumeMounts: [],
+    } as unknown as Parameters<typeof createInstrumentedTemplate>[1]
+    const sharedVolumeOptions = {
+      name: 'shared-volume',
+      mountPath: '/shared-volume',
+      mountOptions: {emptyDir: {medium: 1}},
+      volumeMountNameKey: 'name' as const,
+    }
+    const envVarsByName = {DD_SERVICE: {name: 'DD_SERVICE', value: 'app'}}
+
+    test('instruments every non-Agent container when no selection is given', () => {
+      const result = createInstrumentedTemplate(template, baseSidecar, sharedVolumeOptions, envVarsByName)
+
+      for (const name of ['ingress', 'worker']) {
+        const container = result.containers.find((c) => c.name === name)
+        expect(container?.volumeMounts).toEqual([{name: 'shared-volume', mountPath: '/shared-volume'}])
+        expect(container?.env).toContainEqual({name: 'DD_SERVICE', value: 'app'})
+      }
+    })
+
+    test('instruments only selected containers and leaves others unchanged', () => {
+      const result = createInstrumentedTemplate(template, baseSidecar, sharedVolumeOptions, envVarsByName, {
+        appContainerNames: new Set(['ingress']),
+      })
+
+      const ingress = result.containers.find((c) => c.name === 'ingress')
+      expect(ingress?.volumeMounts).toEqual([{name: 'shared-volume', mountPath: '/shared-volume'}])
+      expect(ingress?.env).toContainEqual({name: 'DD_SERVICE', value: 'app'})
+      expect(result.containers.find((c) => c.name === 'worker')).toBe(template.containers?.[1])
+      expect(result.containers.find((c) => c.name === 'datadog-sidecar')).toBeDefined()
+      expect(result.volumes.map((v) => v.name)).toEqual(['shared-volume'])
+    })
+
+    test('an empty selection instruments no app containers', () => {
+      const result = createInstrumentedTemplate(template, baseSidecar, sharedVolumeOptions, envVarsByName, {
+        appContainerNames: new Set(),
+      })
+
+      expect(result.containers[0]).toBe(template.containers?.[0])
+      expect(result.containers[1]).toBe(template.containers?.[1])
+      expect(result.containers.find((c) => c.name === 'datadog-sidecar')).toBeDefined()
+    })
+  })
 })

--- a/packages/base/src/helpers/serverless/common.ts
+++ b/packages/base/src/helpers/serverless/common.ts
@@ -208,6 +208,14 @@ interface SharedVolumeOptions {
   volumeMountNameKey: 'name' | 'volumeName'
 }
 
+export interface InstrumentedTemplateOptions {
+  /**
+   * When provided, only the named app containers receive the Agent environment variables and the shared log mount.
+   * Every other non-Agent container is returned unchanged. When omitted, all non-Agent containers are instrumented.
+   */
+  appContainerNames?: ReadonlySet<string>
+}
+
 /**
  * Given the configuration, an app template, the base sidecar configuration, and base shared volume,
  */
@@ -215,7 +223,8 @@ export const createInstrumentedTemplate = (
   template: FullyOptional<AppTemplate>,
   baseSidecar: FullyOptional<Container>,
   sharedVolumeOptions: SharedVolumeOptions,
-  envVarsByName: Record<string, FullyOptional<EnvVar>>
+  envVarsByName: Record<string, FullyOptional<EnvVar>>,
+  options: InstrumentedTemplateOptions = {}
 ): AppTemplate => {
   const sharedVolumeMount: VolumeMount = {
     [sharedVolumeOptions.volumeMountNameKey]: sharedVolumeOptions.name,
@@ -257,10 +266,15 @@ export const createInstrumentedTemplate = (
     volumeMounts: ensureSharedVolumeMount(existingSidecarContainer?.volumeMounts ?? baseSidecar.volumeMounts),
   } as Container
 
-  // Update all app containers to add volume mounts and env vars if they don't have them
+  // Update selected app containers to add volume mounts and env vars if they don't have them
+  const {appContainerNames} = options
   const updatedContainers = containers.map((container) => {
     if (container.name === baseSidecar.name) {
       return newSidecarContainer
+    }
+
+    if (appContainerNames && !appContainerNames.has(container.name ?? '')) {
+      return container
     }
 
     return {


### PR DESCRIPTION
### What and why?

Allow serverless platform adapters to target instrumentation at selected application containers.

### How?

`createInstrumentedTemplate` accepts an optional set of application container names. Existing callers continue instrumenting every non-Agent container when the selector is omitted.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
