### PR TITLE
Add plugin distribution and native dependency controls

### DIFF
--- a/bin/lint-packages.ts
+++ b/bin/lint-packages.ts
@@ -66,6 +66,10 @@ type Package = {
     dependencies: Record<string, string>
     devDependencies: Record<string, string>
     peerDependencies: Record<string, string>
+    datadogCi?: {
+      officialContainer?: boolean
+      standalone?: boolean
+    }
   }
 }
 
@@ -103,6 +107,7 @@ const loadPackage = (folderName: string): Package => {
       dependencies: (packageJson.dependencies ?? {}) as Record<string, string>,
       devDependencies: (packageJson.devDependencies ?? {}) as Record<string, string>,
       peerDependencies: (packageJson.peerDependencies ?? {}) as Record<string, string>,
+      datadogCi: packageJson.datadogCi,
     },
   }
 }
@@ -289,6 +294,8 @@ const builtinPlugins = pluginPackages.filter((p) => p.packageJson.name in datado
 const installablePlugins = pluginPackages.filter(
   (p) => !(p.packageJson.name in datadogCiPackage.packageJson.devDependencies)
 )
+const containerPlugins = installablePlugins.filter((p) => p.packageJson.datadogCi?.officialContainer !== false)
+const standalonePlugins = pluginPackages.filter((p) => p.packageJson.datadogCi?.standalone !== false)
 
 const exceptionScopes: CommandScope[] = [...noPluginExceptions].map((scope) => ({
   scope,
@@ -583,7 +590,7 @@ ${builtinPlugins.map(formatCommandList).join('\n')}
 }
 
 export const allPluginCommands = {
-${pluginPackages.map(formatCommandList).join('\n')}
+${standalonePlugins.map(formatCommandList).join('\n')}
 }
 `
   )
@@ -593,7 +600,7 @@ ${pluginPackages.map(formatCommandList).join('\n')}
 // #region - Format file: container/Dockerfile
 TO_APPLY.push(matchAndReplace('container/Dockerfile')`
 RUN npm install -g @datadog/datadog-ci@$VERSION \\
-    ${installablePlugins.map((p) => `@datadog/datadog-ci-plugin-${p.scope}@$VERSION \\`).join('\n')}
+    ${containerPlugins.map((p) => `@datadog/datadog-ci-plugin-${p.scope}@$VERSION \\`).join('\n')}
     && echo -e "Installed packages:\\n$(npm list -g | grep -o '@datadog/.*')"
 `)
 // #endregion

--- a/packages/base/src/helpers/plugin.ts
+++ b/packages/base/src/helpers/plugin.ts
@@ -152,7 +152,8 @@ export const checkPlugin = async (scope: string, command?: string): Promise<bool
 
 /**
  * Installs a plugin as a dev dependency in the current project with the right package manager.
- * Plugin bundles are self-contained (all deps vendored), so only the plugin itself is needed.
+ * Plugin bundles are normally self-contained. Plugins may keep native runtime dependencies external so the package
+ * manager can install the platform-specific binding beside them.
  */
 export const installPlugin = async (packageOrScope: string): Promise<boolean> => {
   if (!isValidScope(packageOrScope)) {

--- a/scripts/tsdown-plugin.mjs
+++ b/scripts/tsdown-plugin.mjs
@@ -26,6 +26,7 @@ const extraBundlePatterns = Array.isArray(bundleConfig.extraBundlePatterns) ? bu
 const extraBundleExternalPatterns = Array.isArray(bundleConfig.extraBundleExternalPatterns)
   ? bundleConfig.extraBundleExternalPatterns
   : []
+const externalPatterns = Array.isArray(bundleConfig.externalPatterns) ? bundleConfig.externalPatterns : []
 const srcDir = path.join(packageDir, 'src')
 
 const srcCommandsDir = path.join(packageDir, 'src', 'commands')
@@ -108,7 +109,10 @@ try {
     outputOptions: createOutputOptions(),
     deps: {
       alwaysBundle: [/.*/],
-      neverBundle: ['cpu-features'],
+      neverBundle: [
+        'cpu-features',
+        ...externalPatterns.map((prefix) => new RegExp(`^${prefix.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`)),
+      ],
       onlyBundle: false,
     },
   }


### PR DESCRIPTION
### What and why?

This adds generic package metadata for plugins that should remain npm-only and generic bundler support for native runtime dependencies that must be installed beside a plugin instead of vendored into its JavaScript bundle. This is the prerequisite for an auth plugin backed by a platform keyring without adding native bindings to the main datadog-ci package.

### How?

The package generator now honors optional `datadogCi.standalone` and `datadogCi.officialContainer` flags when generating standalone and official-container plugin lists. The plugin bundler also accepts `bundle.externalPatterns` entries and adds them to its main bundle external dependency list. Existing plugins are unchanged because both controls are opt-in.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)

Validated with `yarn build`, `yarn lint`, `yarn lint:packages`, and the downstream auth-plugin artifact and standalone smoke tests.
