### PR TITLE
chore: cache alpine bootstrap

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -677,7 +677,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Restore x86_64 apk.static
         id: apk-static-cache
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ${{ runner.temp }}/apk
           key: apk-static-v2.14.10-x86_64-34bb1a96f0258982377a289392d4ea9f3f4b767a4bb5806b1b87179b79ad8a1c
@@ -689,6 +689,12 @@ jobs:
             https://gitlab.alpinelinux.org/api/v4/projects/5/packages/generic/v2.14.10/x86_64/apk.static
       - name: Verify x86_64 apk.static
         run: echo "34bb1a96f0258982377a289392d4ea9f3f4b767a4bb5806b1b87179b79ad8a1c  $RUNNER_TEMP/apk" | sha256sum -c
+      - name: Cache x86_64 apk.static
+        if: steps.apk-static-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: ${{ runner.temp }}/apk
+          key: ${{ steps.apk-static-cache.outputs.cache-primary-key }}
       - name: Setup Alpine
         uses: jirutka/setup-alpine@ae3b3ddba35054804fc4a3507b519fa7e8152050 # v1.4.1
         with:
@@ -734,7 +740,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Restore aarch64 apk.static
         id: apk-static-cache
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ${{ runner.temp }}/apk
           key: apk-static-v2.14.10-aarch64-e471d35aa221d031abe9b6288aede12a8e9f1a398954e5a2e1d1bce1727b4ef4
@@ -746,6 +752,12 @@ jobs:
             https://gitlab.alpinelinux.org/api/v4/projects/5/packages/generic/v2.14.10/aarch64/apk.static
       - name: Verify aarch64 apk.static
         run: echo "e471d35aa221d031abe9b6288aede12a8e9f1a398954e5a2e1d1bce1727b4ef4  $RUNNER_TEMP/apk" | sha256sum -c
+      - name: Cache aarch64 apk.static
+        if: steps.apk-static-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: ${{ runner.temp }}/apk
+          key: ${{ steps.apk-static-cache.outputs.cache-primary-key }}
       - name: Setup Alpine
         uses: jirutka/setup-alpine@ae3b3ddba35054804fc4a3507b519fa7e8152050 # v1.4.1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -675,16 +675,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-      # setup-alpine downloads apk.static with a single 10s-timeout curl, and the gitlab mirror
-      # is unreliable from CI runners. Pre-fetch it with retries into the path setup-alpine
-      # caches ($RUNNER_TEMP/apk); the action then skips its own flaky download.
-      - name: Pre-fetch x86_64 apk.static (work around flaky gitlab mirror)
+      - name: Restore x86_64 apk.static
+        id: apk-static-cache
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: ${{ runner.temp }}/apk
+          key: apk-static-v2.14.10-x86_64-34bb1a96f0258982377a289392d4ea9f3f4b767a4bb5806b1b87179b79ad8a1c
+      - name: Download x86_64 apk.static
+        if: steps.apk-static-cache.outputs.cache-hit != 'true'
         run: |
-          mkdir -p "$RUNNER_TEMP"
           curl -4 -fsSL --retry 5 --retry-all-errors --retry-delay 5 --connect-timeout 30 --max-time 180 \
             -o "$RUNNER_TEMP/apk" \
             https://gitlab.alpinelinux.org/api/v4/projects/5/packages/generic/v2.14.10/x86_64/apk.static
-          echo "34bb1a96f0258982377a289392d4ea9f3f4b767a4bb5806b1b87179b79ad8a1c  $RUNNER_TEMP/apk" | sha256sum -c
+      - name: Verify x86_64 apk.static
+        run: echo "34bb1a96f0258982377a289392d4ea9f3f4b767a4bb5806b1b87179b79ad8a1c  $RUNNER_TEMP/apk" | sha256sum -c
       - name: Setup Alpine
         uses: jirutka/setup-alpine@ae3b3ddba35054804fc4a3507b519fa7e8152050 # v1.4.1
         with:
@@ -728,16 +732,20 @@ jobs:
     runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-      # setup-alpine downloads apk.static with a single 10s-timeout curl, and the gitlab mirror
-      # is unreliable from CI runners. Pre-fetch it with retries into the path setup-alpine
-      # caches ($RUNNER_TEMP/apk); the action then skips its own flaky download.
-      - name: Pre-fetch aarch64 apk.static (work around flaky gitlab mirror)
+      - name: Restore aarch64 apk.static
+        id: apk-static-cache
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: ${{ runner.temp }}/apk
+          key: apk-static-v2.14.10-aarch64-e471d35aa221d031abe9b6288aede12a8e9f1a398954e5a2e1d1bce1727b4ef4
+      - name: Download aarch64 apk.static
+        if: steps.apk-static-cache.outputs.cache-hit != 'true'
         run: |
-          mkdir -p "$RUNNER_TEMP"
           curl -4 -fsSL --retry 5 --retry-all-errors --retry-delay 5 --connect-timeout 30 --max-time 180 \
             -o "$RUNNER_TEMP/apk" \
             https://gitlab.alpinelinux.org/api/v4/projects/5/packages/generic/v2.14.10/aarch64/apk.static
-          echo "e471d35aa221d031abe9b6288aede12a8e9f1a398954e5a2e1d1bce1727b4ef4  $RUNNER_TEMP/apk" | sha256sum -c
+      - name: Verify aarch64 apk.static
+        run: echo "e471d35aa221d031abe9b6288aede12a8e9f1a398954e5a2e1d1bce1727b4ef4  $RUNNER_TEMP/apk" | sha256sum -c
       - name: Setup Alpine
         uses: jirutka/setup-alpine@ae3b3ddba35054804fc4a3507b519fa7e8152050 # v1.4.1
         with:


### PR DESCRIPTION
### What and why?

Alpine bootstrap can fail when the upstream `apk.static` download times out. Cache verified binaries to avoid that dependency on most CI runs, including runs that later fail in an unrelated step.

### How?

Restore each architecture-specific binary from GitHub Actions cache, download only on a cache miss, verify its checksum, and save it immediately.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
