### PR TITLE
Fix admin approval check in check-npm-packages script

### DIFF
--- a/bin/check-npm-packages.sh
+++ b/bin/check-npm-packages.sh
@@ -95,8 +95,6 @@ if [ -n "${GITHUB_TOKEN:-}" ] && [ -n "${GITHUB_SHA:-}" ]; then
 		ADMIN_PR_APPROVALS=0
 		while IFS= read -r reviewer; do
 			[ -z "$reviewer" ] && continue
-			# `role_name` reflects custom roles built on top of "maintain" (e.g. datadog-ci-admins'
-			# "dd-repo-owner" role), unlike the legacy `permission` field which collapses those down to "write".
 			REVIEWER_ROLE=$(curl -fsS -H "Authorization: token $GITHUB_TOKEN" \
 				"https://api.github.com/repos/$GITHUB_REPOSITORY/collaborators/$reviewer/permission" | jq -r '.role_name // empty')
 			if [ "$REVIEWER_ROLE" = "admin" ] || [ "$REVIEWER_ROLE" = "maintain" ]; then

--- a/bin/check-npm-packages.sh
+++ b/bin/check-npm-packages.sh
@@ -96,7 +96,7 @@ if [ -n "${GITHUB_TOKEN:-}" ] && [ -n "${GITHUB_SHA:-}" ]; then
 		while IFS= read -r reviewer; do
 			[ -z "$reviewer" ] && continue
 			REVIEWER_IS_ADMIN=$(curl -fsS -H "Authorization: token $GITHUB_TOKEN" \
-				"https://api.github.com/repos/$GITHUB_REPOSITORY/collaborators/$reviewer/permission" | jq -r '.user.permissions.maintain // false')
+				"https://api.github.com/repos/$GITHUB_REPOSITORY/collaborators/$reviewer/permission" | jq -r '(.user.permissions.admin or .user.permissions.maintain) // false')
 			if [ "$REVIEWER_IS_ADMIN" = "true" ]; then
 				ADMIN_PR_APPROVALS=$((ADMIN_PR_APPROVALS + 1))
 			fi

--- a/bin/check-npm-packages.sh
+++ b/bin/check-npm-packages.sh
@@ -95,9 +95,9 @@ if [ -n "${GITHUB_TOKEN:-}" ] && [ -n "${GITHUB_SHA:-}" ]; then
 		ADMIN_PR_APPROVALS=0
 		while IFS= read -r reviewer; do
 			[ -z "$reviewer" ] && continue
-			REVIEWER_ROLE=$(curl -fsS -H "Authorization: token $GITHUB_TOKEN" \
-				"https://api.github.com/repos/$GITHUB_REPOSITORY/collaborators/$reviewer/permission" | jq -r '.role_name // empty')
-			if [ "$REVIEWER_ROLE" = "admin" ] || [ "$REVIEWER_ROLE" = "maintain" ]; then
+			REVIEWER_IS_ADMIN=$(curl -fsS -H "Authorization: token $GITHUB_TOKEN" \
+				"https://api.github.com/repos/$GITHUB_REPOSITORY/collaborators/$reviewer/permission" | jq -r '.user.permissions.maintain // false')
+			if [ "$REVIEWER_IS_ADMIN" = "true" ]; then
 				ADMIN_PR_APPROVALS=$((ADMIN_PR_APPROVALS + 1))
 			fi
 		done <<< "$APPROVING_REVIEWERS"

--- a/bin/check-npm-packages.sh
+++ b/bin/check-npm-packages.sh
@@ -95,9 +95,11 @@ if [ -n "${GITHUB_TOKEN:-}" ] && [ -n "${GITHUB_SHA:-}" ]; then
 		ADMIN_PR_APPROVALS=0
 		while IFS= read -r reviewer; do
 			[ -z "$reviewer" ] && continue
-			REVIEWER_PERMISSION=$(curl -fsS -H "Authorization: token $GITHUB_TOKEN" \
-				"https://api.github.com/repos/$GITHUB_REPOSITORY/collaborators/$reviewer/permission" | jq -r '.permission // empty')
-			if [ "$REVIEWER_PERMISSION" = "admin" ]; then
+			# `role_name` reflects custom roles built on top of "maintain" (e.g. datadog-ci-admins'
+			# "dd-repo-owner" role), unlike the legacy `permission` field which collapses those down to "write".
+			REVIEWER_ROLE=$(curl -fsS -H "Authorization: token $GITHUB_TOKEN" \
+				"https://api.github.com/repos/$GITHUB_REPOSITORY/collaborators/$reviewer/permission" | jq -r '.role_name // empty')
+			if [ "$REVIEWER_ROLE" = "admin" ] || [ "$REVIEWER_ROLE" = "maintain" ]; then
 				ADMIN_PR_APPROVALS=$((ADMIN_PR_APPROVALS + 1))
 			fi
 		done <<< "$APPROVING_REVIEWERS"


### PR DESCRIPTION
### What and why?

Maintainers no longer have direct access to the `admin` role. Therefore, maintainers can't approve new versions anymore.

### How?

This is an example output from the reviewer endpoint for myself in this repo:

`https://api.github.com/repos/DataDog/datadog-ci/collaborators/GabrielAnca/permission`

```json
{
  "permission": "write",
  "user": {
    "login": "GabrielAnca",
    "id": 251391,
    "site_admin": false,
    "permissions": {
      "admin": false,
      "maintain": true,
      "push": true,
      "triage": true,
      "pull": true
    },
    "role_name": "dd-repo-owner"
  },
  "role_name": "dd-repo-owner"
}
```

Switching from `permission == admin` -> `user.permissions.maintain == true` to allow all maintainers to push new versions

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration) — N/A, this is a `bin/` release-tooling script with no test coverage, like the rest of `bin/`