### PR TITLE
chore: stream e2e progress

### DIFF
--- a/e2e/setup.ts
+++ b/e2e/setup.ts
@@ -1,4 +1,11 @@
 import {Console} from 'node:console'
 
 // Write progress as it happens rather than letting Jest attach it to each completed test.
-globalThis.console = new Console({stdout: process.stdout, stderr: process.stderr})
+const console = new Console({stdout: process.stdout, stderr: process.stderr})
+
+for (const method of ['debug', 'error', 'info', 'log', 'warn'] as const) {
+  const write = console[method].bind(console)
+  console[method] = (...args: unknown[]) => write(`[${expect.getState().currentTestName ?? 'setup'}]`, ...args)
+}
+
+globalThis.console = console

--- a/e2e/setup.ts
+++ b/e2e/setup.ts
@@ -1,0 +1,4 @@
+import {Console} from 'node:console'
+
+// Write progress as it happens rather than letting Jest attach it to each completed test.
+globalThis.console = new Console({stdout: process.stdout, stderr: process.stderr})

--- a/jest.config-e2e.js
+++ b/jest.config-e2e.js
@@ -39,5 +39,6 @@ module.exports = {
     ],
   },
   roots: ['e2e'],
+  setupFilesAfterEnv: ['<rootDir>/e2e/setup.ts'],
   testTimeout: 300_000,
 }


### PR DESCRIPTION
### What and why?

Stream E2E progress logs during GitHub Actions runs without Jest source-location output.

### How?

Configure the E2E suite to replace Jest's buffered console with Node's direct stdout and stderr console.

<img width="867" height="486" alt="image" src="https://github.com/user-attachments/assets/d0ab8954-780d-4216-912c-cd6aac071fd5" />



### Review checklist

- [x] Feature or bugfix has appropriate tests
