### PR TITLE
[SVLS-9308] Container Apps SSI E2E tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -233,6 +233,8 @@ jobs:
             container-app:
               - 'packages/plugin-container-app/**'
               - 'packages/base/package.json'
+              - 'packages/base/src/commands/container-app/**'
+              - 'packages/base/src/helpers/serverless/ssi/**'
               - 'packages/base/src/helpers/serverless/azure.ts'
               - 'packages/base/src/helpers/serverless/common.ts'
               - 'packages/base/src/helpers/serverless/constants.ts'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,13 +174,13 @@ jobs:
           tenant-id: ${{ vars.AZURE_TENANT_ID_E2E }}
           subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID_E2E }}
       - name: Google Cloud auth (OIDC)
-        if: (needs.check-cloud-run-changes.outputs.should_run == 'true' || needs.check-container-app-changes.outputs.should_run == 'true') && matrix.version == 24
+        if: needs.check-cloud-run-changes.outputs.should_run == 'true' && matrix.version == 24
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
         with:
           workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER_E2E }}
           service_account: ${{ vars.GCP_SERVICE_ACCOUNT_E2E }}
       - name: Set up Google Cloud CLI
-        if: (needs.check-cloud-run-changes.outputs.should_run == 'true' || needs.check-container-app-changes.outputs.should_run == 'true') && matrix.version == 24
+        if: needs.check-cloud-run-changes.outputs.should_run == 'true' && matrix.version == 24
         uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
       - name: Configure AWS credentials (OIDC)
         if: needs.check-lambda-changes.outputs.should_run == 'true' && matrix.version == 24

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,13 +174,13 @@ jobs:
           tenant-id: ${{ vars.AZURE_TENANT_ID_E2E }}
           subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID_E2E }}
       - name: Google Cloud auth (OIDC)
-        if: needs.check-cloud-run-changes.outputs.should_run == 'true' && matrix.version == 24
+        if: (needs.check-cloud-run-changes.outputs.should_run == 'true' || needs.check-container-app-changes.outputs.should_run == 'true') && matrix.version == 24
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
         with:
           workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER_E2E }}
           service_account: ${{ vars.GCP_SERVICE_ACCOUNT_E2E }}
       - name: Set up Google Cloud CLI
-        if: needs.check-cloud-run-changes.outputs.should_run == 'true' && matrix.version == 24
+        if: (needs.check-cloud-run-changes.outputs.should_run == 'true' || needs.check-container-app-changes.outputs.should_run == 'true') && matrix.version == 24
         uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
       - name: Configure AWS credentials (OIDC)
         if: needs.check-lambda-changes.outputs.should_run == 'true' && matrix.version == 24

--- a/e2e/serverless/container-app/container-app-ssi.test.ts
+++ b/e2e/serverless/container-app/container-app-ssi.test.ts
@@ -43,6 +43,9 @@ describeOrSkip('container-app automatic APM instrumentation', () => {
           ` --resource-group "${resourceGroup}"` +
           ` --environment "${process.env.AZURE_CONTAINER_APP_ENV}"` +
           ` --image "${NODE_APPLICATION_IMAGE}"` +
+          ` --registry-server us-central1-docker.pkg.dev` +
+          ` --registry-username oauth2accesstoken` +
+          ` --registry-password "$(gcloud auth print-access-token)"` +
           ` --cpu 0.25 --memory 0.5Gi` +
           ` --min-replicas 0 --max-replicas 1` +
           ` --ingress external --target-port 8080` +

--- a/e2e/serverless/container-app/container-app-ssi.test.ts
+++ b/e2e/serverless/container-app/container-app-ssi.test.ts
@@ -60,7 +60,7 @@ describeOrSkip('container-app automatic APM instrumentation', () => {
       verifySsiInstrumented(appName, resourceGroup, subscriptionId, runId, NODE_APPLICATION_IMAGE)
 
       const appUrl = getContainerAppUrl(appName, resourceGroup, subscriptionId)
-      await Promise.all([
+      const [traffic, telemetry] = await Promise.allSettled([
         triggerTraffic(appUrl, {attempts: 20, requiredSuccesses: 10, intervalSeconds: 10}),
         checkTelemetryFlowing(
           {
@@ -72,6 +72,12 @@ describeOrSkip('container-app automatic APM instrumentation', () => {
           {checkLogs: false}
         ),
       ])
+      if (traffic.status === 'rejected') {
+        throw traffic.reason
+      }
+      if (telemetry.status === 'rejected') {
+        throw telemetry.reason
+      }
 
       const retry = await execPromiseWithRetries(instrumentCommand, {
         DD_API_KEY: process.env.DATADOG_API_KEY,

--- a/e2e/serverless/container-app/container-app-ssi.test.ts
+++ b/e2e/serverless/container-app/container-app-ssi.test.ts
@@ -1,0 +1,112 @@
+import crypto from 'node:crypto'
+
+import {DATADOG_CI_COMMAND, execPromiseWithRetries} from '../../helpers/exec'
+
+import {checkTelemetryFlowing} from '../helpers/telemetry-checker'
+import {triggerTraffic} from '../helpers/traffic'
+
+import {getContainerAppUrl, verifySsiInstrumented, verifyUninstrumented} from './container-app-verifier'
+
+const NODE_APPLICATION_IMAGE =
+  'us-central1-docker.pkg.dev/datadog-serverless-gcp-dev/e2e-workloads/node-ssi@sha256:5943fc61fc30fd77fd847819b37b2cf32dbc394c107116621610bd4b13099ce2'
+
+const describeOrSkip =
+  process.env.SKIP_CONTAINER_APP_TESTS === 'true' || process.env.IS_STANDALONE_BINARY === 'true'
+    ? describe.skip
+    : describe
+
+describeOrSkip('container-app automatic APM instrumentation', () => {
+  const subscriptionId = process.env.AZURE_SUBSCRIPTION_ID!
+  const resourceGroup = process.env.AZURE_RESOURCE_GROUP!
+  const runId = crypto.randomBytes(4).toString('hex')
+  const appName = `one-e2e-capp-ssi-${runId}`
+  const instrumentCommand =
+    `${DATADOG_CI_COMMAND} container-app instrument` +
+    ` -s "${subscriptionId}"` +
+    ` -g "${resourceGroup}"` +
+    ` -n "${appName}"` +
+    ` --service "${appName}"` +
+    ` --env e2e` +
+    ` --version "${runId}"` +
+    ` --extra-tags "one_e2e_run_id:${runId}"` +
+    ` --tracing inject` +
+    ` --language nodejs` +
+    ` --no-source-code-integration`
+
+  it('injects, retries, traces, and removes the Node.js tracer', async () => {
+    let lifecycleError: Error | undefined
+    let cleanupError: Error | undefined
+    try {
+      const create = await execPromiseWithRetries(
+        `az containerapp create` +
+          ` --name "${appName}"` +
+          ` --resource-group "${resourceGroup}"` +
+          ` --environment "${process.env.AZURE_CONTAINER_APP_ENV}"` +
+          ` --image "${NODE_APPLICATION_IMAGE}"` +
+          ` --cpu 0.25 --memory 0.5Gi` +
+          ` --min-replicas 0 --max-replicas 1` +
+          ` --ingress external --target-port 8080` +
+          ` --tags one_e2e_created=${Math.floor(Date.now() / 1000)}` +
+          ` --output none`
+      )
+      if (create.exitCode !== 0) {
+        throw new Error(`Failed to create container app (exit code ${create.exitCode}): ${create.stderr}`)
+      }
+
+      const instrument = await execPromiseWithRetries(instrumentCommand, {
+        DD_API_KEY: process.env.DATADOG_API_KEY,
+      })
+      expect(instrument.exitCode).toBe(0)
+      verifySsiInstrumented(appName, resourceGroup, subscriptionId, runId, NODE_APPLICATION_IMAGE)
+
+      const appUrl = getContainerAppUrl(appName, resourceGroup, subscriptionId)
+      await Promise.all([
+        triggerTraffic(appUrl, {attempts: 20, requiredSuccesses: 10, intervalSeconds: 10}),
+        checkTelemetryFlowing(
+          {
+            serviceName: appName,
+            env: 'e2e',
+            version: runId,
+            tags: [`one_e2e_run_id:${runId}`],
+          },
+          {checkLogs: false}
+        ),
+      ])
+
+      const retry = await execPromiseWithRetries(instrumentCommand, {
+        DD_API_KEY: process.env.DATADOG_API_KEY,
+      })
+      expect(retry.exitCode).toBe(0)
+      verifySsiInstrumented(appName, resourceGroup, subscriptionId, runId, NODE_APPLICATION_IMAGE)
+
+      const uninstrument = await execPromiseWithRetries(
+        `${DATADOG_CI_COMMAND} container-app uninstrument` +
+          ` -s "${subscriptionId}"` +
+          ` -g "${resourceGroup}"` +
+          ` -n "${appName}"`,
+        {DD_API_KEY: process.env.DATADOG_API_KEY}
+      )
+      expect(uninstrument.exitCode).toBe(0)
+      verifyUninstrumented(appName, resourceGroup, subscriptionId)
+    } catch (error) {
+      lifecycleError = error instanceof Error ? error : new Error(String(error))
+    } finally {
+      const cleanup = await execPromiseWithRetries(
+        `az containerapp delete --name "${appName}" --resource-group "${resourceGroup}" --yes --output none`
+      )
+      if (cleanup.exitCode !== 0) {
+        cleanupError = new Error(`Failed to delete container app (exit code ${cleanup.exitCode}): ${cleanup.stderr}`)
+      }
+    }
+
+    if (lifecycleError && cleanupError) {
+      throw new Error(`${String(lifecycleError)}\n${cleanupError.message}`)
+    }
+    if (cleanupError) {
+      throw cleanupError
+    }
+    if (lifecycleError) {
+      throw lifecycleError
+    }
+  }, 1_200_000)
+})

--- a/e2e/serverless/container-app/container-app-ssi.test.ts
+++ b/e2e/serverless/container-app/container-app-ssi.test.ts
@@ -8,7 +8,7 @@ import {triggerTraffic} from '../helpers/traffic'
 import {getContainerAppUrl, verifySsiInstrumented, verifyUninstrumented} from './container-app-verifier'
 
 const NODE_APPLICATION_IMAGE =
-  'us-central1-docker.pkg.dev/datadog-serverless-gcp-dev/e2e-workloads/node-ssi@sha256:5943fc61fc30fd77fd847819b37b2cf32dbc394c107116621610bd4b13099ce2'
+  'dde2etfcapp.azurecr.io/node-ssi@sha256:1794d7e5edeea7dbe940e74037b4c715a0355af47080fb7fbfbd4bc4a93bfb89'
 
 const describeOrSkip =
   process.env.SKIP_CONTAINER_APP_TESTS === 'true' || process.env.IS_STANDALONE_BINARY === 'true'
@@ -43,9 +43,6 @@ describeOrSkip('container-app automatic APM instrumentation', () => {
           ` --resource-group "${resourceGroup}"` +
           ` --environment "${process.env.AZURE_CONTAINER_APP_ENV}"` +
           ` --image "${NODE_APPLICATION_IMAGE}"` +
-          ` --registry-server us-central1-docker.pkg.dev` +
-          ` --registry-username oauth2accesstoken` +
-          ` --registry-password "$(gcloud auth print-access-token)"` +
           ` --cpu 0.25 --memory 0.5Gi` +
           ` --min-replicas 0 --max-replicas 1` +
           ` --ingress external --target-port 8080` +

--- a/e2e/serverless/container-app/container-app-verifier.ts
+++ b/e2e/serverless/container-app/container-app-verifier.ts
@@ -3,6 +3,14 @@ import {execSync} from '../../helpers/exec'
 interface ContainerApp {
   properties: {
     template: {
+      initContainers?: {
+        name: string
+        image: string
+        command?: string[]
+        args?: string[]
+        resources?: {cpu?: number; memory?: string}
+        volumeMounts?: {volumeName: string; mountPath?: string}[]
+      }[]
       containers: {
         name: string
         image: string
@@ -24,6 +32,11 @@ interface ContainerApp {
 const SIDECAR_NAME = 'datadog-sidecar'
 const SHARED_VOLUME_NAME = 'shared-volume'
 const DD_API_KEY_SECRET_NAME = 'dd-api-key'
+const TRACER_NAME = 'datadog-tracer'
+const TRACER_MOUNT_PATH = '/datadog-lib'
+const NODE_TRACER_IMAGE = 'datadoghq.azurecr.io/dd-lib-js-init:latest'
+const NODE_OPTIONS_FRAGMENT = '--require /datadog-lib/node_modules/dd-trace/init.js'
+const INJECTION_MODE_TAG = '_dd.injection.mode:serverless-single-lang'
 const EXPECTED_ENV = 'e2e'
 const REQUIRED_ENV_VARS = [
   'DD_API_KEY',
@@ -37,7 +50,7 @@ const REQUIRED_ENV_VARS = [
   'DD_TAGS',
   'DD_APM_ENABLED',
 ]
-const DATADOG_TAGS = ['service', 'env', 'version', 'dd_sls_ci']
+const DATADOG_TAGS = ['service', 'env', 'version', 'dd_sls_ci', 'dd_sls_injection_mode']
 
 const getContainerApp = (appName: string, resourceGroup: string, subscriptionId: string): ContainerApp => {
   const output = execSync(
@@ -125,6 +138,82 @@ export const verifyInstrumented = (
   console.log('\nAll instrumented checks passed.')
 }
 
+export const verifySsiInstrumented = (
+  appName: string,
+  resourceGroup: string,
+  subscriptionId: string,
+  runId: string,
+  applicationImage: string
+): void => {
+  console.log(`Fetching container app "${appName}"...`)
+  const app = getContainerApp(appName, resourceGroup, subscriptionId)
+  const template = app.properties.template
+  const containers = template.containers ?? []
+  const initContainers = template.initContainers ?? []
+  const volumes = template.volumes ?? []
+  const tags = app.tags ?? {}
+
+  const sidecar = containers.find(({name}) => name === SIDECAR_NAME)
+  expect(sidecar).toBeDefined()
+  const applicationContainers = containers.filter(({name}) => name !== SIDECAR_NAME)
+  expect(applicationContainers).toHaveLength(1)
+  const application = applicationContainers[0]
+  expect(application.image).toBe(applicationImage)
+
+  const tracerContainers = initContainers.filter(({name}) => name === TRACER_NAME)
+  expect(tracerContainers).toHaveLength(1)
+  expect(tracerContainers[0]).toEqual(
+    expect.objectContaining({
+      image: NODE_TRACER_IMAGE,
+      command: ['/datadog-init/copy-lib.sh'],
+      args: [TRACER_MOUNT_PATH],
+      resources: expect.objectContaining({cpu: 0.25, memory: '0.5Gi'}),
+      volumeMounts: [{volumeName: TRACER_NAME, mountPath: TRACER_MOUNT_PATH}],
+    })
+  )
+
+  expect(volumes.filter(({name}) => name === TRACER_NAME)).toEqual([expect.objectContaining({storageType: 'EmptyDir'})])
+  expect(
+    containers
+      .filter((container) => container.volumeMounts?.some(({volumeName}) => volumeName === TRACER_NAME))
+      .map(({name}) => name)
+  ).toEqual([application.name])
+  expect(
+    initContainers
+      .filter((container) => container.volumeMounts?.some(({volumeName}) => volumeName === TRACER_NAME))
+      .map(({name}) => name)
+  ).toEqual([TRACER_NAME])
+  expect(
+    containers
+      .filter((container) => container.volumeMounts?.some(({mountPath}) => mountPath === TRACER_MOUNT_PATH))
+      .map(({name}) => name)
+  ).toEqual([application.name])
+  expect(
+    initContainers
+      .filter((container) => container.volumeMounts?.some(({mountPath}) => mountPath === TRACER_MOUNT_PATH))
+      .map(({name}) => name)
+  ).toEqual([TRACER_NAME])
+  expect(application.volumeMounts?.filter(({volumeName}) => volumeName === TRACER_NAME)).toEqual([
+    {volumeName: TRACER_NAME, mountPath: TRACER_MOUNT_PATH},
+  ])
+  expect(sidecar!.volumeMounts).not.toContainEqual(expect.objectContaining({volumeName: TRACER_NAME}))
+  expect(sidecar!.volumeMounts).not.toContainEqual(expect.objectContaining({mountPath: TRACER_MOUNT_PATH}))
+  expect(sidecar!.env?.some(({value}) => value?.includes(NODE_OPTIONS_FRAGMENT))).not.toBe(true)
+
+  const nodeOptions = application.env?.filter(({name}) => name === 'NODE_OPTIONS') ?? []
+  expect(nodeOptions).toHaveLength(1)
+  expect(nodeOptions[0].value?.split(NODE_OPTIONS_FRAGMENT)).toHaveLength(2)
+  const traceEnabled = application.env?.filter(({name}) => name === 'DD_TRACE_ENABLED') ?? []
+  const ddTags = application.env?.filter(({name}) => name === 'DD_TAGS') ?? []
+  expect(traceEnabled).toHaveLength(1)
+  expect(ddTags).toHaveLength(1)
+  const env = envByName(application)
+  expect(env.DD_TRACE_ENABLED.value).toBe('true')
+  expect(env.DD_TAGS.value?.split(INJECTION_MODE_TAG)).toHaveLength(2)
+  expect(env.DD_TAGS.value).toContain(`one_e2e_run_id:${runId}`)
+  expect(tags.dd_sls_injection_mode).toBe('single_language')
+}
+
 export const verifyUninstrumented = (appName: string, resourceGroup: string, subscriptionId: string): void => {
   console.log(`Fetching container app "${appName}"...`)
   const app = getContainerApp(appName, resourceGroup, subscriptionId)
@@ -132,6 +221,7 @@ export const verifyUninstrumented = (appName: string, resourceGroup: string, sub
 
   const template = app.properties.template
   const config = app.properties.configuration
+  const initContainers = template.initContainers || []
   const containers = template.containers || []
   const volumes = template.volumes || []
   const secrets = config.secrets || []
@@ -142,11 +232,15 @@ export const verifyUninstrumented = (appName: string, resourceGroup: string, sub
 
   const volume = volumes.find((v) => v.name === SHARED_VOLUME_NAME)
   expect(volume).toBeUndefined()
+  expect(initContainers.find(({name}) => name === TRACER_NAME)).toBeUndefined()
+  expect(volumes.find(({name}) => name === TRACER_NAME)).toBeUndefined()
 
   for (const container of containers) {
     const env = container.env || []
     const ddVars = env.filter((e) => e.name.startsWith('DD_'))
     expect(ddVars).toHaveLength(0)
+    expect(container.volumeMounts).not.toContainEqual(expect.objectContaining({volumeName: TRACER_NAME}))
+    expect(env.find(({name}) => name === 'NODE_OPTIONS')?.value ?? '').not.toContain(NODE_OPTIONS_FRAGMENT)
   }
 
   const apiKeySecret = secrets.find((s) => s.name === DD_API_KEY_SECRET_NAME)

--- a/e2e/serverless/container-app/container-app-verifier.ts
+++ b/e2e/serverless/container-app/container-app-verifier.ts
@@ -196,8 +196,8 @@ export const verifySsiInstrumented = (
   expect(application.volumeMounts?.filter(({volumeName}) => volumeName === TRACER_NAME)).toEqual([
     {volumeName: TRACER_NAME, mountPath: TRACER_MOUNT_PATH},
   ])
-  expect(sidecar!.volumeMounts).not.toContainEqual(expect.objectContaining({volumeName: TRACER_NAME}))
-  expect(sidecar!.volumeMounts).not.toContainEqual(expect.objectContaining({mountPath: TRACER_MOUNT_PATH}))
+  expect(sidecar!.volumeMounts ?? []).not.toContainEqual(expect.objectContaining({volumeName: TRACER_NAME}))
+  expect(sidecar!.volumeMounts ?? []).not.toContainEqual(expect.objectContaining({mountPath: TRACER_MOUNT_PATH}))
   expect(sidecar!.env?.some(({value}) => value?.includes(NODE_OPTIONS_FRAGMENT))).not.toBe(true)
 
   const nodeOptions = application.env?.filter(({name}) => name === 'NODE_OPTIONS') ?? []
@@ -239,7 +239,7 @@ export const verifyUninstrumented = (appName: string, resourceGroup: string, sub
     const env = container.env || []
     const ddVars = env.filter((e) => e.name.startsWith('DD_'))
     expect(ddVars).toHaveLength(0)
-    expect(container.volumeMounts).not.toContainEqual(expect.objectContaining({volumeName: TRACER_NAME}))
+    expect(container.volumeMounts ?? []).not.toContainEqual(expect.objectContaining({volumeName: TRACER_NAME}))
     expect(env.find(({name}) => name === 'NODE_OPTIONS')?.value ?? '').not.toContain(NODE_OPTIONS_FRAGMENT)
   }
 

--- a/packages/base/src/commands/container-app/common.ts
+++ b/packages/base/src/commands/container-app/common.ts
@@ -6,7 +6,10 @@ import {enableFips} from '../../helpers/fips'
 import {dryRunTag} from '../../helpers/renderer'
 import {parseResourceId} from '../../helpers/serverless/azure'
 import {ENV_VAR_REGEX, EXTRA_TAGS_REG_EXP} from '../../helpers/serverless/constants'
-import {DEFAULT_CONFIG_PATHS, resolveConfigFromFile} from '../../helpers/utils'
+import type {Libc} from '../../helpers/serverless/ssi/injection-spec'
+import type {Language} from '../../helpers/serverless/ssi/tracer'
+import type {TracingInput} from '../../helpers/serverless/ssi/tracing'
+import {DEFAULT_CONFIG_PATHS, removeUndefinedValues, resolveConfigFromFile} from '../../helpers/utils'
 
 import {BaseCommand} from '../..'
 
@@ -38,6 +41,11 @@ export type ContainerAppConfigOptions = Partial<{
   sharedVolumePath: string
   logsPath: string
   envVars: string[]
+  tracing: TracingInput
+  language: Language | 'go'
+  tracerVersion: string
+  tracerLibc: Libc
+  containerName: string
   // no-dd-sa:typescript-best-practices/boolean-prop-naming
   sourceCodeIntegration: boolean
   // no-dd-sa:typescript-best-practices/boolean-prop-naming
@@ -97,23 +105,32 @@ export abstract class ContainerAppCommand extends BaseCommand {
   }
 
   public async ensureConfig(): Promise<[ContainerAppBySubscriptionAndGroup, ContainerAppConfigOptions, string[]]> {
-    const config = (
+    const commandConfig = {
+      subscriptionId: this.subscriptionId,
+      resourceGroup: this.resourceGroup,
+      containerAppName: this.containerAppName,
+      envVars: this.envVars,
+      ...this.additionalConfig,
+    }
+    const fileConfig = (
       await resolveConfigFromFile<{containerApp: ContainerAppConfigOptions}>(
-        {
-          containerApp: {
-            subscriptionId: this.subscriptionId,
-            resourceGroup: this.resourceGroup,
-            containerAppName: this.containerAppName,
-            envVars: this.envVars,
-            ...this.additionalConfig,
-          },
-        },
+        {containerApp: commandConfig},
         {
           configPath: this.configPath,
           defaultConfigPaths: DEFAULT_CONFIG_PATHS,
         }
       )
     ).containerApp
+    const config = {
+      ...fileConfig,
+      ...removeUndefinedValues({
+        tracing: commandConfig.tracing,
+        language: commandConfig.language,
+        tracerVersion: commandConfig.tracerVersion,
+        tracerLibc: commandConfig.tracerLibc,
+        containerName: commandConfig.containerName,
+      }),
+    }
     const containerApps: ContainerAppBySubscriptionAndGroup = {}
     const errors: string[] = []
     if (process.env.DD_API_KEY === undefined) {

--- a/packages/base/src/commands/container-app/common.ts
+++ b/packages/base/src/commands/container-app/common.ts
@@ -7,7 +7,8 @@ import {dryRunTag} from '../../helpers/renderer'
 import {parseResourceId} from '../../helpers/serverless/azure'
 import {ENV_VAR_REGEX, EXTRA_TAGS_REG_EXP} from '../../helpers/serverless/constants'
 import type {Libc} from '../../helpers/serverless/ssi/injection-spec'
-import type {TracingInput} from '../../helpers/serverless/ssi/tracing'
+import {TRACING_INPUT_METADATA} from '../../helpers/serverless/ssi/tracing'
+import type {TracingInput, TracingMode} from '../../helpers/serverless/ssi/tracing'
 import {DEFAULT_CONFIG_PATHS, resolveConfigFromFile} from '../../helpers/utils'
 
 import {BaseCommand} from '../..'
@@ -16,6 +17,11 @@ import {BaseCommand} from '../..'
  * Maps Subscription ID to Resource Group to Container App names.
  */
 export type ContainerAppBySubscriptionAndGroup = Record<string, Record<string, string[]>>
+export type ContainerAppTracingInput = Extract<TracingInput, TracingMode>
+
+export const CONTAINER_APP_TRACING_INPUTS = TRACING_INPUT_METADATA.filter(({input, mode}) => input === mode).map(
+  ({input}) => input
+) as readonly ContainerAppTracingInput[]
 
 /**
  * Configuration options provided by the user through
@@ -40,7 +46,7 @@ export type ContainerAppConfigOptions = Partial<{
   sharedVolumePath: string
   logsPath: string
   envVars: string[]
-  tracing: TracingInput
+  tracing: ContainerAppTracingInput
   language: string
   tracerVersion: string
   tracerLibc: Libc

--- a/packages/base/src/commands/container-app/common.ts
+++ b/packages/base/src/commands/container-app/common.ts
@@ -7,8 +7,8 @@ import {dryRunTag} from '../../helpers/renderer'
 import {parseResourceId} from '../../helpers/serverless/azure'
 import {ENV_VAR_REGEX, EXTRA_TAGS_REG_EXP} from '../../helpers/serverless/constants'
 import type {Libc} from '../../helpers/serverless/ssi/injection-spec'
-import {TRACING_INPUT_METADATA} from '../../helpers/serverless/ssi/tracing'
-import type {TracingInput, TracingMode} from '../../helpers/serverless/ssi/tracing'
+import {TRACING_MODES} from '../../helpers/serverless/ssi/tracing'
+import type {TracingMode} from '../../helpers/serverless/ssi/tracing'
 import {DEFAULT_CONFIG_PATHS, resolveConfigFromFile} from '../../helpers/utils'
 
 import {BaseCommand} from '../..'
@@ -17,12 +17,6 @@ import {BaseCommand} from '../..'
  * Maps Subscription ID to Resource Group to Container App names.
  */
 export type ContainerAppBySubscriptionAndGroup = Record<string, Record<string, string[]>>
-export type ContainerAppTracingInput = Extract<TracingInput, TracingMode>
-
-export const CONTAINER_APP_TRACING_INPUTS = TRACING_INPUT_METADATA.filter(({input, mode}) => input === mode).map(
-  ({input}) => input
-) as readonly ContainerAppTracingInput[]
-
 /**
  * Configuration options provided by the user through
  * the CLI in order to instrument properly.
@@ -46,7 +40,7 @@ export type ContainerAppConfigOptions = Partial<{
   sharedVolumePath: string
   logsPath: string
   envVars: string[]
-  tracing: ContainerAppTracingInput
+  tracing: TracingMode
   language: string
   tracerVersion: string
   tracerLibc: Libc

--- a/packages/base/src/commands/container-app/common.ts
+++ b/packages/base/src/commands/container-app/common.ts
@@ -9,7 +9,7 @@ import {ENV_VAR_REGEX, EXTRA_TAGS_REG_EXP} from '../../helpers/serverless/consta
 import type {Libc} from '../../helpers/serverless/ssi/injection-spec'
 import type {Language} from '../../helpers/serverless/ssi/tracer'
 import type {TracingInput} from '../../helpers/serverless/ssi/tracing'
-import {DEFAULT_CONFIG_PATHS, removeUndefinedValues, resolveConfigFromFile} from '../../helpers/utils'
+import {DEFAULT_CONFIG_PATHS, resolveConfigFromFile} from '../../helpers/utils'
 
 import {BaseCommand} from '../..'
 
@@ -112,7 +112,7 @@ export abstract class ContainerAppCommand extends BaseCommand {
       envVars: this.envVars,
       ...this.additionalConfig,
     }
-    const fileConfig = (
+    const config = (
       await resolveConfigFromFile<{containerApp: ContainerAppConfigOptions}>(
         {containerApp: commandConfig},
         {
@@ -121,16 +121,6 @@ export abstract class ContainerAppCommand extends BaseCommand {
         }
       )
     ).containerApp
-    const config = {
-      ...fileConfig,
-      ...removeUndefinedValues({
-        tracing: commandConfig.tracing,
-        language: commandConfig.language,
-        tracerVersion: commandConfig.tracerVersion,
-        tracerLibc: commandConfig.tracerLibc,
-        containerName: commandConfig.containerName,
-      }),
-    }
     const containerApps: ContainerAppBySubscriptionAndGroup = {}
     const errors: string[] = []
     if (process.env.DD_API_KEY === undefined) {

--- a/packages/base/src/commands/container-app/common.ts
+++ b/packages/base/src/commands/container-app/common.ts
@@ -7,7 +7,6 @@ import {dryRunTag} from '../../helpers/renderer'
 import {parseResourceId} from '../../helpers/serverless/azure'
 import {ENV_VAR_REGEX, EXTRA_TAGS_REG_EXP} from '../../helpers/serverless/constants'
 import type {Libc} from '../../helpers/serverless/ssi/injection-spec'
-import type {Language} from '../../helpers/serverless/ssi/tracer'
 import type {TracingInput} from '../../helpers/serverless/ssi/tracing'
 import {DEFAULT_CONFIG_PATHS, resolveConfigFromFile} from '../../helpers/utils'
 
@@ -42,7 +41,7 @@ export type ContainerAppConfigOptions = Partial<{
   logsPath: string
   envVars: string[]
   tracing: TracingInput
-  language: Language | 'go'
+  language: string
   tracerVersion: string
   tracerLibc: Libc
   containerName: string

--- a/packages/base/src/commands/container-app/common.ts
+++ b/packages/base/src/commands/container-app/common.ts
@@ -17,6 +17,7 @@ import {BaseCommand} from '../..'
  * Maps Subscription ID to Resource Group to Container App names.
  */
 export type ContainerAppBySubscriptionAndGroup = Record<string, Record<string, string[]>>
+
 /**
  * Configuration options provided by the user through
  * the CLI in order to instrument properly.

--- a/packages/base/src/commands/container-app/instrument.ts
+++ b/packages/base/src/commands/container-app/instrument.ts
@@ -1,7 +1,7 @@
 import type {ContainerAppConfigOptions} from './common'
 
 import {Command, Option} from 'clipanion'
-import {isNumber} from 'typanion'
+import * as t from 'typanion'
 
 import {executePluginCommand} from '../../helpers/plugin'
 import {
@@ -11,8 +11,18 @@ import {
   DEFAULT_SIDECAR_NAME,
   SIDECAR_IMAGE,
 } from '../../helpers/serverless/constants'
+import {DEFAULT_TRACER_LIBC, LIBCS} from '../../helpers/serverless/ssi/injection-spec'
+import {
+  DEFAULT_TRACER_VERSION,
+  LANGUAGE_METADATA,
+  TRACER_IMAGE_TAG_REG_EXP,
+  type Language,
+} from '../../helpers/serverless/ssi/tracer'
+import {TRACING_INPUTS} from '../../helpers/serverless/ssi/tracing'
 
 import {ContainerAppCommand} from './common'
+
+export const CONTAINER_APP_LANGUAGES = [...(Object.keys(LANGUAGE_METADATA) as Language[]), 'go'] as const
 
 export const DEFAULT_SIDECAR_CPU = 0.5
 export const DEFAULT_SIDECAR_MEMORY = 1
@@ -50,14 +60,39 @@ export class ContainerAppInstrumentCommand extends ContainerAppCommand {
   })
   private sidecarCpu = Option.String('--sidecar-cpu', {
     description: `The number of CPUs to allocate to the sidecar container. Defaults to '${DEFAULT_SIDECAR_CPU}'.`,
-    validator: isNumber(),
+    validator: t.isNumber(),
   })
   private sidecarMemory = Option.String('--sidecar-memory', {
     description: `The amount of memory (in GiB) to allocate to the sidecar container. Defaults to '${DEFAULT_SIDECAR_MEMORY}'.`,
-    validator: isNumber(),
+    validator: t.isNumber(),
   })
   private sidecarImage = Option.String('--sidecar-image', SIDECAR_IMAGE, {
     description: `Override to pin a specific version tag or to use a mirrored image from a custom registry (e.g., ACR) to avoid pull rate limits. Defaults to '${SIDECAR_IMAGE}'`,
+  })
+  private tracing: ContainerAppConfigOptions['tracing'] = Option.String('--tracing', {
+    description:
+      'Configure APM instrumentation. Use "manual" when the tracer is installed, "inject" with --language for automatic instrumentation, or "disabled" to turn tracing off. The legacy values "true"/"1" and "false"/"0" map to "manual" and "disabled".',
+    validator: t.isEnum(TRACING_INPUTS),
+  })
+  private language: ContainerAppConfigOptions['language'] = Option.String('--language', {
+    description: `Set the application language for log parsing. With --tracing inject, this also selects the tracer. Possible values: ${CONTAINER_APP_LANGUAGES.map(
+      (language) => `"${language}"`
+    ).join(', ')}.`,
+    validator: t.isEnum(CONTAINER_APP_LANGUAGES),
+  })
+  private tracerVersion = Option.String('--tracer-version', {
+    description: `Set the tracer image tag for automatic instrumentation. Defaults to '${DEFAULT_TRACER_VERSION}'.`,
+    validator: t.cascade(t.isString(), t.matchesRegExp(TRACER_IMAGE_TAG_REG_EXP)),
+  })
+  private tracerLibc: ContainerAppConfigOptions['tracerLibc'] = Option.String('--tracer-libc', {
+    description: `Set the C standard library used by the application image. Possible values: ${LIBCS.map(
+      (libc) => `"${libc}"`
+    ).join(', ')}. Defaults to '${DEFAULT_TRACER_LIBC}'.`,
+    validator: t.isEnum(LIBCS),
+  })
+  private containerName = Option.String('--container-name', {
+    description:
+      'Select the application container to instrument when the Container App has multiple application containers.',
   })
 
   private sourceCodeIntegration = Option.Boolean('--source-code-integration,--sourceCodeIntegration', true, {
@@ -86,6 +121,11 @@ export class ContainerAppInstrumentCommand extends ContainerAppCommand {
       sidecarCpu: this.sidecarCpu,
       sidecarMemory: this.sidecarMemory,
       sidecarImage: this.sidecarImage,
+      tracing: this.tracing,
+      language: this.language,
+      tracerVersion: this.tracerVersion,
+      tracerLibc: this.tracerLibc,
+      containerName: this.containerName,
       sourceCodeIntegration: this.sourceCodeIntegration,
       uploadGitMetadata: this.uploadGitMetadata,
       extraTags: this.extraTags,

--- a/packages/base/src/commands/container-app/instrument.ts
+++ b/packages/base/src/commands/container-app/instrument.ts
@@ -13,8 +13,9 @@ import {
 } from '../../helpers/serverless/constants'
 import {DEFAULT_TRACER_LIBC, LIBCS} from '../../helpers/serverless/ssi/injection-spec'
 import {DEFAULT_TRACER_VERSION, TRACER_IMAGE_TAG_REG_EXP} from '../../helpers/serverless/ssi/tracer'
+import {TRACING_MODES} from '../../helpers/serverless/ssi/tracing'
 
-import {CONTAINER_APP_TRACING_INPUTS, ContainerAppCommand} from './common'
+import {ContainerAppCommand} from './common'
 
 export const DEFAULT_SIDECAR_CPU = 0.5
 export const DEFAULT_SIDECAR_MEMORY = 1
@@ -64,7 +65,7 @@ export class ContainerAppInstrumentCommand extends ContainerAppCommand {
   private tracing: ContainerAppConfigOptions['tracing'] = Option.String('--tracing', {
     description:
       'Configure APM instrumentation. Use `manual` when the tracer is installed, `inject` with `--language` for automatic instrumentation, or `disabled` to turn tracing off. Defaults to `manual`.',
-    validator: t.isEnum(CONTAINER_APP_TRACING_INPUTS),
+    validator: t.isEnum(TRACING_MODES),
   })
   private language: ContainerAppConfigOptions['language'] = Option.String('--language', {
     description:

--- a/packages/base/src/commands/container-app/instrument.ts
+++ b/packages/base/src/commands/container-app/instrument.ts
@@ -12,17 +12,10 @@ import {
   SIDECAR_IMAGE,
 } from '../../helpers/serverless/constants'
 import {DEFAULT_TRACER_LIBC, LIBCS} from '../../helpers/serverless/ssi/injection-spec'
-import {
-  DEFAULT_TRACER_VERSION,
-  LANGUAGE_METADATA,
-  TRACER_IMAGE_TAG_REG_EXP,
-  type Language,
-} from '../../helpers/serverless/ssi/tracer'
+import {DEFAULT_TRACER_VERSION, TRACER_IMAGE_TAG_REG_EXP} from '../../helpers/serverless/ssi/tracer'
 import {TRACING_INPUTS} from '../../helpers/serverless/ssi/tracing'
 
 import {ContainerAppCommand} from './common'
-
-export const CONTAINER_APP_LANGUAGES = [...(Object.keys(LANGUAGE_METADATA) as Language[]), 'go'] as const
 
 export const DEFAULT_SIDECAR_CPU = 0.5
 export const DEFAULT_SIDECAR_MEMORY = 1
@@ -75,10 +68,9 @@ export class ContainerAppInstrumentCommand extends ContainerAppCommand {
     validator: t.isEnum(TRACING_INPUTS),
   })
   private language: ContainerAppConfigOptions['language'] = Option.String('--language', {
-    description: `Set the application language for log parsing. With --tracing inject, this also selects the tracer. Possible values: ${CONTAINER_APP_LANGUAGES.map(
-      (language) => `"${language}"`
-    ).join(', ')}.`,
-    validator: t.isEnum(CONTAINER_APP_LANGUAGES),
+    description:
+      'Set the application language for log parsing. With --tracing inject, this selects a supported tracer.',
+    validator: t.cascade(t.isString(), t.matchesRegExp(/.+/)),
   })
   private tracerVersion = Option.String('--tracer-version', {
     description: `Set the tracer image tag for automatic instrumentation. Defaults to '${DEFAULT_TRACER_VERSION}'.`,

--- a/packages/base/src/commands/container-app/instrument.ts
+++ b/packages/base/src/commands/container-app/instrument.ts
@@ -12,7 +12,11 @@ import {
   SIDECAR_IMAGE,
 } from '../../helpers/serverless/constants'
 import {DEFAULT_TRACER_LIBC, LIBCS} from '../../helpers/serverless/ssi/injection-spec'
-import {DEFAULT_TRACER_VERSION, TRACER_IMAGE_TAG_REG_EXP} from '../../helpers/serverless/ssi/tracer'
+import {
+  DEFAULT_TRACER_VERSION,
+  TRACER_IMAGE_TAG_REG_EXP,
+  TRACER_INJECTION_LANGUAGES,
+} from '../../helpers/serverless/ssi/tracer'
 import {TRACING_MODES} from '../../helpers/serverless/ssi/tracing'
 
 import {ContainerAppCommand} from './common'
@@ -68,8 +72,9 @@ export class ContainerAppInstrumentCommand extends ContainerAppCommand {
     validator: t.isEnum(TRACING_MODES),
   })
   private language: ContainerAppConfigOptions['language'] = Option.String('--language', {
-    description:
-      'Set the application language for log parsing. With `--tracing inject`, this selects a supported tracer.',
+    description: `Set the application language for log parsing. With \`--tracing inject\`, this selects a supported tracer. Supported injection values: ${TRACER_INJECTION_LANGUAGES.map(
+      (language) => `\`${language}\``
+    ).join(', ')}.`,
     validator: t.cascade(t.isString(), t.matchesRegExp(/.+/)),
   })
   private tracerVersion = Option.String('--tracer-version', {

--- a/packages/base/src/commands/container-app/instrument.ts
+++ b/packages/base/src/commands/container-app/instrument.ts
@@ -13,9 +13,8 @@ import {
 } from '../../helpers/serverless/constants'
 import {DEFAULT_TRACER_LIBC, LIBCS} from '../../helpers/serverless/ssi/injection-spec'
 import {DEFAULT_TRACER_VERSION, TRACER_IMAGE_TAG_REG_EXP} from '../../helpers/serverless/ssi/tracer'
-import {TRACING_INPUTS} from '../../helpers/serverless/ssi/tracing'
 
-import {ContainerAppCommand} from './common'
+import {CONTAINER_APP_TRACING_INPUTS, ContainerAppCommand} from './common'
 
 export const DEFAULT_SIDECAR_CPU = 0.5
 export const DEFAULT_SIDECAR_MEMORY = 1
@@ -64,8 +63,8 @@ export class ContainerAppInstrumentCommand extends ContainerAppCommand {
   })
   private tracing: ContainerAppConfigOptions['tracing'] = Option.String('--tracing', {
     description:
-      'Configure APM instrumentation. Use `manual` when the tracer is installed, `inject` with `--language` for automatic instrumentation, or `disabled` to turn tracing off. The legacy values `true`/`1` and `false`/`0` map to `manual` and `disabled`.',
-    validator: t.isEnum(TRACING_INPUTS),
+      'Configure APM instrumentation. Use `manual` when the tracer is installed, `inject` with `--language` for automatic instrumentation, or `disabled` to turn tracing off. Defaults to `manual`.',
+    validator: t.isEnum(CONTAINER_APP_TRACING_INPUTS),
   })
   private language: ContainerAppConfigOptions['language'] = Option.String('--language', {
     description:

--- a/packages/base/src/commands/container-app/instrument.ts
+++ b/packages/base/src/commands/container-app/instrument.ts
@@ -64,12 +64,12 @@ export class ContainerAppInstrumentCommand extends ContainerAppCommand {
   })
   private tracing: ContainerAppConfigOptions['tracing'] = Option.String('--tracing', {
     description:
-      'Configure APM instrumentation. Use "manual" when the tracer is installed, "inject" with --language for automatic instrumentation, or "disabled" to turn tracing off. The legacy values "true"/"1" and "false"/"0" map to "manual" and "disabled".',
+      'Configure APM instrumentation. Use `manual` when the tracer is installed, `inject` with `--language` for automatic instrumentation, or `disabled` to turn tracing off. The legacy values `true`/`1` and `false`/`0` map to `manual` and `disabled`.',
     validator: t.isEnum(TRACING_INPUTS),
   })
   private language: ContainerAppConfigOptions['language'] = Option.String('--language', {
     description:
-      'Set the application language for log parsing. With --tracing inject, this selects a supported tracer.',
+      'Set the application language for log parsing. With `--tracing inject`, this selects a supported tracer.',
     validator: t.cascade(t.isString(), t.matchesRegExp(/.+/)),
   })
   private tracerVersion = Option.String('--tracer-version', {

--- a/packages/base/src/helpers/serverless/ssi/constants.ts
+++ b/packages/base/src/helpers/serverless/ssi/constants.ts
@@ -1,3 +1,4 @@
+export const TRACER_CONTAINER_NAME = 'datadog-tracer'
 export const TRACER_COPY_CONTAINER_NAME = 'datadog-tracer-copy'
 export const TRACER_VOLUME_NAME = 'datadog-tracer'
 export const TRACER_MOUNT_PATH = '/datadog-lib'

--- a/packages/base/src/helpers/serverless/ssi/injection-spec.ts
+++ b/packages/base/src/helpers/serverless/ssi/injection-spec.ts
@@ -5,7 +5,8 @@ import type {EnvFragment} from './env'
 import {buildSingleLanguageTracerImage, type Language, type SingleLanguageTracerRegistry} from './tracer'
 
 export const DEFAULT_TRACER_ROOT = '/datadog-lib'
-export const LIBCS = ['glibc', 'musl'] as const
+export const DEFAULT_TRACER_LIBC = 'glibc' as const
+export const LIBCS = [DEFAULT_TRACER_LIBC, 'musl'] as const
 
 export type Libc = (typeof LIBCS)[number]
 

--- a/packages/base/src/helpers/serverless/ssi/tracer.ts
+++ b/packages/base/src/helpers/serverless/ssi/tracer.ts
@@ -18,7 +18,8 @@ export const LANGUAGE_METADATA = {
 export type Language = keyof typeof LANGUAGE_METADATA
 export type TracerLanguage = (typeof LANGUAGE_METADATA)[Language]['tracerLanguage']
 
-const IMAGE_TAG_REG_EXP = /^[\w][\w.-]{0,127}$/
+export const DEFAULT_TRACER_VERSION = 'latest' as const
+export const TRACER_IMAGE_TAG_REG_EXP = /^[\w][\w.-]{0,127}$/
 
 /** Returns the copy-lib.sh completion marker for one tracer image. */
 export const getTracerCopyCompletionMarker = (language: Language, mountPath: string): string =>
@@ -36,7 +37,7 @@ export const buildSingleLanguageTracerImage = (
     throw new Error(`Unsupported language: ${String(language)}`)
   }
   const metadata = LANGUAGE_METADATA[language]
-  if (typeof version !== 'string' || !IMAGE_TAG_REG_EXP.test(version)) {
+  if (typeof version !== 'string' || !TRACER_IMAGE_TAG_REG_EXP.test(version)) {
     throw new Error(`Invalid tracer version: ${JSON.stringify(version)}`)
   }
 

--- a/packages/base/src/helpers/serverless/ssi/tracer.ts
+++ b/packages/base/src/helpers/serverless/ssi/tracer.ts
@@ -18,6 +18,11 @@ export const LANGUAGE_METADATA = {
 export type Language = keyof typeof LANGUAGE_METADATA
 export type TracerLanguage = (typeof LANGUAGE_METADATA)[Language]['tracerLanguage']
 
+export const TRACER_INJECTION_LANGUAGES: readonly Language[] = Object.keys(LANGUAGE_METADATA) as Language[]
+
+export const isTracerInjectionLanguage = (language: string): language is Language =>
+  Object.prototype.hasOwnProperty.call(LANGUAGE_METADATA, language)
+
 export const DEFAULT_TRACER_VERSION = 'latest' as const
 export const TRACER_IMAGE_TAG_REG_EXP = /^[\w][\w.-]{0,127}$/
 

--- a/packages/base/src/helpers/serverless/ssi/tracing.ts
+++ b/packages/base/src/helpers/serverless/ssi/tracing.ts
@@ -1,21 +1,3 @@
-export const TRACING_INPUT_METADATA = [
-  {input: 'true', mode: 'manual'},
-  {input: '1', mode: 'manual'},
-  {input: 'manual', mode: 'manual'},
-  {input: 'false', mode: 'disabled'},
-  {input: '0', mode: 'disabled'},
-  {input: 'disabled', mode: 'disabled'},
-  {input: 'inject', mode: 'inject'},
-] as const
+export const TRACING_MODES = ['manual', 'disabled', 'inject'] as const
 
-export type TracingInput = (typeof TRACING_INPUT_METADATA)[number]['input']
-export type TracingMode = (typeof TRACING_INPUT_METADATA)[number]['mode']
-
-export const TRACING_INPUTS = TRACING_INPUT_METADATA.map(({input}) => input)
-
-const TRACING_MODE_BY_INPUT = Object.fromEntries(
-  TRACING_INPUT_METADATA.map(({input, mode}) => [input, mode])
-) as Record<TracingInput, TracingMode>
-
-export const normalizeTracingInput = (input: TracingInput | undefined): TracingMode | undefined =>
-  input === undefined ? undefined : TRACING_MODE_BY_INPUT[input]
+export type TracingMode = (typeof TRACING_MODES)[number]

--- a/packages/base/src/helpers/serverless/ssi/tracing.ts
+++ b/packages/base/src/helpers/serverless/ssi/tracing.ts
@@ -1,0 +1,21 @@
+export const TRACING_INPUT_METADATA = [
+  {input: 'true', mode: 'manual'},
+  {input: '1', mode: 'manual'},
+  {input: 'manual', mode: 'manual'},
+  {input: 'false', mode: 'disabled'},
+  {input: '0', mode: 'disabled'},
+  {input: 'disabled', mode: 'disabled'},
+  {input: 'inject', mode: 'inject'},
+] as const
+
+export type TracingInput = (typeof TRACING_INPUT_METADATA)[number]['input']
+export type TracingMode = (typeof TRACING_INPUT_METADATA)[number]['mode']
+
+export const TRACING_INPUTS = TRACING_INPUT_METADATA.map(({input}) => input)
+
+const TRACING_MODE_BY_INPUT = Object.fromEntries(
+  TRACING_INPUT_METADATA.map(({input, mode}) => [input, mode])
+) as Record<TracingInput, TracingMode>
+
+export const normalizeTracingInput = (input: TracingInput | undefined): TracingMode | undefined =>
+  input === undefined ? undefined : TRACING_MODE_BY_INPUT[input]

--- a/packages/plugin-cloud-run/src/__tests__/ssi.test.ts
+++ b/packages/plugin-cloud-run/src/__tests__/ssi.test.ts
@@ -1,7 +1,6 @@
 import type {InstrumentServiceConfigOptions} from '../service-config'
 import type {IContainer, IEnvVar, IService} from '../types'
 import type {Libc} from '@datadog/datadog-ci-base/helpers/serverless/ssi/injection-spec'
-import type {Language} from '@datadog/datadog-ci-base/helpers/serverless/ssi/tracer'
 
 import {
   DD_TRACE_ENABLED_ENV_VAR,
@@ -14,10 +13,10 @@ import {
   getLanguageCompatibilityErrors,
   getLanguageInjectionSpec,
 } from '@datadog/datadog-ci-base/helpers/serverless/ssi/injection-spec'
+import {TRACER_INJECTION_LANGUAGES, type Language} from '@datadog/datadog-ci-base/helpers/serverless/ssi/tracer'
 
 import {instrumentServiceConfig} from '../service-config'
 import {
-  TRACER_INJECTION_LANGUAGES,
   mergeLanguageInjectionEnv,
   removeLanguageInjectionEnv,
   resolveSsiConfig,

--- a/packages/plugin-cloud-run/src/ssi.ts
+++ b/packages/plugin-cloud-run/src/ssi.ts
@@ -21,9 +21,7 @@ import {
   getLanguageCompatibilityErrors,
   getLanguageInjectionSpec,
 } from '@datadog/datadog-ci-base/helpers/serverless/ssi/injection-spec'
-import {LANGUAGE_METADATA} from '@datadog/datadog-ci-base/helpers/serverless/ssi/tracer'
-
-export const TRACER_INJECTION_LANGUAGES: readonly Language[] = Object.keys(LANGUAGE_METADATA) as Language[]
+import {TRACER_INJECTION_LANGUAGES} from '@datadog/datadog-ci-base/helpers/serverless/ssi/tracer'
 export const CLOUD_RUN_LANGUAGES = [...TRACER_INJECTION_LANGUAGES, 'go'] as const
 
 export type CloudRunLanguage = (typeof CLOUD_RUN_LANGUAGES)[number]

--- a/packages/plugin-container-app/README.md
+++ b/packages/plugin-container-app/README.md
@@ -57,6 +57,8 @@ Use `--tracing inject --language <language>` to add a Java, Node.js, .NET, Pytho
 
 Tracer injection uses the `latest` tracer version and `glibc` by default. Use `--tracer-version` to pin an image tag, or `--tracer-libc musl` for a musl-based image. Ruby injection does not support musl, and .NET tracer versions before 3.0 are not supported.
 
+Automatic instrumentation can increase cold-start delays when the app scales to zero. For scale-to-zero workloads, install the tracer in the application image, and use `--tracing manual`.
+
 For a Container App with multiple application containers, use `--container-name` to select one container. This differs from `--name`, which selects the Container App resource.
 
 Other tracing modes are:
@@ -189,6 +191,8 @@ Instead of supplying arguments, you can create a configuration file in your proj
     "environment": "prod",
     "version": "1.0.0",
     "logPath": "/custom-path/*.log",
+    "tracing": "inject",
+    "language": "python",
     "sourceCodeIntegration": true,
     "uploadGitMetadata": true,
     "extraTags": "team:backend,project:api",

--- a/packages/plugin-container-app/README.md
+++ b/packages/plugin-container-app/README.md
@@ -35,6 +35,14 @@ datadog-ci container-app instrument \
   --env prod \
   --version 1.0.0
 
+# Add a Python tracer automatically
+datadog-ci container-app instrument \
+  --subscription-id <subscription-id> \
+  --resource-group <resource-group-name> \
+  --name <container-app-name> \
+  --tracing inject \
+  --language python
+
 # Dry run to preview changes
 datadog-ci container-app instrument \
   --subscription-id <subscription-id> \
@@ -42,6 +50,22 @@ datadog-ci container-app instrument \
   --name <container-app-name> \
   --dry-run
 ```
+
+### Automatic APM instrumentation
+
+Use `--tracing inject --language <language>` to add a Java, Node.js, .NET, Python, Ruby, or PHP tracer without rebuilding the application image. The command copies the tracer through an init container and keeps the Datadog sidecar for trace transport.
+
+Tracer injection uses the `latest` tracer version and `glibc` by default. Use `--tracer-version` to pin an image tag, or `--tracer-libc musl` for a musl-based image. Ruby injection does not support musl, and .NET tracer versions before 3.0 are not supported.
+
+For a Container App with multiple application containers, use `--container-name` to select one container. This differs from `--name`, which selects the Container App resource.
+
+Other tracing modes are:
+
+- `--tracing manual`, `true`, or `1`: Use a tracer already installed in the application image.
+- `--tracing disabled`, `false`, or `0`: Disable tracing and remove an injected tracer.
+- Omit `--tracing`: Preserve existing tracer injection.
+
+You can use `--language` without `--tracing inject` to set `DD_SOURCE` for log parsing. Go requires manual instrumentation: install `dd-trace-go`, and use `--tracing manual`.
 
 ### `uninstrument`
 
@@ -124,6 +148,11 @@ You can pass the following arguments to `instrument` to specify its behavior. Th
 | `--sidecar-cpu` |  | The number of CPUs to allocate to the sidecar container. | `0.5` |
 | `--sidecar-memory` |  | The amount of memory (in GiB) to allocate to the sidecar container. | `1` |
 | `--sidecar-image` |  | Override to pin a specific version tag or to use a mirrored image from a custom registry (e.g., ACR) to avoid pull rate limits. | `index.docker.io/datadog/serverless-init:latest` |
+| `--tracing` |  | Configure APM instrumentation. Use "manual" when the tracer is installed, "inject" with --language for automatic instrumentation, or "disabled" to turn tracing off. The legacy values "true"/"1" and "false"/"0" map to "manual" and "disabled". |  |
+| `--language` |  | Set the application language for log parsing. With --tracing inject, this also selects the tracer. Possible values: "java", "nodejs", "csharp", "python", "ruby", "php", "go". |  |
+| `--tracer-version` |  | Set the tracer image tag for automatic instrumentation. | `latest` |
+| `--tracer-libc` |  | Set the C standard library used by the application image. Possible values: "glibc", "musl". | `glibc` |
+| `--container-name` |  | Select the application container to instrument when the Container App has multiple application containers. |  |
 | `--source-code-integration` or `--sourceCodeIntegration` |  | Whether to enable the Datadog Source Code integration. This tags your service(s) with the Git repository and the latest commit hash of the local directory. Specify `--no-source-code-integration` to disable. | `true` |
 | `--upload-git-metadata` or `--uploadGitMetadata` |  | Whether to enable Git metadata uploading, as a part of the source code integration. Git metadata uploading is only required if you don't have the Datadog GitHub integration installed. Specify `--no-upload-git-metadata` to disable. | `true` |
 | `--extra-tags` or `--extraTags` |  | Additional tags to add to the app in the format "key1:value1,key2:value2". |  |

--- a/packages/plugin-container-app/README.md
+++ b/packages/plugin-container-app/README.md
@@ -149,8 +149,8 @@ You can pass the following arguments to `instrument` to specify its behavior. Th
 | `--sidecar-cpu` |  | The number of CPUs to allocate to the sidecar container. | `0.5` |
 | `--sidecar-memory` |  | The amount of memory (in GiB) to allocate to the sidecar container. | `1` |
 | `--sidecar-image` |  | Override to pin a specific version tag or to use a mirrored image from a custom registry (e.g., ACR) to avoid pull rate limits. | `index.docker.io/datadog/serverless-init:latest` |
-| `--tracing` |  | Configure APM instrumentation. Use "manual" when the tracer is installed, "inject" with --language for automatic instrumentation, or "disabled" to turn tracing off. The legacy values "true"/"1" and "false"/"0" map to "manual" and "disabled". |  |
-| `--language` |  | Set the application language for log parsing. With --tracing inject, this selects a supported tracer. |  |
+| `--tracing` |  | Configure APM instrumentation. Use `manual` when the tracer is installed, `inject` with `--language` for automatic instrumentation, or `disabled` to turn tracing off. The legacy values `true`/`1` and `false`/`0` map to `manual` and `disabled`. |  |
+| `--language` |  | Set the application language for log parsing. With `--tracing inject`, this selects a supported tracer. |  |
 | `--tracer-version` |  | Set the tracer image tag for automatic instrumentation. | `latest` |
 | `--tracer-libc` |  | Set the C standard library used by the application image. Possible values: "glibc", "musl". | `glibc` |
 | `--container-name` |  | Select the application container to instrument when the Container App has multiple application containers. |  |

--- a/packages/plugin-container-app/README.md
+++ b/packages/plugin-container-app/README.md
@@ -55,7 +55,7 @@ datadog-ci container-app instrument \
 
 Use `--tracing inject --language <language>` to add a Java, Node.js, .NET, Python, Ruby, or PHP tracer without rebuilding the application image. The command copies the tracer through an init container and keeps the Datadog sidecar for trace transport.
 
-Tracer injection uses the `latest` tracer version and `glibc` by default. Use `--tracer-version` to pin an image tag, or `--tracer-libc musl` for a musl-based image. Ruby injection does not support musl, and .NET tracer versions before 3.0 are not supported.
+Tracer injection uses the `latest` tracer version and `glibc` by default. Use `--tracer-version` to pin an image tag, or `--tracer-libc musl` for a musl-based image. Ruby injection does not support musl, and .NET tracer versions before 3.0 are not supported. Runtime support follows the [APM compatibility requirements](https://docs.datadoghq.com/tracing/trace_collection/compatibility/); `latest` can drop runtimes after they reach end of life.
 
 Automatic instrumentation can increase cold-start delays when the app scales to zero. For scale-to-zero workloads, install the tracer in the application image, and use `--tracing manual`.
 

--- a/packages/plugin-container-app/README.md
+++ b/packages/plugin-container-app/README.md
@@ -64,10 +64,9 @@ For a Container App with multiple application containers, use `--container-name`
 Other tracing modes are:
 
 - `--tracing manual`, `true`, or `1`: Use a tracer already installed in the application image.
-- `--tracing disabled`, `false`, or `0`: Disable tracing and remove an injected tracer.
-- Omit `--tracing`: Preserve existing tracer injection.
+- `--tracing disabled`, `false`, or `0`: Disable tracing.
 
-You can use `--language` without `--tracing inject` to set `DD_SOURCE` for log parsing. Go requires manual instrumentation: install `dd-trace-go`, and use `--tracing manual`.
+You can use any nonempty `--language` value without `--tracing inject` to set `DD_SOURCE` for log parsing. With `--tracing inject`, use Java, Node.js, .NET, Python, Ruby, or PHP.
 
 ### `uninstrument`
 
@@ -151,7 +150,7 @@ You can pass the following arguments to `instrument` to specify its behavior. Th
 | `--sidecar-memory` |  | The amount of memory (in GiB) to allocate to the sidecar container. | `1` |
 | `--sidecar-image` |  | Override to pin a specific version tag or to use a mirrored image from a custom registry (e.g., ACR) to avoid pull rate limits. | `index.docker.io/datadog/serverless-init:latest` |
 | `--tracing` |  | Configure APM instrumentation. Use "manual" when the tracer is installed, "inject" with --language for automatic instrumentation, or "disabled" to turn tracing off. The legacy values "true"/"1" and "false"/"0" map to "manual" and "disabled". |  |
-| `--language` |  | Set the application language for log parsing. With --tracing inject, this also selects the tracer. Possible values: "java", "nodejs", "csharp", "python", "ruby", "php", "go". |  |
+| `--language` |  | Set the application language for log parsing. With --tracing inject, this selects a supported tracer. |  |
 | `--tracer-version` |  | Set the tracer image tag for automatic instrumentation. | `latest` |
 | `--tracer-libc` |  | Set the C standard library used by the application image. Possible values: "glibc", "musl". | `glibc` |
 | `--container-name` |  | Select the application container to instrument when the Container App has multiple application containers. |  |

--- a/packages/plugin-container-app/README.md
+++ b/packages/plugin-container-app/README.md
@@ -61,10 +61,7 @@ Automatic instrumentation can increase cold-start delays when the app scales to 
 
 For a Container App with multiple application containers, use `--container-name` to select one container. This differs from `--name`, which selects the Container App resource.
 
-Other tracing modes are:
-
-- `--tracing manual`, `true`, or `1`: Use a tracer already installed in the application image.
-- `--tracing disabled`, `false`, or `0`: Disable tracing.
+Tracing defaults to `manual`, which uses a tracer already installed in the application image. Use `--tracing disabled` to turn tracing off.
 
 You can use any nonempty `--language` value without `--tracing inject` to set `DD_SOURCE` for log parsing. With `--tracing inject`, use Java, Node.js, .NET, Python, Ruby, or PHP.
 
@@ -149,7 +146,7 @@ You can pass the following arguments to `instrument` to specify its behavior. Th
 | `--sidecar-cpu` |  | The number of CPUs to allocate to the sidecar container. | `0.5` |
 | `--sidecar-memory` |  | The amount of memory (in GiB) to allocate to the sidecar container. | `1` |
 | `--sidecar-image` |  | Override to pin a specific version tag or to use a mirrored image from a custom registry (e.g., ACR) to avoid pull rate limits. | `index.docker.io/datadog/serverless-init:latest` |
-| `--tracing` |  | Configure APM instrumentation. Use `manual` when the tracer is installed, `inject` with `--language` for automatic instrumentation, or `disabled` to turn tracing off. The legacy values `true`/`1` and `false`/`0` map to `manual` and `disabled`. |  |
+| `--tracing` |  | Configure APM instrumentation. Use `manual` when the tracer is installed, `inject` with `--language` for automatic instrumentation, or `disabled` to turn tracing off. Defaults to `manual`. |  |
 | `--language` |  | Set the application language for log parsing. With `--tracing inject`, this selects a supported tracer. |  |
 | `--tracer-version` |  | Set the tracer image tag for automatic instrumentation. | `latest` |
 | `--tracer-libc` |  | Set the C standard library used by the application image. Possible values: "glibc", "musl". | `glibc` |
@@ -213,7 +210,8 @@ Alternatively, you can use resource IDs:
       "/subscriptions/<subscription-id>/resourceGroups/<resource-group-name>/providers/Microsoft.App/containerApps/<container-app-name2>"
     ],
     "service": "my-service",
-    "environment": "prod"
+    "environment": "prod",
+    "tracing": "manual"
   }
 }
 ```

--- a/packages/plugin-container-app/README.md
+++ b/packages/plugin-container-app/README.md
@@ -53,7 +53,7 @@ datadog-ci container-app instrument \
 
 ### Automatic APM instrumentation
 
-Use `--tracing inject --language <language>` to add a Java, Node.js, .NET, Python, Ruby, or PHP tracer without rebuilding the application image. The command copies the tracer through an init container and keeps the Datadog sidecar for trace transport.
+Use `--tracing inject --language <language>` to add a tracer without rebuilding the application image. Supported language values are `java`, `nodejs`, `csharp`, `python`, `ruby`, and `php`. The command copies the tracer through an init container and keeps the Datadog sidecar for trace transport.
 
 Tracer injection uses the `latest` tracer version and `glibc` by default. Use `--tracer-version` to pin an image tag, or `--tracer-libc musl` for a musl-based image. Ruby injection does not support musl, and .NET tracer versions before 3.0 are not supported. Runtime support follows the [APM compatibility requirements](https://docs.datadoghq.com/tracing/trace_collection/compatibility/); `latest` can drop runtimes after they reach end of life.
 
@@ -124,7 +124,7 @@ You must expose these environment variables in the environment where you are run
 Configuration can be done using command-line arguments or a JSON configuration file (see the next section).
 
 #### `instrument`
-You can pass the following arguments to `instrument` to specify its behavior. These arguments override the values set in the configuration file, if any.
+You can pass the following arguments to `instrument` to specify its behavior. Values in the configuration file override command-line arguments.
 
 <!-- BEGIN_USAGE:instrument -->
 | Argument | Shorthand | Description | Default |
@@ -147,7 +147,7 @@ You can pass the following arguments to `instrument` to specify its behavior. Th
 | `--sidecar-memory` |  | The amount of memory (in GiB) to allocate to the sidecar container. | `1` |
 | `--sidecar-image` |  | Override to pin a specific version tag or to use a mirrored image from a custom registry (e.g., ACR) to avoid pull rate limits. | `index.docker.io/datadog/serverless-init:latest` |
 | `--tracing` |  | Configure APM instrumentation. Use `manual` when the tracer is installed, `inject` with `--language` for automatic instrumentation, or `disabled` to turn tracing off. Defaults to `manual`. |  |
-| `--language` |  | Set the application language for log parsing. With `--tracing inject`, this selects a supported tracer. |  |
+| `--language` |  | Set the application language for log parsing. With `--tracing inject`, this selects a supported tracer. Supported injection values: `java`, `nodejs`, `csharp`, `python`, `ruby`, `php`. |  |
 | `--tracer-version` |  | Set the tracer image tag for automatic instrumentation. | `latest` |
 | `--tracer-libc` |  | Set the C standard library used by the application image. Possible values: "glibc", "musl". | `glibc` |
 | `--container-name` |  | Select the application container to instrument when the Container App has multiple application containers. |  |

--- a/packages/plugin-container-app/src/__tests__/__snapshots__/instrument.test.ts.snap
+++ b/packages/plugin-container-app/src/__tests__/__snapshots__/instrument.test.ts.snap
@@ -9,7 +9,7 @@ Updating configuration for my-container-app:
 +     "secrets": [
 +       {
 +         "name": "dd-api-key",
-+         "value": "PLACEHOLDER"
++         "value": "<redacted>"
 +       }
 +     ]
     },
@@ -176,7 +176,7 @@ exports[`container-app instrument snapshot tests prints dry run data with basic 
 +     "secrets": [
 +       {
 +         "name": "dd-api-key",
-+         "value": "PLACEHOLDER"
++         "value": "<redacted>"
 +       }
 +     ]
     },

--- a/packages/plugin-container-app/src/__tests__/__snapshots__/uninstrument.test.ts.snap
+++ b/packages/plugin-container-app/src/__tests__/__snapshots__/uninstrument.test.ts.snap
@@ -9,11 +9,11 @@ Updating configuration for my-container-app:
       "secrets": [
         {
 -         "name": "dd-api-key",
--         "value": "PLACEHOLDER"
+-         "value": "<redacted>"
 -       },
 -       {
           "name": "other-secret",
-          "value": "OTHER"
+          "value": "<redacted>"
         }
       ]
     },
@@ -114,11 +114,11 @@ exports[`container-app uninstrument snapshot tests prints dry run data 1`] = `
       "secrets": [
         {
 -         "name": "dd-api-key",
--         "value": "PLACEHOLDER"
+-         "value": "<redacted>"
 -       },
 -       {
           "name": "other-secret",
-          "value": "OTHER"
+          "value": "<redacted>"
         }
       ]
     },

--- a/packages/plugin-container-app/src/__tests__/instrument.test.ts
+++ b/packages/plugin-container-app/src/__tests__/instrument.test.ts
@@ -270,7 +270,7 @@ Ensure you copied the value and not the Key ID.
 
       expect(code).toBe(0)
       expect(context.stdout.toString()).toContain(
-        'Tracing defaults to manual. Use --tracing inject --language <language> to retain automatic tracer injection.'
+        'Tracing defaults to manual for my-container-app. Use --tracing inject --language <language> to retain automatic tracer injection.'
       )
     })
 

--- a/packages/plugin-container-app/src/__tests__/instrument.test.ts
+++ b/packages/plugin-container-app/src/__tests__/instrument.test.ts
@@ -41,6 +41,7 @@ import {DefaultAzureCredential} from '@azure/identity'
 import {makeRunCLI} from '@datadog/datadog-ci-base/helpers/__tests__/testing-tools'
 
 import {PluginCommand as InstrumentCommand} from '../commands/instrument'
+import {SINGLE_LANGUAGE_SSI_MODE, SSI_INJECTION_MODE_TAG} from '../ssi'
 
 import {
   CONTAINER_APP_ID,
@@ -248,6 +249,29 @@ Ensure you copied the value and not the Key ID.
       expect(validateApiKey).not.toHaveBeenCalled()
       expect(getToken).not.toHaveBeenCalled()
       expect(containerAppsOperations.get).not.toHaveBeenCalled()
+    })
+
+    test.each(['true', 'false', '1', '0'])('Rejects legacy tracing input %s', async (tracing) => {
+      const {code} = await runCLI([...DEFAULT_INSTRUMENT_ARGS, '--tracing', tracing])
+
+      expect(code).toBe(1)
+      expect(validateApiKey).not.toHaveBeenCalled()
+      expect(getToken).not.toHaveBeenCalled()
+      expect(containerAppsOperations.get).not.toHaveBeenCalled()
+    })
+
+    test('Warns when omitted tracing removes automatic injection', async () => {
+      containerAppsOperations.get.mockResolvedValue({
+        ...DEFAULT_CONTAINER_APP,
+        tags: {[SSI_INJECTION_MODE_TAG]: SINGLE_LANGUAGE_SSI_MODE},
+      })
+
+      const {code, context} = await runCLI(DEFAULT_INSTRUMENT_ARGS)
+
+      expect(code).toBe(0)
+      expect(context.stdout.toString()).toContain(
+        'Tracing defaults to manual. Use --tracing inject --language <language> to retain automatic tracer injection.'
+      )
     })
 
     test('Sets DD_SOURCE without injecting a tracer when only --language is provided', async () => {
@@ -1010,7 +1034,7 @@ Ensure you copied the value and not the Key ID.
       expect(containerAppsOperations.beginUpdateAndWait).not.toHaveBeenCalled()
     })
 
-    test('leaves default variables alone on the main container', async () => {
+    test('enables tracing on the main container by default', async () => {
       const containerAppWithCorrectSidecar: ContainerApp = {
         ...DEFAULT_CONTAINER_APP,
         tags: {service: 'my-container-app'},
@@ -1081,7 +1105,20 @@ Ensure you copied the value and not the Key ID.
       }
 
       await command.instrumentSidecar(client, DEFAULT_CONFIG_WITH_DEFAULT_SERVICE, 'rg', containerAppWithCorrectSidecar)
-      expect(containerAppsOperations.beginUpdateAndWait).not.toHaveBeenCalled()
+      expect(containerAppsOperations.beginUpdateAndWait).toHaveBeenCalledWith(
+        'rg',
+        'my-container-app',
+        expect.objectContaining({
+          template: expect.objectContaining({
+            containers: expect.arrayContaining([
+              expect.objectContaining({
+                name: 'main-container',
+                env: expect.arrayContaining([{name: 'DD_TRACE_ENABLED', value: 'true'}]),
+              }),
+            ]),
+          }),
+        })
+      )
     })
 
     test('does not call Azure APIs in dry run mode', async () => {

--- a/packages/plugin-container-app/src/__tests__/instrument.test.ts
+++ b/packages/plugin-container-app/src/__tests__/instrument.test.ts
@@ -1410,13 +1410,13 @@ Ensure you copied the value and not the Key ID.
       expect(containerAppsOperations.get).toHaveBeenCalledWith('rg2', 'app2')
     })
 
-    test('Retries after a tracer tag update failure without duplicating configuration', async () => {
+    test('Continues after a tracer tag update failure without duplicating configuration', async () => {
       updateTags.mockClear().mockRejectedValueOnce(new Error('tag update error'))
 
       const first = await runCLI([...DEFAULT_INSTRUMENT_ARGS, '--tracing', 'inject', '--language', 'nodejs'])
-      expect(first.code).toEqual(1)
+      expect(first.code).toEqual(0)
       expect(first.context.stdout.toString()).toContain(
-        '[Error] Failed to instrument my-container-app: Error: tag update error'
+        '[Error] Failed to update tags for my-container-app: Error: tag update error'
       )
       const updatedApp = containerAppsOperations.beginUpdateAndWait.mock.calls[0][2] as ContainerApp
 

--- a/packages/plugin-container-app/src/__tests__/instrument.test.ts
+++ b/packages/plugin-container-app/src/__tests__/instrument.test.ts
@@ -234,6 +234,44 @@ Ensure you copied the value and not the Key ID.
       expect(updateTags).not.toHaveBeenCalled()
     })
 
+    test.each<[string[], string]>([
+      [['--tracing', 'inject'], '--tracing inject requires --language'],
+      [
+        ['--tracing', 'inject', '--language', 'nodejs', '--shared-volume-name', 'datadog-tracer'],
+        '--shared-volume-name',
+      ],
+    ])('Validates tracer configuration before authentication or API calls', async (args, message) => {
+      const {code, context} = await runCLI([...DEFAULT_INSTRUMENT_ARGS, ...args])
+
+      expect(code).toBe(1)
+      expect(context.stdout.toString()).toContain(message)
+      expect(validateApiKey).not.toHaveBeenCalled()
+      expect(getToken).not.toHaveBeenCalled()
+      expect(containerAppsOperations.get).not.toHaveBeenCalled()
+    })
+
+    test('Sets DD_SOURCE without injecting a tracer when only --language is provided', async () => {
+      const {code} = await runCLI([...DEFAULT_INSTRUMENT_ARGS, '--language', 'python'])
+
+      expect(code).toBe(0)
+      expect(containerAppsOperations.beginUpdateAndWait).toHaveBeenCalledWith(
+        'my-resource-group',
+        'my-container-app',
+        expect.objectContaining({
+          template: expect.objectContaining({
+            containers: expect.arrayContaining([
+              expect.objectContaining({
+                name: 'main-container',
+                env: expect.arrayContaining([{name: 'DD_SOURCE', value: 'python'}]),
+              }),
+            ]),
+          }),
+        })
+      )
+      const updatedApp = containerAppsOperations.beginUpdateAndWait.mock.calls[0][2] as ContainerApp
+      expect(updatedApp.template?.initContainers).toBeUndefined()
+    })
+
     test('Handles errors during sidecar instrumentation', async () => {
       containerAppsOperations.beginUpdateAndWait.mockClear().mockRejectedValue(new Error('sidecar error'))
       const {code, context} = await runCLI(DEFAULT_INSTRUMENT_ARGS)
@@ -1372,16 +1410,33 @@ Ensure you copied the value and not the Key ID.
       expect(containerAppsOperations.get).toHaveBeenCalledWith('rg2', 'app2')
     })
 
-    test('Tag update failure does not fail entire operation', async () => {
-      updateTags.mockClear().mockRejectedValue(new Error('tag update error'))
+    test('Retries after a tracer tag update failure without duplicating configuration', async () => {
+      updateTags.mockClear().mockRejectedValueOnce(new Error('tag update error'))
 
-      const {code, context} = await runCLI(DEFAULT_INSTRUMENT_ARGS)
-      expect(code).toEqual(0)
-      const output = context.stdout.toString()
-      expect(output).toContain('Updating configuration for my-container-app')
-      expect(output).toContain('[Error] Failed to update tags for my-container-app')
-      expect(containerAppsOperations.beginUpdateAndWait).toHaveBeenCalled()
-      expect(updateTags).toHaveBeenCalled()
+      const first = await runCLI([...DEFAULT_INSTRUMENT_ARGS, '--tracing', 'inject', '--language', 'nodejs'])
+      expect(first.code).toEqual(1)
+      expect(first.context.stdout.toString()).toContain(
+        '[Error] Failed to instrument my-container-app: Error: tag update error'
+      )
+      const updatedApp = containerAppsOperations.beginUpdateAndWait.mock.calls[0][2] as ContainerApp
+
+      containerAppsOperations.get.mockResolvedValue(updatedApp)
+      containerAppsOperations.listSecrets.mockResolvedValue({value: updatedApp.configuration?.secrets})
+      containerAppsOperations.beginUpdateAndWait.mockClear()
+      updateTags.mockResolvedValue({})
+
+      const retry = await runCLI([...DEFAULT_INSTRUMENT_ARGS, '--tracing', 'inject', '--language', 'nodejs'])
+      expect(retry.code).toEqual(0)
+      expect(containerAppsOperations.beginUpdateAndWait).not.toHaveBeenCalled()
+      expect(updateTags).toHaveBeenLastCalledWith(CONTAINER_APP_ID, {
+        properties: {
+          tags: {
+            service: 'my-container-app',
+            dd_sls_ci: 'vXXXX',
+            dd_sls_injection_mode: 'single_language',
+          },
+        },
+      })
     })
 
     test('Uses custom sidecar name', async () => {

--- a/packages/plugin-container-app/src/__tests__/instrument.test.ts
+++ b/packages/plugin-container-app/src/__tests__/instrument.test.ts
@@ -274,6 +274,30 @@ Ensure you copied the value and not the Key ID.
       )
     })
 
+    test('Redacts secrets in the configuration diff without redacting the Azure update', async () => {
+      containerAppsOperations.listSecrets.mockResolvedValue({
+        value: [
+          {name: 'dd-api-key', value: 'source-dd-secret-value'},
+          {name: 'other-secret', value: 'sensitive-value'},
+        ],
+      })
+
+      const {code, context} = await runCLI(DEFAULT_INSTRUMENT_ARGS)
+
+      expect(code).toBe(0)
+      expect(context.stdout.toString()).not.toContain('sensitive-value')
+      expect(context.stdout.toString()).not.toContain('source-dd-secret-value')
+      expect(containerAppsOperations.beginUpdateAndWait).toHaveBeenCalledWith(
+        'my-resource-group',
+        'my-container-app',
+        expect.objectContaining({
+          configuration: expect.objectContaining({
+            secrets: expect.arrayContaining([{name: 'other-secret', value: 'sensitive-value'}]),
+          }),
+        })
+      )
+    })
+
     test('Sets DD_SOURCE without injecting a tracer when only --language is provided', async () => {
       const {code} = await runCLI([...DEFAULT_INSTRUMENT_ARGS, '--language', 'python'])
 

--- a/packages/plugin-container-app/src/__tests__/ssi.test.ts
+++ b/packages/plugin-container-app/src/__tests__/ssi.test.ts
@@ -73,7 +73,7 @@ describe('Container Apps automatic APM instrumentation', () => {
 
     test.each([
       [{tracing: 'inject'}, '--language'],
-      [{tracing: 'inject', language: 'go'}, 'supports only these languages'],
+      [{tracing: 'inject', language: 'go'}, 'Install dd-trace-go'],
       [{tracing: 'inject', language: 'rust'}, 'supports only these languages'],
       [{tracerVersion: '1.2.3'}, '--tracing inject'],
       [{tracerLibc: 'musl'}, '--tracing inject'],

--- a/packages/plugin-container-app/src/__tests__/ssi.test.ts
+++ b/packages/plugin-container-app/src/__tests__/ssi.test.ts
@@ -15,6 +15,7 @@ import {PluginCommand as InstrumentCommand} from '../commands/instrument'
 import {
   SINGLE_LANGUAGE_SSI_MODE,
   SSI_INJECTION_MODE_TAG,
+  hasSsi,
   mergeLanguageInjectionEnv,
   removeLanguageInjectionEnv,
   resolveSsiConfig,
@@ -76,7 +77,8 @@ describe('Container Apps automatic APM instrumentation', () => {
 
     test.each([
       [{tracing: 'inject'}, '--language'],
-      [{tracing: 'inject', language: 'go'}, 'dd-trace-go'],
+      [{tracing: 'inject', language: 'go'}, 'supports only these languages'],
+      [{tracing: 'inject', language: 'rust'}, 'supports only these languages'],
       [{tracerVersion: '1.2.3'}, '--tracing inject'],
       [{tracerLibc: 'musl'}, '--tracing inject'],
       [{tracing: 'inject', language: 'ruby', tracerLibc: 'musl'}, 'does not support musl'],
@@ -90,6 +92,13 @@ describe('Container Apps automatic APM instrumentation', () => {
         expect(result.kind === 'errors' && result.errors.join('\n')).toContain(message)
       }
     )
+
+    test('accepts arbitrary language values without injection', () => {
+      expect(resolveSsiConfig({...DEFAULT_CONFIG, tracing: 'manual', language: 'rust'})).toMatchObject({
+        kind: 'no-injection',
+        tracing: 'manual',
+      })
+    })
 
     test('warns for Java 24+', () => {
       expect(resolveSsiConfig(injectConfig('java')).warnings.join('\n')).toContain('Java 24+')
@@ -233,7 +242,28 @@ describe('Container Apps automatic APM instrumentation', () => {
       expect(second.template).toEqual(first.template)
     })
 
-    test('validates stale managed environment before a language transition', () => {
+    test('validates the selected environment before injection', () => {
+      const app = {
+        ...DEFAULT_CONTAINER_APP,
+        template: {
+          ...DEFAULT_CONTAINER_APP.template,
+          containers: [
+            {
+              ...DEFAULT_CONTAINER_APP.template!.containers![0],
+              env: [
+                ...(DEFAULT_CONTAINER_APP.template!.containers![0].env ?? []),
+                {name: 'NODE_OPTIONS', value: 'first'},
+                {name: 'NODE_OPTIONS', value: 'second'},
+              ],
+            },
+          ],
+        },
+      }
+
+      expect(() => createInstrumentedApp(injectConfig(), app)).toThrow(/NODE_OPTIONS appears more than once/)
+    })
+
+    test('does not reject unrelated managed environment during a language transition', () => {
       const node = createInstrumentedApp(injectConfig())
       const app = node.template!.containers![0]
       const unsafe = {
@@ -248,7 +278,7 @@ describe('Container Apps automatic APM instrumentation', () => {
         },
       }
 
-      expect(() => createInstrumentedApp(injectConfig('python'), unsafe)).toThrow(/NODE_OPTIONS appears more than once/)
+      expect(() => createInstrumentedApp(injectConfig('python'), unsafe)).not.toThrow()
     })
 
     test('replaces an owned tracer with another language', () => {
@@ -285,20 +315,25 @@ describe('Container Apps automatic APM instrumentation', () => {
       expect(getEnv(app.env, DD_TRACE_ENABLED_ENV_VAR)?.value).toBe(traceEnabled)
     })
 
-    test('omitted tracing preserves existing injection when updating DD_TAGS', () => {
+    test('detects SSI from the process marker', () => {
+      expect(
+        hasSsi({
+          ...DEFAULT_CONTAINER_APP,
+          template: {containers: [{name: 'app', env: [{name: 'DD_TAGS', value: SINGLE_LANGUAGE_INJECTION_MODE_TAG}]}]},
+        })
+      ).toBe(true)
+    })
+
+    test('omitted tracing removes existing injection', () => {
       const injected = createInstrumentedApp(injectConfig())
       const result = createInstrumentedApp(
         {...DEFAULT_CONFIG, service: 'my-container-app', extraTags: 'team:serverless'},
         injected
       )
 
-      expect(result.template?.initContainers).toEqual(injected.template?.initContainers)
-      expect(getEnv(result.template?.containers?.[0].env, 'NODE_OPTIONS')).toEqual(
-        getEnv(injected.template?.containers?.[0].env, 'NODE_OPTIONS')
-      )
-      expect(getEnv(result.template?.containers?.[0].env, 'DD_TAGS')?.value).toBe(
-        `${SINGLE_LANGUAGE_INJECTION_MODE_TAG},team:serverless`
-      )
+      expect(result.template?.initContainers).toEqual([])
+      expect(getEnv(result.template?.containers?.[0].env, 'NODE_OPTIONS')).toBeUndefined()
+      expect(getEnv(result.template?.containers?.[0].env, 'DD_TAGS')?.value).toBe('team:serverless')
     })
   })
 })

--- a/packages/plugin-container-app/src/__tests__/ssi.test.ts
+++ b/packages/plugin-container-app/src/__tests__/ssi.test.ts
@@ -1,0 +1,304 @@
+import type {ContainerApp, EnvironmentVar} from '@azure/arm-appcontainers'
+import type {ContainerAppConfigOptions} from '@datadog/datadog-ci-base/commands/container-app/common'
+import type {Language} from '@datadog/datadog-ci-base/helpers/serverless/ssi/tracer'
+
+import {createCommand} from '@datadog/datadog-ci-base/helpers/__tests__/testing-tools'
+import {DD_TRACE_ENABLED_ENV_VAR} from '@datadog/datadog-ci-base/helpers/serverless/constants'
+import {
+  TRACER_CONTAINER_NAME,
+  TRACER_MOUNT_PATH,
+  TRACER_VOLUME_NAME,
+} from '@datadog/datadog-ci-base/helpers/serverless/ssi/constants'
+import {SINGLE_LANGUAGE_INJECTION_MODE_TAG} from '@datadog/datadog-ci-base/helpers/serverless/ssi/env'
+
+import {PluginCommand as InstrumentCommand} from '../commands/instrument'
+import {
+  SINGLE_LANGUAGE_SSI_MODE,
+  SSI_INJECTION_MODE_TAG,
+  mergeLanguageInjectionEnv,
+  removeLanguageInjectionEnv,
+  resolveSsiConfig,
+  selectApplicationContainer,
+} from '../ssi'
+
+import {DEFAULT_CONFIG, DEFAULT_CONTAINER_APP} from './common'
+
+const injectConfig = (language: ContainerAppConfigOptions['language'] = 'nodejs'): ContainerAppConfigOptions => ({
+  ...DEFAULT_CONFIG,
+  service: DEFAULT_CONTAINER_APP.name,
+  sourceCodeIntegration: false,
+  tracing: 'inject',
+  language,
+})
+
+const getEnv = (env: EnvironmentVar[] | undefined, name: string) => env?.find((variable) => variable.name === name)
+
+const createInstrumentedApp = (config: ContainerAppConfigOptions, app: ContainerApp = DEFAULT_CONTAINER_APP) => {
+  const command = createCommand(InstrumentCommand)
+
+  return command.createInstrumentedAppConfig(config, DEFAULT_CONFIG.subscriptionId!, DEFAULT_CONFIG.resourceGroup!, app)
+}
+
+describe('Container Apps automatic APM instrumentation', () => {
+  describe('input resolution', () => {
+    test.each([
+      [undefined, undefined],
+      ['manual', 'manual'],
+      ['true', 'manual'],
+      ['1', 'manual'],
+      ['disabled', 'disabled'],
+      ['false', 'disabled'],
+      ['0', 'disabled'],
+    ] as const)('resolves tracing input %s without injection', (tracing, expected) => {
+      expect(resolveSsiConfig({...DEFAULT_CONFIG, tracing})).toEqual({
+        kind: 'no-injection',
+        tracing: expected,
+        warnings: [],
+      })
+    })
+
+    test.each<[Language, string]>([
+      ['java', 'java'],
+      ['nodejs', 'js'],
+      ['csharp', 'dotnet'],
+      ['python', 'python'],
+      ['ruby', 'ruby'],
+      ['php', 'php'],
+    ])('uses the Azure tracer image for %s', (language, tracerLanguage) => {
+      const result = resolveSsiConfig(injectConfig(language))
+
+      expect(result.kind).toBe('single-language')
+      expect(result.kind === 'single-language' && result.spec.image).toBe(
+        `datadoghq.azurecr.io/dd-lib-${tracerLanguage}-init:latest`
+      )
+      expect(result.kind === 'single-language' && result.libc).toBe('glibc')
+    })
+
+    test.each([
+      [{tracing: 'inject'}, '--language'],
+      [{tracing: 'inject', language: 'go'}, 'dd-trace-go'],
+      [{tracerVersion: '1.2.3'}, '--tracing inject'],
+      [{tracerLibc: 'musl'}, '--tracing inject'],
+      [{tracing: 'inject', language: 'ruby', tracerLibc: 'musl'}, 'does not support musl'],
+      [{tracing: 'inject', language: 'csharp', tracerVersion: '2.51.0'}, 'version 3.0 or later'],
+    ] satisfies [Partial<ContainerAppConfigOptions>, string][])(
+      'rejects incompatible options %#',
+      (options, message) => {
+        const result = resolveSsiConfig({...DEFAULT_CONFIG, ...options})
+
+        expect(result.kind).toBe('errors')
+        expect(result.kind === 'errors' && result.errors.join('\n')).toContain(message)
+      }
+    )
+
+    test('warns for Java 24+', () => {
+      expect(resolveSsiConfig(injectConfig('java')).warnings.join('\n')).toContain('Java 24+')
+    })
+  })
+
+  describe('application container selection', () => {
+    const containers = [{name: 'app'}, {name: 'worker'}, {name: 'datadog-sidecar'}]
+
+    test('selects the sole non-Agent container', () => {
+      expect(selectApplicationContainer([containers[0], containers[2]], 'datadog-sidecar', undefined)).toBe(0)
+    })
+
+    test.each(['worker', ' worker '])('selects an explicit container from a multi-container app', (name) => {
+      expect(selectApplicationContainer(containers, 'datadog-sidecar', name)).toBe(1)
+    })
+
+    test('treats a blank selector as omitted', () => {
+      expect(selectApplicationContainer([containers[0], containers[2]], 'datadog-sidecar', '   ')).toBe(0)
+    })
+
+    test.each([
+      [undefined, 'multiple candidates'],
+      ['missing', 'was not found'],
+    ])('rejects an invalid selector %s', (name, message) => {
+      expect(() => selectApplicationContainer(containers, 'datadog-sidecar', name)).toThrow(message)
+    })
+  })
+
+  describe('native environment', () => {
+    const nodeResult = resolveSsiConfig(injectConfig('nodejs'))
+    const nodeSpec = nodeResult.kind === 'single-language' ? nodeResult.spec : undefined
+
+    test('merges and removes exact tracer fragments without replacing unrelated values', () => {
+      const original = [
+        {name: 'NODE_OPTIONS', value: '--inspect'},
+        {name: 'DD_TAGS', value: 'team:serverless'},
+        {name: 'KEEP', value: 'value'},
+      ]
+      const merged = mergeLanguageInjectionEnv(original, nodeSpec!)
+
+      expect(getEnv(merged, 'NODE_OPTIONS')?.value).toBe(
+        '--inspect --require /datadog-lib/node_modules/dd-trace/init.js'
+      )
+      expect(getEnv(merged, 'DD_TAGS')?.value).toBe(`${SINGLE_LANGUAGE_INJECTION_MODE_TAG},team:serverless`)
+      expect(removeLanguageInjectionEnv(merged)).toEqual(original)
+    })
+
+    test.each([
+      [
+        {name: 'NODE_OPTIONS', value: 'first'},
+        {name: 'NODE_OPTIONS', value: 'second'},
+      ],
+      [{name: 'NODE_OPTIONS', secretRef: 'node-options'}],
+    ])('rejects an unsafe managed environment %#', (...env) => {
+      expect(() => mergeLanguageInjectionEnv(env, nodeSpec!)).toThrow(/NODE_OPTIONS/)
+    })
+
+    test('rejects a conflicting scalar value', () => {
+      const dotnet = resolveSsiConfig(injectConfig('csharp'))
+      const spec = dotnet.kind === 'single-language' ? dotnet.spec : undefined
+
+      expect(() => mergeLanguageInjectionEnv([{name: 'CORECLR_ENABLE_PROFILING', value: '0'}], spec!)).toThrow(
+        /expected "1"/
+      )
+    })
+
+    test('enforces the .NET LD_PRELOAD limit', () => {
+      const dotnet = resolveSsiConfig(injectConfig('csharp'))
+      const spec = dotnet.kind === 'single-language' ? dotnet.spec : undefined
+
+      expect(() => mergeLanguageInjectionEnv([{name: 'LD_PRELOAD', value: 'x'.repeat(1024)}], spec!)).toThrow(
+        /1024-byte limit/
+      )
+    })
+  })
+
+  describe('ARM configuration', () => {
+    test.each<[Language, string, string]>([
+      ['java', 'JAVA_TOOL_OPTIONS', '-javaagent:/datadog-lib/dd-java-agent.jar'],
+      ['nodejs', 'NODE_OPTIONS', '--require /datadog-lib/node_modules/dd-trace/init.js'],
+      ['csharp', 'DD_DOTNET_TRACER_HOME', '/datadog-lib'],
+      ['python', 'PYTHONPATH', '/datadog-lib'],
+      ['ruby', 'RUBYOPT', '-r/datadog-lib/auto_inject'],
+      ['php', 'DD_LOADER_PACKAGE_PATH', '/datadog-lib'],
+    ])('adds the %s native environment to the selected application container', (language, envName, value) => {
+      const result = createInstrumentedApp(injectConfig(language))
+      const app = result.template!.containers![0]
+
+      expect(getEnv(app.env, envName)?.value).toContain(value)
+      expect(getEnv(app.env, DD_TRACE_ENABLED_ENV_VAR)?.value).toBe('true')
+      expect(getEnv(app.env, 'DD_TAGS')?.value).toContain(SINGLE_LANGUAGE_INJECTION_MODE_TAG)
+      expect(result.template?.initContainers).toContainEqual({
+        name: TRACER_CONTAINER_NAME,
+        image: expect.stringContaining('datadoghq.azurecr.io/dd-lib-'),
+        command: ['/datadog-init/copy-lib.sh'],
+        args: [TRACER_MOUNT_PATH],
+        resources: {cpu: 0.25, memory: '0.5Gi'},
+        volumeMounts: [{volumeName: TRACER_VOLUME_NAME, mountPath: TRACER_MOUNT_PATH}],
+      })
+      expect(result.template?.volumes).toContainEqual({name: TRACER_VOLUME_NAME, storageType: 'EmptyDir'})
+      expect(app.volumeMounts).toContainEqual({volumeName: TRACER_VOLUME_NAME, mountPath: TRACER_MOUNT_PATH})
+      expect(
+        result.template?.containers?.find(({name}) => name === 'datadog-sidecar')?.volumeMounts
+      ).not.toContainEqual(expect.objectContaining({volumeName: TRACER_VOLUME_NAME}))
+    })
+
+    test('instruments only the explicitly selected application container', () => {
+      const worker = {name: 'worker', image: 'worker', env: [{name: 'ROLE', value: 'worker'}]}
+      const app = {
+        ...DEFAULT_CONTAINER_APP,
+        template: {
+          ...DEFAULT_CONTAINER_APP.template,
+          containers: [...DEFAULT_CONTAINER_APP.template!.containers!, worker],
+          initContainers: [{name: 'customer-init', image: 'customer-init'}],
+          volumes: [{name: 'customer-volume', storageType: 'EmptyDir'}],
+        },
+      }
+      const result = createInstrumentedApp({...injectConfig(), containerName: 'worker'}, app)
+      const main = result.template!.containers![0]
+      const selected = result.template!.containers![1]
+
+      expect(getEnv(main.env, 'NODE_OPTIONS')).toBeUndefined()
+      expect(main.volumeMounts).not.toContainEqual(expect.objectContaining({volumeName: TRACER_VOLUME_NAME}))
+      expect(getEnv(selected.env, 'NODE_OPTIONS')).toBeDefined()
+      expect(result.template?.initContainers?.[0]).toEqual({name: 'customer-init', image: 'customer-init'})
+      expect(result.template?.volumes?.[0]).toEqual({name: 'customer-volume', storageType: 'EmptyDir'})
+    })
+
+    test.each([
+      ['sharedVolumeName', TRACER_VOLUME_NAME, '--shared-volume-name'],
+      ['sharedVolumePath', TRACER_MOUNT_PATH, '--shared-volume-path'],
+    ] as const)('rejects the tracer collision on %s', (field, value, message) => {
+      expect(() => createInstrumentedApp({...injectConfig(), [field]: value})).toThrow(message)
+    })
+
+    test('retries markerless configuration without duplicating managed state', () => {
+      const first = createInstrumentedApp(injectConfig())
+      const second = createInstrumentedApp(injectConfig(), first)
+
+      expect(second.template).toEqual(first.template)
+    })
+
+    test('validates stale managed environment before a language transition', () => {
+      const node = createInstrumentedApp(injectConfig())
+      const app = node.template!.containers![0]
+      const unsafe = {
+        ...node,
+        tags: {...node.tags, [SSI_INJECTION_MODE_TAG]: SINGLE_LANGUAGE_SSI_MODE},
+        template: {
+          ...node.template,
+          containers: [
+            {...app, env: [...(app.env ?? []), {name: 'NODE_OPTIONS', value: '--customer-option'}]},
+            ...node.template!.containers!.slice(1),
+          ],
+        },
+      }
+
+      expect(() => createInstrumentedApp(injectConfig('python'), unsafe)).toThrow(/NODE_OPTIONS appears more than once/)
+    })
+
+    test('replaces an owned tracer with another language', () => {
+      const node = createInstrumentedApp(injectConfig())
+      const owned = {
+        ...node,
+        tags: {...node.tags, [SSI_INJECTION_MODE_TAG]: SINGLE_LANGUAGE_SSI_MODE},
+      }
+      const python = createInstrumentedApp(injectConfig('python'), owned)
+      const app = python.template!.containers![0]
+
+      expect(getEnv(app.env, 'NODE_OPTIONS')).toBeUndefined()
+      expect(getEnv(app.env, 'PYTHONPATH')?.value).toBe(TRACER_MOUNT_PATH)
+      expect(python.template?.initContainers).toHaveLength(1)
+      expect(python.template?.volumes?.filter(({name}) => name === TRACER_VOLUME_NAME)).toHaveLength(1)
+    })
+
+    test.each([
+      ['manual', 'true'],
+      ['disabled', 'false'],
+    ] as const)('removes owned injection for %s tracing', (tracing, traceEnabled) => {
+      const injected = createInstrumentedApp(injectConfig())
+      const owned = {
+        ...injected,
+        tags: {...injected.tags, [SSI_INJECTION_MODE_TAG]: SINGLE_LANGUAGE_SSI_MODE},
+      }
+      const result = createInstrumentedApp({...DEFAULT_CONFIG, service: 'my-container-app', tracing}, owned)
+      const app = result.template!.containers![0]
+
+      expect(result.template?.initContainers).toEqual([])
+      expect(result.template?.volumes).not.toContainEqual(expect.objectContaining({name: TRACER_VOLUME_NAME}))
+      expect(app.volumeMounts).not.toContainEqual(expect.objectContaining({volumeName: TRACER_VOLUME_NAME}))
+      expect(getEnv(app.env, 'NODE_OPTIONS')).toBeUndefined()
+      expect(getEnv(app.env, DD_TRACE_ENABLED_ENV_VAR)?.value).toBe(traceEnabled)
+    })
+
+    test('omitted tracing preserves existing injection when updating DD_TAGS', () => {
+      const injected = createInstrumentedApp(injectConfig())
+      const result = createInstrumentedApp(
+        {...DEFAULT_CONFIG, service: 'my-container-app', extraTags: 'team:serverless'},
+        injected
+      )
+
+      expect(result.template?.initContainers).toEqual(injected.template?.initContainers)
+      expect(getEnv(result.template?.containers?.[0].env, 'NODE_OPTIONS')).toEqual(
+        getEnv(injected.template?.containers?.[0].env, 'NODE_OPTIONS')
+      )
+      expect(getEnv(result.template?.containers?.[0].env, 'DD_TAGS')?.value).toBe(
+        `${SINGLE_LANGUAGE_INJECTION_MODE_TAG},team:serverless`
+      )
+    })
+  })
+})

--- a/packages/plugin-container-app/src/__tests__/ssi.test.ts
+++ b/packages/plugin-container-app/src/__tests__/ssi.test.ts
@@ -187,7 +187,7 @@ describe('Container Apps automatic APM instrumentation', () => {
         image: expect.stringContaining('datadoghq.azurecr.io/dd-lib-'),
         command: ['/datadog-init/copy-lib.sh'],
         args: [TRACER_MOUNT_PATH],
-        resources: {cpu: 0.25, memory: '0.5Gi'},
+        resources: {cpu: 0.25, memory: '0.5Gi', ephemeralStorage: '1Gi'},
         volumeMounts: [{volumeName: TRACER_VOLUME_NAME, mountPath: TRACER_MOUNT_PATH}],
       })
       expect(result.template?.volumes).toContainEqual({name: TRACER_VOLUME_NAME, storageType: 'EmptyDir'})

--- a/packages/plugin-container-app/src/__tests__/ssi.test.ts
+++ b/packages/plugin-container-app/src/__tests__/ssi.test.ts
@@ -74,6 +74,7 @@ describe('Container Apps automatic APM instrumentation', () => {
     test.each([
       [{tracing: 'inject'}, '--language'],
       [{tracing: 'inject', language: 'go'}, 'Install dd-trace-go'],
+      [{tracing: 'inject', language: 'dotnet'}, 'supports only these languages'],
       [{tracing: 'inject', language: 'rust'}, 'supports only these languages'],
       [{tracerVersion: '1.2.3'}, '--tracing inject'],
       [{tracerLibc: 'musl'}, '--tracing inject'],
@@ -185,6 +186,7 @@ describe('Container Apps automatic APM instrumentation', () => {
       const app = result.template!.containers![0]
 
       expect(getEnv(app.env, envName)?.value).toContain(value)
+      expect(getEnv(app.env, 'DD_SOURCE')?.value).toBe(language)
       expect(getEnv(app.env, DD_TRACE_ENABLED_ENV_VAR)?.value).toBe('true')
       expect(getEnv(app.env, 'DD_TAGS')?.value).toContain(SINGLE_LANGUAGE_INJECTION_MODE_TAG)
       expect(result.template?.initContainers).toContainEqual({
@@ -231,9 +233,20 @@ describe('Container Apps automatic APM instrumentation', () => {
       expect(() => createInstrumentedApp({...injectConfig(), [field]: value})).toThrow(message)
     })
 
-    test('retries markerless configuration without duplicating managed state', () => {
+    test('retries configuration without injection markers', () => {
       const first = createInstrumentedApp(injectConfig())
-      const second = createInstrumentedApp(injectConfig(), first)
+      const app = first.template!.containers![0]
+      const markerless = {
+        ...first,
+        template: {
+          ...first.template,
+          containers: [
+            {...app, env: app.env?.filter(({name}) => name !== 'DD_TAGS')},
+            ...first.template!.containers!.slice(1),
+          ],
+        },
+      }
+      const second = createInstrumentedApp(injectConfig(), markerless)
 
       expect(second.template).toEqual(first.template)
     })

--- a/packages/plugin-container-app/src/__tests__/ssi.test.ts
+++ b/packages/plugin-container-app/src/__tests__/ssi.test.ts
@@ -43,13 +43,9 @@ const createInstrumentedApp = (config: ContainerAppConfigOptions, app: Container
 describe('Container Apps automatic APM instrumentation', () => {
   describe('input resolution', () => {
     test.each([
-      [undefined, undefined],
+      [undefined, 'manual'],
       ['manual', 'manual'],
-      ['true', 'manual'],
-      ['1', 'manual'],
       ['disabled', 'disabled'],
-      ['false', 'disabled'],
-      ['0', 'disabled'],
     ] as const)('resolves tracing input %s without injection', (tracing, expected) => {
       expect(resolveSsiConfig({...DEFAULT_CONFIG, tracing})).toEqual({
         kind: 'no-injection',
@@ -281,17 +277,82 @@ describe('Container Apps automatic APM instrumentation', () => {
       expect(() => createInstrumentedApp(injectConfig('python'), unsafe)).not.toThrow()
     })
 
-    test('replaces an owned tracer with another language', () => {
+    test('replaces owned injection across all application containers', () => {
       const node = createInstrumentedApp(injectConfig())
+      const app = node.template!.containers![0]
       const owned = {
         ...node,
         tags: {...node.tags, [SSI_INJECTION_MODE_TAG]: SINGLE_LANGUAGE_SSI_MODE},
+        template: {
+          ...node.template,
+          containers: [
+            app,
+            {
+              name: 'worker',
+              image: 'worker',
+              env: [
+                {
+                  name: 'JAVA_TOOL_OPTIONS',
+                  value: '-Xmx512m -javaagent:/datadog-lib/dd-java-agent.jar -XX:+IgnoreUnrecognizedVMOptions',
+                },
+                {name: 'CORECLR_ENABLE_PROFILING', value: '1'},
+                {name: 'CORECLR_PROFILER', value: '{846F5F1C-F9AE-4B07-969E-05C26BC060D8}'},
+                {name: 'CORECLR_PROFILER_PATH', value: '/datadog-lib/Datadog.Trace.ClrProfiler.Native.so'},
+                {name: 'DD_DOTNET_TRACER_HOME', value: '/datadog-lib'},
+                {
+                  name: 'LD_PRELOAD',
+                  value: 'customer /datadog-lib/continuousprofiler/Datadog.Linux.ApiWrapper.x64.so',
+                },
+                {name: 'PYTHONPATH', value: 'customer:/datadog-lib'},
+                {name: 'RUBYOPT', value: '-r/datadog-lib/auto_inject -W1'},
+                {
+                  name: 'PHP_INI_SCAN_DIR',
+                  value: ':/customer:/datadog-lib/linux-gnu/loader:/datadog-lib/linux-musl/loader',
+                },
+                {name: 'DD_LOADER_PACKAGE_PATH', value: '/datadog-lib'},
+                {name: 'DD_TAGS', value: `${SINGLE_LANGUAGE_INJECTION_MODE_TAG},team:worker`},
+              ],
+              volumeMounts: [
+                {volumeName: 'customer-volume', mountPath: '/customer'},
+                {volumeName: TRACER_VOLUME_NAME, mountPath: '/other'},
+                {volumeName: 'legacy-volume', mountPath: TRACER_MOUNT_PATH},
+              ],
+            },
+          ],
+        },
       }
-      const python = createInstrumentedApp(injectConfig('python'), owned)
-      const app = python.template!.containers![0]
+      const python = createInstrumentedApp({...injectConfig('python'), containerName: 'main-container'}, owned)
+      const pythonApp = python.template!.containers![0]
+      const worker = python.template!.containers![1]
 
-      expect(getEnv(app.env, 'NODE_OPTIONS')).toBeUndefined()
-      expect(getEnv(app.env, 'PYTHONPATH')?.value).toBe(TRACER_MOUNT_PATH)
+      expect(getEnv(pythonApp.env, 'NODE_OPTIONS')).toBeUndefined()
+      expect(getEnv(pythonApp.env, 'PYTHONPATH')?.value).toBe(TRACER_MOUNT_PATH)
+      expect(worker.env).toEqual(
+        expect.arrayContaining([
+          {name: 'JAVA_TOOL_OPTIONS', value: '-Xmx512m'},
+          {name: 'LD_PRELOAD', value: 'customer'},
+          {name: 'PYTHONPATH', value: 'customer'},
+          {name: 'RUBYOPT', value: '-W1'},
+          {name: 'PHP_INI_SCAN_DIR', value: ':/customer'},
+          {name: 'DD_TAGS', value: 'team:worker'},
+        ])
+      )
+      expect(
+        worker.env?.filter(({name}) =>
+          [
+            'CORECLR_ENABLE_PROFILING',
+            'CORECLR_PROFILER',
+            'CORECLR_PROFILER_PATH',
+            'DD_DOTNET_TRACER_HOME',
+            'DD_LOADER_PACKAGE_PATH',
+          ].includes(name!)
+        )
+      ).toEqual([])
+      expect(worker.volumeMounts).toEqual([
+        {volumeName: 'customer-volume', mountPath: '/customer'},
+        {volumeName: 'shared-volume', mountPath: '/shared-volume'},
+      ])
+      expect(python.tags?.[SSI_INJECTION_MODE_TAG]).toBe(SINGLE_LANGUAGE_SSI_MODE)
       expect(python.template?.initContainers).toHaveLength(1)
       expect(python.template?.volumes?.filter(({name}) => name === TRACER_VOLUME_NAME)).toHaveLength(1)
     })
@@ -324,7 +385,7 @@ describe('Container Apps automatic APM instrumentation', () => {
       ).toBe(true)
     })
 
-    test('omitted tracing removes existing injection', () => {
+    test('omitted tracing removes existing injection with manual tracing enabled', () => {
       const injected = createInstrumentedApp(injectConfig())
       const result = createInstrumentedApp(
         {...DEFAULT_CONFIG, service: 'my-container-app', extraTags: 'team:serverless'},
@@ -334,6 +395,7 @@ describe('Container Apps automatic APM instrumentation', () => {
       expect(result.template?.initContainers).toEqual([])
       expect(getEnv(result.template?.containers?.[0].env, 'NODE_OPTIONS')).toBeUndefined()
       expect(getEnv(result.template?.containers?.[0].env, 'DD_TAGS')?.value).toBe('team:serverless')
+      expect(getEnv(result.template?.containers?.[0].env, DD_TRACE_ENABLED_ENV_VAR)?.value).toBe('true')
     })
   })
 })

--- a/packages/plugin-container-app/src/__tests__/uninstrument.test.ts
+++ b/packages/plugin-container-app/src/__tests__/uninstrument.test.ts
@@ -98,6 +98,21 @@ describe('container-app uninstrument', () => {
       updateTags.mockClear().mockResolvedValue({})
     })
 
+    test('redacts secrets in the configuration diff', async () => {
+      containerAppsOperations.get.mockResolvedValueOnce({...INSTRUMENTED_CONTAINER_APP})
+      containerAppsOperations.listSecrets.mockResolvedValueOnce({
+        value: [
+          {name: 'dd-api-key', value: 'api-key'},
+          {name: 'other-secret', value: 'sensitive-value'},
+        ],
+      })
+
+      const {context} = await runCLI(DEFAULT_ARGS)
+
+      expect(context.stdout.toString()).not.toContain('sensitive-value')
+      expect(context.stdout.toString()).toContain('<redacted>')
+    })
+
     test('Removes sidecar, volume, DD env vars, secret, and tags', async () => {
       const {code, context} = await runCLI(DEFAULT_ARGS)
       const output = context.stdout.toString()
@@ -179,9 +194,9 @@ Please ensure that you have the Azure CLI installed (https://aka.ms/azure-cli) a
 
       const {code, context} = await runCLI(DEFAULT_ARGS)
 
-      expect(code).toBe(1)
+      expect(code).toBe(0)
       expect(context.stdout.toString()).toContain(
-        '[Error] Failed to uninstrument my-container-app: Error: tag removal error'
+        '[Error] Failed to remove tags for my-container-app: Error: tag removal error'
       )
       expect(containerAppsOperations.beginUpdateAndWait).toHaveBeenCalled()
     })

--- a/packages/plugin-container-app/src/__tests__/uninstrument.test.ts
+++ b/packages/plugin-container-app/src/__tests__/uninstrument.test.ts
@@ -464,7 +464,7 @@ Please ensure that you have the Azure CLI installed (https://aka.ms/azure-cli) a
       const result = command.createUninstrumentedAppConfig(config, DEFAULT_CONTAINER_APP)
 
       expect(result.template?.containers).toHaveLength(1)
-      expect(result.template?.volumes).toEqual([])
+      expect(result.template?.volumes).toBeUndefined()
     })
 
     test('preserves non-DD env vars', () => {

--- a/packages/plugin-container-app/src/__tests__/uninstrument.test.ts
+++ b/packages/plugin-container-app/src/__tests__/uninstrument.test.ts
@@ -33,6 +33,7 @@ import {
 } from '@datadog/datadog-ci-base/helpers/serverless/ssi/constants'
 
 import {PluginCommand as UninstrumentCommand} from '../commands/uninstrument'
+import {SINGLE_LANGUAGE_SSI_MODE, SSI_INJECTION_MODE_TAG} from '../ssi'
 
 import {CONTAINER_APP_ID, DEFAULT_ARGS, DEFAULT_CONFIG, DEFAULT_CONTAINER_APP, NULL_SUBSCRIPTION_ID} from './common'
 
@@ -402,6 +403,7 @@ Please ensure that you have the Azure CLI installed (https://aka.ms/azure-cli) a
         tags: {
           ...INSTRUMENTED_CONTAINER_APP.tags,
           owner: 'payments',
+          [SSI_INJECTION_MODE_TAG]: SINGLE_LANGUAGE_SSI_MODE,
         },
         template: {
           ...INSTRUMENTED_CONTAINER_APP.template,

--- a/packages/plugin-container-app/src/__tests__/uninstrument.test.ts
+++ b/packages/plugin-container-app/src/__tests__/uninstrument.test.ts
@@ -11,6 +11,7 @@ jest.mock('@azure/identity', () => ({
 const containerAppsOperations = {
   get: jest.fn(),
   beginUpdateAndWait: jest.fn(),
+  listSecrets: jest.fn(),
 }
 
 const updateTags = jest.fn().mockResolvedValue({})
@@ -25,6 +26,11 @@ import type {ContainerApp, Container} from '@azure/arm-appcontainers'
 
 import {makeRunCLI} from '@datadog/datadog-ci-base/helpers/__tests__/testing-tools'
 import {DEFAULT_SIDECAR_NAME, DEFAULT_VOLUME_NAME} from '@datadog/datadog-ci-base/helpers/serverless/constants'
+import {
+  TRACER_CONTAINER_NAME,
+  TRACER_MOUNT_PATH,
+  TRACER_VOLUME_NAME,
+} from '@datadog/datadog-ci-base/helpers/serverless/ssi/constants'
 
 import {PluginCommand as UninstrumentCommand} from '../commands/uninstrument'
 
@@ -84,6 +90,9 @@ describe('container-app uninstrument', () => {
       jest.resetModules()
       getToken.mockClear().mockResolvedValue({token: 'token'})
       containerAppsOperations.get.mockReset().mockResolvedValue(INSTRUMENTED_CONTAINER_APP)
+      containerAppsOperations.listSecrets.mockReset().mockResolvedValue({
+        value: INSTRUMENTED_CONTAINER_APP.configuration!.secrets,
+      })
       containerAppsOperations.beginUpdateAndWait.mockReset().mockResolvedValue({})
       updateTags.mockClear().mockResolvedValue({})
     })
@@ -164,6 +173,18 @@ Please ensure that you have the Azure CLI installed (https://aka.ms/azure-cli) a
       expect(updateTags).not.toHaveBeenCalled()
     })
 
+    test('Fails when tag removal fails', async () => {
+      updateTags.mockRejectedValue(new Error('tag removal error'))
+
+      const {code, context} = await runCLI(DEFAULT_ARGS)
+
+      expect(code).toBe(1)
+      expect(context.stdout.toString()).toContain(
+        '[Error] Failed to uninstrument my-container-app: Error: tag removal error'
+      )
+      expect(containerAppsOperations.beginUpdateAndWait).toHaveBeenCalled()
+    })
+
     test('Errors if no Azure Container App is specified', async () => {
       const {code, context} = await runCLI([])
       expect(code).toEqual(1)
@@ -230,6 +251,7 @@ Please ensure that you have the Azure CLI installed (https://aka.ms/azure-cli) a
         },
       }
       containerAppsOperations.get.mockReset().mockResolvedValue(customInstrumentedApp)
+      containerAppsOperations.listSecrets.mockResolvedValue({value: customInstrumentedApp.configuration!.secrets})
 
       const {code} = await runCLI([
         ...DEFAULT_ARGS,
@@ -316,6 +338,9 @@ Please ensure that you have the Azure CLI installed (https://aka.ms/azure-cli) a
       jest.resetModules()
       getToken.mockClear().mockResolvedValue({token: 'token'})
       containerAppsOperations.get.mockReset().mockResolvedValue(INSTRUMENTED_CONTAINER_APP)
+      containerAppsOperations.listSecrets.mockReset().mockResolvedValue({
+        value: INSTRUMENTED_CONTAINER_APP.configuration!.secrets,
+      })
       containerAppsOperations.beginUpdateAndWait.mockReset().mockResolvedValue({})
       updateTags.mockClear().mockResolvedValue({})
     })
@@ -369,6 +394,67 @@ Please ensure that you have the Azure CLI installed (https://aka.ms/azure-cli) a
 
       // Should remove dd-api-key secret
       expect(result.configuration?.secrets).toEqual([{name: 'other-secret', value: 'OTHER'}])
+    })
+
+    test('removes recognizable tracer injection and preserves unrelated state', () => {
+      const app: ContainerApp = {
+        ...INSTRUMENTED_CONTAINER_APP,
+        tags: {
+          ...INSTRUMENTED_CONTAINER_APP.tags,
+          owner: 'payments',
+        },
+        template: {
+          ...INSTRUMENTED_CONTAINER_APP.template,
+          initContainers: [
+            {name: 'customer-init', image: 'customer'},
+            {
+              name: TRACER_CONTAINER_NAME,
+              image: 'datadoghq.azurecr.io/dd-lib-js-init:latest',
+              command: ['/datadog-init/copy-lib.sh'],
+              args: [TRACER_MOUNT_PATH],
+              resources: {cpu: 0.25, memory: '0.5Gi'},
+              volumeMounts: [{volumeName: TRACER_VOLUME_NAME, mountPath: TRACER_MOUNT_PATH}],
+            },
+          ],
+          containers: INSTRUMENTED_CONTAINER_APP.template!.containers!.map((container, index) =>
+            index === 0
+              ? {
+                  ...container,
+                  env: [
+                    ...(container.env ?? []),
+                    {
+                      name: 'NODE_OPTIONS',
+                      value: '--inspect --require /datadog-lib/node_modules/dd-trace/init.js',
+                    },
+                    {name: 'KEEP', value: 'value'},
+                  ],
+                  volumeMounts: [
+                    ...(container.volumeMounts ?? []),
+                    {volumeName: 'customer-volume', mountPath: '/customer'},
+                    {volumeName: TRACER_VOLUME_NAME, mountPath: TRACER_MOUNT_PATH},
+                  ],
+                }
+              : container
+          ),
+          volumes: [
+            ...(INSTRUMENTED_CONTAINER_APP.template!.volumes ?? []),
+            {name: 'customer-volume', storageType: 'EmptyDir'},
+            {name: TRACER_VOLUME_NAME, storageType: 'EmptyDir'},
+          ],
+        },
+      }
+
+      const result = command.createUninstrumentedAppConfig(DEFAULT_CONFIG, app)
+      const main = result.template!.containers![0]
+
+      expect(result.template?.initContainers).toEqual([{name: 'customer-init', image: 'customer'}])
+      expect(result.template?.volumes).toEqual([{name: 'customer-volume', storageType: 'EmptyDir'}])
+      expect(main.volumeMounts).toEqual([{volumeName: 'customer-volume', mountPath: '/customer'}])
+      expect(main.env).toEqual([
+        {name: 'PORT', value: '8080'},
+        {name: 'NODE_OPTIONS', value: '--inspect'},
+        {name: 'KEEP', value: 'value'},
+      ])
     })
 
     test('handles app with no sidecar or shared volume gracefully', () => {

--- a/packages/plugin-container-app/src/__tests__/uninstrument.test.ts
+++ b/packages/plugin-container-app/src/__tests__/uninstrument.test.ts
@@ -33,6 +33,7 @@ import {
 } from '@datadog/datadog-ci-base/helpers/serverless/ssi/constants'
 
 import {PluginCommand as UninstrumentCommand} from '../commands/uninstrument'
+import {SSI_INJECTION_MODE_TAG} from '../ssi'
 
 import {CONTAINER_APP_ID, DEFAULT_ARGS, DEFAULT_CONFIG, DEFAULT_CONTAINER_APP, NULL_SUBSCRIPTION_ID} from './common'
 
@@ -582,6 +583,17 @@ Please ensure that you have the Azure CLI installed (https://aka.ms/azure-cli) a
 
       expect(updateTags).toHaveBeenCalledWith(CONTAINER_APP_ID, {
         properties: {tags: {}},
+      })
+    })
+
+    test('removes managed tags with empty values', async () => {
+      await command.removeTags(NULL_SUBSCRIPTION_ID, 'my-resource-group', {
+        ...INSTRUMENTED_CONTAINER_APP,
+        tags: {[SSI_INJECTION_MODE_TAG]: '', owner: 'payments'},
+      })
+
+      expect(updateTags).toHaveBeenCalledWith(CONTAINER_APP_ID, {
+        properties: {tags: {owner: 'payments'}},
       })
     })
 

--- a/packages/plugin-container-app/src/__tests__/uninstrument.test.ts
+++ b/packages/plugin-container-app/src/__tests__/uninstrument.test.ts
@@ -33,7 +33,6 @@ import {
 } from '@datadog/datadog-ci-base/helpers/serverless/ssi/constants'
 
 import {PluginCommand as UninstrumentCommand} from '../commands/uninstrument'
-import {SINGLE_LANGUAGE_SSI_MODE, SSI_INJECTION_MODE_TAG} from '../ssi'
 
 import {CONTAINER_APP_ID, DEFAULT_ARGS, DEFAULT_CONFIG, DEFAULT_CONTAINER_APP, NULL_SUBSCRIPTION_ID} from './common'
 
@@ -412,47 +411,47 @@ Please ensure that you have the Azure CLI installed (https://aka.ms/azure-cli) a
       expect(result.configuration?.secrets).toEqual([{name: 'other-secret', value: 'OTHER'}])
     })
 
-    test('removes recognizable tracer injection and preserves unrelated state', () => {
+    test('removes stale tracer injection and preserves unrelated state', () => {
       const app: ContainerApp = {
         ...INSTRUMENTED_CONTAINER_APP,
-        tags: {
-          ...INSTRUMENTED_CONTAINER_APP.tags,
-          owner: 'payments',
-          [SSI_INJECTION_MODE_TAG]: SINGLE_LANGUAGE_SSI_MODE,
-        },
+        tags: {...INSTRUMENTED_CONTAINER_APP.tags, owner: 'payments'},
         template: {
           ...INSTRUMENTED_CONTAINER_APP.template,
           initContainers: [
             {name: 'customer-init', image: 'customer'},
+            {name: TRACER_CONTAINER_NAME, image: 'stale-tracer'},
+          ],
+          containers: [
+            ...INSTRUMENTED_CONTAINER_APP.template!.containers!.map((container, index) =>
+              index === 0
+                ? {
+                    ...container,
+                    env: [
+                      ...(container.env ?? []),
+                      {
+                        name: 'NODE_OPTIONS',
+                        value: '--inspect --require /datadog-lib/node_modules/dd-trace/init.js',
+                      },
+                      {name: 'KEEP', value: 'value'},
+                    ],
+                    volumeMounts: [
+                      ...(container.volumeMounts ?? []),
+                      {volumeName: 'customer-volume', mountPath: '/customer'},
+                      {volumeName: TRACER_VOLUME_NAME, mountPath: TRACER_MOUNT_PATH},
+                    ],
+                  }
+                : container
+            ),
             {
-              name: TRACER_CONTAINER_NAME,
-              image: 'datadoghq.azurecr.io/dd-lib-js-init:latest',
-              command: ['/datadog-init/copy-lib.sh'],
-              args: [TRACER_MOUNT_PATH],
-              resources: {cpu: 0.25, memory: '0.5Gi'},
-              volumeMounts: [{volumeName: TRACER_VOLUME_NAME, mountPath: TRACER_MOUNT_PATH}],
+              name: 'worker',
+              image: 'worker',
+              env: [{name: 'PYTHONPATH', value: 'customer:/datadog-lib'}],
+              volumeMounts: [
+                {volumeName: 'customer-volume', mountPath: '/customer'},
+                {volumeName: 'legacy-volume', mountPath: TRACER_MOUNT_PATH},
+              ],
             },
           ],
-          containers: INSTRUMENTED_CONTAINER_APP.template!.containers!.map((container, index) =>
-            index === 0
-              ? {
-                  ...container,
-                  env: [
-                    ...(container.env ?? []),
-                    {
-                      name: 'NODE_OPTIONS',
-                      value: '--inspect --require /datadog-lib/node_modules/dd-trace/init.js',
-                    },
-                    {name: 'KEEP', value: 'value'},
-                  ],
-                  volumeMounts: [
-                    ...(container.volumeMounts ?? []),
-                    {volumeName: 'customer-volume', mountPath: '/customer'},
-                    {volumeName: TRACER_VOLUME_NAME, mountPath: TRACER_MOUNT_PATH},
-                  ],
-                }
-              : container
-          ),
           volumes: [
             ...(INSTRUMENTED_CONTAINER_APP.template!.volumes ?? []),
             {name: 'customer-volume', storageType: 'EmptyDir'},
@@ -463,6 +462,7 @@ Please ensure that you have the Azure CLI installed (https://aka.ms/azure-cli) a
 
       const result = command.createUninstrumentedAppConfig(DEFAULT_CONFIG, app)
       const main = result.template!.containers![0]
+      const worker = result.template!.containers![1]
 
       expect(result.template?.initContainers).toEqual([{name: 'customer-init', image: 'customer'}])
       expect(result.template?.volumes).toEqual([{name: 'customer-volume', storageType: 'EmptyDir'}])
@@ -472,6 +472,10 @@ Please ensure that you have the Azure CLI installed (https://aka.ms/azure-cli) a
         {name: 'NODE_OPTIONS', value: '--inspect'},
         {name: 'KEEP', value: 'value'},
       ])
+      expect(worker).toMatchObject({
+        env: [{name: 'PYTHONPATH', value: 'customer'}],
+        volumeMounts: [{volumeName: 'customer-volume', mountPath: '/customer'}],
+      })
     })
 
     test('handles app with no sidecar or shared volume gracefully', () => {

--- a/packages/plugin-container-app/src/commands/instrument.ts
+++ b/packages/plugin-container-app/src/commands/instrument.ts
@@ -35,8 +35,9 @@ import {
   SINGLE_LANGUAGE_SSI_MODE,
   SSI_INJECTION_MODE_TAG,
   applySingleLanguageSsi,
-  assertLanguageInjectionEnvCanBeMerged,
-  hasCompleteSsiSignature,
+  assertExistingLanguageInjectionCanBeReplaced,
+  assertSsiResourcesCanBeAdded,
+  hasSsi,
   preserveInjectionModeTag,
   removeSsiState,
   resolveSsiConfig,
@@ -159,6 +160,14 @@ export class PluginCommand extends ContainerAppInstrumentCommand {
       containerApp.configuration = {...containerApp.configuration, secrets: secrets.value}
       config = {...config, service: config.service ?? containerAppName}
 
+      if (ssiConfig.kind === 'single-language' && (containerApp.template?.scale?.minReplicas ?? 0) === 0) {
+        this.context.stdout.write(
+          renderSoftWarning(
+            `Automatic APM instrumentation can increase cold-start delays for ${containerAppName} because scale-to-zero is enabled. Prefer manual instrumentation for scale-to-zero workloads.`
+          )
+        )
+      }
+
       await this.instrumentSidecar(containerAppClient, config, resourceGroup, containerApp, ssiConfig)
       await this.addTags(config, containerAppClient.subscriptionId, resourceGroup, containerApp, ssiConfig)
     } catch (error) {
@@ -251,21 +260,20 @@ export class PluginCommand extends ContainerAppInstrumentCommand {
 
     let sourceApp = containerApp
     let targetIndex: number | undefined
+    const ssiExists = hasSsi(containerApp)
     if (ssiConfig.kind === 'single-language') {
       targetIndex = selectApplicationContainer(
         containerApp.template?.containers ?? [],
         config.sidecarName!,
         config.containerName
       )
-      assertLanguageInjectionEnvCanBeMerged(containerApp.template?.containers?.[targetIndex].env)
-      const hasMarker = containerApp.tags?.[SSI_INJECTION_MODE_TAG] === SINGLE_LANGUAGE_SSI_MODE
-      if (hasMarker || hasCompleteSsiSignature(containerApp, targetIndex)) {
+      if (ssiExists) {
+        assertExistingLanguageInjectionCanBeReplaced(containerApp)
         sourceApp = removeSsiState(containerApp)
+      } else {
+        assertSsiResourcesCanBeAdded(containerApp, targetIndex, config.sidecarName!)
       }
-    } else if (
-      ssiConfig.tracing !== undefined &&
-      containerApp.tags?.[SSI_INJECTION_MODE_TAG] === SINGLE_LANGUAGE_SSI_MODE
-    ) {
+    } else if (ssiConfig.tracing !== undefined && ssiExists) {
       sourceApp = removeSsiState(containerApp)
     }
 

--- a/packages/plugin-container-app/src/commands/instrument.ts
+++ b/packages/plugin-container-app/src/commands/instrument.ts
@@ -37,6 +37,7 @@ import {
   assertLanguageInjectionEnvCanBeMerged,
   assertSsiResourcesCanBeAdded,
   hasSsi,
+  hasSsiMarker,
   removeSsiState,
   resolveSsiConfig,
   selectApplicationContainer,
@@ -158,10 +159,10 @@ export class PluginCommand extends ContainerAppInstrumentCommand {
       containerApp.configuration = {...containerApp.configuration, secrets: secrets.value}
       config = {...config, service: config.service ?? containerAppName}
 
-      if (config.tracing === undefined && hasSsi(containerApp)) {
+      if (config.tracing === undefined && hasSsiMarker(containerApp)) {
         this.context.stdout.write(
           renderSoftWarning(
-            'Tracing defaults to manual. Use --tracing inject --language <language> to retain automatic tracer injection.'
+            `Tracing defaults to manual for ${containerAppName}. Use --tracing inject --language <language> to retain automatic tracer injection.`
           )
         )
       }
@@ -271,7 +272,8 @@ export class PluginCommand extends ContainerAppInstrumentCommand {
     }
 
     const ssiExists = hasSsi(containerApp)
-    const sourceApp = ssiExists ? removeSsiState(containerApp) : containerApp
+    const shouldReplaceSsi = hasSsiMarker(containerApp) || (ssiConfig.kind === 'single-language' && ssiExists)
+    const sourceApp = shouldReplaceSsi ? removeSsiState(containerApp) : containerApp
     let targetIndex: number | undefined
     if (ssiConfig.kind === 'single-language') {
       targetIndex = selectApplicationContainer(

--- a/packages/plugin-container-app/src/commands/instrument.ts
+++ b/packages/plugin-container-app/src/commands/instrument.ts
@@ -10,7 +10,6 @@ import {
   DEFAULT_SIDECAR_CPU,
   DEFAULT_SIDECAR_MEMORY,
 } from '@datadog/datadog-ci-base/commands/container-app/instrument'
-import {DATADOG_SITE_US1} from '@datadog/datadog-ci-base/constants'
 import {getDatadogSite} from '@datadog/datadog-ci-base/helpers/api'
 import {newApiKeyValidator} from '@datadog/datadog-ci-base/helpers/apikey'
 import {renderError, renderSoftWarning} from '@datadog/datadog-ci-base/helpers/renderer'
@@ -35,10 +34,9 @@ import {
   SINGLE_LANGUAGE_SSI_MODE,
   SSI_INJECTION_MODE_TAG,
   applySingleLanguageSsi,
-  assertExistingLanguageInjectionCanBeReplaced,
+  assertLanguageInjectionEnvCanBeMerged,
   assertSsiResourcesCanBeAdded,
   hasSsi,
-  preserveInjectionModeTag,
   removeSsiState,
   resolveSsiConfig,
   selectApplicationContainer,
@@ -199,16 +197,22 @@ export class PluginCommand extends ContainerAppInstrumentCommand {
     }
     if (ssiConfig.kind === 'single-language') {
       updatedTags[SSI_INJECTION_MODE_TAG] = SINGLE_LANGUAGE_SSI_MODE
-    } else if (ssiConfig.kind === 'no-injection' && ssiConfig.tracing !== undefined) {
+    } else if (ssiConfig.kind === 'no-injection') {
       delete updatedTags[SSI_INJECTION_MODE_TAG]
     }
     if (!sortedEqual(containerApp.tags, updatedTags)) {
       this.context.stdout.write(`${this.dryRunPrefix}Updating tags for ${chalk.bold(containerApp.name)}\n`)
       if (!this.dryRun) {
-        await this.tagClient.beginCreateOrUpdateAtScopeAndWait(
-          `/subscriptions/${subscriptionId}/resourceGroups/${resourceGroup}/providers/Microsoft.App/containerApps/${containerApp.name}`,
-          {properties: {tags: updatedTags}}
-        )
+        try {
+          await this.tagClient.beginCreateOrUpdateAtScopeAndWait(
+            `/subscriptions/${subscriptionId}/resourceGroups/${resourceGroup}/providers/Microsoft.App/containerApps/${containerApp.name}`,
+            {properties: {tags: updatedTags}}
+          )
+        } catch (error) {
+          this.context.stdout.write(
+            renderError(`Failed to update tags for ${containerApp.name}: ${formatError(error)}`)
+          )
+        }
       }
     }
   }
@@ -267,13 +271,13 @@ export class PluginCommand extends ContainerAppInstrumentCommand {
         config.sidecarName!,
         config.containerName
       )
+      assertLanguageInjectionEnvCanBeMerged(containerApp.template?.containers?.[targetIndex]?.env, ssiConfig.spec)
       if (ssiExists) {
-        assertExistingLanguageInjectionCanBeReplaced(containerApp)
         sourceApp = removeSsiState(containerApp)
       } else {
         assertSsiResourcesCanBeAdded(containerApp, targetIndex, config.sidecarName!)
       }
-    } else if (ssiConfig.tracing !== undefined && ssiExists) {
+    } else if (ssiExists) {
       sourceApp = removeSsiState(containerApp)
     }
 
@@ -306,7 +310,7 @@ export class PluginCommand extends ContainerAppInstrumentCommand {
     }
 
     // Use shared helper to create instrumented template
-    let updatedTemplate = createInstrumentedTemplate(
+    const updatedTemplate = createInstrumentedTemplate(
       sourceApp.template ?? {},
       baseSidecar,
       {
@@ -317,16 +321,6 @@ export class PluginCommand extends ContainerAppInstrumentCommand {
       },
       envVarsByName
     )
-    if (ssiConfig.kind === 'no-injection' && ssiConfig.tracing === undefined) {
-      updatedTemplate = {
-        ...updatedTemplate,
-        containers: updatedTemplate.containers.map((container, index) => ({
-          ...container,
-          env: preserveInjectionModeTag(sourceApp.template?.containers?.[index]?.env, container.env),
-        })),
-      }
-    }
-
     const secrets = sourceApp.configuration?.secrets ?? []
     const hasApiKey = secrets.some(({name}) => name === DD_API_KEY_SECRET_NAME)
     const updatedSecrets: Secret[] = secrets.map((secret) =>

--- a/packages/plugin-container-app/src/commands/instrument.ts
+++ b/packages/plugin-container-app/src/commands/instrument.ts
@@ -20,13 +20,30 @@ import {
   generateConfigDiff,
   sortedEqual,
 } from '@datadog/datadog-ci-base/helpers/serverless/common'
-import {DEFAULT_HEALTH_CHECK_PORT, SIDECAR_IMAGE} from '@datadog/datadog-ci-base/helpers/serverless/constants'
+import {
+  DD_TRACE_ENABLED_ENV_VAR,
+  DEFAULT_HEALTH_CHECK_PORT,
+  SIDECAR_IMAGE,
+} from '@datadog/datadog-ci-base/helpers/serverless/constants'
 import {handleSourceCodeIntegration} from '@datadog/datadog-ci-base/helpers/serverless/source-code-integration'
 import {SERVERLESS_CLI_VERSION_TAG_NAME, SERVERLESS_CLI_VERSION_TAG_VALUE} from '@datadog/datadog-ci-base/helpers/tags'
 import {maskString} from '@datadog/datadog-ci-base/helpers/utils'
 import chalk from 'chalk'
 
 import {DD_API_KEY_SECRET_NAME, getEnvVarsByName} from '../common'
+import {
+  SINGLE_LANGUAGE_SSI_MODE,
+  SSI_INJECTION_MODE_TAG,
+  applySingleLanguageSsi,
+  assertLanguageInjectionEnvCanBeMerged,
+  hasCompleteSsiSignature,
+  preserveInjectionModeTag,
+  removeSsiState,
+  resolveSsiConfig,
+  selectApplicationContainer,
+  SsiConfigError,
+  type SsiConfigResult,
+} from '../ssi'
 
 export class PluginCommand extends ContainerAppInstrumentCommand {
   private cred!: DefaultAzureCredential
@@ -35,12 +52,23 @@ export class PluginCommand extends ContainerAppInstrumentCommand {
   public async execute(): Promise<0 | 1> {
     this.enableFips()
     const [containerAppsToInstrument, config, errors] = await this.ensureConfig()
+    const ssiConfig = resolveSsiConfig(config)
+    if (ssiConfig.kind === 'errors') {
+      for (const error of ssiConfig.errors) {
+        this.context.stdout.write(renderError(error))
+      }
+
+      return 1
+    }
     if (errors.length > 0) {
       for (const error of errors) {
         this.context.stdout.write(renderError(error))
       }
 
       return 1
+    }
+    for (const warning of ssiConfig.warnings) {
+      this.context.stdout.write(renderSoftWarning(warning))
     }
 
     try {
@@ -80,7 +108,7 @@ export class PluginCommand extends ContainerAppInstrumentCommand {
     this.context.stdout.write(`${this.dryRunPrefix}🐶 Beginning instrumentation of Azure Container App(s)\n`)
     const results = await Promise.all(
       Object.entries(containerAppsToInstrument).map(([subscriptionId, resourceGroupToNames]) =>
-        this.processSubscription(subscriptionId, resourceGroupToNames, config)
+        this.processSubscription(subscriptionId, resourceGroupToNames, config, ssiConfig)
       )
     )
     const success = results.every((result) => result)
@@ -96,13 +124,14 @@ export class PluginCommand extends ContainerAppInstrumentCommand {
   public async processSubscription(
     subscriptionId: string,
     resourceGroupToNames: Record<string, string[]>,
-    config: ContainerAppConfigOptions
+    config: ContainerAppConfigOptions,
+    ssiConfig: SsiConfigResult = resolveSsiConfig(config)
   ): Promise<boolean> {
     const containerAppClient = new ContainerAppsAPIClient(this.cred, subscriptionId)
     const results = await Promise.all(
       Object.entries(resourceGroupToNames).flatMap(([resourceGroup, containerAppNames]) =>
         containerAppNames.map((containerAppName) =>
-          this.processContainerApp(containerAppClient, config, resourceGroup, containerAppName)
+          this.processContainerApp(containerAppClient, config, resourceGroup, containerAppName, ssiConfig)
         )
       )
     )
@@ -118,7 +147,8 @@ export class PluginCommand extends ContainerAppInstrumentCommand {
     containerAppClient: ContainerAppsAPIClient,
     config: ContainerAppConfigOptions,
     resourceGroup: string,
-    containerAppName: string
+    containerAppName: string,
+    ssiConfig: SsiConfigResult = resolveSsiConfig(config)
   ): Promise<boolean> {
     try {
       const [containerApp, secrets] = await Promise.all([
@@ -129,8 +159,8 @@ export class PluginCommand extends ContainerAppInstrumentCommand {
       containerApp.configuration = {...containerApp.configuration, secrets: secrets.value}
       config = {...config, service: config.service ?? containerAppName}
 
-      await this.instrumentSidecar(containerAppClient, config, resourceGroup, containerApp)
-      await this.addTags(config, containerAppClient.subscriptionId, resourceGroup, containerApp)
+      await this.instrumentSidecar(containerAppClient, config, resourceGroup, containerApp, ssiConfig)
+      await this.addTags(config, containerAppClient.subscriptionId, resourceGroup, containerApp, ssiConfig)
     } catch (error) {
       this.context.stdout.write(renderError(`Failed to instrument ${containerAppName}: ${formatError(error)}`))
 
@@ -144,7 +174,8 @@ export class PluginCommand extends ContainerAppInstrumentCommand {
     config: ContainerAppConfigOptions,
     subscriptionId: string,
     resourceGroup: string,
-    containerApp: ContainerApp
+    containerApp: ContainerApp,
+    ssiConfig: SsiConfigResult = resolveSsiConfig(config)
   ): Promise<void> {
     const updatedTags: Record<string, string> = {
       ...containerApp.tags,
@@ -157,19 +188,18 @@ export class PluginCommand extends ContainerAppInstrumentCommand {
     if (config.version) {
       updatedTags.version = config.version
     }
+    if (ssiConfig.kind === 'single-language') {
+      updatedTags[SSI_INJECTION_MODE_TAG] = SINGLE_LANGUAGE_SSI_MODE
+    } else if (ssiConfig.kind === 'no-injection' && ssiConfig.tracing !== undefined) {
+      delete updatedTags[SSI_INJECTION_MODE_TAG]
+    }
     if (!sortedEqual(containerApp.tags, updatedTags)) {
       this.context.stdout.write(`${this.dryRunPrefix}Updating tags for ${chalk.bold(containerApp.name)}\n`)
       if (!this.dryRun) {
-        try {
-          await this.tagClient.beginCreateOrUpdateAtScopeAndWait(
-            `/subscriptions/${subscriptionId}/resourceGroups/${resourceGroup}/providers/Microsoft.App/containerApps/${containerApp.name}`,
-            {properties: {tags: updatedTags}}
-          )
-        } catch (error) {
-          this.context.stdout.write(
-            renderError(`Failed to update tags for ${chalk.bold(containerApp.name)}: ${formatError(error)}`)
-          )
-        }
+        await this.tagClient.beginCreateOrUpdateAtScopeAndWait(
+          `/subscriptions/${subscriptionId}/resourceGroups/${resourceGroup}/providers/Microsoft.App/containerApps/${containerApp.name}`,
+          {properties: {tags: updatedTags}}
+        )
       }
     }
   }
@@ -178,13 +208,15 @@ export class PluginCommand extends ContainerAppInstrumentCommand {
     client: ContainerAppsAPIClient,
     config: ContainerAppConfigOptions,
     resourceGroup: string,
-    containerApp: ContainerApp
+    containerApp: ContainerApp,
+    ssiConfig: SsiConfigResult = resolveSsiConfig(config)
   ) {
     const updatedAppConfig = this.createInstrumentedAppConfig(
       config,
       client.subscriptionId,
       resourceGroup,
-      containerApp
+      containerApp,
+      ssiConfig
     )
     if (sortedEqual(containerApp, updatedAppConfig)) {
       this.context.stdout.write(
@@ -210,9 +242,39 @@ export class PluginCommand extends ContainerAppInstrumentCommand {
     config: ContainerAppConfigOptions,
     subscriptionId: string,
     resourceGroup: string,
-    containerApp: ContainerApp
+    containerApp: ContainerApp,
+    ssiConfig: SsiConfigResult = resolveSsiConfig(config)
   ): ContainerApp {
+    if (ssiConfig.kind === 'errors') {
+      throw new SsiConfigError(ssiConfig.errors.join('\n'))
+    }
+
+    let sourceApp = containerApp
+    let targetIndex: number | undefined
+    if (ssiConfig.kind === 'single-language') {
+      targetIndex = selectApplicationContainer(
+        containerApp.template?.containers ?? [],
+        config.sidecarName!,
+        config.containerName
+      )
+      assertLanguageInjectionEnvCanBeMerged(containerApp.template?.containers?.[targetIndex].env)
+      const hasMarker = containerApp.tags?.[SSI_INJECTION_MODE_TAG] === SINGLE_LANGUAGE_SSI_MODE
+      if (hasMarker || hasCompleteSsiSignature(containerApp, targetIndex)) {
+        sourceApp = removeSsiState(containerApp)
+      }
+    } else if (
+      ssiConfig.tracing !== undefined &&
+      containerApp.tags?.[SSI_INJECTION_MODE_TAG] === SINGLE_LANGUAGE_SSI_MODE
+    ) {
+      sourceApp = removeSsiState(containerApp)
+    }
+
     const envVarsByName = getEnvVarsByName(config, subscriptionId, resourceGroup)
+    if (ssiConfig.kind === 'single-language' || ssiConfig.tracing === 'manual') {
+      envVarsByName[DD_TRACE_ENABLED_ENV_VAR] = {name: DD_TRACE_ENABLED_ENV_VAR, value: 'true'}
+    } else if (ssiConfig.tracing === 'disabled') {
+      envVarsByName[DD_TRACE_ENABLED_ENV_VAR] = {name: DD_TRACE_ENABLED_ENV_VAR, value: 'false'}
+    }
     // Build base sidecar container
     const baseSidecar: Container = {
       name: config.sidecarName,
@@ -236,8 +298,8 @@ export class PluginCommand extends ContainerAppInstrumentCommand {
     }
 
     // Use shared helper to create instrumented template
-    const updatedTemplate = createInstrumentedTemplate(
-      containerApp.template ?? {},
+    let updatedTemplate = createInstrumentedTemplate(
+      sourceApp.template ?? {},
       baseSidecar,
       {
         name: config.sharedVolumeName!,
@@ -247,8 +309,17 @@ export class PluginCommand extends ContainerAppInstrumentCommand {
       },
       envVarsByName
     )
+    if (ssiConfig.kind === 'no-injection' && ssiConfig.tracing === undefined) {
+      updatedTemplate = {
+        ...updatedTemplate,
+        containers: updatedTemplate.containers.map((container, index) => ({
+          ...container,
+          env: preserveInjectionModeTag(sourceApp.template?.containers?.[index]?.env, container.env),
+        })),
+      }
+    }
 
-    const secrets = containerApp.configuration?.secrets ?? []
+    const secrets = sourceApp.configuration?.secrets ?? []
     const hasApiKey = secrets.some(({name}) => name === DD_API_KEY_SECRET_NAME)
     const updatedSecrets: Secret[] = secrets.map((secret) =>
       secret.name === DD_API_KEY_SECRET_NAME ? {name: DD_API_KEY_SECRET_NAME, value: process.env.DD_API_KEY!} : secret
@@ -257,10 +328,14 @@ export class PluginCommand extends ContainerAppInstrumentCommand {
       updatedSecrets.push({name: DD_API_KEY_SECRET_NAME, value: process.env.DD_API_KEY!})
     }
 
-    return {
-      ...containerApp,
-      configuration: {...containerApp.configuration, secrets: updatedSecrets},
+    const instrumentedApp = {
+      ...sourceApp,
+      configuration: {...sourceApp.configuration, secrets: updatedSecrets},
       template: updatedTemplate,
     }
+
+    return ssiConfig.kind === 'single-language'
+      ? applySingleLanguageSsi(instrumentedApp, targetIndex!, ssiConfig.spec)
+      : instrumentedApp
   }
 }

--- a/packages/plugin-container-app/src/commands/instrument.ts
+++ b/packages/plugin-container-app/src/commands/instrument.ts
@@ -158,6 +158,14 @@ export class PluginCommand extends ContainerAppInstrumentCommand {
       containerApp.configuration = {...containerApp.configuration, secrets: secrets.value}
       config = {...config, service: config.service ?? containerAppName}
 
+      if (config.tracing === undefined && hasSsi(containerApp)) {
+        this.context.stdout.write(
+          renderSoftWarning(
+            'Tracing defaults to manual. Use --tracing inject --language <language> to retain automatic tracer injection.'
+          )
+        )
+      }
+
       if (ssiConfig.kind === 'single-language' && (containerApp.template?.scale?.minReplicas ?? 0) === 0) {
         this.context.stdout.write(
           renderSoftWarning(
@@ -262,23 +270,19 @@ export class PluginCommand extends ContainerAppInstrumentCommand {
       throw new SsiConfigError(ssiConfig.errors.join('\n'))
     }
 
-    let sourceApp = containerApp
-    let targetIndex: number | undefined
     const ssiExists = hasSsi(containerApp)
+    const sourceApp = ssiExists ? removeSsiState(containerApp) : containerApp
+    let targetIndex: number | undefined
     if (ssiConfig.kind === 'single-language') {
       targetIndex = selectApplicationContainer(
-        containerApp.template?.containers ?? [],
+        sourceApp.template?.containers ?? [],
         config.sidecarName!,
         config.containerName
       )
-      assertLanguageInjectionEnvCanBeMerged(containerApp.template?.containers?.[targetIndex]?.env, ssiConfig.spec)
-      if (ssiExists) {
-        sourceApp = removeSsiState(containerApp)
-      } else {
+      assertLanguageInjectionEnvCanBeMerged(sourceApp.template?.containers?.[targetIndex]?.env, ssiConfig.spec)
+      if (!ssiExists) {
         assertSsiResourcesCanBeAdded(containerApp, targetIndex, config.sidecarName!)
       }
-    } else if (ssiExists) {
-      sourceApp = removeSsiState(containerApp)
     }
 
     const envVarsByName = getEnvVarsByName(config, subscriptionId, resourceGroup)

--- a/packages/plugin-container-app/src/commands/instrument.ts
+++ b/packages/plugin-container-app/src/commands/instrument.ts
@@ -29,7 +29,7 @@ import {SERVERLESS_CLI_VERSION_TAG_NAME, SERVERLESS_CLI_VERSION_TAG_VALUE} from 
 import {maskString} from '@datadog/datadog-ci-base/helpers/utils'
 import chalk from 'chalk'
 
-import {DD_API_KEY_SECRET_NAME, getEnvVarsByName} from '../common'
+import {DD_API_KEY_SECRET_NAME, getEnvVarsByName, redactSecrets} from '../common'
 import {
   SINGLE_LANGUAGE_SSI_MODE,
   SSI_INJECTION_MODE_TAG,
@@ -249,7 +249,7 @@ export class PluginCommand extends ContainerAppInstrumentCommand {
       return
     }
 
-    const configDiff = generateConfigDiff(containerApp, updatedAppConfig)
+    const configDiff = generateConfigDiff(redactSecrets(containerApp), redactSecrets(updatedAppConfig))
     this.context.stdout.write(
       `${this.dryRunPrefix}Updating configuration for ${chalk.bold(containerApp.name)}:\n${configDiff}\n`
     )

--- a/packages/plugin-container-app/src/commands/uninstrument.ts
+++ b/packages/plugin-container-app/src/commands/uninstrument.ts
@@ -1,4 +1,4 @@
-import type {ContainerApp, Container, VolumeMount} from '@azure/arm-appcontainers'
+import type {ContainerApp, Container} from '@azure/arm-appcontainers'
 import type {TagsOperations} from '@azure/arm-resources'
 import type {ContainerAppConfigOptions} from '@datadog/datadog-ci-base/commands/container-app/common'
 
@@ -9,12 +9,11 @@ import {ContainerAppUninstrumentCommand} from '@datadog/datadog-ci-base/commands
 import {renderError, renderSoftWarning} from '@datadog/datadog-ci-base/helpers/renderer'
 import {ensureAzureAuth, formatError} from '@datadog/datadog-ci-base/helpers/serverless/azure'
 import {generateConfigDiff, parseEnvVars} from '@datadog/datadog-ci-base/helpers/serverless/common'
-import {TRACER_CONTAINER_NAME, TRACER_VOLUME_NAME} from '@datadog/datadog-ci-base/helpers/serverless/ssi/constants'
 import {SERVERLESS_CLI_VERSION_TAG_NAME} from '@datadog/datadog-ci-base/helpers/tags'
 import chalk from 'chalk'
 
 import {DD_API_KEY_SECRET_NAME} from '../common'
-import {SSI_INJECTION_MODE_TAG, removeLanguageInjectionEnv} from '../ssi'
+import {SSI_INJECTION_MODE_TAG, hasSsi, removeSsiState} from '../ssi'
 
 export class PluginCommand extends ContainerAppUninstrumentCommand {
   private cred!: DefaultAzureCredential
@@ -144,9 +143,9 @@ export class PluginCommand extends ContainerAppUninstrumentCommand {
   }
 
   public createUninstrumentedAppConfig(config: ContainerAppConfigOptions, containerApp: ContainerApp): ContainerApp {
-    const containers = containerApp.template?.containers ?? []
-    const initContainers = containerApp.template?.initContainers
-    const volumes = containerApp.template?.volumes ?? []
+    const sourceApp = hasSsi(containerApp) ? removeSsiState(containerApp) : containerApp
+    const containers = sourceApp.template?.containers ?? []
+    const volumes = sourceApp.template?.volumes ?? []
     // Remove sidecar container
     let updatedContainers = containers.filter((c) => c.name !== config.sidecarName)
 
@@ -159,21 +158,20 @@ export class PluginCommand extends ContainerAppUninstrumentCommand {
     }
 
     // Remove shared volume
-    const updatedVolumes = volumes.filter((v) => v.name !== config.sharedVolumeName && v.name !== TRACER_VOLUME_NAME)
+    const updatedVolumes = volumes.filter((v) => v.name !== config.sharedVolumeName)
 
     // Update app containers to remove volume mounts and DD_* env vars
     updatedContainers = updatedContainers.map((c) => this.updateAppContainer(c, config))
 
     // Remove DD_API_KEY secret
-    const secrets = containerApp.configuration?.secrets ?? []
+    const secrets = sourceApp.configuration?.secrets ?? []
     const updatedSecrets = secrets.filter((secret) => secret.name !== DD_API_KEY_SECRET_NAME)
 
     return {
-      ...containerApp,
-      configuration: {...containerApp.configuration, secrets: updatedSecrets},
+      ...sourceApp,
+      configuration: {...sourceApp.configuration, secrets: updatedSecrets},
       template: {
-        ...containerApp.template,
-        ...(initContainers ? {initContainers: initContainers.filter(({name}) => name !== TRACER_CONTAINER_NAME)} : {}),
+        ...sourceApp.template,
         containers: updatedContainers,
         volumes: updatedVolumes,
       },
@@ -182,16 +180,13 @@ export class PluginCommand extends ContainerAppUninstrumentCommand {
 
   // Remove volume mount, DD_* env vars, and custom env vars
   private updateAppContainer(appContainer: Container, config: ContainerAppConfigOptions): Container {
-    const existingVolumeMounts = appContainer.volumeMounts || []
-    const updatedVolumeMounts = existingVolumeMounts.filter(
-      (v: VolumeMount) => v.volumeName !== config.sharedVolumeName && v.volumeName !== TRACER_VOLUME_NAME
-    )
+    const existingVolumeMounts = appContainer.volumeMounts ?? []
+    const updatedVolumeMounts = existingVolumeMounts.filter((v) => v.volumeName !== config.sharedVolumeName)
 
     const customEnvVars = parseEnvVars(config.envVars)
 
-    const existingEnvVars = removeLanguageInjectionEnv(appContainer.env)
     // Remove env vars beginning with DD_ and custom env vars
-    const updatedEnvVars = existingEnvVars.filter(
+    const updatedEnvVars = (appContainer.env ?? []).filter(
       (v) => v.name && !v.name.startsWith('DD_') && !(v.name in customEnvVars)
     )
 

--- a/packages/plugin-container-app/src/commands/uninstrument.ts
+++ b/packages/plugin-container-app/src/commands/uninstrument.ts
@@ -173,9 +173,7 @@ export class PluginCommand extends ContainerAppUninstrumentCommand {
       configuration: {...containerApp.configuration, secrets: updatedSecrets},
       template: {
         ...containerApp.template,
-        ...(initContainers === undefined
-          ? {}
-          : {initContainers: initContainers.filter(({name}) => name !== TRACER_CONTAINER_NAME)}),
+        ...(initContainers ? {initContainers: initContainers.filter(({name}) => name !== TRACER_CONTAINER_NAME)} : {}),
         containers: updatedContainers,
         volumes: updatedVolumes,
       },

--- a/packages/plugin-container-app/src/commands/uninstrument.ts
+++ b/packages/plugin-container-app/src/commands/uninstrument.ts
@@ -116,10 +116,16 @@ export class PluginCommand extends ContainerAppUninstrumentCommand {
     if (tagsChanged) {
       this.context.stdout.write(`${this.dryRunPrefix}Removing tags from ${chalk.bold(containerApp.name)}\n`)
       if (!this.dryRun) {
-        await this.tagClient.beginCreateOrUpdateAtScopeAndWait(
-          `/subscriptions/${subscriptionId}/resourceGroups/${resourceGroup}/providers/Microsoft.App/containerApps/${containerApp.name}`,
-          {properties: {tags: updatedTags}}
-        )
+        try {
+          await this.tagClient.beginCreateOrUpdateAtScopeAndWait(
+            `/subscriptions/${subscriptionId}/resourceGroups/${resourceGroup}/providers/Microsoft.App/containerApps/${containerApp.name}`,
+            {properties: {tags: updatedTags}}
+          )
+        } catch (error) {
+          this.context.stdout.write(
+            renderError(`Failed to remove tags for ${containerApp.name}: ${formatError(error)}`)
+          )
+        }
       }
     }
   }
@@ -135,7 +141,7 @@ export class PluginCommand extends ContainerAppUninstrumentCommand {
       return
     }
 
-    const configDiff = generateConfigDiff(containerApp, updatedAppConfig)
+    const configDiff = generateConfigDiff(redactSecrets(containerApp), redactSecrets(updatedAppConfig))
     this.context.stdout.write(
       `${this.dryRunPrefix}Updating configuration for ${chalk.bold(containerApp.name)}:\n${configDiff}\n`
     )
@@ -200,3 +206,13 @@ export class PluginCommand extends ContainerAppUninstrumentCommand {
     }
   }
 }
+
+const redactSecrets = (containerApp: ContainerApp): ContainerApp => ({
+  ...containerApp,
+  configuration: {
+    ...containerApp.configuration,
+    secrets: containerApp.configuration?.secrets?.map((secret) =>
+      secret.value === undefined ? secret : {...secret, value: '<redacted>'}
+    ),
+  },
+})

--- a/packages/plugin-container-app/src/commands/uninstrument.ts
+++ b/packages/plugin-container-app/src/commands/uninstrument.ts
@@ -9,10 +9,12 @@ import {ContainerAppUninstrumentCommand} from '@datadog/datadog-ci-base/commands
 import {renderError, renderSoftWarning} from '@datadog/datadog-ci-base/helpers/renderer'
 import {ensureAzureAuth, formatError} from '@datadog/datadog-ci-base/helpers/serverless/azure'
 import {generateConfigDiff, parseEnvVars} from '@datadog/datadog-ci-base/helpers/serverless/common'
+import {TRACER_CONTAINER_NAME, TRACER_VOLUME_NAME} from '@datadog/datadog-ci-base/helpers/serverless/ssi/constants'
 import {SERVERLESS_CLI_VERSION_TAG_NAME} from '@datadog/datadog-ci-base/helpers/tags'
 import chalk from 'chalk'
 
 import {DD_API_KEY_SECRET_NAME} from '../common'
+import {SSI_INJECTION_MODE_TAG, removeLanguageInjectionEnv} from '../ssi'
 
 export class PluginCommand extends ContainerAppUninstrumentCommand {
   private cred!: DefaultAzureCredential
@@ -80,7 +82,11 @@ export class PluginCommand extends ContainerAppUninstrumentCommand {
     subscriptionId: string
   ): Promise<boolean> {
     try {
-      const containerApp = await containerAppClient.containerApps.get(resourceGroup, containerAppName)
+      const [containerApp, secrets] = await Promise.all([
+        containerAppClient.containerApps.get(resourceGroup, containerAppName),
+        containerAppClient.containerApps.listSecrets(resourceGroup, containerAppName),
+      ])
+      containerApp.configuration = {...containerApp.configuration, secrets: secrets.value}
 
       await this.uninstrumentSidecar(containerAppClient, config, resourceGroup, containerApp)
       await this.removeTags(subscriptionId, resourceGroup, containerApp)
@@ -99,26 +105,22 @@ export class PluginCommand extends ContainerAppUninstrumentCommand {
     delete updatedTags.env
     delete updatedTags.version
     delete updatedTags[SERVERLESS_CLI_VERSION_TAG_NAME]
+    delete updatedTags[SSI_INJECTION_MODE_TAG]
 
     const tagsChanged =
       containerApp.tags?.service ||
       containerApp.tags?.env ||
       containerApp.tags?.version ||
-      containerApp.tags?.[SERVERLESS_CLI_VERSION_TAG_NAME]
+      containerApp.tags?.[SERVERLESS_CLI_VERSION_TAG_NAME] ||
+      containerApp.tags?.[SSI_INJECTION_MODE_TAG]
 
     if (tagsChanged) {
       this.context.stdout.write(`${this.dryRunPrefix}Removing tags from ${chalk.bold(containerApp.name)}\n`)
       if (!this.dryRun) {
-        try {
-          await this.tagClient.beginCreateOrUpdateAtScopeAndWait(
-            `/subscriptions/${subscriptionId}/resourceGroups/${resourceGroup}/providers/Microsoft.App/containerApps/${containerApp.name}`,
-            {properties: {tags: updatedTags}}
-          )
-        } catch (error) {
-          this.context.stdout.write(
-            renderError(`Failed to remove tags from ${chalk.bold(containerApp.name)}: ${formatError(error)}`)
-          )
-        }
+        await this.tagClient.beginCreateOrUpdateAtScopeAndWait(
+          `/subscriptions/${subscriptionId}/resourceGroups/${resourceGroup}/providers/Microsoft.App/containerApps/${containerApp.name}`,
+          {properties: {tags: updatedTags}}
+        )
       }
     }
   }
@@ -142,9 +144,9 @@ export class PluginCommand extends ContainerAppUninstrumentCommand {
   }
 
   public createUninstrumentedAppConfig(config: ContainerAppConfigOptions, containerApp: ContainerApp): ContainerApp {
-    const containers = containerApp?.template?.containers ?? []
-    const volumes = containerApp?.template?.volumes || []
-
+    const containers = containerApp.template?.containers ?? []
+    const initContainers = containerApp.template?.initContainers
+    const volumes = containerApp.template?.volumes ?? []
     // Remove sidecar container
     let updatedContainers = containers.filter((c) => c.name !== config.sidecarName)
 
@@ -157,7 +159,7 @@ export class PluginCommand extends ContainerAppUninstrumentCommand {
     }
 
     // Remove shared volume
-    const updatedVolumes = volumes.filter((v) => v.name !== config.sharedVolumeName)
+    const updatedVolumes = volumes.filter((v) => v.name !== config.sharedVolumeName && v.name !== TRACER_VOLUME_NAME)
 
     // Update app containers to remove volume mounts and DD_* env vars
     updatedContainers = updatedContainers.map((c) => this.updateAppContainer(c, config))
@@ -171,6 +173,9 @@ export class PluginCommand extends ContainerAppUninstrumentCommand {
       configuration: {...containerApp.configuration, secrets: updatedSecrets},
       template: {
         ...containerApp.template,
+        ...(initContainers === undefined
+          ? {}
+          : {initContainers: initContainers.filter(({name}) => name !== TRACER_CONTAINER_NAME)}),
         containers: updatedContainers,
         volumes: updatedVolumes,
       },
@@ -181,12 +186,12 @@ export class PluginCommand extends ContainerAppUninstrumentCommand {
   private updateAppContainer(appContainer: Container, config: ContainerAppConfigOptions): Container {
     const existingVolumeMounts = appContainer.volumeMounts || []
     const updatedVolumeMounts = existingVolumeMounts.filter(
-      (v: VolumeMount) => v.volumeName !== config.sharedVolumeName
+      (v: VolumeMount) => v.volumeName !== config.sharedVolumeName && v.volumeName !== TRACER_VOLUME_NAME
     )
 
     const customEnvVars = parseEnvVars(config.envVars)
 
-    const existingEnvVars = appContainer.env || []
+    const existingEnvVars = removeLanguageInjectionEnv(appContainer.env)
     // Remove env vars beginning with DD_ and custom env vars
     const updatedEnvVars = existingEnvVars.filter(
       (v) => v.name && !v.name.startsWith('DD_') && !(v.name in customEnvVars)

--- a/packages/plugin-container-app/src/commands/uninstrument.ts
+++ b/packages/plugin-container-app/src/commands/uninstrument.ts
@@ -12,7 +12,7 @@ import {generateConfigDiff, parseEnvVars, sortedEqual} from '@datadog/datadog-ci
 import {SERVERLESS_CLI_VERSION_TAG_NAME} from '@datadog/datadog-ci-base/helpers/tags'
 import chalk from 'chalk'
 
-import {DD_API_KEY_SECRET_NAME} from '../common'
+import {DD_API_KEY_SECRET_NAME, redactSecrets} from '../common'
 import {SSI_INJECTION_MODE_TAG, removeSsiState} from '../ssi'
 
 export class PluginCommand extends ContainerAppUninstrumentCommand {
@@ -206,13 +206,3 @@ export class PluginCommand extends ContainerAppUninstrumentCommand {
     }
   }
 }
-
-const redactSecrets = (containerApp: ContainerApp): ContainerApp => ({
-  ...containerApp,
-  configuration: {
-    ...containerApp.configuration,
-    secrets: containerApp.configuration?.secrets?.map((secret) =>
-      secret.value === undefined ? secret : {...secret, value: '<redacted>'}
-    ),
-  },
-})

--- a/packages/plugin-container-app/src/commands/uninstrument.ts
+++ b/packages/plugin-container-app/src/commands/uninstrument.ts
@@ -106,14 +106,7 @@ export class PluginCommand extends ContainerAppUninstrumentCommand {
     delete updatedTags[SERVERLESS_CLI_VERSION_TAG_NAME]
     delete updatedTags[SSI_INJECTION_MODE_TAG]
 
-    const tagsChanged =
-      containerApp.tags?.service ||
-      containerApp.tags?.env ||
-      containerApp.tags?.version ||
-      containerApp.tags?.[SERVERLESS_CLI_VERSION_TAG_NAME] ||
-      containerApp.tags?.[SSI_INJECTION_MODE_TAG]
-
-    if (tagsChanged) {
+    if (!sortedEqual(containerApp.tags ?? {}, updatedTags)) {
       this.context.stdout.write(`${this.dryRunPrefix}Removing tags from ${chalk.bold(containerApp.name)}\n`)
       if (!this.dryRun) {
         try {

--- a/packages/plugin-container-app/src/commands/uninstrument.ts
+++ b/packages/plugin-container-app/src/commands/uninstrument.ts
@@ -13,7 +13,7 @@ import {SERVERLESS_CLI_VERSION_TAG_NAME} from '@datadog/datadog-ci-base/helpers/
 import chalk from 'chalk'
 
 import {DD_API_KEY_SECRET_NAME} from '../common'
-import {SSI_INJECTION_MODE_TAG, hasSsi, removeSsiState} from '../ssi'
+import {SSI_INJECTION_MODE_TAG, removeSsiState} from '../ssi'
 
 export class PluginCommand extends ContainerAppUninstrumentCommand {
   private cred!: DefaultAzureCredential
@@ -152,7 +152,7 @@ export class PluginCommand extends ContainerAppUninstrumentCommand {
   }
 
   public createUninstrumentedAppConfig(config: ContainerAppConfigOptions, containerApp: ContainerApp): ContainerApp {
-    const sourceApp = hasSsi(containerApp) ? removeSsiState(containerApp) : containerApp
+    const sourceApp = removeSsiState(containerApp)
     const containers = sourceApp.template?.containers ?? []
     const volumes = sourceApp.template?.volumes ?? []
     // Remove sidecar container

--- a/packages/plugin-container-app/src/commands/uninstrument.ts
+++ b/packages/plugin-container-app/src/commands/uninstrument.ts
@@ -8,7 +8,7 @@ import {DefaultAzureCredential} from '@azure/identity'
 import {ContainerAppUninstrumentCommand} from '@datadog/datadog-ci-base/commands/container-app/uninstrument'
 import {renderError, renderSoftWarning} from '@datadog/datadog-ci-base/helpers/renderer'
 import {ensureAzureAuth, formatError} from '@datadog/datadog-ci-base/helpers/serverless/azure'
-import {generateConfigDiff, parseEnvVars} from '@datadog/datadog-ci-base/helpers/serverless/common'
+import {generateConfigDiff, parseEnvVars, sortedEqual} from '@datadog/datadog-ci-base/helpers/serverless/common'
 import {SERVERLESS_CLI_VERSION_TAG_NAME} from '@datadog/datadog-ci-base/helpers/tags'
 import chalk from 'chalk'
 
@@ -131,6 +131,9 @@ export class PluginCommand extends ContainerAppUninstrumentCommand {
     containerApp: ContainerApp
   ) {
     const updatedAppConfig = this.createUninstrumentedAppConfig(config, containerApp)
+    if (sortedEqual(containerApp, updatedAppConfig)) {
+      return
+    }
 
     const configDiff = generateConfigDiff(containerApp, updatedAppConfig)
     this.context.stdout.write(
@@ -173,7 +176,7 @@ export class PluginCommand extends ContainerAppUninstrumentCommand {
       template: {
         ...sourceApp.template,
         containers: updatedContainers,
-        volumes: updatedVolumes,
+        ...(updatedVolumes.length !== volumes.length ? {volumes: updatedVolumes} : {}),
       },
     }
   }
@@ -192,8 +195,8 @@ export class PluginCommand extends ContainerAppUninstrumentCommand {
 
     return {
       ...appContainer,
-      volumeMounts: updatedVolumeMounts,
-      env: updatedEnvVars,
+      ...(updatedVolumeMounts.length !== existingVolumeMounts.length ? {volumeMounts: updatedVolumeMounts} : {}),
+      ...(updatedEnvVars.length !== (appContainer.env?.length ?? 0) ? {env: updatedEnvVars} : {}),
     }
   }
 }

--- a/packages/plugin-container-app/src/common.ts
+++ b/packages/plugin-container-app/src/common.ts
@@ -2,6 +2,7 @@ import type {EnvironmentVar} from '@azure/arm-appcontainers'
 import type {ContainerAppConfigOptions} from '@datadog/datadog-ci-base/commands/container-app/common'
 
 import {getBaseEnvVars} from '@datadog/datadog-ci-base/helpers/serverless/common'
+import {DD_SOURCE_ENV_VAR} from '@datadog/datadog-ci-base/helpers/serverless/constants'
 
 export const DD_API_KEY_SECRET_NAME = 'dd-api-key'
 
@@ -23,6 +24,9 @@ export const getEnvVarsByName = (
   envVars.DD_AZURE_RESOURCE_GROUP = {name: 'DD_AZURE_RESOURCE_GROUP', value: resourceGroup}
   envVars.DD_SERVERLESS_LOG_PATH = {name: 'DD_SERVERLESS_LOG_PATH', value: config.logsPath}
   envVars.DD_APM_ENABLED = {name: 'DD_APM_ENABLED', value: 'true'}
+  if (config.language) {
+    envVars[DD_SOURCE_ENV_VAR] = {name: DD_SOURCE_ENV_VAR, value: config.language}
+  }
 
   return envVars
 }

--- a/packages/plugin-container-app/src/common.ts
+++ b/packages/plugin-container-app/src/common.ts
@@ -1,10 +1,20 @@
-import type {EnvironmentVar} from '@azure/arm-appcontainers'
+import type {ContainerApp, EnvironmentVar} from '@azure/arm-appcontainers'
 import type {ContainerAppConfigOptions} from '@datadog/datadog-ci-base/commands/container-app/common'
 
 import {getBaseEnvVars} from '@datadog/datadog-ci-base/helpers/serverless/common'
 import {DD_SOURCE_ENV_VAR} from '@datadog/datadog-ci-base/helpers/serverless/constants'
 
 export const DD_API_KEY_SECRET_NAME = 'dd-api-key'
+
+export const redactSecrets = (containerApp: ContainerApp): ContainerApp => ({
+  ...containerApp,
+  configuration: {
+    ...containerApp.configuration,
+    secrets: containerApp.configuration?.secrets?.map((secret) =>
+      secret.value === undefined ? secret : {...secret, value: '<redacted>'}
+    ),
+  },
+})
 
 export const getEnvVarsByName = (
   config: ContainerAppConfigOptions,

--- a/packages/plugin-container-app/src/ssi.ts
+++ b/packages/plugin-container-app/src/ssi.ts
@@ -5,7 +5,6 @@ import type {LanguageInjectionSpec, Libc} from '@datadog/datadog-ci-base/helpers
 import type {Language} from '@datadog/datadog-ci-base/helpers/serverless/ssi/tracer'
 import type {TracingMode} from '@datadog/datadog-ci-base/helpers/serverless/ssi/tracing'
 
-import {CONTAINER_APP_LANGUAGES} from '@datadog/datadog-ci-base/commands/container-app/instrument'
 import {DD_TAGS_ENV_VAR} from '@datadog/datadog-ci-base/helpers/serverless/constants'
 import {
   TRACER_CONTAINER_NAME,
@@ -92,12 +91,10 @@ export const resolveSsiConfig = (config: ContainerAppConfigOptions): SsiConfigRe
       warnings: [],
     }
   }
-  if (config.language === 'go') {
+  if (!isTracerInjectionLanguage(config.language)) {
     return {
       kind: 'errors',
-      errors: [
-        'Go automatic instrumentation is not supported. Install dd-trace-go in the application and use --tracing manual.',
-      ],
+      errors: [`--tracing inject supports only these languages: ${TRACER_INJECTION_LANGUAGES.join(', ')}.`],
       warnings: [],
     }
   }
@@ -174,17 +171,6 @@ export const assertLanguageInjectionEnvCanBeMerged = (
   spec: LanguageInjectionSpec
 ): void => assertEnvironmentFragmentsCanBeMerged(env, spec.env)
 
-export const assertExistingLanguageInjectionCanBeReplaced = (containerApp: ContainerApp): void => {
-  for (const container of containerApp.template?.containers ?? []) {
-    const hasMarker = container.env?.some(
-      ({name, secretRef, value}) => name === DD_TAGS_ENV_VAR && !secretRef && hasInjectionModeTag(value)
-    )
-    if (hasMarker) {
-      assertEnvironmentFragmentsCanBeMerged(container.env, LANGUAGE_ENV_FRAGMENTS)
-    }
-  }
-}
-
 export const assertSsiResourcesCanBeAdded = (
   containerApp: ContainerApp,
   targetIndex: number,
@@ -234,21 +220,6 @@ export const mergeLanguageInjectionEnv = (
   return upsertEnv(merged, DD_TAGS_ENV_VAR, mergeInjectionModeTag(existingTags?.value))
 }
 
-/** Keeps an existing process injection tag when Agent configuration updates DD_TAGS. */
-export const preserveInjectionModeTag = <T extends EnvironmentVar>(
-  existingEnv: readonly EnvironmentVar[] | undefined,
-  updatedEnv: readonly T[] | undefined
-): T[] => {
-  const existingTags = existingEnv?.find(({name, secretRef}) => name === DD_TAGS_ENV_VAR && !secretRef)?.value
-  if (!hasInjectionModeTag(existingTags)) {
-    return [...(updatedEnv ?? [])]
-  }
-  const updated = updatedEnv ?? []
-  const updatedTags = updated.find(({name}) => name === DD_TAGS_ENV_VAR)
-
-  return upsertEnv(updated, DD_TAGS_ENV_VAR, mergeInjectionModeTag(updatedTags?.value))
-}
-
 /** Removes exact native tracer fragments for every supported language. */
 export const removeLanguageInjectionEnv = (existingEnv: readonly EnvironmentVar[] | undefined): EnvironmentVar[] =>
   (existingEnv ?? []).flatMap((variable) => {
@@ -266,6 +237,11 @@ export const removeLanguageInjectionEnv = (existingEnv: readonly EnvironmentVar[
 export const hasSsi = (containerApp: ContainerApp): boolean =>
   (containerApp.tags !== undefined &&
     Object.prototype.hasOwnProperty.call(containerApp.tags, SSI_INJECTION_MODE_TAG)) ||
+  (containerApp.template?.containers ?? []).some((container) =>
+    container.env?.some(
+      ({name, secretRef, value}) => name === DD_TAGS_ENV_VAR && !secretRef && hasInjectionModeTag(value)
+    )
+  ) ||
   (containerApp.template?.containers ?? []).some((_, index) => hasCompleteSsiSignature(containerApp, index))
 
 export const hasCompleteSsiSignature = (containerApp: ContainerApp, targetIndex: number): boolean => {
@@ -347,10 +323,8 @@ const validateSsiInputs = (config: ContainerAppConfigOptions): string[] => {
       `Invalid tracing mode ${JSON.stringify(config.tracing)}. Possible values: ${TRACING_INPUTS.join(', ')}.`
     )
   }
-  if (config.language !== undefined && !(CONTAINER_APP_LANGUAGES as readonly string[]).includes(config.language)) {
-    errors.push(
-      `Invalid language ${JSON.stringify(config.language)}. Possible values: ${CONTAINER_APP_LANGUAGES.join(', ')}.`
-    )
+  if (config.language !== undefined && (typeof config.language !== 'string' || config.language.length === 0)) {
+    errors.push(`Invalid language ${JSON.stringify(config.language)}.`)
   }
   if (
     config.tracerVersion !== undefined &&
@@ -367,6 +341,9 @@ const validateSsiInputs = (config: ContainerAppConfigOptions): string[] => {
 
   return errors
 }
+
+const isTracerInjectionLanguage = (language: string): language is Language =>
+  (TRACER_INJECTION_LANGUAGES as readonly string[]).includes(language)
 
 const formatContainerNames = (candidates: readonly {container: Container}[]): string =>
   candidates.map(({container}) => container.name || '<unnamed>').join(', ')

--- a/packages/plugin-container-app/src/ssi.ts
+++ b/packages/plugin-container-app/src/ssi.ts
@@ -1,10 +1,13 @@
 import type {Container, ContainerApp, EnvironmentVar, InitContainer} from '@azure/arm-appcontainers'
-import type {ContainerAppConfigOptions} from '@datadog/datadog-ci-base/commands/container-app/common'
 import type {EnvFragment} from '@datadog/datadog-ci-base/helpers/serverless/ssi/env'
 import type {LanguageInjectionSpec, Libc} from '@datadog/datadog-ci-base/helpers/serverless/ssi/injection-spec'
 import type {Language} from '@datadog/datadog-ci-base/helpers/serverless/ssi/tracer'
 import type {TracingMode} from '@datadog/datadog-ci-base/helpers/serverless/ssi/tracing'
 
+import {
+  CONTAINER_APP_TRACING_INPUTS,
+  type ContainerAppConfigOptions,
+} from '@datadog/datadog-ci-base/commands/container-app/common'
 import {DD_TAGS_ENV_VAR} from '@datadog/datadog-ci-base/helpers/serverless/constants'
 import {
   TRACER_CONTAINER_NAME,
@@ -30,7 +33,6 @@ import {
   LANGUAGE_METADATA,
   TRACER_IMAGE_TAG_REG_EXP,
 } from '@datadog/datadog-ci-base/helpers/serverless/ssi/tracer'
-import {TRACING_INPUTS, normalizeTracingInput} from '@datadog/datadog-ci-base/helpers/serverless/ssi/tracing'
 
 export const SSI_INJECTION_MODE_TAG = 'dd_sls_injection_mode'
 export const SINGLE_LANGUAGE_SSI_MODE = 'single_language'
@@ -39,7 +41,7 @@ export const TRACER_INJECTION_LANGUAGES: readonly Language[] = Object.keys(LANGU
 
 export type SsiConfigResult = (
   | {kind: 'errors'; errors: readonly string[]}
-  | {kind: 'no-injection'; tracing: Exclude<TracingMode, 'inject'> | undefined}
+  | {kind: 'no-injection'; tracing: Exclude<TracingMode, 'inject'>}
   | {kind: 'single-language'; language: Language; libc: Libc; spec: LanguageInjectionSpec}
 ) & {warnings: readonly string[]}
 
@@ -50,7 +52,7 @@ export const resolveSsiConfig = (config: ContainerAppConfigOptions): SsiConfigRe
     return {kind: 'errors', errors, warnings: []}
   }
 
-  const tracing = normalizeTracingInput(config.tracing)
+  const tracing = config.tracing ?? 'manual'
   if (tracing !== 'inject') {
     const unusedFlags = [
       config.tracerVersion !== undefined ? '--tracer-version' : undefined,
@@ -270,19 +272,39 @@ export const hasCompleteSsiSignature = (containerApp: ContainerApp, targetIndex:
   )
 }
 
-export const removeSsiState = (containerApp: ContainerApp): ContainerApp => ({
-  ...containerApp,
-  template: {
-    ...containerApp.template,
-    initContainers: (containerApp.template?.initContainers ?? []).filter(({name}) => name !== TRACER_CONTAINER_NAME),
-    containers: (containerApp.template?.containers ?? []).map((container) => ({
-      ...container,
-      env: removeLanguageInjectionEnv(container.env),
-      volumeMounts: (container.volumeMounts ?? []).filter(({volumeName}) => volumeName !== TRACER_VOLUME_NAME),
-    })),
-    volumes: (containerApp.template?.volumes ?? []).filter(({name}) => name !== TRACER_VOLUME_NAME),
-  },
-})
+export const removeSsiState = (containerApp: ContainerApp): ContainerApp => {
+  const template = containerApp.template
+  const initContainers = template?.initContainers?.filter(({name}) => name !== TRACER_CONTAINER_NAME)
+  const volumes = template?.volumes?.filter(({name}) => name !== TRACER_VOLUME_NAME)
+  const containers = template?.containers?.map((container) => {
+    const env = removeLanguageInjectionEnv(container.env)
+    const volumeMounts = container.volumeMounts?.filter(
+      ({volumeName, mountPath}) => volumeName !== TRACER_VOLUME_NAME && mountPath !== TRACER_MOUNT_PATH
+    )
+    const envChanged =
+      env.length !== (container.env?.length ?? 0) || env.some((variable, index) => variable !== container.env?.[index])
+    const mountsChanged = volumeMounts?.length !== container.volumeMounts?.length
+
+    return envChanged || mountsChanged
+      ? {...container, ...(envChanged ? {env} : {}), ...(mountsChanged ? {volumeMounts} : {})}
+      : container
+  })
+  const containersChanged = containers?.some((container, index) => container !== template?.containers?.[index])
+
+  return {
+    ...containerApp,
+    ...(template === undefined
+      ? {}
+      : {
+          template: {
+            ...template,
+            ...(initContainers?.length !== template.initContainers?.length ? {initContainers} : {}),
+            ...(containersChanged ? {containers} : {}),
+            ...(volumes?.length !== template.volumes?.length ? {volumes} : {}),
+          },
+        }),
+  }
+}
 
 export const applySingleLanguageSsi = (
   containerApp: ContainerApp,
@@ -318,9 +340,9 @@ export class SsiConfigError extends Error {
 
 const validateSsiInputs = (config: ContainerAppConfigOptions): string[] => {
   const errors: string[] = []
-  if (config.tracing !== undefined && !(TRACING_INPUTS as readonly string[]).includes(config.tracing)) {
+  if (config.tracing !== undefined && !(CONTAINER_APP_TRACING_INPUTS as readonly string[]).includes(config.tracing)) {
     errors.push(
-      `Invalid tracing mode ${JSON.stringify(config.tracing)}. Possible values: ${TRACING_INPUTS.join(', ')}.`
+      `Invalid tracing mode ${JSON.stringify(config.tracing)}. Possible values: ${CONTAINER_APP_TRACING_INPUTS.join(', ')}.`
     )
   }
   if (config.language !== undefined && (typeof config.language !== 'string' || config.language.length === 0)) {

--- a/packages/plugin-container-app/src/ssi.ts
+++ b/packages/plugin-container-app/src/ssi.ts
@@ -1,0 +1,421 @@
+import type {Container, ContainerApp, EnvironmentVar, InitContainer} from '@azure/arm-appcontainers'
+import type {ContainerAppConfigOptions} from '@datadog/datadog-ci-base/commands/container-app/common'
+import type {EnvFragment} from '@datadog/datadog-ci-base/helpers/serverless/ssi/env'
+import type {LanguageInjectionSpec, Libc} from '@datadog/datadog-ci-base/helpers/serverless/ssi/injection-spec'
+import type {Language} from '@datadog/datadog-ci-base/helpers/serverless/ssi/tracer'
+import type {TracingMode} from '@datadog/datadog-ci-base/helpers/serverless/ssi/tracing'
+
+import {CONTAINER_APP_LANGUAGES} from '@datadog/datadog-ci-base/commands/container-app/instrument'
+import {DD_TAGS_ENV_VAR} from '@datadog/datadog-ci-base/helpers/serverless/constants'
+import {
+  TRACER_CONTAINER_NAME,
+  TRACER_MOUNT_PATH,
+  TRACER_VOLUME_NAME,
+} from '@datadog/datadog-ci-base/helpers/serverless/ssi/constants'
+import {
+  hasEnvFragment,
+  hasInjectionModeTag,
+  mergeEnvFragment,
+  mergeInjectionModeTag,
+  removeEnvFragment,
+  removeInjectionModeTag,
+} from '@datadog/datadog-ci-base/helpers/serverless/ssi/env'
+import {
+  DEFAULT_TRACER_LIBC,
+  LIBCS,
+  getLanguageCompatibilityErrors,
+  getLanguageInjectionSpec,
+} from '@datadog/datadog-ci-base/helpers/serverless/ssi/injection-spec'
+import {
+  DEFAULT_TRACER_VERSION,
+  LANGUAGE_METADATA,
+  TRACER_IMAGE_TAG_REG_EXP,
+} from '@datadog/datadog-ci-base/helpers/serverless/ssi/tracer'
+import {TRACING_INPUTS, normalizeTracingInput} from '@datadog/datadog-ci-base/helpers/serverless/ssi/tracing'
+
+export const SSI_INJECTION_MODE_TAG = 'dd_sls_injection_mode'
+export const SINGLE_LANGUAGE_SSI_MODE = 'single_language'
+export const CONTAINER_APP_TRACER_REGISTRY = 'datadoghq.azurecr.io' as const
+export const TRACER_INJECTION_LANGUAGES: readonly Language[] = Object.keys(LANGUAGE_METADATA) as Language[]
+
+export type SsiConfigResult = (
+  | {kind: 'errors'; errors: readonly string[]}
+  | {kind: 'no-injection'; tracing: Exclude<TracingMode, 'inject'> | undefined}
+  | {kind: 'single-language'; language: Language; libc: Libc; spec: LanguageInjectionSpec}
+) & {warnings: readonly string[]}
+
+/** Resolves Container Apps tracer inputs before any remote work. */
+export const resolveSsiConfig = (config: ContainerAppConfigOptions): SsiConfigResult => {
+  const errors = validateSsiInputs(config)
+  if (errors.length > 0) {
+    return {kind: 'errors', errors, warnings: []}
+  }
+
+  const tracing = normalizeTracingInput(config.tracing)
+  if (tracing !== 'inject') {
+    const unusedFlags = [
+      config.tracerVersion !== undefined ? '--tracer-version' : undefined,
+      config.tracerLibc !== undefined ? '--tracer-libc' : undefined,
+    ].filter((flag): flag is string => flag !== undefined)
+
+    return unusedFlags.length > 0
+      ? {
+          kind: 'errors',
+          errors: [
+            `Tracer options ${unusedFlags.join(', ')} require --tracing inject. Remove these options or use --tracing inject.`,
+          ],
+          warnings: [],
+        }
+      : {kind: 'no-injection', tracing, warnings: []}
+  }
+
+  const collisionErrors = [
+    config.sharedVolumeName === TRACER_VOLUME_NAME
+      ? `--shared-volume-name cannot be '${TRACER_VOLUME_NAME}' with --tracing inject. Choose a different logging volume name.`
+      : undefined,
+    config.sharedVolumePath === TRACER_MOUNT_PATH
+      ? `--shared-volume-path cannot be '${TRACER_MOUNT_PATH}' with --tracing inject. Choose a different logging volume path.`
+      : undefined,
+  ].filter((error): error is string => error !== undefined)
+  if (collisionErrors.length > 0) {
+    return {kind: 'errors', errors: collisionErrors, warnings: []}
+  }
+
+  if (config.language === undefined) {
+    return {
+      kind: 'errors',
+      errors: [
+        `--tracing inject requires --language until automatic multi-language injection is supported. Possible values: ${TRACER_INJECTION_LANGUAGES.join(
+          ', '
+        )}.`,
+      ],
+      warnings: [],
+    }
+  }
+  if (config.language === 'go') {
+    return {
+      kind: 'errors',
+      errors: [
+        'Go automatic instrumentation is not supported. Install dd-trace-go in the application and use --tracing manual.',
+      ],
+      warnings: [],
+    }
+  }
+
+  const version = config.tracerVersion ?? DEFAULT_TRACER_VERSION
+  const libc = config.tracerLibc ?? DEFAULT_TRACER_LIBC
+  const compatibilityErrors = getLanguageCompatibilityErrors({language: config.language, libc, version})
+  if (compatibilityErrors.length > 0) {
+    return {kind: 'errors', errors: compatibilityErrors, warnings: []}
+  }
+
+  return {
+    kind: 'single-language',
+    language: config.language,
+    libc,
+    spec: getLanguageInjectionSpec({
+      language: config.language,
+      registry: CONTAINER_APP_TRACER_REGISTRY,
+      version,
+      libc,
+      root: TRACER_MOUNT_PATH,
+    }),
+    warnings:
+      config.language === 'java'
+        ? [
+            'Java 24+ applications require an additional JVM flag that datadog-ci cannot set safely without knowing your runtime version.',
+          ]
+        : [],
+  }
+}
+
+/** Selects one application container by stable index. */
+export const selectApplicationContainer = (
+  containers: readonly Container[],
+  sidecarName: string,
+  requestedName: string | undefined
+): number => {
+  const candidates = containers
+    .map((container, index) => ({container, index}))
+    .filter(({container}) => container.name !== sidecarName)
+  const containerName = requestedName?.trim() || undefined
+
+  if (containerName !== undefined) {
+    const matches = candidates.filter(({container}) => container.name === containerName)
+    if (matches.length !== 1) {
+      throw new SsiConfigError(
+        matches.length === 0
+          ? `Application container '${containerName}' was not found. Choose one of: ${formatContainerNames(candidates)}.`
+          : `Application container name '${containerName}' is not unique. Give each application container a unique name before retrying.`
+      )
+    }
+
+    return matches[0].index
+  }
+
+  if (candidates.length === 1) {
+    return candidates[0].index
+  }
+  if (candidates.length === 0) {
+    throw new SsiConfigError(
+      'Cannot enable automatic instrumentation because no application container was found. Add an application container, or choose a different --sidecar-name if it matches your application container.'
+    )
+  }
+
+  throw new SsiConfigError(
+    `Cannot select an application container because the Container App has multiple candidates: ${formatContainerNames(
+      candidates
+    )}. Specify one with --container-name.`
+  )
+}
+
+export const assertLanguageInjectionEnvCanBeMerged = (env: readonly EnvironmentVar[] | undefined): void => {
+  const targetNames = new Set([...LANGUAGE_ENV_FRAGMENTS.map(({name}) => name), DD_TAGS_ENV_VAR])
+  for (const name of targetNames) {
+    const matching = (env ?? []).filter((variable) => variable.name === name)
+    if (matching.length > 1) {
+      throw new SsiConfigError(
+        `${name} appears more than once on the selected application container. Remove the duplicate before retrying.`
+      )
+    }
+    if (matching[0]?.secretRef) {
+      throw new SsiConfigError(
+        `${name} on the selected application container comes from a secret reference. Set it to a literal value or remove it before retrying.`
+      )
+    }
+  }
+}
+
+export const mergeLanguageInjectionEnv = (
+  existingEnv: readonly EnvironmentVar[] | undefined,
+  spec: LanguageInjectionSpec
+): EnvironmentVar[] => {
+  assertLanguageInjectionEnvCanBeMerged(existingEnv)
+  const merged = spec.env.reduce<EnvironmentVar[]>(
+    (env, fragment) => {
+      const existing = env.find(({name}) => name === fragment.name)
+
+      return upsertEnv(env, fragment.name, mergeLanguageEnvFragment(existing?.value, fragment))
+    },
+    [...(existingEnv ?? [])]
+  )
+  const existingTags = merged.find(({name}) => name === DD_TAGS_ENV_VAR)
+
+  return upsertEnv(merged, DD_TAGS_ENV_VAR, mergeInjectionModeTag(existingTags?.value))
+}
+
+/** Keeps an existing process injection tag when Agent configuration updates DD_TAGS. */
+export const preserveInjectionModeTag = <T extends EnvironmentVar>(
+  existingEnv: readonly EnvironmentVar[] | undefined,
+  updatedEnv: readonly T[] | undefined
+): T[] => {
+  const existingTags = existingEnv?.find(({name, secretRef}) => name === DD_TAGS_ENV_VAR && !secretRef)?.value
+  if (!hasInjectionModeTag(existingTags)) {
+    return [...(updatedEnv ?? [])]
+  }
+  const updated = updatedEnv ?? []
+  const updatedTags = updated.find(({name}) => name === DD_TAGS_ENV_VAR)
+
+  return upsertEnv(updated, DD_TAGS_ENV_VAR, mergeInjectionModeTag(updatedTags?.value))
+}
+
+/** Removes exact native tracer fragments for every supported language. */
+export const removeLanguageInjectionEnv = (existingEnv: readonly EnvironmentVar[] | undefined): EnvironmentVar[] =>
+  (existingEnv ?? []).flatMap((variable) => {
+    if (!variable.name || variable.secretRef || !variable.value) {
+      return [variable]
+    }
+
+    const fragments = LANGUAGE_ENV_FRAGMENTS.filter(({name}) => name === variable.name)
+    const withoutTag = variable.name === DD_TAGS_ENV_VAR ? removeInjectionModeTag(variable.value) : variable.value
+    const value = fragments.reduce<string | undefined>(removeEnvFragment, withoutTag)
+
+    return value === undefined ? [] : [value === variable.value ? variable : {...variable, value}]
+  })
+
+export const hasCompleteSsiSignature = (containerApp: ContainerApp, targetIndex: number): boolean => {
+  const template = containerApp.template
+  const target = template?.containers?.[targetIndex]
+  if (!target) {
+    return false
+  }
+
+  const initContainers = template?.initContainers?.filter(isManagedInitContainer) ?? []
+  const volumes =
+    template?.volumes?.filter(({name, storageType}) => name === TRACER_VOLUME_NAME && storageType === 'EmptyDir') ?? []
+  const tracerMounts = (template?.containers ?? []).flatMap((container, index) =>
+    (container.volumeMounts ?? [])
+      .filter(({volumeName}) => volumeName === TRACER_VOLUME_NAME)
+      .map((mount) => ({index, mount}))
+  )
+
+  return (
+    initContainers.length === 1 &&
+    volumes.length === 1 &&
+    tracerMounts.length === 1 &&
+    tracerMounts[0].index === targetIndex &&
+    tracerMounts[0].mount.mountPath === TRACER_MOUNT_PATH &&
+    hasManagedTracerEnvironment(target.env, getInitContainerLanguage(initContainers[0]))
+  )
+}
+
+export const removeSsiState = (containerApp: ContainerApp): ContainerApp => ({
+  ...containerApp,
+  template: {
+    ...containerApp.template,
+    initContainers: (containerApp.template?.initContainers ?? []).filter(({name}) => name !== TRACER_CONTAINER_NAME),
+    containers: (containerApp.template?.containers ?? []).map((container) => ({
+      ...container,
+      env: removeLanguageInjectionEnv(container.env),
+      volumeMounts: (container.volumeMounts ?? []).filter(({volumeName}) => volumeName !== TRACER_VOLUME_NAME),
+    })),
+    volumes: (containerApp.template?.volumes ?? []).filter(({name}) => name !== TRACER_VOLUME_NAME),
+  },
+})
+
+export const applySingleLanguageSsi = (
+  containerApp: ContainerApp,
+  targetIndex: number,
+  spec: LanguageInjectionSpec
+): ContainerApp => ({
+  ...containerApp,
+  template: {
+    ...containerApp.template,
+    initContainers: [...(containerApp.template?.initContainers ?? []), buildTracerInitContainer(spec)],
+    containers: (containerApp.template?.containers ?? []).map((container, index) =>
+      index === targetIndex
+        ? {
+            ...container,
+            env: mergeLanguageInjectionEnv(container.env, spec),
+            volumeMounts: [
+              ...(container.volumeMounts ?? []),
+              {volumeName: TRACER_VOLUME_NAME, mountPath: TRACER_MOUNT_PATH},
+            ],
+          }
+        : container
+    ),
+    volumes: [...(containerApp.template?.volumes ?? []), {name: TRACER_VOLUME_NAME, storageType: 'EmptyDir'}],
+  },
+})
+
+export class SsiConfigError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'SsiConfigError'
+  }
+}
+
+const validateSsiInputs = (config: ContainerAppConfigOptions): string[] => {
+  const errors: string[] = []
+  if (config.tracing !== undefined && !(TRACING_INPUTS as readonly string[]).includes(config.tracing)) {
+    errors.push(
+      `Invalid tracing mode ${JSON.stringify(config.tracing)}. Possible values: ${TRACING_INPUTS.join(', ')}.`
+    )
+  }
+  if (config.language !== undefined && !(CONTAINER_APP_LANGUAGES as readonly string[]).includes(config.language)) {
+    errors.push(
+      `Invalid language ${JSON.stringify(config.language)}. Possible values: ${CONTAINER_APP_LANGUAGES.join(', ')}.`
+    )
+  }
+  if (
+    config.tracerVersion !== undefined &&
+    (typeof config.tracerVersion !== 'string' || !TRACER_IMAGE_TAG_REG_EXP.test(config.tracerVersion))
+  ) {
+    errors.push(`Invalid tracer version ${JSON.stringify(config.tracerVersion)}.`)
+  }
+  if (config.tracerLibc !== undefined && !(LIBCS as readonly string[]).includes(config.tracerLibc)) {
+    errors.push(`Invalid tracer libc ${JSON.stringify(config.tracerLibc)}. Possible values: ${LIBCS.join(', ')}.`)
+  }
+  if (config.containerName !== undefined && typeof config.containerName !== 'string') {
+    errors.push(`Invalid application container name ${JSON.stringify(config.containerName)}.`)
+  }
+
+  return errors
+}
+
+const formatContainerNames = (candidates: readonly {container: Container}[]): string =>
+  candidates.map(({container}) => container.name || '<unnamed>').join(', ')
+
+const upsertEnv = <T extends EnvironmentVar>(env: readonly T[], name: string, value: string): T[] => {
+  const index = env.findIndex((variable) => variable.name === name)
+
+  return index === -1
+    ? [...env, {name, value} as T]
+    : env.map((variable, variableIndex) => (variableIndex === index ? {...variable, value} : variable))
+}
+
+const mergeLanguageEnvFragment = (currentValue: string | undefined, fragment: EnvFragment): string => {
+  try {
+    return mergeEnvFragment(currentValue, fragment)
+  } catch (error) {
+    throw new SsiConfigError(
+      `Cannot enable automatic instrumentation while updating ${fragment.name}: ${
+        error instanceof Error ? error.message : String(error)
+      }`
+    )
+  }
+}
+
+const LANGUAGE_ENV_VARIANTS = TRACER_INJECTION_LANGUAGES.flatMap((language) =>
+  LIBCS.map((libc) => ({
+    language,
+    env: getLanguageInjectionSpec({
+      language,
+      libc,
+      registry: CONTAINER_APP_TRACER_REGISTRY,
+      version: DEFAULT_TRACER_VERSION,
+      root: TRACER_MOUNT_PATH,
+    }).env,
+  }))
+)
+const LANGUAGE_ENV_FRAGMENTS: readonly EnvFragment[] = LANGUAGE_ENV_VARIANTS.flatMap(({env}) => env)
+
+const hasManagedTracerEnvironment = (
+  env: readonly EnvironmentVar[] | undefined,
+  language: Language | undefined
+): boolean => {
+  const literalEnv = env ?? []
+  const tags = literalEnv.find(({name, secretRef}) => name === DD_TAGS_ENV_VAR && !secretRef)?.value
+  if (!hasInjectionModeTag(tags)) {
+    return false
+  }
+
+  return LANGUAGE_ENV_VARIANTS.some(
+    (variant) =>
+      variant.language === language &&
+      variant.env.every((fragment) =>
+        hasEnvFragment(literalEnv.find(({name, secretRef}) => name === fragment.name && !secretRef)?.value, fragment)
+      )
+  )
+}
+
+const getInitContainerLanguage = (container: InitContainer): Language | undefined =>
+  TRACER_INJECTION_LANGUAGES.find((language) => {
+    const prefix = `${CONTAINER_APP_TRACER_REGISTRY}/dd-lib-${LANGUAGE_METADATA[language].tracerLanguage}-init:`
+    const version = container.image?.startsWith(prefix) ? container.image.slice(prefix.length) : undefined
+
+    return version !== undefined && TRACER_IMAGE_TAG_REG_EXP.test(version)
+  })
+
+const isManagedInitContainer = (container: InitContainer): boolean =>
+  container.name === TRACER_CONTAINER_NAME &&
+  getInitContainerLanguage(container) !== undefined &&
+  container.command?.length === 1 &&
+  container.command[0] === '/datadog-init/copy-lib.sh' &&
+  container.args?.length === 1 &&
+  container.args[0] === TRACER_MOUNT_PATH &&
+  container.resources?.cpu === 0.25 &&
+  container.resources.memory === '0.5Gi' &&
+  container.volumeMounts?.length === 1 &&
+  container.volumeMounts.some(
+    ({volumeName, mountPath}) => volumeName === TRACER_VOLUME_NAME && mountPath === TRACER_MOUNT_PATH
+  )
+
+const buildTracerInitContainer = (spec: LanguageInjectionSpec): InitContainer => ({
+  name: TRACER_CONTAINER_NAME,
+  image: spec.image,
+  command: ['/datadog-init/copy-lib.sh'],
+  args: [TRACER_MOUNT_PATH],
+  resources: {cpu: 0.25, memory: '0.5Gi'},
+  volumeMounts: [{volumeName: TRACER_VOLUME_NAME, mountPath: TRACER_MOUNT_PATH}],
+})

--- a/packages/plugin-container-app/src/ssi.ts
+++ b/packages/plugin-container-app/src/ssi.ts
@@ -169,20 +169,50 @@ export const selectApplicationContainer = (
   )
 }
 
-export const assertLanguageInjectionEnvCanBeMerged = (env: readonly EnvironmentVar[] | undefined): void => {
-  const targetNames = new Set([...LANGUAGE_ENV_FRAGMENTS.map(({name}) => name), DD_TAGS_ENV_VAR])
-  for (const name of targetNames) {
-    const matching = (env ?? []).filter((variable) => variable.name === name)
-    if (matching.length > 1) {
-      throw new SsiConfigError(
-        `${name} appears more than once on the selected application container. Remove the duplicate before retrying.`
-      )
+export const assertLanguageInjectionEnvCanBeMerged = (
+  env: readonly EnvironmentVar[] | undefined,
+  spec: LanguageInjectionSpec
+): void => assertEnvironmentFragmentsCanBeMerged(env, spec.env)
+
+export const assertExistingLanguageInjectionCanBeReplaced = (containerApp: ContainerApp): void => {
+  for (const container of containerApp.template?.containers ?? []) {
+    const hasMarker = container.env?.some(
+      ({name, secretRef, value}) => name === DD_TAGS_ENV_VAR && !secretRef && hasInjectionModeTag(value)
+    )
+    if (hasMarker) {
+      assertEnvironmentFragmentsCanBeMerged(container.env, LANGUAGE_ENV_FRAGMENTS)
     }
-    if (matching[0]?.secretRef) {
-      throw new SsiConfigError(
-        `${name} on the selected application container comes from a secret reference. Set it to a literal value or remove it before retrying.`
+  }
+}
+
+export const assertSsiResourcesCanBeAdded = (
+  containerApp: ContainerApp,
+  targetIndex: number,
+  sidecarName: string
+): void => {
+  if (containerApp.template?.initContainers?.some(({name}) => name === TRACER_CONTAINER_NAME)) {
+    throw new SsiConfigError(
+      `An init container named '${TRACER_CONTAINER_NAME}' already exists. Rename or remove it before retrying.`
+    )
+  }
+  if (containerApp.template?.volumes?.some(({name}) => name === TRACER_VOLUME_NAME)) {
+    throw new SsiConfigError(
+      `A volume named '${TRACER_VOLUME_NAME}' already exists. Rename or remove it before retrying.`
+    )
+  }
+
+  const hasConflictingMount = (containerApp.template?.containers ?? []).some(
+    (container, index) =>
+      container.name !== sidecarName &&
+      (container.volumeMounts ?? []).some(
+        ({volumeName, mountPath}) =>
+          volumeName === TRACER_VOLUME_NAME || (index === targetIndex && mountPath === TRACER_MOUNT_PATH)
       )
-    }
+  )
+  if (hasConflictingMount) {
+    throw new SsiConfigError(
+      `An application container volume mount conflicts with the managed '${TRACER_VOLUME_NAME}' volume at '${TRACER_MOUNT_PATH}'. Rename or remove the conflicting mount before retrying.`
+    )
   }
 }
 
@@ -190,7 +220,7 @@ export const mergeLanguageInjectionEnv = (
   existingEnv: readonly EnvironmentVar[] | undefined,
   spec: LanguageInjectionSpec
 ): EnvironmentVar[] => {
-  assertLanguageInjectionEnvCanBeMerged(existingEnv)
+  assertLanguageInjectionEnvCanBeMerged(existingEnv, spec)
   const merged = spec.env.reduce<EnvironmentVar[]>(
     (env, fragment) => {
       const existing = env.find(({name}) => name === fragment.name)
@@ -232,6 +262,11 @@ export const removeLanguageInjectionEnv = (existingEnv: readonly EnvironmentVar[
 
     return value === undefined ? [] : [value === variable.value ? variable : {...variable, value}]
   })
+
+export const hasSsi = (containerApp: ContainerApp): boolean =>
+  (containerApp.tags !== undefined &&
+    Object.prototype.hasOwnProperty.call(containerApp.tags, SSI_INJECTION_MODE_TAG)) ||
+  (containerApp.template?.containers ?? []).some((_, index) => hasCompleteSsiSignature(containerApp, index))
 
 export const hasCompleteSsiSignature = (containerApp: ContainerApp, targetIndex: number): boolean => {
   const template = containerApp.template
@@ -336,6 +371,26 @@ const validateSsiInputs = (config: ContainerAppConfigOptions): string[] => {
 const formatContainerNames = (candidates: readonly {container: Container}[]): string =>
   candidates.map(({container}) => container.name || '<unnamed>').join(', ')
 
+const assertEnvironmentFragmentsCanBeMerged = (
+  env: readonly EnvironmentVar[] | undefined,
+  fragments: readonly EnvFragment[]
+): void => {
+  const targetNames = new Set([...fragments.map(({name}) => name), DD_TAGS_ENV_VAR])
+  for (const name of targetNames) {
+    const matching = (env ?? []).filter((variable) => variable.name === name)
+    if (matching.length > 1) {
+      throw new SsiConfigError(
+        `${name} appears more than once on the selected application container. Remove the duplicate before retrying.`
+      )
+    }
+    if (matching[0]?.secretRef) {
+      throw new SsiConfigError(
+        `${name} on the selected application container comes from a secret reference. Set it to a literal value or remove it before retrying.`
+      )
+    }
+  }
+}
+
 const upsertEnv = <T extends EnvironmentVar>(env: readonly T[], name: string, value: string): T[] => {
   const index = env.findIndex((variable) => variable.name === name)
 
@@ -416,6 +471,6 @@ const buildTracerInitContainer = (spec: LanguageInjectionSpec): InitContainer =>
   image: spec.image,
   command: ['/datadog-init/copy-lib.sh'],
   args: [TRACER_MOUNT_PATH],
-  resources: {cpu: 0.25, memory: '0.5Gi'},
+  resources: {cpu: 0.25, memory: '0.5Gi', ephemeralStorage: '1Gi'},
   volumeMounts: [{volumeName: TRACER_VOLUME_NAME, mountPath: TRACER_MOUNT_PATH}],
 })

--- a/packages/plugin-container-app/src/ssi.ts
+++ b/packages/plugin-container-app/src/ssi.ts
@@ -1,13 +1,9 @@
 import type {Container, ContainerApp, EnvironmentVar, InitContainer} from '@azure/arm-appcontainers'
+import type {ContainerAppConfigOptions} from '@datadog/datadog-ci-base/commands/container-app/common'
 import type {EnvFragment} from '@datadog/datadog-ci-base/helpers/serverless/ssi/env'
 import type {LanguageInjectionSpec, Libc} from '@datadog/datadog-ci-base/helpers/serverless/ssi/injection-spec'
 import type {Language} from '@datadog/datadog-ci-base/helpers/serverless/ssi/tracer'
-import type {TracingMode} from '@datadog/datadog-ci-base/helpers/serverless/ssi/tracing'
 
-import {
-  CONTAINER_APP_TRACING_INPUTS,
-  type ContainerAppConfigOptions,
-} from '@datadog/datadog-ci-base/commands/container-app/common'
 import {DD_TAGS_ENV_VAR} from '@datadog/datadog-ci-base/helpers/serverless/constants'
 import {
   TRACER_CONTAINER_NAME,
@@ -33,6 +29,7 @@ import {
   LANGUAGE_METADATA,
   TRACER_IMAGE_TAG_REG_EXP,
 } from '@datadog/datadog-ci-base/helpers/serverless/ssi/tracer'
+import {TRACING_MODES, type TracingMode} from '@datadog/datadog-ci-base/helpers/serverless/ssi/tracing'
 
 export const SSI_INJECTION_MODE_TAG = 'dd_sls_injection_mode'
 export const SINGLE_LANGUAGE_SSI_MODE = 'single_language'
@@ -89,6 +86,15 @@ export const resolveSsiConfig = (config: ContainerAppConfigOptions): SsiConfigRe
         `--tracing inject requires --language until automatic multi-language injection is supported. Possible values: ${TRACER_INJECTION_LANGUAGES.join(
           ', '
         )}.`,
+      ],
+      warnings: [],
+    }
+  }
+  if (config.language === 'go') {
+    return {
+      kind: 'errors',
+      errors: [
+        'Go automatic instrumentation is not supported. Install dd-trace-go in the application image and use --tracing manual.',
       ],
       warnings: [],
     }
@@ -340,10 +346,8 @@ export class SsiConfigError extends Error {
 
 const validateSsiInputs = (config: ContainerAppConfigOptions): string[] => {
   const errors: string[] = []
-  if (config.tracing !== undefined && !(CONTAINER_APP_TRACING_INPUTS as readonly string[]).includes(config.tracing)) {
-    errors.push(
-      `Invalid tracing mode ${JSON.stringify(config.tracing)}. Possible values: ${CONTAINER_APP_TRACING_INPUTS.join(', ')}.`
-    )
+  if (config.tracing !== undefined && !(TRACING_MODES as readonly string[]).includes(config.tracing)) {
+    errors.push(`Invalid tracing mode ${JSON.stringify(config.tracing)}. Possible values: ${TRACING_MODES.join(', ')}.`)
   }
   if (config.language !== undefined && (typeof config.language !== 'string' || config.language.length === 0)) {
     errors.push(`Invalid language ${JSON.stringify(config.language)}.`)

--- a/packages/plugin-container-app/src/ssi.ts
+++ b/packages/plugin-container-app/src/ssi.ts
@@ -28,14 +28,14 @@ import {
   DEFAULT_TRACER_VERSION,
   LANGUAGE_METADATA,
   TRACER_IMAGE_TAG_REG_EXP,
+  TRACER_INJECTION_LANGUAGES,
+  isTracerInjectionLanguage,
 } from '@datadog/datadog-ci-base/helpers/serverless/ssi/tracer'
 import {TRACING_MODES, type TracingMode} from '@datadog/datadog-ci-base/helpers/serverless/ssi/tracing'
 
 export const SSI_INJECTION_MODE_TAG = 'dd_sls_injection_mode'
 export const SINGLE_LANGUAGE_SSI_MODE = 'single_language'
 export const CONTAINER_APP_TRACER_REGISTRY = 'datadoghq.azurecr.io' as const
-export const TRACER_INJECTION_LANGUAGES: readonly Language[] = Object.keys(LANGUAGE_METADATA) as Language[]
-
 export type SsiConfigResult = (
   | {kind: 'errors'; errors: readonly string[]}
   | {kind: 'no-injection'; tracing: Exclude<TracingMode, 'inject'>}
@@ -242,14 +242,17 @@ export const removeLanguageInjectionEnv = (existingEnv: readonly EnvironmentVar[
     return value === undefined ? [] : [value === variable.value ? variable : {...variable, value}]
   })
 
-export const hasSsi = (containerApp: ContainerApp): boolean =>
+export const hasSsiMarker = (containerApp: ContainerApp): boolean =>
   (containerApp.tags !== undefined &&
     Object.prototype.hasOwnProperty.call(containerApp.tags, SSI_INJECTION_MODE_TAG)) ||
   (containerApp.template?.containers ?? []).some((container) =>
     container.env?.some(
       ({name, secretRef, value}) => name === DD_TAGS_ENV_VAR && !secretRef && hasInjectionModeTag(value)
     )
-  ) ||
+  )
+
+export const hasSsi = (containerApp: ContainerApp): boolean =>
+  hasSsiMarker(containerApp) ||
   (containerApp.template?.containers ?? []).some((_, index) => hasCompleteSsiSignature(containerApp, index))
 
 export const hasCompleteSsiSignature = (containerApp: ContainerApp, targetIndex: number): boolean => {
@@ -368,9 +371,6 @@ const validateSsiInputs = (config: ContainerAppConfigOptions): string[] => {
   return errors
 }
 
-const isTracerInjectionLanguage = (language: string): language is Language =>
-  (TRACER_INJECTION_LANGUAGES as readonly string[]).includes(language)
-
 const formatContainerNames = (candidates: readonly {container: Container}[]): string =>
   candidates.map(({container}) => container.name || '<unnamed>').join(', ')
 
@@ -433,10 +433,6 @@ const hasManagedTracerEnvironment = (
   language: Language | undefined
 ): boolean => {
   const literalEnv = env ?? []
-  const tags = literalEnv.find(({name, secretRef}) => name === DD_TAGS_ENV_VAR && !secretRef)?.value
-  if (!hasInjectionModeTag(tags)) {
-    return false
-  }
 
   return LANGUAGE_ENV_VARIANTS.some(
     (variant) =>


### PR DESCRIPTION
### What and why?

Configuration tests cannot prove that Azure starts the tracer init container or that a tracer-free workload emits spans. This adds a packaged-CLI lifecycle test for automatic Node.js instrumentation on Azure Container Apps.

### How?

The test deploys a digest-pinned tracer-free image, instruments it twice, verifies the live init-container configuration and idempotence, drives traffic until spans reach Datadog, and verifies full cleanup. The Container Apps CI path filter now includes the shared command and tracer helper paths.

### Manual validation

The full lifecycle passed against `dde2etfcapp.azurecr.io/node-ssi@sha256:1794d7e5edeea7dbe940e74037b4c715a0355af47080fb7fbfbd4bc4a93bfb89` in the shared Azure E2E environment, including span ingestion and cleanup.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
