### PR TITLE
v5.22.1

### DIFF
--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-base",
-  "version": "5.22.0",
+  "version": "5.22.1",
   "description": "Base package for Datadog CI",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/datadog-ci/package.json
+++ b/packages/datadog-ci/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci",
-  "version": "5.22.0",
+  "version": "5.22.1",
   "description": "Use Datadog from your CI.",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-aas/package.json
+++ b/packages/plugin-aas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-aas",
-  "version": "5.22.0",
+  "version": "5.22.1",
   "description": "Datadog CI plugin for `aas` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-cloud-run/package.json
+++ b/packages/plugin-cloud-run/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-cloud-run",
-  "version": "5.22.0",
+  "version": "5.22.1",
   "description": "Datadog CI plugin for `cloud-run` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-container-app/package.json
+++ b/packages/plugin-container-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-container-app",
-  "version": "5.22.0",
+  "version": "5.22.1",
   "description": "Datadog CI plugin for `container-app` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-coverage/package.json
+++ b/packages/plugin-coverage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-coverage",
-  "version": "5.22.0",
+  "version": "5.22.1",
   "description": "Datadog CI plugin for `coverage` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-deployment/package.json
+++ b/packages/plugin-deployment/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-deployment",
-  "version": "5.22.0",
+  "version": "5.22.1",
   "description": "Datadog CI plugin for `deployment` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-dora/package.json
+++ b/packages/plugin-dora/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-dora",
-  "version": "5.22.0",
+  "version": "5.22.1",
   "description": "Datadog CI plugin for `dora` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-gate/package.json
+++ b/packages/plugin-gate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-gate",
-  "version": "5.22.0",
+  "version": "5.22.1",
   "description": "Datadog CI plugin for `gate` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-junit/package.json
+++ b/packages/plugin-junit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-junit",
-  "version": "5.22.0",
+  "version": "5.22.1",
   "description": "Datadog CI plugin for `junit` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-lambda/package.json
+++ b/packages/plugin-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-lambda",
-  "version": "5.22.0",
+  "version": "5.22.1",
   "description": "Datadog CI plugin for `lambda` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-sarif/package.json
+++ b/packages/plugin-sarif/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-sarif",
-  "version": "5.22.0",
+  "version": "5.22.1",
   "description": "Datadog CI plugin for `sarif` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-sbom/package.json
+++ b/packages/plugin-sbom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-sbom",
-  "version": "5.22.0",
+  "version": "5.22.1",
   "description": "Datadog CI plugin for `sbom` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-stepfunctions/package.json
+++ b/packages/plugin-stepfunctions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-stepfunctions",
-  "version": "5.22.0",
+  "version": "5.22.1",
   "description": "Datadog CI plugin for `stepfunctions` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-synthetics/package.json
+++ b/packages/plugin-synthetics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-synthetics",
-  "version": "5.22.0",
+  "version": "5.22.1",
   "description": "Datadog CI plugin for `synthetics` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-terraform/package.json
+++ b/packages/plugin-terraform/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-terraform",
-  "version": "5.22.0",
+  "version": "5.22.1",
   "description": "Datadog CI plugin for `terraform` commands",
   "license": "Apache-2.0",
   "keywords": [


### PR DESCRIPTION
<!-- Release notes generated using configuration in .github/release.yml at v5.22.1 -->

## What's Changed
### Dependencies
* Set IMG_REGISTRIES on the public image publish job by @AliDatadog in https://github.com/DataDog/datadog-ci/pull/2437
* fix(deps): vuln tar (patch → 7.5.22)  by @gh-worker-campaigns-3e9aa4[bot] in https://github.com/DataDog/datadog-ci/pull/2440
* fix(deps): vuln brace-expansion (patch → 5.0.9)  by @gh-worker-campaigns-3e9aa4[bot] in https://github.com/DataDog/datadog-ci/pull/2441
* fix(deps): vuln fast-uri (minor → 3.1.5)  by @gh-worker-campaigns-3e9aa4[bot] in https://github.com/DataDog/datadog-ci/pull/2447
* fix(deps): vuln js-yaml (minor → 4.3.1)  by @gh-worker-campaigns-3e9aa4[bot] in https://github.com/DataDog/datadog-ci/pull/2443
* fix(deps): vuln undici (minor → 7.29.0)  by @gh-worker-campaigns-3e9aa4[bot] in https://github.com/DataDog/datadog-ci/pull/2442
### Serverless
* chore: Update Lambda layer versions by @gh-worker-campaigns-3e9aa4[bot] in https://github.com/DataDog/datadog-ci/pull/2444
* [SVLS-9307] tracer metadata foundation by @ava-silver in https://github.com/DataDog/datadog-ci/pull/2416
* [SVLS-9307] environment fragment ownership by @ava-silver in https://github.com/DataDog/datadog-ci/pull/2421
* [SVLS-9307] language injection specifications by @ava-silver in https://github.com/DataDog/datadog-ci/pull/2422
* [SVLS-9306] runtime copy foundation by @ava-silver in https://github.com/DataDog/datadog-ci/pull/2417
* [SVLS-9302] define Cloud Run SSI configuration by @ava-silver in https://github.com/DataDog/datadog-ci/pull/2423
* [SVLS-9302] add Cloud Run SSI environment handlers by @ava-silver in https://github.com/DataDog/datadog-ci/pull/2424
* [SVLS-9302] separate Cloud Run configuration from command orchestration by @ava-silver in https://github.com/DataDog/datadog-ci/pull/2425
### Synthetics
* [SYNTH-28544] Fix bug when triggering a test suite by @Drarig29 in https://github.com/DataDog/datadog-ci/pull/2446
### Chores
* chore: add mention of clipanion/typanion validators by @ava-silver in https://github.com/DataDog/datadog-ci/pull/2438
* chore: make skills and codeowners agent agnostic by @ava-silver in https://github.com/DataDog/datadog-ci/pull/2439
* [ci] Fix flaky `check-*-changes` CI jobs on ADMS PRs by @Drarig29 in https://github.com/DataDog/datadog-ci/pull/2448
* chore: stream e2e progress by @ava-silver in https://github.com/DataDog/datadog-ci/pull/2449


**Full Changelog**: https://github.com/DataDog/datadog-ci/compare/v5.22.0...v5.22.1

[SVLS-9307]: https://datadoghq.atlassian.net/browse/SVLS-9307?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ