### PR TITLE
[SYNTH-28544] Fix bug when triggering a test suite

### DIFF
--- a/packages/base/src/helpers/request/datadog-route.ts
+++ b/packages/base/src/helpers/request/datadog-route.ts
@@ -29,6 +29,7 @@ export const DATADOG_ROUTE_PATHS = [
   '/synthetics/mobile/applications/:applicationId/multipart-upload-complete',
   '/synthetics/mobile/applications/validation-job-status/:jobId',
   '/synthetics/settings',
+  '/synthetics/suites/:suiteId',
   '/synthetics/tests/:testId',
   '/synthetics/tests/:testId/version_history/:version?only_check_existence=true',
   '/synthetics/tests/:testType/:testId',

--- a/packages/plugin-synthetics/README.md
+++ b/packages/plugin-synthetics/README.md
@@ -232,16 +232,18 @@ npm run datadog-ci-synthetics
 
 Run tests by executing the CLI through **Yarn**:
 
-The `run-tests` sub-command accepts the `--public-id` (or shorthand `-p`) argument to trigger only the specified test. It can be set multiple times to run multiple tests:
+The `run-tests` command accepts one or more `--public-id` (or shorthand `-p`) arguments:
 
 ```bash
 yarn datadog-ci synthetics run-tests --public-id aaa-aaa-aaa --public-id bbb-bbb-bbb
 ```
 
-You can also specify a specific version of a test using the format `<public-id>@<version>`:
+A `--public-id` argument can refer to a test, a specific version of a test (e.g. `aaa-aaa-aaa@2`) or to a [Test Suite][20], in which case all tests in the suite are run.
+
+Example running a test's latest version, a test's specific version, and a [Test Suite][20]:
 
 ```bash
-yarn datadog-ci synthetics run-tests --public-id aaa-aaa-aaa@2 --public-id bbb-bbb-bbb@4
+yarn datadog-ci synthetics run-tests --public-id aaa-aaa-aaa --public-id bbb-bbb-bbb@3 --public-id ccc-ccc-ccc
 ```
 
 It is also possible to trigger tests corresponding to a search query by using the `--search` (or shorthand `-s`) argument. With this option, the overrides defined in your [global configuration file](#global-configuration-file) apply to all tests discovered with the search query.
@@ -425,7 +427,7 @@ The proxy to be used for outgoing connections to Datadog. `host` and `port` keys
 
 Public IDs of Synthetic tests to run. If no value is provided, tests are discovered in Synthetic [test configuration files](#test-files).
 
-You can specify a specific version of a test using the format `<public-id>@<version>`. For example, `abc-def-ghi@123` runs version 123 of the test with public ID `abc-def-ghi`. If no version is specified, the latest version of the test is used.
+A public ID can refer to a test, a specific version of a test (e.g. `aaa-aaa-aaa@2`) or to a [Test Suite](https://docs.datadoghq.com/synthetics/test_suites/), in which case all tests in the suite are run.
 
 **Configuration options**
 
@@ -1132,6 +1134,7 @@ Additional helpful documentation, links, and articles:
 [17]: https://app.datadoghq.com/synthetics/settings/continuous-testing
 [18]: https://docs.datadoghq.com/synthetics/mobile_app_testing/
 [19]: https://github.com/DataDog/datadog-ci/blob/master/packages/plugin-synthetics/src/interfaces.ts#L223-L254
+[20]: https://docs.datadoghq.com/synthetics/test_suites/
 
 <!--
   This page is single-sourced:

--- a/packages/plugin-synthetics/README.md
+++ b/packages/plugin-synthetics/README.md
@@ -427,7 +427,7 @@ The proxy to be used for outgoing connections to Datadog. `host` and `port` keys
 
 Public IDs of Synthetic tests to run. If no value is provided, tests are discovered in Synthetic [test configuration files](#test-files).
 
-A public ID can refer to a test, a specific version of a test (e.g. `aaa-aaa-aaa@2`) or to a [Test Suite](https://docs.datadoghq.com/synthetics/test_suites/), in which case all tests in the suite are run.
+A public ID can refer to a test, a specific version of a test (e.g. `aaa-aaa-aaa@2`) or to a [Test Suite][20], in which case all tests in the suite are run.
 
 **Configuration options**
 

--- a/packages/plugin-synthetics/src/__tests__/batch.test.ts
+++ b/packages/plugin-synthetics/src/__tests__/batch.test.ts
@@ -243,6 +243,38 @@ describe('waitForResults', () => {
     ).toEqual([result])
   })
 
+  test('should match a batch result to a triggered suite by membership', async () => {
+    // The polled result carries no `test` details of its own here, to isolate the suite-membership matching
+    // (in reality the member test's own details would come back via `pollResult.test` and get merged in).
+    mockApi({
+      pollResultsImplementation: async () => [{...deepExtend({}, pollResult), test: {}} as PollResult],
+    })
+
+    const suiteTest: Test = {
+      ...apiTest,
+      public_id: 'suite-pid',
+      type: 'suite',
+      memberPublicIds: [apiTest.public_id],
+    } as Test
+
+    const results = await waitForResults(
+      api,
+      trigger,
+      [suiteTest],
+      {
+        batchTimeout: 120000,
+        datadogSite: DEFAULT_COMMAND_CONFIG.datadogSite,
+        failOnCriticalErrors: false,
+        subdomain: DEFAULT_COMMAND_CONFIG.subdomain,
+      },
+      mockReporter
+    )
+
+    const memberTest = {...suiteTest, public_id: apiTest.public_id}
+    expect(results).toEqual([{...result, test: memberTest}])
+    expect(mockReporter.testsWait).toHaveBeenCalledWith([memberTest], expect.anything(), 'bid')
+  })
+
   test('should show results as they arrive', async () => {
     jest.spyOn(internalUtils, 'wait').mockImplementation(async () => waiter.resolve())
 

--- a/packages/plugin-synthetics/src/__tests__/fixtures.ts
+++ b/packages/plugin-synthetics/src/__tests__/fixtures.ts
@@ -677,6 +677,7 @@ export const mockApi = (override?: Partial<APIHelper>): APIHelper => {
   return {
     getBatch: jest.fn(),
     getMobileApplicationPresignedURLs: jest.fn(),
+    getSyntheticsSuite: jest.fn(),
     getTest: jest.fn(),
     getTestVersion: jest.fn(),
     getLocalTestDefinition: jest.fn(),

--- a/packages/plugin-synthetics/src/__tests__/reporters/__snapshots__/default.test.ts.snap
+++ b/packages/plugin-synthetics/src/__tests__/reporters/__snapshots__/default.test.ts.snap
@@ -438,6 +438,11 @@ exports[`Default reporter testTrigger Skipped test, with 2 test overrides 1`] = 
 "
 `;
 
+exports[`Default reporter testTrigger Suite, containing multiple tests 1`] = `
+"[[1m[2maaa-bbb-ccc[22m[22m] Found suite "[32m[1mUser profile management[22m[39m" containing 2 tests
+"
+`;
+
 exports[`Default reporter testsWait outputs triggered tests 1`] = `
 "View pending summary in Datadog: [2m[36mhttps://app.datadoghq.com/synthetics/explorer/ci?batchResultId=123[39m[22m
 

--- a/packages/plugin-synthetics/src/__tests__/reporters/default.test.ts
+++ b/packages/plugin-synthetics/src/__tests__/reporters/default.test.ts
@@ -20,6 +20,7 @@ import type {
   SelectiveRerunDecision,
   ServerTest,
   Summary,
+  Test,
   TestPlan,
   UserConfigOverride,
 } from '../../interfaces'
@@ -121,9 +122,7 @@ describe('Default reporter', () => {
       writeMock.mockClear()
     })
 
-    const testObject: Pick<ServerTest, 'name'> = {
-      name: 'Request on example.org',
-    }
+    const testObject = {name: 'Request on example.org'} as Test
     const testId = 'aaa-bbb-ccc'
 
     const cases: [string, ExecutionRule, UserConfigOverride][] = [
@@ -160,6 +159,13 @@ describe('Default reporter', () => {
 
     test.each(cases)('%s', (title, executionRule, testOverrides) => {
       reporter.testTrigger(testObject, testId, executionRule, testOverrides)
+      const mostRecentOutput = writeMock.mock.calls[writeMock.mock.calls.length - 1][0]
+      expect(mostRecentOutput).toMatchSnapshot()
+    })
+
+    test('Suite, containing multiple tests', () => {
+      const suiteObject = {name: 'User profile management', type: 'suite' as const, memberPublicIds: ['a', 'b']} as Test
+      reporter.testTrigger(suiteObject, testId, ExecutionRule.BLOCKING, {})
       const mostRecentOutput = writeMock.mock.calls[writeMock.mock.calls.length - 1][0]
       expect(mostRecentOutput).toMatchSnapshot()
     })

--- a/packages/plugin-synthetics/src/__tests__/test.test.ts
+++ b/packages/plugin-synthetics/src/__tests__/test.test.ts
@@ -358,4 +358,51 @@ describe('getTestAndOverrideConfig', () => {
       'The tunnel is only supported with HTTP API tests and Browser tests (public ID: 123-456-789, type: api, sub-type: multi, step sub-types: [dns, ssl]).'
     )
   })
+
+  test('Not found error when public ID is neither a test nor a suite', async () => {
+    jest.mocked(requestModule.httpRequest).mockImplementation(((_e: any) => {
+      throw getRequestError(404, {errors: ['Not found']})
+    }) as any)
+
+    const triggerConfig = {suite: 'Suite 1', id: '123-456-789'}
+    expect(await getTestAndOverrideConfig(api, triggerConfig, mockReporter, getSummary())).toStrictEqual({
+      errorMessage: '[123-456-789] Test not found: query on https://app.datadoghq.com/example returned: "Not found"',
+    })
+  })
+
+  test('Resolves a Test Suite public ID as a suite placeholder', async () => {
+    jest.mocked(requestModule.httpRequest).mockImplementation(((e: any) => {
+      if (e.url?.includes('/synthetics/suites/aet-7st-a66')) {
+        return Promise.resolve({
+          data: {
+            data: {
+              id: 'aet-7st-a66',
+              attributes: {
+                name: 'User profile management',
+                tests: [{public_id: 'gb2-jzk-t3k'}],
+              },
+            },
+          },
+          status: 200,
+          statusText: 'OK',
+          headers: {},
+          config: e,
+        })
+      }
+
+      throw getRequestError(404, {errors: ['Synthetics test not found']})
+    }) as any)
+
+    const triggerConfig = {suite: 'Suite 1', id: 'aet-7st-a66'}
+    expect(await getTestAndOverrideConfig(api, triggerConfig, mockReporter, getSummary())).toEqual(
+      expect.objectContaining({
+        test: expect.objectContaining({
+          public_id: 'aet-7st-a66',
+          type: 'suite',
+          name: 'User profile management',
+          memberPublicIds: ['gb2-jzk-t3k'],
+        }),
+      })
+    )
+  })
 })

--- a/packages/plugin-synthetics/src/api.ts
+++ b/packages/plugin-synthetics/src/api.ts
@@ -15,6 +15,7 @@ import type {
   RawPollResultTest,
   RawPollResult,
   ServerBatch,
+  ServerSuiteResponse,
   ServerTest,
   SyntheticsOrgSettings,
   TestSearchResult,
@@ -117,6 +118,19 @@ const getTest =
         url: testType
           ? datadogRoute('/synthetics/tests/:testType/:testId', {testId, testType})
           : datadogRoute('/synthetics/tests/:testId', {testId}),
+      },
+      request,
+      {retryOn429: true}
+    )
+
+    return resp.data
+  }
+
+const getSyntheticsSuite =
+  (request: (args: RequestConfig) => Promise<RequestResponse<ServerSuiteResponse>>) => async (suiteId: string) => {
+    const resp = await retryRequest(
+      {
+        url: datadogRoute('/synthetics/suites/:suiteId', {suiteId}),
       },
       request,
       {retryOn429: true}
@@ -470,6 +484,7 @@ export const apiConstructor = (configuration: APIConfiguration) => {
   return {
     getBatch: getBatch(requestV1),
     getMobileApplicationPresignedURLs: getMobileApplicationPresignedURLs(requestUnstable),
+    getSyntheticsSuite: getSyntheticsSuite(requestV2),
     getTest: getTest(requestV1),
     getTestVersion: getTestVersion(requestV2),
     getLocalTestDefinition: getLocalTestDefinition(requestV1),

--- a/packages/plugin-synthetics/src/batch.ts
+++ b/packages/plugin-synthetics/src/batch.ts
@@ -7,7 +7,6 @@ import type {
   Payload,
   PollResult,
   Result,
-  ResultDisplayInfo,
   ResultInBatch,
   ServerResult,
   Test,
@@ -36,6 +35,22 @@ import {getAppBaseURL, isTestSupportedByTunnel} from './utils/public'
 export const DEFAULT_BATCH_TIMEOUT = 30 * 60 * 1000
 
 const POLLING_INTERVAL = 5000 // In ms
+
+/**
+ * Information required to convert a `PollResult` to a `Result`.
+ */
+type ResultDisplayInfo = {
+  getLocation: (datacenterId: string, test: Test) => string
+  options: {
+    batchTimeout: number
+    datadogSite: string
+    failOnCriticalErrors?: boolean
+    failOnTimeout?: boolean
+    subdomain: string
+  }
+  /** All tests, including suite members. With preserved order, and not deduplicated. */
+  tests: Test[]
+}
 
 export const runTests = async (
   api: APIHelper,
@@ -128,7 +143,9 @@ export const waitForResults = async (
       .catch(() => (isTunnelConnected = false))
   }
 
-  reporter.testsWait(tests, getAppBaseURL(options), trigger.batchId)
+  const allTests = tests.flatMap(expandSuiteMembers)
+
+  reporter.testsWait(allTests, getAppBaseURL(options), trigger.batchId)
 
   const locationNames = trigger.locations.reduce<LocationsMapping>((mapping, location) => {
     mapping[location.name] = location.display_name
@@ -145,7 +162,7 @@ export const waitForResults = async (
   const resultDisplayInfo = {
     getLocation,
     options,
-    tests,
+    tests: allTests,
   }
 
   const results = await waitForBatchToFinish(api, trigger.batchId, options.batchTimeout, resultDisplayInfo, reporter)
@@ -321,8 +338,8 @@ const reportWaitingTests = (
   const baseUrl = getAppBaseURL(resultDisplayInfo.options)
   const {tests} = resultDisplayInfo
 
-  const inProgressPublicIds = new Set()
-  const skippedBySelectiveRerunPublicIds = new Set()
+  const inProgressPublicIds = new Set<string>()
+  const skippedBySelectiveRerunPublicIds = new Set<string>()
 
   for (const result of batch.results) {
     if (result.status === 'in_progress') {
@@ -337,10 +354,10 @@ const reportWaitingTests = (
   let skippedCount = 0
 
   for (const test of tests) {
-    if (inProgressPublicIds.has(test.public_id)) {
+    if (inProgressPublicIds.has(test.public_id!)) {
       remainingTests.push(test)
     }
-    if (skippedBySelectiveRerunPublicIds.has(test.public_id)) {
+    if (skippedBySelectiveRerunPublicIds.has(test.public_id!)) {
       skippedCount++
     }
   }
@@ -354,8 +371,7 @@ const getResultFromBatch = (
   resultDisplayInfo: ResultDisplayInfo,
   safeDeadlineReached = false
 ): Result => {
-  const {tests} = resultDisplayInfo
-  const test = getTestByPublicId(resultInBatch.test_public_id, tests)
+  const test = resultDisplayInfo.tests.find((t) => t.public_id === resultInBatch.test_public_id)!
 
   const hasTimedOut = resultInBatch.timed_out ?? safeDeadlineReached
   const timedOutRetry = isTimedOutRetry(resultInBatch.retries, resultInBatch.max_retries, resultInBatch.timed_out)
@@ -498,7 +514,12 @@ const isResidualResult = (
   return false
 }
 
-const getTestByPublicId = (id: string, tests: Test[]): Test => tests.find((t) => t.public_id === id)!
+// The backend fans out a Test Suite into its member tests at trigger time, so a batch result's `test_public_id` may be a suite member
+// rather than one of the top-level triggered public IDs. For display purposes, a suite is represented by its member tests rather than as a single entry.
+const expandSuiteMembers = (test: Test): Test[] =>
+  'memberPublicIds' in test
+    ? test.memberPublicIds.map((memberPublicId) => ({...test, public_id: memberPublicId}))
+    : [test]
 
 const getResultIds = (results: ResultInBatch[]): string[] => excludeSkipped(results).map((r) => r.result_id)
 

--- a/packages/plugin-synthetics/src/interfaces.ts
+++ b/packages/plugin-synthetics/src/interfaces.ts
@@ -133,21 +133,6 @@ export type PollResult = {
   device?: Device
 }
 
-/**
- * Information required to convert a `PollResult` to a `Result`.
- */
-export type ResultDisplayInfo = {
-  getLocation: (datacenterId: string, test: Test) => string
-  options: {
-    batchTimeout: number
-    datadogSite: string
-    failOnCriticalErrors?: boolean
-    failOnTimeout?: boolean
-    subdomain: string
-  }
-  tests: Test[]
-}
-
 export type SelectiveRerunDecision =
   | {
       decision: 'run'
@@ -436,8 +421,25 @@ export interface ServerTest extends LocalTestDefinitionWithUnsupportedFields {
   public_id: string
 }
 
-export type Test = (ServerTest | LocalTestDefinitionWithUnsupportedFields) & {
+export interface ServerSuite extends Omit<LocalTestDefinitionWithUnsupportedFields, 'type'> {
+  public_id: string
+  type: 'suite'
+  memberPublicIds: string[]
+}
+
+export type Test = (ServerTest | ServerSuite | LocalTestDefinitionWithUnsupportedFields) & {
   suite?: string
+}
+
+/** Response shape of `GET /api/v2/synthetics/suites/:public_id`. */
+export interface ServerSuiteResponse {
+  data: {
+    id: string
+    attributes: {
+      name: string
+      tests: {public_id: string}[]
+    }
+  }
 }
 
 export interface Assertion {
@@ -677,7 +679,7 @@ export interface BasicAuthCredentials {
 interface BaseTriggerConfig {
   /** Overrides for this Synthetic test only. This takes precedence over all other overrides. */
   testOverrides?: UserConfigOverride
-  /** Name of a test suite (for JUnit reports). */
+  /** Defaults to the file path relative to the repository root, and it only shows in JUnit reports. */
   suite?: string
 }
 export interface RemoteTriggerConfig extends BaseTriggerConfig {
@@ -700,8 +702,15 @@ export enum ExecutionRule {
   SKIPPED = 'skipped',
 }
 
+/**
+ * Represents a "test configuration file", also known as "test file", "Test Config", or `*.synthetics.json` file.
+ *
+ * This can be compared to a "test suite" in other testing frameworks because it's a collection of tests, but it **does not** represent a [Synthetic Test Suite](https://docs.datadoghq.com/synthetics/test_suites/).
+ */
 export interface Suite {
+  /** The parsed JSON content of the file. */
   content: TestConfig
+  /** Defaults to the file path relative to the repository root, and it only shows in JUnit reports. */
   name?: string
 }
 

--- a/packages/plugin-synthetics/src/reporters/default.ts
+++ b/packages/plugin-synthetics/src/reporters/default.ts
@@ -626,13 +626,21 @@ export class DefaultReporter implements MainReporter {
     this.testWaitSpinner.start()
   }
 
-  public testTrigger(
-    test: Pick<Test, 'name'>,
-    testId: string,
-    executionRule: ExecutionRule,
-    testOverrides: UserConfigOverride
-  ) {
+  public testTrigger(test: Test, testId: string, executionRule: ExecutionRule, testOverrides: UserConfigOverride) {
     const idDisplay = `[${chalk.bold.dim(testId)}]`
+
+    if (test.type === 'suite') {
+      const testCount = test.memberPublicIds?.length ?? 0
+
+      this.write(
+        `${idDisplay} Found suite "${chalk.green.bold(test.name)}" containing ${testCount} ${pluralize(
+          'test',
+          testCount
+        )}\n`
+      )
+
+      return
+    }
 
     const getMessage = () => {
       if (executionRule === ExecutionRule.SKIPPED) {

--- a/packages/plugin-synthetics/src/test.ts
+++ b/packages/plugin-synthetics/src/test.ts
@@ -68,10 +68,12 @@ export const getTestConfigs = async (
 
   const testConfigs = suites
     .map((suite) =>
-      suite.content.tests.map((test) => {
+      suite.content.tests.map<TriggerConfig>((test) => {
+        const suiteFileName = suite.name
+
         return {
           testOverrides: test.testOverrides,
-          suite: suite.name,
+          suite: suiteFileName,
           ...(isLocalTriggerConfig(test)
             ? {localTestDefinition: normalizeLocalTestDefinition(test.localTestDefinition)}
             : {
@@ -251,7 +253,7 @@ const getTest = async (
     return {test}
   }
 
-  const {id: publicId, suite, version} = triggerConfig
+  const {id: publicId, suite: suiteFileName, version} = triggerConfig
 
   if (version !== undefined) {
     try {
@@ -278,12 +280,18 @@ const getTest = async (
   try {
     const test = {
       ...(await api.getTest(publicId)),
-      suite,
+      suite: suiteFileName,
     }
 
     return {test}
   } catch (error) {
     if (isNotFoundError(error)) {
+      // The public ID might refer to a test suite rather than a test. In that case, the `/trigger/ci` endpoint fans out the suite into its member tests in the CI batch.
+      const suiteAsTest = await getSuiteAsTest(api, publicId, suiteFileName)
+      if (suiteAsTest) {
+        return {test: suiteAsTest}
+      }
+
       const errorMessage = formatBackendErrors(error)
 
       return {errorMessage: `[${chalk.bold.dim(publicId)}] ${chalk.yellow.bold('Test not found')}: ${errorMessage}`}
@@ -296,6 +304,27 @@ const getTest = async (
     }
 
     throw new EndpointError(`Failed to get test: ${formatBackendErrors(error)}\n`, error.response?.status)
+  }
+}
+
+const getSuiteAsTest = async (api: APIHelper, publicId: string, suite?: string): Promise<Test | undefined> => {
+  try {
+    const {data} = await api.getSyntheticsSuite(publicId)
+
+    // Placeholder test representing the test suite.
+    return {
+      config: {assertions: [], variables: []},
+      locations: [],
+      name: data.attributes.name,
+      options: {},
+      public_id: data.id,
+      type: 'suite',
+      memberPublicIds: data.attributes.tests.map((t) => t.public_id),
+      suite,
+    }
+  } catch (error) {
+    // In most cases, the publicId won't refer to a suite, so we return undefined to favor the "Test not found" error.
+    return undefined
   }
 }
 

--- a/packages/plugin-synthetics/src/utils/public.ts
+++ b/packages/plugin-synthetics/src/utils/public.ts
@@ -167,12 +167,12 @@ export const getSuites = async (pattern: string, reporter: MainReporter): Promis
   }
 
   return Promise.all(
-    files.map(async (file) => {
+    files.map<Promise<Suite>>(async (file) => {
       try {
         const content = await promisify(fs.readFile)(file, 'utf8')
-        const suiteName = await getFilePathRelativeToRepo(file)
+        const suiteFileName = await getFilePathRelativeToRepo(file)
 
-        return {name: suiteName, content: JSON.parse(content)}
+        return {name: suiteFileName, content: JSON.parse(content)}
       } catch (e) {
         throw new Error(`Unable to read and parse the test file ${file}`)
       }


### PR DESCRIPTION
### What and why?

`synthetics run-tests --public-id` fails with `Test not found` / `No tests to run` when given a [Test Suite](https://docs.datadoghq.com/synthetics/test_suites/) public ID instead of a test's. The trigger endpoint (`POST /synthetics/tests/trigger/ci`) already fans a suite out into its member tests server-side, but datadog-ci only knows how to resolve individual test public IDs up front (for the TUI), so a suite ID 404s on `GET /synthetics/tests/:id` and the whole run aborts before it ever reaches the trigger call.

Fixes https://github.com/DataDog/datadog-ci/issues/2445, tracked as [SYNTH-28544](https://datadoghq.atlassian.net/browse/SYNTH-28544).

### How?

When a public ID 404s as a test, we now try resolving it as a suite via `GET /synthetics/suites/:suiteId` before giving up. A resolved suite becomes a lightweight placeholder `Test` (`type: 'suite'`, `memberPublicIds: string[]`) — we don't expand it into individual trigger configs client-side, since the backend already owns that fan-out.

Because batch results for a triggered suite come back keyed by its *member* test public IDs rather than the suite's own ID, `batch.ts` now builds a `testsByPublicId` map that expands suite placeholders into per-member entries up front, so result matching and the "Waiting for N tests" display both work off real test public IDs instead of the suite's.

This PR also does some boyscouting and documents the difference between what's called `Suite` in the code, and Synthetics Test Suites.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)

[SYNTH-28544]: https://datadoghq.atlassian.net/browse/SYNTH-28544?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ