### PR TITLE
chore: align tsconfig with ts7

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "lib": ["es2020"],
     "target": "es6",
-    "module": "commonjs",
+    "module": "node16",
     "moduleResolution": "node16",
     "declaration": true,
     "sourceMap": true,


### PR DESCRIPTION
### What and why?

Update `tsconfig.base.json` to satisfy TypeScript 7 compiler option requirements.

`oxlint --type-aware` relies on `tsgolint` (powered by `typescript-go`), which strictly validates compiler configurations and rejects pairing `"module": "commonjs"` with `"moduleResolution": "node16"`. Setting `"module": "node16"` satisfies TypeScript 7 requirements while keeping the existing build and test pipelines green.

### Customer-facing impact

**No customer-facing changes.**

- **Byte-identical emitted JavaScript**: Because package manifests omit `"type": "module"`, TypeScript under `node16` continues emitting CommonJS (`require` and `exports`). A `diff -u` across compiled `dist/` artifacts before and after this change confirmed byte-for-byte identical output.
- **Identical standalone binaries & bundles**: `tsdown` bundle generation and standalone executables build without changes.
- **Verified in CI**: All 23 CI matrix jobs (Node 20, 22, 24, Windows, and standalone binaries across Linux, macOS, and Windows) pass cleanly.

### How?

- Set `"module": "node16"` in `tsconfig.base.json`.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
