### PR TITLE
Strip characters XML cannot represent before building the JUnit report

### DIFF
--- a/packages/plugin-synthetics/src/__tests__/reporters/junit.test.ts
+++ b/packages/plugin-synthetics/src/__tests__/reporters/junit.test.ts
@@ -10,7 +10,7 @@ import type {PluginCommand as RunTestsCommand} from '../../commands/run-tests'
 import type {Device, Result, ServerTest} from '../../interfaces'
 import {ExecutionRule} from '../../interfaces'
 import type {Args, XMLTestCase} from '../../reporters/junit'
-import {getDefaultSuiteStats, getDefaultTestCaseStats, JUnitReporter} from '../../reporters/junit'
+import {getDefaultSuiteStats, getDefaultTestCaseStats, JUnitReporter, stripInvalidXmlChars} from '../../reporters/junit'
 
 import {
   BATCH_ID,
@@ -72,6 +72,41 @@ describe('Junit reporter', () => {
       expect(reporter['builder'].buildObject).toHaveBeenCalledWith(reporter['json'])
       expect(fs.writeFileSync).toHaveBeenCalledWith('junit.xml', expect.any(String), 'utf8')
       expect(writeMock).toHaveBeenCalledTimes(1)
+
+      // Cleaning
+      await fsp.unlink(reporter['destination'])
+    })
+
+    it('should still write the report when a result carries control characters', async () => {
+      const browserResult: Result = {
+        ...globalBrowserResultMock,
+        result: {
+          ...getBrowserServerResult(),
+          steps: [
+            {
+              ...getStep(),
+              browser_errors: [
+                {
+                  description: 'https://example.com/?q=\u0000\u001b binary',
+                  name: 'error name',
+                  type: 'error type',
+                },
+              ],
+              failure: {message: 'failed \u0001'},
+              warnings: [{message: 'warning \u0002', type: 'warning type'}],
+            },
+          ],
+        },
+      }
+      reporter.resultEnd(browserResult, '', '')
+      reporter.runEnd(globalSummaryMock, '')
+
+      expect(writeMock).not.toHaveBeenCalledWith(expect.stringContaining("Couldn't write the JUnit report"))
+      expect(fs.writeFileSync).toHaveBeenCalledWith('junit.xml', expect.any(String), 'utf8')
+
+      const xml = (fs.writeFileSync as jest.Mock).mock.calls[0][1] as string
+      expect(xml).toContain('https://example.com/?q= binary')
+      expect(xml).not.toMatch(/[\u0000-\u0008]/)
 
       // Cleaning
       await fsp.unlink(reporter['destination'])
@@ -604,5 +639,15 @@ describe('GitLab test report compatibility', () => {
         _: '- Assertion failed:\n    ▶ responseTime should be less than 1000. Actual: 1234',
       },
     ])
+  })
+})
+
+describe('stripInvalidXmlChars', () => {
+  it('drops the characters XML 1.0 cannot represent', () => {
+    expect(stripInvalidXmlChars('a\u0000b\u001fc')).toBe('abc')
+  })
+
+  it('keeps tab, newline, carriage return and astral characters', () => {
+    expect(stripInvalidXmlChars('a\tb\nc\rd\u{1F600}')).toBe('a\tb\nc\rd\u{1F600}')
   })
 })

--- a/packages/plugin-synthetics/src/reporters/junit.ts
+++ b/packages/plugin-synthetics/src/reporters/junit.ts
@@ -163,6 +163,42 @@ const getResultIdentification = (test: Test, id: string, location: string, devic
   return `${test.name} - ${id}`
 }
 
+// XML 1.0 allows #x9, #xA, #xD, and the printable ranges below. Result payloads
+// can carry raw response bytes, and a single control character makes xml2js
+// throw for the whole document, which loses the entire report rather than the
+// one bad value.
+const invalidXmlChars = /[^\u0009\u000A\u000D\u0020-\uD7FF\uE000-\uFFFD\u{10000}-\u{10FFFF}]/gu
+
+export const stripInvalidXmlChars = (value: string): string => value.replace(invalidXmlChars, '')
+
+export const stripInvalidXmlCharsInPlace = (node: unknown): void => {
+  if (Array.isArray(node)) {
+    node.forEach((entry, index) => {
+      if (typeof entry === 'string') {
+        node[index] = stripInvalidXmlChars(entry)
+      } else {
+        stripInvalidXmlCharsInPlace(entry)
+      }
+    })
+
+    return
+  }
+
+  if (!node || typeof node !== 'object') {
+    return
+  }
+
+  const record = node as Record<string, unknown>
+  for (const key of Object.keys(record)) {
+    const value = record[key]
+    if (typeof value === 'string') {
+      record[key] = stripInvalidXmlChars(value)
+    } else {
+      stripInvalidXmlCharsInPlace(value)
+    }
+  }
+}
+
 export const getDefaultTestCaseStats = (): TestCaseStats => ({
   steps_allowfailures: 0,
   steps_count: 0,
@@ -292,6 +328,7 @@ export class JUnitReporter extends FileReporter implements Reporter {
 
     // Write the file
     try {
+      stripInvalidXmlCharsInPlace(this.json)
       this.writeReportToFile(this.builder.buildObject(this.json))
     } catch (e) {
       this.write(`\n❌ Couldn't write the JUnit report to ${this.destination}:\n${e}\n`)


### PR DESCRIPTION
### What and why?

Fixes #2475.

A browser test result can carry raw response bytes in `browser_errors[].description`. Those bytes reach the XML tree verbatim, and `xml2js` refuses to build a document containing C0 control characters, so `buildObject` throws and the `try/catch` around it drops the report for the whole batch. Since the catch only logs, the run still exits 0, and a green CI job quietly uploads nothing.

Rather than sanitize the three or four known fields, this walks the finished document once in `runEnd` and strips the characters XML 1.0 cannot represent from every string in it. That covers `browser_errors[].description`, `failure.message` and `warnings[].message`, and also anything else the API might put in a name, a step description or an attribute. Tab, newline, carriage return and astral characters are all kept.

I left the two secondary suggestions in the issue alone. Degrading per value instead of per report, and making the write failure visible in the exit code, are behaviour changes worth deciding separately; this one is contained to what the reporter emits.

### Test coverage

`stripInvalidXmlChars` gets its own two cases, and there is a reporter-level test that pushes a result whose browser error, failure message and warning all carry control characters through `resultEnd` and `runEnd`, then asserts the file was written, the text survived minus the bad bytes, and no "Couldn't write the JUnit report" line was printed. All three fail on master.

`yarn jest packages/plugin-synthetics/src/__tests__/reporters/junit.test.ts` is 23 passing. `default.test.ts` and `mobile/app-upload.test.ts` fail in my checkout with the same 54 failures and 74 snapshot mismatches before and after this change, so they look unrelated. Lint is clean on both files.
