### PR TITLE
chore: make skills and codeowners agent agnostic

### DIFF
--- a/.agents/skills
+++ b/.agents/skills
@@ -1,0 +1,1 @@
+../.claude/skills

--- a/.claude/skills/create-plugin/SKILL.md
+++ b/.claude/skills/create-plugin/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: create-plugin
+description: Scaffold a new datadog-ci plugin end-to-end using repository conventions.
+---
+
 # Create Plugin
 
 Scaffold a new datadog-ci plugin end-to-end. Walk the user through each step, confirming the scope name and whether the plugin should be built-in or separately installable.

--- a/.claude/skills/write-tests/SKILL.md
+++ b/.claude/skills/write-tests/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: write-tests
+description: Write tests for datadog-ci commands and helpers using established repository patterns.
+---
+
 # Write Tests
 
 Write tests for datadog-ci commands and helpers following the repo's established patterns. Before writing tests, read existing tests in the same package to match local patterns.

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -79,7 +79,8 @@ packages/base/src/helpers/**tests**/user-provided-git.test.ts  @DataDog/datadog-
 # Documentation
 *.md  @DataDog/datadog-ci-admins @DataDog/documentation
 
-# Claude Code config (no docs review needed)
+# Agent config (no docs review needed)
+AGENTS.md       @DataDog/datadog-ci-admins
 CLAUDE.md       @DataDog/datadog-ci-admins
 .claude/        @DataDog/datadog-ci-admins
 

--- a/.gitignore
+++ b/.gitignore
@@ -77,7 +77,8 @@ dist
 .claude/todos/
 .claude/credits.json
 
-.agents
+.agents/*
+!.agents/skills
 skills-lock.json
 
 # Test generated files

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,7 @@ Prettier + ESLint enforce formatting and style. Run `yarn format` to auto-fix, `
 Not enforced by lint -- follow manually:
 - Use `getRequestBuilder()` from `helpers/utils` or `httpRequest()` from `helpers/request` for HTTP -- not raw fetch or axios
 - Use `datadogRoute()` from `helpers/request/datadog-route` to build Datadog API paths, and `thirdParty()` from `helpers/request/third-party` for external URLs. Never try to bypass this with casts, and never use `thirdParty()` for Datadog API calls.
+- Prefer Clipanion/Typanion validators/types for independent CLI arguments rather than custom validation logic where possible.
 
 ## Testing
 


### PR DESCRIPTION
### What and why?

It'd be nice to have the claude skills as agent skills, like we do in web-ui. Also updates the codeowners and text to be non-claude specific

### How?

add a symlink such that:
```bash
$ ls .agents/skills/*

.agents/skills/create-plugin:
  SKILL.md

.agents/skills/write-tests:
  SKILL.md
```

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
