### PR TITLE
[SVLS-9302] Extend Cloud Run uninstrumentation for Single-Language SSI

### DIFF
--- a/packages/plugin-cloud-run/src/__tests__/uninstrument.test.ts
+++ b/packages/plugin-cloud-run/src/__tests__/uninstrument.test.ts
@@ -9,11 +9,17 @@ import {
   SERVICE_ENV_VAR,
   VERSION_ENV_VAR,
 } from '@datadog/datadog-ci-base/helpers/serverless/constants'
+import {TRACER_COPY_CONTAINER_NAME, TRACER_VOLUME_NAME} from '@datadog/datadog-ci-base/helpers/serverless/ssi/constants'
+import {SINGLE_LANGUAGE_INJECTION_MODE_TAG} from '@datadog/datadog-ci-base/helpers/serverless/ssi/env'
 
 import {PluginCommand as UninstrumentCommand} from '../commands/uninstrument'
 import * as cloudRunPromptModule from '../prompt'
 import {uninstrumentServiceConfig} from '../service-config'
 import * as utils from '../utils'
+
+const SSI_ADOPTED_INGRESS_CONTAINER_NAME = 'datadog-app'
+const SSI_INJECTION_MODE_LABEL = 'dd_sls_injection_mode'
+const SINGLE_LANGUAGE_SSI_MODE = 'single_language'
 
 jest.mock('../utils', () => ({
   ...jest.requireActual('../utils'),
@@ -215,6 +221,74 @@ describe('UninstrumentCommand', () => {
         {name: 'NODE_ENV', value: 'production'},
         {name: 'CUSTOM_VAR', value: 'keep-me'},
       ])
+    })
+
+    test('removes owned SSI state from a named ingress', () => {
+      ;(command as any).envVars = ['CONFIGURED_VAR=remove-me']
+      const service: IService = {
+        labels: {[SSI_INJECTION_MODE_LABEL]: SINGLE_LANGUAGE_SSI_MODE, customer: 'keep-me'},
+        template: {
+          containers: [
+            {
+              name: 'app',
+              env: [
+                {
+                  name: 'NODE_OPTIONS',
+                  value: '--inspect --require /datadog-lib/node_modules/dd-trace/init.js',
+                },
+                {name: DD_TAGS_ENV_VAR, value: `${SINGLE_LANGUAGE_INJECTION_MODE_TAG},team:backend`},
+                {name: 'DD_CUSTOM', value: 'remove-me'},
+                {name: 'CONFIGURED_VAR', value: 'remove-me'},
+                {name: 'CUSTOM_VAR', value: 'keep-me'},
+              ],
+              volumeMounts: [
+                {name: 'shared-volume', mountPath: '/shared-volume'},
+                {name: TRACER_VOLUME_NAME, mountPath: '/datadog-lib'},
+                {name: 'customer-volume', mountPath: '/customer'},
+              ],
+              dependsOn: ['datadog-sidecar', TRACER_COPY_CONTAINER_NAME, 'database'],
+            },
+            {name: 'datadog-sidecar'},
+            {name: TRACER_COPY_CONTAINER_NAME},
+          ],
+          volumes: [
+            {name: 'shared-volume', emptyDir: {}},
+            {name: TRACER_VOLUME_NAME, emptyDir: {}},
+            {name: 'customer-volume', emptyDir: {}},
+          ],
+        },
+      }
+
+      const result = command.createUninstrumentedServiceConfig(service)
+
+      expect(result.labels).toEqual({customer: 'keep-me'})
+      expect(result.template?.containers).toEqual([
+        expect.objectContaining({
+          name: 'app',
+          env: [
+            {name: 'NODE_OPTIONS', value: '--inspect'},
+            {name: 'CUSTOM_VAR', value: 'keep-me'},
+          ],
+          volumeMounts: [{name: 'customer-volume', mountPath: '/customer'}],
+          dependsOn: ['database'],
+        }),
+      ])
+      expect(result.template?.volumes).toEqual([{name: 'customer-volume', emptyDir: {}}])
+    })
+
+    test('restores an adopted datadog-app name and removes its provenance label', () => {
+      const service: IService = {
+        labels: {
+          [SSI_INJECTION_MODE_LABEL]: SINGLE_LANGUAGE_SSI_MODE,
+          customer: 'keep-me',
+        },
+        template: {containers: [{name: SSI_ADOPTED_INGRESS_CONTAINER_NAME}]},
+      }
+
+      const result = command.createUninstrumentedServiceConfig(service)
+
+      expect(result.labels).toEqual({customer: 'keep-me'})
+      expect(result.template?.containers?.[0].name).toBe('')
     })
 
     test('handles service with no sidecar or shared volume gracefully', () => {

--- a/packages/plugin-cloud-run/src/__tests__/uninstrument.test.ts
+++ b/packages/plugin-cloud-run/src/__tests__/uninstrument.test.ts
@@ -282,13 +282,43 @@ describe('UninstrumentCommand', () => {
           [SSI_INJECTION_MODE_LABEL]: SINGLE_LANGUAGE_SSI_MODE,
           customer: 'keep-me',
         },
-        template: {containers: [{name: SSI_ADOPTED_INGRESS_CONTAINER_NAME}]},
+        template: {
+          containers: [
+            {
+              name: SSI_ADOPTED_INGRESS_CONTAINER_NAME,
+              volumeMounts: [{name: TRACER_VOLUME_NAME, mountPath: '/datadog-lib'}],
+            },
+          ],
+        },
       }
 
       const result = command.createUninstrumentedServiceConfig(service)
 
       expect(result.labels).toEqual({customer: 'keep-me'})
       expect(result.template?.containers?.[0].name).toBe('')
+    })
+
+    test('does not restore an unrelated datadog-app worker without the tracer mount', () => {
+      const service: IService = {
+        labels: {[SSI_INJECTION_MODE_LABEL]: SINGLE_LANGUAGE_SSI_MODE},
+        template: {
+          containers: [
+            {
+              name: 'ingress',
+              ports: [{containerPort: 8080}],
+              volumeMounts: [{name: TRACER_VOLUME_NAME, mountPath: '/datadog-lib'}],
+            },
+            {name: SSI_ADOPTED_INGRESS_CONTAINER_NAME},
+          ],
+        },
+      }
+
+      const result = command.createUninstrumentedServiceConfig(service)
+
+      expect(result.template?.containers?.map((container) => container.name)).toEqual([
+        'ingress',
+        SSI_ADOPTED_INGRESS_CONTAINER_NAME,
+      ])
     })
 
     test('handles service with no sidecar or shared volume gracefully', () => {

--- a/packages/plugin-cloud-run/src/__tests__/uninstrument.test.ts
+++ b/packages/plugin-cloud-run/src/__tests__/uninstrument.test.ts
@@ -304,7 +304,7 @@ describe('UninstrumentCommand', () => {
         template: {
           containers: [
             {
-              name: 'ingress',
+              name: 'main',
               ports: [{containerPort: 8080}],
               volumeMounts: [{name: TRACER_VOLUME_NAME, mountPath: '/datadog-lib'}],
             },
@@ -316,7 +316,7 @@ describe('UninstrumentCommand', () => {
       const result = command.createUninstrumentedServiceConfig(service)
 
       expect(result.template?.containers?.map((container) => container.name)).toEqual([
-        'ingress',
+        'main',
         SSI_ADOPTED_INGRESS_CONTAINER_NAME,
       ])
     })

--- a/packages/plugin-cloud-run/src/__tests__/uninstrument.test.ts
+++ b/packages/plugin-cloud-run/src/__tests__/uninstrument.test.ts
@@ -223,7 +223,7 @@ describe('UninstrumentCommand', () => {
       ])
     })
 
-    test('removes owned SSI state from a named ingress', () => {
+    test('removes owned SSI state from a named main container', () => {
       ;(command as any).envVars = ['CONFIGURED_VAR=remove-me']
       const service: IService = {
         labels: {[SSI_INJECTION_MODE_LABEL]: SINGLE_LANGUAGE_SSI_MODE, customer: 'keep-me'},

--- a/packages/plugin-cloud-run/src/service-config.ts
+++ b/packages/plugin-cloud-run/src/service-config.ts
@@ -21,7 +21,11 @@ const UNIFIED_SERVICE_TAG_LABELS = {
   environment: 'env',
   version: 'version',
 } as const
-const INSTRUMENTATION_LABELS = new Set([...Object.values(UNIFIED_SERVICE_TAG_LABELS), SERVERLESS_CLI_VERSION_TAG_NAME])
+const INSTRUMENTATION_LABELS = new Set([
+  ...Object.values(UNIFIED_SERVICE_TAG_LABELS),
+  SERVERLESS_CLI_VERSION_TAG_NAME,
+  SSI_INJECTION_MODE_LABEL,
+])
 
 export interface InstrumentServiceConfigOptions {
   readonly ssiConfig?: SsiConfigResult
@@ -136,10 +140,24 @@ export const uninstrumentServiceConfig = (
   const volumes: IVolume[] = template.volumes || []
   const sidecarRemoved = containers.some((container) => container.name === options.sidecarName)
   const sharedVolumeRemoved = volumes.some((volume) => volume.name === options.sharedVolumeName)
+  const ownsSsiState = service.labels?.[SSI_INJECTION_MODE_LABEL] === SINGLE_LANGUAGE_SSI_MODE
   const updatedContainers = containers
-    .filter((container) => container.name !== options.sidecarName)
-    .map((container) => removeContainerInstrumentation(container, options.sharedVolumeName, options.envVarNames))
-  const updatedVolumes = volumes.filter((volume) => volume.name !== options.sharedVolumeName)
+    .filter(
+      (container) =>
+        container.name !== options.sidecarName && (!ownsSsiState || container.name !== TRACER_COPY_CONTAINER_NAME)
+    )
+    .map((container) =>
+      removeContainerInstrumentation(
+        container,
+        options.sidecarName,
+        options.sharedVolumeName,
+        options.envVarNames,
+        ownsSsiState
+      )
+    )
+  const updatedVolumes = volumes.filter(
+    (volume) => volume.name !== options.sharedVolumeName && (!ownsSsiState || volume.name !== TRACER_VOLUME_NAME)
+  )
   const labels = Object.fromEntries(
     Object.entries(service.labels ?? {}).filter(([name]) => !INSTRUMENTATION_LABELS.has(name))
   )
@@ -287,12 +305,23 @@ const buildSidecarContainer = (template: IServiceTemplate, options: InstrumentSe
 
 const removeContainerInstrumentation = (
   container: IContainer,
+  agentContainerName: string,
   sharedVolumeName: string,
-  envVarNames: ReadonlySet<string>
-): IContainer => ({
-  ...container,
-  volumeMounts: (container.volumeMounts || []).filter((volumeMount) => volumeMount.name !== sharedVolumeName),
-  env: (container.env || []).filter(
-    (envVar) => envVar.name && !envVar.name.startsWith('DD_') && !envVarNames.has(envVar.name)
-  ),
-})
+  envVarNames: ReadonlySet<string>,
+  ownsSsiState: boolean
+): IContainer => {
+  const hasTracerMount = container.volumeMounts?.some((mount) => mount.name === TRACER_VOLUME_NAME) ?? false
+  let updated = ownsSsiState && hasTracerMount ? scrubPriorSsiContainer(container, true) : container
+  if (ownsSsiState) {
+    updated = removeDependency(updated, agentContainerName)
+  }
+
+  return {
+    ...updated,
+    name: ownsSsiState && updated.name === SSI_ADOPTED_INGRESS_CONTAINER_NAME ? '' : updated.name,
+    volumeMounts: (updated.volumeMounts || []).filter((volumeMount) => volumeMount.name !== sharedVolumeName),
+    env: (updated.env || []).filter(
+      (envVar) => envVar.name && !envVar.name.startsWith('DD_') && !envVarNames.has(envVar.name)
+    ),
+  }
+}

--- a/packages/plugin-cloud-run/src/service-config.ts
+++ b/packages/plugin-cloud-run/src/service-config.ts
@@ -311,14 +311,14 @@ const removeContainerInstrumentation = (
   ownsSsiState: boolean
 ): IContainer => {
   const hasTracerMount = container.volumeMounts?.some((mount) => mount.name === TRACER_VOLUME_NAME) ?? false
-  let updated = ownsSsiState && hasTracerMount ? scrubPriorSsiContainer(container, true) : container
+  let updated = ownsSsiState && hasTracerMount ? removeExistingSsiContainer(container, true) : container
   if (ownsSsiState) {
     updated = removeDependency(updated, agentContainerName)
   }
 
   return {
     ...updated,
-    name: ownsSsiState && updated.name === SSI_ADOPTED_INGRESS_CONTAINER_NAME ? '' : updated.name,
+    name: ownsSsiState && updated.name === SSI_ADOPTED_MAIN_CONTAINER_NAME ? '' : updated.name,
     volumeMounts: (updated.volumeMounts || []).filter((volumeMount) => volumeMount.name !== sharedVolumeName),
     env: (updated.env || []).filter(
       (envVar) => envVar.name && !envVar.name.startsWith('DD_') && !envVarNames.has(envVar.name)

--- a/packages/plugin-cloud-run/src/service-config.ts
+++ b/packages/plugin-cloud-run/src/service-config.ts
@@ -318,7 +318,7 @@ const removeContainerInstrumentation = (
 
   return {
     ...updated,
-    name: ownsSsiState && updated.name === SSI_ADOPTED_MAIN_CONTAINER_NAME ? '' : updated.name,
+    name: ownsSsiState && hasTracerMount && updated.name === SSI_ADOPTED_MAIN_CONTAINER_NAME ? '' : updated.name,
     volumeMounts: (updated.volumeMounts || []).filter((volumeMount) => volumeMount.name !== sharedVolumeName),
     env: (updated.env || []).filter(
       (envVar) => envVar.name && !envVar.name.startsWith('DD_') && !envVarNames.has(envVar.name)


### PR DESCRIPTION
### What and why?

Extend Cloud Run uninstrumentation to remove Single-Language SSI configuration.

### How?

Remove owned tracer resources, mounts, dependencies, environment fragments, and adoption metadata while preserving unrelated service configuration.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
