### PR TITLE
fix(sourcemaps): reject legacy uploads with debug ID injection

### DIFF
--- a/packages/base/src/commands/sourcemaps/README.md
+++ b/packages/base/src/commands/sourcemaps/README.md
@@ -58,7 +58,7 @@ This command will upload all JavaScript sourcemaps and their corresponding JavaS
 
 With `--debug-id`, this command uploads only bundles that already contain a debug ID. It does not modify build artifacts; run `sourcemaps inject` first when debug IDs are missing.
 
-Service/version uploads reject minified bundles containing the Datadog `DD_SOURCE_CODE_CONTEXT` runtime injection. Debug-ID and service/version matching are mutually exclusive; upload those bundles with `--debug-id`, or rebuild them without the injection before using service/version matching. A `ddDebugId` value by itself, without `DD_SOURCE_CODE_CONTEXT`, does not trigger this check.
+Service/version uploads reject minified bundles containing the Datadog `DD_SOURCE_CODE_CONTEXT` runtime injection. Debug ID and service/version matching are mutually exclusive; upload those bundles with `--debug-id`, or rebuild them without the injection before using service/version matching. A `ddDebugId` value by itself, without `DD_SOURCE_CODE_CONTEXT`, does not trigger this check.
 
 To upload the sourcemaps in the build folder, this command should be run:
 

--- a/packages/base/src/commands/sourcemaps/README.md
+++ b/packages/base/src/commands/sourcemaps/README.md
@@ -58,6 +58,8 @@ This command will upload all JavaScript sourcemaps and their corresponding JavaS
 
 With `--debug-id`, this command uploads only bundles that already contain a debug ID. It does not modify build artifacts; run `sourcemaps inject` first when debug IDs are missing.
 
+Service/version uploads reject minified bundles containing the Datadog `DD_SOURCE_CODE_CONTEXT` runtime injection. Debug-ID and service/version matching are mutually exclusive; upload those bundles with `--debug-id`, or rebuild them without the injection before using service/version matching. A `ddDebugId` value by itself, without `DD_SOURCE_CODE_CONTEXT`, does not trigger this check.
+
 To upload the sourcemaps in the build folder, this command should be run:
 
 ```bash

--- a/packages/base/src/commands/sourcemaps/README.md
+++ b/packages/base/src/commands/sourcemaps/README.md
@@ -58,7 +58,7 @@ This command will upload all JavaScript sourcemaps and their corresponding JavaS
 
 With `--debug-id`, this command uploads only bundles that already contain a debug ID. It does not modify build artifacts; run `sourcemaps inject` first when debug IDs are missing.
 
-Service/version uploads reject minified bundles containing the Datadog `DD_SOURCE_CODE_CONTEXT` runtime injection. Debug ID and service/version matching are mutually exclusive; upload those bundles with `--debug-id`, or rebuild them without the injection before using service/version matching. A `ddDebugId` value by itself, without `DD_SOURCE_CODE_CONTEXT`, does not trigger this check.
+Service/version uploads reject minified bundles containing the Datadog `ddDebugId` runtime injection. Debug ID and service/version matching are mutually exclusive; upload those bundles with `--debug-id`, or rebuild them without the injection before using service/version matching.
 
 To upload the sourcemaps in the build folder, this command should be run:
 

--- a/packages/base/src/commands/sourcemaps/__tests__/debugId.test.ts
+++ b/packages/base/src/commands/sourcemaps/__tests__/debugId.test.ts
@@ -10,6 +10,7 @@ import {
   DEBUG_ID_SEARCH_CHUNK_BYTES,
   extractDebugId,
   generateDebugId,
+  hasSourceCodeContext,
   injectMissingDebugIds,
   injectDebugIdSnippet,
 } from '../debugId'
@@ -110,6 +111,36 @@ describe('extractDebugId', () => {
 
   test('returns undefined when the file cannot be read', () => {
     expect(extractDebugId('nonexistent.js')).toBeUndefined()
+  })
+})
+
+describe('hasSourceCodeContext', () => {
+  test('detects DD_SOURCE_CODE_CONTEXT', () => {
+    withTempDirectory((directory) => {
+      const filePath = upath.join(directory, 'injected.min.js')
+      fs.writeFileSync(filePath, `${'x'.repeat(DEBUG_ID_SEARCH_CHUNK_BYTES + 100)}DD_SOURCE_CODE_CONTEXT`)
+
+      expect(hasSourceCodeContext(filePath)).toBe(true)
+    })
+  })
+
+  test('detects DD_SOURCE_CODE_CONTEXT split across two chunks', () => {
+    withTempDirectory((directory) => {
+      const filePath = upath.join(directory, 'split-context.min.js')
+      const marker = 'DD_SOURCE_CODE_CONTEXT'
+      fs.writeFileSync(filePath, `${'x'.repeat(DEBUG_ID_SEARCH_CHUNK_BYTES - 10)}${marker}`)
+
+      expect(hasSourceCodeContext(filePath)).toBe(true)
+    })
+  })
+
+  test('does not treat a standalone debug ID as injected source code context', () => {
+    withTempDirectory((directory) => {
+      const filePath = upath.join(directory, 'debug-id-only.min.js')
+      fs.writeFileSync(filePath, `{"ddDebugId":"${DEBUG_ID}"}`)
+
+      expect(hasSourceCodeContext(filePath)).toBe(false)
+    })
   })
 })
 

--- a/packages/base/src/commands/sourcemaps/__tests__/debugId.test.ts
+++ b/packages/base/src/commands/sourcemaps/__tests__/debugId.test.ts
@@ -11,10 +11,8 @@ import {
   DEBUG_ID_SEARCH_CHUNK_BYTES,
   extractDebugId,
   generateDebugId,
-  hasSourceCodeContext,
   injectMissingDebugIds,
   injectDebugIdSnippet,
-  SOURCE_CODE_CONTEXT_SEARCH_CHUNK_BYTES,
 } from '../debugId'
 import {Sourcemap} from '../interfaces'
 
@@ -104,48 +102,6 @@ describe('extractDebugId', () => {
 
   test('returns undefined when the file cannot be read', () => {
     expect(extractDebugId('nonexistent.js')).toBeUndefined()
-  })
-})
-
-describe('hasSourceCodeContext', () => {
-  test('detects DD_SOURCE_CODE_CONTEXT with a debug ID', async () => {
-    await withTempDirectory(async (directory) => {
-      const filePath = upath.join(directory, 'injected.min.js')
-      fs.writeFileSync(
-        filePath,
-        `${'x'.repeat(SOURCE_CODE_CONTEXT_SEARCH_CHUNK_BYTES + 100)}{"ddDebugId":"${DEBUG_ID}"},"DD_SOURCE_CODE_CONTEXT"`
-      )
-
-      await expect(hasSourceCodeContext(filePath)).resolves.toBe(true)
-    })
-  })
-
-  test('detects a debug ID source code context split across two chunks', async () => {
-    await withTempDirectory(async (directory) => {
-      const filePath = upath.join(directory, 'split-context.min.js')
-      const context = `{"ddDebugId":"${DEBUG_ID}"},"DD_SOURCE_CODE_CONTEXT"`
-      fs.writeFileSync(filePath, `${'x'.repeat(SOURCE_CODE_CONTEXT_SEARCH_CHUNK_BYTES - context.length + 1)}${context}`)
-
-      await expect(hasSourceCodeContext(filePath)).resolves.toBe(true)
-    })
-  })
-
-  test('does not treat DD_SOURCE_CODE_CONTEXT without a debug ID as debug ID injection', async () => {
-    await withTempDirectory(async (directory) => {
-      const filePath = upath.join(directory, 'mfe-context.min.js')
-      fs.writeFileSync(filePath, `({"ddDebugId":"${DEBUG_ID}"});({"mfeName":"checkout"},"DD_SOURCE_CODE_CONTEXT")`)
-
-      await expect(hasSourceCodeContext(filePath)).resolves.toBe(false)
-    })
-  })
-
-  test('does not treat a standalone debug ID as injected source code context', async () => {
-    await withTempDirectory(async (directory) => {
-      const filePath = upath.join(directory, 'debug-id-only.min.js')
-      fs.writeFileSync(filePath, `{"ddDebugId":"${DEBUG_ID}"}`)
-
-      await expect(hasSourceCodeContext(filePath)).resolves.toBe(false)
-    })
   })
 })
 

--- a/packages/base/src/commands/sourcemaps/__tests__/debugId.test.ts
+++ b/packages/base/src/commands/sourcemaps/__tests__/debugId.test.ts
@@ -13,6 +13,7 @@ import {
   hasSourceCodeContext,
   injectMissingDebugIds,
   injectDebugIdSnippet,
+  SOURCE_CODE_CONTEXT_SEARCH_CHUNK_BYTES,
 } from '../debugId'
 import {Sourcemap} from '../interfaces'
 
@@ -25,6 +26,15 @@ const withTempDirectory = (callback: (directory: string) => void): void => {
   const directory = fs.mkdtempSync(upath.join(os.tmpdir(), 'datadog-ci-debug-id-'))
   try {
     callback(directory)
+  } finally {
+    fs.rmSync(directory, {recursive: true, force: true})
+  }
+}
+
+const withTempDirectoryAsync = async (callback: (directory: string) => Promise<void>): Promise<void> => {
+  const directory = fs.mkdtempSync(upath.join(os.tmpdir(), 'datadog-ci-debug-id-'))
+  try {
+    await callback(directory)
   } finally {
     fs.rmSync(directory, {recursive: true, force: true})
   }
@@ -115,31 +125,31 @@ describe('extractDebugId', () => {
 })
 
 describe('hasSourceCodeContext', () => {
-  test('detects DD_SOURCE_CODE_CONTEXT', () => {
-    withTempDirectory((directory) => {
+  test('detects DD_SOURCE_CODE_CONTEXT', async () => {
+    await withTempDirectoryAsync(async (directory) => {
       const filePath = upath.join(directory, 'injected.min.js')
-      fs.writeFileSync(filePath, `${'x'.repeat(DEBUG_ID_SEARCH_CHUNK_BYTES + 100)}DD_SOURCE_CODE_CONTEXT`)
+      fs.writeFileSync(filePath, `${'x'.repeat(SOURCE_CODE_CONTEXT_SEARCH_CHUNK_BYTES + 100)}DD_SOURCE_CODE_CONTEXT`)
 
-      expect(hasSourceCodeContext(filePath)).toBe(true)
+      await expect(hasSourceCodeContext(filePath)).resolves.toBe(true)
     })
   })
 
-  test('detects DD_SOURCE_CODE_CONTEXT split across two chunks', () => {
-    withTempDirectory((directory) => {
+  test('detects DD_SOURCE_CODE_CONTEXT split across two chunks', async () => {
+    await withTempDirectoryAsync(async (directory) => {
       const filePath = upath.join(directory, 'split-context.min.js')
       const marker = 'DD_SOURCE_CODE_CONTEXT'
-      fs.writeFileSync(filePath, `${'x'.repeat(DEBUG_ID_SEARCH_CHUNK_BYTES - 10)}${marker}`)
+      fs.writeFileSync(filePath, `${'x'.repeat(SOURCE_CODE_CONTEXT_SEARCH_CHUNK_BYTES - 10)}${marker}`)
 
-      expect(hasSourceCodeContext(filePath)).toBe(true)
+      await expect(hasSourceCodeContext(filePath)).resolves.toBe(true)
     })
   })
 
-  test('does not treat a standalone debug ID as injected source code context', () => {
-    withTempDirectory((directory) => {
+  test('does not treat a standalone debug ID as injected source code context', async () => {
+    await withTempDirectoryAsync(async (directory) => {
       const filePath = upath.join(directory, 'debug-id-only.min.js')
       fs.writeFileSync(filePath, `{"ddDebugId":"${DEBUG_ID}"}`)
 
-      expect(hasSourceCodeContext(filePath)).toBe(false)
+      await expect(hasSourceCodeContext(filePath)).resolves.toBe(false)
     })
   })
 })

--- a/packages/base/src/commands/sourcemaps/__tests__/debugId.test.ts
+++ b/packages/base/src/commands/sourcemaps/__tests__/debugId.test.ts
@@ -108,22 +108,34 @@ describe('extractDebugId', () => {
 })
 
 describe('hasSourceCodeContext', () => {
-  test('detects DD_SOURCE_CODE_CONTEXT', async () => {
+  test('detects DD_SOURCE_CODE_CONTEXT with a debug ID', async () => {
     await withTempDirectory(async (directory) => {
       const filePath = upath.join(directory, 'injected.min.js')
-      fs.writeFileSync(filePath, `${'x'.repeat(SOURCE_CODE_CONTEXT_SEARCH_CHUNK_BYTES + 100)}DD_SOURCE_CODE_CONTEXT`)
+      fs.writeFileSync(
+        filePath,
+        `${'x'.repeat(SOURCE_CODE_CONTEXT_SEARCH_CHUNK_BYTES + 100)}{"ddDebugId":"${DEBUG_ID}"},"DD_SOURCE_CODE_CONTEXT"`
+      )
 
       await expect(hasSourceCodeContext(filePath)).resolves.toBe(true)
     })
   })
 
-  test('detects DD_SOURCE_CODE_CONTEXT split across two chunks', async () => {
+  test('detects a debug ID source code context split across two chunks', async () => {
     await withTempDirectory(async (directory) => {
       const filePath = upath.join(directory, 'split-context.min.js')
-      const marker = 'DD_SOURCE_CODE_CONTEXT'
-      fs.writeFileSync(filePath, `${'x'.repeat(SOURCE_CODE_CONTEXT_SEARCH_CHUNK_BYTES - 10)}${marker}`)
+      const context = `{"ddDebugId":"${DEBUG_ID}"},"DD_SOURCE_CODE_CONTEXT"`
+      fs.writeFileSync(filePath, `${'x'.repeat(SOURCE_CODE_CONTEXT_SEARCH_CHUNK_BYTES - context.length + 1)}${context}`)
 
       await expect(hasSourceCodeContext(filePath)).resolves.toBe(true)
+    })
+  })
+
+  test('does not treat DD_SOURCE_CODE_CONTEXT without a debug ID as debug ID injection', async () => {
+    await withTempDirectory(async (directory) => {
+      const filePath = upath.join(directory, 'mfe-context.min.js')
+      fs.writeFileSync(filePath, `({"ddDebugId":"${DEBUG_ID}"});({"mfeName":"checkout"},"DD_SOURCE_CODE_CONTEXT")`)
+
+      await expect(hasSourceCodeContext(filePath)).resolves.toBe(false)
     })
   })
 

--- a/packages/base/src/commands/sourcemaps/__tests__/debugId.test.ts
+++ b/packages/base/src/commands/sourcemaps/__tests__/debugId.test.ts
@@ -1,9 +1,10 @@
 import fs from 'fs'
-import os from 'os'
 import {Writable} from 'stream'
 
 import {SourceMapConsumer, SourceMapGenerator} from 'source-map'
 import upath from 'upath'
+
+import {withTempDirectory} from '@datadog/datadog-ci-base/helpers/__tests__/testing-tools'
 
 import {
   addDebugIdToPayloads,
@@ -21,24 +22,6 @@ const DEBUG_ID = '2f1d7f52-4e1b-4f7c-8c0d-2f4a5f6d8e91'
 
 const makeSourcemap = (minifiedFilePath: string) =>
   new Sourcemap(minifiedFilePath, `https://static.com/${minifiedFilePath}`, `${minifiedFilePath}.map`, minifiedFilePath)
-
-const withTempDirectory = (callback: (directory: string) => void): void => {
-  const directory = fs.mkdtempSync(upath.join(os.tmpdir(), 'datadog-ci-debug-id-'))
-  try {
-    callback(directory)
-  } finally {
-    fs.rmSync(directory, {recursive: true, force: true})
-  }
-}
-
-const withTempDirectoryAsync = async (callback: (directory: string) => Promise<void>): Promise<void> => {
-  const directory = fs.mkdtempSync(upath.join(os.tmpdir(), 'datadog-ci-debug-id-'))
-  try {
-    await callback(directory)
-  } finally {
-    fs.rmSync(directory, {recursive: true, force: true})
-  }
-}
 
 describe('extractDebugId', () => {
   afterEach(() => {
@@ -126,7 +109,7 @@ describe('extractDebugId', () => {
 
 describe('hasSourceCodeContext', () => {
   test('detects DD_SOURCE_CODE_CONTEXT', async () => {
-    await withTempDirectoryAsync(async (directory) => {
+    await withTempDirectory(async (directory) => {
       const filePath = upath.join(directory, 'injected.min.js')
       fs.writeFileSync(filePath, `${'x'.repeat(SOURCE_CODE_CONTEXT_SEARCH_CHUNK_BYTES + 100)}DD_SOURCE_CODE_CONTEXT`)
 
@@ -135,7 +118,7 @@ describe('hasSourceCodeContext', () => {
   })
 
   test('detects DD_SOURCE_CODE_CONTEXT split across two chunks', async () => {
-    await withTempDirectoryAsync(async (directory) => {
+    await withTempDirectory(async (directory) => {
       const filePath = upath.join(directory, 'split-context.min.js')
       const marker = 'DD_SOURCE_CODE_CONTEXT'
       fs.writeFileSync(filePath, `${'x'.repeat(SOURCE_CODE_CONTEXT_SEARCH_CHUNK_BYTES - 10)}${marker}`)
@@ -145,7 +128,7 @@ describe('hasSourceCodeContext', () => {
   })
 
   test('does not treat a standalone debug ID as injected source code context', async () => {
-    await withTempDirectoryAsync(async (directory) => {
+    await withTempDirectory(async (directory) => {
       const filePath = upath.join(directory, 'debug-id-only.min.js')
       fs.writeFileSync(filePath, `{"ddDebugId":"${DEBUG_ID}"}`)
 

--- a/packages/base/src/commands/sourcemaps/__tests__/upload.test.ts
+++ b/packages/base/src/commands/sourcemaps/__tests__/upload.test.ts
@@ -376,7 +376,7 @@ describe('execute', () => {
     expect(context.stdout.toString()).not.toContain('[DRYRUN] Uploading sourcemap')
   })
 
-  test('service/version mode allows a standalone debug ID without DD_SOURCE_CODE_CONTEXT', async () => {
+  test('service/version mode rejects a standalone debug ID', async () => {
     await withTempDirectory(async (directory) => {
       fs.writeFileSync(
         upath.join(directory, 'bundle.js'),
@@ -389,10 +389,9 @@ describe('execute', () => {
 
       const {context, code} = await runCLI([directory])
 
-      expect(code).toBe(0)
-      expect(context.stdout.toString()).toContain('[DRYRUN] Uploading sourcemap')
-      expect(context.stdout.toString()).not.toContain('(debug ID:')
-      expect(context.stderr.toString()).not.toContain('A Datadog debug ID injection was found')
+      expect(code).toBe(1)
+      expect(context.stderr.toString()).toContain('A Datadog debug ID injection was found')
+      expect(context.stdout.toString()).not.toContain('[DRYRUN] Uploading sourcemap')
     })
   })
 

--- a/packages/base/src/commands/sourcemaps/__tests__/upload.test.ts
+++ b/packages/base/src/commands/sourcemaps/__tests__/upload.test.ts
@@ -1,10 +1,9 @@
 import fs from 'fs'
-import os from 'os'
 
 import chalk from 'chalk'
 import upath from 'upath'
 
-import {createCommand, makeRunCLI} from '@datadog/datadog-ci-base/helpers/__tests__/testing-tools'
+import {createCommand, makeRunCLI, withTempDirectory} from '@datadog/datadog-ci-base/helpers/__tests__/testing-tools'
 
 import {Sourcemap} from '../interfaces'
 import {SourcemapsUploadCommand} from '../upload'
@@ -317,23 +316,20 @@ describe('execute', () => {
   })
 
   test('debug id mode uploads a build-plugin bundle whose sourcemap has no debug_id', async () => {
-    const directory = fs.mkdtempSync(upath.join(os.tmpdir(), 'datadog-ci-sourcemaps-upload-'))
-    const jsPath = upath.join(directory, 'bundle.js')
-    fs.writeFileSync(
-      jsPath,
-      `(function() {})({"ddDebugId":"2f1d7f52-4e1b-4f7c-8c0d-2f4a5f6d8e91"});\n//# sourceMappingURL=bundle.js.map`
-    )
-    fs.writeFileSync(`${jsPath}.map`, JSON.stringify({version: 3, sources: ['original.js'], mappings: 'AAAA'}))
+    await withTempDirectory(async (directory) => {
+      const jsPath = upath.join(directory, 'bundle.js')
+      fs.writeFileSync(
+        jsPath,
+        `(function() {})({"ddDebugId":"2f1d7f52-4e1b-4f7c-8c0d-2f4a5f6d8e91"});\n//# sourceMappingURL=bundle.js.map`
+      )
+      fs.writeFileSync(`${jsPath}.map`, JSON.stringify({version: 3, sources: ['original.js'], mappings: 'AAAA'}))
 
-    try {
       const {context, code} = await runCLIWithDebugId([directory])
 
       expect(code).toBe(0)
       expect(context.stdout.toString()).toContain('[DRYRUN] Uploading sourcemap')
       expect(context.stdout.toString()).toContain('(debug ID: 2f1d7f52-4e1b-4f7c-8c0d-2f4a5f6d8e91)')
-    } finally {
-      fs.rmSync(directory, {recursive: true, force: true})
-    }
+    })
   })
 
   test('debug id missing in all files aborts without mutating build artifacts', async () => {
@@ -381,8 +377,7 @@ describe('execute', () => {
   })
 
   test('service/version mode allows a standalone debug ID without DD_SOURCE_CODE_CONTEXT', async () => {
-    const directory = fs.mkdtempSync(upath.join(os.tmpdir(), 'datadog-ci-debug-id-only-'))
-    try {
+    await withTempDirectory(async (directory) => {
       fs.writeFileSync(
         upath.join(directory, 'bundle.js'),
         `({"ddDebugId":"2f1d7f52-4e1b-4f7c-8c0d-2f4a5f6d8e91"});\n//# sourceMappingURL=bundle.js.map`
@@ -398,9 +393,7 @@ describe('execute', () => {
       expect(context.stdout.toString()).toContain('[DRYRUN] Uploading sourcemap')
       expect(context.stdout.toString()).not.toContain('(debug ID:')
       expect(context.stderr.toString()).not.toContain('A Datadog debug ID injection was found')
-    } finally {
-      fs.rmSync(directory, {recursive: true, force: true})
-    }
+    })
   })
 
   test('relative path with double dots', async () => {

--- a/packages/base/src/commands/sourcemaps/__tests__/upload.test.ts
+++ b/packages/base/src/commands/sourcemaps/__tests__/upload.test.ts
@@ -370,6 +370,39 @@ describe('execute', () => {
     expect(stdout).toContain('because no debug ID was found')
   })
 
+  test('service/version mode rejects bundles containing DD_SOURCE_CODE_CONTEXT', async () => {
+    const {context, code} = await runCLI(['./src/commands/sourcemaps/__tests__/fixtures/bundle-with-debug-id'])
+
+    expect(code).toBe(1)
+    expect(context.stderr.toString()).toContain('A Datadog debug ID injection was found')
+    expect(context.stderr.toString()).toContain('Debug-ID uploads and service/version uploads are mutually exclusive')
+    expect(context.stderr.toString()).toContain('Re-run with --debug-id')
+    expect(context.stdout.toString()).not.toContain('[DRYRUN] Uploading sourcemap')
+  })
+
+  test('service/version mode allows a standalone debug ID without DD_SOURCE_CODE_CONTEXT', async () => {
+    const directory = fs.mkdtempSync(upath.join(os.tmpdir(), 'datadog-ci-debug-id-only-'))
+    try {
+      fs.writeFileSync(
+        upath.join(directory, 'bundle.js'),
+        `({"ddDebugId":"2f1d7f52-4e1b-4f7c-8c0d-2f4a5f6d8e91"});\n//# sourceMappingURL=bundle.js.map`
+      )
+      fs.writeFileSync(
+        upath.join(directory, 'bundle.js.map'),
+        JSON.stringify({version: 3, sources: ['original.js'], mappings: 'AAAA'})
+      )
+
+      const {context, code} = await runCLI([directory])
+
+      expect(code).toBe(0)
+      expect(context.stdout.toString()).toContain('[DRYRUN] Uploading sourcemap')
+      expect(context.stdout.toString()).not.toContain('(debug ID:')
+      expect(context.stderr.toString()).not.toContain('A Datadog debug ID injection was found')
+    } finally {
+      fs.rmSync(directory, {recursive: true, force: true})
+    }
+  })
+
   test('relative path with double dots', async () => {
     const {context, code} = await runCLI(['./src/commands/sourcemaps/__tests__/doesnotexist/../fixtures/basic'])
     const output = context.stdout.toString().split('\n')

--- a/packages/base/src/commands/sourcemaps/debugId.ts
+++ b/packages/base/src/commands/sourcemaps/debugId.ts
@@ -66,25 +66,33 @@ export const extractDebugId = (filePath: string): string | undefined => searchFi
 // small reads. Keep an overlap so markers split across chunk boundaries are still detected.
 export const hasSourceCodeContext = async (filePath: string): Promise<boolean> => {
   try {
-    const stream = fs.createReadStream(filePath, {
-      encoding: 'utf8',
-      highWaterMark: SOURCE_CODE_CONTEXT_SEARCH_CHUNK_BYTES,
-    })
-    let overlap = ''
+    const fileHandle = await fs.promises.open(filePath, 'r')
+    try {
+      const buffer = Buffer.alloc(SOURCE_CODE_CONTEXT_SEARCH_CHUNK_BYTES)
+      let overlap = ''
+      let position = 0
 
-    for await (const chunk of stream) {
-      const searchableContent = overlap + chunk
-      if (searchableContent.includes(SOURCE_CODE_CONTEXT_MARKER)) {
-        return true
+      while (true) {
+        const {bytesRead} = await fileHandle.read(buffer, 0, SOURCE_CODE_CONTEXT_SEARCH_CHUNK_BYTES, position)
+        if (bytesRead === 0) {
+          return false
+        }
+
+        const searchableContent = overlap + buffer.toString('utf8', 0, bytesRead)
+        if (searchableContent.includes(SOURCE_CODE_CONTEXT_MARKER)) {
+          return true
+        }
+
+        overlap = searchableContent.slice(-FILE_SEARCH_OVERLAP_CHARACTERS)
+        position += bytesRead
       }
-
-      overlap = searchableContent.slice(-FILE_SEARCH_OVERLAP_CHARACTERS)
+    } finally {
+      await fileHandle.close()
     }
   } catch {
     // Unreadable file: treated as not having the source code context marker.
+    return false
   }
-
-  return false
 }
 
 type ParsedSourcemap = RawSourceMap & Record<string, unknown>

--- a/packages/base/src/commands/sourcemaps/debugId.ts
+++ b/packages/base/src/commands/sourcemaps/debugId.ts
@@ -123,7 +123,7 @@ export const addDebugIdToPayloads = (payloads: Sourcemap[]): boolean => {
 // Keep this runtime snippet in sync with build-plugins:
 // https://github.com/DataDog/build-plugins/blob/c9384d115d53578f220cd5e1f29994acb96a1782/packages/plugins/rum/src/getSourceCodeContextSnippet.ts#L55
 const buildSnippet = (debugId: string): string =>
-  `(function(c,n){try{if(typeof window==='undefined')return;var w=window,m=w[n]=w[n]||{},s=new Error().stack;s&&(m[s]=c)}catch(e){}})({"ddDebugId":"${debugId}"},"DD_SOURCE_CODE_CONTEXT");`
+  `(function(c,n){try{if(typeof window==='undefined')return;var w=window,m=w[n]=w[n]||{},s=new Error().stack;s&&(m[s]=c)}catch(e){}})({"ddDebugId":"${debugId}"},"${SOURCE_CODE_CONTEXT_MARKER}");`
 
 const HASHBANG_REGEX = /^#!.*(?:\r\n|\r|\n)/
 

--- a/packages/base/src/commands/sourcemaps/debugId.ts
+++ b/packages/base/src/commands/sourcemaps/debugId.ts
@@ -10,6 +10,12 @@ import {ReplaceSource, SourceMapSource} from 'webpack-sources'
 
 const DEBUG_ID_REGEX = /"?ddDebugId"?:"([0-9a-fA-F-]{36})"/
 const SOURCE_CODE_CONTEXT_MARKER = 'DD_SOURCE_CODE_CONTEXT'
+// DD_SOURCE_CODE_CONTEXT also carries non-debug metadata such as MFE attribution. Match the
+// generated context-object suffix instead of either marker alone: ddDebugId is emitted as the
+// final context property immediately before the DD_SOURCE_CODE_CONTEXT argument.
+const SOURCE_CODE_CONTEXT_WITH_DEBUG_ID_REGEX = new RegExp(
+  `${DEBUG_ID_REGEX.source}\\s*}\\s*,\\s*"${SOURCE_CODE_CONTEXT_MARKER}"`
+)
 
 // Keep this progressive scanner in sync with build-plugins PR #489:
 // https://github.com/DataDog/build-plugins/pull/489
@@ -21,6 +27,8 @@ export const SOURCE_CODE_CONTEXT_SEARCH_CHUNK_BYTES = 64 * 1024
 // Keep enough content from the previous chunk to match a debug ID literal split across a read
 // boundary. The longest supported literal is shorter than this overlap.
 const FILE_SEARCH_OVERLAP_CHARACTERS = 64
+// The combined ddDebugId/context suffix is longer than a standalone debug ID literal.
+const SOURCE_CODE_CONTEXT_SEARCH_OVERLAP_CHARACTERS = 128
 const VARIANT_CHARS = ['8', '9', 'a', 'b'] as const
 
 const matchDebugId = (fileContent: string): string | undefined => DEBUG_ID_REGEX.exec(fileContent)?.[1]
@@ -79,11 +87,11 @@ export const hasSourceCodeContext = async (filePath: string): Promise<boolean> =
         }
 
         const searchableContent = overlap + buffer.toString('utf8', 0, bytesRead)
-        if (searchableContent.includes(SOURCE_CODE_CONTEXT_MARKER)) {
+        if (SOURCE_CODE_CONTEXT_WITH_DEBUG_ID_REGEX.test(searchableContent)) {
           return true
         }
 
-        overlap = searchableContent.slice(-FILE_SEARCH_OVERLAP_CHARACTERS)
+        overlap = searchableContent.slice(-SOURCE_CODE_CONTEXT_SEARCH_OVERLAP_CHARACTERS)
         position += bytesRead
       }
     } finally {

--- a/packages/base/src/commands/sourcemaps/debugId.ts
+++ b/packages/base/src/commands/sourcemaps/debugId.ts
@@ -10,25 +10,16 @@ import {ReplaceSource, SourceMapSource} from 'webpack-sources'
 
 const DEBUG_ID_REGEX = /"?ddDebugId"?:"([0-9a-fA-F-]{36})"/
 const SOURCE_CODE_CONTEXT_MARKER = 'DD_SOURCE_CODE_CONTEXT'
-// DD_SOURCE_CODE_CONTEXT also carries non-debug metadata such as MFE attribution. Match the
-// generated context-object suffix instead of either marker alone: ddDebugId is emitted as the
-// final context property immediately before the DD_SOURCE_CODE_CONTEXT argument.
-const SOURCE_CODE_CONTEXT_WITH_DEBUG_ID_REGEX = new RegExp(
-  `${DEBUG_ID_REGEX.source}\\s*}\\s*,\\s*"${SOURCE_CODE_CONTEXT_MARKER}"`
-)
 
 // Keep this progressive scanner in sync with build-plugins PR #489:
 // https://github.com/DataDog/build-plugins/pull/489
 // Read progressively so the common case only needs the first KiB, while still supporting
 // bundlers or transforms that place the injected snippet later in the artifact.
 export const DEBUG_ID_SEARCH_CHUNK_BYTES = 1024
-export const SOURCE_CODE_CONTEXT_SEARCH_CHUNK_BYTES = 64 * 1024
 
 // Keep enough content from the previous chunk to match a debug ID literal split across a read
 // boundary. The longest supported literal is shorter than this overlap.
 const FILE_SEARCH_OVERLAP_CHARACTERS = 64
-// The combined ddDebugId/context suffix is longer than a standalone debug ID literal.
-const SOURCE_CODE_CONTEXT_SEARCH_OVERLAP_CHARACTERS = 128
 const VARIANT_CHARS = ['8', '9', 'a', 'b'] as const
 
 const matchDebugId = (fileContent: string): string | undefined => DEBUG_ID_REGEX.exec(fileContent)?.[1]
@@ -68,40 +59,6 @@ const searchFile = <T>(filePath: string, match: (fileContent: string) => T | und
 }
 
 export const extractDebugId = (filePath: string): string | undefined => searchFile(filePath, matchDebugId)
-
-// Default service/version uploads may contain many large bundles. Scan them asynchronously in
-// larger chunks so checking marker-free files does not block the event loop with thousands of
-// small reads. Keep an overlap so markers split across chunk boundaries are still detected.
-export const hasSourceCodeContext = async (filePath: string): Promise<boolean> => {
-  try {
-    const fileHandle = await fs.promises.open(filePath, 'r')
-    try {
-      const buffer = Buffer.alloc(SOURCE_CODE_CONTEXT_SEARCH_CHUNK_BYTES)
-      let overlap = ''
-      let position = 0
-
-      while (true) {
-        const {bytesRead} = await fileHandle.read(buffer, 0, SOURCE_CODE_CONTEXT_SEARCH_CHUNK_BYTES, position)
-        if (bytesRead === 0) {
-          return false
-        }
-
-        const searchableContent = overlap + buffer.toString('utf8', 0, bytesRead)
-        if (SOURCE_CODE_CONTEXT_WITH_DEBUG_ID_REGEX.test(searchableContent)) {
-          return true
-        }
-
-        overlap = searchableContent.slice(-SOURCE_CODE_CONTEXT_SEARCH_OVERLAP_CHARACTERS)
-        position += bytesRead
-      }
-    } finally {
-      await fileHandle.close()
-    }
-  } catch {
-    // Unreadable file: treated as not having the source code context marker.
-    return false
-  }
-}
 
 type ParsedSourcemap = RawSourceMap & Record<string, unknown>
 

--- a/packages/base/src/commands/sourcemaps/debugId.ts
+++ b/packages/base/src/commands/sourcemaps/debugId.ts
@@ -9,6 +9,7 @@ import {parse} from '@babel/parser'
 import {ReplaceSource, SourceMapSource} from 'webpack-sources'
 
 const DEBUG_ID_REGEX = /"?ddDebugId"?:"([0-9a-fA-F-]{36})"/
+const SOURCE_CODE_CONTEXT_MARKER = 'DD_SOURCE_CODE_CONTEXT'
 
 // Keep this progressive scanner in sync with build-plugins PR #489:
 // https://github.com/DataDog/build-plugins/pull/489
@@ -18,14 +19,14 @@ export const DEBUG_ID_SEARCH_CHUNK_BYTES = 1024
 
 // Keep enough content from the previous chunk to match a debug ID literal split across a read
 // boundary. The longest supported literal is shorter than this overlap.
-const DEBUG_ID_SEARCH_OVERLAP_CHARACTERS = 64
+const FILE_SEARCH_OVERLAP_CHARACTERS = 64
 const VARIANT_CHARS = ['8', '9', 'a', 'b'] as const
 
 const matchDebugId = (fileContent: string): string | undefined => DEBUG_ID_REGEX.exec(fileContent)?.[1]
 
-// Search in fixed-size reads and stop as soon as the debug ID is found. Only a small overlap is
-// retained between reads, so even the worst case (scanning to EOF) uses bounded memory.
-export const extractDebugId = (filePath: string): string | undefined => {
+// Search in fixed-size reads and stop as soon as a match is found. Only a small overlap is retained
+// between reads, so even the worst case (scanning to EOF) uses bounded memory.
+const searchFile = <T>(filePath: string, match: (fileContent: string) => T | undefined): T | undefined => {
   try {
     const fileDescriptor = fs.openSync(filePath, 'r')
     try {
@@ -40,22 +41,27 @@ export const extractDebugId = (filePath: string): string | undefined => {
         }
 
         const searchableContent = overlap + buffer.toString('utf-8', 0, bytesRead)
-        const debugId = matchDebugId(searchableContent)
-        if (debugId) {
-          return debugId
+        const result = match(searchableContent)
+        if (result !== undefined) {
+          return result
         }
 
-        overlap = searchableContent.slice(-DEBUG_ID_SEARCH_OVERLAP_CHARACTERS)
+        overlap = searchableContent.slice(-FILE_SEARCH_OVERLAP_CHARACTERS)
         position += bytesRead
       }
     } finally {
       fs.closeSync(fileDescriptor)
     }
   } catch {
-    // Unreadable file: treated as having no debug ID.
+    // Unreadable file: treated as having no match.
     return undefined
   }
 }
+
+export const extractDebugId = (filePath: string): string | undefined => searchFile(filePath, matchDebugId)
+
+export const hasSourceCodeContext = (filePath: string): boolean =>
+  searchFile(filePath, (fileContent) => (fileContent.includes(SOURCE_CODE_CONTEXT_MARKER) ? true : undefined)) ?? false
 
 type ParsedSourcemap = RawSourceMap & Record<string, unknown>
 

--- a/packages/base/src/commands/sourcemaps/debugId.ts
+++ b/packages/base/src/commands/sourcemaps/debugId.ts
@@ -16,6 +16,7 @@ const SOURCE_CODE_CONTEXT_MARKER = 'DD_SOURCE_CODE_CONTEXT'
 // Read progressively so the common case only needs the first KiB, while still supporting
 // bundlers or transforms that place the injected snippet later in the artifact.
 export const DEBUG_ID_SEARCH_CHUNK_BYTES = 1024
+export const SOURCE_CODE_CONTEXT_SEARCH_CHUNK_BYTES = 64 * 1024
 
 // Keep enough content from the previous chunk to match a debug ID literal split across a read
 // boundary. The longest supported literal is shorter than this overlap.
@@ -60,8 +61,31 @@ const searchFile = <T>(filePath: string, match: (fileContent: string) => T | und
 
 export const extractDebugId = (filePath: string): string | undefined => searchFile(filePath, matchDebugId)
 
-export const hasSourceCodeContext = (filePath: string): boolean =>
-  searchFile(filePath, (fileContent) => (fileContent.includes(SOURCE_CODE_CONTEXT_MARKER) ? true : undefined)) ?? false
+// Default service/version uploads may contain many large bundles. Scan them asynchronously in
+// larger chunks so checking marker-free files does not block the event loop with thousands of
+// small reads. Keep an overlap so markers split across chunk boundaries are still detected.
+export const hasSourceCodeContext = async (filePath: string): Promise<boolean> => {
+  try {
+    const stream = fs.createReadStream(filePath, {
+      encoding: 'utf8',
+      highWaterMark: SOURCE_CODE_CONTEXT_SEARCH_CHUNK_BYTES,
+    })
+    let overlap = ''
+
+    for await (const chunk of stream) {
+      const searchableContent = overlap + chunk
+      if (searchableContent.includes(SOURCE_CODE_CONTEXT_MARKER)) {
+        return true
+      }
+
+      overlap = searchableContent.slice(-FILE_SEARCH_OVERLAP_CHARACTERS)
+    }
+  } catch {
+    // Unreadable file: treated as not having the source code context marker.
+  }
+
+  return false
+}
 
 type ParsedSourcemap = RawSourceMap & Record<string, unknown>
 

--- a/packages/base/src/commands/sourcemaps/renderer.ts
+++ b/packages/base/src/commands/sourcemaps/renderer.ts
@@ -51,6 +51,9 @@ export const renderFailedUpload = (sourcemap: Sourcemap, errorMessage: string) =
 
 export const renderNoDebugIdFound = () => 'No debug ID found in any minified file. Aborting upload.\n'
 
+export const renderSourceCodeContextFoundWithoutDebugIdFlag = () =>
+  'A Datadog debug ID injection was found in at least one minified file, but --debug-id was not set. Debug-ID uploads and service/version uploads are mutually exclusive. Re-run with --debug-id or rebuild the bundles without the Datadog debug ID injection. Aborting upload.\n'
+
 export const renderRetriedUpload = (payload: Sourcemap, errorMessage: string, attempt: number) => {
   const sourcemapPathBold = `[${chalk.bold.dim(payload.sourcemapPath)}]`
 

--- a/packages/base/src/commands/sourcemaps/upload.ts
+++ b/packages/base/src/commands/sourcemaps/upload.ts
@@ -31,7 +31,7 @@ import {getRequestBuilder, buildPath} from '@datadog/datadog-ci-base/helpers/uti
 import * as validation from '@datadog/datadog-ci-base/helpers/validation'
 import {cliVersion} from '@datadog/datadog-ci-base/version'
 
-import {addDebugIdToPayloads} from './debugId'
+import {addDebugIdToPayloads, extractDebugId} from './debugId'
 import {findSourcemaps} from './findSourcemaps'
 import {Sourcemap} from './interfaces'
 import {
@@ -147,10 +147,12 @@ export class SourcemapsUploadCommand extends BaseCommand {
         return 1
       }
     } else {
-      if (payloads.length > 0 && addDebugIdToPayloads(payloads)) {
-        this.context.stderr.write(renderSourceCodeContextFoundWithoutDebugIdFlag())
+      for (const {minifiedFilePath} of payloads) {
+        if (extractDebugId(minifiedFilePath) !== undefined) {
+          this.context.stderr.write(renderSourceCodeContextFoundWithoutDebugIdFlag())
 
-        return 1
+          return 1
+        }
       }
     }
 

--- a/packages/base/src/commands/sourcemaps/upload.ts
+++ b/packages/base/src/commands/sourcemaps/upload.ts
@@ -31,7 +31,7 @@ import {getRequestBuilder, buildPath} from '@datadog/datadog-ci-base/helpers/uti
 import * as validation from '@datadog/datadog-ci-base/helpers/validation'
 import {cliVersion} from '@datadog/datadog-ci-base/version'
 
-import {addDebugIdToPayloads, hasSourceCodeContext} from './debugId'
+import {addDebugIdToPayloads} from './debugId'
 import {findSourcemaps} from './findSourcemaps'
 import {Sourcemap} from './interfaces'
 import {
@@ -147,12 +147,7 @@ export class SourcemapsUploadCommand extends BaseCommand {
         return 1
       }
     } else {
-      const hasSourceCodeContextResults = await doWithMaxConcurrency(
-        this.maxConcurrency,
-        payloads,
-        ({minifiedFilePath}) => hasSourceCodeContext(minifiedFilePath)
-      )
-      if (hasSourceCodeContextResults.some(Boolean)) {
+      if (payloads.length > 0 && addDebugIdToPayloads(payloads)) {
         this.context.stderr.write(renderSourceCodeContextFoundWithoutDebugIdFlag())
 
         return 1

--- a/packages/base/src/commands/sourcemaps/upload.ts
+++ b/packages/base/src/commands/sourcemaps/upload.ts
@@ -31,7 +31,7 @@ import {getRequestBuilder, buildPath} from '@datadog/datadog-ci-base/helpers/uti
 import * as validation from '@datadog/datadog-ci-base/helpers/validation'
 import {cliVersion} from '@datadog/datadog-ci-base/version'
 
-import {addDebugIdToPayloads} from './debugId'
+import {addDebugIdToPayloads, hasSourceCodeContext} from './debugId'
 import {findSourcemaps} from './findSourcemaps'
 import {Sourcemap} from './interfaces'
 import {
@@ -42,6 +42,7 @@ import {
   renderFailedUpload,
   renderGitDataNotAttachedWarning,
   renderGitWarning,
+  renderSourceCodeContextFoundWithoutDebugIdFlag,
   renderInvalidPrefix,
   renderNoDebugIdFound,
   renderRetriedUpload,
@@ -139,9 +140,14 @@ export class SourcemapsUploadCommand extends BaseCommand {
     const useGit = this.disableGit === undefined || !this.disableGit
     const initialTime = Date.now()
     const payloads = await this.getPayloadsToUpload(useGit)
+    if (this.debugId) {
+      if (payloads.length > 0 && !addDebugIdToPayloads(payloads)) {
+        this.context.stderr.write(renderNoDebugIdFound())
 
-    if (this.debugId && payloads.length > 0 && !addDebugIdToPayloads(payloads)) {
-      this.context.stderr.write(renderNoDebugIdFound())
+        return 1
+      }
+    } else if (payloads.some(({minifiedFilePath}) => hasSourceCodeContext(minifiedFilePath))) {
+      this.context.stderr.write(renderSourceCodeContextFoundWithoutDebugIdFlag())
 
       return 1
     }

--- a/packages/base/src/commands/sourcemaps/upload.ts
+++ b/packages/base/src/commands/sourcemaps/upload.ts
@@ -146,10 +146,17 @@ export class SourcemapsUploadCommand extends BaseCommand {
 
         return 1
       }
-    } else if (payloads.some(({minifiedFilePath}) => hasSourceCodeContext(minifiedFilePath))) {
-      this.context.stderr.write(renderSourceCodeContextFoundWithoutDebugIdFlag())
+    } else {
+      const hasSourceCodeContextResults = await doWithMaxConcurrency(
+        this.maxConcurrency,
+        payloads,
+        ({minifiedFilePath}) => hasSourceCodeContext(minifiedFilePath)
+      )
+      if (hasSourceCodeContextResults.some(Boolean)) {
+        this.context.stderr.write(renderSourceCodeContextFoundWithoutDebugIdFlag())
 
-      return 1
+        return 1
+      }
     }
 
     const requestBuilder = this.getRequestBuilder()

--- a/packages/base/src/helpers/__tests__/testing-tools.ts
+++ b/packages/base/src/helpers/__tests__/testing-tools.ts
@@ -1,3 +1,6 @@
+import fs from 'fs'
+import os from 'os'
+
 import type {MockCommandContext} from '../interfaces'
 import type {BaseContext, CommandClass} from 'clipanion'
 import type {CommandOption} from 'clipanion/lib/advanced/options'
@@ -13,6 +16,25 @@ export const MOCK_BASE_URL = 'https://app.datadoghq.com/'
 export const MOCK_DATADOG_API_KEY = '02aeb762fff59ac0d5ad1536cd9633bd'
 export const MOCK_CWD = 'mock-folder'
 export const MOCK_FLARE_FOLDER_PATH = upath.join(MOCK_CWD, '.datadog-ci')
+
+export const withTempDirectory = <T>(callback: (directory: string) => T): T => {
+  const directory = fs.mkdtempSync(upath.join(os.tmpdir(), 'datadog-ci-test-'))
+  const cleanup = () => fs.rmSync(directory, {recursive: true, force: true})
+
+  try {
+    const result = callback(directory)
+    if (result instanceof Promise) {
+      return result.finally(cleanup) as T
+    }
+
+    cleanup()
+
+    return result
+  } catch (error) {
+    cleanup()
+    throw error
+  }
+}
 
 interface MockContextOptions {
   /**


### PR DESCRIPTION
### What and why?

Prevent service/version sourcemap uploads when a minified bundle contains a Datadog debug ID injection.

Debug ID and service/version matching are mutually exclusive. Allowing an injected bundle to use service/version metadata can produce sourcemaps that do not match runtime errors.

### How?

- Detect a `ddDebugId` literal in discovered minified files by reusing the existing `extractDebugId` helper (via `addDebugIdToPayloads`).
- Abort before uploading when a debug ID is found with service/version matching.
- Preserve the existing `--debug-id` upload behavior.

build-plugins always emits `ddDebugId` inside the `DD_SOURCE_CODE_CONTEXT` runtime snippet, so detecting the literal is equivalent to detecting the injection for real bundles.

### Testing

- Focused sourcemap tests: 95 passed
- `tsc --noEmit`
- `eslint` on changed files
- Local CLI dry-runs for both upload modes

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)