### PR TITLE
[SVLS-9308] full language coverage for container app single-language ssi e2e

### DIFF
--- a/e2e/serverless/container-app/container-app-ssi.test.ts
+++ b/e2e/serverless/container-app/container-app-ssi.test.ts
@@ -7,8 +7,51 @@ import {triggerTraffic} from '../helpers/traffic'
 
 import {getContainerAppUrl, verifySsiInstrumented, verifyUninstrumented} from './container-app-verifier'
 
-const NODE_APPLICATION_IMAGE =
-  'dde2etfcapp.azurecr.io/node-ssi@sha256:1794d7e5edeea7dbe940e74037b4c715a0355af47080fb7fbfbd4bc4a93bfb89'
+const SSI_CASES = [
+  {
+    language: 'csharp',
+    applicationImage: 'dde2etfcapp.azurecr.io/dotnet-ssi:latest',
+    tracerRepository: 'dotnet',
+    nativeEnv: {name: 'CORECLR_PROFILER_PATH', fragment: '/datadog-lib/Datadog.Trace.ClrProfiler.Native.so'},
+  },
+  {
+    language: 'java',
+    applicationImage: 'dde2etfcapp.azurecr.io/java-ssi:latest',
+    tracerRepository: 'java',
+    nativeEnv: {name: 'JAVA_TOOL_OPTIONS', fragment: '-javaagent:/datadog-lib/dd-java-agent.jar'},
+  },
+  {
+    language: 'nodejs',
+    applicationImage: 'dde2etfcapp.azurecr.io/node-ssi:latest',
+    tracerRepository: 'js',
+    nativeEnv: {name: 'NODE_OPTIONS', fragment: '--require /datadog-lib/node_modules/dd-trace/init.js'},
+  },
+  {
+    language: 'php',
+    applicationImage: 'dde2etfcapp.azurecr.io/php-ssi:latest',
+    tracerRepository: 'php',
+    nativeEnv: {name: 'PHP_INI_SCAN_DIR', fragment: '/datadog-lib/linux-gnu/loader'},
+  },
+  {
+    language: 'python',
+    applicationImage: 'dde2etfcapp.azurecr.io/python-ssi:latest',
+    tracerRepository: 'python',
+    nativeEnv: {name: 'PYTHONPATH', fragment: '/datadog-lib'},
+  },
+  {
+    language: 'ruby',
+    applicationImage: 'dde2etfcapp.azurecr.io/ruby-ssi:latest',
+    tracerRepository: 'ruby',
+    nativeEnv: {name: 'RUBYOPT', fragment: '-r/datadog-lib/auto_inject'},
+  },
+] as const
+
+const assertCommandSucceeded = (action: string, result: {exitCode: number; stdout: string; stderr: string}): void => {
+  if (result.exitCode !== 0) {
+    const output = [result.stderr, result.stdout].filter(Boolean).join('\n') || 'no command output'
+    throw new Error(`Failed to ${action} container app (exit code ${result.exitCode}): ${output}`)
+  }
+}
 
 const describeOrSkip =
   process.env.SKIP_CONTAINER_APP_TESTS === 'true' || process.env.IS_STANDALONE_BINARY === 'true'
@@ -18,101 +61,107 @@ const describeOrSkip =
 describeOrSkip('container-app automatic APM instrumentation', () => {
   const subscriptionId = process.env.AZURE_SUBSCRIPTION_ID!
   const resourceGroup = process.env.AZURE_RESOURCE_GROUP!
-  const runId = crypto.randomBytes(4).toString('hex')
-  const appName = `one-e2e-capp-ssi-${runId}`
-  const instrumentCommand =
-    `${DATADOG_CI_COMMAND} container-app instrument` +
-    ` -s "${subscriptionId}"` +
-    ` -g "${resourceGroup}"` +
-    ` -n "${appName}"` +
-    ` --service "${appName}"` +
-    ` --env e2e` +
-    ` --version "${runId}"` +
-    ` --extra-tags "one_e2e_run_id:${runId}"` +
-    ` --tracing inject` +
-    ` --language nodejs` +
-    ` --no-source-code-integration`
 
-  it('injects, retries, traces, and removes the Node.js tracer', async () => {
-    let lifecycleError: Error | undefined
-    let cleanupError: Error | undefined
-    try {
-      const create = await execPromiseWithRetries(
-        `az containerapp create` +
-          ` --name "${appName}"` +
-          ` --resource-group "${resourceGroup}"` +
-          ` --environment "${process.env.AZURE_CONTAINER_APP_ENV}"` +
-          ` --image "${NODE_APPLICATION_IMAGE}"` +
-          ` --cpu 0.25 --memory 0.5Gi` +
-          ` --min-replicas 0 --max-replicas 1` +
-          ` --ingress external --target-port 8080` +
-          ` --tags one_e2e_created=${Math.floor(Date.now() / 1000)}` +
-          ` --output none`
-      )
-      if (create.exitCode !== 0) {
-        throw new Error(`Failed to create container app (exit code ${create.exitCode}): ${create.stderr}`)
+  it.concurrent.each(SSI_CASES)(
+    'injects, retries, traces, and removes the $language tracer',
+    async (ssiCase) => {
+      const {language, applicationImage, tracerRepository, nativeEnv} = ssiCase
+      const runId = crypto.randomBytes(4).toString('hex')
+      const appName = `one-e2e-capp-ssi-${language}-${runId}`
+      const instrumentCommand =
+        `${DATADOG_CI_COMMAND} container-app instrument` +
+        ` -s "${subscriptionId}"` +
+        ` -g "${resourceGroup}"` +
+        ` -n "${appName}"` +
+        ` --service "${appName}"` +
+        ` --env e2e` +
+        ` --version "${runId}"` +
+        ` --extra-tags "one_e2e_run_id:${runId}"` +
+        ` --tracing inject` +
+        ` --language "${language}"` +
+        ` --no-source-code-integration`
+      const expectation = {applicationImage, tracerRepository, nativeEnv, runId}
+
+      let lifecycleError: Error | undefined
+      let cleanupError: Error | undefined
+      try {
+        const create = await execPromiseWithRetries(
+          `az containerapp create` +
+            ` --name "${appName}"` +
+            ` --resource-group "${resourceGroup}"` +
+            ` --environment "${process.env.AZURE_CONTAINER_APP_ENV}"` +
+            ` --image "${applicationImage}"` +
+            ` --cpu 0.25 --memory 0.5Gi` +
+            ` --min-replicas 0 --max-replicas 1` +
+            ` --ingress external --target-port 8080` +
+            ` --tags one_e2e_created=${Math.floor(Date.now() / 1000)}` +
+            ` --output none`
+        )
+        assertCommandSucceeded('create', create)
+
+        const instrument = await execPromiseWithRetries(instrumentCommand, {
+          DD_API_KEY: process.env.DATADOG_API_KEY,
+        })
+        assertCommandSucceeded('instrument', instrument)
+        verifySsiInstrumented(appName, resourceGroup, subscriptionId, expectation)
+
+        const appUrl = getContainerAppUrl(appName, resourceGroup, subscriptionId)
+        const [traffic, telemetry] = await Promise.allSettled([
+          triggerTraffic(appUrl, {attempts: 20, requiredSuccesses: 10, intervalSeconds: 10}),
+          checkTelemetryFlowing(
+            {
+              serviceName: appName,
+              env: 'e2e',
+              version: runId,
+              tags: [`one_e2e_run_id:${runId}`],
+            },
+            {checkLogs: false}
+          ),
+        ])
+        if (traffic.status === 'rejected') {
+          throw traffic.reason
+        }
+        if (telemetry.status === 'rejected') {
+          throw telemetry.reason
+        }
+
+        const retry = await execPromiseWithRetries(instrumentCommand, {
+          DD_API_KEY: process.env.DATADOG_API_KEY,
+        })
+        assertCommandSucceeded('re-instrument', retry)
+        verifySsiInstrumented(appName, resourceGroup, subscriptionId, expectation)
+
+        const uninstrument = await execPromiseWithRetries(
+          `${DATADOG_CI_COMMAND} container-app uninstrument` +
+            ` -s "${subscriptionId}"` +
+            ` -g "${resourceGroup}"` +
+            ` -n "${appName}"`,
+          {DD_API_KEY: process.env.DATADOG_API_KEY}
+        )
+        assertCommandSucceeded('uninstrument', uninstrument)
+        verifyUninstrumented(appName, resourceGroup, subscriptionId, nativeEnv)
+      } catch (error) {
+        lifecycleError = error instanceof Error ? error : new Error(String(error))
+      } finally {
+        const cleanup = await execPromiseWithRetries(
+          `az containerapp delete --name "${appName}" --resource-group "${resourceGroup}" --yes --output none`
+        )
+        if (cleanup.exitCode !== 0) {
+          const output = [cleanup.stderr, cleanup.stdout].filter(Boolean).join('\n') || 'no command output'
+          cleanupError = new Error(`Failed to delete container app (exit code ${cleanup.exitCode}): ${output}`)
+        }
       }
 
-      const instrument = await execPromiseWithRetries(instrumentCommand, {
-        DD_API_KEY: process.env.DATADOG_API_KEY,
-      })
-      expect(instrument.exitCode).toBe(0)
-      verifySsiInstrumented(appName, resourceGroup, subscriptionId, runId, NODE_APPLICATION_IMAGE)
-
-      const appUrl = getContainerAppUrl(appName, resourceGroup, subscriptionId)
-      const [traffic, telemetry] = await Promise.allSettled([
-        triggerTraffic(appUrl, {attempts: 20, requiredSuccesses: 10, intervalSeconds: 10}),
-        checkTelemetryFlowing(
-          {
-            serviceName: appName,
-            env: 'e2e',
-            version: runId,
-            tags: [`one_e2e_run_id:${runId}`],
-          },
-          {checkLogs: false}
-        ),
-      ])
-      if (traffic.status === 'rejected') {
-        throw traffic.reason
+      if (lifecycleError && cleanupError) {
+        throw new Error(`${String(lifecycleError)}\n${cleanupError.message}`)
       }
-      if (telemetry.status === 'rejected') {
-        throw telemetry.reason
+      if (cleanupError) {
+        throw cleanupError
       }
-
-      const retry = await execPromiseWithRetries(instrumentCommand, {
-        DD_API_KEY: process.env.DATADOG_API_KEY,
-      })
-      expect(retry.exitCode).toBe(0)
-      verifySsiInstrumented(appName, resourceGroup, subscriptionId, runId, NODE_APPLICATION_IMAGE)
-
-      const uninstrument = await execPromiseWithRetries(
-        `${DATADOG_CI_COMMAND} container-app uninstrument` +
-          ` -s "${subscriptionId}"` +
-          ` -g "${resourceGroup}"` +
-          ` -n "${appName}"`,
-        {DD_API_KEY: process.env.DATADOG_API_KEY}
-      )
-      expect(uninstrument.exitCode).toBe(0)
-      verifyUninstrumented(appName, resourceGroup, subscriptionId)
-    } catch (error) {
-      lifecycleError = error instanceof Error ? error : new Error(String(error))
-    } finally {
-      const cleanup = await execPromiseWithRetries(
-        `az containerapp delete --name "${appName}" --resource-group "${resourceGroup}" --yes --output none`
-      )
-      if (cleanup.exitCode !== 0) {
-        cleanupError = new Error(`Failed to delete container app (exit code ${cleanup.exitCode}): ${cleanup.stderr}`)
+      if (lifecycleError) {
+        throw lifecycleError
       }
-    }
-
-    if (lifecycleError && cleanupError) {
-      throw new Error(`${String(lifecycleError)}\n${cleanupError.message}`)
-    }
-    if (cleanupError) {
-      throw cleanupError
-    }
-    if (lifecycleError) {
-      throw lifecycleError
-    }
-  }, 1_200_000)
+    },
+    1_200_000
+  )
 })

--- a/e2e/serverless/container-app/container-app-verifier.ts
+++ b/e2e/serverless/container-app/container-app-verifier.ts
@@ -34,8 +34,6 @@ const SHARED_VOLUME_NAME = 'shared-volume'
 const DD_API_KEY_SECRET_NAME = 'dd-api-key'
 const TRACER_NAME = 'datadog-tracer'
 const TRACER_MOUNT_PATH = '/datadog-lib'
-const NODE_TRACER_IMAGE = 'datadoghq.azurecr.io/dd-lib-js-init:latest'
-const NODE_OPTIONS_FRAGMENT = '--require /datadog-lib/node_modules/dd-trace/init.js'
 const INJECTION_MODE_TAG = '_dd.injection.mode:serverless-single-lang'
 const EXPECTED_ENV = 'e2e'
 const REQUIRED_ENV_VARS = [
@@ -64,6 +62,28 @@ const envByName = (
   container: ContainerApp['properties']['template']['containers'][number]
 ): Record<string, {name: string; value?: string; secretRef?: string}> => {
   return Object.fromEntries((container.env || []).map((env) => [env.name, env]))
+}
+
+const verifyDatadogEnv = (
+  containers: ContainerApp['properties']['template']['containers'],
+  appName: string,
+  runId: string
+): void => {
+  for (const container of containers) {
+    const env = envByName(container)
+    for (const varName of REQUIRED_ENV_VARS) {
+      expect(env[varName]).toBeDefined()
+    }
+    expect(env.DD_API_KEY.secretRef).toBe(DD_API_KEY_SECRET_NAME)
+    expect(env.DD_SERVICE.value).toBe(appName)
+    expect(env.DD_ENV.value).toBe(EXPECTED_ENV)
+    expect(env.DD_VERSION.value).toBe(runId)
+    expect(env.DD_TRACE_ENABLED.value).toBe('true')
+    expect(env.DD_LOGS_INJECTION.value).toBe('true')
+    expect(env.DD_HEALTH_PORT.value).toBe('5555')
+    expect(env.DD_TAGS.value).toContain(`one_e2e_run_id:${runId}`)
+    expect(env.DD_APM_ENABLED.value).toBe('true')
+  }
 }
 
 export const getContainerAppUrl = (appName: string, resourceGroup: string, subscriptionId: string): string => {
@@ -110,21 +130,7 @@ export const verifyInstrumented = (
   const sidecarMounts = sidecar!.volumeMounts || []
   expect(sidecarMounts.some((m) => m.volumeName === SHARED_VOLUME_NAME)).toBe(true)
 
-  for (const container of containers) {
-    const env = envByName(container)
-    for (const varName of REQUIRED_ENV_VARS) {
-      expect(env[varName]).toBeDefined()
-    }
-    expect(env.DD_API_KEY.secretRef).toBe(DD_API_KEY_SECRET_NAME)
-    expect(env.DD_SERVICE.value).toBe(appName)
-    expect(env.DD_ENV.value).toBe(EXPECTED_ENV)
-    expect(env.DD_VERSION.value).toBe(runId)
-    expect(env.DD_TRACE_ENABLED.value).toBe('true')
-    expect(env.DD_LOGS_INJECTION.value).toBe('true')
-    expect(env.DD_HEALTH_PORT.value).toBe('5555')
-    expect(env.DD_TAGS.value).toContain(`one_e2e_run_id:${runId}`)
-    expect(env.DD_APM_ENABLED.value).toBe('true')
-  }
+  verifyDatadogEnv(containers, appName, runId)
 
   const apiKeySecret = secrets.find((s) => s.name === DD_API_KEY_SECRET_NAME)
   expect(apiKeySecret).toBeDefined()
@@ -138,12 +144,23 @@ export const verifyInstrumented = (
   console.log('\nAll instrumented checks passed.')
 }
 
+interface NativeEnvExpectation {
+  name: string
+  fragment: string
+}
+
+interface SsiExpectation {
+  applicationImage: string
+  tracerRepository: string
+  nativeEnv: NativeEnvExpectation
+  runId: string
+}
+
 export const verifySsiInstrumented = (
   appName: string,
   resourceGroup: string,
   subscriptionId: string,
-  runId: string,
-  applicationImage: string
+  expectation: SsiExpectation
 ): void => {
   console.log(`Fetching container app "${appName}"...`)
   const app = getContainerApp(appName, resourceGroup, subscriptionId)
@@ -158,13 +175,16 @@ export const verifySsiInstrumented = (
   const applicationContainers = containers.filter(({name}) => name !== SIDECAR_NAME)
   expect(applicationContainers).toHaveLength(1)
   const application = applicationContainers[0]
-  expect(application.image).toBe(applicationImage)
+  expect(application.image).toBe(expectation.applicationImage)
 
+  verifyDatadogEnv(containers, appName, expectation.runId)
+
+  const tracerImage = `datadoghq.azurecr.io/dd-lib-${expectation.tracerRepository}-init:latest`
   const tracerContainers = initContainers.filter(({name}) => name === TRACER_NAME)
   expect(tracerContainers).toHaveLength(1)
   expect(tracerContainers[0]).toEqual(
     expect.objectContaining({
-      image: NODE_TRACER_IMAGE,
+      image: tracerImage,
       command: ['/datadog-init/copy-lib.sh'],
       args: [TRACER_MOUNT_PATH],
       resources: expect.objectContaining({cpu: 0.25, memory: '0.5Gi'}),
@@ -198,23 +218,29 @@ export const verifySsiInstrumented = (
   ])
   expect(sidecar!.volumeMounts ?? []).not.toContainEqual(expect.objectContaining({volumeName: TRACER_NAME}))
   expect(sidecar!.volumeMounts ?? []).not.toContainEqual(expect.objectContaining({mountPath: TRACER_MOUNT_PATH}))
-  expect(sidecar!.env?.some(({value}) => value?.includes(NODE_OPTIONS_FRAGMENT))).not.toBe(true)
+  expect(
+    sidecar!.env?.some(
+      ({name, value}) => name === expectation.nativeEnv.name && value?.includes(expectation.nativeEnv.fragment)
+    )
+  ).not.toBe(true)
 
-  const nodeOptions = application.env?.filter(({name}) => name === 'NODE_OPTIONS') ?? []
-  expect(nodeOptions).toHaveLength(1)
-  expect(nodeOptions[0].value?.split(NODE_OPTIONS_FRAGMENT)).toHaveLength(2)
-  const traceEnabled = application.env?.filter(({name}) => name === 'DD_TRACE_ENABLED') ?? []
-  const ddTags = application.env?.filter(({name}) => name === 'DD_TAGS') ?? []
-  expect(traceEnabled).toHaveLength(1)
-  expect(ddTags).toHaveLength(1)
-  const env = envByName(application)
-  expect(env.DD_TRACE_ENABLED.value).toBe('true')
-  expect(env.DD_TAGS.value?.split(INJECTION_MODE_TAG)).toHaveLength(2)
-  expect(env.DD_TAGS.value).toContain(`one_e2e_run_id:${runId}`)
+  const applicationEnv = envByName(application)
+  expect(applicationEnv[expectation.nativeEnv.name]?.value ?? '').toContain(expectation.nativeEnv.fragment)
+  expect(applicationEnv.DD_TAGS.value).toContain(INJECTION_MODE_TAG)
+  expect(tags.service).toBe(appName)
+  expect(tags.env).toBe(EXPECTED_ENV)
+  expect(tags.version).toBe(expectation.runId)
+  expect(tags.dd_sls_ci).toBeDefined()
   expect(tags.dd_sls_injection_mode).toBe('single_language')
+  expect(tags.one_e2e_created).toBeDefined()
 }
 
-export const verifyUninstrumented = (appName: string, resourceGroup: string, subscriptionId: string): void => {
+export const verifyUninstrumented = (
+  appName: string,
+  resourceGroup: string,
+  subscriptionId: string,
+  nativeEnv?: NativeEnvExpectation
+): void => {
   console.log(`Fetching container app "${appName}"...`)
   const app = getContainerApp(appName, resourceGroup, subscriptionId)
   console.log('\nVerifying uninstrumented state:\n')
@@ -240,7 +266,9 @@ export const verifyUninstrumented = (appName: string, resourceGroup: string, sub
     const ddVars = env.filter((e) => e.name.startsWith('DD_'))
     expect(ddVars).toHaveLength(0)
     expect(container.volumeMounts ?? []).not.toContainEqual(expect.objectContaining({volumeName: TRACER_NAME}))
-    expect(env.find(({name}) => name === 'NODE_OPTIONS')?.value ?? '').not.toContain(NODE_OPTIONS_FRAGMENT)
+    if (nativeEnv) {
+      expect(env.find(({name}) => name === nativeEnv.name)?.value ?? '').not.toContain(nativeEnv.fragment)
+    }
   }
 
   const apiKeySecret = secrets.find((s) => s.name === DD_API_KEY_SECRET_NAME)


### PR DESCRIPTION
### What and why?

Azure Container Apps automatic tracer injection had end-to-end coverage only for Node.js. Runtime-specific injection failures for Java, .NET, Python, Ruby, and PHP could go undetected.

### How?

Parameterize the SSI case across all six supported runtimes, using the matching tracer repository and native environment fragment for each workload. Run the independent cases concurrently and verify injection, telemetry, idempotent reinstrumentation, cleanup, and resource deletion.

### Test plan

- [x] Manual Azure Container Apps SSI E2E: all six runtimes passed, including trace delivery and cleanup.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
