### PR TITLE
[SVLS-9302] apply cloud run runtime copy

### DIFF
--- a/packages/plugin-cloud-run/src/__tests__/ssi.test.ts
+++ b/packages/plugin-cloud-run/src/__tests__/ssi.test.ts
@@ -290,7 +290,11 @@ describe('SSI service preparation', () => {
     const app = result.template?.containers?.find((container) => container.name === 'app')
 
     expect(result.template?.containers?.find((container) => container.name === 'worker')).toEqual(worker)
-    expect(app?.volumeMounts).toEqual([{name: 'shared-volume', mountPath: '/shared-volume'}])
+    expect(app?.volumeMounts).toEqual([
+      {name: 'shared-volume', mountPath: '/shared-volume'},
+      {name: 'datadog-tracer', mountPath: '/datadog-lib'},
+    ])
+    expect(app?.dependsOn).toEqual(['datadog-tracer-copy', 'datadog-sidecar'])
     expect(app?.env).toContainEqual({name: DD_TRACE_ENABLED_ENV_VAR, value: 'true'})
     expect(app?.env).toContainEqual({
       name: 'NODE_OPTIONS',
@@ -298,8 +302,42 @@ describe('SSI service preparation', () => {
     })
     expect(app?.env?.find((variable) => variable.name === 'DD_TAGS')?.value).toBe(SINGLE_LANGUAGE_INJECTION_MODE_TAG)
     expect(result.labels?.dd_sls_injection_mode).toBe('single_language')
-    expect(result.template?.containers?.some((container) => container.name === 'datadog-tracer-copy')).toBe(false)
-    expect(result.template?.volumes?.some((volume) => volume.name === 'datadog-tracer')).toBe(false)
+  })
+
+  test('applies the verified runtime-copy sidecar and Memory volume', () => {
+    const result = instrumentServiceConfig(serviceWithWorker(), serviceConfigOptions())
+    const tracer = result.template?.containers?.find((container) => container.name === 'datadog-tracer-copy')
+
+    expect(tracer).toMatchObject({
+      image: 'gcr.io/datadoghq/dd-lib-js-init:latest',
+      command: ['/bin/sh'],
+      volumeMounts: [{name: 'datadog-tracer', mountPath: '/datadog-lib'}],
+      startupProbe: {
+        tcpSocket: {port: 18999},
+        initialDelaySeconds: 0,
+        periodSeconds: 5,
+        failureThreshold: 48,
+        timeoutSeconds: 1,
+      },
+    })
+    expect(tracer?.args?.slice(2)).toEqual([
+      'datadog-tracer-copy',
+      '/datadog-lib',
+      '/datadog-lib/.copy-finished',
+      '18999',
+      '1',
+      '/datadog-lib/node_modules/dd-trace/init.js',
+    ])
+    const script = tracer?.args?.[1] ?? ''
+    expect(script).toContain('/datadog-init/copy-lib.sh "$root"')
+    expect(script).toContain('[ ! -f "$marker" ]')
+    expect(script).toContain('[ -r "$candidate" ]')
+    expect(script).toContain('echo "datadog: no TCP listener is available in the tracer image" >&2\n  exit 1')
+    expect(script.indexOf('if command -v nc')).toBeGreaterThan(script.indexOf('none of these tracer artifacts'))
+    expect(result.template?.volumes?.find((volume) => volume.name === 'datadog-tracer')).toEqual({
+      name: 'datadog-tracer',
+      emptyDir: {medium: 1},
+    })
   })
 
   test('tracks an adopted unnamed main container without taking over a customer name', () => {
@@ -324,8 +362,6 @@ describe('SSI service preparation', () => {
     app.dependsOn = ['datadog-tracer-copy', 'datadog-sidecar']
     worker.dependsOn = ['datadog-tracer-copy', 'datadog-sidecar']
     worker.env = mergeLanguageInjectionEnv(worker.env, getSpec('nodejs'))
-    node.template!.containers!.push({name: 'datadog-tracer-copy', image: 'old-tracer'} as IContainer)
-    node.template!.volumes!.push({name: 'datadog-tracer'})
 
     const result = instrumentServiceConfig(node, serviceConfigOptions('python'))
     const updatedApp = result.template?.containers?.find((container) => container.name === 'app')
@@ -333,11 +369,15 @@ describe('SSI service preparation', () => {
 
     expect(updatedApp?.env).toContainEqual({name: 'NODE_OPTIONS', value: '--inspect'})
     expect(updatedApp?.env).toContainEqual({name: 'PYTHONPATH', value: '/datadog-lib'})
-    expect(updatedApp?.dependsOn).toEqual(['datadog-sidecar'])
+    expect(updatedApp?.dependsOn).toEqual(['datadog-tracer-copy', 'datadog-sidecar'])
     expect(updatedWorker?.env).toEqual(worker.env)
     expect(updatedWorker?.dependsOn).toEqual(['datadog-sidecar'])
-    expect(result.template?.containers?.some((container) => container.name === 'datadog-tracer-copy')).toBe(false)
-    expect(result.template?.volumes?.some((volume) => volume.name === 'datadog-tracer')).toBe(false)
+    expect(result.template?.containers?.filter((container) => container.name === 'datadog-tracer-copy')).toHaveLength(1)
+    expect(result.template?.containers?.find((container) => container.name === 'datadog-tracer-copy')?.image).toBe(
+      'gcr.io/datadoghq/dd-lib-python-init:latest'
+    )
+    expect(result.template?.volumes?.filter((volume) => volume.name === 'datadog-tracer')).toHaveLength(1)
+    expect(instrumentServiceConfig(result, serviceConfigOptions('python'))).toEqual(result)
   })
 
   test('no-injection preserves unrelated containers and the requested tracing state', () => {

--- a/packages/plugin-cloud-run/src/service-config.ts
+++ b/packages/plugin-cloud-run/src/service-config.ts
@@ -1,5 +1,6 @@
 import type {SsiConfigResult} from './ssi'
 import type {IContainer, IEnvVar, IService, IServiceTemplate, IVolume} from './types'
+import type {RuntimeCopyPlan} from '@datadog/datadog-ci-base/helpers/serverless/ssi/runtime-copy'
 
 import {createInstrumentedTemplate} from '@datadog/datadog-ci-base/helpers/serverless/common'
 import {
@@ -7,7 +8,13 @@ import {
   HEALTH_PORT_ENV_VAR,
   DEFAULT_HEALTH_CHECK_PORT,
 } from '@datadog/datadog-ci-base/helpers/serverless/constants'
-import {TRACER_COPY_CONTAINER_NAME, TRACER_VOLUME_NAME} from '@datadog/datadog-ci-base/helpers/serverless/ssi/constants'
+import {
+  TRACER_COPY_CONTAINER_NAME,
+  TRACER_MOUNT_PATH,
+  TRACER_READINESS_PORT,
+  TRACER_VOLUME_NAME,
+} from '@datadog/datadog-ci-base/helpers/serverless/ssi/constants'
+import {buildRuntimeCopyPlan} from '@datadog/datadog-ci-base/helpers/serverless/ssi/runtime-copy'
 import {SERVERLESS_CLI_VERSION_TAG_NAME, SERVERLESS_CLI_VERSION_TAG_VALUE} from '@datadog/datadog-ci-base/helpers/tags'
 
 import {mergeLanguageInjectionEnv, removeLanguageInjectionEnv, selectMainContainer, SsiConfigError} from './ssi'
@@ -52,6 +59,123 @@ interface UninstrumentServiceConfigResult {
   readonly service: IService
   readonly sidecarRemoved: boolean
   readonly sharedVolumeRemoved: boolean
+}
+
+const TRACER_COPY_SCRIPT = [
+  'set -e',
+  'root=$1',
+  'marker=$2',
+  'port=$3',
+  'shift 3',
+  'if [ ! -x /datadog-init/copy-lib.sh ]; then echo "datadog: /datadog-init/copy-lib.sh is missing from the tracer image" >&2; exit 1; fi',
+  '/datadog-init/copy-lib.sh "$root"',
+  'if [ ! -f "$marker" ]; then echo "datadog: tracer copy did not complete (missing $marker)" >&2; exit 1; fi',
+  'while [ "$#" -gt 0 ]; do',
+  '  count=$1',
+  '  shift',
+  '  found=""',
+  '  names=""',
+  '  i=0',
+  '  while [ "$i" -lt "$count" ]; do',
+  '    candidate=$1',
+  '    shift',
+  '    names="$names $candidate"',
+  '    if [ -z "$found" ] && [ -r "$candidate" ]; then found=$candidate; fi',
+  '    i=$((i+1))',
+  '  done',
+  '  if [ -z "$found" ]; then echo "datadog: none of these tracer artifacts were copied:$names" >&2; exit 1; fi',
+  'done',
+  'echo "datadog: tracer install verified in $root"',
+  // TODO(SVLS-9302): Node.js and Ruby lack nc/python; all tracer images need a stable readiness-server contract.
+  'if command -v nc >/dev/null 2>&1; then',
+  '  while true; do nc -l -p "$port" </dev/null >/dev/null 2>&1 || nc -l "$port" </dev/null >/dev/null 2>&1 || sleep 1; done',
+  'elif command -v python3 >/dev/null 2>&1; then',
+  '  python3 -c \'import socket,sys\nlistener=socket.socket()\nlistener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)\nlistener.bind(("0.0.0.0", int(sys.argv[1])))\nlistener.listen(64)\nwhile True:\n    listener.accept()[0].close()\' "$port"',
+  'else',
+  '  echo "datadog: no TCP listener is available in the tracer image" >&2',
+  '  exit 1',
+  'fi',
+].join('\n')
+
+const buildTracerCopyArgs = (plan: RuntimeCopyPlan): string[] => {
+  if (plan.ordering.kind !== 'cloud-run-idling-sidecar') {
+    throw new Error(`Unsupported Cloud Run runtime-copy ordering: ${plan.ordering.kind}`)
+  }
+
+  const artifactArgs = plan.artifacts.flatMap((requirement) => [String(requirement.length), ...requirement])
+
+  return [
+    '-c',
+    TRACER_COPY_SCRIPT,
+    plan.containerName,
+    plan.mountPath,
+    plan.completionMarker,
+    String(plan.ordering.readinessPort),
+    ...artifactArgs,
+  ]
+}
+
+const buildTracerCopyContainer = (plan: RuntimeCopyPlan): IContainer => {
+  if (plan.ordering.kind !== 'cloud-run-idling-sidecar') {
+    throw new Error(`Unsupported Cloud Run runtime-copy ordering: ${plan.ordering.kind}`)
+  }
+
+  return {
+    name: plan.containerName,
+    image: plan.image,
+    command: ['/bin/sh'],
+    args: buildTracerCopyArgs(plan),
+    volumeMounts: [{name: plan.volumeName, mountPath: plan.mountPath}],
+    resources: plan.resources?.memory ? {limits: {memory: plan.resources.memory}} : undefined,
+    startupProbe: {
+      tcpSocket: {port: plan.ordering.readinessPort},
+      initialDelaySeconds: 0,
+      periodSeconds: 5,
+      failureThreshold: 48,
+      timeoutSeconds: 1,
+    },
+  }
+}
+
+const buildTracerVolume = (volumeName: string): IVolume => ({
+  name: volumeName,
+  emptyDir: {medium: MEMORY_VOLUME_MEDIUM},
+})
+
+const applyRuntimeCopyPlan = (
+  template: IServiceTemplate,
+  plan: RuntimeCopyPlan,
+  ingressName: string,
+  dependencyNames: readonly string[]
+): IServiceTemplate => {
+  const containers = [...(template.containers ?? [])]
+  const ingressIndex = containers.findIndex((container) => container.name === ingressName)
+  if (ingressIndex === -1) {
+    throw new SsiConfigError(`Ingress container '${ingressName}' was not found in the service template.`)
+  }
+
+  const ingress = containers[ingressIndex]
+  const managedDependencies = new Set([plan.containerName, ...dependencyNames])
+  containers[ingressIndex] = {
+    ...ingress,
+    volumeMounts: [
+      ...(ingress.volumeMounts ?? []).filter((mount) => mount.name !== plan.volumeName),
+      {name: plan.volumeName, mountPath: plan.mountPath},
+    ],
+    dependsOn: [
+      ...(ingress.dependsOn ?? []).filter((name) => !managedDependencies.has(name)),
+      plan.containerName,
+      ...dependencyNames,
+    ],
+  }
+
+  containers.push(buildTracerCopyContainer(plan))
+
+  return {
+    ...template,
+    containers,
+    volumes: [...(template.volumes ?? []), buildTracerVolume(plan.volumeName)],
+  }
 }
 
 export const instrumentServiceConfig = (service: IService, options: InstrumentServiceConfigOptions): IService => {
@@ -125,6 +249,18 @@ export const instrumentServiceConfig = (service: IService, options: InstrumentSe
           : container
       ),
     }
+    const plan = buildRuntimeCopyPlan(
+      {
+        image: ssiConfig.spec.image,
+        containerName: TRACER_COPY_CONTAINER_NAME,
+        volumeName: TRACER_VOLUME_NAME,
+        mountPath: TRACER_MOUNT_PATH,
+        completionMarker: `${TRACER_MOUNT_PATH}/.copy-finished`,
+        artifacts: ssiConfig.spec.artifacts as RuntimeCopyPlan['artifacts'],
+      },
+      {kind: 'cloud-run-idling-sidecar', readinessPort: TRACER_READINESS_PORT}
+    )
+    template = applyRuntimeCopyPlan(template, plan, [...appContainerNames!][0], [options.sidecarName])
     labels[SSI_INJECTION_MODE_LABEL] = SINGLE_LANGUAGE_SSI_MODE
   }
 

--- a/packages/plugin-cloud-run/src/service-config.ts
+++ b/packages/plugin-cloud-run/src/service-config.ts
@@ -145,25 +145,25 @@ const buildTracerVolume = (volumeName: string): IVolume => ({
 const applyRuntimeCopyPlan = (
   template: IServiceTemplate,
   plan: RuntimeCopyPlan,
-  ingressName: string,
+  mainContainerName: string,
   dependencyNames: readonly string[]
 ): IServiceTemplate => {
   const containers = [...(template.containers ?? [])]
-  const ingressIndex = containers.findIndex((container) => container.name === ingressName)
-  if (ingressIndex === -1) {
-    throw new SsiConfigError(`Ingress container '${ingressName}' was not found in the service template.`)
+  const mainContainerIndex = containers.findIndex((container) => container.name === mainContainerName)
+  if (mainContainerIndex === -1) {
+    throw new SsiConfigError(`Main container '${mainContainerName}' was not found in the service template.`)
   }
 
-  const ingress = containers[ingressIndex]
+  const mainContainer = containers[mainContainerIndex]
   const managedDependencies = new Set([plan.containerName, ...dependencyNames])
-  containers[ingressIndex] = {
-    ...ingress,
+  containers[mainContainerIndex] = {
+    ...mainContainer,
     volumeMounts: [
-      ...(ingress.volumeMounts ?? []).filter((mount) => mount.name !== plan.volumeName),
+      ...(mainContainer.volumeMounts ?? []).filter((mount) => mount.name !== plan.volumeName),
       {name: plan.volumeName, mountPath: plan.mountPath},
     ],
     dependsOn: [
-      ...(ingress.dependsOn ?? []).filter((name) => !managedDependencies.has(name)),
+      ...(mainContainer.dependsOn ?? []).filter((name) => !managedDependencies.has(name)),
       plan.containerName,
       ...dependencyNames,
     ],
@@ -260,7 +260,7 @@ export const instrumentServiceConfig = (service: IService, options: InstrumentSe
       },
       {kind: 'cloud-run-idling-sidecar', readinessPort: TRACER_READINESS_PORT}
     )
-    template = applyRuntimeCopyPlan(template, plan, [...appContainerNames!][0], [options.sidecarName])
+    template = applyRuntimeCopyPlan(template, plan, [...targetContainerNames!][0], [options.sidecarName])
     labels[SSI_INJECTION_MODE_LABEL] = SINGLE_LANGUAGE_SSI_MODE
   }
 


### PR DESCRIPTION
### What and why?

Apply the shared runtime-copy plan to Cloud Run Single-Language SSI service configuration.

### How?

Add a verified tracer-copy sidecar, memory volume, ingress mount, startup probe, and container dependencies. Copy failures prevent the ingress from starting.

Node.js and Ruby tracer images currently lack a listener for the TCP startup probe, so those images fail closed pending a stable readiness-server contract.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
