### PR TITLE
[SVLS-9302] validate cloud run ssi transitions

### DIFF
--- a/packages/plugin-cloud-run/src/__tests__/ssi.test.ts
+++ b/packages/plugin-cloud-run/src/__tests__/ssi.test.ts
@@ -383,7 +383,7 @@ describe('SSI service preparation', () => {
   test.each([
     ['directly', false],
     ['transitively', true],
-  ] as const)('rejects an Agent that %s depends on the ingress', (_description, transitive) => {
+  ] as const)('rejects an Agent that %s depends on the main container', (_description, transitive) => {
     const service = serviceWithWorker()
     if (transitive) {
       service.template!.containers![1].dependsOn = ['app']

--- a/packages/plugin-cloud-run/src/__tests__/ssi.test.ts
+++ b/packages/plugin-cloud-run/src/__tests__/ssi.test.ts
@@ -380,6 +380,22 @@ describe('SSI service preparation', () => {
     expect(instrumentServiceConfig(result, serviceConfigOptions('python'))).toEqual(result)
   })
 
+  test.each([
+    ['directly', false],
+    ['transitively', true],
+  ] as const)('rejects an Agent that %s depends on the ingress', (_description, transitive) => {
+    const service = serviceWithWorker()
+    if (transitive) {
+      service.template!.containers![1].dependsOn = ['app']
+    }
+    service.template!.containers!.push({
+      name: 'datadog-sidecar',
+      dependsOn: [transitive ? 'worker' : 'app'],
+    } as IContainer)
+
+    expect(() => instrumentServiceConfig(service, serviceConfigOptions())).toThrow(SsiConfigError)
+  })
+
   test('no-injection preserves unrelated containers and the requested tracing state', () => {
     const service = serviceWithWorker()
     const tracer = {name: 'datadog-tracer-copy', image: 'old-tracer', env: [{name: 'KEEP', value: 'true'}]}

--- a/packages/plugin-cloud-run/src/__tests__/uninstrument.test.ts
+++ b/packages/plugin-cloud-run/src/__tests__/uninstrument.test.ts
@@ -288,6 +288,7 @@ describe('UninstrumentCommand', () => {
               name: SSI_ADOPTED_INGRESS_CONTAINER_NAME,
               volumeMounts: [{name: TRACER_VOLUME_NAME, mountPath: '/datadog-lib'}],
             },
+            {name: 'worker', dependsOn: [SSI_ADOPTED_INGRESS_CONTAINER_NAME, 'database']},
           ],
         },
       }
@@ -296,6 +297,7 @@ describe('UninstrumentCommand', () => {
 
       expect(result.labels).toEqual({customer: 'keep-me'})
       expect(result.template?.containers?.[0].name).toBe('')
+      expect(result.template?.containers?.[1].dependsOn).toEqual(['database'])
     })
 
     test('does not restore an unrelated datadog-app worker without the tracer mount', () => {

--- a/packages/plugin-cloud-run/src/service-config.ts
+++ b/packages/plugin-cloud-run/src/service-config.ts
@@ -155,6 +155,7 @@ const applyRuntimeCopyPlan = (
   }
 
   const mainContainer = containers[mainContainerIndex]
+  assertNoDependencyCycle(containers, ingressName, [plan.containerName, ...dependencyNames])
   const managedDependencies = new Set([plan.containerName, ...dependencyNames])
   containers[mainContainerIndex] = {
     ...mainContainer,
@@ -175,6 +176,32 @@ const applyRuntimeCopyPlan = (
     ...template,
     containers,
     volumes: [...(template.volumes ?? []), buildTracerVolume(plan.volumeName)],
+  }
+}
+
+const assertNoDependencyCycle = (
+  containers: readonly IContainer[],
+  ingressName: string,
+  dependencyNames: readonly string[]
+): void => {
+  const containersByName = new Map(
+    containers.flatMap((container) => (container.name ? [[container.name, container] as const] : []))
+  )
+  for (const dependencyName of dependencyNames) {
+    const pending = [dependencyName]
+    const visited = new Set<string>()
+    while (pending.length > 0) {
+      const name = pending.pop()!
+      if (name === ingressName) {
+        throw new SsiConfigError(
+          `Cannot make ingress container '${ingressName}' depend on '${dependencyName}' because that container already depends on the ingress directly or transitively.`
+        )
+      }
+      if (!visited.has(name)) {
+        visited.add(name)
+        pending.push(...(containersByName.get(name)?.dependsOn ?? []))
+      }
+    }
   }
 }
 
@@ -277,6 +304,13 @@ export const uninstrumentServiceConfig = (
   const sidecarRemoved = containers.some((container) => container.name === options.sidecarName)
   const sharedVolumeRemoved = volumes.some((volume) => volume.name === options.sharedVolumeName)
   const ownsSsiState = service.labels?.[SSI_INJECTION_MODE_LABEL] === SINGLE_LANGUAGE_SSI_MODE
+  const restoreAdoptedIngressName =
+    ownsSsiState &&
+    containers.some(
+      (container) =>
+        container.name === SSI_ADOPTED_INGRESS_CONTAINER_NAME &&
+        (container.volumeMounts ?? []).some((mount) => mount.name === TRACER_VOLUME_NAME)
+    )
   const updatedContainers = containers
     .filter(
       (container) =>
@@ -288,7 +322,8 @@ export const uninstrumentServiceConfig = (
         options.sidecarName,
         options.sharedVolumeName,
         options.envVarNames,
-        ownsSsiState
+        ownsSsiState,
+        restoreAdoptedIngressName
       )
     )
   const updatedVolumes = volumes.filter(
@@ -444,12 +479,16 @@ const removeContainerInstrumentation = (
   agentContainerName: string,
   sharedVolumeName: string,
   envVarNames: ReadonlySet<string>,
-  ownsSsiState: boolean
+  ownsSsiState: boolean,
+  restoreAdoptedIngressName: boolean
 ): IContainer => {
   const hasTracerMount = container.volumeMounts?.some((mount) => mount.name === TRACER_VOLUME_NAME) ?? false
   let updated = ownsSsiState && hasTracerMount ? removeExistingSsiContainer(container, true) : container
   if (ownsSsiState) {
     updated = removeDependency(updated, agentContainerName)
+  }
+  if (restoreAdoptedIngressName) {
+    updated = removeDependency(updated, SSI_ADOPTED_INGRESS_CONTAINER_NAME)
   }
 
   return {

--- a/packages/plugin-cloud-run/src/service-config.ts
+++ b/packages/plugin-cloud-run/src/service-config.ts
@@ -155,7 +155,7 @@ const applyRuntimeCopyPlan = (
   }
 
   const mainContainer = containers[mainContainerIndex]
-  assertNoDependencyCycle(containers, ingressName, [plan.containerName, ...dependencyNames])
+  assertNoDependencyCycle(containers, mainContainerName, [plan.containerName, ...dependencyNames])
   const managedDependencies = new Set([plan.containerName, ...dependencyNames])
   containers[mainContainerIndex] = {
     ...mainContainer,
@@ -181,7 +181,7 @@ const applyRuntimeCopyPlan = (
 
 const assertNoDependencyCycle = (
   containers: readonly IContainer[],
-  ingressName: string,
+  mainContainerName: string,
   dependencyNames: readonly string[]
 ): void => {
   const containersByName = new Map(
@@ -192,9 +192,9 @@ const assertNoDependencyCycle = (
     const visited = new Set<string>()
     while (pending.length > 0) {
       const name = pending.pop()!
-      if (name === ingressName) {
+      if (name === mainContainerName) {
         throw new SsiConfigError(
-          `Cannot make ingress container '${ingressName}' depend on '${dependencyName}' because that container already depends on the ingress directly or transitively.`
+          `Cannot make main container '${mainContainerName}' depend on '${dependencyName}' because that container already depends on the main container directly or transitively.`
         )
       }
       if (!visited.has(name)) {
@@ -304,11 +304,11 @@ export const uninstrumentServiceConfig = (
   const sidecarRemoved = containers.some((container) => container.name === options.sidecarName)
   const sharedVolumeRemoved = volumes.some((volume) => volume.name === options.sharedVolumeName)
   const ownsSsiState = service.labels?.[SSI_INJECTION_MODE_LABEL] === SINGLE_LANGUAGE_SSI_MODE
-  const restoreAdoptedIngressName =
+  const restoreAdoptedMainContainerName =
     ownsSsiState &&
     containers.some(
       (container) =>
-        container.name === SSI_ADOPTED_INGRESS_CONTAINER_NAME &&
+        container.name === SSI_ADOPTED_MAIN_CONTAINER_NAME &&
         (container.volumeMounts ?? []).some((mount) => mount.name === TRACER_VOLUME_NAME)
     )
   const updatedContainers = containers
@@ -323,7 +323,7 @@ export const uninstrumentServiceConfig = (
         options.sharedVolumeName,
         options.envVarNames,
         ownsSsiState,
-        restoreAdoptedIngressName
+        restoreAdoptedMainContainerName
       )
     )
   const updatedVolumes = volumes.filter(
@@ -480,15 +480,15 @@ const removeContainerInstrumentation = (
   sharedVolumeName: string,
   envVarNames: ReadonlySet<string>,
   ownsSsiState: boolean,
-  restoreAdoptedIngressName: boolean
+  restoreAdoptedMainContainerName: boolean
 ): IContainer => {
   const hasTracerMount = container.volumeMounts?.some((mount) => mount.name === TRACER_VOLUME_NAME) ?? false
   let updated = ownsSsiState && hasTracerMount ? removeExistingSsiContainer(container, true) : container
   if (ownsSsiState) {
     updated = removeDependency(updated, agentContainerName)
   }
-  if (restoreAdoptedIngressName) {
-    updated = removeDependency(updated, SSI_ADOPTED_INGRESS_CONTAINER_NAME)
+  if (restoreAdoptedMainContainerName) {
+    updated = removeDependency(updated, SSI_ADOPTED_MAIN_CONTAINER_NAME)
   }
 
   return {


### PR DESCRIPTION
### What and why?

Keep markerless SSI language and mode transitions from leaving invalid Cloud Run configuration.

### How?

Transitions always scrub recognized prior tracer fragments, remove dependencies on a disappearing synthetic ingress name, and reject direct or transitive dependency cycles before adding runtime-copy ordering.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
