### PR TITLE
chore: limit serverless e2e

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,23 +167,23 @@ jobs:
           yarn config set nodeLinker node-modules
           yarn install --no-immutable
       - name: Azure login (OIDC)
-        if: needs.check-container-app-changes.outputs.should_run == 'true' || needs.check-aas-changes.outputs.should_run == 'true'
+        if: (needs.check-container-app-changes.outputs.should_run == 'true' || needs.check-aas-changes.outputs.should_run == 'true') && matrix.version == 24
         uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3
         with:
           client-id: ${{ vars.AZURE_CLIENT_ID_E2E }}
           tenant-id: ${{ vars.AZURE_TENANT_ID_E2E }}
           subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID_E2E }}
       - name: Google Cloud auth (OIDC)
-        if: needs.check-cloud-run-changes.outputs.should_run == 'true'
+        if: needs.check-cloud-run-changes.outputs.should_run == 'true' && matrix.version == 24
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
         with:
           workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER_E2E }}
           service_account: ${{ vars.GCP_SERVICE_ACCOUNT_E2E }}
       - name: Set up Google Cloud CLI
-        if: needs.check-cloud-run-changes.outputs.should_run == 'true'
+        if: needs.check-cloud-run-changes.outputs.should_run == 'true' && matrix.version == 24
         uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
       - name: Configure AWS credentials (OIDC)
-        if: needs.check-lambda-changes.outputs.should_run == 'true'
+        if: needs.check-lambda-changes.outputs.should_run == 'true' && matrix.version == 24
         uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
           role-to-assume: ${{ vars.AWS_ROLE_ARN_E2E }}
@@ -196,10 +196,10 @@ jobs:
           DD_API_KEY: ${{ secrets.DD_API_KEY_CI_VISIBILITY }}
           DD_APP_KEY: ${{ secrets.DD_APP_KEY_CI_VISIBILITY }}
           GITHUB_SHA: ${{ github.sha }}
-          SKIP_CONTAINER_APP_TESTS: ${{ needs.check-container-app-changes.outputs.should_run != 'true' || needs.check-version-bump-only.outputs.result == 'true' }}
-          SKIP_AAS_TESTS: ${{ needs.check-aas-changes.outputs.should_run != 'true' || needs.check-version-bump-only.outputs.result == 'true' }}
-          SKIP_CLOUD_RUN_TESTS: ${{ needs.check-cloud-run-changes.outputs.should_run != 'true' || needs.check-version-bump-only.outputs.result == 'true' }}
-          SKIP_LAMBDA_TESTS: ${{ needs.check-lambda-changes.outputs.should_run != 'true' }}
+          SKIP_CONTAINER_APP_TESTS: ${{ matrix.version != 24 || needs.check-container-app-changes.outputs.should_run != 'true' || needs.check-version-bump-only.outputs.result == 'true' }}
+          SKIP_AAS_TESTS: ${{ matrix.version != 24 || needs.check-aas-changes.outputs.should_run != 'true' || needs.check-version-bump-only.outputs.result == 'true' }}
+          SKIP_CLOUD_RUN_TESTS: ${{ matrix.version != 24 || needs.check-cloud-run-changes.outputs.should_run != 'true' || needs.check-version-bump-only.outputs.result == 'true' }}
+          SKIP_LAMBDA_TESTS: ${{ matrix.version != 24 || needs.check-lambda-changes.outputs.should_run != 'true' }}
           GCP_PROJECT_ID: ${{ vars.GCP_PROJECT_ID_E2E }}
           GCP_REGION: ${{ vars.GCP_REGION_E2E }}
           GCP_CLOUD_RUN_APP_IMAGE_E2E: ${{ vars.GCP_CLOUD_RUN_APP_IMAGE_E2E }}


### PR DESCRIPTION
### What and why?

Serverless E2E suites (container-app, AAS, cloud-run, lambda) ran once per Node version in the `e2e-test` matrix, creating cloud resources three times per commit and straining the shared account's app budget. This runs them on Node 24 only, cutting resource creation by 3x while keeping non-serverless E2E across all Node versions.

### How?

Each `SKIP_*_TESTS` flag and the cloud OIDC auth steps now require `matrix.version == 24`, so serverless suites and their credentials are active on a single Node version. Path filters and the version-bump check are unchanged.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration) (not applicable -- CI-only change)
