### PR TITLE
[SVLS-9302] cloud run ssi e2e tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -264,6 +264,7 @@ jobs:
               - 'packages/base/src/helpers/serverless/common.ts'
               - 'packages/base/src/helpers/serverless/constants.ts'
               - 'packages/base/src/helpers/serverless/source-code-integration.ts'
+              - 'packages/base/src/helpers/serverless/ssi/**'
               - 'e2e/serverless/cloud-run/**'
               - 'e2e/serverless/helpers/**'
               - '.github/workflows/ci.yml'

--- a/e2e/serverless/cloud-run/cloud-run-ssi.test.ts
+++ b/e2e/serverless/cloud-run/cloud-run-ssi.test.ts
@@ -88,7 +88,7 @@ describeOrSkip('cloud-run SSI', () => {
             ` --tracing inject` +
             ` --language "${language}"` +
             ` --no-source-code-integration`,
-          {DATADOG_API_KEY: process.env.DATADOG_API_KEY}
+          {DD_API_KEY: process.env.DATADOG_API_KEY}
         )
         expect(instrumentResult).toEqual(expect.objectContaining({exitCode: 0}))
 

--- a/e2e/serverless/cloud-run/cloud-run-ssi.test.ts
+++ b/e2e/serverless/cloud-run/cloud-run-ssi.test.ts
@@ -13,48 +13,42 @@ const describeOrSkip =
 const SSI_CASES = [
   {
     language: 'csharp',
-    image:
-      'us-central1-docker.pkg.dev/datadog-serverless-gcp-dev/e2e-workloads/dotnet-ssi@sha256:3c7ce68221fb7703cb6b925d791a98fd22b05489dbbac1fad94ed60b6fedb366',
+    image: 'us-central1-docker.pkg.dev/datadog-serverless-gcp-dev/e2e-workloads/dotnet-ssi:latest',
     tracerRepository: 'dotnet',
     envName: 'CORECLR_PROFILER_PATH',
     envValue: '/datadog-lib/Datadog.Trace.ClrProfiler.Native.so',
   },
   {
     language: 'java',
-    image:
-      'us-central1-docker.pkg.dev/datadog-serverless-gcp-dev/e2e-workloads/java-ssi@sha256:9951a0cf3626ea7beb98fa8cc42a82f0efc17937f884c4bd9da29a69146f2fdd',
+    image: 'us-central1-docker.pkg.dev/datadog-serverless-gcp-dev/e2e-workloads/java-ssi:latest',
     tracerRepository: 'java',
     envName: 'JAVA_TOOL_OPTIONS',
     envValue: '-javaagent:/datadog-lib/dd-java-agent.jar',
   },
   {
     language: 'nodejs',
-    image:
-      'us-central1-docker.pkg.dev/datadog-serverless-gcp-dev/e2e-workloads/node-ssi@sha256:5943fc61fc30fd77fd847819b37b2cf32dbc394c107116621610bd4b13099ce2',
+    image: 'us-central1-docker.pkg.dev/datadog-serverless-gcp-dev/e2e-workloads/node-ssi:latest',
     tracerRepository: 'js',
     envName: 'NODE_OPTIONS',
     envValue: '--require /datadog-lib/node_modules/dd-trace/init.js',
   },
   {
     language: 'php',
-    image:
-      'us-central1-docker.pkg.dev/datadog-serverless-gcp-dev/e2e-workloads/php-ssi@sha256:9dac8b55bdf31c5416f9e02ec1d79e3eb163d67658fc54123072ae773d1ca1c6',
+    image: 'us-central1-docker.pkg.dev/datadog-serverless-gcp-dev/e2e-workloads/php-ssi:latest',
     tracerRepository: 'php',
     envName: 'PHP_INI_SCAN_DIR',
     envValue: '/datadog-lib/linux-gnu/loader',
   },
   {
     language: 'python',
-    image:
-      'us-central1-docker.pkg.dev/datadog-serverless-gcp-dev/e2e-workloads/python-ssi@sha256:8d231a35ca52b04db5ffab295b195ce7b6c4feae68cb02ae6496199e853681ff',
+    image: 'us-central1-docker.pkg.dev/datadog-serverless-gcp-dev/e2e-workloads/python-ssi:latest',
     tracerRepository: 'python',
     envName: 'PYTHONPATH',
     envValue: '/datadog-lib',
   },
   {
     language: 'ruby',
-    image:
-      'us-central1-docker.pkg.dev/datadog-serverless-gcp-dev/e2e-workloads/ruby-ssi@sha256:7863a6cb7c029ef551789a9ea555d97a642f5012dee5412dfb4b3f78b3ad4ea5',
+    image: 'us-central1-docker.pkg.dev/datadog-serverless-gcp-dev/e2e-workloads/ruby-ssi:latest',
     tracerRepository: 'ruby',
     envName: 'RUBYOPT',
     envValue: '-r/datadog-lib/auto_inject',

--- a/e2e/serverless/cloud-run/cloud-run-ssi.test.ts
+++ b/e2e/serverless/cloud-run/cloud-run-ssi.test.ts
@@ -1,0 +1,134 @@
+import crypto from 'node:crypto'
+
+import {DATADOG_CI_COMMAND, execPromise, execPromiseWithRetries} from '../../helpers/exec'
+
+import {checkTelemetryFlowing} from '../helpers/telemetry-checker'
+import {triggerTraffic} from '../helpers/traffic'
+
+import {verifySsiInstrumented} from './cloud-run-verifier'
+
+const describeOrSkip =
+  process.env.SKIP_CLOUD_RUN_TESTS === 'true' || process.env.IS_STANDALONE_BINARY === 'true' ? describe.skip : describe
+
+const SSI_CASES = [
+  {
+    language: 'csharp',
+    image:
+      'us-central1-docker.pkg.dev/datadog-serverless-gcp-dev/e2e-workloads/dotnet-ssi@sha256:3c7ce68221fb7703cb6b925d791a98fd22b05489dbbac1fad94ed60b6fedb366',
+    tracerRepository: 'dotnet',
+    envName: 'CORECLR_PROFILER_PATH',
+    envValue: '/datadog-lib/Datadog.Trace.ClrProfiler.Native.so',
+  },
+  {
+    language: 'java',
+    image:
+      'us-central1-docker.pkg.dev/datadog-serverless-gcp-dev/e2e-workloads/java-ssi@sha256:9951a0cf3626ea7beb98fa8cc42a82f0efc17937f884c4bd9da29a69146f2fdd',
+    tracerRepository: 'java',
+    envName: 'JAVA_TOOL_OPTIONS',
+    envValue: '-javaagent:/datadog-lib/dd-java-agent.jar',
+  },
+  {
+    language: 'nodejs',
+    image:
+      'us-central1-docker.pkg.dev/datadog-serverless-gcp-dev/e2e-workloads/node-ssi@sha256:5943fc61fc30fd77fd847819b37b2cf32dbc394c107116621610bd4b13099ce2',
+    tracerRepository: 'js',
+    envName: 'NODE_OPTIONS',
+    envValue: '--require /datadog-lib/node_modules/dd-trace/init.js',
+  },
+  {
+    language: 'php',
+    image:
+      'us-central1-docker.pkg.dev/datadog-serverless-gcp-dev/e2e-workloads/php-ssi@sha256:9dac8b55bdf31c5416f9e02ec1d79e3eb163d67658fc54123072ae773d1ca1c6',
+    tracerRepository: 'php',
+    envName: 'PHP_INI_SCAN_DIR',
+    envValue: '/datadog-lib/linux-gnu/loader',
+  },
+  {
+    language: 'python',
+    image:
+      'us-central1-docker.pkg.dev/datadog-serverless-gcp-dev/e2e-workloads/python-ssi@sha256:8d231a35ca52b04db5ffab295b195ce7b6c4feae68cb02ae6496199e853681ff',
+    tracerRepository: 'python',
+    envName: 'PYTHONPATH',
+    envValue: '/datadog-lib',
+  },
+  {
+    language: 'ruby',
+    image:
+      'us-central1-docker.pkg.dev/datadog-serverless-gcp-dev/e2e-workloads/ruby-ssi@sha256:7863a6cb7c029ef551789a9ea555d97a642f5012dee5412dfb4b3f78b3ad4ea5',
+    tracerRepository: 'ruby',
+    envName: 'RUBYOPT',
+    envValue: '-r/datadog-lib/auto_inject',
+  },
+] as const
+
+describeOrSkip('cloud-run SSI', () => {
+  const project = process.env.GCP_PROJECT_ID!
+  const region = process.env.GCP_REGION!
+
+  it.concurrent.each(SSI_CASES)(
+    'injects the $language tracer',
+    async ({language, image, tracerRepository, envName, envValue}) => {
+      const serviceName = `one-e2e-ci-cr-ssi-${language}-${crypto.randomBytes(4).toString('hex')}`
+
+      try {
+        const deployResult = await execPromiseWithRetries(
+          `gcloud run deploy "${serviceName}"` +
+            ` --project "${project}"` +
+            ` --region "${region}"` +
+            ` --platform managed` +
+            ` --image "${image}"` +
+            ` --allow-unauthenticated` +
+            ` --min-instances 0` +
+            ` --max-instances 1` +
+            ` --quiet` +
+            ` --format=none` +
+            ` --labels one_e2e_created=${Math.floor(Date.now() / 1000)}`
+        )
+        expect(deployResult).toEqual(expect.objectContaining({exitCode: 0}))
+
+        const instrumentResult = await execPromiseWithRetries(
+          `${DATADOG_CI_COMMAND} cloud-run instrument` +
+            ` --project "${project}"` +
+            ` --region "${region}"` +
+            ` --service "${serviceName}"` +
+            ` --tracing inject` +
+            ` --language "${language}"` +
+            ` --no-source-code-integration`,
+          {DATADOG_API_KEY: process.env.DATADOG_API_KEY}
+        )
+        expect(instrumentResult).toEqual(expect.objectContaining({exitCode: 0}))
+
+        verifySsiInstrumented(serviceName, project, region, {
+          appImage: image,
+          tracerRepository,
+          envName,
+          envValue,
+        })
+
+        const urlResult = await execPromise(
+          `gcloud run services describe "${serviceName}"` +
+            ` --project "${project}"` +
+            ` --region "${region}"` +
+            ` --format="value(status.url)"`
+        )
+        expect(urlResult.exitCode).toBe(0)
+
+        await triggerTraffic(urlResult.stdout.trim())
+        await checkTelemetryFlowing({serviceName}, {checkLogs: false})
+      } finally {
+        const deleteResult = await execPromise(
+          `gcloud run services delete "${serviceName}"` +
+            ` --project "${project}"` +
+            ` --region "${region}"` +
+            ` --platform managed` +
+            ` --quiet` +
+            ` --format=none`
+        )
+        if (deleteResult.exitCode !== 0) {
+          console.error(`Failed to delete Cloud Run service "${serviceName}": ${deleteResult.stderr}`)
+        }
+      }
+    },
+    600_000
+  )
+})

--- a/e2e/serverless/cloud-run/cloud-run-ssi.test.ts
+++ b/e2e/serverless/cloud-run/cloud-run-ssi.test.ts
@@ -2,6 +2,7 @@ import crypto from 'node:crypto'
 
 import {DATADOG_CI_COMMAND, execPromise, execPromiseWithRetries} from '../../helpers/exec'
 
+import {SSI_CASES as ssiCases} from '../helpers/ssi'
 import {checkTelemetryFlowing} from '../helpers/telemetry-checker'
 import {triggerTraffic} from '../helpers/traffic'
 
@@ -10,50 +11,12 @@ import {verifySsiInstrumented} from './cloud-run-verifier'
 const describeOrSkip =
   process.env.SKIP_CLOUD_RUN_TESTS === 'true' || process.env.IS_STANDALONE_BINARY === 'true' ? describe.skip : describe
 
-const SSI_CASES = [
-  {
-    language: 'csharp',
-    image: 'us-central1-docker.pkg.dev/datadog-serverless-gcp-dev/e2e-workloads/dotnet-ssi:latest',
-    tracerRepository: 'dotnet',
-    envName: 'CORECLR_PROFILER_PATH',
-    envValue: '/datadog-lib/Datadog.Trace.ClrProfiler.Native.so',
-  },
-  {
-    language: 'java',
-    image: 'us-central1-docker.pkg.dev/datadog-serverless-gcp-dev/e2e-workloads/java-ssi:latest',
-    tracerRepository: 'java',
-    envName: 'JAVA_TOOL_OPTIONS',
-    envValue: '-javaagent:/datadog-lib/dd-java-agent.jar',
-  },
-  {
-    language: 'nodejs',
-    image: 'us-central1-docker.pkg.dev/datadog-serverless-gcp-dev/e2e-workloads/node-ssi:latest',
-    tracerRepository: 'js',
-    envName: 'NODE_OPTIONS',
-    envValue: '--require /datadog-lib/node_modules/dd-trace/init.js',
-  },
-  {
-    language: 'php',
-    image: 'us-central1-docker.pkg.dev/datadog-serverless-gcp-dev/e2e-workloads/php-ssi:latest',
-    tracerRepository: 'php',
-    envName: 'PHP_INI_SCAN_DIR',
-    envValue: '/datadog-lib/linux-gnu/loader',
-  },
-  {
-    language: 'python',
-    image: 'us-central1-docker.pkg.dev/datadog-serverless-gcp-dev/e2e-workloads/python-ssi:latest',
-    tracerRepository: 'python',
-    envName: 'PYTHONPATH',
-    envValue: '/datadog-lib',
-  },
-  {
-    language: 'ruby',
-    image: 'us-central1-docker.pkg.dev/datadog-serverless-gcp-dev/e2e-workloads/ruby-ssi:latest',
-    tracerRepository: 'ruby',
-    envName: 'RUBYOPT',
-    envValue: '-r/datadog-lib/auto_inject',
-  },
-] as const
+const SSI_CASES = ssiCases.map(({fixtureImageName, nativeEnv, ...ssiCase}) => ({
+  ...ssiCase,
+  image: `us-central1-docker.pkg.dev/datadog-serverless-gcp-dev/e2e-workloads/${fixtureImageName}:latest`,
+  envName: nativeEnv.name,
+  envValue: nativeEnv.value,
+}))
 
 describeOrSkip('cloud-run SSI', () => {
   const project = process.env.GCP_PROJECT_ID!

--- a/e2e/serverless/cloud-run/cloud-run-verifier.ts
+++ b/e2e/serverless/cloud-run/cloud-run-verifier.ts
@@ -48,7 +48,7 @@ interface CloudRunService {
 
 const SIDECAR_NAME = 'datadog-sidecar'
 const SHARED_VOLUME_NAME = 'shared-volume'
-const TRACER_COPY_CONTAINER_NAME = 'datadog-tracer-copy'
+const TRACER_COPY_CONTAINER_NAME = 'datadog-tracer'
 const TRACER_MOUNT_PATH = '/datadog-lib'
 const TRACER_READINESS_PORT = 18999
 const TRACER_VOLUME_NAME = 'datadog-tracer'

--- a/e2e/serverless/cloud-run/cloud-run-verifier.ts
+++ b/e2e/serverless/cloud-run/cloud-run-verifier.ts
@@ -14,7 +14,12 @@ interface VolumeMount {
 interface Container {
   name: string
   image?: string
+  args?: string[]
+  dependsOn?: string[]
   env?: EnvVar[]
+  startupProbe?: {
+    tcpSocket?: {port?: number}
+  }
   volumeMounts?: VolumeMount[]
 }
 
@@ -43,6 +48,10 @@ interface CloudRunService {
 
 const SIDECAR_NAME = 'datadog-sidecar'
 const SHARED_VOLUME_NAME = 'shared-volume'
+const TRACER_COPY_CONTAINER_NAME = 'datadog-tracer-copy'
+const TRACER_MOUNT_PATH = '/datadog-lib'
+const TRACER_READINESS_PORT = 18999
+const TRACER_VOLUME_NAME = 'datadog-tracer'
 const REQUIRED_ENV_VARS = [
   'DD_API_KEY',
   'DD_SITE',
@@ -111,6 +120,50 @@ export const verifyInstrumented = (serviceName: string, project: string, region:
   expect(labels.dd_sls_ci).toBeDefined()
 
   console.log('\nAll instrumented checks passed.')
+}
+
+interface SsiExpectation {
+  appImage: string
+  tracerRepository: string
+  envName: string
+  envValue: string
+}
+
+export const verifySsiInstrumented = (
+  serviceName: string,
+  project: string,
+  region: string,
+  expectation: SsiExpectation
+): void => {
+  const service = getCloudRunService(serviceName, project, region)
+  const template = getTemplate(service)
+  const containers = template.containers ?? []
+  const labels = getLabels(service)
+  const appContainers = containers.filter(({name}) => name !== SIDECAR_NAME && name !== TRACER_COPY_CONTAINER_NAME)
+
+  expect(appContainers).toHaveLength(1)
+  const app = appContainers[0]
+  expect(app.image).toBe(expectation.appImage)
+  expect(app.dependsOn).toEqual(expect.arrayContaining([SIDECAR_NAME, TRACER_COPY_CONTAINER_NAME]))
+  expect(app.volumeMounts).toContainEqual({name: TRACER_VOLUME_NAME, mountPath: TRACER_MOUNT_PATH})
+  expect(app.env).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({name: 'DD_TRACE_ENABLED', value: 'true'}),
+      expect.objectContaining({name: expectation.envName, value: expect.stringContaining(expectation.envValue)}),
+    ])
+  )
+
+  const tracerCopy = containers.find(({name}) => name === TRACER_COPY_CONTAINER_NAME)
+  expect(tracerCopy).toBeDefined()
+  expect(tracerCopy!.image).toContain(`/dd-lib-${expectation.tracerRepository}-init:latest`)
+  expect(tracerCopy!.volumeMounts).toContainEqual({name: TRACER_VOLUME_NAME, mountPath: TRACER_MOUNT_PATH})
+  expect(tracerCopy!.startupProbe?.tcpSocket?.port).toBe(TRACER_READINESS_PORT)
+  expect(tracerCopy!.args).toContain(String(TRACER_READINESS_PORT))
+
+  expect(template.volumes).toEqual(
+    expect.arrayContaining([expect.objectContaining({name: TRACER_VOLUME_NAME, emptyDir: expect.anything()})])
+  )
+  expect(labels.dd_sls_injection_mode).toBe('single_language')
 }
 
 export const verifyUninstrumented = (serviceName: string, project: string, region: string): void => {

--- a/e2e/serverless/cloud-run/cloud-run-verifier.ts
+++ b/e2e/serverless/cloud-run/cloud-run-verifier.ts
@@ -73,13 +73,13 @@ const getCloudRunService = (serviceName: string, project: string, region: string
   return JSON.parse(output)
 }
 
-const getTemplate = (service: CloudRunService): ServiceTemplate => {
-  return service.template ?? service.spec?.template?.spec ?? {}
-}
+const getTemplate = (service: CloudRunService): ServiceTemplate =>
+  service.template?.containers?.length ? service.template : (service.spec?.template?.spec ?? service.template ?? {})
 
-const getLabels = (service: CloudRunService): Record<string, string> => {
-  return service.labels ?? service.metadata?.labels ?? {}
-}
+const getLabels = (service: CloudRunService): Record<string, string> => ({
+  ...service.metadata?.labels,
+  ...service.labels,
+})
 
 const getVolumeName = (mount: VolumeMount): string | undefined => mount.name ?? mount.volumeName
 
@@ -144,7 +144,6 @@ export const verifySsiInstrumented = (
   expect(appContainers).toHaveLength(1)
   const app = appContainers[0]
   expect(app.image).toBe(expectation.appImage)
-  expect(app.dependsOn).toEqual(expect.arrayContaining([SIDECAR_NAME, TRACER_COPY_CONTAINER_NAME]))
   expect(app.volumeMounts).toContainEqual({name: TRACER_VOLUME_NAME, mountPath: TRACER_MOUNT_PATH})
   expect(app.env).toEqual(
     expect.arrayContaining([

--- a/e2e/serverless/container-app/container-app-ssi.test.ts
+++ b/e2e/serverless/container-app/container-app-ssi.test.ts
@@ -2,49 +2,17 @@ import crypto from 'node:crypto'
 
 import {DATADOG_CI_COMMAND, execPromiseWithRetries} from '../../helpers/exec'
 
+import {SSI_CASES as ssiCases} from '../helpers/ssi'
 import {checkTelemetryFlowing} from '../helpers/telemetry-checker'
 import {triggerTraffic} from '../helpers/traffic'
 
 import {getContainerAppUrl, verifySsiInstrumented, verifyUninstrumented} from './container-app-verifier'
 
-const SSI_CASES = [
-  {
-    language: 'csharp',
-    applicationImage: 'dde2etfcapp.azurecr.io/dotnet-ssi:latest',
-    tracerRepository: 'dotnet',
-    nativeEnv: {name: 'CORECLR_PROFILER_PATH', fragment: '/datadog-lib/Datadog.Trace.ClrProfiler.Native.so'},
-  },
-  {
-    language: 'java',
-    applicationImage: 'dde2etfcapp.azurecr.io/java-ssi:latest',
-    tracerRepository: 'java',
-    nativeEnv: {name: 'JAVA_TOOL_OPTIONS', fragment: '-javaagent:/datadog-lib/dd-java-agent.jar'},
-  },
-  {
-    language: 'nodejs',
-    applicationImage: 'dde2etfcapp.azurecr.io/node-ssi:latest',
-    tracerRepository: 'js',
-    nativeEnv: {name: 'NODE_OPTIONS', fragment: '--require /datadog-lib/node_modules/dd-trace/init.js'},
-  },
-  {
-    language: 'php',
-    applicationImage: 'dde2etfcapp.azurecr.io/php-ssi:latest',
-    tracerRepository: 'php',
-    nativeEnv: {name: 'PHP_INI_SCAN_DIR', fragment: '/datadog-lib/linux-gnu/loader'},
-  },
-  {
-    language: 'python',
-    applicationImage: 'dde2etfcapp.azurecr.io/python-ssi:latest',
-    tracerRepository: 'python',
-    nativeEnv: {name: 'PYTHONPATH', fragment: '/datadog-lib'},
-  },
-  {
-    language: 'ruby',
-    applicationImage: 'dde2etfcapp.azurecr.io/ruby-ssi:latest',
-    tracerRepository: 'ruby',
-    nativeEnv: {name: 'RUBYOPT', fragment: '-r/datadog-lib/auto_inject'},
-  },
-] as const
+const SSI_CASES = ssiCases.map(({fixtureImageName, nativeEnv, ...ssiCase}) => ({
+  ...ssiCase,
+  applicationImage: `dde2etfcapp.azurecr.io/${fixtureImageName}:latest`,
+  nativeEnv: {name: nativeEnv.name, fragment: nativeEnv.value},
+}))
 
 const assertCommandSucceeded = (action: string, result: {exitCode: number; stdout: string; stderr: string}): void => {
   if (result.exitCode !== 0) {

--- a/e2e/serverless/helpers/ssi.ts
+++ b/e2e/serverless/helpers/ssi.ts
@@ -1,0 +1,38 @@
+export const SSI_CASES = [
+  {
+    language: 'csharp',
+    fixtureImageName: 'dotnet-ssi',
+    tracerRepository: 'dotnet',
+    nativeEnv: {name: 'CORECLR_PROFILER_PATH', value: '/datadog-lib/Datadog.Trace.ClrProfiler.Native.so'},
+  },
+  {
+    language: 'java',
+    fixtureImageName: 'java-ssi',
+    tracerRepository: 'java',
+    nativeEnv: {name: 'JAVA_TOOL_OPTIONS', value: '-javaagent:/datadog-lib/dd-java-agent.jar'},
+  },
+  {
+    language: 'nodejs',
+    fixtureImageName: 'node-ssi',
+    tracerRepository: 'js',
+    nativeEnv: {name: 'NODE_OPTIONS', value: '--require /datadog-lib/node_modules/dd-trace/init.js'},
+  },
+  {
+    language: 'php',
+    fixtureImageName: 'php-ssi',
+    tracerRepository: 'php',
+    nativeEnv: {name: 'PHP_INI_SCAN_DIR', value: '/datadog-lib/linux-gnu/loader'},
+  },
+  {
+    language: 'python',
+    fixtureImageName: 'python-ssi',
+    tracerRepository: 'python',
+    nativeEnv: {name: 'PYTHONPATH', value: '/datadog-lib'},
+  },
+  {
+    language: 'ruby',
+    fixtureImageName: 'ruby-ssi',
+    tracerRepository: 'ruby',
+    nativeEnv: {name: 'RUBYOPT', value: '-r/datadog-lib/auto_inject'},
+  },
+] as const


### PR DESCRIPTION
### What and why?

Verify that single-language tracer injection works on real Cloud Run services without an application-image rebuild. This PR changes E2E coverage only; it adds no customer-facing CLI behavior.

### How?

Each case deploys a tracer-free Java, Node.js, .NET, Python, Ruby, or PHP fixture from [serverless-ci#208](https://github.com/DataDog/serverless-ci/pull/208), instruments it, checks its configuration, sends traffic, checks for spans, and deletes the service. Fixture and tracer images intentionally use `latest`.

Instrumentation uses the same Datadog organization as the span checker, so CI's separate CI Visibility credentials do not redirect workload telemetry.

### Manual validation

A clean local run passes configuration, traffic, and span checks for .NET, Node.js, PHP, Python, and Ruby. Retained Cloud Run logs showed that the Ruby `latest` fixture still referenced a build from before the merged production-mode and route changes. Rebuilding that controlled artifact from `serverless-ci/main` resolves the request timeouts; Ruby now returns three HTTP 200 responses and produces spans.

Java remains blocked because its published init image lacks `/datadog-init/probe-server`. This is the only remaining runtime blocker.

### How to validate

Authenticate `gcloud` and application-default credentials. Set `GCP_PROJECT_ID`, `GCP_REGION`, and Datadog credentials: `DATADOG_API_KEY` and `DATADOG_APP_KEY` must belong to the same organization, with span-read permission for the application key. The GCP identity needs Cloud Run deployment/deletion permissions and access to the fixture images in `datadog-serverless-gcp-dev/e2e-workloads`.

```sh
DATADOG_CI_COMMAND='yarn launch' \
SKIP_CLOUD_RUN_TESTS=false IS_STANDALONE_BINARY=false \
yarn e2e:test e2e/serverless/cloud-run/cloud-run-ssi.test.ts --runInBand
```

This creates billable, publicly invokable temporary services and attempts to delete them after each case. Expect all six cases to pass configuration, traffic, and span checks after the Java init-image release. Check cleanup output for any service that needs manual deletion.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
