### PR TITLE
[SVLS-9316] cloud run multi language instrumentation

### DIFF
--- a/e2e/serverless/cloud-run/cloud-run-ssi.test.ts
+++ b/e2e/serverless/cloud-run/cloud-run-ssi.test.ts
@@ -89,64 +89,61 @@ describeOrSkip('cloud-run SSI', () => {
     600_000
   )
 
-  it.concurrent.each(SSI_CASES)(
-    'detects and injects the $language tracer',
-    async ({language, image}) => {
-      const serviceName = `one-e2e-ci-cr-ssi-multi-${language}-${crypto.randomBytes(4).toString('hex')}`
+  it('detects and injects the Node.js tracer', async () => {
+    const serviceName = `one-e2e-ci-cr-ssi-multi-nodejs-${crypto.randomBytes(4).toString('hex')}`
+    const {image} = SSI_CASES.find(({language}) => language === 'nodejs')!
 
-      try {
-        const deployResult = await execPromiseWithRetries(
-          `gcloud run deploy "${serviceName}"` +
-            ` --project "${project}"` +
-            ` --region "${region}"` +
-            ` --platform managed` +
-            ` --image "${image}"` +
-            ` --allow-unauthenticated` +
-            ` --min-instances 0` +
-            ` --max-instances 1` +
-            ` --quiet` +
-            ` --format=none` +
-            ` --labels one_e2e_created=${Math.floor(Date.now() / 1000)}`
-        )
-        expect(deployResult).toEqual(expect.objectContaining({exitCode: 0}))
+    try {
+      const deployResult = await execPromiseWithRetries(
+        `gcloud run deploy "${serviceName}"` +
+          ` --project "${project}"` +
+          ` --region "${region}"` +
+          ` --platform managed` +
+          ` --image "${image}"` +
+          ` --allow-unauthenticated` +
+          ` --min-instances 0` +
+          ` --max-instances 1` +
+          ` --quiet` +
+          ` --format=none` +
+          ` --labels one_e2e_created=${Math.floor(Date.now() / 1000)}`
+      )
+      expect(deployResult).toEqual(expect.objectContaining({exitCode: 0}))
 
-        const instrumentResult = await execPromiseWithRetries(
-          `${DATADOG_CI_COMMAND} cloud-run instrument` +
-            ` --project "${project}"` +
-            ` --region "${region}"` +
-            ` --service "${serviceName}"` +
-            ` --tracing inject` +
-            ` --no-source-code-integration`,
-          {DD_API_KEY: process.env.DATADOG_API_KEY}
-        )
-        expect(instrumentResult).toEqual(expect.objectContaining({exitCode: 0}))
+      const instrumentResult = await execPromiseWithRetries(
+        `${DATADOG_CI_COMMAND} cloud-run instrument` +
+          ` --project "${project}"` +
+          ` --region "${region}"` +
+          ` --service "${serviceName}"` +
+          ` --tracing inject` +
+          ` --no-source-code-integration`,
+        {DD_API_KEY: process.env.DATADOG_API_KEY}
+      )
+      expect(instrumentResult).toEqual(expect.objectContaining({exitCode: 0}))
 
-        verifyMultiLanguageSsiInstrumented(serviceName, project, region, {appImage: image})
+      verifyMultiLanguageSsiInstrumented(serviceName, project, region, {appImage: image})
 
-        const urlResult = await execPromise(
-          `gcloud run services describe "${serviceName}"` +
-            ` --project "${project}"` +
-            ` --region "${region}"` +
-            ` --format="value(status.url)"`
-        )
-        expect(urlResult.exitCode).toBe(0)
+      const urlResult = await execPromise(
+        `gcloud run services describe "${serviceName}"` +
+          ` --project "${project}"` +
+          ` --region "${region}"` +
+          ` --format="value(status.url)"`
+      )
+      expect(urlResult.exitCode).toBe(0)
 
-        await triggerTraffic(urlResult.stdout.trim())
-        await checkTelemetryFlowing({serviceName}, {checkLogs: false})
-      } finally {
-        const deleteResult = await execPromise(
-          `gcloud run services delete "${serviceName}"` +
-            ` --project "${project}"` +
-            ` --region "${region}"` +
-            ` --platform managed` +
-            ` --quiet` +
-            ` --format=none`
-        )
-        if (deleteResult.exitCode !== 0) {
-          console.error(`Failed to delete Cloud Run service "${serviceName}": ${deleteResult.stderr}`)
-        }
+      await triggerTraffic(urlResult.stdout.trim())
+      await checkTelemetryFlowing({serviceName}, {checkLogs: false})
+    } finally {
+      const deleteResult = await execPromise(
+        `gcloud run services delete "${serviceName}"` +
+          ` --project "${project}"` +
+          ` --region "${region}"` +
+          ` --platform managed` +
+          ` --quiet` +
+          ` --format=none`
+      )
+      if (deleteResult.exitCode !== 0) {
+        console.error(`Failed to delete Cloud Run service "${serviceName}": ${deleteResult.stderr}`)
       }
-    },
-    600_000
-  )
+    }
+  }, 600_000)
 })

--- a/e2e/serverless/cloud-run/cloud-run-ssi.test.ts
+++ b/e2e/serverless/cloud-run/cloud-run-ssi.test.ts
@@ -117,7 +117,7 @@ describeOrSkip('cloud-run SSI', () => {
             ` --service "${serviceName}"` +
             ` --tracing inject` +
             ` --no-source-code-integration`,
-          {DATADOG_API_KEY: process.env.DATADOG_API_KEY}
+          {DD_API_KEY: process.env.DATADOG_API_KEY}
         )
         expect(instrumentResult).toEqual(expect.objectContaining({exitCode: 0}))
 

--- a/e2e/serverless/cloud-run/cloud-run-ssi.test.ts
+++ b/e2e/serverless/cloud-run/cloud-run-ssi.test.ts
@@ -6,7 +6,7 @@ import {SSI_CASES as ssiCases} from '../helpers/ssi'
 import {checkTelemetryFlowing} from '../helpers/telemetry-checker'
 import {triggerTraffic} from '../helpers/traffic'
 
-import {verifySsiInstrumented} from './cloud-run-verifier'
+import {verifyMultiLanguageSsiInstrumented, verifySsiInstrumented} from './cloud-run-verifier'
 
 const describeOrSkip =
   process.env.SKIP_CLOUD_RUN_TESTS === 'true' || process.env.IS_STANDALONE_BINARY === 'true' ? describe.skip : describe
@@ -61,6 +61,67 @@ describeOrSkip('cloud-run SSI', () => {
           envName,
           envValue,
         })
+
+        const urlResult = await execPromise(
+          `gcloud run services describe "${serviceName}"` +
+            ` --project "${project}"` +
+            ` --region "${region}"` +
+            ` --format="value(status.url)"`
+        )
+        expect(urlResult.exitCode).toBe(0)
+
+        await triggerTraffic(urlResult.stdout.trim())
+        await checkTelemetryFlowing({serviceName}, {checkLogs: false})
+      } finally {
+        const deleteResult = await execPromise(
+          `gcloud run services delete "${serviceName}"` +
+            ` --project "${project}"` +
+            ` --region "${region}"` +
+            ` --platform managed` +
+            ` --quiet` +
+            ` --format=none`
+        )
+        if (deleteResult.exitCode !== 0) {
+          console.error(`Failed to delete Cloud Run service "${serviceName}": ${deleteResult.stderr}`)
+        }
+      }
+    },
+    600_000
+  )
+
+  it.concurrent.each(SSI_CASES)(
+    'detects and injects the $language tracer',
+    async ({language, image}) => {
+      const serviceName = `one-e2e-ci-cr-ssi-multi-${language}-${crypto.randomBytes(4).toString('hex')}`
+
+      try {
+        const deployResult = await execPromiseWithRetries(
+          `gcloud run deploy "${serviceName}"` +
+            ` --project "${project}"` +
+            ` --region "${region}"` +
+            ` --platform managed` +
+            ` --image "${image}"` +
+            ` --allow-unauthenticated` +
+            ` --min-instances 0` +
+            ` --max-instances 1` +
+            ` --quiet` +
+            ` --format=none` +
+            ` --labels one_e2e_created=${Math.floor(Date.now() / 1000)}`
+        )
+        expect(deployResult).toEqual(expect.objectContaining({exitCode: 0}))
+
+        const instrumentResult = await execPromiseWithRetries(
+          `${DATADOG_CI_COMMAND} cloud-run instrument` +
+            ` --project "${project}"` +
+            ` --region "${region}"` +
+            ` --service "${serviceName}"` +
+            ` --tracing inject` +
+            ` --no-source-code-integration`,
+          {DATADOG_API_KEY: process.env.DATADOG_API_KEY}
+        )
+        expect(instrumentResult).toEqual(expect.objectContaining({exitCode: 0}))
+
+        verifyMultiLanguageSsiInstrumented(serviceName, project, region, {appImage: image})
 
         const urlResult = await execPromise(
           `gcloud run services describe "${serviceName}"` +

--- a/e2e/serverless/cloud-run/cloud-run-verifier.ts
+++ b/e2e/serverless/cloud-run/cloud-run-verifier.ts
@@ -42,6 +42,7 @@ interface CloudRunService {
   template?: ServiceTemplate
   spec?: {
     template?: {
+      metadata?: {annotations?: Record<string, string>}
       spec?: ServiceTemplate
     }
   }
@@ -86,6 +87,12 @@ const getLabels = (service: CloudRunService): Record<string, string> => ({
 })
 
 const getVolumeName = (mount: VolumeMount): string | undefined => mount.name ?? mount.volumeName
+
+const getContainerDependencies = (service: CloudRunService, container: Container): string[] | undefined =>
+  container.dependsOn ??
+  JSON.parse(service.spec?.template?.metadata?.annotations?.['run.googleapis.com/container-dependencies'] ?? '{}')[
+    container.name
+  ]
 
 export const verifyInstrumented = (serviceName: string, project: string, region: string): void => {
   console.log(`Fetching Cloud Run service "${serviceName}"...`)
@@ -191,7 +198,9 @@ export const verifyMultiLanguageSsiInstrumented = (
   expect(appContainers).toHaveLength(1)
   const app = appContainers[0]
   expect(app.image).toBe(expectation.appImage)
-  expect(app.dependsOn).toEqual(expect.arrayContaining([SIDECAR_NAME, TRACER_COPY_CONTAINER_NAME]))
+  expect(getContainerDependencies(service, app)).toEqual(
+    expect.arrayContaining([SIDECAR_NAME, TRACER_COPY_CONTAINER_NAME])
+  )
   expect(app.volumeMounts).toContainEqual({name: TRACER_VOLUME_NAME, mountPath: COMPOSITE_TRACER_MOUNT_PATH})
   expect(app.env).toEqual(
     expect.arrayContaining([

--- a/e2e/serverless/cloud-run/cloud-run-verifier.ts
+++ b/e2e/serverless/cloud-run/cloud-run-verifier.ts
@@ -17,6 +17,7 @@ interface Container {
   args?: string[]
   dependsOn?: string[]
   env?: EnvVar[]
+  resources?: {limits?: Record<string, string>}
   startupProbe?: {
     tcpSocket?: {port?: number}
   }
@@ -25,7 +26,7 @@ interface Container {
 
 interface Volume {
   name: string
-  emptyDir?: unknown
+  emptyDir?: {medium?: string; sizeLimit?: string}
 }
 
 interface ServiceTemplate {
@@ -49,7 +50,10 @@ interface CloudRunService {
 const SIDECAR_NAME = 'datadog-sidecar'
 const SHARED_VOLUME_NAME = 'shared-volume'
 const TRACER_COPY_CONTAINER_NAME = 'datadog-tracer'
-const TRACER_MOUNT_PATH = '/datadog-lib'
+const SINGLE_TRACER_MOUNT_PATH = '/datadog-lib'
+const COMPOSITE_TRACER_MOUNT_PATH = '/opt/datadog-packages'
+const COMPOSITE_PRELOAD = `${COMPOSITE_TRACER_MOUNT_PATH}/datadog-apm-inject/stable/inject/launcher.preload.so`
+const COMPOSITE_COMPLETION_MARKER = `${COMPOSITE_TRACER_MOUNT_PATH}/.datadog-composite-copy-finished`
 const TRACER_READINESS_PORT = 18999
 const TRACER_VOLUME_NAME = 'datadog-tracer'
 const REQUIRED_ENV_VARS = [
@@ -100,7 +104,7 @@ export const verifyInstrumented = (serviceName: string, project: string, region:
   const volume = volumes.find((v) => v.name === SHARED_VOLUME_NAME)
   expect(volume).toBeDefined()
 
-  const appContainers = containers.filter((c) => c.name !== SIDECAR_NAME)
+  const appContainers = containers.filter((c) => c.name !== SIDECAR_NAME && c.name !== TRACER_COPY_CONTAINER_NAME)
   expect(appContainers.length).toBeGreaterThan(0)
 
   for (const container of appContainers) {
@@ -144,7 +148,7 @@ export const verifySsiInstrumented = (
   expect(appContainers).toHaveLength(1)
   const app = appContainers[0]
   expect(app.image).toBe(expectation.appImage)
-  expect(app.volumeMounts).toContainEqual({name: TRACER_VOLUME_NAME, mountPath: TRACER_MOUNT_PATH})
+  expect(app.volumeMounts).toContainEqual({name: TRACER_VOLUME_NAME, mountPath: SINGLE_TRACER_MOUNT_PATH})
   expect(app.env).toEqual(
     expect.arrayContaining([
       expect.objectContaining({name: 'DD_TRACE_ENABLED', value: 'true'}),
@@ -155,7 +159,10 @@ export const verifySsiInstrumented = (
   const tracerCopy = containers.find(({name}) => name === TRACER_COPY_CONTAINER_NAME)
   expect(tracerCopy).toBeDefined()
   expect(tracerCopy!.image).toContain(`/dd-lib-${expectation.tracerRepository}-init:latest`)
-  expect(tracerCopy!.volumeMounts).toContainEqual({name: TRACER_VOLUME_NAME, mountPath: TRACER_MOUNT_PATH})
+  expect(tracerCopy!.volumeMounts).toContainEqual({
+    name: TRACER_VOLUME_NAME,
+    mountPath: SINGLE_TRACER_MOUNT_PATH,
+  })
   expect(tracerCopy!.startupProbe?.tcpSocket?.port).toBe(TRACER_READINESS_PORT)
   expect(tracerCopy!.args).toContain(String(TRACER_READINESS_PORT))
 
@@ -163,6 +170,59 @@ export const verifySsiInstrumented = (
     expect.arrayContaining([expect.objectContaining({name: TRACER_VOLUME_NAME, emptyDir: expect.anything()})])
   )
   expect(labels.dd_sls_injection_mode).toBe('single_language')
+}
+
+interface MultiLanguageSsiExpectation {
+  appImage: string
+}
+
+export const verifyMultiLanguageSsiInstrumented = (
+  serviceName: string,
+  project: string,
+  region: string,
+  expectation: MultiLanguageSsiExpectation
+): void => {
+  const service = getCloudRunService(serviceName, project, region)
+  const template = getTemplate(service)
+  const containers = template.containers ?? []
+  const labels = getLabels(service)
+  const appContainers = containers.filter(({name}) => name !== SIDECAR_NAME && name !== TRACER_COPY_CONTAINER_NAME)
+
+  expect(appContainers).toHaveLength(1)
+  const app = appContainers[0]
+  expect(app.image).toBe(expectation.appImage)
+  expect(app.dependsOn).toEqual(expect.arrayContaining([SIDECAR_NAME, TRACER_COPY_CONTAINER_NAME]))
+  expect(app.volumeMounts).toContainEqual({name: TRACER_VOLUME_NAME, mountPath: COMPOSITE_TRACER_MOUNT_PATH})
+  expect(app.env).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({name: 'DD_TRACE_ENABLED', value: 'true'}),
+      expect.objectContaining({name: 'LD_PRELOAD', value: expect.stringContaining(COMPOSITE_PRELOAD)}),
+      expect.objectContaining({name: 'DD_INJECT_SENDER_TYPE', value: 'serverless'}),
+    ])
+  )
+
+  const tracerCopy = containers.find(({name}) => name === TRACER_COPY_CONTAINER_NAME)
+  expect(tracerCopy).toBeDefined()
+  expect(tracerCopy!.image).toContain('/dd-lib-composite-init:latest')
+  expect(tracerCopy!.volumeMounts).toContainEqual({
+    name: TRACER_VOLUME_NAME,
+    mountPath: COMPOSITE_TRACER_MOUNT_PATH,
+  })
+  expect(tracerCopy!.resources?.limits?.memory).toBe('2Gi')
+  expect(tracerCopy!.startupProbe?.tcpSocket?.port).toBe(TRACER_READINESS_PORT)
+  expect(tracerCopy!.args).toEqual(
+    expect.arrayContaining([COMPOSITE_TRACER_MOUNT_PATH, COMPOSITE_COMPLETION_MARKER, String(TRACER_READINESS_PORT)])
+  )
+
+  expect(template.volumes).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        name: TRACER_VOLUME_NAME,
+        emptyDir: expect.objectContaining({medium: 'MEMORY', sizeLimit: '1.5Gi'}),
+      }),
+    ])
+  )
+  expect(labels.dd_sls_injection_mode).toBe('multi_language')
 }
 
 export const verifyUninstrumented = (serviceName: string, project: string, region: string): void => {
@@ -176,7 +236,9 @@ export const verifyUninstrumented = (serviceName: string, project: string, regio
   const labels = getLabels(service)
 
   expect(containers.find((c) => c.name === SIDECAR_NAME)).toBeUndefined()
+  expect(containers.find((c) => c.name === TRACER_COPY_CONTAINER_NAME)).toBeUndefined()
   expect(volumes.find((v) => v.name === SHARED_VOLUME_NAME)).toBeUndefined()
+  expect(volumes.find((v) => v.name === TRACER_VOLUME_NAME)).toBeUndefined()
 
   for (const container of containers) {
     const mounts = container.volumeMounts || []

--- a/e2e/serverless/cloud-run/cloud-run-verifier.ts
+++ b/e2e/serverless/cloud-run/cloud-run-verifier.ts
@@ -12,7 +12,7 @@ interface VolumeMount {
 }
 
 interface Container {
-  name: string
+  name?: string
   image?: string
   args?: string[]
   dependsOn?: string[]
@@ -91,7 +91,7 @@ const getVolumeName = (mount: VolumeMount): string | undefined => mount.name ?? 
 const getContainerDependencies = (service: CloudRunService, container: Container): string[] | undefined =>
   container.dependsOn ??
   JSON.parse(service.spec?.template?.metadata?.annotations?.['run.googleapis.com/container-dependencies'] ?? '{}')[
-    container.name
+    container.name ?? ''
   ]
 
 export const verifyInstrumented = (serviceName: string, project: string, region: string): void => {
@@ -227,7 +227,7 @@ export const verifyMultiLanguageSsiInstrumented = (
     expect.arrayContaining([
       expect.objectContaining({
         name: TRACER_VOLUME_NAME,
-        emptyDir: expect.objectContaining({medium: 'MEMORY', sizeLimit: '1.5Gi'}),
+        emptyDir: expect.objectContaining({medium: expect.stringMatching(/^memory$/i), sizeLimit: '1.5Gi'}),
       }),
     ])
   )

--- a/packages/base/src/commands/cloud-run/__tests__/instrument.test.ts
+++ b/packages/base/src/commands/cloud-run/__tests__/instrument.test.ts
@@ -44,6 +44,14 @@ describe('CloudRunInstrumentCommand', () => {
     expect(parsedOptions?.tracing).toBe(tracing)
   })
 
+  test('describes automatic language detection', async () => {
+    const {code, context} = await runCLI(['--help'])
+
+    expect(code).toBe(0)
+    expect(context.stdout.toString()).toContain('detect the language and add a tracer automatically')
+    expect(context.stdout.toString()).toContain('Omit this option with --tracing inject')
+  })
+
   test('accepts automatic instrumentation options', async () => {
     const {code} = await runCLI([
       '--language',

--- a/packages/base/src/commands/cloud-run/instrument.ts
+++ b/packages/base/src/commands/cloud-run/instrument.ts
@@ -64,7 +64,7 @@ export class CloudRunInstrumentCommand extends BaseCommand {
   })
   protected tracing = Option.String('--tracing', {
     description:
-      'Configure APM instrumentation. Use "manual" when the tracer is installed, "inject" with --language for automatic instrumentation, or "disabled" to turn tracing off. The legacy values "true"/"1" and "false"/"0" map to "manual" and "disabled".',
+      'Configure APM instrumentation. Use "manual" when the tracer is installed, "inject" to detect the language and add a tracer automatically, or "disabled" to turn tracing off. Add --language with "inject" to select one tracer. The legacy values "true"/"1" and "false"/"0" map to "manual" and "disabled".',
     validator: t.isEnum(TRACING_INPUTS),
   })
   protected serviceTag = Option.String('--service-tag,--serviceTag', {
@@ -111,14 +111,14 @@ export class CloudRunInstrumentCommand extends BaseCommand {
   protected language = Option.String('--language', {
     description: `Set the application language for advanced log parsing. With --tracing inject, also select the tracer for automatic instrumentation. Supported injection values: ${TRACER_INJECTION_LANGUAGES.map(
       (language) => `"${language}"`
-    ).join(', ')}.`,
+    ).join(', ')}. Omit this option with --tracing inject to detect the language automatically.`,
   })
   protected tracerVersion = Option.String('--tracer-version', {
-    description: `The tracer image tag to use with --tracing inject. Defaults to '${DEFAULT_TRACER_VERSION}'.`,
+    description: `The tracer image tag to use with --tracing inject --language. Defaults to '${DEFAULT_TRACER_VERSION}'.`,
     validator: t.cascade(t.isString(), t.matchesRegExp(TRACER_IMAGE_TAG_REG_EXP)),
   })
   protected tracerLibc = Option.String('--tracer-libc', {
-    description: `The C standard library used by the application image for automatic instrumentation. Possible values: ${LIBCS.map(
+    description: `The C standard library used by the application image with --tracing inject --language. Possible values: ${LIBCS.map(
       (libc) => `"${libc}"`
     ).join(', ')}. Defaults to '${DEFAULT_TRACER_LIBC}'.`,
     validator: t.isEnum(LIBCS),

--- a/packages/base/src/helpers/serverless/ssi/injection-spec.ts
+++ b/packages/base/src/helpers/serverless/ssi/injection-spec.ts
@@ -21,29 +21,6 @@ export interface LanguageInjectionSpec {
   readonly env: readonly EnvFragment[]
 }
 
-export interface CompositeInjectionSpec {
-  readonly image: string
-  readonly mountPath: string
-  readonly env: readonly EnvFragment[]
-}
-
-export const COMPOSITE_TRACER_MOUNT_PATH = '/opt/datadog-packages'
-
-/** Builds the composite tracer image and activation contract for a cloud registry. */
-export const getCompositeInjectionSpec = (registry: SingleLanguageTracerRegistry): CompositeInjectionSpec => ({
-  image: `${registry}/dd-lib-composite-init:latest`,
-  mountPath: COMPOSITE_TRACER_MOUNT_PATH,
-  env: [
-    {
-      name: 'LD_PRELOAD',
-      value: `${COMPOSITE_TRACER_MOUNT_PATH}/datadog-apm-inject/stable/inject/launcher.preload.so`,
-      separator: ' ',
-      mode: 'prepend',
-    },
-    {name: 'DD_INJECT_SENDER_TYPE', value: 'serverless', mode: 'set-if-absent'},
-  ],
-})
-
 export interface LanguageInjectionOptions {
   readonly language: Language
   readonly registry: TracerRegistry

--- a/packages/base/src/helpers/serverless/ssi/injection-spec.ts
+++ b/packages/base/src/helpers/serverless/ssi/injection-spec.ts
@@ -21,6 +21,29 @@ export interface LanguageInjectionSpec {
   readonly env: readonly EnvFragment[]
 }
 
+export interface CompositeInjectionSpec {
+  readonly image: string
+  readonly mountPath: string
+  readonly env: readonly EnvFragment[]
+}
+
+export const COMPOSITE_TRACER_MOUNT_PATH = '/opt/datadog-packages'
+
+/** Builds the composite tracer image and activation contract for a cloud registry. */
+export const getCompositeInjectionSpec = (registry: SingleLanguageTracerRegistry): CompositeInjectionSpec => ({
+  image: `${registry}/dd-lib-composite-init:latest`,
+  mountPath: COMPOSITE_TRACER_MOUNT_PATH,
+  env: [
+    {
+      name: 'LD_PRELOAD',
+      value: `${COMPOSITE_TRACER_MOUNT_PATH}/datadog-apm-inject/stable/inject/launcher.preload.so`,
+      separator: ' ',
+      mode: 'prepend',
+    },
+    {name: 'DD_INJECT_SENDER_TYPE', value: 'serverless', mode: 'set-if-absent'},
+  ],
+})
+
 export interface LanguageInjectionOptions {
   readonly language: Language
   readonly registry: TracerRegistry

--- a/packages/plugin-cloud-run/README.md
+++ b/packages/plugin-cloud-run/README.md
@@ -16,20 +16,23 @@ datadog-ci cloud-run instrument -i
 # Instrument a service with a pinned or custom sidecar image
 datadog-ci cloud-run instrument -p <gcp-project> -r us-central1 -s <service-name> --sidecar-image gcr.io/datadoghq/serverless-init@sha256:<sha256>
 
-# Enable automatic APM instrumentation for a Python service
+# Enable automatic APM instrumentation with language detection
+datadog-ci cloud-run instrument -p <gcp-project> -r us-central1 -s <service-name> --tracing inject
+
+# Inject only the Python tracer
 datadog-ci cloud-run instrument -p <gcp-project> -r us-central1 -s <service-name> --tracing inject --language python
 
 # Dry run of all updates
 datadog-ci cloud-run instrument -p <gcp-project> -r us-central1 -s <service-name> -d
 ```
 
-`--tracing` controls APM instrumentation. Use `manual` when the application image already includes a tracer, `inject` with `--language` to install a Java, Node.js, .NET, Python, Ruby, or PHP tracer automatically, or `disabled` to turn tracing off. The existing values `true`/`1` and `false`/`0` remain aliases for `manual` and `disabled`. If omitted, the command preserves an existing `DD_TRACE_ENABLED` value or enables tracing when none is set.
+`--tracing` controls APM instrumentation. Use `inject` to detect the application language and inject a tracer automatically. Add `--language` to inject only the Java, Node.js, .NET, Python, Ruby, or PHP tracer. Use `manual` when the application image already includes a tracer, or use `disabled` to turn tracing off. The values `true`/`1` and `false`/`0` are aliases for `manual` and `disabled`. If you omit `--tracing`, the command preserves existing automatic instrumentation and `DD_TRACE_ENABLED` values, or enables tracing when no value exists.
 
-`--tracing inject` without `--language` is reserved for future multi-language automatic instrumentation and currently returns an unsupported error. Go tracers cannot be injected; install `dd-trace-go` in the application and use `--tracing manual`.
+Go tracers cannot be injected. Install `dd-trace-go` in the application, and use `--tracing manual`.
 
-`--language` continues to set `DD_SOURCE` for log parsing without enabling automatic instrumentation by itself. `--tracer-version`, `--tracer-libc`, and `--tracer-volume-medium` only apply with `--tracing inject`.
+`--language` without `--tracing inject` continues to set `DD_SOURCE` for log parsing. `--tracer-version` and `--tracer-libc` require both `--tracing inject` and `--language`. `--tracer-volume-medium` requires `--tracing inject`.
 
-Injected tracers use a 500 MiB memory-backed volume by default. Set `--tracer-volume-medium disk` to use a 10 GiB disk-backed volume. Disk volumes are a Preview feature that requires the BETA launch stage and second generation execution environment. The command sets those requirements when needed, preserves an existing ALPHA launch stage, and never falls back to memory if Cloud Run rejects the disk configuration.
+Automatic language detection uses a 1.5 GiB memory-backed volume and sets the tracer container's memory limit to 2 GiB. Explicit `--language` uses a 500 MiB memory-backed volume. Set `--tracer-volume-medium disk` to use a 10 GiB disk-backed volume in either mode. Disk volumes are a Preview feature that requires the BETA launch stage and second generation execution environment. The command sets those requirements when needed, preserves an existing ALPHA launch stage, and does not fall back to memory if Cloud Run rejects the disk configuration.
 
 Automatic instrumentation targets the main Cloud Run container. The command fails without changing the service when multiple containers make main-container selection ambiguous.
 
@@ -84,7 +87,7 @@ You can pass the following arguments to `instrument` to specify its behavior.
 | `--log-level` or `--logLevel` |  | Specify your Datadog log level. |  |
 | `--source-code-integration` or `--sourceCodeIntegration` |  | Whether to enable the Datadog Source Code integration. This tags your service(s) with the Git repository and the latest commit hash of the local directory. Specify `--no-source-code-integration` to disable. | `true` |
 | `--upload-git-metadata` or `--uploadGitMetadata` |  | Whether to enable Git metadata uploading, as a part of the source code integration. Git metadata uploading is only required if you don't have the Datadog GitHub integration installed. Specify `--no-upload-git-metadata` to disable. | `true` |
-| `--tracing` |  | Configure APM instrumentation. Use "manual" when the tracer is installed, "inject" with --language for automatic instrumentation, or "disabled" to turn tracing off. The legacy values "true"/"1" and "false"/"0" map to "manual" and "disabled". |  |
+| `--tracing` |  | Configure APM instrumentation. Use "manual" when the tracer is installed, "inject" to detect the language and add a tracer automatically, or "disabled" to turn tracing off. Add --language with "inject" to select one tracer. The legacy values "true"/"1" and "false"/"0" map to "manual" and "disabled". |  |
 | `--service-tag` or `--serviceTag` |  | The value for the service tag. Use this to group related Cloud Run services belonging to similar workloads. For example, `my-service`. If not provided, the Cloud Run service name is used. |  |
 | `--version` |  | The value for the version tag. Use this to correlate spikes in latency, load, or errors to new versions. For example, `1.0.0`. |  |
 | `--env` |  | The value for the env tag. Use this to separate your staging, development, and production environments. For example, `prod`. |  |
@@ -97,9 +100,9 @@ You can pass the following arguments to `instrument` to specify its behavior.
 | `--logs-path` |  | (Not recommended) Specify a custom log file path. Must begin with the shared volume path. | `/shared-volume/logs/*.log` |
 | `--sidecar-cpus` |  | The number of CPUs to allocate to the sidecar container. | `1` |
 | `--sidecar-memory` |  | The amount of memory to allocate to the sidecar container. | `512Mi` |
-| `--language` |  | Set the application language for advanced log parsing. With --tracing inject, also select the tracer for automatic instrumentation. Supported injection values: "java", "nodejs", "csharp", "python", "ruby", "php". |  |
-| `--tracer-version` |  | The tracer image tag to use with --tracing inject. | `latest` |
-| `--tracer-libc` |  | The C standard library used by the application image for automatic instrumentation. Possible values: "glibc", "musl". | `glibc` |
+| `--language` |  | Set the application language for advanced log parsing. With --tracing inject, also select the tracer for automatic instrumentation. Supported injection values: "java", "nodejs", "csharp", "python", "ruby", "php". Omit this option with --tracing inject to detect the language automatically. |  |
+| `--tracer-version` |  | The tracer image tag to use with --tracing inject --language. | `latest` |
+| `--tracer-libc` |  | The C standard library used by the application image with --tracing inject --language. Possible values: "glibc", "musl". | `glibc` |
 | `--tracer-volume-medium` |  | Storage medium for the injected tracer volume. Possible values: "memory", "disk". Defaults to "memory". "disk" uses a 10 GiB Preview volume, promotes the launch stage to at least BETA, and requires the second generation execution environment. |  |
 | `--tracer-readiness-port` |  | The tracer container readiness port. Must not conflict with the main application port or the Agent health-check port. | `18999` |
 <!-- END_USAGE:instrument -->

--- a/packages/plugin-cloud-run/README.md
+++ b/packages/plugin-cloud-run/README.md
@@ -36,6 +36,8 @@ Automatic language detection uses a 1.5 GiB memory-backed volume and sets the tr
 
 Automatic instrumentation targets the main Cloud Run container. The command fails without changing the service when multiple containers make main-container selection ambiguous.
 
+Automatic instrumentation can increase cold-start delays when the service scales to zero. For latency-sensitive scale-to-zero workloads, install the tracer in the application image, and use `--tracing manual`.
+
 ### `uninstrument`
 
 Run `datadog-ci cloud-run uninstrument` to revert Datadog instrumentation from a Cloud Run service. This command updates the configuration by removing the sidecar container, the shared log volume, and Datadog environment variables.

--- a/packages/plugin-cloud-run/src/__tests__/__snapshots__/instrument.test.ts.snap
+++ b/packages/plugin-cloud-run/src/__tests__/__snapshots__/instrument.test.ts.snap
@@ -19,7 +19,6 @@ exports[`InstrumentCommand snapshot tests interactive mode 1`] = `
 +     "dd_sls_ci": "v0_0_0",
 +     "service": "interactive-service"
 +   },
-    "name": "projects/interactive-project/locations/us-west1/services/interactive-service",
     "template": {
       "containers": [
         {
@@ -32,7 +31,7 @@ exports[`InstrumentCommand snapshot tests interactive mode 1`] = `
 +             "name": "DD_HEALTH_PORT",
 +             "value": "5555"
 +           },
-+           {
+            {
 +             "name": "DD_LOGS_INJECTION",
 +             "value": "true"
 +           },
@@ -52,14 +51,14 @@ exports[`InstrumentCommand snapshot tests interactive mode 1`] = `
 +             "name": "DD_TRACE_ENABLED",
 +             "value": "true"
 +           },
-            {
++           {
               "name": "NODE_ENV",
               "value": "production"
             }
           ],
           "image": "gcr.io/test-project/test-app:latest",
-          "name": "main-app",
--         "volumeMounts": []
+-         "name": "main-app"
++         "name": "main-app",
 +         "volumeMounts": [
 +           {
 +             "mountPath": "/shared-volume",
@@ -108,7 +107,6 @@ exports[`InstrumentCommand snapshot tests interactive mode 1`] = `
 +         },
 +         "startupProbe": {
 +           "failureThreshold": 3,
-+           "initialDelaySeconds": 0,
 +           "periodSeconds": 10,
 +           "tcpSocket": {
 +             "port": 5555
@@ -123,8 +121,7 @@ exports[`InstrumentCommand snapshot tests interactive mode 1`] = `
 +         ]
         }
       ],
--     "revision": "test-service-v1",
--     "volumes": []
+-     "revision": "test-service-v1"
 +     "volumes": [
 +       {
 +         "emptyDir": {
@@ -160,7 +157,6 @@ exports[`InstrumentCommand snapshot tests prints dry run data with basic flags 1
 +     "service": "test-service",
 +     "version": "1.0.0"
 +   },
-    "name": "projects/test-project/locations/us-central1/services/test-service",
     "template": {
       "containers": [
         {
@@ -189,7 +185,7 @@ exports[`InstrumentCommand snapshot tests prints dry run data with basic flags 1
 +             "name": "DD_SERVICE",
 +             "value": "test-service"
 +           },
-            {
++           {
 +             "name": "DD_SITE",
 +             "value": "datadoghq.com"
 +           },
@@ -201,14 +197,14 @@ exports[`InstrumentCommand snapshot tests prints dry run data with basic flags 1
 +             "name": "DD_VERSION",
 +             "value": "1.0.0"
 +           },
-+           {
+            {
               "name": "NODE_ENV",
               "value": "production"
             }
           ],
           "image": "gcr.io/test-project/test-app:latest",
-          "name": "main-app",
--         "volumeMounts": []
+-         "name": "main-app"
++         "name": "main-app",
 +         "volumeMounts": [
 +           {
 +             "mountPath": "/shared-volume",
@@ -265,7 +261,6 @@ exports[`InstrumentCommand snapshot tests prints dry run data with basic flags 1
 +         },
 +         "startupProbe": {
 +           "failureThreshold": 3,
-+           "initialDelaySeconds": 0,
 +           "periodSeconds": 10,
 +           "tcpSocket": {
 +             "port": 5555
@@ -280,8 +275,7 @@ exports[`InstrumentCommand snapshot tests prints dry run data with basic flags 1
 +         ]
         }
       ],
--     "revision": "test-service-v1",
--     "volumes": []
+-     "revision": "test-service-v1"
 +     "volumes": [
 +       {
 +         "emptyDir": {

--- a/packages/plugin-cloud-run/src/__tests__/__snapshots__/uninstrument.test.ts.snap
+++ b/packages/plugin-cloud-run/src/__tests__/__snapshots__/uninstrument.test.ts.snap
@@ -17,13 +17,11 @@ exports[`UninstrumentCommand snapshot tests interactive mode 1`] = `
 -   "labels": {
 -     "service": "test-service"
 -   },
-+   "labels": {},
-    "name": "projects/test-project/locations/us-central1/services/test-service",
     "template": {
       "containers": [
-        {
-          "env": [
-            {
+-       {
+-         "env": [
+-           {
 -             "name": "DD_API_KEY",
 -             "value": "test-api-key"
 -           }
@@ -37,9 +35,9 @@ exports[`UninstrumentCommand snapshot tests interactive mode 1`] = `
 -           }
 -         ]
 -       },
--       {
--         "env": [
--           {
+        {
+          "env": [
+            {
 -             "name": "DD_SERVICE",
 -             "value": "test-service"
 -           },
@@ -53,24 +51,22 @@ exports[`UninstrumentCommand snapshot tests interactive mode 1`] = `
             }
           ],
           "image": "gcr.io/test-project/test-app:latest",
-          "name": "main-app",
+-         "name": "main-app",
 -         "volumeMounts": [
 -           {
 -             "mountPath": "/shared-volume",
 -             "name": "shared-volume"
 -           }
 -         ]
-+         "volumeMounts": []
-        }
-      ],
+-       }
+-     ],
 -     "revision": "test-service-v1",
 -     "volumes": [
 -       {
--         "emptyDir": {},
 -         "name": "shared-volume"
--       }
--     ]
-+     "volumes": []
++         "name": "main-app"
+        }
+      ]
     }
   }
 ✅ Cloud Run uninstrumentation completed successfully!
@@ -94,13 +90,11 @@ exports[`UninstrumentCommand snapshot tests prints dry run data 1`] = `
 -   "labels": {
 -     "service": "test-service"
 -   },
-+   "labels": {},
-    "name": "projects/test-project/locations/us-central1/services/test-service",
     "template": {
       "containers": [
-        {
-          "env": [
-            {
+-       {
+-         "env": [
+-           {
 -             "name": "DD_API_KEY",
 -             "value": "test-api-key"
 -           }
@@ -114,9 +108,9 @@ exports[`UninstrumentCommand snapshot tests prints dry run data 1`] = `
 -           }
 -         ]
 -       },
--       {
--         "env": [
--           {
+        {
+          "env": [
+            {
 -             "name": "DD_SERVICE",
 -             "value": "test-service"
 -           },
@@ -130,24 +124,22 @@ exports[`UninstrumentCommand snapshot tests prints dry run data 1`] = `
             }
           ],
           "image": "gcr.io/test-project/test-app:latest",
-          "name": "main-app",
+-         "name": "main-app",
 -         "volumeMounts": [
 -           {
 -             "mountPath": "/shared-volume",
 -             "name": "shared-volume"
 -           }
 -         ]
-+         "volumeMounts": []
-        }
-      ],
+-       }
+-     ],
 -     "revision": "test-service-v1",
 -     "volumes": [
 -       {
--         "emptyDir": {},
 -         "name": "shared-volume"
--       }
--     ]
-+     "volumes": []
++         "name": "main-app"
+        }
+      ]
     }
   }
 

--- a/packages/plugin-cloud-run/src/__tests__/instrument.test.ts
+++ b/packages/plugin-cloud-run/src/__tests__/instrument.test.ts
@@ -27,6 +27,7 @@ const mockServicesClient = {
   updateService: jest.fn(),
 }
 jest.mock('@google-cloud/run', () => ({
+  ...jest.requireActual('@google-cloud/run'),
   ServicesClient: jest.fn(() => mockServicesClient),
 }))
 
@@ -47,6 +48,12 @@ describe('InstrumentCommand', () => {
     mockServicesClient.servicePath.mockImplementation(
       (project, region, service) => `projects/${project}/locations/${region}/services/${service}`
     )
+    mockServicesClient.updateService.mockImplementation(({service}) => [
+      {
+        metadata: service,
+        promise: jest.fn().mockResolvedValue([]),
+      },
+    ])
   })
 
   describe('validates required variables', () => {
@@ -137,8 +144,8 @@ describe('InstrumentCommand', () => {
     ]
 
     test.each([
-      [['--tracing', 'inject', '--tracer-version', 'latest'], 'require --language'],
-      [['--tracing', 'inject', '--tracer-libc', 'glibc'], 'require --language'],
+      [['--tracing', 'inject', '--tracer-version', 'latest'], 'requires --language'],
+      [['--tracing', 'inject', '--tracer-libc', 'glibc'], 'requires --language'],
       [['--tracer-version', 'latest'], 'require --tracing inject'],
       [['--tracer-volume-medium', 'disk'], 'require --tracing inject'],
       [['--tracing', 'inject', '--language', 'go'], 'dd-trace-go'],
@@ -305,11 +312,6 @@ describe('InstrumentCommand', () => {
       process.env[SERVICE_ENV_VAR] = 'test-service'
 
       mockServicesClient.getService.mockResolvedValue([mockService])
-
-      const mockOperation = {
-        promise: jest.fn().mockResolvedValue([]),
-      }
-      mockServicesClient.updateService.mockResolvedValue([mockOperation])
 
       jest.restoreAllMocks()
 

--- a/packages/plugin-cloud-run/src/__tests__/instrument.test.ts
+++ b/packages/plugin-cloud-run/src/__tests__/instrument.test.ts
@@ -137,7 +137,8 @@ describe('InstrumentCommand', () => {
     ]
 
     test.each([
-      [['--tracing', 'inject'], 'requires --language'],
+      [['--tracing', 'inject', '--tracer-version', 'latest'], 'require --language'],
+      [['--tracing', 'inject', '--tracer-libc', 'glibc'], 'require --language'],
       [['--tracer-version', 'latest'], 'require --tracing inject'],
       [['--tracer-volume-medium', 'disk'], 'require --tracing inject'],
       [['--tracing', 'inject', '--language', 'go'], 'dd-trace-go'],
@@ -185,6 +186,20 @@ describe('InstrumentCommand', () => {
       const options = instrumentConfig.mock.calls[0][1]
       expect(options.ssiConfig?.kind).toBe(configKind)
       expect(options.envVarsByName.DD_TRACE_ENABLED?.value).toBe(traceEnabled)
+    })
+
+    test('--tracing inject without a language selects multi-language injection', async () => {
+      mockServicesClient.getService.mockResolvedValue([service])
+      const instrumentConfig = jest.spyOn(serviceConfigModule, 'instrumentServiceConfig')
+
+      const {code} = await runCLI([...requiredFlags, '--dry-run', '--tracing', 'inject'])
+
+      expect(code).toBe(0)
+      expect(instrumentConfig.mock.calls[0][1].ssiConfig).toEqual({
+        kind: 'multi-language',
+        tracerVolumeMedium: 'memory',
+        warnings: [],
+      })
     })
 
     test('--language sets the log source without automatic instrumentation', async () => {

--- a/packages/plugin-cloud-run/src/__tests__/instrument.test.ts
+++ b/packages/plugin-cloud-run/src/__tests__/instrument.test.ts
@@ -51,7 +51,7 @@ describe('InstrumentCommand', () => {
     mockServicesClient.updateService.mockImplementation(({service}) => [
       {
         metadata: service,
-        promise: jest.fn().mockResolvedValue([]),
+        promise: jest.fn().mockResolvedValue([service]),
       },
     ])
   })
@@ -202,11 +202,13 @@ describe('InstrumentCommand', () => {
       const {code} = await runCLI([...requiredFlags, '--dry-run', '--tracing', 'inject'])
 
       expect(code).toBe(0)
-      expect(instrumentConfig.mock.calls[0][1].ssiConfig).toEqual({
-        kind: 'multi-language',
-        tracerVolumeMedium: 'memory',
-        warnings: [],
-      })
+      expect(instrumentConfig.mock.calls[0][1].ssiConfig).toEqual(
+        expect.objectContaining({
+          kind: 'multi-language',
+          tracerVolumeMedium: 'memory',
+          warnings: [],
+        })
+      )
     })
 
     test('--language sets the log source without automatic instrumentation', async () => {

--- a/packages/plugin-cloud-run/src/__tests__/ssi.test.ts
+++ b/packages/plugin-cloud-run/src/__tests__/ssi.test.ts
@@ -22,10 +22,14 @@ import {TRACER_INJECTION_LANGUAGES, type Language} from '@datadog/datadog-ci-bas
 
 import {instrumentServiceConfig} from '../service-config'
 import {
+  COMPOSITE_TRACER_COMPLETION_MARKER,
+  COMPOSITE_TRACER_IMAGE,
+  COMPOSITE_TRACER_MOUNT_PATH,
   getTracingEnvValue,
+  mergeCompositeInjectionEnv,
   mergeLanguageInjectionEnv,
   normalizeTracingMode,
-  removeLanguageInjectionEnv,
+  removeInjectionEnv,
   resolveSsiConfig,
   selectMainContainer,
   SsiConfigError,
@@ -97,21 +101,20 @@ describe('resolveSsiConfig', () => {
     )
   })
 
-  test('defaults the tracer volume to memory and accepts disk', () => {
-    const memory = resolveSsiConfig({...defaultOptions, tracing: 'inject', language: 'nodejs'})
-    const disk = resolveSsiConfig({
-      ...defaultOptions,
-      tracing: 'inject',
-      language: 'nodejs',
-      tracerVolumeMedium: 'disk',
-    })
+  test.each([
+    ['nodejs', 'single-language'],
+    [undefined, 'multi-language'],
+  ] as const)('defaults %s injection to memory and accepts disk', (language, kind) => {
+    const memory = resolveSsiConfig({...defaultOptions, tracing: 'inject', language})
+    const disk = resolveSsiConfig({...defaultOptions, tracing: 'inject', language, tracerVolumeMedium: 'disk'})
 
-    expect(memory).toMatchObject({kind: 'single-language', tracerVolumeMedium: 'memory'})
-    expect(disk).toMatchObject({kind: 'single-language', tracerVolumeMedium: 'disk'})
+    expect(memory).toMatchObject({kind, tracerVolumeMedium: 'memory'})
+    expect(disk).toMatchObject({kind, tracerVolumeMedium: 'disk'})
   })
 
   test.each([
-    [{tracing: 'inject'}, '--language'],
+    [{tracing: 'inject', tracerVersion: 'latest'}, '--tracer-version'],
+    [{tracing: 'inject', tracerLibc: 'glibc'}, '--tracer-libc'],
     [{tracing: 'inject', language: 'go'}, '--tracing manual'],
     [{tracing: 'inject', language: 'ruby', tracerLibc: 'musl'}, 'musl'],
     [{tracing: 'inject', language: 'csharp', tracerVersion: '2.51.0'}, 'Use tracer version 3.0'],
@@ -174,6 +177,42 @@ describe('language injection environment', () => {
     ).toThrow(/more than once/)
   })
 
+  test('merges and removes multi-language activation while preserving compatible preload entries', () => {
+    const existing: IEnvVar[] = [{name: 'LD_PRELOAD', value: '/customer/preload.so'}]
+    const injected = mergeCompositeInjectionEnv(existing)
+
+    expect(injected).toEqual([
+      {
+        name: 'LD_PRELOAD',
+        value: '/opt/datadog-packages/datadog-apm-inject/stable/inject/launcher.preload.so /customer/preload.so',
+      },
+      {name: 'DD_INJECT_SENDER_TYPE', value: 'serverless'},
+    ])
+    expect(mergeCompositeInjectionEnv(injected)).toEqual(injected)
+    expect(removeInjectionEnv(injected)).toEqual(existing)
+  })
+
+  test.each(['LD_PRELOAD', 'DD_INJECT_SENDER_TYPE'])('rejects duplicate multi-language %s values', (name) => {
+    expect(() =>
+      mergeCompositeInjectionEnv([
+        {name, value: 'first'},
+        {name, value: 'second'},
+      ])
+    ).toThrow(/more than once/)
+  })
+
+  test.each(['LD_PRELOAD', 'DD_INJECT_SENDER_TYPE'])('rejects a secret-backed multi-language %s value', (name) => {
+    expect(() => mergeCompositeInjectionEnv([{name, valueSource: {secretKeyRef: {secret: 'secret'}}}])).toThrow(
+      SsiConfigError
+    )
+  })
+
+  test('rejects a conflicting injection sender', () => {
+    expect(() => mergeCompositeInjectionEnv([{name: 'DD_INJECT_SENDER_TYPE', value: 'customer'}])).toThrow(
+      /DD_INJECT_SENDER_TYPE is already set/
+    )
+  })
+
   test('reports a conflicting scalar value', () => {
     expect(() =>
       mergeLanguageInjectionEnv([{name: 'CORECLR_ENABLE_PROFILING', value: '0'}], getSpec('csharp'))
@@ -189,7 +228,7 @@ describe('language injection environment', () => {
       getSpec(language, libc)
     )
 
-    expect(removeLanguageInjectionEnv(injected)).toEqual([
+    expect(removeInjectionEnv(injected)).toEqual([
       {name: 'CUSTOM', value: 'keep'},
       {name: 'DD_TAGS', value: 'team:backend'},
     ])
@@ -199,7 +238,7 @@ describe('language injection environment', () => {
     const markerlessJava = mergeLanguageInjectionEnv([{name: 'CUSTOM', value: 'keep'}], getSpec('java')).filter(
       (variable) => variable.name !== 'DD_TAGS'
     )
-    const replaced = mergeLanguageInjectionEnv(removeLanguageInjectionEnv(markerlessJava), nodeSpec)
+    const replaced = mergeLanguageInjectionEnv(removeInjectionEnv(markerlessJava), nodeSpec)
 
     expect(replaced).toEqual([
       {name: 'CUSTOM', value: 'keep'},
@@ -214,15 +253,15 @@ describe('language injection environment', () => {
       {name: 'DD_TAGS', value: ''},
     ]
 
-    expect(removeLanguageInjectionEnv(env)).toEqual(env)
+    expect(removeInjectionEnv(env)).toEqual(env)
   })
 
   test('removes both known PHP libc paths while preserving other scan directories', () => {
     const glibc = getSpec('php', 'glibc').env[0].value
     const musl = getSpec('php', 'musl').env[0].value
-    expect(
-      removeLanguageInjectionEnv([{name: 'PHP_INI_SCAN_DIR', value: `/etc/php:${glibc}:${musl}:/custom/php`}])
-    ).toEqual([{name: 'PHP_INI_SCAN_DIR', value: '/etc/php:/custom/php'}])
+    expect(removeInjectionEnv([{name: 'PHP_INI_SCAN_DIR', value: `/etc/php:${glibc}:${musl}:/custom/php`}])).toEqual([
+      {name: 'PHP_INI_SCAN_DIR', value: '/etc/php:/custom/php'},
+    ])
   })
 })
 
@@ -261,13 +300,13 @@ describe('selectMainContainer', () => {
 })
 
 const serviceConfigOptions = (
-  language: Language | 'none' = 'nodejs',
+  language: Language | 'multi' | 'none' = 'nodejs',
   tracerVolumeMedium: SsiOptions['tracerVolumeMedium'] = undefined
 ): InstrumentServiceConfigOptions => ({
   ssiConfig: resolveSsiConfig({
     ...defaultOptions,
     tracing: language === 'none' ? undefined : 'inject',
-    language: language === 'none' ? undefined : language,
+    language: language === 'none' || language === 'multi' ? undefined : language,
     tracerVolumeMedium,
   }),
   ddService: 'service',
@@ -374,6 +413,53 @@ describe('SSI service preparation', () => {
     })
   })
 
+  test('applies multi-language activation and the composite memory lifecycle', () => {
+    const result = instrumentServiceConfig(serviceWithWorker(), serviceConfigOptions('multi'))
+    const app = result.template?.containers?.find((container) => container.name === 'app')
+    const tracer = result.template?.containers?.find((container) => container.name === TRACER_CONTAINER_NAME)
+
+    expect(app?.env).toEqual(
+      expect.arrayContaining([
+        {
+          name: 'LD_PRELOAD',
+          value: `${COMPOSITE_TRACER_MOUNT_PATH}/datadog-apm-inject/stable/inject/launcher.preload.so`,
+        },
+        {name: 'DD_INJECT_SENDER_TYPE', value: 'serverless'},
+      ])
+    )
+    expect(app?.volumeMounts).toContainEqual({name: TRACER_CONTAINER_NAME, mountPath: COMPOSITE_TRACER_MOUNT_PATH})
+    expect(app?.dependsOn).toEqual([TRACER_CONTAINER_NAME, 'datadog-sidecar'])
+    expect(tracer).toMatchObject({
+      image: COMPOSITE_TRACER_IMAGE,
+      volumeMounts: [{name: TRACER_CONTAINER_NAME, mountPath: COMPOSITE_TRACER_MOUNT_PATH}],
+      resources: {limits: {memory: '2Gi'}},
+    })
+    expect(tracer?.args?.slice(2)).toEqual([
+      TRACER_CONTAINER_NAME,
+      COMPOSITE_TRACER_MOUNT_PATH,
+      COMPOSITE_TRACER_COMPLETION_MARKER,
+      String(TRACER_READINESS_PORT),
+    ])
+    expect(result.template?.volumes?.find((volume) => volume.name === TRACER_CONTAINER_NAME)).toEqual({
+      name: TRACER_CONTAINER_NAME,
+      emptyDir: {medium: 1, sizeLimit: '1.5Gi'},
+    })
+    expect(result.labels?.dd_sls_injection_mode).toBe('multi_language')
+  })
+
+  test('uses disk for multi-language injection without a tracer memory limit', () => {
+    const result = instrumentServiceConfig(serviceWithWorker(), serviceConfigOptions('multi', 'disk'))
+    const tracer = result.template?.containers?.find((container) => container.name === TRACER_CONTAINER_NAME)
+
+    expect(tracer?.resources).toBeUndefined()
+    expect(result.template?.volumes?.find((volume) => volume.name === TRACER_CONTAINER_NAME)).toEqual({
+      name: TRACER_CONTAINER_NAME,
+      emptyDir: {medium: 2, sizeLimit: '10Gi'},
+    })
+    expect(result.launchStage).toBe('BETA')
+    expect(result.template?.executionEnvironment).toBe(2)
+  })
+
   test.each([
     [undefined, 'BETA'],
     ['LAUNCH_STAGE_UNSPECIFIED', 'BETA'],
@@ -438,6 +524,43 @@ describe('SSI service preparation', () => {
     expect(result.launchStage).toBe('BETA')
     expect(result.template?.executionEnvironment).toBe(2)
   })
+
+  test('switches between single- and multi-language injection idempotently', () => {
+    const single = instrumentServiceConfig(serviceWithWorker(), serviceConfigOptions())
+    const multi = instrumentServiceConfig(single, serviceConfigOptions('multi'))
+    const singleAgain = instrumentServiceConfig(multi, serviceConfigOptions('python'))
+
+    expect(multi.labels?.dd_sls_injection_mode).toBe('multi_language')
+    expect(multi.template?.containers?.find(({name}) => name === 'app')?.env).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({name: 'NODE_OPTIONS', value: expect.stringContaining('/datadog-lib')}),
+      ])
+    )
+    expect(instrumentServiceConfig(multi, serviceConfigOptions('multi'))).toEqual(multi)
+    expect(singleAgain.labels?.dd_sls_injection_mode).toBe('single_language')
+    expect(singleAgain.template?.containers?.find(({name}) => name === 'app')?.env).toEqual(
+      expect.arrayContaining([expect.objectContaining({name: 'PYTHONPATH', value: '/datadog-lib'})])
+    )
+    expect(singleAgain.template?.containers?.find(({name}) => name === 'app')?.env).not.toEqual(
+      expect.arrayContaining([expect.objectContaining({name: 'DD_INJECT_SENDER_TYPE'})])
+    )
+  })
+
+  test.each([
+    ['single-language', 'NODE_OPTIONS', serviceConfigOptions()],
+    ['multi-language', 'LD_PRELOAD', serviceConfigOptions('multi')],
+  ] satisfies [string, string, InstrumentServiceConfigOptions][])(
+    'rejects duplicate %s environment values before Agent environment normalization',
+    (_mode, name, options) => {
+      const service = serviceWithWorker()
+      service.template!.containers![0].env = [
+        {name, value: 'first'},
+        {name, value: 'second'},
+      ]
+
+      expect(() => instrumentServiceConfig(service, options)).toThrow(/more than once/)
+    }
+  )
 
   test('uses the configured readiness port for the tracer container', () => {
     const result = instrumentServiceConfig(serviceWithWorker(), {
@@ -620,6 +743,55 @@ describe('SSI service preparation', () => {
     expect(app.env?.find((variable) => variable.name === 'DD_TAGS')).toBeUndefined()
     expect(app.volumeMounts?.map((mount) => mount.name)).not.toContain('datadog-tracer')
     expect(result.template!.containers![1].dependsOn).toBeUndefined()
+  })
+
+  test('manual tracing removes drifted multi-language state and preserves single-language fragments', () => {
+    const service = serviceWithWorker()
+    service.template!.containers![0].env = [
+      {name: 'NODE_OPTIONS', value: '--inspect --require /datadog-lib/node_modules/dd-trace/init.js'},
+    ]
+    const injected = instrumentServiceConfig(service, serviceConfigOptions('multi'))
+    const injectedApp = injected.template!.containers!.find(({name}) => name === 'app')!
+    injectedApp.volumeMounts = injectedApp.volumeMounts?.filter(({name}) => name !== TRACER_CONTAINER_NAME)
+    const options = serviceConfigOptions('none')
+    const result = instrumentServiceConfig(injected, {
+      ...options,
+      ssiConfig: resolveSsiConfig({...defaultOptions, tracing: 'manual'}),
+      envVarsByName: {
+        ...options.envVarsByName,
+        [DD_TRACE_ENABLED_ENV_VAR]: {name: DD_TRACE_ENABLED_ENV_VAR, value: 'true'},
+      },
+    })
+    const app = result.template?.containers?.find(({name}) => name === 'app')
+
+    expect(result.labels).not.toHaveProperty('dd_sls_injection_mode')
+    expect(result.template?.containers?.find(({name}) => name === TRACER_CONTAINER_NAME)).toBeUndefined()
+    expect(app?.env).toContainEqual({
+      name: 'NODE_OPTIONS',
+      value: '--inspect --require /datadog-lib/node_modules/dd-trace/init.js',
+    })
+    expect(app?.env?.find(({name}) => name === 'LD_PRELOAD')).toBeUndefined()
+    expect(app?.env?.find(({name}) => name === 'DD_INJECT_SENDER_TYPE')).toBeUndefined()
+  })
+
+  test('single-language cleanup preserves multi-language sender configuration', () => {
+    const service = serviceWithWorker()
+    service.template!.containers![0].env!.push({name: 'DD_INJECT_SENDER_TYPE', value: 'serverless'})
+    const injected = instrumentServiceConfig(service, serviceConfigOptions())
+    const options = serviceConfigOptions('none')
+    const result = instrumentServiceConfig(injected, {
+      ...options,
+      ssiConfig: resolveSsiConfig({...defaultOptions, tracing: 'disabled'}),
+      envVarsByName: {
+        ...options.envVarsByName,
+        [DD_TRACE_ENABLED_ENV_VAR]: {name: DD_TRACE_ENABLED_ENV_VAR, value: 'false'},
+      },
+    })
+
+    expect(result.template?.containers?.find(({name}) => name === 'app')?.env).toContainEqual({
+      name: 'DD_INJECT_SENDER_TYPE',
+      value: 'serverless',
+    })
   })
 
   test('omitting SSI configuration preserves owned SSI', () => {

--- a/packages/plugin-cloud-run/src/__tests__/ssi.test.ts
+++ b/packages/plugin-cloud-run/src/__tests__/ssi.test.ts
@@ -666,7 +666,7 @@ describe('SSI service preparation', () => {
     expect(instrumentServiceConfig(injected, serviceConfigOptions('python')).template?.containers?.[0].name).toBe('')
   })
 
-  test('replaces owned SSI without removing unrelated container configuration', () => {
+  test('replaces owned SSI and removes stale injection from other containers', () => {
     const node = instrumentServiceConfig(serviceWithWorker(), serviceConfigOptions())
     const app = node.template!.containers![0]
     const worker = node.template!.containers![1]
@@ -681,7 +681,7 @@ describe('SSI service preparation', () => {
     expect(updatedApp?.env).toContainEqual({name: 'NODE_OPTIONS', value: '--inspect'})
     expect(updatedApp?.env).toContainEqual({name: 'PYTHONPATH', value: '/datadog-lib'})
     expect(updatedApp?.dependsOn).toEqual(['datadog-tracer', 'datadog-sidecar'])
-    expect(updatedWorker?.env).toEqual(worker.env)
+    expect(updatedWorker?.env).toEqual([{name: 'WORKER', value: 'true'}])
     expect(updatedWorker?.dependsOn).toEqual(['datadog-sidecar'])
     expect(result.template?.containers?.filter((container) => container.name === 'datadog-tracer')).toHaveLength(1)
     expect(result.template?.containers?.find((container) => container.name === 'datadog-tracer')?.image).toBe(
@@ -745,7 +745,7 @@ describe('SSI service preparation', () => {
     expect(result.template!.containers![1].dependsOn).toBeUndefined()
   })
 
-  test('manual tracing removes drifted multi-language state and preserves single-language fragments', () => {
+  test('manual tracing removes all drifted injection state', () => {
     const service = serviceWithWorker()
     service.template!.containers![0].env = [
       {name: 'NODE_OPTIONS', value: '--inspect --require /datadog-lib/node_modules/dd-trace/init.js'},
@@ -766,15 +766,12 @@ describe('SSI service preparation', () => {
 
     expect(result.labels).not.toHaveProperty('dd_sls_injection_mode')
     expect(result.template?.containers?.find(({name}) => name === TRACER_CONTAINER_NAME)).toBeUndefined()
-    expect(app?.env).toContainEqual({
-      name: 'NODE_OPTIONS',
-      value: '--inspect --require /datadog-lib/node_modules/dd-trace/init.js',
-    })
+    expect(app?.env).toContainEqual({name: 'NODE_OPTIONS', value: '--inspect'})
     expect(app?.env?.find(({name}) => name === 'LD_PRELOAD')).toBeUndefined()
     expect(app?.env?.find(({name}) => name === 'DD_INJECT_SENDER_TYPE')).toBeUndefined()
   })
 
-  test('single-language cleanup preserves multi-language sender configuration', () => {
+  test('single-language cleanup removes multi-language activation', () => {
     const service = serviceWithWorker()
     service.template!.containers![0].env!.push({name: 'DD_INJECT_SENDER_TYPE', value: 'serverless'})
     const injected = instrumentServiceConfig(service, serviceConfigOptions())
@@ -788,7 +785,7 @@ describe('SSI service preparation', () => {
       },
     })
 
-    expect(result.template?.containers?.find(({name}) => name === 'app')?.env).toContainEqual({
+    expect(result.template?.containers?.find(({name}) => name === 'app')?.env).not.toContainEqual({
       name: 'DD_INJECT_SENDER_TYPE',
       value: 'serverless',
     })

--- a/packages/plugin-cloud-run/src/__tests__/uninstrument.test.ts
+++ b/packages/plugin-cloud-run/src/__tests__/uninstrument.test.ts
@@ -34,6 +34,7 @@ const mockServicesClient = {
 }
 
 jest.mock('@google-cloud/run', () => ({
+  ...jest.requireActual('@google-cloud/run'),
   ServicesClient: jest.fn(() => mockServicesClient),
 }))
 
@@ -47,6 +48,12 @@ describe('UninstrumentCommand', () => {
       (project: string, region: string, service: string) =>
         `projects/${project}/locations/${region}/services/${service}`
     )
+    mockServicesClient.updateService.mockImplementation(({service}) => [
+      {
+        metadata: service,
+        promise: jest.fn().mockResolvedValue([]),
+      },
+    ])
   })
 
   describe('validates required variables', () => {
@@ -129,7 +136,6 @@ describe('UninstrumentCommand', () => {
 
     beforeEach(() => {
       mockServicesClient.getService.mockResolvedValue([mockService])
-      mockServicesClient.updateService.mockResolvedValue([{promise: jest.fn().mockResolvedValue([])}])
       jest.restoreAllMocks()
       ;(utils.checkAuthentication as jest.Mock).mockResolvedValue(true)
     })
@@ -279,7 +285,7 @@ describe('UninstrumentCommand', () => {
       expect(result.template?.volumes).toEqual([{name: 'customer-volume', emptyDir: {}}])
     })
 
-    test('removes recognizable multi-language state without an injection label', () => {
+    test('preserves unowned tracer resources', () => {
       const preload = '/opt/datadog-packages/datadog-apm-inject/stable/inject/launcher.preload.so'
       const service: IService = {
         labels: {customer: 'keep-me'},
@@ -308,14 +314,15 @@ describe('UninstrumentCommand', () => {
         expect.objectContaining({
           name: 'app',
           env: [
-            {name: 'LD_PRELOAD', value: '/customer/preload.so'},
+            {name: 'LD_PRELOAD', value: `${preload} /customer/preload.so`},
             {name: 'CUSTOM_VAR', value: 'keep-me'},
           ],
-          volumeMounts: [],
-          dependsOn: ['database'],
+          volumeMounts: [{name: TRACER_VOLUME_NAME, mountPath: '/opt/datadog-packages'}],
+          dependsOn: [TRACER_CONTAINER_NAME, 'database'],
         }),
+        expect.objectContaining({name: TRACER_CONTAINER_NAME}),
       ])
-      expect(result.template?.volumes).toEqual([])
+      expect(result.template?.volumes).toEqual([{name: TRACER_VOLUME_NAME, emptyDir: {}}])
     })
 
     test('keeps an unnamed main container unnamed', () => {

--- a/packages/plugin-cloud-run/src/__tests__/uninstrument.test.ts
+++ b/packages/plugin-cloud-run/src/__tests__/uninstrument.test.ts
@@ -279,6 +279,45 @@ describe('UninstrumentCommand', () => {
       expect(result.template?.volumes).toEqual([{name: 'customer-volume', emptyDir: {}}])
     })
 
+    test('removes recognizable multi-language state without an injection label', () => {
+      const preload = '/opt/datadog-packages/datadog-apm-inject/stable/inject/launcher.preload.so'
+      const service: IService = {
+        labels: {customer: 'keep-me'},
+        template: {
+          containers: [
+            {
+              name: 'app',
+              env: [
+                {name: 'LD_PRELOAD', value: `${preload} /customer/preload.so`},
+                {name: 'DD_INJECT_SENDER_TYPE', value: 'serverless'},
+                {name: 'CUSTOM_VAR', value: 'keep-me'},
+              ],
+              volumeMounts: [{name: TRACER_VOLUME_NAME, mountPath: '/opt/datadog-packages'}],
+              dependsOn: [TRACER_CONTAINER_NAME, 'database'],
+            },
+            {name: TRACER_CONTAINER_NAME},
+          ],
+          volumes: [{name: TRACER_VOLUME_NAME, emptyDir: {}}],
+        },
+      }
+
+      const result = command.createUninstrumentedServiceConfig(service)
+
+      expect(result.labels).toEqual({customer: 'keep-me'})
+      expect(result.template?.containers).toEqual([
+        expect.objectContaining({
+          name: 'app',
+          env: [
+            {name: 'LD_PRELOAD', value: '/customer/preload.so'},
+            {name: 'CUSTOM_VAR', value: 'keep-me'},
+          ],
+          volumeMounts: [],
+          dependsOn: ['database'],
+        }),
+      ])
+      expect(result.template?.volumes).toEqual([])
+    })
+
     test('keeps an unnamed main container unnamed', () => {
       const service: IService = {
         labels: {

--- a/packages/plugin-cloud-run/src/__tests__/uninstrument.test.ts
+++ b/packages/plugin-cloud-run/src/__tests__/uninstrument.test.ts
@@ -51,7 +51,7 @@ describe('UninstrumentCommand', () => {
     mockServicesClient.updateService.mockImplementation(({service}) => [
       {
         metadata: service,
-        promise: jest.fn().mockResolvedValue([]),
+        promise: jest.fn().mockResolvedValue([service]),
       },
     ])
   })
@@ -323,6 +323,50 @@ describe('UninstrumentCommand', () => {
         expect.objectContaining({name: TRACER_CONTAINER_NAME}),
       ])
       expect(result.template?.volumes).toEqual([{name: TRACER_VOLUME_NAME, emptyDir: {}}])
+    })
+
+    test('removes a complete markerless composite SSI signature', () => {
+      const preload = '/opt/datadog-packages/datadog-apm-inject/stable/inject/launcher.preload.so'
+      const service: IService = {
+        labels: {customer: 'keep-me'},
+        template: {
+          containers: [
+            {
+              name: 'app',
+              env: [
+                {name: 'LD_PRELOAD', value: `${preload} /customer/preload.so`},
+                {name: 'DD_INJECT_SENDER_TYPE', value: 'serverless'},
+                {name: 'CUSTOM_VAR', value: 'keep-me'},
+              ],
+              volumeMounts: [{name: TRACER_VOLUME_NAME, mountPath: '/opt/datadog-packages'}],
+              dependsOn: [TRACER_CONTAINER_NAME, 'database'],
+            },
+            {
+              name: TRACER_CONTAINER_NAME,
+              image: 'gcr.io/datadoghq/dd-lib-composite-init:latest',
+              command: ['/bin/sh'],
+              args: ['-c', 'script', TRACER_CONTAINER_NAME, '/opt/datadog-packages'],
+            },
+          ],
+          volumes: [{name: TRACER_VOLUME_NAME, emptyDir: {}}],
+        },
+      }
+
+      const result = command.createUninstrumentedServiceConfig(service)
+
+      expect(result.labels).toEqual({customer: 'keep-me'})
+      expect(result.template?.containers).toEqual([
+        expect.objectContaining({
+          name: 'app',
+          env: [
+            {name: 'LD_PRELOAD', value: '/customer/preload.so'},
+            {name: 'CUSTOM_VAR', value: 'keep-me'},
+          ],
+          volumeMounts: [],
+          dependsOn: ['database'],
+        }),
+      ])
+      expect(result.template?.volumes).toEqual([])
     })
 
     test('keeps an unnamed main container unnamed', () => {

--- a/packages/plugin-cloud-run/src/commands/instrument.ts
+++ b/packages/plugin-cloud-run/src/commands/instrument.ts
@@ -1,3 +1,4 @@
+import type {ServiceUpdatePreview} from '../service-update'
 import type {SsiConfigResult} from '../ssi'
 import type {IEnvVar, IService} from '../types'
 import type {ServerlessConfigOptions} from '@datadog/datadog-ci-base/helpers/serverless/common'
@@ -9,7 +10,7 @@ import {newApiKeyValidator} from '@datadog/datadog-ci-base/helpers/apikey'
 import {toBoolean} from '@datadog/datadog-ci-base/helpers/env'
 import {enableFips} from '@datadog/datadog-ci-base/helpers/fips'
 import {renderError, renderSoftWarning} from '@datadog/datadog-ci-base/helpers/renderer'
-import {generateConfigDiff, getBaseEnvVars} from '@datadog/datadog-ci-base/helpers/serverless/common'
+import {getBaseEnvVars} from '@datadog/datadog-ci-base/helpers/serverless/common'
 import {
   DD_LOG_LEVEL_ENV_VAR,
   DD_SOURCE_ENV_VAR,
@@ -30,8 +31,16 @@ import chalk from 'chalk'
 import {requestGCPProject, requestGCPRegion, requestServiceName, requestSite, requestConfirmation} from '../prompt'
 import {dryRunPrefix, renderAuthenticationInstructions, withSpinner} from '../renderer'
 import {instrumentServiceConfig} from '../service-config'
+import {previewServiceUpdate} from '../service-update'
 import {getTracingEnvValue, normalizeTracingMode, resolveSsiConfig} from '../ssi'
 import {checkAuthentication, fetchServiceConfigs} from '../utils'
+
+interface InstrumentedServiceUpdate {
+  existingService: IService
+  updatedService: IService
+  serviceName: string
+  preview: ServiceUpdatePreview
+}
 
 export class PluginCommand extends CloudRunInstrumentCommand {
   protected fipsConfig = {
@@ -188,52 +197,45 @@ export class PluginCommand extends CloudRunInstrumentCommand {
     this.context.stdout.write(
       chalk.bold(`\n${dryRunPrefix(this.dryRun)}🚀 Instrumenting Cloud Run services with sidecar...\n`)
     )
-    for (let i = 0; i < existingServiceConfigs.length; i++) {
-      const serviceConfig = existingServiceConfigs[i]
-      const serviceName = services[i]
+    const updates = await Promise.all(
+      existingServiceConfigs.map(async (existingService, index): Promise<InstrumentedServiceUpdate> => {
+        const serviceName = services[index]
+        try {
+          const ssiConfig = this.getSsiConfig()
+          if (
+            (ssiConfig.kind === 'single-language' || ssiConfig.kind === 'multi-language') &&
+            (existingService.template?.scaling?.minInstanceCount ?? 0) === 0
+          ) {
+            this.context.stdout.write(
+              renderSoftWarning(
+                `Automatic APM instrumentation can increase cold-start delays for ${serviceName} because scale-to-zero is enabled. Prefer manual instrumentation for scale-to-zero workloads.`
+              )
+            )
+          }
+          const updatedService = this.createInstrumentedServiceConfig(existingService, ddService ?? serviceName)
+          const preview = await previewServiceUpdate(client, existingService, updatedService)
+
+          return {existingService, updatedService, serviceName, preview}
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error)
+          throw new Error(`Failed to validate service ${serviceName}: ${message}`)
+        }
+      })
+    )
+
+    const updatedServices: string[] = []
+    for (const update of updates) {
       try {
-        const actualDDService = ddService ?? serviceName
-        await this.instrumentService(client, serviceConfig, serviceName, actualDDService)
+        if (await this.instrumentService(client, update)) {
+          updatedServices.push(update.serviceName)
+        }
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error)
-        throw new Error(`Failed to instrument service ${serviceName}: ${message}`)
+        const partialSuccess =
+          updatedServices.length === 0 ? '' : `\nServices updated before the failure: ${updatedServices.join(', ')}.`
+        throw new Error(`Failed to instrument service ${update.serviceName}: ${message}${partialSuccess}`)
       }
     }
-  }
-
-  public async instrumentService(
-    client: ServicesClient,
-    existingService: IService,
-    serviceName: string,
-    ddService: string
-  ) {
-    const updatedService = this.createInstrumentedServiceConfig(existingService, ddService)
-    this.context.stdout.write(generateConfigDiff(existingService, updatedService))
-    if (this.dryRun) {
-      this.context.stdout.write(
-        `\n\n${dryRunPrefix(this.dryRun)}Would have updated service ${chalk.bold(
-          serviceName
-        )} with the above changes.\n`
-      )
-
-      return
-    } else if (this.interactive) {
-      const confirmed = await requestConfirmation('\nDo you want to apply the changes?')
-      if (!confirmed) {
-        throw new Error('Instrumentation cancelled by user.')
-      }
-    }
-
-    await withSpinner(
-      `Instrumenting service ${chalk.bold(serviceName)}...`,
-      async () => {
-        const [operation] = await client.updateService({
-          service: updatedService,
-        })
-        await operation.promise()
-      },
-      `Instrumented service ${chalk.bold(serviceName)}`
-    )
   }
 
   public createInstrumentedServiceConfig(service: IService, ddService: string): IService {
@@ -283,5 +285,44 @@ export class PluginCommand extends CloudRunInstrumentCommand {
     }
 
     return Object.fromEntries(Object.entries(envVars).map(([name, value]) => [name, {name, value}]))
+  }
+
+  private async instrumentService(client: ServicesClient, update: InstrumentedServiceUpdate): Promise<boolean> {
+    const {existingService, updatedService, serviceName, preview} = update
+    this.context.stdout.write(preview.diff)
+    if (!preview.hasChanges && existingService.terminalCondition?.state === 'CONDITION_SUCCEEDED') {
+      this.context.stdout.write(
+        `\n\n${dryRunPrefix(this.dryRun)}Service ${chalk.bold(serviceName)} already has the requested instrumentation.\n`
+      )
+
+      return false
+    }
+    if (this.dryRun) {
+      this.context.stdout.write(
+        `\n\n${dryRunPrefix(this.dryRun)}Would have updated service ${chalk.bold(
+          serviceName
+        )} with the above changes.\n`
+      )
+
+      return false
+    } else if (this.interactive) {
+      const confirmed = await requestConfirmation('\nDo you want to apply the changes?')
+      if (!confirmed) {
+        throw new Error('Instrumentation cancelled by user.')
+      }
+    }
+
+    await withSpinner(
+      `Instrumenting service ${chalk.bold(serviceName)}...`,
+      async () => {
+        const [operation] = await client.updateService({
+          service: updatedService,
+        })
+        await operation.promise()
+      },
+      `Instrumented service ${chalk.bold(serviceName)}`
+    )
+
+    return true
   }
 }

--- a/packages/plugin-cloud-run/src/commands/uninstrument.ts
+++ b/packages/plugin-cloud-run/src/commands/uninstrument.ts
@@ -1,3 +1,4 @@
+import type {ServiceUpdatePreview} from '../service-update'
 import type {IService} from '../types'
 
 import {CloudRunUninstrumentCommand} from '@datadog/datadog-ci-base/commands/cloud-run/uninstrument'
@@ -5,14 +6,22 @@ import {FIPS_ENV_VAR, FIPS_IGNORE_ERROR_ENV_VAR} from '@datadog/datadog-ci-base/
 import {toBoolean} from '@datadog/datadog-ci-base/helpers/env'
 import {enableFips} from '@datadog/datadog-ci-base/helpers/fips'
 import {renderError, renderSoftWarning} from '@datadog/datadog-ci-base/helpers/renderer'
-import {generateConfigDiff, parseEnvVars} from '@datadog/datadog-ci-base/helpers/serverless/common'
+import {parseEnvVars} from '@datadog/datadog-ci-base/helpers/serverless/common'
 import {ServicesClient} from '@google-cloud/run'
 import chalk from 'chalk'
 
 import {requestGCPProject, requestGCPRegion, requestServiceName, requestConfirmation} from '../prompt'
 import {dryRunPrefix, renderAuthenticationInstructions, withSpinner} from '../renderer'
 import {uninstrumentServiceConfig} from '../service-config'
+import {previewServiceUpdate} from '../service-update'
 import {checkAuthentication, fetchServiceConfigs} from '../utils'
+
+interface UninstrumentedServiceUpdate {
+  existingService: IService
+  updatedService: IService
+  serviceName: string
+  preview: ServiceUpdatePreview
+}
 
 export class PluginCommand extends CloudRunUninstrumentCommand {
   protected fipsConfig = {
@@ -71,7 +80,8 @@ export class PluginCommand extends CloudRunUninstrumentCommand {
     try {
       await this.uninstrumentSidecar(this.project, this.services, this.region)
     } catch (error) {
-      this.context.stderr.write(dryRunPrefix(this.dryRun) + renderError(`Uninstrumentation failed: ${error}\n`))
+      const message = error instanceof Error ? error.message : String(error)
+      this.context.stderr.write(dryRunPrefix(this.dryRun) + renderError(`Uninstrumentation failed: ${message}\n`))
 
       return 1
     }
@@ -94,48 +104,34 @@ export class PluginCommand extends CloudRunUninstrumentCommand {
     this.context.stdout.write(
       chalk.bold(`\n${dryRunPrefix(this.dryRun)}🚀 Uninstrumenting Cloud Run services with sidecar...\n`)
     )
-    for (let i = 0; i < existingServiceConfigs.length; i++) {
-      const serviceConfig = existingServiceConfigs[i]
-      const serviceName = services[i]
-      try {
-        await this.uninstrumentService(client, serviceConfig, serviceName)
-      } catch (error) {
-        this.context.stderr.write(
-          dryRunPrefix(this.dryRun) + renderError(`Failed to instrument service ${serviceName}: ${error}\n`)
-        )
-        throw error
-      }
-    }
-  }
+    const updates = await Promise.all(
+      existingServiceConfigs.map(async (existingService, index): Promise<UninstrumentedServiceUpdate> => {
+        const serviceName = services[index]
+        try {
+          const updatedService = this.createUninstrumentedServiceConfig(existingService)
+          const preview = await previewServiceUpdate(client, existingService, updatedService)
 
-  public async uninstrumentService(client: ServicesClient, existingService: IService, serviceName: string) {
-    const updatedService = this.createUninstrumentedServiceConfig(existingService)
-    this.context.stdout.write(generateConfigDiff(existingService, updatedService))
-    if (this.dryRun) {
-      this.context.stdout.write(
-        `\n\n${dryRunPrefix(this.dryRun)}Would have updated service ${chalk.bold(
-          serviceName
-        )} with the above changes.\n`
-      )
-
-      return
-    } else if (this.interactive) {
-      const confirmed = await requestConfirmation('\nDo you want to apply the changes?')
-      if (!confirmed) {
-        throw new Error('Uninstrumentation cancelled by user.')
-      }
-    }
-
-    await withSpinner(
-      `Uninstrumenting service ${chalk.bold(serviceName)}...`,
-      async () => {
-        const [operation] = await client.updateService({
-          service: updatedService,
-        })
-        await operation.promise()
-      },
-      `Uninstrumented service ${chalk.bold(serviceName)}`
+          return {existingService, updatedService, serviceName, preview}
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error)
+          throw new Error(`Failed to validate service ${serviceName}: ${message}`)
+        }
+      })
     )
+
+    const updatedServices: string[] = []
+    for (const update of updates) {
+      try {
+        if (await this.uninstrumentService(client, update)) {
+          updatedServices.push(update.serviceName)
+        }
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error)
+        const partialSuccess =
+          updatedServices.length === 0 ? '' : `\nServices updated before the failure: ${updatedServices.join(', ')}.`
+        throw new Error(`Failed to uninstrument service ${update.serviceName}: ${message}${partialSuccess}`)
+      }
+    }
   }
 
   public createUninstrumentedServiceConfig(service: IService): IService {
@@ -160,5 +156,44 @@ export class PluginCommand extends CloudRunUninstrumentCommand {
     }
 
     return result.service
+  }
+
+  private async uninstrumentService(client: ServicesClient, update: UninstrumentedServiceUpdate): Promise<boolean> {
+    const {existingService, updatedService, serviceName, preview} = update
+    this.context.stdout.write(preview.diff)
+    if (!preview.hasChanges && existingService.terminalCondition?.state === 'CONDITION_SUCCEEDED') {
+      this.context.stdout.write(
+        `\n\n${dryRunPrefix(this.dryRun)}Service ${chalk.bold(serviceName)} is already uninstrumented.\n`
+      )
+
+      return false
+    }
+    if (this.dryRun) {
+      this.context.stdout.write(
+        `\n\n${dryRunPrefix(this.dryRun)}Would have updated service ${chalk.bold(
+          serviceName
+        )} with the above changes.\n`
+      )
+
+      return false
+    } else if (this.interactive) {
+      const confirmed = await requestConfirmation('\nDo you want to apply the changes?')
+      if (!confirmed) {
+        throw new Error('Uninstrumentation cancelled by user.')
+      }
+    }
+
+    await withSpinner(
+      `Uninstrumenting service ${chalk.bold(serviceName)}...`,
+      async () => {
+        const [operation] = await client.updateService({
+          service: updatedService,
+        })
+        await operation.promise()
+      },
+      `Uninstrumented service ${chalk.bold(serviceName)}`
+    )
+
+    return true
   }
 }

--- a/packages/plugin-cloud-run/src/service-config.ts
+++ b/packages/plugin-cloud-run/src/service-config.ts
@@ -121,7 +121,7 @@ export const instrumentServiceConfig = (service: IService, options: InstrumentSe
       )
     }
   } else {
-    if (!hasSsi && (hasTracerContainer || hasTracerVolume)) {
+    if (existingSsiMode === undefined && (hasTracerContainer || hasTracerVolume)) {
       const resources = [hasTracerContainer ? 'container' : undefined, hasTracerVolume ? 'volume' : undefined].filter(
         (resource): resource is string => resource !== undefined
       )
@@ -138,9 +138,6 @@ export const instrumentServiceConfig = (service: IService, options: InstrumentSe
       reservedContainerNames(options.sidecarName)
     )
     assertTracerReadinessPortAvailable(mainContainer, options.sidecarName, tracerReadinessPort, healthCheckPort)
-    if (!hasSsi) {
-      assertTracerMountPathAvailable(mainContainer)
-    }
     sourceTemplate =
       existingSsiMode !== undefined || hasTracerContainer
         ? removeExistingSsiState(sourceTemplate, mainContainer, existingSsiMode)
@@ -149,6 +146,7 @@ export const instrumentServiceConfig = (service: IService, options: InstrumentSe
       sourceTemplate.containers ?? [],
       reservedContainerNames(options.sidecarName)
     )
+    assertTracerMountPathAvailable(updatedMainContainer, getTracerMountPath(ssiConfig))
     assertInjectionEnvCanBeMerged(updatedMainContainer.env, ssiConfig)
     targetContainers = new Set([updatedMainContainer])
     envVarsByName[DD_TRACE_ENABLED_ENV_VAR] = {name: DD_TRACE_ENABLED_ENV_VAR, value: 'true'}
@@ -185,7 +183,7 @@ export const instrumentServiceConfig = (service: IService, options: InstrumentSe
   if (ssiConfig.kind === 'single-language' || ssiConfig.kind === 'multi-language') {
     const mainContainer = selectMainContainer(template.containers ?? [], reservedContainerNames(options.sidecarName))
     const isMultiLanguage = ssiConfig.kind === 'multi-language'
-    const mountPath = isMultiLanguage ? COMPOSITE_TRACER_MOUNT_PATH : TRACER_MOUNT_PATH
+    const mountPath = getTracerMountPath(ssiConfig)
     const configuredMainContainer = {
       ...mainContainer,
       env: isMultiLanguage
@@ -241,15 +239,26 @@ export const uninstrumentServiceConfig = (
   const template: IServiceTemplate = service.template || {}
   const containers: IContainer[] = template.containers || []
   const volumes: IVolume[] = template.volumes || []
+  const ssiMode = getOwnedSsiMode(service.labels?.[SSI_INJECTION_MODE_LABEL])
   const sidecarRemoved = containers.some((container) => container.name === options.sidecarName)
   const sharedVolumeRemoved = volumes.some((volume) => volume.name === options.sharedVolumeName)
   const updatedContainers = containers
-    .filter((container) => container.name !== options.sidecarName && container.name !== TRACER_CONTAINER_NAME)
+    .filter(
+      (container) =>
+        container.name !== options.sidecarName && (ssiMode === undefined || container.name !== TRACER_CONTAINER_NAME)
+    )
     .map((container) =>
-      removeContainerInstrumentation(container, options.sidecarName, options.sharedVolumeName, options.envVarNames)
+      removeContainerInstrumentation(
+        container,
+        options.sidecarName,
+        options.sharedVolumeName,
+        options.envVarNames,
+        ssiMode
+      )
     )
   const updatedVolumes = volumes.filter(
-    (volume) => volume.name !== options.sharedVolumeName && volume.name !== TRACER_VOLUME_NAME
+    (volume) =>
+      volume.name !== options.sharedVolumeName && (ssiMode === undefined || volume.name !== TRACER_VOLUME_NAME)
   )
   const labels = Object.fromEntries(
     Object.entries(service.labels ?? {}).filter(([name]) => !INSTRUMENTATION_LABELS.has(name))
@@ -358,14 +367,16 @@ const tracerVolumeConfig = (medium: TracerVolumeMedium, memorySize: string) =>
 
 const atLeastBetaLaunchStage = (launchStage: IService['launchStage']) =>
   launchStage === 'ALPHA' ? launchStage : 'BETA'
+const getTracerMountPath = (config: Extract<SsiConfigResult, {kind: 'single-language' | 'multi-language'}>): string =>
+  config.kind === 'multi-language' ? COMPOSITE_TRACER_MOUNT_PATH : TRACER_MOUNT_PATH
 
-const assertTracerMountPathAvailable = (mainContainer: IContainer): void => {
-  const existingMount = mainContainer.volumeMounts?.find((mount) => mount.mountPath === TRACER_MOUNT_PATH)
+const assertTracerMountPathAvailable = (mainContainer: IContainer, mountPath: string): void => {
+  const existingMount = mainContainer.volumeMounts?.find((mount) => mount.mountPath === mountPath)
   if (existingMount) {
     throw new SsiConfigError(
       `Cannot enable automatic instrumentation because volume '${
         existingMount.name || '<unnamed>'
-      }' already uses managed tracer mount path '${TRACER_MOUNT_PATH}' on container '${
+      }' already uses managed tracer mount path '${mountPath}' on container '${
         mainContainer.name || '<unnamed>'
       }'. Change the existing mount path, then retry.`
     )
@@ -515,9 +526,10 @@ const removeContainerInstrumentation = (
   container: IContainer,
   agentContainerName: string,
   sharedVolumeName: string,
-  envVarNames: ReadonlySet<string>
+  envVarNames: ReadonlySet<string>,
+  ssiMode: OwnedSsiMode | undefined
 ): IContainer => {
-  const withoutSsi = removeExistingSsiContainer(container, true)
+  const withoutSsi = ssiMode === undefined ? container : removeExistingSsiContainer(container, true, ssiMode)
   const updated = removeDependency(withoutSsi, agentContainerName)
 
   return {

--- a/packages/plugin-cloud-run/src/service-config.ts
+++ b/packages/plugin-cloud-run/src/service-config.ts
@@ -18,7 +18,19 @@ import {
 import {getTracerCopyCompletionMarker} from '@datadog/datadog-ci-base/helpers/serverless/ssi/tracer'
 import {SERVERLESS_CLI_VERSION_TAG_NAME, SERVERLESS_CLI_VERSION_TAG_VALUE} from '@datadog/datadog-ci-base/helpers/tags'
 
-import {mergeLanguageInjectionEnv, removeLanguageInjectionEnv, selectMainContainer, SsiConfigError} from './ssi'
+import {
+  assertInjectionEnvCanBeMerged,
+  COMPOSITE_TRACER_COMPLETION_MARKER,
+  COMPOSITE_TRACER_IMAGE,
+  COMPOSITE_TRACER_MOUNT_PATH,
+  mergeCompositeInjectionEnv,
+  mergeLanguageInjectionEnv,
+  removeCompositeInjectionEnv,
+  removeInjectionEnv,
+  removeSingleLanguageInjectionEnv,
+  selectMainContainer,
+  SsiConfigError,
+} from './ssi'
 
 type EmptyDirMedium = NonNullable<NonNullable<IVolume['emptyDir']>['medium']>
 
@@ -30,6 +42,10 @@ const SSI_INJECTION_MODE_LABEL = 'dd_sls_injection_mode'
 const SINGLE_LANGUAGE_SSI_MODE = 'single_language'
 const LEGACY_TRACER_CONTAINER_NAME = 'datadog-tracer-copy'
 const MANAGED_TRACER_CONTAINER_NAMES = new Set([TRACER_CONTAINER_NAME, LEGACY_TRACER_CONTAINER_NAME])
+const MULTI_LANGUAGE_SSI_MODE = 'multi_language'
+type OwnedSsiMode = typeof SINGLE_LANGUAGE_SSI_MODE | typeof MULTI_LANGUAGE_SSI_MODE
+const MULTI_LANGUAGE_VOLUME_SIZE_LIMIT = '1.5Gi'
+const MULTI_LANGUAGE_TRACER_MEMORY_LIMIT = '2Gi'
 const UNIFIED_SERVICE_TAG_LABELS = {
   service: 'service',
   environment: 'env',
@@ -83,14 +99,19 @@ export const instrumentServiceConfig = (service: IService, options: InstrumentSe
     ...options.envVarsByName,
     [HEALTH_PORT_ENV_VAR]: {name: HEALTH_PORT_ENV_VAR, value: String(healthCheckPort)},
   }
-  const hasSsi = service.labels?.[SSI_INJECTION_MODE_LABEL] === SINGLE_LANGUAGE_SSI_MODE
+  const existingSsiMode = getOwnedSsiMode(service.labels?.[SSI_INJECTION_MODE_LABEL])
   const sourceContainers = sourceTemplate.containers ?? []
   const hasTracerContainer = sourceContainers.some(isManagedTracerContainer)
   const hasTracerVolume = sourceTemplate.volumes?.some((volume) => volume.name === TRACER_VOLUME_NAME) ?? false
-  const shouldRemoveSsi = hasSsi && ssiConfig.kind === 'no-injection' && ssiConfig.tracing !== undefined
+  const shouldRemoveSsi =
+    existingSsiMode !== undefined && ssiConfig.kind === 'no-injection' && ssiConfig.tracing !== undefined
 
   if (shouldRemoveSsi) {
-    sourceTemplate = removeExistingSsiState(sourceTemplate)
+    const mainContainer = selectMainContainer(
+      sourceTemplate.containers ?? [],
+      new Set([options.sidecarName, TRACER_CONTAINER_NAME])
+    )
+    sourceTemplate = removeExistingSsiState(sourceTemplate, mainContainer, existingSsiMode)
   } else if (ssiConfig.kind === 'no-injection') {
     if (hasTracerContainer) {
       targetContainers = new Set(
@@ -121,11 +142,14 @@ export const instrumentServiceConfig = (service: IService, options: InstrumentSe
       assertTracerMountPathAvailable(mainContainer)
     }
     sourceTemplate =
-      hasSsi || hasTracerContainer ? removeExistingSsiState(sourceTemplate, mainContainer) : sourceTemplate
+      existingSsiMode !== undefined || hasTracerContainer
+        ? removeExistingSsiState(sourceTemplate, mainContainer, existingSsiMode)
+        : sourceTemplate
     const updatedMainContainer = selectMainContainer(
       sourceTemplate.containers ?? [],
       reservedContainerNames(options.sidecarName)
     )
+    assertInjectionEnvCanBeMerged(updatedMainContainer.env, ssiConfig)
     targetContainers = new Set([updatedMainContainer])
     envVarsByName[DD_TRACE_ENABLED_ENV_VAR] = {name: DD_TRACE_ENABLED_ENV_VAR, value: 'true'}
   }
@@ -158,11 +182,15 @@ export const instrumentServiceConfig = (service: IService, options: InstrumentSe
     delete labels[SSI_INJECTION_MODE_LABEL]
   }
 
-  if (ssiConfig.kind === 'single-language') {
+  if (ssiConfig.kind === 'single-language' || ssiConfig.kind === 'multi-language') {
     const mainContainer = selectMainContainer(template.containers ?? [], reservedContainerNames(options.sidecarName))
+    const isMultiLanguage = ssiConfig.kind === 'multi-language'
+    const mountPath = isMultiLanguage ? COMPOSITE_TRACER_MOUNT_PATH : TRACER_MOUNT_PATH
     const configuredMainContainer = {
       ...mainContainer,
-      env: mergeLanguageInjectionEnv(mainContainer.env, ssiConfig.spec),
+      env: isMultiLanguage
+        ? mergeCompositeInjectionEnv(mainContainer.env)
+        : mergeLanguageInjectionEnv(mainContainer.env, ssiConfig.spec),
     }
     template = {
       ...template,
@@ -173,18 +201,26 @@ export const instrumentServiceConfig = (service: IService, options: InstrumentSe
     template = applyTracerContainer(
       template,
       {
-        image: ssiConfig.spec.image,
-        completionMarker: getTracerCopyCompletionMarker(ssiConfig.language, TRACER_MOUNT_PATH),
+        image: isMultiLanguage ? COMPOSITE_TRACER_IMAGE : ssiConfig.spec.image,
+        completionMarker: isMultiLanguage
+          ? COMPOSITE_TRACER_COMPLETION_MARKER
+          : getTracerCopyCompletionMarker(ssiConfig.language, TRACER_MOUNT_PATH),
+        mountPath,
         readinessPort: tracerReadinessPort,
         tracerVolumeMedium: ssiConfig.tracerVolumeMedium,
+        memoryVolumeSize: isMultiLanguage ? MULTI_LANGUAGE_VOLUME_SIZE_LIMIT : TRACER_VOLUME_SIZE_LIMIT,
+        memoryLimit:
+          isMultiLanguage && ssiConfig.tracerVolumeMedium === 'memory' ? MULTI_LANGUAGE_TRACER_MEMORY_LIMIT : undefined,
       },
       configuredMainContainer,
       [options.sidecarName]
     )
-    labels[SSI_INJECTION_MODE_LABEL] = SINGLE_LANGUAGE_SSI_MODE
+    labels[SSI_INJECTION_MODE_LABEL] = isMultiLanguage ? MULTI_LANGUAGE_SSI_MODE : SINGLE_LANGUAGE_SSI_MODE
   }
 
-  const usesDiskTracerVolume = ssiConfig.kind === 'single-language' && ssiConfig.tracerVolumeMedium === 'disk'
+  const usesDiskTracerVolume =
+    (ssiConfig.kind === 'single-language' || ssiConfig.kind === 'multi-language') &&
+    ssiConfig.tracerVolumeMedium === 'disk'
 
   return {
     ...service,
@@ -207,20 +243,13 @@ export const uninstrumentServiceConfig = (
   const volumes: IVolume[] = template.volumes || []
   const sidecarRemoved = containers.some((container) => container.name === options.sidecarName)
   const sharedVolumeRemoved = volumes.some((volume) => volume.name === options.sharedVolumeName)
-  const hasSsi = service.labels?.[SSI_INJECTION_MODE_LABEL] === SINGLE_LANGUAGE_SSI_MODE
   const updatedContainers = containers
-    .filter((container) => container.name !== options.sidecarName && (!hasSsi || !isManagedTracerContainer(container)))
+    .filter((container) => container.name !== options.sidecarName && container.name !== TRACER_CONTAINER_NAME)
     .map((container) =>
-      removeContainerInstrumentation(
-        container,
-        options.sidecarName,
-        options.sharedVolumeName,
-        options.envVarNames,
-        hasSsi
-      )
+      removeContainerInstrumentation(container, options.sidecarName, options.sharedVolumeName, options.envVarNames)
     )
   const updatedVolumes = volumes.filter(
-    (volume) => volume.name !== options.sharedVolumeName && (!hasSsi || volume.name !== TRACER_VOLUME_NAME)
+    (volume) => volume.name !== options.sharedVolumeName && volume.name !== TRACER_VOLUME_NAME
   )
   const labels = Object.fromEntries(
     Object.entries(service.labels ?? {}).filter(([name]) => !INSTRUMENTATION_LABELS.has(name))
@@ -252,8 +281,11 @@ const TRACER_RUNTIME_SCRIPT = [
 interface TracerContainerConfig {
   image: string
   completionMarker: string
+  mountPath: string
   readinessPort: number
   tracerVolumeMedium: TracerVolumeMedium
+  memoryVolumeSize: string
+  memoryLimit: string | undefined
 }
 
 const buildTracerContainer = (config: TracerContainerConfig): IContainer => ({
@@ -264,11 +296,12 @@ const buildTracerContainer = (config: TracerContainerConfig): IContainer => ({
     '-c',
     TRACER_RUNTIME_SCRIPT,
     TRACER_CONTAINER_NAME,
-    TRACER_MOUNT_PATH,
+    config.mountPath,
     config.completionMarker,
     String(config.readinessPort),
   ],
-  volumeMounts: [{name: TRACER_VOLUME_NAME, mountPath: TRACER_MOUNT_PATH}],
+  volumeMounts: [{name: TRACER_VOLUME_NAME, mountPath: config.mountPath}],
+  ...(config.memoryLimit ? {resources: {limits: {memory: config.memoryLimit}}} : {}),
   startupProbe: {
     tcpSocket: {port: config.readinessPort},
     initialDelaySeconds: 0,
@@ -292,7 +325,7 @@ const applyTracerContainer = (
           ...container,
           volumeMounts: [
             ...(container.volumeMounts ?? []).filter((mount) => mount.name !== TRACER_VOLUME_NAME),
-            {name: TRACER_VOLUME_NAME, mountPath: TRACER_MOUNT_PATH},
+            {name: TRACER_VOLUME_NAME, mountPath: config.mountPath},
           ],
           dependsOn: [
             ...(container.dependsOn ?? []).filter((name) => !managedDependencies.has(name)),
@@ -312,16 +345,16 @@ const applyTracerContainer = (
       ...(template.volumes ?? []),
       {
         name: TRACER_VOLUME_NAME,
-        emptyDir: tracerVolumeConfig(config.tracerVolumeMedium),
+        emptyDir: tracerVolumeConfig(config.tracerVolumeMedium, config.memoryVolumeSize),
       },
     ],
   }
 }
 
-const tracerVolumeConfig = (medium: TracerVolumeMedium) =>
+const tracerVolumeConfig = (medium: TracerVolumeMedium, memorySize: string) =>
   medium === 'disk'
     ? {medium: DISK_VOLUME_MEDIUM, sizeLimit: DISK_VOLUME_SIZE_LIMIT}
-    : {medium: MEMORY_VOLUME_MEDIUM, sizeLimit: TRACER_VOLUME_SIZE_LIMIT}
+    : {medium: MEMORY_VOLUME_MEDIUM, sizeLimit: memorySize}
 
 const atLeastBetaLaunchStage = (launchStage: IService['launchStage']) =>
   launchStage === 'ALPHA' ? launchStage : 'BETA'
@@ -360,7 +393,17 @@ const assertTracerReadinessPortAvailable = (
   }
 }
 
-const removeExistingSsiState = (template: IServiceTemplate, mainContainer?: IContainer): IServiceTemplate => ({
+const getOwnedSsiMode = (mode: string | undefined): OwnedSsiMode | undefined => {
+  if (mode === SINGLE_LANGUAGE_SSI_MODE || mode === MULTI_LANGUAGE_SSI_MODE) {
+    return mode
+  }
+}
+
+const removeExistingSsiState = (
+  template: IServiceTemplate,
+  mainContainer?: IContainer,
+  mode?: OwnedSsiMode
+): IServiceTemplate => ({
   ...template,
   containers: (template.containers ?? [])
     .filter((container) => !isManagedTracerContainer(container))
@@ -369,15 +412,20 @@ const removeExistingSsiState = (template: IServiceTemplate, mainContainer?: ICon
         container,
         mainContainer === undefined
           ? (container.volumeMounts ?? []).some((mount) => mount.name === TRACER_VOLUME_NAME)
-          : container === mainContainer
+          : container === mainContainer,
+        mode
       )
     ),
   volumes: (template.volumes ?? []).filter((volume) => volume.name !== TRACER_VOLUME_NAME),
 })
 
-const removeExistingSsiContainer = (container: IContainer, isMainContainer: boolean): IContainer => {
+const removeExistingSsiContainer = (
+  container: IContainer,
+  isMainContainer: boolean,
+  mode?: OwnedSsiMode
+): IContainer => {
   const existingEnv = container.env ?? []
-  const env = isMainContainer ? removeLanguageInjectionEnv(existingEnv) : existingEnv
+  const env = isMainContainer ? removeSsiEnv(existingEnv, mode) : existingEnv
   const envChanged = env.length !== existingEnv.length || env.some((variable, index) => variable !== existingEnv[index])
   const existingMounts = container.volumeMounts ?? []
   const volumeMounts = existingMounts.filter((mount) => mount.name !== TRACER_VOLUME_NAME)
@@ -391,6 +439,17 @@ const removeExistingSsiContainer = (container: IContainer, isMainContainer: bool
   }
 
   return removeDependencies(cleaned, MANAGED_TRACER_CONTAINER_NAMES)
+}
+
+const removeSsiEnv = (env: readonly IEnvVar[], mode: OwnedSsiMode | undefined): IEnvVar[] => {
+  switch (mode) {
+    case SINGLE_LANGUAGE_SSI_MODE:
+      return removeSingleLanguageInjectionEnv(env)
+    case MULTI_LANGUAGE_SSI_MODE:
+      return removeCompositeInjectionEnv(env)
+    default:
+      return removeInjectionEnv(env)
+  }
 }
 
 const isManagedTracerContainer = (container: IContainer): boolean =>
@@ -456,11 +515,9 @@ const removeContainerInstrumentation = (
   container: IContainer,
   agentContainerName: string,
   sharedVolumeName: string,
-  envVarNames: ReadonlySet<string>,
-  hasSsi: boolean
+  envVarNames: ReadonlySet<string>
 ): IContainer => {
-  const hasTracerMount = container.volumeMounts?.some((mount) => mount.name === TRACER_VOLUME_NAME) ?? false
-  const withoutSsi = hasSsi && hasTracerMount ? removeExistingSsiContainer(container, true) : container
+  const withoutSsi = removeExistingSsiContainer(container, true)
   const updated = removeDependency(withoutSsi, agentContainerName)
 
   return {

--- a/packages/plugin-cloud-run/src/service-config.ts
+++ b/packages/plugin-cloud-run/src/service-config.ts
@@ -25,9 +25,7 @@ import {
   COMPOSITE_TRACER_MOUNT_PATH,
   mergeCompositeInjectionEnv,
   mergeLanguageInjectionEnv,
-  removeCompositeInjectionEnv,
   removeInjectionEnv,
-  removeSingleLanguageInjectionEnv,
   selectMainContainer,
   SsiConfigError,
 } from './ssi'
@@ -40,10 +38,10 @@ const DISK_VOLUME_SIZE_LIMIT = '10Gi'
 const GEN2_EXECUTION_ENVIRONMENT = 2 as const // google.cloud.run.v2.ExecutionEnvironment.EXECUTION_ENVIRONMENT_GEN2
 const SSI_INJECTION_MODE_LABEL = 'dd_sls_injection_mode'
 const SINGLE_LANGUAGE_SSI_MODE = 'single_language'
+const MULTI_LANGUAGE_SSI_MODE = 'multi_language'
 const LEGACY_TRACER_CONTAINER_NAME = 'datadog-tracer-copy'
 const MANAGED_TRACER_CONTAINER_NAMES = new Set([TRACER_CONTAINER_NAME, LEGACY_TRACER_CONTAINER_NAME])
-const MULTI_LANGUAGE_SSI_MODE = 'multi_language'
-type OwnedSsiMode = typeof SINGLE_LANGUAGE_SSI_MODE | typeof MULTI_LANGUAGE_SSI_MODE
+const MANAGED_TRACER_MOUNT_PATHS = new Set([TRACER_MOUNT_PATH, COMPOSITE_TRACER_MOUNT_PATH])
 const MULTI_LANGUAGE_VOLUME_SIZE_LIMIT = '1.5Gi'
 const MULTI_LANGUAGE_TRACER_MEMORY_LIMIT = '2Gi'
 const UNIFIED_SERVICE_TAG_LABELS = {
@@ -99,19 +97,14 @@ export const instrumentServiceConfig = (service: IService, options: InstrumentSe
     ...options.envVarsByName,
     [HEALTH_PORT_ENV_VAR]: {name: HEALTH_PORT_ENV_VAR, value: String(healthCheckPort)},
   }
-  const existingSsiMode = getOwnedSsiMode(service.labels?.[SSI_INJECTION_MODE_LABEL])
+  const hasSsi = hasSsiState(service)
   const sourceContainers = sourceTemplate.containers ?? []
   const hasTracerContainer = sourceContainers.some(isManagedTracerContainer)
   const hasTracerVolume = sourceTemplate.volumes?.some((volume) => volume.name === TRACER_VOLUME_NAME) ?? false
-  const shouldRemoveSsi =
-    existingSsiMode !== undefined && ssiConfig.kind === 'no-injection' && ssiConfig.tracing !== undefined
+  const shouldRemoveSsi = hasSsi && ssiConfig.kind === 'no-injection' && ssiConfig.tracing !== undefined
 
   if (shouldRemoveSsi) {
-    const mainContainer = selectMainContainer(
-      sourceTemplate.containers ?? [],
-      new Set([options.sidecarName, TRACER_CONTAINER_NAME])
-    )
-    sourceTemplate = removeExistingSsiState(sourceTemplate, mainContainer, existingSsiMode)
+    sourceTemplate = removeSsiState(sourceTemplate)
   } else if (ssiConfig.kind === 'no-injection') {
     if (hasTracerContainer) {
       targetContainers = new Set(
@@ -121,7 +114,7 @@ export const instrumentServiceConfig = (service: IService, options: InstrumentSe
       )
     }
   } else {
-    if (existingSsiMode === undefined && (hasTracerContainer || hasTracerVolume)) {
+    if (!hasSsi && (hasTracerContainer || hasTracerVolume)) {
       const resources = [hasTracerContainer ? 'container' : undefined, hasTracerVolume ? 'volume' : undefined].filter(
         (resource): resource is string => resource !== undefined
       )
@@ -138,10 +131,7 @@ export const instrumentServiceConfig = (service: IService, options: InstrumentSe
       reservedContainerNames(options.sidecarName)
     )
     assertTracerReadinessPortAvailable(mainContainer, options.sidecarName, tracerReadinessPort, healthCheckPort)
-    sourceTemplate =
-      existingSsiMode !== undefined || hasTracerContainer
-        ? removeExistingSsiState(sourceTemplate, mainContainer, existingSsiMode)
-        : sourceTemplate
+    sourceTemplate = hasSsi ? removeSsiState(sourceTemplate) : sourceTemplate
     const updatedMainContainer = selectMainContainer(
       sourceTemplate.containers ?? [],
       reservedContainerNames(options.sidecarName)
@@ -199,7 +189,7 @@ export const instrumentServiceConfig = (service: IService, options: InstrumentSe
     template = applyTracerContainer(
       template,
       {
-        image: isMultiLanguage ? COMPOSITE_TRACER_IMAGE : ssiConfig.spec.image,
+        image: ssiConfig.spec.image,
         completionMarker: isMultiLanguage
           ? COMPOSITE_TRACER_COMPLETION_MARKER
           : getTracerCopyCompletionMarker(ssiConfig.language, TRACER_MOUNT_PATH),
@@ -239,27 +229,15 @@ export const uninstrumentServiceConfig = (
   const template: IServiceTemplate = service.template || {}
   const containers: IContainer[] = template.containers || []
   const volumes: IVolume[] = template.volumes || []
-  const ssiMode = getOwnedSsiMode(service.labels?.[SSI_INJECTION_MODE_LABEL])
+  const templateWithoutSsi = hasSsiState(service) ? removeSsiState(template) : template
   const sidecarRemoved = containers.some((container) => container.name === options.sidecarName)
   const sharedVolumeRemoved = volumes.some((volume) => volume.name === options.sharedVolumeName)
-  const updatedContainers = containers
-    .filter(
-      (container) =>
-        container.name !== options.sidecarName && (ssiMode === undefined || container.name !== TRACER_CONTAINER_NAME)
-    )
+  const updatedContainers = (templateWithoutSsi.containers ?? [])
+    .filter((container) => container.name !== options.sidecarName)
     .map((container) =>
-      removeContainerInstrumentation(
-        container,
-        options.sidecarName,
-        options.sharedVolumeName,
-        options.envVarNames,
-        ssiMode
-      )
+      removeContainerInstrumentation(container, options.sidecarName, options.sharedVolumeName, options.envVarNames)
     )
-  const updatedVolumes = volumes.filter(
-    (volume) =>
-      volume.name !== options.sharedVolumeName && (ssiMode === undefined || volume.name !== TRACER_VOLUME_NAME)
-  )
+  const updatedVolumes = (templateWithoutSsi.volumes ?? []).filter((volume) => volume.name !== options.sharedVolumeName)
   const labels = Object.fromEntries(
     Object.entries(service.labels ?? {}).filter(([name]) => !INSTRUMENTATION_LABELS.has(name))
   )
@@ -368,7 +346,7 @@ const tracerVolumeConfig = (medium: TracerVolumeMedium, memorySize: string) =>
 const atLeastBetaLaunchStage = (launchStage: IService['launchStage']) =>
   launchStage === 'ALPHA' ? launchStage : 'BETA'
 const getTracerMountPath = (config: Extract<SsiConfigResult, {kind: 'single-language' | 'multi-language'}>): string =>
-  config.kind === 'multi-language' ? COMPOSITE_TRACER_MOUNT_PATH : TRACER_MOUNT_PATH
+  config.kind === 'multi-language' ? config.spec.mountPath : TRACER_MOUNT_PATH
 
 const assertTracerMountPathAvailable = (mainContainer: IContainer, mountPath: string): void => {
   const existingMount = mainContainer.volumeMounts?.find((mount) => mount.mountPath === mountPath)
@@ -404,67 +382,59 @@ const assertTracerReadinessPortAvailable = (
   }
 }
 
-const getOwnedSsiMode = (mode: string | undefined): OwnedSsiMode | undefined => {
-  if (mode === SINGLE_LANGUAGE_SSI_MODE || mode === MULTI_LANGUAGE_SSI_MODE) {
-    return mode
-  }
+const hasSsiState = (service: IService): boolean =>
+  service.labels?.[SSI_INJECTION_MODE_LABEL] !== undefined || hasCompleteSsiSignature(service.template)
+
+const hasCompleteSsiSignature = (template: IServiceTemplate | null | undefined): boolean => {
+  const tracerContainers = (template?.containers ?? []).filter(isCompleteManagedTracerContainer)
+  const tracerVolumes = (template?.volumes ?? []).filter(
+    (volume) => volume.name === TRACER_VOLUME_NAME && volume.emptyDir !== undefined
+  )
+  const targets = (template?.containers ?? []).filter(
+    (container) =>
+      (container.volumeMounts ?? []).some(
+        (mount) => mount.name === TRACER_VOLUME_NAME && MANAGED_TRACER_MOUNT_PATHS.has(mount.mountPath ?? '')
+      ) &&
+      container.dependsOn?.some((name) => MANAGED_TRACER_CONTAINER_NAMES.has(name)) &&
+      hasInjectionEnv(container.env)
+  )
+
+  return tracerContainers.length === 1 && tracerVolumes.length === 1 && targets.length === 1
 }
 
-const removeExistingSsiState = (
-  template: IServiceTemplate,
-  mainContainer?: IContainer,
-  mode?: OwnedSsiMode
-): IServiceTemplate => ({
+const hasInjectionEnv = (env: readonly IEnvVar[] | null | undefined): boolean => {
+  const updated = removeInjectionEnv(env)
+
+  return updated.length !== (env?.length ?? 0) || updated.some((variable, index) => variable !== env?.[index])
+}
+
+const removeSsiState = (template: IServiceTemplate): IServiceTemplate => ({
   ...template,
   containers: (template.containers ?? [])
     .filter((container) => !isManagedTracerContainer(container))
-    .map((container) =>
-      removeExistingSsiContainer(
-        container,
-        mainContainer === undefined
-          ? (container.volumeMounts ?? []).some((mount) => mount.name === TRACER_VOLUME_NAME)
-          : container === mainContainer,
-        mode
-      )
-    ),
+    .map((container) => {
+      const env = removeInjectionEnv(container.env)
+      const volumeMounts = (container.volumeMounts ?? []).filter((mount) => mount.name !== TRACER_VOLUME_NAME)
+
+      return {
+        ...removeDependencies({...container, env, volumeMounts}, MANAGED_TRACER_CONTAINER_NAMES),
+      }
+    }),
   volumes: (template.volumes ?? []).filter((volume) => volume.name !== TRACER_VOLUME_NAME),
 })
 
-const removeExistingSsiContainer = (
-  container: IContainer,
-  isMainContainer: boolean,
-  mode?: OwnedSsiMode
-): IContainer => {
-  const existingEnv = container.env ?? []
-  const env = isMainContainer ? removeSsiEnv(existingEnv, mode) : existingEnv
-  const envChanged = env.length !== existingEnv.length || env.some((variable, index) => variable !== existingEnv[index])
-  const existingMounts = container.volumeMounts ?? []
-  const volumeMounts = existingMounts.filter((mount) => mount.name !== TRACER_VOLUME_NAME)
-
-  let cleaned = container
-  if (envChanged) {
-    cleaned = {...cleaned, env}
-  }
-  if (volumeMounts.length !== existingMounts.length) {
-    cleaned = {...cleaned, volumeMounts}
-  }
-
-  return removeDependencies(cleaned, MANAGED_TRACER_CONTAINER_NAMES)
-}
-
-const removeSsiEnv = (env: readonly IEnvVar[], mode: OwnedSsiMode | undefined): IEnvVar[] => {
-  switch (mode) {
-    case SINGLE_LANGUAGE_SSI_MODE:
-      return removeSingleLanguageInjectionEnv(env)
-    case MULTI_LANGUAGE_SSI_MODE:
-      return removeCompositeInjectionEnv(env)
-    default:
-      return removeInjectionEnv(env)
-  }
-}
-
 const isManagedTracerContainer = (container: IContainer): boolean =>
   typeof container.name === 'string' && MANAGED_TRACER_CONTAINER_NAMES.has(container.name)
+
+const isCompleteManagedTracerContainer = (container: IContainer): boolean =>
+  isManagedTracerContainer(container) &&
+  (container.image === COMPOSITE_TRACER_IMAGE ||
+    /^gcr\.io\/datadoghq\/dd-lib-(?:java|js|dotnet|python|rb|php)-init:[\w.-]+$/.test(container.image ?? '')) &&
+  container.command?.length === 1 &&
+  container.command[0] === '/bin/sh' &&
+  container.args?.[0] === '-c' &&
+  container.args[2] === container.name &&
+  MANAGED_TRACER_MOUNT_PATHS.has(container.args[3] ?? '')
 
 const reservedContainerNames = (sidecarName: string): ReadonlySet<string> =>
   new Set([sidecarName, ...MANAGED_TRACER_CONTAINER_NAMES])
@@ -526,11 +496,9 @@ const removeContainerInstrumentation = (
   container: IContainer,
   agentContainerName: string,
   sharedVolumeName: string,
-  envVarNames: ReadonlySet<string>,
-  ssiMode: OwnedSsiMode | undefined
+  envVarNames: ReadonlySet<string>
 ): IContainer => {
-  const withoutSsi = ssiMode === undefined ? container : removeExistingSsiContainer(container, true, ssiMode)
-  const updated = removeDependency(withoutSsi, agentContainerName)
+  const updated = removeDependency(container, agentContainerName)
 
   return {
     ...updated,

--- a/packages/plugin-cloud-run/src/service-config.ts
+++ b/packages/plugin-cloud-run/src/service-config.ts
@@ -1,7 +1,7 @@
 import type {SsiConfigResult} from './ssi'
 import type {IContainer, IEnvVar, IService, IServiceTemplate, IVolume} from './types'
-import type {TracerVolumeMedium} from '@datadog/datadog-ci-base/commands/cloud-run/constants'
 
+import {CLOUD_RUN_TRACER_REGISTRY, type TracerVolumeMedium} from '@datadog/datadog-ci-base/commands/cloud-run/constants'
 import {createInstrumentedTemplate} from '@datadog/datadog-ci-base/helpers/serverless/common'
 import {
   DD_TRACE_ENABLED_ENV_VAR,
@@ -15,7 +15,7 @@ import {
   TRACER_VOLUME_NAME,
   TRACER_VOLUME_SIZE_LIMIT,
 } from '@datadog/datadog-ci-base/helpers/serverless/ssi/constants'
-import {getTracerCopyCompletionMarker} from '@datadog/datadog-ci-base/helpers/serverless/ssi/tracer'
+import {getTracerCopyCompletionMarker, LANGUAGE_METADATA} from '@datadog/datadog-ci-base/helpers/serverless/ssi/tracer'
 import {SERVERLESS_CLI_VERSION_TAG_NAME, SERVERLESS_CLI_VERSION_TAG_VALUE} from '@datadog/datadog-ci-base/helpers/tags'
 
 import {
@@ -428,13 +428,17 @@ const isManagedTracerContainer = (container: IContainer): boolean =>
 
 const isCompleteManagedTracerContainer = (container: IContainer): boolean =>
   isManagedTracerContainer(container) &&
-  (container.image === COMPOSITE_TRACER_IMAGE ||
-    /^gcr\.io\/datadoghq\/dd-lib-(?:java|js|dotnet|python|rb|php)-init:[\w.-]+$/.test(container.image ?? '')) &&
+  (container.image === COMPOSITE_TRACER_IMAGE || isManagedSingleLanguageTracerImage(container.image)) &&
   container.command?.length === 1 &&
   container.command[0] === '/bin/sh' &&
   container.args?.[0] === '-c' &&
   container.args[2] === container.name &&
   MANAGED_TRACER_MOUNT_PATHS.has(container.args[3] ?? '')
+
+const isManagedSingleLanguageTracerImage = (image: string | null | undefined): boolean =>
+  Object.values(LANGUAGE_METADATA).some(({tracerLanguage}) =>
+    image?.startsWith(`${CLOUD_RUN_TRACER_REGISTRY}/dd-lib-${tracerLanguage}-init:`)
+  )
 
 const reservedContainerNames = (sidecarName: string): ReadonlySet<string> =>
   new Set([sidecarName, ...MANAGED_TRACER_CONTAINER_NAMES])

--- a/packages/plugin-cloud-run/src/service-update.ts
+++ b/packages/plugin-cloud-run/src/service-update.ts
@@ -1,0 +1,61 @@
+import type {IService} from './types'
+import type {ServicesClient} from '@google-cloud/run'
+
+import {generateConfigDiff, sortedEqual} from '@datadog/datadog-ci-base/helpers/serverless/common'
+import {protos} from '@google-cloud/run'
+
+export interface ServiceUpdatePreview {
+  diff: string
+  hasChanges: boolean
+}
+
+/** Validates an update without applying it and compares the server-normalized configuration. */
+export const previewServiceUpdate = async (
+  client: ServicesClient,
+  existingService: IService,
+  updatedService: IService
+): Promise<ServiceUpdatePreview> => {
+  const [operation] = await client.updateService({service: updatedService, validateOnly: true})
+  const existingPreview = normalizeService(existingService)
+  const updatedPreview = normalizeService(operation.metadata as IService)
+
+  return {
+    diff: generateConfigDiff(existingPreview, updatedPreview),
+    hasChanges: !sortedEqual(existingPreview, updatedPreview),
+  }
+}
+
+const normalizeService = (service: IService): unknown => {
+  const serviceType = protos.google.cloud.run.v2.Service
+  const mutableConfig = {
+    labels: service.labels,
+    launchStage: service.launchStage,
+    template: service.template,
+  }
+  const canonicalService = serviceType.toObject(serviceType.fromObject(mutableConfig), {
+    enums: Number,
+    longs: String,
+  })
+
+  return removeProtoDefaults(canonicalService)
+}
+
+const removeProtoDefaults = (value: unknown): unknown => {
+  if (!value) {
+    return undefined
+  }
+  if (Array.isArray(value)) {
+    const values = value.map(removeProtoDefaults).filter((item) => item !== undefined)
+
+    return values.length === 0 ? undefined : values
+  }
+  if (typeof value === 'object') {
+    const entries = Object.entries(value)
+      .map(([key, item]) => [key, removeProtoDefaults(item)] as const)
+      .filter(([, item]) => item !== undefined)
+
+    return entries.length === 0 ? undefined : Object.fromEntries(entries)
+  }
+
+  return value
+}

--- a/packages/plugin-cloud-run/src/service-update.ts
+++ b/packages/plugin-cloud-run/src/service-update.ts
@@ -16,8 +16,9 @@ export const previewServiceUpdate = async (
   updatedService: IService
 ): Promise<ServiceUpdatePreview> => {
   const [operation] = await client.updateService({service: updatedService, validateOnly: true})
+  const [validatedService] = await operation.promise()
   const existingPreview = normalizeService(existingService)
-  const updatedPreview = normalizeService(operation.metadata as IService)
+  const updatedPreview = normalizeService(validatedService as IService)
 
   return {
     diff: generateConfigDiff(existingPreview, updatedPreview),

--- a/packages/plugin-cloud-run/src/service-update.ts
+++ b/packages/plugin-cloud-run/src/service-update.ts
@@ -16,9 +16,8 @@ export const previewServiceUpdate = async (
   updatedService: IService
 ): Promise<ServiceUpdatePreview> => {
   const [operation] = await client.updateService({service: updatedService, validateOnly: true})
-  const [validatedService] = await operation.promise()
   const existingPreview = normalizeService(existingService)
-  const updatedPreview = normalizeService(validatedService as IService)
+  const updatedPreview = normalizeService(operation.metadata as IService)
 
   return {
     diff: generateConfigDiff(existingPreview, updatedPreview),

--- a/packages/plugin-cloud-run/src/ssi.ts
+++ b/packages/plugin-cloud-run/src/ssi.ts
@@ -31,6 +31,20 @@ import {
 } from '@datadog/datadog-ci-base/helpers/serverless/ssi/injection-spec'
 import {TRACER_INJECTION_LANGUAGES} from '@datadog/datadog-ci-base/helpers/serverless/ssi/tracer'
 
+export const COMPOSITE_TRACER_IMAGE = 'gcr.io/datadoghq/dd-lib-composite-init:latest'
+export const COMPOSITE_TRACER_MOUNT_PATH = '/opt/datadog-packages'
+export const COMPOSITE_TRACER_COMPLETION_MARKER = `${COMPOSITE_TRACER_MOUNT_PATH}/.datadog-composite-copy-finished`
+
+const COMPOSITE_ENV_FRAGMENTS: readonly EnvFragment[] = [
+  {
+    name: 'LD_PRELOAD',
+    value: `${COMPOSITE_TRACER_MOUNT_PATH}/datadog-apm-inject/stable/inject/launcher.preload.so`,
+    separator: ' ',
+    mode: 'prepend',
+  },
+  {name: 'DD_INJECT_SENDER_TYPE', value: 'serverless', mode: 'set-if-absent'},
+]
+
 export interface SsiOptions {
   readonly language: string | undefined
   readonly tracing: TracingMode | undefined
@@ -49,6 +63,7 @@ export type SsiConfigResult = (
       spec: LanguageInjectionSpec
       tracerVolumeMedium: TracerVolumeMedium
     }
+  | {kind: 'multi-language'; tracerVolumeMedium: TracerVolumeMedium}
 ) & {warnings: readonly string[]}
 
 /** Resolves SSI inputs to a mode or validation errors. */
@@ -68,11 +83,24 @@ export const resolveSsiConfig = (options: SsiOptions): SsiConfigResult => {
   }
 
   if (options.language === undefined) {
-    return {
-      kind: 'errors',
-      errors: ['--tracing inject requires --language until automatic multi-language injection is supported.'],
-      warnings: [],
-    }
+    const unsupportedFlags = [
+      options.tracerVersion !== undefined ? '--tracer-version' : undefined,
+      options.tracerLibc !== undefined ? '--tracer-libc' : undefined,
+    ].filter((flag): flag is string => flag !== undefined)
+
+    return unsupportedFlags.length > 0
+      ? {
+          kind: 'errors',
+          errors: [
+            `${unsupportedFlags.join(', ')} require --language because automatic language detection cannot apply per-language tracer settings. Add --language or remove these options.`,
+          ],
+          warnings: [],
+        }
+      : {
+          kind: 'multi-language',
+          tracerVolumeMedium: options.tracerVolumeMedium ?? 'memory',
+          warnings: [],
+        }
   }
 
   if (!isCloudRunLanguage(options.language)) {
@@ -185,17 +213,29 @@ export const selectMainContainer = (
   )
 }
 
+export const assertInjectionEnvCanBeMerged = (
+  existingEnv: readonly IEnvVar[] | null | undefined,
+  config: Extract<SsiConfigResult, {kind: 'single-language' | 'multi-language'}>
+): void => {
+  const env = existingEnv ?? []
+  if (config.kind === 'single-language') {
+    assertEnvCanBeMerged(env, config.spec.env, [DD_TAGS_ENV_VAR])
+  } else {
+    assertEnvCanBeMerged(env, COMPOSITE_ENV_FRAGMENTS)
+  }
+}
+
 export const mergeLanguageInjectionEnv = (
   existingEnv: readonly IEnvVar[] | null | undefined,
   spec: LanguageInjectionSpec
 ): IEnvVar[] => {
   const env = existingEnv ?? []
-  assertLanguageInjectionEnvCanBeMerged(env, spec)
+  assertEnvCanBeMerged(env, spec.env, [DD_TAGS_ENV_VAR])
   const merged = spec.env.reduce<IEnvVar[]>(
     (current, fragment) => {
       const existing = findEnv(current, fragment.name)
 
-      return upsertEnv(current, fragment.name, mergeLanguageEnvFragment(existing?.value ?? undefined, fragment))
+      return upsertEnv(current, fragment.name, mergeInjectionEnvFragment(existing?.value ?? undefined, fragment))
     },
     [...env]
   )
@@ -204,15 +244,43 @@ export const mergeLanguageInjectionEnv = (
   return upsertEnv(merged, DD_TAGS_ENV_VAR, mergeInjectionModeTag(existingTags?.value ?? undefined))
 }
 
-/** Removes exact tracer fragments for every supported language so replacing a tracer cannot leave stale settings. */
-export const removeLanguageInjectionEnv = (existingEnv: readonly IEnvVar[] | null | undefined): IEnvVar[] =>
+export const mergeCompositeInjectionEnv = (existingEnv: readonly IEnvVar[] | null | undefined): IEnvVar[] => {
+  const env = existingEnv ?? []
+  assertEnvCanBeMerged(env, COMPOSITE_ENV_FRAGMENTS)
+
+  return COMPOSITE_ENV_FRAGMENTS.reduce<IEnvVar[]>(
+    (current, fragment) => {
+      const existing = findEnv(current, fragment.name)
+
+      return upsertEnv(current, fragment.name, mergeInjectionEnvFragment(existing?.value ?? undefined, fragment))
+    },
+    [...env]
+  )
+}
+
+export const removeSingleLanguageInjectionEnv = (existingEnv: readonly IEnvVar[] | null | undefined): IEnvVar[] =>
+  removeEnvFragments(existingEnv, LANGUAGE_ENV_FRAGMENTS, true)
+
+export const removeCompositeInjectionEnv = (existingEnv: readonly IEnvVar[] | null | undefined): IEnvVar[] =>
+  removeEnvFragments(existingEnv, COMPOSITE_ENV_FRAGMENTS, false)
+
+/** Removes exact tracer fragments for every supported injection mode during full uninstrumentation. */
+export const removeInjectionEnv = (existingEnv: readonly IEnvVar[] | null | undefined): IEnvVar[] =>
+  removeEnvFragments(existingEnv, [...LANGUAGE_ENV_FRAGMENTS, ...COMPOSITE_ENV_FRAGMENTS], true)
+
+const removeEnvFragments = (
+  existingEnv: readonly IEnvVar[] | null | undefined,
+  ownedFragments: readonly EnvFragment[],
+  removeTag: boolean
+): IEnvVar[] =>
   (existingEnv ?? []).flatMap((variable) => {
     if (!variable.name || variable.valueSource || !variable.value) {
       return [variable]
     }
 
-    const fragments = LANGUAGE_ENV_FRAGMENTS.filter((fragment) => fragment.name === variable.name)
-    const withoutTag = variable.name === DD_TAGS_ENV_VAR ? removeInjectionModeTag(variable.value) : variable.value
+    const fragments = ownedFragments.filter((fragment) => fragment.name === variable.name)
+    const withoutTag =
+      removeTag && variable.name === DD_TAGS_ENV_VAR ? removeInjectionModeTag(variable.value) : variable.value
     const value = fragments.reduce<string | undefined>(removeEnvFragment, withoutTag)
 
     return value === undefined ? [] : [value === variable.value ? variable : {...variable, value}]
@@ -221,8 +289,12 @@ export const removeLanguageInjectionEnv = (existingEnv: readonly IEnvVar[] | nul
 const findEnv = (env: readonly IEnvVar[], name: string): IEnvVar | undefined =>
   env.find((variable) => variable.name === name)
 
-const assertLanguageInjectionEnvCanBeMerged = (env: readonly IEnvVar[], spec: LanguageInjectionSpec): void => {
-  const targetNames = new Set([...spec.env.map((fragment) => fragment.name), DD_TAGS_ENV_VAR])
+const assertEnvCanBeMerged = (
+  env: readonly IEnvVar[],
+  fragments: readonly EnvFragment[],
+  extraNames: readonly string[] = []
+): void => {
+  const targetNames = new Set([...fragments.map((fragment) => fragment.name), ...extraNames])
   for (const name of targetNames) {
     const matching = env.filter((variable) => variable.name === name)
     if (matching.length > 1) {
@@ -236,6 +308,10 @@ const assertLanguageInjectionEnvCanBeMerged = (env: readonly IEnvVar[], spec: La
       )
     }
   }
+
+  for (const fragment of fragments) {
+    mergeInjectionEnvFragment(findEnv(env, fragment.name)?.value ?? undefined, fragment)
+  }
 }
 
 const upsertEnv = (env: readonly IEnvVar[], name: string, value: string): IEnvVar[] => {
@@ -246,7 +322,7 @@ const upsertEnv = (env: readonly IEnvVar[], name: string, value: string): IEnvVa
     : env.map((variable, variableIndex) => (variableIndex === index ? {...variable, value} : variable))
 }
 
-const mergeLanguageEnvFragment = (currentValue: string | undefined, fragment: EnvFragment): string => {
+const mergeInjectionEnvFragment = (currentValue: string | undefined, fragment: EnvFragment): string => {
   try {
     return mergeEnvFragment(currentValue, fragment)
   } catch (error) {

--- a/packages/plugin-cloud-run/src/ssi.ts
+++ b/packages/plugin-cloud-run/src/ssi.ts
@@ -92,7 +92,9 @@ export const resolveSsiConfig = (options: SsiOptions): SsiConfigResult => {
       ? {
           kind: 'errors',
           errors: [
-            `${unsupportedFlags.join(', ')} require --language because automatic language detection cannot apply per-language tracer settings. Add --language or remove these options.`,
+            `${unsupportedFlags.join(', ')} ${
+              unsupportedFlags.length === 1 ? 'requires' : 'require'
+            } --language because automatic language detection cannot apply per-language tracer settings. Add --language or remove these options.`,
           ],
           warnings: [],
         }
@@ -101,6 +103,20 @@ export const resolveSsiConfig = (options: SsiOptions): SsiConfigResult => {
           tracerVolumeMedium: options.tracerVolumeMedium ?? 'memory',
           warnings: [],
         }
+  }
+
+  if (!isCloudRunLanguage(options.language)) {
+    return {
+      kind: 'errors',
+      errors: [
+        `Automatic instrumentation does not support language ${JSON.stringify(
+          options.language
+        )}. Use one of ${TRACER_INJECTION_LANGUAGES.map((language) => JSON.stringify(language)).join(
+          ', '
+        )}, or omit --language to detect it automatically.`,
+      ],
+      warnings: [],
+    }
   }
 
   if (!isCloudRunLanguage(options.language)) {

--- a/packages/plugin-cloud-run/src/ssi.ts
+++ b/packages/plugin-cloud-run/src/ssi.ts
@@ -6,7 +6,11 @@ import type {
   TracingMode,
 } from '@datadog/datadog-ci-base/commands/cloud-run/constants'
 import type {EnvFragment} from '@datadog/datadog-ci-base/helpers/serverless/ssi/env'
-import type {LanguageInjectionSpec, Libc} from '@datadog/datadog-ci-base/helpers/serverless/ssi/injection-spec'
+import type {
+  CompositeInjectionSpec,
+  LanguageInjectionSpec,
+  Libc,
+} from '@datadog/datadog-ci-base/helpers/serverless/ssi/injection-spec'
 import type {Language} from '@datadog/datadog-ci-base/helpers/serverless/ssi/tracer'
 
 import {
@@ -25,25 +29,20 @@ import {
   removeInjectionModeTag,
 } from '@datadog/datadog-ci-base/helpers/serverless/ssi/env'
 import {
+  COMPOSITE_TRACER_MOUNT_PATH,
   LIBCS,
+  getCompositeInjectionSpec,
   getLanguageCompatibilityErrors,
   getLanguageInjectionSpec,
 } from '@datadog/datadog-ci-base/helpers/serverless/ssi/injection-spec'
 import {TRACER_INJECTION_LANGUAGES} from '@datadog/datadog-ci-base/helpers/serverless/ssi/tracer'
 
-export const COMPOSITE_TRACER_IMAGE = 'gcr.io/datadoghq/dd-lib-composite-init:latest'
-export const COMPOSITE_TRACER_MOUNT_PATH = '/opt/datadog-packages'
-export const COMPOSITE_TRACER_COMPLETION_MARKER = `${COMPOSITE_TRACER_MOUNT_PATH}/.datadog-composite-copy-finished`
+export {COMPOSITE_TRACER_MOUNT_PATH} from '@datadog/datadog-ci-base/helpers/serverless/ssi/injection-spec'
 
-const COMPOSITE_ENV_FRAGMENTS: readonly EnvFragment[] = [
-  {
-    name: 'LD_PRELOAD',
-    value: `${COMPOSITE_TRACER_MOUNT_PATH}/datadog-apm-inject/stable/inject/launcher.preload.so`,
-    separator: ' ',
-    mode: 'prepend',
-  },
-  {name: 'DD_INJECT_SENDER_TYPE', value: 'serverless', mode: 'set-if-absent'},
-]
+const COMPOSITE_INJECTION_SPEC = getCompositeInjectionSpec(CLOUD_RUN_TRACER_REGISTRY)
+export const COMPOSITE_TRACER_IMAGE = COMPOSITE_INJECTION_SPEC.image
+export const COMPOSITE_TRACER_COMPLETION_MARKER = `${COMPOSITE_TRACER_MOUNT_PATH}/.datadog-composite-copy-finished`
+const COMPOSITE_ENV_FRAGMENTS = COMPOSITE_INJECTION_SPEC.env
 
 export interface SsiOptions {
   readonly language: string | undefined
@@ -63,7 +62,7 @@ export type SsiConfigResult = (
       spec: LanguageInjectionSpec
       tracerVolumeMedium: TracerVolumeMedium
     }
-  | {kind: 'multi-language'; tracerVolumeMedium: TracerVolumeMedium}
+  | {kind: 'multi-language'; spec: CompositeInjectionSpec; tracerVolumeMedium: TracerVolumeMedium}
 ) & {warnings: readonly string[]}
 
 /** Resolves SSI inputs to a mode or validation errors. */
@@ -100,6 +99,7 @@ export const resolveSsiConfig = (options: SsiOptions): SsiConfigResult => {
         }
       : {
           kind: 'multi-language',
+          spec: COMPOSITE_INJECTION_SPEC,
           tracerVolumeMedium: options.tracerVolumeMedium ?? 'memory',
           warnings: [],
         }
@@ -114,18 +114,6 @@ export const resolveSsiConfig = (options: SsiOptions): SsiConfigResult => {
         )}. Use one of ${TRACER_INJECTION_LANGUAGES.map((language) => JSON.stringify(language)).join(
           ', '
         )}, or omit --language to detect it automatically.`,
-      ],
-      warnings: [],
-    }
-  }
-
-  if (!isCloudRunLanguage(options.language)) {
-    return {
-      kind: 'errors',
-      errors: [
-        `Automatic instrumentation does not support language ${JSON.stringify(
-          options.language
-        )}. Use one of ${TRACER_INJECTION_LANGUAGES.map((language) => JSON.stringify(language)).join(', ')}.`,
       ],
       warnings: [],
     }
@@ -274,13 +262,7 @@ export const mergeCompositeInjectionEnv = (existingEnv: readonly IEnvVar[] | nul
   )
 }
 
-export const removeSingleLanguageInjectionEnv = (existingEnv: readonly IEnvVar[] | null | undefined): IEnvVar[] =>
-  removeEnvFragments(existingEnv, LANGUAGE_ENV_FRAGMENTS, true)
-
-export const removeCompositeInjectionEnv = (existingEnv: readonly IEnvVar[] | null | undefined): IEnvVar[] =>
-  removeEnvFragments(existingEnv, COMPOSITE_ENV_FRAGMENTS, false)
-
-/** Removes exact tracer fragments for every supported injection mode during full uninstrumentation. */
+/** Removes exact tracer fragments for every supported injection mode. */
 export const removeInjectionEnv = (existingEnv: readonly IEnvVar[] | null | undefined): IEnvVar[] =>
   removeEnvFragments(existingEnv, [...LANGUAGE_ENV_FRAGMENTS, ...COMPOSITE_ENV_FRAGMENTS], true)
 

--- a/packages/plugin-cloud-run/src/ssi.ts
+++ b/packages/plugin-cloud-run/src/ssi.ts
@@ -5,12 +5,9 @@ import type {
   TracingInput,
   TracingMode,
 } from '@datadog/datadog-ci-base/commands/cloud-run/constants'
+import type {CompositeInjectionSpec} from '@datadog/datadog-ci-base/helpers/serverless/ssi/composite'
 import type {EnvFragment} from '@datadog/datadog-ci-base/helpers/serverless/ssi/env'
-import type {
-  CompositeInjectionSpec,
-  LanguageInjectionSpec,
-  Libc,
-} from '@datadog/datadog-ci-base/helpers/serverless/ssi/injection-spec'
+import type {LanguageInjectionSpec, Libc} from '@datadog/datadog-ci-base/helpers/serverless/ssi/injection-spec'
 import type {Language} from '@datadog/datadog-ci-base/helpers/serverless/ssi/tracer'
 
 import {
@@ -21,6 +18,10 @@ import {
   TRACING_MODE_BY_INPUT,
 } from '@datadog/datadog-ci-base/commands/cloud-run/constants'
 import {DD_TAGS_ENV_VAR} from '@datadog/datadog-ci-base/helpers/serverless/constants'
+import {
+  COMPOSITE_TRACER_MOUNT_PATH,
+  getCompositeInjectionSpec,
+} from '@datadog/datadog-ci-base/helpers/serverless/ssi/composite'
 import {TRACER_MOUNT_PATH} from '@datadog/datadog-ci-base/helpers/serverless/ssi/constants'
 import {
   mergeEnvFragment,
@@ -29,15 +30,13 @@ import {
   removeInjectionModeTag,
 } from '@datadog/datadog-ci-base/helpers/serverless/ssi/env'
 import {
-  COMPOSITE_TRACER_MOUNT_PATH,
   LIBCS,
-  getCompositeInjectionSpec,
   getLanguageCompatibilityErrors,
   getLanguageInjectionSpec,
 } from '@datadog/datadog-ci-base/helpers/serverless/ssi/injection-spec'
 import {TRACER_INJECTION_LANGUAGES} from '@datadog/datadog-ci-base/helpers/serverless/ssi/tracer'
 
-export {COMPOSITE_TRACER_MOUNT_PATH} from '@datadog/datadog-ci-base/helpers/serverless/ssi/injection-spec'
+export {COMPOSITE_TRACER_MOUNT_PATH} from '@datadog/datadog-ci-base/helpers/serverless/ssi/composite'
 
 const COMPOSITE_INJECTION_SPEC = getCompositeInjectionSpec(CLOUD_RUN_TRACER_REGISTRY)
 export const COMPOSITE_TRACER_IMAGE = COMPOSITE_INJECTION_SPEC.image

--- a/packages/plugin-cloud-run/src/utils.ts
+++ b/packages/plugin-cloud-run/src/utils.ts
@@ -39,9 +39,13 @@ export const fetchServiceConfigs = async (
 
           return serv
         } catch (error) {
-          throw new Error(
-            `Service ${serviceName} not found in project ${project}, region ${region}.\n\nNo services were instrumented.\n`
-          )
+          const cause = error instanceof Error ? error.message : String(error)
+          const message =
+            error instanceof Error && 'code' in error && error.code === 5
+              ? `Service ${serviceName} not found in project ${project}, region ${region}.`
+              : `Failed to fetch service ${serviceName} in project ${project}, region ${region}: ${cause}`
+
+          throw new Error(`${message}\n\nNo services were changed.\n`)
         }
       },
       `Fetched service configuration for ${chalk.bold(serviceName)}`


### PR DESCRIPTION
### What and why?

Cloud Run customers should be able to enable automatic tracer injection without knowing their application's language.

- `--tracing inject` without `--language` uses the composite tracer to detect Java, Node.js, .NET, Python, Ruby, or PHP.
- `--language` preserves explicit single-language injection.
- Instrumentation validates all selected services before applying updates, skips no-op updates, and reports partial completion.

### How?

The command mounts the composite tracer at `/opt/datadog-packages`, activates it in the application container, and removes owned single-language or composite-tracer state during cleanup. Automatic detection uses a 1.5 GiB memory-backed volume and a 2 GiB tracer-container memory limit. Both injection modes support Preview disk storage.

### Manual validation

A local run with published `latest` images passed configuration, traffic, and span checks for Java, Node.js, .NET, Python, Ruby, and PHP. The run deleted its temporary services.

### How to validate

Use a disposable, tracer-free Cloud Run service with authenticated `gcloud`, application-default credentials, `DD_API_KEY`, and `DD_SITE`.

```sh
yarn launch cloud-run instrument \
  --project "$PROJECT" --region "$REGION" --service "$SERVICE" \
  --tracing inject --no-source-code-integration
```

Confirm that the ready revision mounts the composite tracer at `/opt/datadog-packages`, sends traces, skips a repeated identical command, and removes Datadog-owned resources after `cloud-run uninstrument`.

The [Cloud Run E2E prerequisites and command](https://github.com/DataDog/datadog-ci/pull/2455) include the automatic-detection Node.js case. Use `--testNamePattern='detects and injects'` to run it.

### Review checklist

- [x] Feature or bugfix has appropriate tests.
