### PR TITLE
[SYNTH-28953] Show each Test Suite member's own name/type in the default reporter

### DIFF
--- a/packages/plugin-synthetics/src/__tests__/batch.test.ts
+++ b/packages/plugin-synthetics/src/__tests__/batch.test.ts
@@ -243,10 +243,14 @@ describe('waitForResults', () => {
     ).toEqual([result])
   })
 
-  test('should match a batch result to a triggered suite by membership', async () => {
-    // The polled result carries no `test` details of its own here, to isolate the suite-membership matching
-    // (in reality the member test's own details would come back via `pollResult.test` and get merged in).
+  test('should match a batch result to a triggered suite member, using its own name and type from the result', async () => {
+    // The batch result is the only source of the member's own name/type here: the suite API only knows its
+    // public ID, and the polled result carries no `test` details of its own in this scenario.
     mockApi({
+      getBatchImplementation: async () => ({
+        ...deepExtend({}, batch),
+        results: [{...getPassedResultInBatch(), test_name: 'Member test', test_public_id: 'member-pid'}],
+      }),
       pollResultsImplementation: async () => [{...deepExtend({}, pollResult), test: {}} as PollResult],
     })
 
@@ -254,7 +258,7 @@ describe('waitForResults', () => {
       ...apiTest,
       public_id: 'suite-pid',
       type: 'suite',
-      memberPublicIds: [apiTest.public_id],
+      memberPublicIds: ['member-pid'],
     } as Test
 
     const results = await waitForResults(
@@ -270,9 +274,14 @@ describe('waitForResults', () => {
       mockReporter
     )
 
-    const memberTest = {...suiteTest, public_id: apiTest.public_id}
-    expect(results).toEqual([{...result, test: memberTest}])
-    expect(mockReporter.testsWait).toHaveBeenCalledWith([memberTest], expect.anything(), 'bid')
+    expect(results[0].test.name).toBe('Member test')
+    expect(results[0].test.public_id).toBe('member-pid')
+    expect(results[0].test.type).toBe('api')
+    expect(mockReporter.testsWait).toHaveBeenCalledWith(
+      [{...suiteTest, public_id: 'member-pid'}],
+      expect.anything(),
+      'bid'
+    )
   })
 
   test('should show results as they arrive', async () => {

--- a/packages/plugin-synthetics/src/__tests__/fixtures.ts
+++ b/packages/plugin-synthetics/src/__tests__/fixtures.ts
@@ -577,7 +577,9 @@ export const getInProgressResultInBatch = (): BaseResultInBatch => {
     // eslint-disable-next-line no-null/no-null
     max_retries: null,
     status: 'in_progress',
+    test_name: 'Test name',
     test_public_id: 'pid',
+    test_type: 'api',
     // eslint-disable-next-line no-null/no-null
     timed_out: null,
   }
@@ -585,7 +587,9 @@ export const getInProgressResultInBatch = (): BaseResultInBatch => {
 
 export const getSkippedResultInBatch = (): ResultInBatchSkippedBySelectiveRerun => {
   return {
+    test_name: 'Test name',
     test_public_id: 'pid',
+    test_type: 'api',
     execution_rule: ExecutionRule.SKIPPED,
     // eslint-disable-next-line no-null/no-null
     retries: null,

--- a/packages/plugin-synthetics/src/batch.ts
+++ b/packages/plugin-synthetics/src/batch.ts
@@ -371,7 +371,16 @@ const getResultFromBatch = (
   resultDisplayInfo: ResultDisplayInfo,
   safeDeadlineReached = false
 ): Result => {
-  const test = resultDisplayInfo.tests.find((t) => t.public_id === resultInBatch.test_public_id)!
+  const knownTest = resultDisplayInfo.tests.find((t) => t.public_id === resultInBatch.test_public_id)
+
+  // The batch result already carries the test's own name and type directly from the backend, which is the only
+  // way to get them for Test Suite members (the suite API only returns their public IDs, not their details).
+  const test: Test = {
+    ...(knownTest ?? {config: {assertions: [], variables: []}, locations: [], options: {}}),
+    name: resultInBatch.test_name,
+    public_id: resultInBatch.test_public_id,
+    type: resultInBatch.test_type,
+  }
 
   const hasTimedOut = resultInBatch.timed_out ?? safeDeadlineReached
   const timedOutRetry = isTimedOutRetry(resultInBatch.retries, resultInBatch.max_retries, resultInBatch.timed_out)

--- a/packages/plugin-synthetics/src/interfaces.ts
+++ b/packages/plugin-synthetics/src/interfaces.ts
@@ -6,6 +6,7 @@ import type {ProxyConfiguration} from '@datadog/datadog-ci-base/helpers/utils'
 import type {Writable} from 'stream'
 
 export type SupportedReporter = 'junit' | 'json' | 'default'
+export type TestType = 'api' | 'browser' | 'mobile' | 'network'
 
 export interface MainReporter {
   log(log: string): void
@@ -116,7 +117,7 @@ export interface RawPollResult {
 
 export interface RawPollResultTest {
   id: string
-  type: 'browser' | 'api' | 'mobile'
+  type: TestType
   subtype?: string
   config: {
     request?: {
@@ -126,7 +127,7 @@ export interface RawPollResultTest {
 }
 
 export type PollResult = {
-  test_type: 'api' | 'browser' | 'mobile'
+  test_type: TestType
   test: RecursivePartial<Test>
   result?: ServerResult
   resultID: string
@@ -264,7 +265,7 @@ export interface BaseResultInBatch {
   status: Status
   test_name: string
   test_public_id: string
-  test_type: 'api' | 'browser' | 'mobile'
+  test_type: TestType
   timed_out: boolean | null
 }
 
@@ -373,7 +374,7 @@ export interface LocalTestDefinition {
   public_id?: string
   subtype?: string // This is optional in the browser and api schemas
   steps?: TestStepWithUnsupportedFields[] // From browser schema
-  type: 'api' | 'browser' | 'mobile'
+  type: TestType
 }
 
 interface Options {

--- a/packages/plugin-synthetics/src/interfaces.ts
+++ b/packages/plugin-synthetics/src/interfaces.ts
@@ -262,7 +262,9 @@ export interface BaseResultInBatch {
   max_retries: number | null
   selective_rerun?: SelectiveRerunDecision
   status: Status
+  test_name: string
   test_public_id: string
+  test_type: 'api' | 'browser' | 'mobile'
   timed_out: boolean | null
 }
 

--- a/packages/plugin-synthetics/src/test.ts
+++ b/packages/plugin-synthetics/src/test.ts
@@ -311,7 +311,8 @@ const getSuiteAsTest = async (api: APIHelper, publicId: string, suite?: string):
   try {
     const {data} = await api.getSyntheticsSuite(publicId)
 
-    // Placeholder test representing the test suite.
+    // Placeholder test representing the test suite. Its members' own name/type/etc. aren't fetched
+    // here: the batch results for them already carry that information directly (`test_name`, `test_type`).
     return {
       config: {assertions: [], variables: []},
       locations: [],


### PR DESCRIPTION
### What and why?

`datadog-ci synthetics run-tests` was showing the suite's own name for every result of a triggered [Test Suite](https://docs.datadoghq.com/synthetics/test_suites/) member, instead of each member's own name. The batch result for a member already carries its own `test_name`/`test_type` directly from the backend, but `getResultFromBatch()` ignored them and only matched against the locally pre-fetched `Test` list, where a suite member is only known by public ID (via the suite's `memberPublicIds`) and inherits the suite's placeholder name.

Fixes https://datadoghq.atlassian.net/browse/SYNTH-28953

### How?

`BaseResultInBatch` now types the `test_name`/`test_type` fields the batch endpoint already returns per result. `getResultFromBatch()` builds each result's display `Test` from those fields directly, falling back to the pre-fetched test (or a minimal placeholder) only for the fields the batch result doesn't carry (`config`/`locations`/`options`). This also gets rid of the old `.find(...)!` non-null assertion, which could throw if a result's public ID didn't match anything in the known list — that path is now a normal fallback instead of a crash.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)