### PR TITLE
[SVLS-9313] Add multi-language ssi support for container apps

### DIFF
--- a/e2e/serverless/container-app/container-app-ssi.test.ts
+++ b/e2e/serverless/container-app/container-app-ssi.test.ts
@@ -23,7 +23,7 @@ const SSI_CASES = [
   })),
   {
     kind: 'multi-language',
-    testName: 'auto-detected Node.js',
+    testName: 'auto-detected Node.js at the 2-GiB ephemeral-storage boundary',
     applicationImage: 'dde2etfcapp.azurecr.io/node-ssi:latest',
   },
 ] as const
@@ -61,6 +61,7 @@ describeOrSkip('container-app automatic APM instrumentation', () => {
         ` --extra-tags "one_e2e_run_id:${runId}"` +
         ` --tracing inject` +
         (ssiCase.kind === 'single-language' ? ` --language "${ssiCase.language}"` : '') +
+        (ssiCase.kind === 'multi-language' ? ' --sidecar-cpu 0.25 --sidecar-memory 0.5' : '') +
         ` --no-source-code-integration`
 
       let lifecycleError: Error | undefined

--- a/e2e/serverless/container-app/container-app-ssi.test.ts
+++ b/e2e/serverless/container-app/container-app-ssi.test.ts
@@ -13,11 +13,20 @@ import {
   verifyUninstrumented,
 } from './container-app-verifier'
 
-const SSI_CASES = ssiCases.map(({fixtureImageName, nativeEnv, ...ssiCase}) => ({
-  ...ssiCase,
-  applicationImage: `dde2etfcapp.azurecr.io/${fixtureImageName}:latest`,
-  nativeEnv: {name: nativeEnv.name, fragment: nativeEnv.value},
-}))
+const SSI_CASES = [
+  ...ssiCases.map(({fixtureImageName, nativeEnv, ...ssiCase}) => ({
+    ...ssiCase,
+    kind: 'single-language' as const,
+    testName: ssiCase.language,
+    applicationImage: `dde2etfcapp.azurecr.io/${fixtureImageName}:latest`,
+    nativeEnv: {name: nativeEnv.name, fragment: nativeEnv.value},
+  })),
+  {
+    kind: 'multi-language',
+    testName: 'auto-detected Node.js',
+    applicationImage: 'dde2etfcapp.azurecr.io/node-ssi:latest',
+  },
+] as const
 
 const assertCommandSucceeded = (action: string, result: {exitCode: number; stdout: string; stderr: string}): void => {
   if (result.exitCode !== 0) {
@@ -36,11 +45,11 @@ describeOrSkip('container-app automatic APM instrumentation', () => {
   const resourceGroup = process.env.AZURE_RESOURCE_GROUP!
 
   it.concurrent.each(SSI_CASES)(
-    'injects, retries, traces, and removes the $language tracer',
+    'injects, retries, traces, and removes the $testName tracer',
     async (ssiCase) => {
-      const {language, applicationImage, tracerRepository, nativeEnv} = ssiCase
+      const {applicationImage} = ssiCase
       const runId = crypto.randomBytes(4).toString('hex')
-      const appName = `one-e2e-capp-ssi-${language}-${runId}`
+      const appName = `one-e2e-capp-ssi-${ssiCase.kind === 'single-language' ? ssiCase.language : 'auto'}-${runId}`
       const instrumentCommand =
         `${DATADOG_CI_COMMAND} container-app instrument` +
         ` -s "${subscriptionId}"` +
@@ -51,9 +60,8 @@ describeOrSkip('container-app automatic APM instrumentation', () => {
         ` --version "${runId}"` +
         ` --extra-tags "one_e2e_run_id:${runId}"` +
         ` --tracing inject` +
-        ` --language "${language}"` +
+        (ssiCase.kind === 'single-language' ? ` --language "${ssiCase.language}"` : '') +
         ` --no-source-code-integration`
-      const expectation = {applicationImage, tracerRepository, nativeEnv, runId}
 
       let lifecycleError: Error | undefined
       let cleanupError: Error | undefined
@@ -76,7 +84,11 @@ describeOrSkip('container-app automatic APM instrumentation', () => {
           DD_API_KEY: process.env.DATADOG_API_KEY,
         })
         assertCommandSucceeded('instrument', instrument)
-        verifySsiInstrumented(appName, resourceGroup, subscriptionId, expectation)
+        if (ssiCase.kind === 'single-language') {
+          verifySsiInstrumented(appName, resourceGroup, subscriptionId, {...ssiCase, runId})
+        } else {
+          verifyMultiLanguageSsiInstrumented(appName, resourceGroup, subscriptionId, runId, applicationImage)
+        }
 
         const appUrl = getContainerAppUrl(appName, resourceGroup, subscriptionId)
         const [traffic, telemetry] = await Promise.allSettled([
@@ -102,7 +114,11 @@ describeOrSkip('container-app automatic APM instrumentation', () => {
           DD_API_KEY: process.env.DATADOG_API_KEY,
         })
         assertCommandSucceeded('re-instrument', retry)
-        verifySsiInstrumented(appName, resourceGroup, subscriptionId, expectation)
+        if (ssiCase.kind === 'single-language') {
+          verifySsiInstrumented(appName, resourceGroup, subscriptionId, {...ssiCase, runId})
+        } else {
+          verifyMultiLanguageSsiInstrumented(appName, resourceGroup, subscriptionId, runId, applicationImage)
+        }
 
         const uninstrument = await execPromiseWithRetries(
           `${DATADOG_CI_COMMAND} container-app uninstrument` +
@@ -112,7 +128,12 @@ describeOrSkip('container-app automatic APM instrumentation', () => {
           {DD_API_KEY: process.env.DATADOG_API_KEY}
         )
         assertCommandSucceeded('uninstrument', uninstrument)
-        verifyUninstrumented(appName, resourceGroup, subscriptionId, nativeEnv)
+        verifyUninstrumented(
+          appName,
+          resourceGroup,
+          subscriptionId,
+          ssiCase.kind === 'single-language' ? ssiCase.nativeEnv : undefined
+        )
       } catch (error) {
         lifecycleError = error instanceof Error ? error : new Error(String(error))
       } finally {
@@ -137,88 +158,4 @@ describeOrSkip('container-app automatic APM instrumentation', () => {
     },
     1_200_000
   )
-
-  it('detects Node.js, injects its tracer, and removes the composite', async () => {
-    const applicationImage = SSI_CASES.find(({language}) => language === 'nodejs')!.applicationImage
-    const runId = crypto.randomBytes(4).toString('hex')
-    const appName = `one-e2e-capp-ssi-auto-${runId}`
-    const instrumentCommand =
-      `${DATADOG_CI_COMMAND} container-app instrument` +
-      ` -s "${subscriptionId}"` +
-      ` -g "${resourceGroup}"` +
-      ` -n "${appName}"` +
-      ` --service "${appName}"` +
-      ` --env e2e` +
-      ` --version "${runId}"` +
-      ` --extra-tags "one_e2e_run_id:${runId}"` +
-      ` --tracing inject` +
-      ` --no-source-code-integration`
-
-    let lifecycleError: Error | undefined
-    let cleanupError: Error | undefined
-    try {
-      const create = await execPromiseWithRetries(
-        `az containerapp create` +
-          ` --name "${appName}"` +
-          ` --resource-group "${resourceGroup}"` +
-          ` --environment "${process.env.AZURE_CONTAINER_APP_ENV}"` +
-          ` --image "${applicationImage}"` +
-          ` --cpu 0.25 --memory 0.5Gi` +
-          ` --min-replicas 0 --max-replicas 1` +
-          ` --ingress external --target-port 8080` +
-          ` --tags one_e2e_created=${Math.floor(Date.now() / 1000)}` +
-          ` --output none`
-      )
-      assertCommandSucceeded('create', create)
-
-      const instrument = await execPromiseWithRetries(instrumentCommand, {DD_API_KEY: process.env.DATADOG_API_KEY})
-      assertCommandSucceeded('instrument', instrument)
-      verifyMultiLanguageSsiInstrumented(appName, resourceGroup, subscriptionId, runId, applicationImage)
-
-      const appUrl = getContainerAppUrl(appName, resourceGroup, subscriptionId)
-      const [traffic, telemetry] = await Promise.allSettled([
-        triggerTraffic(appUrl, {attempts: 20, requiredSuccesses: 10, intervalSeconds: 10}),
-        checkTelemetryFlowing(
-          {serviceName: appName, env: 'e2e', version: runId, tags: [`one_e2e_run_id:${runId}`]},
-          {checkLogs: false}
-        ),
-      ])
-      if (traffic.status === 'rejected') {
-        throw traffic.reason
-      }
-      if (telemetry.status === 'rejected') {
-        throw telemetry.reason
-      }
-
-      const uninstrument = await execPromiseWithRetries(
-        `${DATADOG_CI_COMMAND} container-app uninstrument` +
-          ` -s "${subscriptionId}"` +
-          ` -g "${resourceGroup}"` +
-          ` -n "${appName}"`,
-        {DD_API_KEY: process.env.DATADOG_API_KEY}
-      )
-      assertCommandSucceeded('uninstrument', uninstrument)
-      verifyUninstrumented(appName, resourceGroup, subscriptionId)
-    } catch (error) {
-      lifecycleError = error instanceof Error ? error : new Error(String(error))
-    } finally {
-      const cleanup = await execPromiseWithRetries(
-        `az containerapp delete --name "${appName}" --resource-group "${resourceGroup}" --yes --output none`
-      )
-      if (cleanup.exitCode !== 0) {
-        const output = [cleanup.stderr, cleanup.stdout].filter(Boolean).join('\n') || 'no command output'
-        cleanupError = new Error(`Failed to delete container app (exit code ${cleanup.exitCode}): ${output}`)
-      }
-    }
-
-    if (lifecycleError && cleanupError) {
-      throw new Error(`${String(lifecycleError)}\n${cleanupError.message}`)
-    }
-    if (cleanupError) {
-      throw cleanupError
-    }
-    if (lifecycleError) {
-      throw lifecycleError
-    }
-  }, 1_200_000)
 })

--- a/e2e/serverless/container-app/container-app-ssi.test.ts
+++ b/e2e/serverless/container-app/container-app-ssi.test.ts
@@ -6,7 +6,12 @@ import {SSI_CASES as ssiCases} from '../helpers/ssi'
 import {checkTelemetryFlowing} from '../helpers/telemetry-checker'
 import {triggerTraffic} from '../helpers/traffic'
 
-import {getContainerAppUrl, verifySsiInstrumented, verifyUninstrumented} from './container-app-verifier'
+import {
+  getContainerAppUrl,
+  verifyMultiLanguageSsiInstrumented,
+  verifySsiInstrumented,
+  verifyUninstrumented,
+} from './container-app-verifier'
 
 const SSI_CASES = ssiCases.map(({fixtureImageName, nativeEnv, ...ssiCase}) => ({
   ...ssiCase,
@@ -26,110 +31,142 @@ const describeOrSkip =
     ? describe.skip
     : describe
 
+type Verify = (appName: string, resourceGroup: string, subscriptionId: string, runId: string) => void
+
+interface SsiCase {
+  appNamePrefix: string
+  applicationImage: string
+  extraArgs?: string
+  nativeEnv?: {name: string; fragment: string}
+  retry: boolean
+  verify: Verify
+}
+
 describeOrSkip('container-app automatic APM instrumentation', () => {
   const subscriptionId = process.env.AZURE_SUBSCRIPTION_ID!
   const resourceGroup = process.env.AZURE_RESOURCE_GROUP!
 
+  const runSsiLifecycle = async ({
+    appNamePrefix,
+    applicationImage,
+    extraArgs = '',
+    nativeEnv,
+    retry,
+    verify,
+  }: SsiCase) => {
+    const runId = crypto.randomBytes(4).toString('hex')
+    const appName = `${appNamePrefix}-${runId}`
+    const instrumentCommand =
+      `${DATADOG_CI_COMMAND} container-app instrument` +
+      ` -s "${subscriptionId}"` +
+      ` -g "${resourceGroup}"` +
+      ` -n "${appName}"` +
+      ` --service "${appName}"` +
+      ` --env e2e` +
+      ` --version "${runId}"` +
+      ` --extra-tags "one_e2e_run_id:${runId}"` +
+      ` --tracing inject` +
+      extraArgs +
+      ` --no-source-code-integration`
+    let lifecycleError: Error | undefined
+    let cleanupError: Error | undefined
+
+    try {
+      const create = await execPromiseWithRetries(
+        `az containerapp create` +
+          ` --name "${appName}"` +
+          ` --resource-group "${resourceGroup}"` +
+          ` --environment "${process.env.AZURE_CONTAINER_APP_ENV}"` +
+          ` --image "${applicationImage}"` +
+          ` --cpu 0.25 --memory 0.5Gi` +
+          ` --min-replicas 0 --max-replicas 1` +
+          ` --ingress external --target-port 8080` +
+          ` --tags one_e2e_created=${Math.floor(Date.now() / 1000)}` +
+          ` --output none`
+      )
+      assertCommandSucceeded('create', create)
+
+      const instrument = async () => {
+        const result = await execPromiseWithRetries(instrumentCommand, {DD_API_KEY: process.env.DATADOG_API_KEY})
+        assertCommandSucceeded('instrument', result)
+        verify(appName, resourceGroup, subscriptionId, runId)
+      }
+      await instrument()
+
+      const appUrl = getContainerAppUrl(appName, resourceGroup, subscriptionId)
+      const [traffic, telemetry] = await Promise.allSettled([
+        triggerTraffic(appUrl, {attempts: 20, requiredSuccesses: 10, intervalSeconds: 10}),
+        checkTelemetryFlowing(
+          {serviceName: appName, env: 'e2e', version: runId, tags: [`one_e2e_run_id:${runId}`]},
+          {checkLogs: false}
+        ),
+      ])
+      if (traffic.status === 'rejected') {
+        throw traffic.reason
+      }
+      if (telemetry.status === 'rejected') {
+        throw telemetry.reason
+      }
+
+      if (retry) {
+        await instrument()
+      }
+
+      const uninstrument = await execPromiseWithRetries(
+        `${DATADOG_CI_COMMAND} container-app uninstrument` +
+          ` -s "${subscriptionId}"` +
+          ` -g "${resourceGroup}"` +
+          ` -n "${appName}"`,
+        {DD_API_KEY: process.env.DATADOG_API_KEY}
+      )
+      assertCommandSucceeded('uninstrument', uninstrument)
+      verifyUninstrumented(appName, resourceGroup, subscriptionId, nativeEnv)
+    } catch (error) {
+      lifecycleError = error instanceof Error ? error : new Error(String(error))
+    } finally {
+      const cleanup = await execPromiseWithRetries(
+        `az containerapp delete --name "${appName}" --resource-group "${resourceGroup}" --yes --output none`
+      )
+      if (cleanup.exitCode !== 0) {
+        const output = [cleanup.stderr, cleanup.stdout].filter(Boolean).join('\n') || 'no command output'
+        cleanupError = new Error(`Failed to delete container app (exit code ${cleanup.exitCode}): ${output}`)
+      }
+    }
+
+    if (lifecycleError && cleanupError) {
+      throw new Error(`${String(lifecycleError)}\n${cleanupError.message}`)
+    }
+    if (cleanupError) {
+      throw cleanupError
+    }
+    if (lifecycleError) {
+      throw lifecycleError
+    }
+  }
+
   it.concurrent.each(SSI_CASES)(
     'injects, retries, traces, and removes the $language tracer',
-    async (ssiCase) => {
-      const {language, applicationImage, tracerRepository, nativeEnv} = ssiCase
-      const runId = crypto.randomBytes(4).toString('hex')
-      const appName = `one-e2e-capp-ssi-${language}-${runId}`
-      const instrumentCommand =
-        `${DATADOG_CI_COMMAND} container-app instrument` +
-        ` -s "${subscriptionId}"` +
-        ` -g "${resourceGroup}"` +
-        ` -n "${appName}"` +
-        ` --service "${appName}"` +
-        ` --env e2e` +
-        ` --version "${runId}"` +
-        ` --extra-tags "one_e2e_run_id:${runId}"` +
-        ` --tracing inject` +
-        ` --language "${language}"` +
-        ` --no-source-code-integration`
-      const expectation = {applicationImage, tracerRepository, nativeEnv, runId}
+    (ssiCase) =>
+      runSsiLifecycle({
+        ...ssiCase,
+        appNamePrefix: `one-e2e-capp-ssi-${ssiCase.language}`,
+        extraArgs: ` --language ${ssiCase.language}`,
+        retry: true,
+        verify: (appName, rg, sub, runId) => verifySsiInstrumented(appName, rg, sub, {...ssiCase, runId}),
+      }),
+    1_200_000
+  )
 
-      let lifecycleError: Error | undefined
-      let cleanupError: Error | undefined
-      try {
-        const create = await execPromiseWithRetries(
-          `az containerapp create` +
-            ` --name "${appName}"` +
-            ` --resource-group "${resourceGroup}"` +
-            ` --environment "${process.env.AZURE_CONTAINER_APP_ENV}"` +
-            ` --image "${applicationImage}"` +
-            ` --cpu 0.25 --memory 0.5Gi` +
-            ` --min-replicas 0 --max-replicas 1` +
-            ` --ingress external --target-port 8080` +
-            ` --tags one_e2e_created=${Math.floor(Date.now() / 1000)}` +
-            ` --output none`
-        )
-        assertCommandSucceeded('create', create)
-
-        const instrument = await execPromiseWithRetries(instrumentCommand, {
-          DD_API_KEY: process.env.DATADOG_API_KEY,
-        })
-        assertCommandSucceeded('instrument', instrument)
-        verifySsiInstrumented(appName, resourceGroup, subscriptionId, expectation)
-
-        const appUrl = getContainerAppUrl(appName, resourceGroup, subscriptionId)
-        const [traffic, telemetry] = await Promise.allSettled([
-          triggerTraffic(appUrl, {attempts: 20, requiredSuccesses: 10, intervalSeconds: 10}),
-          checkTelemetryFlowing(
-            {
-              serviceName: appName,
-              env: 'e2e',
-              version: runId,
-              tags: [`one_e2e_run_id:${runId}`],
-            },
-            {checkLogs: false}
-          ),
-        ])
-        if (traffic.status === 'rejected') {
-          throw traffic.reason
-        }
-        if (telemetry.status === 'rejected') {
-          throw telemetry.reason
-        }
-
-        const retry = await execPromiseWithRetries(instrumentCommand, {
-          DD_API_KEY: process.env.DATADOG_API_KEY,
-        })
-        assertCommandSucceeded('re-instrument', retry)
-        verifySsiInstrumented(appName, resourceGroup, subscriptionId, expectation)
-
-        const uninstrument = await execPromiseWithRetries(
-          `${DATADOG_CI_COMMAND} container-app uninstrument` +
-            ` -s "${subscriptionId}"` +
-            ` -g "${resourceGroup}"` +
-            ` -n "${appName}"`,
-          {DD_API_KEY: process.env.DATADOG_API_KEY}
-        )
-        assertCommandSucceeded('uninstrument', uninstrument)
-        verifyUninstrumented(appName, resourceGroup, subscriptionId, nativeEnv)
-      } catch (error) {
-        lifecycleError = error instanceof Error ? error : new Error(String(error))
-      } finally {
-        const cleanup = await execPromiseWithRetries(
-          `az containerapp delete --name "${appName}" --resource-group "${resourceGroup}" --yes --output none`
-        )
-        if (cleanup.exitCode !== 0) {
-          const output = [cleanup.stderr, cleanup.stdout].filter(Boolean).join('\n') || 'no command output'
-          cleanupError = new Error(`Failed to delete container app (exit code ${cleanup.exitCode}): ${output}`)
-        }
-      }
-
-      if (lifecycleError && cleanupError) {
-        throw new Error(`${String(lifecycleError)}\n${cleanupError.message}`)
-      }
-      if (cleanupError) {
-        throw cleanupError
-      }
-      if (lifecycleError) {
-        throw lifecycleError
-      }
-    },
+  it(
+    'detects Node.js, injects its tracer, and removes the composite',
+    () =>
+      runSsiLifecycle({
+        appNamePrefix: 'one-e2e-capp-ssi-auto',
+        applicationImage: SSI_CASES[2].applicationImage,
+        retry: false,
+        verify: (appName, rg, sub, runId) =>
+          verifyMultiLanguageSsiInstrumented(appName, rg, sub, runId, SSI_CASES[2].applicationImage),
+      }),
     1_200_000
   )
 })

--- a/e2e/serverless/container-app/container-app-ssi.test.ts
+++ b/e2e/serverless/container-app/container-app-ssi.test.ts
@@ -31,31 +31,117 @@ const describeOrSkip =
     ? describe.skip
     : describe
 
-type Verify = (appName: string, resourceGroup: string, subscriptionId: string, runId: string) => void
-
-interface SsiCase {
-  appNamePrefix: string
-  applicationImage: string
-  extraArgs?: string
-  nativeEnv?: {name: string; fragment: string}
-  retry: boolean
-  verify: Verify
-}
-
 describeOrSkip('container-app automatic APM instrumentation', () => {
   const subscriptionId = process.env.AZURE_SUBSCRIPTION_ID!
   const resourceGroup = process.env.AZURE_RESOURCE_GROUP!
 
-  const runSsiLifecycle = async ({
-    appNamePrefix,
-    applicationImage,
-    extraArgs = '',
-    nativeEnv,
-    retry,
-    verify,
-  }: SsiCase) => {
+  it.concurrent.each(SSI_CASES)(
+    'injects, retries, traces, and removes the $language tracer',
+    async (ssiCase) => {
+      const {language, applicationImage, tracerRepository, nativeEnv} = ssiCase
+      const runId = crypto.randomBytes(4).toString('hex')
+      const appName = `one-e2e-capp-ssi-${language}-${runId}`
+      const instrumentCommand =
+        `${DATADOG_CI_COMMAND} container-app instrument` +
+        ` -s "${subscriptionId}"` +
+        ` -g "${resourceGroup}"` +
+        ` -n "${appName}"` +
+        ` --service "${appName}"` +
+        ` --env e2e` +
+        ` --version "${runId}"` +
+        ` --extra-tags "one_e2e_run_id:${runId}"` +
+        ` --tracing inject` +
+        ` --language "${language}"` +
+        ` --no-source-code-integration`
+      const expectation = {applicationImage, tracerRepository, nativeEnv, runId}
+
+      let lifecycleError: Error | undefined
+      let cleanupError: Error | undefined
+      try {
+        const create = await execPromiseWithRetries(
+          `az containerapp create` +
+            ` --name "${appName}"` +
+            ` --resource-group "${resourceGroup}"` +
+            ` --environment "${process.env.AZURE_CONTAINER_APP_ENV}"` +
+            ` --image "${applicationImage}"` +
+            ` --cpu 0.25 --memory 0.5Gi` +
+            ` --min-replicas 0 --max-replicas 1` +
+            ` --ingress external --target-port 8080` +
+            ` --tags one_e2e_created=${Math.floor(Date.now() / 1000)}` +
+            ` --output none`
+        )
+        assertCommandSucceeded('create', create)
+
+        const instrument = await execPromiseWithRetries(instrumentCommand, {
+          DD_API_KEY: process.env.DATADOG_API_KEY,
+        })
+        assertCommandSucceeded('instrument', instrument)
+        verifySsiInstrumented(appName, resourceGroup, subscriptionId, expectation)
+
+        const appUrl = getContainerAppUrl(appName, resourceGroup, subscriptionId)
+        const [traffic, telemetry] = await Promise.allSettled([
+          triggerTraffic(appUrl, {attempts: 20, requiredSuccesses: 10, intervalSeconds: 10}),
+          checkTelemetryFlowing(
+            {
+              serviceName: appName,
+              env: 'e2e',
+              version: runId,
+              tags: [`one_e2e_run_id:${runId}`],
+            },
+            {checkLogs: false}
+          ),
+        ])
+        if (traffic.status === 'rejected') {
+          throw traffic.reason
+        }
+        if (telemetry.status === 'rejected') {
+          throw telemetry.reason
+        }
+
+        const retry = await execPromiseWithRetries(instrumentCommand, {
+          DD_API_KEY: process.env.DATADOG_API_KEY,
+        })
+        assertCommandSucceeded('re-instrument', retry)
+        verifySsiInstrumented(appName, resourceGroup, subscriptionId, expectation)
+
+        const uninstrument = await execPromiseWithRetries(
+          `${DATADOG_CI_COMMAND} container-app uninstrument` +
+            ` -s "${subscriptionId}"` +
+            ` -g "${resourceGroup}"` +
+            ` -n "${appName}"`,
+          {DD_API_KEY: process.env.DATADOG_API_KEY}
+        )
+        assertCommandSucceeded('uninstrument', uninstrument)
+        verifyUninstrumented(appName, resourceGroup, subscriptionId, nativeEnv)
+      } catch (error) {
+        lifecycleError = error instanceof Error ? error : new Error(String(error))
+      } finally {
+        const cleanup = await execPromiseWithRetries(
+          `az containerapp delete --name "${appName}" --resource-group "${resourceGroup}" --yes --output none`
+        )
+        if (cleanup.exitCode !== 0) {
+          const output = [cleanup.stderr, cleanup.stdout].filter(Boolean).join('\n') || 'no command output'
+          cleanupError = new Error(`Failed to delete container app (exit code ${cleanup.exitCode}): ${output}`)
+        }
+      }
+
+      if (lifecycleError && cleanupError) {
+        throw new Error(`${String(lifecycleError)}\n${cleanupError.message}`)
+      }
+      if (cleanupError) {
+        throw cleanupError
+      }
+      if (lifecycleError) {
+        throw lifecycleError
+      }
+    },
+    1_200_000
+  )
+
+  it('detects Node.js, injects its tracer, and removes the composite', async () => {
+    const applicationImage = SSI_CASES.find(({language}) => language === 'nodejs')!.applicationImage
     const runId = crypto.randomBytes(4).toString('hex')
-    const appName = `${appNamePrefix}-${runId}`
+    const appName = `one-e2e-capp-ssi-auto-${runId}`
     const instrumentCommand =
       `${DATADOG_CI_COMMAND} container-app instrument` +
       ` -s "${subscriptionId}"` +
@@ -66,11 +152,10 @@ describeOrSkip('container-app automatic APM instrumentation', () => {
       ` --version "${runId}"` +
       ` --extra-tags "one_e2e_run_id:${runId}"` +
       ` --tracing inject` +
-      extraArgs +
       ` --no-source-code-integration`
+
     let lifecycleError: Error | undefined
     let cleanupError: Error | undefined
-
     try {
       const create = await execPromiseWithRetries(
         `az containerapp create` +
@@ -86,12 +171,9 @@ describeOrSkip('container-app automatic APM instrumentation', () => {
       )
       assertCommandSucceeded('create', create)
 
-      const instrument = async () => {
-        const result = await execPromiseWithRetries(instrumentCommand, {DD_API_KEY: process.env.DATADOG_API_KEY})
-        assertCommandSucceeded('instrument', result)
-        verify(appName, resourceGroup, subscriptionId, runId)
-      }
-      await instrument()
+      const instrument = await execPromiseWithRetries(instrumentCommand, {DD_API_KEY: process.env.DATADOG_API_KEY})
+      assertCommandSucceeded('instrument', instrument)
+      verifyMultiLanguageSsiInstrumented(appName, resourceGroup, subscriptionId, runId, applicationImage)
 
       const appUrl = getContainerAppUrl(appName, resourceGroup, subscriptionId)
       const [traffic, telemetry] = await Promise.allSettled([
@@ -108,10 +190,6 @@ describeOrSkip('container-app automatic APM instrumentation', () => {
         throw telemetry.reason
       }
 
-      if (retry) {
-        await instrument()
-      }
-
       const uninstrument = await execPromiseWithRetries(
         `${DATADOG_CI_COMMAND} container-app uninstrument` +
           ` -s "${subscriptionId}"` +
@@ -120,7 +198,7 @@ describeOrSkip('container-app automatic APM instrumentation', () => {
         {DD_API_KEY: process.env.DATADOG_API_KEY}
       )
       assertCommandSucceeded('uninstrument', uninstrument)
-      verifyUninstrumented(appName, resourceGroup, subscriptionId, nativeEnv)
+      verifyUninstrumented(appName, resourceGroup, subscriptionId)
     } catch (error) {
       lifecycleError = error instanceof Error ? error : new Error(String(error))
     } finally {
@@ -142,31 +220,5 @@ describeOrSkip('container-app automatic APM instrumentation', () => {
     if (lifecycleError) {
       throw lifecycleError
     }
-  }
-
-  it.concurrent.each(SSI_CASES)(
-    'injects, retries, traces, and removes the $language tracer',
-    (ssiCase) =>
-      runSsiLifecycle({
-        ...ssiCase,
-        appNamePrefix: `one-e2e-capp-ssi-${ssiCase.language}`,
-        extraArgs: ` --language ${ssiCase.language}`,
-        retry: true,
-        verify: (appName, rg, sub, runId) => verifySsiInstrumented(appName, rg, sub, {...ssiCase, runId}),
-      }),
-    1_200_000
-  )
-
-  it(
-    'detects Node.js, injects its tracer, and removes the composite',
-    () =>
-      runSsiLifecycle({
-        appNamePrefix: 'one-e2e-capp-ssi-auto',
-        applicationImage: SSI_CASES[2].applicationImage,
-        retry: false,
-        verify: (appName, rg, sub, runId) =>
-          verifyMultiLanguageSsiInstrumented(appName, rg, sub, runId, SSI_CASES[2].applicationImage),
-      }),
-    1_200_000
-  )
+  }, 1_200_000)
 })

--- a/e2e/serverless/container-app/container-app-verifier.ts
+++ b/e2e/serverless/container-app/container-app-verifier.ts
@@ -34,6 +34,11 @@ const SHARED_VOLUME_NAME = 'shared-volume'
 const DD_API_KEY_SECRET_NAME = 'dd-api-key'
 const TRACER_NAME = 'datadog-tracer'
 const TRACER_MOUNT_PATH = '/datadog-lib'
+const COMPOSITE_TRACER_MOUNT_PATH = '/opt/datadog-packages'
+const COMPOSITE_TRACER_IMAGE = 'datadoghq.azurecr.io/dd-lib-composite-init:latest'
+const COMPOSITE_PRELOAD = `${COMPOSITE_TRACER_MOUNT_PATH}/datadog-apm-inject/stable/inject/launcher.preload.so`
+const NODE_TRACER_IMAGE = 'datadoghq.azurecr.io/dd-lib-js-init:latest'
+const NODE_OPTIONS_FRAGMENT = '--require /datadog-lib/node_modules/dd-trace/init.js'
 const INJECTION_MODE_TAG = '_dd.injection.mode:serverless-single-lang'
 const EXPECTED_ENV = 'e2e'
 const REQUIRED_ENV_VARS = [
@@ -235,6 +240,52 @@ export const verifySsiInstrumented = (
   expect(tags.one_e2e_created).toBeDefined()
 }
 
+export const verifyMultiLanguageSsiInstrumented = (
+  appName: string,
+  resourceGroup: string,
+  subscriptionId: string,
+  runId: string,
+  applicationImage: string
+): void => {
+  console.log(`Fetching container app "${appName}"...`)
+  const app = getContainerApp(appName, resourceGroup, subscriptionId)
+  const template = app.properties.template
+  const containers = template.containers ?? []
+  const initContainers = template.initContainers ?? []
+  const volumes = template.volumes ?? []
+  const tags = app.tags ?? {}
+
+  const sidecar = containers.find(({name}) => name === SIDECAR_NAME)
+  expect(sidecar).toBeDefined()
+  const applicationContainers = containers.filter(({name}) => name !== SIDECAR_NAME)
+  expect(applicationContainers).toHaveLength(1)
+  const application = applicationContainers[0]
+  expect(application.image).toBe(applicationImage)
+
+  expect(initContainers.filter(({name}) => name === TRACER_NAME)).toEqual([
+    expect.objectContaining({
+      image: COMPOSITE_TRACER_IMAGE,
+      command: ['/datadog-init/copy-lib.sh'],
+      args: [COMPOSITE_TRACER_MOUNT_PATH],
+      resources: expect.objectContaining({cpu: 0.25, memory: '0.5Gi'}),
+      volumeMounts: [{volumeName: TRACER_NAME, mountPath: COMPOSITE_TRACER_MOUNT_PATH}],
+    }),
+  ])
+  expect(volumes.filter(({name}) => name === TRACER_NAME)).toEqual([expect.objectContaining({storageType: 'EmptyDir'})])
+  expect(application.volumeMounts?.filter(({volumeName}) => volumeName === TRACER_NAME)).toEqual([
+    {volumeName: TRACER_NAME, mountPath: COMPOSITE_TRACER_MOUNT_PATH},
+  ])
+  expect(sidecar!.volumeMounts ?? []).not.toContainEqual(expect.objectContaining({volumeName: TRACER_NAME}))
+
+  const env = envByName(application)
+  expect(env.DD_TRACE_ENABLED.value).toBe('true')
+  expect(env.LD_PRELOAD.value?.split(COMPOSITE_PRELOAD)).toHaveLength(2)
+  expect(env.DD_INJECT_SENDER_TYPE.value).toBe('serverless')
+  expect(env.DD_TAGS.value).toContain(`one_e2e_run_id:${runId}`)
+  expect(env.DD_TAGS.value).not.toContain(INJECTION_MODE_TAG)
+  expect(tags.dd_sls_injection_mode).toBe('multi_language')
+}
+
 export const verifyUninstrumented = (
   appName: string,
   resourceGroup: string,
@@ -266,6 +317,11 @@ export const verifyUninstrumented = (
     const ddVars = env.filter((e) => e.name.startsWith('DD_'))
     expect(ddVars).toHaveLength(0)
     expect(container.volumeMounts ?? []).not.toContainEqual(expect.objectContaining({volumeName: TRACER_NAME}))
+    expect(container.volumeMounts ?? []).not.toContainEqual(
+      expect.objectContaining({mountPath: COMPOSITE_TRACER_MOUNT_PATH})
+    )
+    expect(env.find(({name}) => name === 'NODE_OPTIONS')?.value ?? '').not.toContain(NODE_OPTIONS_FRAGMENT)
+    expect(env.find(({name}) => name === 'LD_PRELOAD')?.value ?? '').not.toContain(COMPOSITE_PRELOAD)
     if (nativeEnv) {
       expect(env.find(({name}) => name === nativeEnv.name)?.value ?? '').not.toContain(nativeEnv.fragment)
     }

--- a/e2e/serverless/container-app/container-app-verifier.ts
+++ b/e2e/serverless/container-app/container-app-verifier.ts
@@ -37,7 +37,6 @@ const TRACER_MOUNT_PATH = '/datadog-lib'
 const COMPOSITE_TRACER_MOUNT_PATH = '/opt/datadog-packages'
 const COMPOSITE_TRACER_IMAGE = 'datadoghq.azurecr.io/dd-lib-composite-init:latest'
 const COMPOSITE_PRELOAD = `${COMPOSITE_TRACER_MOUNT_PATH}/datadog-apm-inject/stable/inject/launcher.preload.so`
-const NODE_TRACER_IMAGE = 'datadoghq.azurecr.io/dd-lib-js-init:latest'
 const NODE_OPTIONS_FRAGMENT = '--require /datadog-lib/node_modules/dd-trace/init.js'
 const INJECTION_MODE_TAG = '_dd.injection.mode:serverless-single-lang'
 const EXPECTED_ENV = 'e2e'
@@ -276,14 +275,25 @@ export const verifyMultiLanguageSsiInstrumented = (
     {volumeName: TRACER_NAME, mountPath: COMPOSITE_TRACER_MOUNT_PATH},
   ])
   expect(sidecar!.volumeMounts ?? []).not.toContainEqual(expect.objectContaining({volumeName: TRACER_NAME}))
+  expect(sidecar!.volumeMounts ?? []).not.toContainEqual(
+    expect.objectContaining({mountPath: COMPOSITE_TRACER_MOUNT_PATH})
+  )
+
+  verifyDatadogEnv(containers, appName, runId)
 
   const env = envByName(application)
-  expect(env.DD_TRACE_ENABLED.value).toBe('true')
+  const sidecarEnv = envByName(sidecar!)
   expect(env.LD_PRELOAD.value?.split(COMPOSITE_PRELOAD)).toHaveLength(2)
   expect(env.DD_INJECT_SENDER_TYPE.value).toBe('serverless')
-  expect(env.DD_TAGS.value).toContain(`one_e2e_run_id:${runId}`)
   expect(env.DD_TAGS.value).not.toContain(INJECTION_MODE_TAG)
+  expect(sidecarEnv.LD_PRELOAD?.value ?? '').not.toContain(COMPOSITE_PRELOAD)
+  expect(sidecarEnv.DD_INJECT_SENDER_TYPE).toBeUndefined()
+  expect(tags.service).toBe(appName)
+  expect(tags.env).toBe(EXPECTED_ENV)
+  expect(tags.version).toBe(runId)
+  expect(tags.dd_sls_ci).toBeDefined()
   expect(tags.dd_sls_injection_mode).toBe('multi_language')
+  expect(tags.one_e2e_created).toBeDefined()
 }
 
 export const verifyUninstrumented = (

--- a/e2e/serverless/container-app/container-app-verifier.ts
+++ b/e2e/serverless/container-app/container-app-verifier.ts
@@ -15,6 +15,7 @@ interface ContainerApp {
         name: string
         image: string
         env?: {name: string; value?: string; secretRef?: string}[]
+        resources?: {cpu?: number; memory?: string}
         volumeMounts?: {volumeName: string; mountPath?: string}[]
       }[]
       volumes?: {name: string; storageType: string}[]
@@ -256,10 +257,12 @@ export const verifyMultiLanguageSsiInstrumented = (
 
   const sidecar = containers.find(({name}) => name === SIDECAR_NAME)
   expect(sidecar).toBeDefined()
+  expect(sidecar?.resources).toEqual(expect.objectContaining({cpu: 0.25, memory: '0.5Gi'}))
   const applicationContainers = containers.filter(({name}) => name !== SIDECAR_NAME)
   expect(applicationContainers).toHaveLength(1)
   const application = applicationContainers[0]
   expect(application.image).toBe(applicationImage)
+  expect(application.resources).toEqual(expect.objectContaining({cpu: 0.25, memory: '0.5Gi'}))
 
   expect(initContainers.filter(({name}) => name === TRACER_NAME)).toEqual([
     expect.objectContaining({

--- a/packages/base/src/commands/container-app/instrument.ts
+++ b/packages/base/src/commands/container-app/instrument.ts
@@ -68,21 +68,21 @@ export class ContainerAppInstrumentCommand extends ContainerAppCommand {
   })
   private tracing: ContainerAppConfigOptions['tracing'] = Option.String('--tracing', {
     description:
-      'Configure APM instrumentation. Use `manual` when the tracer is installed, `inject` with `--language` for automatic instrumentation, or `disabled` to turn tracing off. Defaults to `manual`.',
+      'Configure APM instrumentation. Use `manual` when the tracer is installed, `inject` to detect the language and add a tracer automatically, or `disabled` to turn tracing off. Add `--language` with `inject` to select one tracer. Defaults to `manual`.',
     validator: t.isEnum(TRACING_MODES),
   })
   private language: ContainerAppConfigOptions['language'] = Option.String('--language', {
-    description: `Set the application language for log parsing. With \`--tracing inject\`, this selects a supported tracer. Supported injection values: ${TRACER_INJECTION_LANGUAGES.map(
+    description: `Set the application language for log parsing. With \`--tracing inject\`, this selects one tracer instead of detecting the language automatically. Supported injection values: ${TRACER_INJECTION_LANGUAGES.map(
       (language) => `\`${language}\``
     ).join(', ')}.`,
     validator: t.cascade(t.isString(), t.matchesRegExp(/.+/)),
   })
   private tracerVersion = Option.String('--tracer-version', {
-    description: `Set the tracer image tag for automatic instrumentation. Defaults to '${DEFAULT_TRACER_VERSION}'.`,
+    description: `Set the tracer image tag for automatic instrumentation with \`--language\`. Defaults to '${DEFAULT_TRACER_VERSION}'.`,
     validator: t.cascade(t.isString(), t.matchesRegExp(TRACER_IMAGE_TAG_REG_EXP)),
   })
   private tracerLibc: ContainerAppConfigOptions['tracerLibc'] = Option.String('--tracer-libc', {
-    description: `Set the C standard library used by the application image. Possible values: ${LIBCS.map(
+    description: `Set the C standard library used by the application image with \`--language\`. Possible values: ${LIBCS.map(
       (libc) => `"${libc}"`
     ).join(', ')}. Defaults to '${DEFAULT_TRACER_LIBC}'.`,
     validator: t.isEnum(LIBCS),

--- a/packages/base/src/helpers/serverless/__tests__/ssi/tracer.test.ts
+++ b/packages/base/src/helpers/serverless/__tests__/ssi/tracer.test.ts
@@ -1,9 +1,9 @@
 import {
-  SINGLE_LANGUAGE_TRACER_REGISTRIES,
+  TRACER_REGISTRIES,
   buildSingleLanguageTracerImage,
   getTracerCopyCompletionMarker,
   type Language,
-  type SingleLanguageTracerRegistry,
+  type TracerRegistry,
   type TracerLanguage,
 } from '@datadog/datadog-ci-base/helpers/serverless/ssi/tracer'
 
@@ -22,7 +22,7 @@ const languageCases: {
 
 describe('language and image metadata', () => {
   test.each(
-    SINGLE_LANGUAGE_TRACER_REGISTRIES.flatMap((registry) =>
+    TRACER_REGISTRIES.flatMap((registry) =>
       languageCases.map(({language, tracerLanguage}) => ({registry, language, tracerLanguage}))
     )
   )('builds the $registry $tracerLanguage image for $language', ({registry, language, tracerLanguage}) => {
@@ -47,7 +47,7 @@ describe('language and image metadata', () => {
   test.each(['docker.io/datadog', 'gcr.io/datadoghq/', '', ' public.ecr.aws/datadog'])(
     'rejects registry %p',
     (registry) => {
-      expect(() => buildSingleLanguageTracerImage(registry as SingleLanguageTracerRegistry, 'java', 'latest')).toThrow(
+      expect(() => buildSingleLanguageTracerImage(registry as TracerRegistry, 'java', 'latest')).toThrow(
         'Unsupported tracer registry'
       )
     }

--- a/packages/base/src/helpers/serverless/ssi/composite.ts
+++ b/packages/base/src/helpers/serverless/ssi/composite.ts
@@ -1,0 +1,28 @@
+import type {EnvFragment} from './env'
+import type {TracerRegistry} from './tracer'
+
+export const COMPOSITE_TRACER_MOUNT_PATH = '/opt/datadog-packages'
+export const COMPOSITE_TRACER_COMPLETION_MARKER = `${COMPOSITE_TRACER_MOUNT_PATH}/.datadog-composite-copy-finished`
+
+export interface CompositeInjectionSpec {
+  readonly image: string
+  readonly mountPath: string
+  readonly completionMarker: string
+  readonly env: readonly EnvFragment[]
+}
+
+/** Builds the shared composite image and activation contract for a cloud registry. */
+export const getCompositeInjectionSpec = (registry: TracerRegistry): CompositeInjectionSpec => ({
+  image: `${registry}/dd-lib-composite-init:latest`,
+  mountPath: COMPOSITE_TRACER_MOUNT_PATH,
+  completionMarker: COMPOSITE_TRACER_COMPLETION_MARKER,
+  env: [
+    {
+      name: 'LD_PRELOAD',
+      value: `${COMPOSITE_TRACER_MOUNT_PATH}/datadog-apm-inject/stable/inject/launcher.preload.so`,
+      separator: ' ',
+      mode: 'prepend',
+    },
+    {name: 'DD_INJECT_SENDER_TYPE', value: 'serverless', mode: 'set-if-absent'},
+  ],
+})

--- a/packages/base/src/helpers/serverless/ssi/composite.ts
+++ b/packages/base/src/helpers/serverless/ssi/composite.ts
@@ -2,12 +2,10 @@ import type {EnvFragment} from './env'
 import type {TracerRegistry} from './tracer'
 
 export const COMPOSITE_TRACER_MOUNT_PATH = '/opt/datadog-packages'
-export const COMPOSITE_TRACER_COMPLETION_MARKER = `${COMPOSITE_TRACER_MOUNT_PATH}/.datadog-composite-copy-finished`
 
 export interface CompositeInjectionSpec {
   readonly image: string
   readonly mountPath: string
-  readonly completionMarker: string
   readonly env: readonly EnvFragment[]
 }
 
@@ -15,7 +13,6 @@ export interface CompositeInjectionSpec {
 export const getCompositeInjectionSpec = (registry: TracerRegistry): CompositeInjectionSpec => ({
   image: `${registry}/dd-lib-composite-init:latest`,
   mountPath: COMPOSITE_TRACER_MOUNT_PATH,
-  completionMarker: COMPOSITE_TRACER_COMPLETION_MARKER,
   env: [
     {
       name: 'LD_PRELOAD',

--- a/packages/base/src/helpers/serverless/ssi/injection-spec.ts
+++ b/packages/base/src/helpers/serverless/ssi/injection-spec.ts
@@ -4,7 +4,7 @@ import type {EnvFragment} from './env'
 
 import {gt, valid} from 'semver'
 
-import {buildSingleLanguageTracerImage, type Language, type SingleLanguageTracerRegistry} from './tracer'
+import {buildSingleLanguageTracerImage, type Language, type TracerRegistry} from './tracer'
 
 export const DEFAULT_TRACER_ROOT = '/datadog-lib'
 export const DEFAULT_TRACER_LIBC = 'glibc' as const
@@ -23,7 +23,7 @@ export interface LanguageInjectionSpec {
 
 export interface LanguageInjectionOptions {
   readonly language: Language
-  readonly registry: SingleLanguageTracerRegistry
+  readonly registry: TracerRegistry
   readonly version: string
   readonly libc: Libc
   readonly root?: string

--- a/packages/base/src/helpers/serverless/ssi/tracer.ts
+++ b/packages/base/src/helpers/serverless/ssi/tracer.ts
@@ -4,7 +4,8 @@ export const SINGLE_LANGUAGE_TRACER_REGISTRIES = [
   'datadoghq.azurecr.io',
 ] as const
 
-export type SingleLanguageTracerRegistry = (typeof SINGLE_LANGUAGE_TRACER_REGISTRIES)[number]
+export type TracerRegistry = (typeof SINGLE_LANGUAGE_TRACER_REGISTRIES)[number]
+export type SingleLanguageTracerRegistry = TracerRegistry
 
 export const LANGUAGE_METADATA = {
   java: {tracerLanguage: 'java', repository: 'dd-trace-java'},

--- a/packages/base/src/helpers/serverless/ssi/tracer.ts
+++ b/packages/base/src/helpers/serverless/ssi/tracer.ts
@@ -1,11 +1,6 @@
-export const SINGLE_LANGUAGE_TRACER_REGISTRIES = [
-  'gcr.io/datadoghq',
-  'public.ecr.aws/datadog',
-  'datadoghq.azurecr.io',
-] as const
+export const TRACER_REGISTRIES = ['gcr.io/datadoghq', 'public.ecr.aws/datadog', 'datadoghq.azurecr.io'] as const
 
-export type TracerRegistry = (typeof SINGLE_LANGUAGE_TRACER_REGISTRIES)[number]
-export type SingleLanguageTracerRegistry = TracerRegistry
+export type TracerRegistry = (typeof TRACER_REGISTRIES)[number]
 
 export const LANGUAGE_METADATA = {
   java: {tracerLanguage: 'java', repository: 'dd-trace-java'},
@@ -32,11 +27,11 @@ export const getTracerCopyCompletionMarker = (language: Language, mountPath: str
   `${mountPath}/.${LANGUAGE_METADATA[language].repository}-copy-finished`
 
 export const buildSingleLanguageTracerImage = (
-  registry: SingleLanguageTracerRegistry,
+  registry: TracerRegistry,
   language: Language,
   version: string
 ): string => {
-  if (!(SINGLE_LANGUAGE_TRACER_REGISTRIES as readonly string[]).includes(registry)) {
+  if (!(TRACER_REGISTRIES as readonly string[]).includes(registry)) {
     throw new Error(`Unsupported tracer registry: ${String(registry)}`)
   }
   if (!Object.prototype.hasOwnProperty.call(LANGUAGE_METADATA, language)) {

--- a/packages/plugin-container-app/README.md
+++ b/packages/plugin-container-app/README.md
@@ -35,7 +35,14 @@ datadog-ci container-app instrument \
   --env prod \
   --version 1.0.0
 
-# Add a Python tracer automatically
+# Detect the application language and add its tracer automatically
+datadog-ci container-app instrument \
+  --subscription-id <subscription-id> \
+  --resource-group <resource-group-name> \
+  --name <container-app-name> \
+  --tracing inject
+
+# Add only the Python tracer
 datadog-ci container-app instrument \
   --subscription-id <subscription-id> \
   --resource-group <resource-group-name> \
@@ -53,11 +60,13 @@ datadog-ci container-app instrument \
 
 ### Automatic APM instrumentation
 
-Use `--tracing inject --language <language>` to add a tracer without rebuilding the application image. Supported language values are `java`, `nodejs`, `csharp`, `python`, `ruby`, and `php`. The command copies the tracer through an init container and keeps the Datadog sidecar for trace transport.
+Use `--tracing inject` to detect the application language and add its tracer without rebuilding the application image. Add `--language <language>` to copy only one tracer. Supported language values are `java`, `nodejs`, `csharp`, `python`, `ruby`, and `php`. The command copies the tracer through an init container and keeps the Datadog sidecar for trace transport.
 
-Tracer injection uses the `latest` tracer version and `glibc` by default. Use `--tracer-version` to pin an image tag, or `--tracer-libc musl` for a musl-based image. Ruby injection does not support musl, and .NET tracer versions before 3.0 are not supported. Runtime support follows the [APM compatibility requirements](https://docs.datadoghq.com/tracing/trace_collection/compatibility/); `latest` can drop runtimes after they reach end of life.
+`--tracer-version` and `--tracer-libc` require `--language`. Single-language injection uses the `latest` tracer version and `glibc` by default. Ruby injection does not support musl, and .NET tracer versions before 3.0 are not supported. Runtime support follows the [APM compatibility requirements](https://docs.datadoghq.com/tracing/trace_collection/compatibility/); `latest` can drop runtimes after they reach end of life.
 
-Automatic instrumentation can increase cold-start delays when the app scales to zero. For scale-to-zero workloads, install the tracer in the application image, and use `--tracing manual`.
+Go tracers cannot be injected. Install `dd-trace-go` in the application image, and use `--tracing manual`.
+
+Automatic instrumentation can increase cold-start delays when the app scales to zero. Automatic language detection copies a larger composite tracer image than selecting one language. For scale-to-zero workloads, install the tracer in the application image, and use `--tracing manual`.
 
 For a Container App with multiple application containers, use `--container-name` to select one container. This differs from `--name`, which selects the Container App resource.
 
@@ -146,10 +155,10 @@ You can pass the following arguments to `instrument` to specify its behavior. Va
 | `--sidecar-cpu` |  | The number of CPUs to allocate to the sidecar container. | `0.5` |
 | `--sidecar-memory` |  | The amount of memory (in GiB) to allocate to the sidecar container. | `1` |
 | `--sidecar-image` |  | Override to pin a specific version tag or to use a mirrored image from a custom registry (e.g., ACR) to avoid pull rate limits. | `index.docker.io/datadog/serverless-init:latest` |
-| `--tracing` |  | Configure APM instrumentation. Use `manual` when the tracer is installed, `inject` with `--language` for automatic instrumentation, or `disabled` to turn tracing off. Defaults to `manual`. |  |
-| `--language` |  | Set the application language for log parsing. With `--tracing inject`, this selects a supported tracer. Supported injection values: `java`, `nodejs`, `csharp`, `python`, `ruby`, `php`. |  |
-| `--tracer-version` |  | Set the tracer image tag for automatic instrumentation. | `latest` |
-| `--tracer-libc` |  | Set the C standard library used by the application image. Possible values: "glibc", "musl". | `glibc` |
+| `--tracing` |  | Configure APM instrumentation. Use `manual` when the tracer is installed, `inject` to detect the language and add a tracer automatically, or `disabled` to turn tracing off. Add `--language` with `inject` to select one tracer. Defaults to `manual`. |  |
+| `--language` |  | Set the application language for log parsing. With `--tracing inject`, this selects one tracer instead of detecting the language automatically. Supported injection values: `java`, `nodejs`, `csharp`, `python`, `ruby`, `php`. |  |
+| `--tracer-version` |  | Set the tracer image tag for automatic instrumentation with `--language`. | `latest` |
+| `--tracer-libc` |  | Set the C standard library used by the application image with `--language`. Possible values: "glibc", "musl". | `glibc` |
 | `--container-name` |  | Select the application container to instrument when the Container App has multiple application containers. |  |
 | `--source-code-integration` or `--sourceCodeIntegration` |  | Whether to enable the Datadog Source Code integration. This tags your service(s) with the Git repository and the latest commit hash of the local directory. Specify `--no-source-code-integration` to disable. | `true` |
 | `--upload-git-metadata` or `--uploadGitMetadata` |  | Whether to enable Git metadata uploading, as a part of the source code integration. Git metadata uploading is only required if you don't have the Datadog GitHub integration installed. Specify `--no-upload-git-metadata` to disable. | `true` |

--- a/packages/plugin-container-app/src/__tests__/instrument.test.ts
+++ b/packages/plugin-container-app/src/__tests__/instrument.test.ts
@@ -41,7 +41,7 @@ import {DefaultAzureCredential} from '@azure/identity'
 import {makeRunCLI} from '@datadog/datadog-ci-base/helpers/__tests__/testing-tools'
 
 import {PluginCommand as InstrumentCommand} from '../commands/instrument'
-import {SINGLE_LANGUAGE_SSI_MODE, SSI_INJECTION_MODE_TAG} from '../ssi'
+import {MULTI_LANGUAGE_SSI_MODE, SINGLE_LANGUAGE_SSI_MODE, SSI_INJECTION_MODE_TAG} from '../ssi'
 
 import {
   CONTAINER_APP_ID,
@@ -236,7 +236,7 @@ Ensure you copied the value and not the Key ID.
     })
 
     test.each<[string[], string]>([
-      [['--tracing', 'inject'], '--tracing inject requires --language'],
+      [['--tracing', 'inject', '--tracer-version', '1.2.3'], '--tracer-version'],
       [
         ['--tracing', 'inject', '--language', 'nodejs', '--shared-volume-name', 'datadog-tracer'],
         '--shared-volume-name',
@@ -270,7 +270,7 @@ Ensure you copied the value and not the Key ID.
 
       expect(code).toBe(0)
       expect(context.stdout.toString()).toContain(
-        'Tracing defaults to manual for my-container-app. Use --tracing inject --language <language> to retain automatic tracer injection.'
+        'Tracing defaults to manual for my-container-app. Use --tracing inject to retain automatic tracer injection.'
       )
     })
 
@@ -1474,7 +1474,7 @@ Ensure you copied the value and not the Key ID.
     test('Continues after a tracer tag update failure without duplicating configuration', async () => {
       updateTags.mockClear().mockRejectedValueOnce(new Error('tag update error'))
 
-      const first = await runCLI([...DEFAULT_INSTRUMENT_ARGS, '--tracing', 'inject', '--language', 'nodejs'])
+      const first = await runCLI([...DEFAULT_INSTRUMENT_ARGS, '--tracing', 'inject'])
       expect(first.code).toEqual(0)
       expect(first.context.stdout.toString()).toContain(
         '[Error] Failed to update tags for my-container-app: Error: tag update error'
@@ -1486,7 +1486,7 @@ Ensure you copied the value and not the Key ID.
       containerAppsOperations.beginUpdateAndWait.mockClear()
       updateTags.mockResolvedValue({})
 
-      const retry = await runCLI([...DEFAULT_INSTRUMENT_ARGS, '--tracing', 'inject', '--language', 'nodejs'])
+      const retry = await runCLI([...DEFAULT_INSTRUMENT_ARGS, '--tracing', 'inject'])
       expect(retry.code).toEqual(0)
       expect(containerAppsOperations.beginUpdateAndWait).not.toHaveBeenCalled()
       expect(updateTags).toHaveBeenLastCalledWith(CONTAINER_APP_ID, {
@@ -1494,7 +1494,7 @@ Ensure you copied the value and not the Key ID.
           tags: {
             service: 'my-container-app',
             dd_sls_ci: 'vXXXX',
-            dd_sls_injection_mode: 'single_language',
+            dd_sls_injection_mode: MULTI_LANGUAGE_SSI_MODE,
           },
         },
       })

--- a/packages/plugin-container-app/src/__tests__/instrument.test.ts
+++ b/packages/plugin-container-app/src/__tests__/instrument.test.ts
@@ -260,6 +260,38 @@ Ensure you copied the value and not the Key ID.
       expect(containerAppsOperations.get).not.toHaveBeenCalled()
     })
 
+    test('Rejects composite injection before updating an insufficient final configuration', async () => {
+      containerAppsOperations.get.mockResolvedValue({
+        ...DEFAULT_CONTAINER_APP,
+        template: {
+          ...DEFAULT_CONTAINER_APP.template,
+          containers: [
+            {
+              ...DEFAULT_CONTAINER_APP.template!.containers![0],
+              resources: {cpu: 0.125, memory: '0.5Gi'},
+            },
+          ],
+        },
+      })
+
+      const {code, context} = await runCLI([
+        ...DEFAULT_INSTRUMENT_ARGS,
+        '--tracing',
+        'inject',
+        '--sidecar-cpu',
+        '0.125',
+        '--sidecar-memory',
+        '0.5',
+      ])
+
+      expect(code).toBe(1)
+      expect(context.stdout.toString()).toContain(
+        'requires at least 2 GiB of replica ephemeral storage, but the final configuration provides the 1-GiB tier'
+      )
+      expect(containerAppsOperations.beginUpdateAndWait).not.toHaveBeenCalled()
+      expect(updateTags).not.toHaveBeenCalled()
+    })
+
     test('Warns when omitted tracing removes automatic injection', async () => {
       containerAppsOperations.get.mockResolvedValue({
         ...DEFAULT_CONTAINER_APP,

--- a/packages/plugin-container-app/src/__tests__/ssi.test.ts
+++ b/packages/plugin-container-app/src/__tests__/ssi.test.ts
@@ -5,6 +5,10 @@ import type {Language} from '@datadog/datadog-ci-base/helpers/serverless/ssi/tra
 import {createCommand} from '@datadog/datadog-ci-base/helpers/__tests__/testing-tools'
 import {DD_TRACE_ENABLED_ENV_VAR} from '@datadog/datadog-ci-base/helpers/serverless/constants'
 import {
+  COMPOSITE_TRACER_MOUNT_PATH,
+  getCompositeInjectionSpec,
+} from '@datadog/datadog-ci-base/helpers/serverless/ssi/composite'
+import {
   TRACER_CONTAINER_NAME,
   TRACER_MOUNT_PATH,
   TRACER_VOLUME_NAME,
@@ -13,11 +17,14 @@ import {SINGLE_LANGUAGE_INJECTION_MODE_TAG} from '@datadog/datadog-ci-base/helpe
 
 import {PluginCommand as InstrumentCommand} from '../commands/instrument'
 import {
+  CONTAINER_APP_TRACER_REGISTRY,
+  MULTI_LANGUAGE_SSI_MODE,
   SINGLE_LANGUAGE_SSI_MODE,
   SSI_INJECTION_MODE_TAG,
   hasSsi,
+  mergeCompositeInjectionEnv,
   mergeLanguageInjectionEnv,
-  removeLanguageInjectionEnv,
+  removeInjectionEnv,
   resolveSsiConfig,
   selectApplicationContainer,
 } from '../ssi'
@@ -31,6 +38,9 @@ const injectConfig = (language: ContainerAppConfigOptions['language'] = 'nodejs'
   tracing: 'inject',
   language,
 })
+
+const multiLanguageConfig = (): ContainerAppConfigOptions => ({...injectConfig(), language: undefined})
+const compositeSpec = getCompositeInjectionSpec(CONTAINER_APP_TRACER_REGISTRY)
 
 const getEnv = (env: EnvironmentVar[] | undefined, name: string) => env?.find((variable) => variable.name === name)
 
@@ -54,6 +64,14 @@ describe('Container Apps automatic APM instrumentation', () => {
       })
     })
 
+    test('uses the Azure composite when the language is omitted', () => {
+      expect(resolveSsiConfig(multiLanguageConfig())).toEqual({
+        kind: 'multi-language',
+        spec: compositeSpec,
+        warnings: [],
+      })
+    })
+
     test.each<[Language, string]>([
       ['java', 'java'],
       ['nodejs', 'js'],
@@ -72,7 +90,8 @@ describe('Container Apps automatic APM instrumentation', () => {
     })
 
     test.each([
-      [{tracing: 'inject'}, '--language'],
+      [{tracing: 'inject', tracerVersion: '1.2.3'}, '--tracer-version'],
+      [{tracing: 'inject', tracerLibc: 'musl'}, '--tracer-libc'],
       [{tracing: 'inject', language: 'go'}, 'Install dd-trace-go'],
       [{tracing: 'inject', language: 'dotnet'}, 'supports only these languages'],
       [{tracing: 'inject', language: 'rust'}, 'supports only these languages'],
@@ -141,7 +160,41 @@ describe('Container Apps automatic APM instrumentation', () => {
         '--inspect --require /datadog-lib/node_modules/dd-trace/init.js'
       )
       expect(getEnv(merged, 'DD_TAGS')?.value).toBe(`${SINGLE_LANGUAGE_INJECTION_MODE_TAG},team:serverless`)
-      expect(removeLanguageInjectionEnv(merged)).toEqual(original)
+      expect(removeInjectionEnv(merged)).toEqual(original)
+    })
+
+    test('merges and removes composite activation without replacing another preload', () => {
+      const original = [{name: 'LD_PRELOAD', value: '/customer/preload.so'}]
+      const merged = mergeCompositeInjectionEnv(original, compositeSpec)
+
+      expect(merged).toEqual([
+        {
+          name: 'LD_PRELOAD',
+          value: `${COMPOSITE_TRACER_MOUNT_PATH}/datadog-apm-inject/stable/inject/launcher.preload.so /customer/preload.so`,
+        },
+        {name: 'DD_INJECT_SENDER_TYPE', value: 'serverless'},
+      ])
+      expect(mergeCompositeInjectionEnv(merged, compositeSpec)).toEqual(merged)
+      expect(removeInjectionEnv(merged)).toEqual(original)
+    })
+
+    test.each(['LD_PRELOAD', 'DD_INJECT_SENDER_TYPE'])('rejects unsafe composite environment %s', (name) => {
+      expect(() =>
+        mergeCompositeInjectionEnv(
+          [
+            {name, value: 'first'},
+            {name, value: 'second'},
+          ],
+          compositeSpec
+        )
+      ).toThrow(new RegExp(name))
+      expect(() => mergeCompositeInjectionEnv([{name, secretRef: 'secret'}], compositeSpec)).toThrow(new RegExp(name))
+    })
+
+    test('rejects a conflicting injection sender', () => {
+      expect(() =>
+        mergeCompositeInjectionEnv([{name: 'DD_INJECT_SENDER_TYPE', value: 'customer'}], compositeSpec)
+      ).toThrow(/expected "serverless"/)
     })
 
     test.each([
@@ -204,6 +257,29 @@ describe('Container Apps automatic APM instrumentation', () => {
       ).not.toContainEqual(expect.objectContaining({volumeName: TRACER_VOLUME_NAME}))
     })
 
+    test('adds composite activation to the selected application container', () => {
+      const result = createInstrumentedApp(multiLanguageConfig())
+      const app = result.template!.containers![0]
+
+      expect(getEnv(app.env, 'LD_PRELOAD')?.value).toBe(compositeSpec.env[0].value)
+      expect(getEnv(app.env, 'DD_INJECT_SENDER_TYPE')?.value).toBe('serverless')
+      expect(getEnv(app.env, 'DD_SOURCE')).toBeUndefined()
+      expect(getEnv(app.env, 'DD_TAGS')).toBeUndefined()
+      expect(getEnv(app.env, DD_TRACE_ENABLED_ENV_VAR)?.value).toBe('true')
+      expect(result.template?.initContainers).toContainEqual({
+        name: TRACER_CONTAINER_NAME,
+        image: 'datadoghq.azurecr.io/dd-lib-composite-init:latest',
+        command: ['/datadog-init/copy-lib.sh'],
+        args: [COMPOSITE_TRACER_MOUNT_PATH],
+        resources: {cpu: 0.25, memory: '0.5Gi', ephemeralStorage: '1Gi'},
+        volumeMounts: [{volumeName: TRACER_VOLUME_NAME, mountPath: COMPOSITE_TRACER_MOUNT_PATH}],
+      })
+      expect(app.volumeMounts).toContainEqual({
+        volumeName: TRACER_VOLUME_NAME,
+        mountPath: COMPOSITE_TRACER_MOUNT_PATH,
+      })
+    })
+
     test('instruments only the explicitly selected application container', () => {
       const worker = {name: 'worker', image: 'worker', env: [{name: 'ROLE', value: 'worker'}]}
       const app = {
@@ -227,10 +303,11 @@ describe('Container Apps automatic APM instrumentation', () => {
     })
 
     test.each([
-      ['sharedVolumeName', TRACER_VOLUME_NAME, '--shared-volume-name'],
-      ['sharedVolumePath', TRACER_MOUNT_PATH, '--shared-volume-path'],
-    ] as const)('rejects the tracer collision on %s', (field, value, message) => {
-      expect(() => createInstrumentedApp({...injectConfig(), [field]: value})).toThrow(message)
+      ['sharedVolumeName', TRACER_VOLUME_NAME, '--shared-volume-name', injectConfig()],
+      ['sharedVolumePath', TRACER_MOUNT_PATH, '--shared-volume-path', injectConfig()],
+      ['sharedVolumePath', COMPOSITE_TRACER_MOUNT_PATH, '--shared-volume-path', multiLanguageConfig()],
+    ] as const)('rejects the tracer collision on %s', (field, value, message, config) => {
+      expect(() => createInstrumentedApp({...config, [field]: value})).toThrow(message)
     })
 
     test('retries configuration without injection markers', () => {
@@ -247,6 +324,13 @@ describe('Container Apps automatic APM instrumentation', () => {
         },
       }
       const second = createInstrumentedApp(injectConfig(), markerless)
+
+      expect(second.template).toEqual(first.template)
+    })
+
+    test('retries composite configuration without an injection-mode resource tag', () => {
+      const first = createInstrumentedApp(multiLanguageConfig())
+      const second = createInstrumentedApp(multiLanguageConfig(), first)
 
       expect(second.template).toEqual(first.template)
     })
@@ -370,14 +454,30 @@ describe('Container Apps automatic APM instrumentation', () => {
       expect(python.template?.volumes?.filter(({name}) => name === TRACER_VOLUME_NAME)).toHaveLength(1)
     })
 
+    test('switches between single- and multi-language injection idempotently', () => {
+      const node = createInstrumentedApp(injectConfig())
+      const multi = createInstrumentedApp(multiLanguageConfig(), node)
+      const python = createInstrumentedApp(injectConfig('python'), multi)
+      const multiApp = multi.template!.containers![0]
+      const pythonApp = python.template!.containers![0]
+
+      expect(getEnv(multiApp.env, 'NODE_OPTIONS')).toBeUndefined()
+      expect(getEnv(multiApp.env, 'DD_TAGS')).toBeUndefined()
+      expect(getEnv(multiApp.env, 'LD_PRELOAD')?.value).toBe(compositeSpec.env[0].value)
+      expect(createInstrumentedApp(multiLanguageConfig(), multi)).toEqual(multi)
+      expect(getEnv(pythonApp.env, 'LD_PRELOAD')).toBeUndefined()
+      expect(getEnv(pythonApp.env, 'DD_INJECT_SENDER_TYPE')).toBeUndefined()
+      expect(getEnv(pythonApp.env, 'PYTHONPATH')?.value).toBe(TRACER_MOUNT_PATH)
+    })
+
     test.each([
       ['manual', 'true'],
       ['disabled', 'false'],
     ] as const)('removes owned injection for %s tracing', (tracing, traceEnabled) => {
-      const injected = createInstrumentedApp(injectConfig())
+      const injected = createInstrumentedApp(multiLanguageConfig())
       const owned = {
         ...injected,
-        tags: {...injected.tags, [SSI_INJECTION_MODE_TAG]: SINGLE_LANGUAGE_SSI_MODE},
+        tags: {...injected.tags, [SSI_INJECTION_MODE_TAG]: MULTI_LANGUAGE_SSI_MODE},
       }
       const result = createInstrumentedApp({...DEFAULT_CONFIG, service: 'my-container-app', tracing}, owned)
       const app = result.template!.containers![0]
@@ -385,7 +485,8 @@ describe('Container Apps automatic APM instrumentation', () => {
       expect(result.template?.initContainers).toEqual([])
       expect(result.template?.volumes).not.toContainEqual(expect.objectContaining({name: TRACER_VOLUME_NAME}))
       expect(app.volumeMounts).not.toContainEqual(expect.objectContaining({volumeName: TRACER_VOLUME_NAME}))
-      expect(getEnv(app.env, 'NODE_OPTIONS')).toBeUndefined()
+      expect(getEnv(app.env, 'LD_PRELOAD')).toBeUndefined()
+      expect(getEnv(app.env, 'DD_INJECT_SENDER_TYPE')).toBeUndefined()
       expect(getEnv(app.env, DD_TRACE_ENABLED_ENV_VAR)?.value).toBe(traceEnabled)
     })
 

--- a/packages/plugin-container-app/src/__tests__/ssi.test.ts
+++ b/packages/plugin-container-app/src/__tests__/ssi.test.ts
@@ -247,7 +247,7 @@ describe('Container Apps automatic APM instrumentation', () => {
         image: expect.stringContaining('datadoghq.azurecr.io/dd-lib-'),
         command: ['/datadog-init/copy-lib.sh'],
         args: [TRACER_MOUNT_PATH],
-        resources: {cpu: 0.25, memory: '0.5Gi', ephemeralStorage: '1Gi'},
+        resources: {cpu: 0.25, memory: '0.5Gi'},
         volumeMounts: [{volumeName: TRACER_VOLUME_NAME, mountPath: TRACER_MOUNT_PATH}],
       })
       expect(result.template?.volumes).toContainEqual({name: TRACER_VOLUME_NAME, storageType: 'EmptyDir'})
@@ -279,7 +279,7 @@ describe('Container Apps automatic APM instrumentation', () => {
         image: 'datadoghq.azurecr.io/dd-lib-composite-init:latest',
         command: ['/datadog-init/copy-lib.sh'],
         args: [COMPOSITE_TRACER_MOUNT_PATH],
-        resources: {cpu: 0.25, memory: '0.5Gi', ephemeralStorage: '1Gi'},
+        resources: {cpu: 0.25, memory: '0.5Gi'},
         volumeMounts: [{volumeName: TRACER_VOLUME_NAME, mountPath: COMPOSITE_TRACER_MOUNT_PATH}],
       })
       expect(app.volumeMounts).toContainEqual({

--- a/packages/plugin-container-app/src/__tests__/ssi.test.ts
+++ b/packages/plugin-container-app/src/__tests__/ssi.test.ts
@@ -257,9 +257,17 @@ describe('Container Apps automatic APM instrumentation', () => {
       ).not.toContainEqual(expect.objectContaining({volumeName: TRACER_VOLUME_NAME}))
     })
 
-    test('adds composite activation to the selected application container', () => {
-      const result = createInstrumentedApp(multiLanguageConfig())
+    test('adds composite activation only to the selected application container', () => {
+      const sidecar = {name: 'datadog-sidecar', image: 'datadog/serverless-init', env: [{name: 'KEEP', value: 'value'}]}
+      const result = createInstrumentedApp(multiLanguageConfig(), {
+        ...DEFAULT_CONTAINER_APP,
+        template: {
+          ...DEFAULT_CONTAINER_APP.template,
+          containers: [...DEFAULT_CONTAINER_APP.template!.containers!, sidecar],
+        },
+      })
       const app = result.template!.containers![0]
+      const resultSidecar = result.template!.containers![1]
 
       expect(getEnv(app.env, 'LD_PRELOAD')?.value).toBe(compositeSpec.env[0].value)
       expect(getEnv(app.env, 'DD_INJECT_SENDER_TYPE')?.value).toBe('serverless')
@@ -278,6 +286,12 @@ describe('Container Apps automatic APM instrumentation', () => {
         volumeName: TRACER_VOLUME_NAME,
         mountPath: COMPOSITE_TRACER_MOUNT_PATH,
       })
+      expect(getEnv(resultSidecar.env, 'LD_PRELOAD')).toBeUndefined()
+      expect(getEnv(resultSidecar.env, 'DD_INJECT_SENDER_TYPE')).toBeUndefined()
+      expect(resultSidecar.volumeMounts).not.toContainEqual(expect.objectContaining({volumeName: TRACER_VOLUME_NAME}))
+      expect(resultSidecar.volumeMounts).not.toContainEqual(
+        expect.objectContaining({mountPath: COMPOSITE_TRACER_MOUNT_PATH})
+      )
     })
 
     test('instruments only the explicitly selected application container', () => {

--- a/packages/plugin-container-app/src/__tests__/ssi.test.ts
+++ b/packages/plugin-container-app/src/__tests__/ssi.test.ts
@@ -21,6 +21,8 @@ import {
   MULTI_LANGUAGE_SSI_MODE,
   SINGLE_LANGUAGE_SSI_MODE,
   SSI_INJECTION_MODE_TAG,
+  assertSsiEphemeralStorage,
+  getReplicaEphemeralStorageGiB,
   hasSsi,
   mergeCompositeInjectionEnv,
   mergeLanguageInjectionEnv,
@@ -118,6 +120,59 @@ describe('Container Apps automatic APM instrumentation', () => {
 
     test('warns for Java 24+', () => {
       expect(resolveSsiConfig(injectConfig('java')).warnings.join('\n')).toContain('Java 24+')
+    })
+  })
+
+  describe('replica ephemeral storage', () => {
+    test.each([
+      [0.25, 0, 1],
+      [0.25, 0.25, 2],
+      [0.5, 0.5, 4],
+      [1, 0.25, 8],
+    ])('derives the %s + %s vCPU configuration as %s GiB', (applicationCpu, sidecarCpu, storageGiB) => {
+      expect(
+        getReplicaEphemeralStorageGiB([
+          {name: 'app', resources: {cpu: applicationCpu}},
+          {name: 'datadog-sidecar', resources: {cpu: sidecarCpu}},
+        ])
+      ).toBe(storageGiB)
+    })
+
+    test('allows single-language injection at the 1-GiB tier', () => {
+      const config = resolveSsiConfig(injectConfig())
+      if (config.kind !== 'single-language') {
+        throw new Error('Expected single-language injection')
+      }
+
+      expect(() => assertSsiEphemeralStorage([{name: 'app', resources: {cpu: 0.25}}], config)).not.toThrow()
+    })
+
+    test('accepts composite injection at the 2-GiB tier', () => {
+      const config = resolveSsiConfig(multiLanguageConfig())
+      if (config.kind !== 'multi-language') {
+        throw new Error('Expected multi-language injection')
+      }
+
+      expect(() =>
+        assertSsiEphemeralStorage(
+          [
+            {name: 'app', resources: {cpu: 0.25}},
+            {name: 'datadog-sidecar', resources: {cpu: 0.25}},
+          ],
+          config
+        )
+      ).not.toThrow()
+    })
+
+    test('rejects composite injection below the 2-GiB tier', () => {
+      const config = resolveSsiConfig(multiLanguageConfig())
+      if (config.kind !== 'multi-language') {
+        throw new Error('Expected multi-language injection')
+      }
+
+      expect(() => assertSsiEphemeralStorage([{name: 'app', resources: {cpu: 0.25}}], config)).toThrow(
+        'requires at least 2 GiB of replica ephemeral storage, but the final configuration provides the 1-GiB tier'
+      )
     })
   })
 

--- a/packages/plugin-container-app/src/__tests__/uninstrument.test.ts
+++ b/packages/plugin-container-app/src/__tests__/uninstrument.test.ts
@@ -26,6 +26,7 @@ import type {ContainerApp, Container} from '@azure/arm-appcontainers'
 
 import {makeRunCLI} from '@datadog/datadog-ci-base/helpers/__tests__/testing-tools'
 import {DEFAULT_SIDECAR_NAME, DEFAULT_VOLUME_NAME} from '@datadog/datadog-ci-base/helpers/serverless/constants'
+import {COMPOSITE_TRACER_MOUNT_PATH} from '@datadog/datadog-ci-base/helpers/serverless/ssi/composite'
 import {
   TRACER_CONTAINER_NAME,
   TRACER_MOUNT_PATH,
@@ -446,10 +447,19 @@ Please ensure that you have the Azure CLI installed (https://aka.ms/azure-cli) a
             {
               name: 'worker',
               image: 'worker',
-              env: [{name: 'PYTHONPATH', value: 'customer:/datadog-lib'}],
+              env: [
+                {name: 'PYTHONPATH', value: 'customer:/datadog-lib'},
+                {
+                  name: 'LD_PRELOAD',
+                  value:
+                    '/customer/preload.so /opt/datadog-packages/datadog-apm-inject/stable/inject/launcher.preload.so',
+                },
+                {name: 'DD_INJECT_SENDER_TYPE', value: 'serverless'},
+              ],
               volumeMounts: [
                 {volumeName: 'customer-volume', mountPath: '/customer'},
                 {volumeName: 'legacy-volume', mountPath: TRACER_MOUNT_PATH},
+                {volumeName: 'composite-volume', mountPath: COMPOSITE_TRACER_MOUNT_PATH},
               ],
             },
           ],
@@ -474,7 +484,10 @@ Please ensure that you have the Azure CLI installed (https://aka.ms/azure-cli) a
         {name: 'KEEP', value: 'value'},
       ])
       expect(worker).toMatchObject({
-        env: [{name: 'PYTHONPATH', value: 'customer'}],
+        env: [
+          {name: 'PYTHONPATH', value: 'customer'},
+          {name: 'LD_PRELOAD', value: '/customer/preload.so'},
+        ],
         volumeMounts: [{volumeName: 'customer-volume', mountPath: '/customer'}],
       })
     })

--- a/packages/plugin-container-app/src/commands/instrument.ts
+++ b/packages/plugin-container-app/src/commands/instrument.ts
@@ -31,13 +31,13 @@ import chalk from 'chalk'
 
 import {DD_API_KEY_SECRET_NAME, getEnvVarsByName, redactSecrets} from '../common'
 import {
+  MULTI_LANGUAGE_SSI_MODE,
   SINGLE_LANGUAGE_SSI_MODE,
   SSI_INJECTION_MODE_TAG,
-  applySingleLanguageSsi,
-  assertLanguageInjectionEnvCanBeMerged,
+  applySsi,
+  assertInjectionEnvCanBeMerged,
   assertSsiResourcesCanBeAdded,
   hasSsi,
-  hasSsiMarker,
   removeSsiState,
   resolveSsiConfig,
   selectApplicationContainer,
@@ -159,15 +159,18 @@ export class PluginCommand extends ContainerAppInstrumentCommand {
       containerApp.configuration = {...containerApp.configuration, secrets: secrets.value}
       config = {...config, service: config.service ?? containerAppName}
 
-      if (config.tracing === undefined && hasSsiMarker(containerApp)) {
+      if (config.tracing === undefined && hasSsi(containerApp)) {
         this.context.stdout.write(
           renderSoftWarning(
-            `Tracing defaults to manual for ${containerAppName}. Use --tracing inject --language <language> to retain automatic tracer injection.`
+            `Tracing defaults to manual for ${containerAppName}. Use --tracing inject to retain automatic tracer injection.`
           )
         )
       }
 
-      if (ssiConfig.kind === 'single-language' && (containerApp.template?.scale?.minReplicas ?? 0) === 0) {
+      if (
+        (ssiConfig.kind === 'single-language' || ssiConfig.kind === 'multi-language') &&
+        (containerApp.template?.scale?.minReplicas ?? 0) === 0
+      ) {
         this.context.stdout.write(
           renderSoftWarning(
             `Automatic APM instrumentation can increase cold-start delays for ${containerAppName} because scale-to-zero is enabled. Prefer manual instrumentation for scale-to-zero workloads.`
@@ -206,6 +209,8 @@ export class PluginCommand extends ContainerAppInstrumentCommand {
     }
     if (ssiConfig.kind === 'single-language') {
       updatedTags[SSI_INJECTION_MODE_TAG] = SINGLE_LANGUAGE_SSI_MODE
+    } else if (ssiConfig.kind === 'multi-language') {
+      updatedTags[SSI_INJECTION_MODE_TAG] = MULTI_LANGUAGE_SSI_MODE
     } else if (ssiConfig.kind === 'no-injection') {
       delete updatedTags[SSI_INJECTION_MODE_TAG]
     }
@@ -272,23 +277,22 @@ export class PluginCommand extends ContainerAppInstrumentCommand {
     }
 
     const ssiExists = hasSsi(containerApp)
-    const shouldReplaceSsi = hasSsiMarker(containerApp) || (ssiConfig.kind === 'single-language' && ssiExists)
-    const sourceApp = shouldReplaceSsi ? removeSsiState(containerApp) : containerApp
+    const sourceApp = ssiExists ? removeSsiState(containerApp) : containerApp
     let targetIndex: number | undefined
-    if (ssiConfig.kind === 'single-language') {
+    if (ssiConfig.kind === 'single-language' || ssiConfig.kind === 'multi-language') {
       targetIndex = selectApplicationContainer(
         sourceApp.template?.containers ?? [],
         config.sidecarName!,
         config.containerName
       )
-      assertLanguageInjectionEnvCanBeMerged(sourceApp.template?.containers?.[targetIndex]?.env, ssiConfig.spec)
+      assertInjectionEnvCanBeMerged(sourceApp.template?.containers?.[targetIndex]?.env, ssiConfig)
       if (!ssiExists) {
-        assertSsiResourcesCanBeAdded(containerApp, targetIndex, config.sidecarName!)
+        assertSsiResourcesCanBeAdded(containerApp, targetIndex, config.sidecarName!, ssiConfig)
       }
     }
 
     const envVarsByName = getEnvVarsByName(config, subscriptionId, resourceGroup)
-    if (ssiConfig.kind === 'single-language' || ssiConfig.tracing === 'manual') {
+    if (ssiConfig.kind === 'single-language' || ssiConfig.kind === 'multi-language' || ssiConfig.tracing === 'manual') {
       envVarsByName[DD_TRACE_ENABLED_ENV_VAR] = {name: DD_TRACE_ENABLED_ENV_VAR, value: 'true'}
     } else if (ssiConfig.tracing === 'disabled') {
       envVarsByName[DD_TRACE_ENABLED_ENV_VAR] = {name: DD_TRACE_ENABLED_ENV_VAR, value: 'false'}
@@ -342,8 +346,8 @@ export class PluginCommand extends ContainerAppInstrumentCommand {
       template: updatedTemplate,
     }
 
-    return ssiConfig.kind === 'single-language'
-      ? applySingleLanguageSsi(instrumentedApp, targetIndex!, ssiConfig.spec)
+    return ssiConfig.kind === 'single-language' || ssiConfig.kind === 'multi-language'
+      ? applySsi(instrumentedApp, targetIndex!, ssiConfig)
       : instrumentedApp
   }
 }

--- a/packages/plugin-container-app/src/commands/instrument.ts
+++ b/packages/plugin-container-app/src/commands/instrument.ts
@@ -167,17 +167,6 @@ export class PluginCommand extends ContainerAppInstrumentCommand {
         )
       }
 
-      if (
-        (ssiConfig.kind === 'single-language' || ssiConfig.kind === 'multi-language') &&
-        (containerApp.template?.scale?.minReplicas ?? 0) === 0
-      ) {
-        this.context.stdout.write(
-          renderSoftWarning(
-            `Automatic APM instrumentation can increase cold-start delays for ${containerAppName} because scale-to-zero is enabled. Prefer manual instrumentation for scale-to-zero workloads.`
-          )
-        )
-      }
-
       await this.instrumentSidecar(containerAppClient, config, resourceGroup, containerApp, ssiConfig)
       await this.addTags(config, containerAppClient.subscriptionId, resourceGroup, containerApp, ssiConfig)
     } catch (error) {
@@ -259,6 +248,17 @@ export class PluginCommand extends ContainerAppInstrumentCommand {
     this.context.stdout.write(
       `${this.dryRunPrefix}Updating configuration for ${chalk.bold(containerApp.name)}:\n${configDiff}\n`
     )
+
+    if (
+      (ssiConfig.kind === 'single-language' || ssiConfig.kind === 'multi-language') &&
+      (containerApp.template?.scale?.minReplicas ?? 0) === 0
+    ) {
+      this.context.stdout.write(
+        renderSoftWarning(
+          `Automatic APM instrumentation can increase cold-start delays for ${containerApp.name} because scale-to-zero is enabled. Prefer manual instrumentation for scale-to-zero workloads.`
+        )
+      )
+    }
 
     if (!this.dryRun) {
       await client.containerApps.beginUpdateAndWait(resourceGroup, containerApp.name!, updatedAppConfig)

--- a/packages/plugin-container-app/src/commands/instrument.ts
+++ b/packages/plugin-container-app/src/commands/instrument.ts
@@ -36,6 +36,7 @@ import {
   SSI_INJECTION_MODE_TAG,
   applySsi,
   assertInjectionEnvCanBeMerged,
+  assertSsiEphemeralStorage,
   assertSsiResourcesCanBeAdded,
   hasSsi,
   removeSsiState,
@@ -346,8 +347,13 @@ export class PluginCommand extends ContainerAppInstrumentCommand {
       template: updatedTemplate,
     }
 
-    return ssiConfig.kind === 'single-language' || ssiConfig.kind === 'multi-language'
-      ? applySsi(instrumentedApp, targetIndex!, ssiConfig)
-      : instrumentedApp
+    if (ssiConfig.kind === 'single-language' || ssiConfig.kind === 'multi-language') {
+      const updatedApp = applySsi(instrumentedApp, targetIndex!, ssiConfig)
+      assertSsiEphemeralStorage(updatedApp.template?.containers ?? [], ssiConfig)
+
+      return updatedApp
+    }
+
+    return instrumentedApp
   }
 }

--- a/packages/plugin-container-app/src/ssi.ts
+++ b/packages/plugin-container-app/src/ssi.ts
@@ -1,10 +1,12 @@
 import type {Container, ContainerApp, EnvironmentVar, InitContainer} from '@azure/arm-appcontainers'
 import type {ContainerAppConfigOptions} from '@datadog/datadog-ci-base/commands/container-app/common'
+import type {CompositeInjectionSpec} from '@datadog/datadog-ci-base/helpers/serverless/ssi/composite'
 import type {EnvFragment} from '@datadog/datadog-ci-base/helpers/serverless/ssi/env'
 import type {LanguageInjectionSpec, Libc} from '@datadog/datadog-ci-base/helpers/serverless/ssi/injection-spec'
 import type {Language} from '@datadog/datadog-ci-base/helpers/serverless/ssi/tracer'
 
 import {DD_TAGS_ENV_VAR} from '@datadog/datadog-ci-base/helpers/serverless/constants'
+import {getCompositeInjectionSpec} from '@datadog/datadog-ci-base/helpers/serverless/ssi/composite'
 import {
   TRACER_CONTAINER_NAME,
   TRACER_MOUNT_PATH,
@@ -35,12 +37,18 @@ import {TRACING_MODES, type TracingMode} from '@datadog/datadog-ci-base/helpers/
 
 export const SSI_INJECTION_MODE_TAG = 'dd_sls_injection_mode'
 export const SINGLE_LANGUAGE_SSI_MODE = 'single_language'
+export const MULTI_LANGUAGE_SSI_MODE = 'multi_language'
 export const CONTAINER_APP_TRACER_REGISTRY = 'datadoghq.azurecr.io' as const
+const CONTAINER_APP_COMPOSITE_SPEC = getCompositeInjectionSpec(CONTAINER_APP_TRACER_REGISTRY)
+
 export type SsiConfigResult = (
   | {kind: 'errors'; errors: readonly string[]}
   | {kind: 'no-injection'; tracing: Exclude<TracingMode, 'inject'>}
   | {kind: 'single-language'; language: Language; libc: Libc; spec: LanguageInjectionSpec}
+  | {kind: 'multi-language'; spec: CompositeInjectionSpec}
 ) & {warnings: readonly string[]}
+
+type InjectionConfig = Extract<SsiConfigResult, {kind: 'single-language' | 'multi-language'}>
 
 /** Resolves Container Apps tracer inputs before any remote work. */
 export const resolveSsiConfig = (config: ContainerAppConfigOptions): SsiConfigResult => {
@@ -67,28 +75,32 @@ export const resolveSsiConfig = (config: ContainerAppConfigOptions): SsiConfigRe
       : {kind: 'no-injection', tracing, warnings: []}
   }
 
-  const collisionErrors = [
-    config.sharedVolumeName === TRACER_VOLUME_NAME
-      ? `--shared-volume-name cannot be '${TRACER_VOLUME_NAME}' with --tracing inject. Choose a different logging volume name.`
-      : undefined,
-    config.sharedVolumePath === TRACER_MOUNT_PATH
-      ? `--shared-volume-path cannot be '${TRACER_MOUNT_PATH}' with --tracing inject. Choose a different logging volume path.`
-      : undefined,
-  ].filter((error): error is string => error !== undefined)
+  const collisionErrors = getResourceCollisionErrors(
+    config,
+    config.language === undefined ? CONTAINER_APP_COMPOSITE_SPEC.mountPath : TRACER_MOUNT_PATH
+  )
   if (collisionErrors.length > 0) {
     return {kind: 'errors', errors: collisionErrors, warnings: []}
   }
 
   if (config.language === undefined) {
-    return {
-      kind: 'errors',
-      errors: [
-        `--tracing inject requires --language until automatic multi-language injection is supported. Possible values: ${TRACER_INJECTION_LANGUAGES.join(
-          ', '
-        )}.`,
-      ],
-      warnings: [],
+    const unsupportedFlags = [
+      config.tracerVersion !== undefined ? '--tracer-version' : undefined,
+      config.tracerLibc !== undefined ? '--tracer-libc' : undefined,
+    ].filter((flag): flag is string => flag !== undefined)
+    if (unsupportedFlags.length > 0) {
+      return {
+        kind: 'errors',
+        errors: [
+          `${unsupportedFlags.join(', ')} ${
+            unsupportedFlags.length === 1 ? 'requires' : 'require'
+          } --language because automatic language detection cannot apply per-language tracer settings. Add --language or remove these options.`,
+        ],
+        warnings: [],
+      }
     }
+
+    return {kind: 'multi-language', spec: CONTAINER_APP_COMPOSITE_SPEC, warnings: []}
   }
   if (config.language === 'go') {
     return {
@@ -174,15 +186,21 @@ export const selectApplicationContainer = (
   )
 }
 
-export const assertLanguageInjectionEnvCanBeMerged = (
+export const assertInjectionEnvCanBeMerged = (
   env: readonly EnvironmentVar[] | undefined,
-  spec: LanguageInjectionSpec
-): void => assertEnvironmentFragmentsCanBeMerged(env, spec.env)
+  config: InjectionConfig
+): void =>
+  assertEnvironmentFragmentsCanBeMerged(
+    env,
+    config.spec.env,
+    config.kind === 'single-language' ? [DD_TAGS_ENV_VAR] : []
+  )
 
 export const assertSsiResourcesCanBeAdded = (
   containerApp: ContainerApp,
   targetIndex: number,
-  sidecarName: string
+  sidecarName: string,
+  config: InjectionConfig
 ): void => {
   if (containerApp.template?.initContainers?.some(({name}) => name === TRACER_CONTAINER_NAME)) {
     throw new SsiConfigError(
@@ -195,17 +213,18 @@ export const assertSsiResourcesCanBeAdded = (
     )
   }
 
+  const mountPath = getInjectionMountPath(config)
   const hasConflictingMount = (containerApp.template?.containers ?? []).some(
     (container, index) =>
       container.name !== sidecarName &&
       (container.volumeMounts ?? []).some(
-        ({volumeName, mountPath}) =>
-          volumeName === TRACER_VOLUME_NAME || (index === targetIndex && mountPath === TRACER_MOUNT_PATH)
+        ({volumeName, mountPath: existingPath}) =>
+          volumeName === TRACER_VOLUME_NAME || (index === targetIndex && existingPath === mountPath)
       )
   )
   if (hasConflictingMount) {
     throw new SsiConfigError(
-      `An application container volume mount conflicts with the managed '${TRACER_VOLUME_NAME}' volume at '${TRACER_MOUNT_PATH}'. Rename or remove the conflicting mount before retrying.`
+      `An application container volume mount conflicts with the managed '${TRACER_VOLUME_NAME}' volume at '${mountPath}'. Rename or remove the conflicting mount before retrying.`
     )
   }
 }
@@ -214,28 +233,25 @@ export const mergeLanguageInjectionEnv = (
   existingEnv: readonly EnvironmentVar[] | undefined,
   spec: LanguageInjectionSpec
 ): EnvironmentVar[] => {
-  assertLanguageInjectionEnvCanBeMerged(existingEnv, spec)
-  const merged = spec.env.reduce<EnvironmentVar[]>(
-    (env, fragment) => {
-      const existing = env.find(({name}) => name === fragment.name)
-
-      return upsertEnv(env, fragment.name, mergeLanguageEnvFragment(existing?.value, fragment))
-    },
-    [...(existingEnv ?? [])]
-  )
+  const merged = mergeInjectionEnv(existingEnv, spec.env, [DD_TAGS_ENV_VAR])
   const existingTags = merged.find(({name}) => name === DD_TAGS_ENV_VAR)
 
   return upsertEnv(merged, DD_TAGS_ENV_VAR, mergeInjectionModeTag(existingTags?.value))
 }
 
-/** Removes exact native tracer fragments for every supported language. */
-export const removeLanguageInjectionEnv = (existingEnv: readonly EnvironmentVar[] | undefined): EnvironmentVar[] =>
+export const mergeCompositeInjectionEnv = (
+  existingEnv: readonly EnvironmentVar[] | undefined,
+  spec: CompositeInjectionSpec
+): EnvironmentVar[] => mergeInjectionEnv(existingEnv, spec.env)
+
+/** Removes exact tracer fragments for every supported injection mode. */
+export const removeInjectionEnv = (existingEnv: readonly EnvironmentVar[] | undefined): EnvironmentVar[] =>
   (existingEnv ?? []).flatMap((variable) => {
     if (!variable.name || variable.secretRef || !variable.value) {
       return [variable]
     }
 
-    const fragments = LANGUAGE_ENV_FRAGMENTS.filter(({name}) => name === variable.name)
+    const fragments = INJECTION_ENV_FRAGMENTS.filter(({name}) => name === variable.name)
     const withoutTag = variable.name === DD_TAGS_ENV_VAR ? removeInjectionModeTag(variable.value) : variable.value
     const value = fragments.reduce<string | undefined>(removeEnvFragment, withoutTag)
 
@@ -262,7 +278,12 @@ export const hasCompleteSsiSignature = (containerApp: ContainerApp, targetIndex:
     return false
   }
 
-  const initContainers = template?.initContainers?.filter(isManagedInitContainer) ?? []
+  const initContainers =
+    template?.initContainers?.flatMap((container) => {
+      const config = getManagedInitConfig(container)
+
+      return config === undefined ? [] : [{container, config}]
+    }) ?? []
   const volumes =
     template?.volumes?.filter(({name, storageType}) => name === TRACER_VOLUME_NAME && storageType === 'EmptyDir') ?? []
   const tracerMounts = (template?.containers ?? []).flatMap((container, index) =>
@@ -270,14 +291,15 @@ export const hasCompleteSsiSignature = (containerApp: ContainerApp, targetIndex:
       .filter(({volumeName}) => volumeName === TRACER_VOLUME_NAME)
       .map((mount) => ({index, mount}))
   )
+  const managedInit = initContainers[0]
 
   return (
     initContainers.length === 1 &&
     volumes.length === 1 &&
     tracerMounts.length === 1 &&
     tracerMounts[0].index === targetIndex &&
-    tracerMounts[0].mount.mountPath === TRACER_MOUNT_PATH &&
-    hasManagedTracerEnvironment(target.env, getInitContainerLanguage(initContainers[0]))
+    tracerMounts[0].mount.mountPath === managedInit.config.mountPath &&
+    hasManagedTracerEnvironment(target.env, managedInit.config)
   )
 }
 
@@ -286,9 +308,9 @@ export const removeSsiState = (containerApp: ContainerApp): ContainerApp => {
   const initContainers = template?.initContainers?.filter(({name}) => name !== TRACER_CONTAINER_NAME)
   const volumes = template?.volumes?.filter(({name}) => name !== TRACER_VOLUME_NAME)
   const containers = template?.containers?.map((container) => {
-    const env = removeLanguageInjectionEnv(container.env)
+    const env = removeInjectionEnv(container.env)
     const volumeMounts = container.volumeMounts?.filter(
-      ({volumeName, mountPath}) => volumeName !== TRACER_VOLUME_NAME && mountPath !== TRACER_MOUNT_PATH
+      ({volumeName, mountPath}) => volumeName !== TRACER_VOLUME_NAME && !MANAGED_TRACER_MOUNT_PATHS.has(mountPath ?? '')
     )
     const envChanged =
       env.length !== (container.env?.length ?? 0) || env.some((variable, index) => variable !== container.env?.[index])
@@ -315,30 +337,33 @@ export const removeSsiState = (containerApp: ContainerApp): ContainerApp => {
   }
 }
 
-export const applySingleLanguageSsi = (
-  containerApp: ContainerApp,
-  targetIndex: number,
-  spec: LanguageInjectionSpec
-): ContainerApp => ({
-  ...containerApp,
-  template: {
-    ...containerApp.template,
-    initContainers: [...(containerApp.template?.initContainers ?? []), buildTracerInitContainer(spec)],
-    containers: (containerApp.template?.containers ?? []).map((container, index) =>
-      index === targetIndex
-        ? {
-            ...container,
-            env: mergeLanguageInjectionEnv(container.env, spec),
-            volumeMounts: [
-              ...(container.volumeMounts ?? []),
-              {volumeName: TRACER_VOLUME_NAME, mountPath: TRACER_MOUNT_PATH},
-            ],
-          }
-        : container
-    ),
-    volumes: [...(containerApp.template?.volumes ?? []), {name: TRACER_VOLUME_NAME, storageType: 'EmptyDir'}],
-  },
-})
+export const applySsi = (containerApp: ContainerApp, targetIndex: number, config: InjectionConfig): ContainerApp => {
+  const mountPath = getInjectionMountPath(config)
+
+  return {
+    ...containerApp,
+    template: {
+      ...containerApp.template,
+      initContainers: [
+        ...(containerApp.template?.initContainers ?? []),
+        buildTracerInitContainer(config.spec.image, mountPath),
+      ],
+      containers: (containerApp.template?.containers ?? []).map((container, index) =>
+        index === targetIndex
+          ? {
+              ...container,
+              env:
+                config.kind === 'single-language'
+                  ? mergeLanguageInjectionEnv(container.env, config.spec)
+                  : mergeCompositeInjectionEnv(container.env, config.spec),
+              volumeMounts: [...(container.volumeMounts ?? []), {volumeName: TRACER_VOLUME_NAME, mountPath}],
+            }
+          : container
+      ),
+      volumes: [...(containerApp.template?.volumes ?? []), {name: TRACER_VOLUME_NAME, storageType: 'EmptyDir'}],
+    },
+  }
+}
 
 export class SsiConfigError extends Error {
   constructor(message: string) {
@@ -346,6 +371,19 @@ export class SsiConfigError extends Error {
     this.name = 'SsiConfigError'
   }
 }
+
+const getResourceCollisionErrors = (config: ContainerAppConfigOptions, mountPath: string): string[] =>
+  [
+    config.sharedVolumeName === TRACER_VOLUME_NAME
+      ? `--shared-volume-name cannot be '${TRACER_VOLUME_NAME}' with --tracing inject. Choose a different logging volume name.`
+      : undefined,
+    config.sharedVolumePath === mountPath
+      ? `--shared-volume-path cannot be '${mountPath}' with --tracing inject. Choose a different logging volume path.`
+      : undefined,
+  ].filter((error): error is string => error !== undefined)
+
+const getInjectionMountPath = (config: InjectionConfig): string =>
+  config.kind === 'single-language' ? TRACER_MOUNT_PATH : config.spec.mountPath
 
 const validateSsiInputs = (config: ContainerAppConfigOptions): string[] => {
   const errors: string[] = []
@@ -376,9 +414,10 @@ const formatContainerNames = (candidates: readonly {container: Container}[]): st
 
 const assertEnvironmentFragmentsCanBeMerged = (
   env: readonly EnvironmentVar[] | undefined,
-  fragments: readonly EnvFragment[]
+  fragments: readonly EnvFragment[],
+  extraNames: readonly string[] = []
 ): void => {
-  const targetNames = new Set([...fragments.map(({name}) => name), DD_TAGS_ENV_VAR])
+  const targetNames = new Set([...fragments.map(({name}) => name), ...extraNames])
   for (const name of targetNames) {
     const matching = (env ?? []).filter((variable) => variable.name === name)
     if (matching.length > 1) {
@@ -402,7 +441,24 @@ const upsertEnv = <T extends EnvironmentVar>(env: readonly T[], name: string, va
     : env.map((variable, variableIndex) => (variableIndex === index ? {...variable, value} : variable))
 }
 
-const mergeLanguageEnvFragment = (currentValue: string | undefined, fragment: EnvFragment): string => {
+const mergeInjectionEnv = (
+  existingEnv: readonly EnvironmentVar[] | undefined,
+  fragments: readonly EnvFragment[],
+  extraNames: readonly string[] = []
+): EnvironmentVar[] => {
+  assertEnvironmentFragmentsCanBeMerged(existingEnv, fragments, extraNames)
+
+  return fragments.reduce<EnvironmentVar[]>(
+    (env, fragment) => {
+      const existing = env.find(({name}) => name === fragment.name)
+
+      return upsertEnv(env, fragment.name, mergeInjectionEnvFragment(existing?.value, fragment))
+    },
+    [...(existingEnv ?? [])]
+  )
+}
+
+const mergeInjectionEnvFragment = (currentValue: string | undefined, fragment: EnvFragment): string => {
   try {
     return mergeEnvFragment(currentValue, fragment)
   } catch (error) {
@@ -427,19 +483,24 @@ const LANGUAGE_ENV_VARIANTS = TRACER_INJECTION_LANGUAGES.flatMap((language) =>
   }))
 )
 const LANGUAGE_ENV_FRAGMENTS: readonly EnvFragment[] = LANGUAGE_ENV_VARIANTS.flatMap(({env}) => env)
+const INJECTION_ENV_FRAGMENTS: readonly EnvFragment[] = [...LANGUAGE_ENV_FRAGMENTS, ...CONTAINER_APP_COMPOSITE_SPEC.env]
+const MANAGED_TRACER_MOUNT_PATHS = new Set([TRACER_MOUNT_PATH, CONTAINER_APP_COMPOSITE_SPEC.mountPath])
+
+interface ManagedInitConfig {
+  readonly mountPath: string
+  readonly envVariants: readonly (readonly EnvFragment[])[]
+}
 
 const hasManagedTracerEnvironment = (
   env: readonly EnvironmentVar[] | undefined,
-  language: Language | undefined
+  config: ManagedInitConfig
 ): boolean => {
   const literalEnv = env ?? []
 
-  return LANGUAGE_ENV_VARIANTS.some(
-    (variant) =>
-      variant.language === language &&
-      variant.env.every((fragment) =>
-        hasEnvFragment(literalEnv.find(({name, secretRef}) => name === fragment.name && !secretRef)?.value, fragment)
-      )
+  return config.envVariants.some((fragments) =>
+    fragments.every((fragment) =>
+      hasEnvFragment(literalEnv.find(({name, secretRef}) => name === fragment.name && !secretRef)?.value, fragment)
+    )
   )
 }
 
@@ -451,25 +512,42 @@ const getInitContainerLanguage = (container: InitContainer): Language | undefine
     return version !== undefined && TRACER_IMAGE_TAG_REG_EXP.test(version)
   })
 
-const isManagedInitContainer = (container: InitContainer): boolean =>
+const getManagedInitConfig = (container: InitContainer): ManagedInitConfig | undefined => {
+  const language = getInitContainerLanguage(container)
+  const config =
+    language === undefined
+      ? container.image === CONTAINER_APP_COMPOSITE_SPEC.image
+        ? {
+            mountPath: CONTAINER_APP_COMPOSITE_SPEC.mountPath,
+            envVariants: [CONTAINER_APP_COMPOSITE_SPEC.env],
+          }
+        : undefined
+      : {
+          mountPath: TRACER_MOUNT_PATH,
+          envVariants: LANGUAGE_ENV_VARIANTS.filter((variant) => variant.language === language).map(({env}) => env),
+        }
+
+  return config !== undefined && hasManagedInitContainerShape(container, config.mountPath) ? config : undefined
+}
+
+const hasManagedInitContainerShape = (container: InitContainer, mountPath: string): boolean =>
   container.name === TRACER_CONTAINER_NAME &&
-  getInitContainerLanguage(container) !== undefined &&
   container.command?.length === 1 &&
   container.command[0] === '/datadog-init/copy-lib.sh' &&
   container.args?.length === 1 &&
-  container.args[0] === TRACER_MOUNT_PATH &&
+  container.args[0] === mountPath &&
   container.resources?.cpu === 0.25 &&
   container.resources.memory === '0.5Gi' &&
   container.volumeMounts?.length === 1 &&
   container.volumeMounts.some(
-    ({volumeName, mountPath}) => volumeName === TRACER_VOLUME_NAME && mountPath === TRACER_MOUNT_PATH
+    ({volumeName, mountPath: existingPath}) => volumeName === TRACER_VOLUME_NAME && existingPath === mountPath
   )
 
-const buildTracerInitContainer = (spec: LanguageInjectionSpec): InitContainer => ({
+const buildTracerInitContainer = (image: string, mountPath: string): InitContainer => ({
   name: TRACER_CONTAINER_NAME,
-  image: spec.image,
+  image,
   command: ['/datadog-init/copy-lib.sh'],
-  args: [TRACER_MOUNT_PATH],
+  args: [mountPath],
   resources: {cpu: 0.25, memory: '0.5Gi', ephemeralStorage: '1Gi'},
-  volumeMounts: [{volumeName: TRACER_VOLUME_NAME, mountPath: TRACER_MOUNT_PATH}],
+  volumeMounts: [{volumeName: TRACER_VOLUME_NAME, mountPath}],
 })

--- a/packages/plugin-container-app/src/ssi.ts
+++ b/packages/plugin-container-app/src/ssi.ts
@@ -50,6 +50,12 @@ export type SsiConfigResult = (
 
 type InjectionConfig = Extract<SsiConfigResult, {kind: 'single-language' | 'multi-language'}>
 
+const EPHEMERAL_STORAGE_TIERS = [
+  {maximumCpu: 0.25, storageGiB: 1},
+  {maximumCpu: 0.5, storageGiB: 2},
+  {maximumCpu: 1, storageGiB: 4},
+] as const
+
 /** Resolves Container Apps tracer inputs before any remote work. */
 export const resolveSsiConfig = (config: ContainerAppConfigOptions): SsiConfigResult => {
   const errors = validateSsiInputs(config)
@@ -195,6 +201,23 @@ export const assertInjectionEnvCanBeMerged = (
     config.spec.env,
     config.kind === 'single-language' ? [DD_TAGS_ENV_VAR] : []
   )
+
+export const getReplicaEphemeralStorageGiB = (containers: readonly Container[]): number => {
+  const totalCpu = containers.reduce((total, container) => total + (container.resources?.cpu ?? 0), 0)
+
+  return EPHEMERAL_STORAGE_TIERS.find(({maximumCpu}) => totalCpu <= maximumCpu)?.storageGiB ?? 8
+}
+
+export const assertSsiEphemeralStorage = (containers: readonly Container[], config: InjectionConfig): void => {
+  const storageGiB = getReplicaEphemeralStorageGiB(containers)
+  const requiredStorageGiB = config.kind === 'single-language' ? 1 : 2
+
+  if (storageGiB < requiredStorageGiB) {
+    throw new SsiConfigError(
+      `Automatic tracer injection requires at least ${requiredStorageGiB} GiB of replica ephemeral storage, but the final configuration provides the ${storageGiB}-GiB tier. Increase application or Datadog sidecar CPU so their combined CPU exceeds 0.25 vCPU.`
+    )
+  }
+}
 
 export const assertSsiResourcesCanBeAdded = (
   containerApp: ContainerApp,
@@ -548,8 +571,6 @@ const buildTracerInitContainer = (image: string, mountPath: string): InitContain
   image,
   command: ['/datadog-init/copy-lib.sh'],
   args: [mountPath],
-  // Azure derives temporary storage from total replica CPU. The default 0.5-vCPU sidecar and
-  // minimum 0.25-vCPU app yield 4 GiB; ephemeralStorage is response-only.
   resources: {cpu: 0.25, memory: '0.5Gi'},
   volumeMounts: [{volumeName: TRACER_VOLUME_NAME, mountPath}],
 })

--- a/packages/plugin-container-app/src/ssi.ts
+++ b/packages/plugin-container-app/src/ssi.ts
@@ -548,6 +548,8 @@ const buildTracerInitContainer = (image: string, mountPath: string): InitContain
   image,
   command: ['/datadog-init/copy-lib.sh'],
   args: [mountPath],
-  resources: {cpu: 0.25, memory: '0.5Gi', ephemeralStorage: '1Gi'},
+  // Azure derives temporary storage from total replica CPU. The default 0.5-vCPU sidecar and
+  // minimum 0.25-vCPU app yield 4 GiB; ephemeralStorage is response-only.
+  resources: {cpu: 0.25, memory: '0.5Gi'},
   volumeMounts: [{volumeName: TRACER_VOLUME_NAME, mountPath}],
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -8871,7 +8871,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"js-yaml@npm:^4.1.0, js-yaml@npm:^4.3.2":
+"js-yaml@npm:^4.1.0, js-yaml@npm:^4.3.1, js-yaml@npm:^4.3.2":
   version: 4.3.2
   resolution: "js-yaml@npm:4.3.2"
   dependencies:


### PR DESCRIPTION
### What and why?

Azure Container Apps tracer injection required customers to specify an application language. This enables automatic runtime detection when they use `--tracing inject` without `--language`, while preserving explicit single-language injection.

### How?

The command copies the Azure composite tracer through the existing init-container lifecycle and activates `auto_inject`. It preserves declarative cleanup across manual, disabled, single-language, and multi-language transitions, and moves the shared composite contract into `packages/base` for other serverless plugins to reuse.

### Manual validation

A live Azure Container Apps test deployed a tracer-free Node.js 22 application, injected the production composite image, confirmed `_dd.injection.mode:serverless`, received traces in Datadog, and verified `uninstrument` cleanup.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
