### PR TITLE
Set IMG_REGISTRIES on the public image publish job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -47,6 +47,7 @@ publish-docker-image:
   variables:
     IMG_SOURCES: registry.ddbuild.io/ci/datadog-ci:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}
     IMG_DESTINATIONS: ci:${CI_COMMIT_TAG},ci:latest
+    IMG_REGISTRIES: public
     IMG_SIGNING: 'false'
 
 catalog-endpoints-generate:


### PR DESCRIPTION
The `v5.22.0` release failed in [`publish-docker-image`](https://gitlab.ddbuild.io/DataDog/datadog-ci/-/jobs/1917355818):

```
Error: gateway returned HTTP 400: {"title":"Generic Error","detail":"validation failed: registries must have at least one entry"}
```

## Cause

The job never set `IMG_REGISTRIES`. Under the previous `trigger: project: DataDog/public-images` bridge that was harmless — public-images fell back to the `default` tag from `registries.yaml`. artifact-gateway validates the request instead and rejects an empty registry list, so the omission became fatal when the job was converted to call `dd-pkg publish-image` directly in #2413.

## Fix

`public` and `default` resolve to the **same nine registries** (`public-azure`, `dockerhub`, `gcr-datadoghq`, `gar-datadoghq-us`/`-eu`/`-asia`, `ecr-public`, `registry.datad0g.com`, `registry.datadoghq.com`), verified against `registries.yaml`. So this restores the previous publication targets exactly rather than changing where the image goes.

## Blast radius

I audited every repo migrated under BARX-1757 by resolving each publish job's `extends` chain and checking the effective `IMG_REGISTRIES` (including `parallel: matrix:` entries). **datadog-ci was the only one** relying on the implicit default — every other repo sets it on the job, the template, or a matrix entry.

- Jira: [BARX-1947](https://datadoghq.atlassian.net/browse/BARX-1947)


[BARX-1947]: https://datadoghq.atlassian.net/browse/BARX-1947?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ