### PR TITLE
[SYNTH-28953] Align the JSON report's exposed fields with the JUnit report

### DIFF
--- a/packages/plugin-synthetics/src/__tests__/batch.test.ts
+++ b/packages/plugin-synthetics/src/__tests__/batch.test.ts
@@ -284,6 +284,51 @@ describe('waitForResults', () => {
     )
   })
 
+  test('should use the polled subtype/config for a triggered suite member, which is not known ahead of the batch results', async () => {
+    mockApi({
+      getBatchImplementation: async () => ({
+        ...deepExtend({}, batch),
+        results: [{...getPassedResultInBatch(), test_name: 'Member test', test_public_id: 'member-pid'}],
+      }),
+      pollResultsImplementation: async () => [
+        {
+          ...deepExtend({}, pollResult),
+          test: {
+            subtype: 'dns',
+            config: {request: {host: 'example.com', dnsServer: '1.1.1.1'}},
+          },
+        } as PollResult,
+      ],
+    })
+
+    const suiteTest: Test = {
+      ...apiTest,
+      public_id: 'suite-pid',
+      type: 'suite',
+      memberPublicIds: ['member-pid'],
+    } as Test
+
+    const results = await waitForResults(
+      api,
+      trigger,
+      [suiteTest],
+      {
+        batchTimeout: 120000,
+        datadogSite: DEFAULT_COMMAND_CONFIG.datadogSite,
+        failOnCriticalErrors: false,
+        subdomain: DEFAULT_COMMAND_CONFIG.subdomain,
+      },
+      mockReporter
+    )
+
+    const test = results[0].test as Test & {subtype: string}
+    expect(test.subtype).toBe('dns')
+    expect(test.config.request?.host).toBe('example.com')
+    expect(test.config.request?.dnsServer).toBe('1.1.1.1')
+    // Fields the suite member never had (from the placeholder) are untouched by the merge.
+    expect(test.config.assertions).toEqual([])
+  })
+
   test('should show results as they arrive', async () => {
     jest.spyOn(internalUtils, 'wait').mockImplementation(async () => waiter.resolve())
 
@@ -445,6 +490,7 @@ describe('waitForResults', () => {
       3,
       {
         ...result,
+        test: {...result.test, public_id: 'other-public-id'},
         isNonFinal: true,
         resultId: 'rid-3',
         passed: false,
@@ -481,7 +527,13 @@ describe('waitForResults', () => {
     expect(await resultsPromise).toEqual([
       result,
       {...result, result: {...result.result, id: 'rid-2'}, resultId: 'rid-2'},
-      {...result, result: {...result.result, id: 'rid-3-final'}, resultId: 'rid-3-final', retries: 1},
+      {
+        ...result,
+        test: {...result.test, public_id: 'other-public-id'},
+        result: {...result.result, id: 'rid-3-final'},
+        resultId: 'rid-3-final',
+        retries: 1,
+      },
     ])
 
     // One result received
@@ -494,7 +546,13 @@ describe('waitForResults', () => {
     })
     expect(mockReporter.resultEnd).toHaveBeenNthCalledWith(
       4,
-      {...result, result: {...result.result, id: 'rid-3-final'}, resultId: 'rid-3-final', retries: 1},
+      {
+        ...result,
+        test: {...result.test, public_id: 'other-public-id'},
+        result: {...result.result, id: 'rid-3-final'},
+        resultId: 'rid-3-final',
+        retries: 1,
+      },
       MOCK_BASE_URL,
       'bid'
     )
@@ -573,7 +631,12 @@ describe('waitForResults', () => {
 
     expect(await resultsPromise).toEqual([
       {...skippedResult},
-      {...result, result: {...result.result, id: 'rid-2'}, resultId: 'rid-2'},
+      {
+        ...result,
+        test: {...result.test, public_id: 'other-public-id'},
+        result: {...result.result, id: 'rid-2'},
+        resultId: 'rid-2',
+      },
     ])
 
     // One result received
@@ -585,7 +648,12 @@ describe('waitForResults', () => {
     })
     expect(mockReporter.resultEnd).toHaveBeenNthCalledWith(
       2,
-      {...result, result: {...result.result, id: 'rid-2'}, resultId: 'rid-2'},
+      {
+        ...result,
+        test: {...result.test, public_id: 'other-public-id'},
+        result: {...result.result, id: 'rid-2'},
+        resultId: 'rid-2',
+      },
       MOCK_BASE_URL,
       'bid'
     )
@@ -695,7 +763,7 @@ describe('waitForResults', () => {
     expect(await resultsPromise).toEqual([
       {...result, resultId: 'rid', passed: false, result: undefined, timestamp: 123},
       {...result, resultId: 'rid-2'},
-      {...result, resultId: 'rid-3'},
+      {...result, test: {...result.test, public_id: 'other-public-id'}, resultId: 'rid-3'},
     ])
 
     // One result received
@@ -706,7 +774,12 @@ describe('waitForResults', () => {
       result_id: 'rid-3',
     })
     // Result 3 was available instantly
-    expect(mockReporter.resultEnd).toHaveBeenNthCalledWith(2, {...result, resultId: 'rid-3'}, MOCK_BASE_URL, 'bid')
+    expect(mockReporter.resultEnd).toHaveBeenNthCalledWith(
+      2,
+      {...result, test: {...result.test, public_id: 'other-public-id'}, resultId: 'rid-3'},
+      MOCK_BASE_URL,
+      'bid'
+    )
 
     // Result 1 never became available (but the batch says it did not pass)
     expect(mockReporter.resultEnd).toHaveBeenNthCalledWith(

--- a/packages/plugin-synthetics/src/__tests__/reporters/json.test.ts
+++ b/packages/plugin-synthetics/src/__tests__/reporters/json.test.ts
@@ -27,13 +27,62 @@ describe('JSON reporter', () => {
     expect(reporter['destination']).toBe('report.json')
   })
 
-  test('should write final results to disk', async () => {
+  test('should write only the fields exposed in the JUnit report to disk', async () => {
     const result = getBrowserResult('1', getBrowserTest('abc-def-ghi'))
 
     reporter.resultEnd(result)
     reporter.runEnd()
 
-    await expect(fsp.readFile('report.json', 'utf8')).resolves.toBe(JSON.stringify({results: [result]}, undefined, 2))
+    const expectedResult = {
+      test: {
+        name: 'Test name',
+        type: 'browser',
+        public_id: 'abc-def-ghi',
+        message: '',
+        monitor_id: 0,
+        status: 'live',
+        tags: [],
+      },
+      resultId: '1',
+      executionRule: 'blocking',
+      passed: true,
+      timedOut: false,
+      duration: 1000,
+      location: 'Frankfurt (AWS)',
+      retries: 0,
+      maxRetries: 0,
+      device: {
+        id: 'chrome.laptop_large',
+        resolution: {width: 1440, height: 1100},
+      },
+      result: {
+        finished_at: 1,
+        start_url: '',
+        steps: [],
+      },
+    }
+
+    await expect(fsp.readFile('report.json', 'utf8')).resolves.toBe(
+      JSON.stringify({results: [expectedResult]}, undefined, 2)
+    )
+
+    await fsp.unlink('report.json')
+  })
+
+  test('should not expose fields that are not exposed in the JUnit report', async () => {
+    const result = getBrowserResult('1', getBrowserTest('abc-def-ghi'))
+
+    reporter.resultEnd(result)
+    reporter.runEnd()
+
+    const written = JSON.parse(await fsp.readFile('report.json', 'utf8')) as {results: [{test: object}]}
+    const [{test}] = written.results
+
+    // `test.config`/`test.locations`/`test.options` (beyond `options.ci.executionRule`) are part of the test's
+    // full definition, but JUnit never surfaces them, so neither should the JSON report.
+    expect(test).not.toHaveProperty('config')
+    expect(test).not.toHaveProperty('locations')
+    expect(test).not.toHaveProperty('options.device_ids')
 
     await fsp.unlink('report.json')
   })

--- a/packages/plugin-synthetics/src/__tests__/utils/paths.test.ts
+++ b/packages/plugin-synthetics/src/__tests__/utils/paths.test.ts
@@ -1,0 +1,106 @@
+import {pickPaths, withPaths} from '../../utils/paths'
+
+describe('pickPaths', () => {
+  test('picks a top-level field', () => {
+    expect(pickPaths({name: 'a', other: 'b'}, ['name'])).toEqual({name: 'a'})
+  })
+
+  test('picks a nested field, preserving its nested shape', () => {
+    const source = {test: {name: 'a', type: 'api', unused: 'x'}}
+    expect(pickPaths(source, ['test.name', 'test.type'])).toEqual({test: {name: 'a', type: 'api'}})
+  })
+
+  test('omits a path missing from the source', () => {
+    expect(pickPaths({test: {name: 'a'}}, ['test.name', 'test.missing', 'other.missing'])).toEqual({
+      test: {name: 'a'},
+    })
+  })
+
+  test('omits a path through a missing intermediate object', () => {
+    expect(pickPaths({}, ['a.b.c'])).toEqual({})
+  })
+
+  test('does not leave a stray empty object for an intermediate key whose leaf is missing', () => {
+    const source = {test: {name: 'a', options: {device_ids: []}}}
+    expect(pickPaths(source, ['test.name', 'test.options.ci.executionRule'])).toEqual({test: {name: 'a'}})
+  })
+
+  test('omits a path through a null intermediate value', () => {
+    // eslint-disable-next-line no-null/no-null
+    expect(pickPaths({a: null}, ['a.b'])).toEqual({})
+  })
+
+  test('picks a whole array as-is when the path stops at it', () => {
+    const source = {tags: ['a', 'b']}
+    expect(pickPaths(source, ['tags'])).toEqual({tags: ['a', 'b']})
+  })
+
+  test('projects a field across every element of a wildcard array', () => {
+    const source = {
+      steps: [
+        {status: 'passed', other: 1},
+        {status: 'failed', other: 2},
+      ],
+    }
+    expect(pickPaths(source, ['steps[*].status'])).toEqual({steps: [{status: 'passed'}, {status: 'failed'}]})
+  })
+
+  test('omits a missing field for one element without dropping the others', () => {
+    const source = {steps: [{failure: {message: 'oops'}}, {}]}
+    expect(pickPaths(source, ['steps[*].failure.message'])).toEqual({steps: [{failure: {message: 'oops'}}, {}]})
+  })
+
+  test('returns an empty array for a wildcard path over an empty array', () => {
+    expect(pickPaths({steps: []}, ['steps[*].status'])).toEqual({steps: []})
+  })
+
+  test('omits a wildcard path entirely when the array itself is missing', () => {
+    expect(pickPaths({}, ['steps[*].status'])).toEqual({})
+  })
+
+  test('accumulates multiple fields picked from the same wildcard array element', () => {
+    const source = {steps: [{status: 'passed', name: 'step 1', unused: true}]}
+    expect(pickPaths(source, ['steps[*].status', 'steps[*].name'])).toEqual({
+      steps: [{status: 'passed', name: 'step 1'}],
+    })
+  })
+
+  test('supports nested wildcard arrays', () => {
+    const source = {steps: [{browserErrors: [{type: 'x', message: 'boom'}]}]}
+    expect(pickPaths(source, ['steps[*].browserErrors[*].type'])).toEqual({
+      steps: [{browserErrors: [{type: 'x'}]}],
+    })
+  })
+})
+
+describe('withPaths', () => {
+  test('overrides only the given paths, keeping the rest of the base object untouched', () => {
+    const base = {name: 'base', type: 'api', subtype: 'http'}
+    expect(withPaths(base, {subtype: 'dns'}, ['subtype'])).toEqual({name: 'base', type: 'api', subtype: 'dns'})
+  })
+
+  test('leaves the base value when the source is missing the path', () => {
+    const base = {config: {request: {method: 'GET'}}}
+    expect(withPaths(base, {}, ['config.request.method'])).toEqual(base)
+  })
+
+  test('merges into a nested object without dropping sibling fields', () => {
+    const base = {config: {assertions: [], request: {method: 'GET', url: 'http://a'}}}
+    const source = {config: {request: {method: 'POST'}}}
+    expect(withPaths(base, source, ['config.request.method'])).toEqual({
+      config: {assertions: [], request: {method: 'POST', url: 'http://a'}},
+    })
+  })
+
+  test('does not mutate the base object', () => {
+    const base = {config: {request: {method: 'GET'}}}
+    withPaths(base, {config: {request: {method: 'POST'}}}, ['config.request.method'])
+    expect(base.config.request.method).toBe('GET')
+  })
+
+  test('replaces a whole array rather than merging it element-wise', () => {
+    const base = {config: {steps: [{subtype: 'http'}, {subtype: 'http'}]}}
+    const source = {config: {steps: [{subtype: 'dns'}]}}
+    expect(withPaths(base, source, ['config.steps[*].subtype'])).toEqual({config: {steps: [{subtype: 'dns'}]}})
+  })
+})

--- a/packages/plugin-synthetics/src/__tests__/utils/paths.test.ts
+++ b/packages/plugin-synthetics/src/__tests__/utils/paths.test.ts
@@ -42,32 +42,32 @@ describe('pickPaths', () => {
         {status: 'failed', other: 2},
       ],
     }
-    expect(pickPaths(source, ['steps[*].status'])).toEqual({steps: [{status: 'passed'}, {status: 'failed'}]})
+    expect(pickPaths(source, ['steps[].status'])).toEqual({steps: [{status: 'passed'}, {status: 'failed'}]})
   })
 
   test('omits a missing field for one element without dropping the others', () => {
     const source = {steps: [{failure: {message: 'oops'}}, {}]}
-    expect(pickPaths(source, ['steps[*].failure.message'])).toEqual({steps: [{failure: {message: 'oops'}}, {}]})
+    expect(pickPaths(source, ['steps[].failure.message'])).toEqual({steps: [{failure: {message: 'oops'}}, {}]})
   })
 
   test('returns an empty array for a wildcard path over an empty array', () => {
-    expect(pickPaths({steps: []}, ['steps[*].status'])).toEqual({steps: []})
+    expect(pickPaths({steps: []}, ['steps[].status'])).toEqual({steps: []})
   })
 
   test('omits a wildcard path entirely when the array itself is missing', () => {
-    expect(pickPaths({}, ['steps[*].status'])).toEqual({})
+    expect(pickPaths({}, ['steps[].status'])).toEqual({})
   })
 
   test('accumulates multiple fields picked from the same wildcard array element', () => {
     const source = {steps: [{status: 'passed', name: 'step 1', unused: true}]}
-    expect(pickPaths(source, ['steps[*].status', 'steps[*].name'])).toEqual({
+    expect(pickPaths(source, ['steps[].status', 'steps[].name'])).toEqual({
       steps: [{status: 'passed', name: 'step 1'}],
     })
   })
 
   test('supports nested wildcard arrays', () => {
     const source = {steps: [{browserErrors: [{type: 'x', message: 'boom'}]}]}
-    expect(pickPaths(source, ['steps[*].browserErrors[*].type'])).toEqual({
+    expect(pickPaths(source, ['steps[].browserErrors[].type'])).toEqual({
       steps: [{browserErrors: [{type: 'x'}]}],
     })
   })
@@ -101,6 +101,6 @@ describe('withPaths', () => {
   test('replaces a whole array rather than merging it element-wise', () => {
     const base = {config: {steps: [{subtype: 'http'}, {subtype: 'http'}]}}
     const source = {config: {steps: [{subtype: 'dns'}]}}
-    expect(withPaths(base, source, ['config.steps[*].subtype'])).toEqual({config: {steps: [{subtype: 'dns'}]}})
+    expect(withPaths(base, source, ['config.steps[].subtype'])).toEqual({config: {steps: [{subtype: 'dns'}]}})
   })
 })

--- a/packages/plugin-synthetics/src/batch.ts
+++ b/packages/plugin-synthetics/src/batch.ts
@@ -14,10 +14,10 @@ import type {
   TriggerInfo,
 } from './interfaces'
 import type {Tunnel} from './tunnel'
+import type {FieldPath} from './utils/paths'
 import type {Metadata} from '@datadog/datadog-ci-base/helpers/interfaces'
 
 import chalk from 'chalk'
-import deepExtend from 'deep-extend'
 
 import {EndpointError, extractUnauthorizedTestPublicIds, formatBackendErrors, getErrorHttpStatus} from './api'
 import {BatchTimeoutRunawayError, CiError} from './errors'
@@ -30,6 +30,7 @@ import {
   getPublicIdOrPlaceholder,
   wait,
 } from './utils/internal'
+import {withPaths} from './utils/paths'
 import {getAppBaseURL, isTestSupportedByTunnel} from './utils/public'
 
 export const DEFAULT_BATCH_TIMEOUT = 30 * 60 * 1000
@@ -416,6 +417,21 @@ const getResultFromBatch = (
   return createResult(resultInBatch, pollResult, test, hasTimedOut, isUnhealthy, resultDisplayInfo)
 }
 
+// The poll results endpoint reports a test's live `subtype`/`config` (nothing else: no `name`, `options`, `tags`, etc.,
+// even when the test itself has them), which is the only source for them for Test Suite members. They're used by:
+// - `getLocation()`'s tunnel support check (`test.subtype === 'multi' && test.config.steps`, or `test.subtype === 'http'`).
+// - the default reporter's `renderApiRequestDescription()` (`test.subtype` and `test.config.{request,steps}`).
+const POLLED_TEST_FIELDS: readonly FieldPath[] = [
+  'subtype',
+  'config.request.host',
+  'config.request.port',
+  'config.request.dnsServer',
+  'config.request.dnsServerPort',
+  'config.request.method',
+  'config.request.url',
+  'config.steps[*].subtype',
+]
+
 const createResult = (
   resultInBatch: BaseResultInBatch,
   pollResult: PollResult | undefined,
@@ -437,7 +453,7 @@ const createResult = (
     retries: resultInBatch.retries || 0,
     maxRetries: resultInBatch.max_retries || 0,
     selectiveRerun: resultInBatch.selective_rerun,
-    test: deepExtend({}, test, pollResult?.test),
+    test: withPaths(test, pollResult?.test, POLLED_TEST_FIELDS),
     timedOut: hasTimedOut,
     timestamp: pollResult?.result?.finished_at ?? Date.now(),
   }

--- a/packages/plugin-synthetics/src/batch.ts
+++ b/packages/plugin-synthetics/src/batch.ts
@@ -429,7 +429,7 @@ const POLLED_TEST_FIELDS: readonly FieldPath[] = [
   'config.request.dnsServerPort',
   'config.request.method',
   'config.request.url',
-  'config.steps[*].subtype',
+  'config.steps[].subtype',
 ]
 
 const createResult = (

--- a/packages/plugin-synthetics/src/reporters/json.ts
+++ b/packages/plugin-synthetics/src/reporters/json.ts
@@ -1,4 +1,7 @@
 import type {Reporter, ReporterContext, Result} from '../interfaces'
+import type {FieldPath} from '../utils/paths'
+
+import {pickPaths} from '../utils/paths'
 
 import {FileReporter} from './file'
 
@@ -7,8 +10,61 @@ export interface Args {
   jsonReport?: string
 }
 
+// As a starting point for GA, the JSON report exposes exactly the fields the JUnit report exposes (see
+// `junit.ts`'s `getTestCase()`/`getSkippedTestCase()`) -- no more, no less. This list is intentionally
+// separate from (not derived from) JUnit's own field-by-field construction, so the two are free to drift
+// later if a JSON-only or JUnit-only field ever becomes necessary.
+export const JSON_REPORTER_EXPOSED_FIELDS: readonly FieldPath[] = [
+  // Test identity.
+  'test.suite',
+  'test.name',
+  'test.type',
+  'test.public_id',
+  'test.options.ci.executionRule',
+  'test.message',
+  'test.monitor_id',
+  'test.status',
+  'test.tags',
+
+  // Result identity and outcome.
+  'resultId',
+  'initialResultId',
+  'executionRule',
+  'passed',
+  'timedOut',
+  'duration',
+  'location',
+  'retries',
+  'maxRetries',
+  'device.id',
+  'device.resolution.width',
+  'device.resolution.height',
+  'selectiveRerun.decision',
+  'selectiveRerun.reason',
+  'selectiveRerun.linked_result_id',
+
+  // Server-side result payload.
+  'result.finished_at',
+  'result.start_url',
+  'result.failure.code',
+  'result.failure.message',
+
+  // Browser test steps and multistep API test steps.
+  'result.steps[*].status',
+  'result.steps[*].allow_failure',
+  'result.steps[*].description',
+  'result.steps[*].name',
+  'result.steps[*].failure.code',
+  'result.steps[*].failure.message',
+  'result.steps[*].browser_errors[*].type',
+  'result.steps[*].browser_errors[*].name',
+  'result.steps[*].browser_errors[*].description',
+  'result.steps[*].warnings[*].type',
+  'result.steps[*].warnings[*].message',
+]
+
 export class JSONReporter extends FileReporter implements Reporter {
-  private readonly results: Result[] = []
+  private readonly results: Partial<Result>[] = []
 
   constructor({context, jsonReport}: Args) {
     super({
@@ -24,7 +80,7 @@ export class JSONReporter extends FileReporter implements Reporter {
       return
     }
 
-    this.results.push(result)
+    this.results.push(pickPaths(result, JSON_REPORTER_EXPOSED_FIELDS))
   }
 
   public runEnd() {

--- a/packages/plugin-synthetics/src/reporters/json.ts
+++ b/packages/plugin-synthetics/src/reporters/json.ts
@@ -50,17 +50,17 @@ export const JSON_REPORTER_EXPOSED_FIELDS: readonly FieldPath[] = [
   'result.failure.message',
 
   // Browser test steps and multistep API test steps.
-  'result.steps[*].status',
-  'result.steps[*].allow_failure',
-  'result.steps[*].description',
-  'result.steps[*].name',
-  'result.steps[*].failure.code',
-  'result.steps[*].failure.message',
-  'result.steps[*].browser_errors[*].type',
-  'result.steps[*].browser_errors[*].name',
-  'result.steps[*].browser_errors[*].description',
-  'result.steps[*].warnings[*].type',
-  'result.steps[*].warnings[*].message',
+  'result.steps[].status',
+  'result.steps[].allow_failure',
+  'result.steps[].description',
+  'result.steps[].name',
+  'result.steps[].failure.code',
+  'result.steps[].failure.message',
+  'result.steps[].browser_errors[].type',
+  'result.steps[].browser_errors[].name',
+  'result.steps[].browser_errors[].description',
+  'result.steps[].warnings[].type',
+  'result.steps[].warnings[].message',
 ]
 
 export class JSONReporter extends FileReporter implements Reporter {

--- a/packages/plugin-synthetics/src/utils/paths.ts
+++ b/packages/plugin-synthetics/src/utils/paths.ts
@@ -1,10 +1,10 @@
 /**
- * A dot-separated property path, e.g. `'test.name'`. A segment can end with `[*]` to project over every element
- * of an array at that key, e.g. `'result.steps[*].failure.message'`.
+ * A dot-separated property path, e.g. `'test.name'`. A segment can end with `[]` to project over every element
+ * of an array at that key, e.g. `'result.steps[].failure.message'`.
  */
 export type FieldPath = string
 
-const WILDCARD_SUFFIX = '[*]'
+const WILDCARD_SUFFIX = '[]'
 
 const isPlainObject = (value: unknown): value is Record<string, unknown> =>
   // eslint-disable-next-line no-null/no-null

--- a/packages/plugin-synthetics/src/utils/paths.ts
+++ b/packages/plugin-synthetics/src/utils/paths.ts
@@ -1,0 +1,115 @@
+/**
+ * A dot-separated property path, e.g. `'test.name'`. A segment can end with `[*]` to project over every element
+ * of an array at that key, e.g. `'result.steps[*].failure.message'`.
+ */
+export type FieldPath = string
+
+const WILDCARD_SUFFIX = '[*]'
+
+const isPlainObject = (value: unknown): value is Record<string, unknown> =>
+  // eslint-disable-next-line no-null/no-null
+  typeof value === 'object' && value !== null && !Array.isArray(value)
+
+/**
+ * Copies the value at `path` from `source` into `target`, creating intermediate objects/arrays as needed.
+ * Does nothing if `source` doesn't have a value at `path` (including because an intermediate array is empty
+ * or missing) -- crucially, this must never leave behind a stray empty `{}` for an intermediate key whose
+ * deeper value didn't actually exist, which is why every branch reports back whether it wrote anything.
+ * Never mutates `source`; only ever mutates `target` (and objects/arrays it already owns).
+ */
+const assignPath = (target: Record<string, unknown>, source: unknown, segments: string[]): boolean => {
+  if (!isPlainObject(source)) {
+    return false
+  }
+
+  const [rawSegment, ...rest] = segments
+  const isWildcard = rawSegment.endsWith(WILDCARD_SUFFIX)
+  const key = isWildcard ? rawSegment.slice(0, -WILDCARD_SUFFIX.length) : rawSegment
+
+  if (!(key in source)) {
+    return false
+  }
+
+  const value = source[key]
+
+  if (isWildcard) {
+    if (!Array.isArray(value)) {
+      return false
+    }
+    if (rest.length === 0) {
+      target[key] = value
+
+      return true
+    }
+
+    // The array itself is kept once found, at every index, even if a given element has nothing at `rest`
+    // (as an empty `{}`) -- unlike a single nested object, dropping an element here would misalign indices.
+    const projected: Record<string, unknown>[] = Array.isArray(target[key])
+      ? (target[key] as Record<string, unknown>[])
+      : []
+    value.forEach((item, index) => {
+      const element = projected[index] ?? {}
+      assignPath(element, item, rest)
+      projected[index] = element
+    })
+    target[key] = projected
+
+    return true
+  }
+
+  if (rest.length === 0) {
+    target[key] = value
+
+    return true
+  }
+
+  if (!isPlainObject(value)) {
+    return false
+  }
+
+  const child = isPlainObject(target[key]) ? (target[key] as Record<string, unknown>) : {}
+  const wrote = assignPath(child, value, rest)
+  if (wrote) {
+    target[key] = child
+  }
+
+  return wrote
+}
+
+/**
+ * Builds a new object containing only the values found in `source` at `paths`, preserving their nested shape.
+ * A path with no value in `source` (including a missing intermediate key) is silently omitted.
+ */
+export const pickPaths = <T>(source: unknown, paths: readonly FieldPath[]): T => {
+  const result: Record<string, unknown> = {}
+  for (const path of paths) {
+    assignPath(result, source, path.split('.'))
+  }
+
+  return result as T
+}
+
+// Plain objects are merged key by key; anything else present in `patch` (including arrays) fully replaces
+// the corresponding value in `base`, rather than being merged element-wise.
+const mergeDeep = <T>(base: T, patch: unknown): T => {
+  if (patch === undefined) {
+    return base
+  }
+  if (!isPlainObject(base) || !isPlainObject(patch)) {
+    return patch as T
+  }
+
+  const result: Record<string, unknown> = {...base}
+  for (const key of Object.keys(patch)) {
+    result[key] = mergeDeep(base[key], patch[key])
+  }
+
+  return result as T
+}
+
+/**
+ * Returns a new object equal to `base`, with only the values found in `source` at `paths` overridden
+ * (a path missing from `source` leaves `base`'s own value untouched). Never mutates `base` or `source`.
+ */
+export const withPaths = <T extends object>(base: T, source: unknown, paths: readonly FieldPath[]): T =>
+  mergeDeep(base, pickPaths(source, paths))


### PR DESCRIPTION
### What and why?

Builds on #2478 (already merged). Two changes, same underlying motivation: don't let raw backend data flow into datadog-ci's outputs unchecked.

First, `getResultFromBatch()` merged the poll-results endpoint's data onto a test with `deepExtend({}, test, pollResult?.test)` — a full deep merge of whatever the backend happened to send. We already know that's more than our types declare (poll results carry a full `options` object that our `PollResult['test']` type doesn't even mention), so anything the backend adds there in the future would silently show up wherever `result.test` gets read or serialized.

Second, and the main point of this PR: the JSON report (`--jsonReport`) currently writes the *entire* `Result`/`Test` object to disk, while the JUnit report only ever surfaces a specific, hand-picked set of fields. There's no reason for the two to diverge that much — as a starting point for GA, the JSON report should expose exactly what JUnit already exposes.

### How?

Added `utils/paths.ts`: a small dot-path picker (`pickPaths`) with `[]` array-wildcard support (e.g. `'result.steps[].failure.message'` means "every step's failure message"), plus `withPaths()` for merging in only specific paths from a source without touching anything else. This is custom — `get-value`/`set-value` (already a dependency, already used the same way in `deploy-tests-lib.ts`) only get/set a single fixed path with numeric array indices, with no way to project over every array element or to build a new object from multiple paths at once. What's borrowed from them is just the dot-path string convention already established in this package, not any code.

`batch.ts` now merges poll-result data via `withPaths(test, pollResult?.test, POLLED_TEST_FIELDS)`, an explicit 8-path list (`subtype`, `config.request.*`, `config.steps[].subtype`), each commented with which reporter/check actually reads it.

`reporters/json.ts` gets its own `JSON_REPORTER_EXPOSED_FIELDS` list, deliberately *not* derived from JUnit's hand-picked fields — it's a separate list that currently happens to match, so the two are free to drift independently later (e.g. if JSON ever needs something JUnit doesn't, or vice versa). Every result is projected through it before being pushed into the report.

This is a real, intentional change to the JSON report's output shape: it no longer contains the test's `config`/`locations`/full `options`, or anything else JUnit doesn't already show.

### How to read this PR

It's one commit but touches a new mechanism plus two call sites, so read it in this order rather than top-to-bottom by filename:

1. **`utils/paths.ts` + `__tests__/utils/paths.test.ts`** — the mechanism itself. `pickPaths()` builds a new object containing only the given paths; `withPaths()` uses it to override just those paths on an existing object. Worth reading the tests alongside the implementation — a couple of them (the null-intermediate and stray-empty-object cases) exist because the first version of this got those wrong.
2. **`batch.ts`** — the smaller of the two call sites. `POLLED_TEST_FIELDS` replaces the old `deepExtend`, with a comment on each path saying which reporter/check reads it.
3. **`reporters/json.ts`** — the actual point of the PR. `JSON_REPORTER_EXPOSED_FIELDS` is the new allowlist; everything else in this file is just `pickPaths()` being called before a result is pushed.
4. **`__tests__/reporters/json.test.ts`** — shows the shape of the change most concretely: one test asserts the exact projected output for a fixture result, the other asserts specific fields (`config`, `locations`, `options.device_ids`) are gone.
5. **`__tests__/batch.test.ts`** — mostly mechanical updates; a few assertions had been quietly relying on `deepExtend` leaking a mocked `pollResult.test.public_id` onto the real result, which `withPaths` (correctly) no longer does.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)