### PR TITLE
[SVLS-9302] preserve unrelated cloud run config

### DIFF
--- a/packages/plugin-cloud-run/src/__tests__/uninstrument.test.ts
+++ b/packages/plugin-cloud-run/src/__tests__/uninstrument.test.ts
@@ -282,13 +282,43 @@ describe('UninstrumentCommand', () => {
           [SSI_INJECTION_MODE_LABEL]: SINGLE_LANGUAGE_SSI_MODE,
           customer: 'keep-me',
         },
-        template: {containers: [{name: SSI_ADOPTED_INGRESS_CONTAINER_NAME}]},
+        template: {
+          containers: [
+            {
+              name: SSI_ADOPTED_INGRESS_CONTAINER_NAME,
+              volumeMounts: [{name: TRACER_VOLUME_NAME, mountPath: '/datadog-lib'}],
+            },
+          ],
+        },
       }
 
       const result = command.createUninstrumentedServiceConfig(service)
 
       expect(result.labels).toEqual({customer: 'keep-me'})
       expect(result.template?.containers?.[0].name).toBe('')
+    })
+
+    test('does not restore an unrelated datadog-app worker without the tracer mount', () => {
+      const service: IService = {
+        labels: {[SSI_INJECTION_MODE_LABEL]: SINGLE_LANGUAGE_SSI_MODE},
+        template: {
+          containers: [
+            {
+              name: 'ingress',
+              ports: [{containerPort: 8080}],
+              volumeMounts: [{name: TRACER_VOLUME_NAME, mountPath: '/datadog-lib'}],
+            },
+            {name: SSI_ADOPTED_INGRESS_CONTAINER_NAME},
+          ],
+        },
+      }
+
+      const result = command.createUninstrumentedServiceConfig(service)
+
+      expect(result.template?.containers?.map((container) => container.name)).toEqual([
+        'ingress',
+        SSI_ADOPTED_INGRESS_CONTAINER_NAME,
+      ])
     })
 
     test('handles service with no sidecar or shared volume gracefully', () => {

--- a/packages/plugin-cloud-run/src/__tests__/uninstrument.test.ts
+++ b/packages/plugin-cloud-run/src/__tests__/uninstrument.test.ts
@@ -304,7 +304,7 @@ describe('UninstrumentCommand', () => {
         template: {
           containers: [
             {
-              name: 'ingress',
+              name: 'main',
               ports: [{containerPort: 8080}],
               volumeMounts: [{name: TRACER_VOLUME_NAME, mountPath: '/datadog-lib'}],
             },
@@ -316,7 +316,7 @@ describe('UninstrumentCommand', () => {
       const result = command.createUninstrumentedServiceConfig(service)
 
       expect(result.template?.containers?.map((container) => container.name)).toEqual([
-        'ingress',
+        'main',
         SSI_ADOPTED_INGRESS_CONTAINER_NAME,
       ])
     })

--- a/packages/plugin-cloud-run/src/service-config.ts
+++ b/packages/plugin-cloud-run/src/service-config.ts
@@ -318,7 +318,7 @@ const removeContainerInstrumentation = (
 
   return {
     ...updated,
-    name: ownsSsiState && updated.name === SSI_ADOPTED_MAIN_CONTAINER_NAME ? '' : updated.name,
+    name: ownsSsiState && hasTracerMount && updated.name === SSI_ADOPTED_MAIN_CONTAINER_NAME ? '' : updated.name,
     volumeMounts: (updated.volumeMounts || []).filter((volumeMount) => volumeMount.name !== sharedVolumeName),
     env: (updated.env || []).filter(
       (envVar) => envVar.name && !envVar.name.startsWith('DD_') && !envVarNames.has(envVar.name)


### PR DESCRIPTION
### What and why?

Keep markerless SSI replacement and cleanup from modifying unrelated Cloud Run configuration.

### How?

Replacement removes tracer-copy dependencies without dropping existing worker dependencies on the Agent. Uninstrumentation restores the synthetic ingress name only when the adopted container carried the tracer mount.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
