### PR TITLE
[docs] Improve formatting for plugin commands

### DIFF
--- a/packages/datadog-ci/README.md
+++ b/packages/datadog-ci/README.md
@@ -47,15 +47,14 @@ yarn dlx @datadog/datadog-ci@v5 [scope]
 
 Plugins are NPM packages that were split from the main `@datadog/datadog-ci` NPM package to reduce its installation size.
 
-If you are using the NPM package:
-- Run `datadog-ci plugin list` to list the available plugins:
-  ```sh
-  datadog-ci plugin list
-  ```
-- Run `datadog-ci plugin install` to install a plugin:
-  ```sh
-  datadog-ci plugin install <scope>
-  ```
+If you are using the NPM package, you can manage plugins with the following commands:
+```sh
+# List available plugins
+datadog-ci plugin list
+
+# Install a plugin
+datadog-ci plugin install <scope>
+```
 
 If you are using the [standalone binary](#standalone-binary), all plugins are already included, so you don't need to install them separately.
 


### PR DESCRIPTION
### What and why?

Follow-up of #2434, nit with better formatting.

**Before:**

<img width="891" height="399" alt="image" src="https://github.com/user-attachments/assets/70b8cb71-6af7-4cdc-b4f1-aaaa4cae6134" />

**After:**

<img width="895" height="362" alt="image" src="https://github.com/user-attachments/assets/a15103df-ac49-47af-bedd-e92310d68e37" />


### Motivation

Aligns better with the beginning of the README, and inline code isn't touching code blocks anymore

<img width="887" height="694" alt="image" src="https://github.com/user-attachments/assets/c72c9c77-ac06-4a3a-8191-70dc44bdb2f7" />


### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
