### PR TITLE
Add lazy OAuth login plugin

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,6 +4,8 @@
 # Commands (grouped by product)
 
 ## Software Delivery (label: software-delivery)
+packages/plugin-auth                           @DataDog/datadog-ci-admins
+packages/base/src/commands/auth                @DataDog/datadog-ci-admins
 packages/plugin-coverage                       @DataDog/datadog-ci-admins @DataDog/ci-app-backend
 packages/base/src/commands/coverage            @DataDog/datadog-ci-admins @DataDog/ci-app-backend
 packages/plugin-deployment                     @DataDog/datadog-ci-admins @DataDog/ci-app-backend

--- a/.github/advanced-issue-labeler.yml
+++ b/.github/advanced-issue-labeler.yml
@@ -4,6 +4,9 @@ policy:
   - section:
       - id: [command]
         label:
+          - name: datadog-ci
+            keys:
+              - auth
           - name: software-delivery
             keys:
               - coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,6 +149,7 @@ jobs:
             "dependencies": {
               "@datadog/datadog-ci": "./artifacts/@datadog-datadog-ci-${{ matrix.version }}.tgz",
               "@datadog/datadog-ci-plugin-aas": "./artifacts/@datadog-datadog-ci-plugin-aas-${{ matrix.version }}.tgz",
+              "@datadog/datadog-ci-plugin-auth": "./artifacts/@datadog-datadog-ci-plugin-auth-${{ matrix.version }}.tgz",
               "@datadog/datadog-ci-plugin-cloud-run": "./artifacts/@datadog-datadog-ci-plugin-cloud-run-${{ matrix.version }}.tgz",
               "@datadog/datadog-ci-plugin-container-app": "./artifacts/@datadog-datadog-ci-plugin-container-app-${{ matrix.version }}.tgz",
               "@datadog/datadog-ci-plugin-lambda": "./artifacts/@datadog-datadog-ci-plugin-lambda-${{ matrix.version }}.tgz",
@@ -388,6 +389,7 @@ jobs:
             "dependencies": {
               "@datadog/datadog-ci": "./artifacts/@datadog-datadog-ci-${{ matrix.version }}.tgz",
               "@datadog/datadog-ci-plugin-aas": "./artifacts/@datadog-datadog-ci-plugin-aas-${{ matrix.version }}.tgz",
+              "@datadog/datadog-ci-plugin-auth": "./artifacts/@datadog-datadog-ci-plugin-auth-${{ matrix.version }}.tgz",
               "@datadog/datadog-ci-plugin-cloud-run": "./artifacts/@datadog-datadog-ci-plugin-cloud-run-${{ matrix.version }}.tgz",
               "@datadog/datadog-ci-plugin-container-app": "./artifacts/@datadog-datadog-ci-plugin-container-app-${{ matrix.version }}.tgz",
               "@datadog/datadog-ci-plugin-lambda": "./artifacts/@datadog-datadog-ci-plugin-lambda-${{ matrix.version }}.tgz",

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -1,5 +1,7 @@
 FROM alpine
 
+ENV DD_CI_DISTRIBUTION=official-container
+
 WORKDIR /w
 RUN apk add --update npm git
 

--- a/datadog-ci.meta.json
+++ b/datadog-ci.meta.json
@@ -10,6 +10,13 @@
           "@smithy/"
         ]
       }
+    },
+    "@datadog/datadog-ci-plugin-auth": {
+      "bundle": {
+        "externalPatterns": [
+          "@napi-rs/keyring"
+        ]
+      }
     }
   }
 }

--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -64,6 +64,7 @@
   },
   "peerDependencies": {
     "@datadog/datadog-ci-plugin-aas": "workspace:*",
+    "@datadog/datadog-ci-plugin-auth": "workspace:*",
     "@datadog/datadog-ci-plugin-cloud-run": "workspace:*",
     "@datadog/datadog-ci-plugin-container-app": "workspace:*",
     "@datadog/datadog-ci-plugin-coverage": "workspace:*",
@@ -80,6 +81,9 @@
   },
   "peerDependenciesMeta": {
     "@datadog/datadog-ci-plugin-aas": {
+      "optional": true
+    },
+    "@datadog/datadog-ci-plugin-auth": {
       "optional": true
     },
     "@datadog/datadog-ci-plugin-cloud-run": {

--- a/packages/base/src/cli.ts
+++ b/packages/base/src/cli.ts
@@ -4,6 +4,7 @@ import type {RecordWithKebabCaseKeys} from '@datadog/datadog-ci-base/helpers/typ
 // DO NOT EDIT MANUALLY. Update the source of truth in `bin/lint-packages.ts` instead.
 
 import {commands as aasCommands} from './commands/aas/cli'
+import {commands as authCommands} from './commands/auth/cli'
 import {commands as ciEnvCommands} from './commands/ci-env/cli'
 import {commands as cloudRunCommands} from './commands/cloud-run/cli'
 import {commands as containerAppCommands} from './commands/container-app/cli'
@@ -39,6 +40,7 @@ import {commands as wasmSymbolsCommands} from './commands/wasm-symbols/cli'
 // prettier-ignore
 export const commands = {
   'aas': aasCommands,
+  'auth': authCommands,
   'ci-env': ciEnvCommands,
   'cloud-run': cloudRunCommands,
   'container-app': containerAppCommands,

--- a/packages/base/src/commands/auth/__tests__/login.test.ts
+++ b/packages/base/src/commands/auth/__tests__/login.test.ts
@@ -1,0 +1,57 @@
+import {makeRunCLI} from '../../../helpers/__tests__/testing-tools'
+import {isStandaloneBinary} from '../../../helpers/is-standalone-binary'
+import {executePluginCommand} from '../../../helpers/plugin'
+
+import {AuthLoginCommand} from '../login'
+
+jest.mock('../../../helpers/plugin', () => ({executePluginCommand: jest.fn()}))
+jest.mock('../../../helpers/is-standalone-binary', () => ({isStandaloneBinary: jest.fn()}))
+
+const mockExecutePluginCommand = executePluginCommand as jest.MockedFunction<typeof executePluginCommand>
+const mockIsStandaloneBinary = isStandaloneBinary as jest.MockedFunction<typeof isStandaloneBinary>
+
+describe('auth login declaration', () => {
+  const runCLI = makeRunCLI(AuthLoginCommand, ['auth', 'login'])
+
+  beforeEach(() => {
+    mockExecutePluginCommand.mockResolvedValue(0)
+    mockIsStandaloneBinary.mockResolvedValue(false)
+  })
+
+  afterEach(() => jest.resetAllMocks())
+
+  test('delegates to plugin without loading it for help', async () => {
+    const {code} = await runCLI(['--help'])
+    expect(code).toBe(0)
+    expect(mockExecutePluginCommand).not.toHaveBeenCalled()
+  })
+
+  test('delegates parsed options to the plugin', async () => {
+    const {code} = await runCLI(['--site', 'datadoghq.eu', '--scope', 'extra', '--no-browser'])
+    expect(code).toBe(0)
+    expect(mockExecutePluginCommand).toHaveBeenCalledWith(
+      expect.objectContaining({browser: false, scopes: ['extra'], site: 'datadoghq.eu'})
+    )
+  })
+
+  test('rejects conflicting browser options before plugin delegation', async () => {
+    const {code, context} = await runCLI(['--browser', '--no-browser'])
+    expect(code).toBe(1)
+    expect(`${context.stdout.toString()}${context.stderr.toString()}`).toContain('cannot be used together')
+    expect(mockExecutePluginCommand).not.toHaveBeenCalled()
+  })
+
+  test('rejects the official container distribution', async () => {
+    const {code, context} = await runCLI([], {DD_CI_DISTRIBUTION: 'official-container'})
+    expect(code).toBe(1)
+    expect(context.stderr.toString()).toContain('npm distribution')
+    expect(mockExecutePluginCommand).not.toHaveBeenCalled()
+  })
+
+  test('rejects the standalone distribution', async () => {
+    mockIsStandaloneBinary.mockResolvedValue(true)
+    const {code, context} = await runCLI([])
+    expect(code).toBe(1)
+    expect(context.stderr.toString()).toContain('npm distribution')
+  })
+})

--- a/packages/base/src/commands/auth/cli.ts
+++ b/packages/base/src/commands/auth/cli.ts
@@ -1,0 +1,7 @@
+/* eslint-disable import-x/order */
+import {AuthLoginCommand} from './login'
+
+// prettier-ignore
+export const commands = [
+  AuthLoginCommand,
+]

--- a/packages/base/src/commands/auth/login.ts
+++ b/packages/base/src/commands/auth/login.ts
@@ -1,0 +1,62 @@
+import {Command, Option, UsageError} from 'clipanion'
+// Clipanion's public Boolean helper intentionally lets the last repeated positive/negative flag win.
+// This command needs to reject `--browser --no-browser`, so retain the parser state for this one option.
+// eslint-disable-next-line no-restricted-imports
+import {makeCommandOption} from 'clipanion/lib/advanced/options/utils'
+
+import {isStandaloneBinary} from '@datadog/datadog-ci-base/helpers/is-standalone-binary'
+import {executePluginCommand} from '@datadog/datadog-ci-base/helpers/plugin'
+import * as validation from '@datadog/datadog-ci-base/helpers/validation'
+
+import {BaseCommand} from '../..'
+
+const browserPreferenceOption = () =>
+  makeCommandOption<boolean | undefined>({
+    definition: (builder) => {
+      builder.addOption({allowBinding: false, arity: 0, names: ['--browser']})
+    },
+    transformer: (_builder, _key, state) => {
+      const values = state.options.filter(({name}) => name === '--browser').map(({value}) => value as boolean)
+      if (values.length > 1) {
+        throw new UsageError('Options --browser and --no-browser cannot be used together.')
+      }
+
+      return values[0]
+    },
+  })
+
+export class AuthLoginCommand extends BaseCommand {
+  public static paths = [['auth', 'login']]
+
+  public static usage = Command.Usage({
+    category: 'Authentication',
+    description: 'Authenticate datadog-ci with your Datadog account.',
+    details: `
+      Opens Datadog in your browser and stores an OAuth session in your operating system keychain.
+      In a cloud shell or headless terminal, prints a URL and accepts the final localhost redirect URL on stdin.
+      This command is available only from the npm distribution of datadog-ci.
+    `,
+    examples: [
+      ['Log in with the default site and scopes', 'datadog-ci auth login'],
+      ['Log in without opening a browser', 'datadog-ci auth login --no-browser'],
+      ['Log in to the EU site', 'datadog-ci auth login --site datadoghq.eu'],
+    ],
+  })
+
+  protected site = Option.String('--site')
+  protected scopes = Option.Array('--scope')
+  protected browser = browserPreferenceOption()
+  protected callbackPort = Option.String('--callback-port', {validator: validation.isInteger()})
+
+  public async execute(): Promise<number | void> {
+    if ((await isStandaloneBinary()) || process.env.DD_CI_DISTRIBUTION === 'official-container') {
+      this.context.stderr.write(
+        'The auth login command is only available from the npm distribution of datadog-ci. Install @datadog/datadog-ci with npm and try again.\n'
+      )
+
+      return 1
+    }
+
+    return executePluginCommand(this)
+  }
+}

--- a/packages/base/src/helpers/__tests__/testing-tools.ts
+++ b/packages/base/src/helpers/__tests__/testing-tools.ts
@@ -1,10 +1,11 @@
 import fs from 'fs'
 import os from 'os'
+import {PassThrough} from 'stream'
 
 import type {MockCommandContext} from '../interfaces'
 import type {BaseContext, CommandClass} from 'clipanion'
 import type {CommandOption} from 'clipanion/lib/advanced/options'
-import type {Writable} from 'stream'
+import type {Readable, Writable} from 'stream'
 
 import {Cli, Command} from 'clipanion'
 import upath from 'upath'
@@ -47,6 +48,8 @@ interface MockContextOptions {
    * Define a custom environment for the command. That's only useful if your command uses `this.env` instead of `process.env`.
    */
   env?: MockCommandContext['env']
+  /** Override stdin, for example to test an interactive command. */
+  stdin?: Readable
 }
 
 interface MakeRunCLIOptions extends MockContextOptions {
@@ -64,6 +67,7 @@ export const createMockContext = (opts?: MockContextOptions): MockCommandContext
     // Default to a defined (but empty) env so clipanion options using `{env: ...}` don't
     // crash on `context.env[...]`, while keeping tests deterministic (no shell-env leakage).
     env: opts?.env ?? {},
+    stdin: opts?.stdin ?? new PassThrough(),
     stdout: {
       toString: () => out,
       write: (chunk: string) => {

--- a/packages/base/src/helpers/interfaces.ts
+++ b/packages/base/src/helpers/interfaces.ts
@@ -129,4 +129,4 @@ export type RequestBuilder = (args: RequestConfig) => Promise<RequestResponse>
 /**
  * A subset of Clipanion's {@link BaseContext}.
  */
-export type MockCommandContext = Pick<BaseContext, 'stdout' | 'stderr'> & Partial<Pick<BaseContext, 'env'>>
+export type MockCommandContext = Pick<BaseContext, 'stdin' | 'stdout' | 'stderr'> & Partial<Pick<BaseContext, 'env'>>

--- a/packages/base/src/helpers/request/datadog-route.ts
+++ b/packages/base/src/helpers/request/datadog-route.ts
@@ -20,7 +20,9 @@ export const DATADOG_ROUTE_PATHS = [
   '/api/v2/dora/deployment',
   '/api/v2/git/repository/packfile',
   '/api/v2/git/repository/search_commits',
+  '/api/v2/oauth2/register',
   '/api/v2/quality-gates/evaluate',
+  '/api/v2/users/me',
   '/api/v2/srcmap',
   '/api/v2/static-analysis-sca/dependencies',
   '/synthetics/ci/batch/:batchId',
@@ -37,6 +39,7 @@ export const DATADOG_ROUTE_PATHS = [
   '/synthetics/tests/search',
   '/synthetics/tests/trigger/ci',
   '/v1/input',
+  '/oauth2/v1/token',
 ] as const
 
 /**

--- a/packages/datadog-ci/README.md
+++ b/packages/datadog-ci/README.md
@@ -56,7 +56,7 @@ datadog-ci plugin list
 datadog-ci plugin install <scope>
 ```
 
-If you are using the [standalone binary](#standalone-binary), all plugins are already included, so you don't need to install them separately.
+If you are using the [standalone binary](#standalone-binary), supported standalone plugins are already included, so you don't need to install them separately. `auth login` is npm-only and is not included in the standalone binary or the official `datadog/ci` container.
 
 ### Plugin auto-installation
 
@@ -79,6 +79,12 @@ The following `<scope>` and `<command>` values are available.
 
 - `instrument`: Apply Datadog instrumentation to the given Azure Web Apps (or slots).
 - `uninstrument`: Revert Datadog instrumentation from the given Azure Web Apps (or slots).
+
+#### `auth`
+
+<sub>**README:** [📚](/packages/plugin-auth) | **Plugin:** `@datadog/datadog-ci-plugin-auth` (installed on demand)</sub>
+
+- `login`: Authenticate the npm CLI with Datadog OAuth. Cloud shells use a copy-and-paste callback flow.
 
 #### `cloud-run`
 

--- a/packages/plugin-auth/LICENSE
+++ b/packages/plugin-auth/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2020 Datadog, Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/plugin-auth/README.md
+++ b/packages/plugin-auth/README.md
@@ -1,0 +1,13 @@
+# Authentication
+
+Authenticate the npm distribution of `datadog-ci` with Datadog OAuth.
+
+```bash
+datadog-ci auth login [--site datadoghq.com] [--scope additional_scope] [--browser|--no-browser] [--callback-port 8000]
+```
+
+The command opens a browser when possible. In cloud shells and headless terminals it prints the authorization URL and asks you to paste the final localhost redirect URL. Credentials are stored in the operating system keychain when available, with a protected platform configuration file as fallback.
+
+`user_self_profile_read` is always requested. Repeat `--scope` to request additional scopes. The site resolves from `--site`, `DATADOG_SITE`, or `DD_SITE`, and defaults to `datadoghq.com`.
+
+This plugin is installed on demand by the npm CLI. It is intentionally unavailable in standalone binaries and the official `datadog/ci` container so its native keyring dependency is downloaded only when authentication is used.

--- a/packages/plugin-auth/package.json
+++ b/packages/plugin-auth/package.json
@@ -1,0 +1,58 @@
+{
+  "name": "@datadog/datadog-ci-plugin-auth",
+  "version": "5.23.0",
+  "description": "Datadog CI plugin for `auth` commands",
+  "license": "Apache-2.0",
+  "keywords": [
+    "datadog",
+    "datadog-ci",
+    "plugin"
+  ],
+  "homepage": "https://github.com/DataDog/datadog-ci/tree/master/packages/plugin-auth",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/DataDog/datadog-ci.git",
+    "directory": "packages/plugin-auth"
+  },
+  "main": "dist/bundle.js",
+  "types": "dist/bundle.d.ts",
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "types": "./dist/bundle.d.ts",
+      "default": "./dist/bundle.js"
+    },
+    "./commands/*": {
+      "development": "./src/commands/*.ts",
+      "default": "./dist/commands/*.js"
+    }
+  },
+  "files": [
+    "dist/bundle.js",
+    "dist/bundle.js.map",
+    "dist/bundle.js.LEGAL.txt",
+    "dist/bundle.d.ts",
+    "dist/commands/*.js",
+    "README",
+    "LICENSE"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "yarn package:clean; yarn package:build",
+    "lint": "yarn package:lint",
+    "prepack": "yarn package:clean-dist; yarn package:bundle:npm"
+  },
+  "dependencies": {
+    "@napi-rs/keyring": "2.0.0"
+  },
+  "devDependencies": {
+    "@datadog/datadog-ci-base": "workspace:*",
+    "open": "11.0.2"
+  },
+  "datadogCi": {
+    "officialContainer": false,
+    "standalone": false
+  }
+}

--- a/packages/plugin-auth/src/__tests__/callback.test.ts
+++ b/packages/plugin-auth/src/__tests__/callback.test.ts
@@ -1,0 +1,75 @@
+import http from 'node:http'
+import {PassThrough} from 'node:stream'
+
+import {parseCallbackUrl, readManualCallback, startCallbackServer, withTimeout} from '../callback'
+
+describe('OAuth callback', () => {
+  test('parses a successful localhost redirect', () => {
+    expect(
+      parseCallbackUrl(
+        'http://localhost:8000/oauth/callback?code=secret-code&state=expected&domain=datadoghq.eu',
+        'expected'
+      )
+    ).toEqual({code: 'secret-code', domain: 'datadoghq.eu'})
+  })
+
+  test.each([
+    ['not a url', 'complete localhost'],
+    ['https://localhost:8000/oauth/callback?code=x&state=s', 'Expected an http://localhost'],
+    ['http://localhost:8000/wrong?code=x&state=s', 'ending in /oauth/callback'],
+    ['http://localhost:8000/oauth/callback?code=x&state=wrong', 'state did not match'],
+    ['http://localhost:8000/oauth/callback?state=s', 'authorization code'],
+    ['http://localhost:8000/oauth/callback?error=access_denied&error_description=No&state=s', 'denied: No'],
+  ])('rejects invalid callback %s', (url, message) => {
+    expect(() => parseCallbackUrl(url, 's')).toThrow(message)
+  })
+
+  test('times out a callback wait', async () => {
+    await expect(withTimeout(new Promise<never>(() => undefined), 1)).rejects.toThrow('timed out')
+  })
+
+  test('rejects non-interactive manual input without waiting', async () => {
+    const stdin = Object.assign(new PassThrough(), {isTTY: false})
+    await expect(readManualCallback(stdin, new PassThrough(), 'state')).rejects.toThrow('interactive stdin')
+  })
+
+  test('allows retrying a malformed pasted URL', async () => {
+    const stdin = Object.assign(new PassThrough(), {isTTY: true})
+    let output = ''
+    const stdout = new PassThrough()
+    stdout.on('data', (chunk) => (output += chunk.toString()))
+    const callback = readManualCallback(stdin, stdout, 'state')
+    stdin.write('not-a-url\n')
+    stdin.write('http://localhost:8000/oauth/callback?code=code&state=state\n')
+    await expect(callback).resolves.toEqual({code: 'code', domain: undefined})
+    expect(output).toContain('complete localhost redirect URL')
+  })
+
+  test('reports an explicitly busy port and releases a successful listener', async () => {
+    const busy = http.createServer()
+    await new Promise<void>((resolve) => busy.listen(32191, '127.0.0.1', resolve))
+    await expect(startCallbackServer('state', 32191)).rejects.toMatchObject({code: 'EADDRINUSE'})
+    await new Promise<void>((resolve) => busy.close(() => resolve()))
+
+    const callbackServer = await startCallbackServer('state', 32191)
+    await callbackServer.close()
+    const rebound = http.createServer()
+    await new Promise<void>((resolve) => rebound.listen(32191, '127.0.0.1', resolve))
+    await new Promise<void>((resolve) => rebound.close(() => resolve()))
+  })
+
+  test('escapes OAuth errors in the browser response', async () => {
+    const callbackServer = await startCallbackServer('state', 32192)
+    const rejection = callbackServer.callback.then(
+      () => undefined,
+      (error) => error as Error
+    )
+    const response = await fetch(
+      'http://127.0.0.1:32192/oauth/callback?error=access_denied&error_description=%3Cscript%3Ebad%3C%2Fscript%3E&state=state'
+    )
+    expect(response.status).toBe(400)
+    expect(await response.text()).toContain('&lt;script&gt;bad&lt;/script&gt;')
+    expect((await rejection)?.message).toContain('authorization was denied')
+    await callbackServer.close()
+  })
+})

--- a/packages/plugin-auth/src/__tests__/environment.test.ts
+++ b/packages/plugin-auth/src/__tests__/environment.test.ts
@@ -1,0 +1,27 @@
+import {isBrowserlessEnvironment, shouldOpenBrowser} from '../environment'
+
+describe('browser environment detection', () => {
+  test.each([
+    ['Google Cloud Shell', {CLOUD_SHELL: 'true'}],
+    ['AWS CloudShell execution env', {AWS_EXECUTION_ENV: 'AWSCloudShell'}],
+    ['AWS CloudShell user', {AWS_CLOUDSHELL_USER_ID: 'user'}],
+    ['Azure Cloud Shell', {ACC_CLOUD: 'true'}],
+    ['Azure PowerShell host', {AZUREPS_HOST_ENVIRONMENT: 'cloud-shell'}],
+    ['Codespaces', {CODESPACES: 'true'}],
+    ['SSH', {SSH_CONNECTION: 'remote'}],
+  ])('detects %s', (_, env) => {
+    expect(isBrowserlessEnvironment(env, 'darwin')).toBe(true)
+  })
+
+  test('detects display-less Linux', () => {
+    expect(isBrowserlessEnvironment({}, 'linux')).toBe(true)
+    expect(isBrowserlessEnvironment({DISPLAY: ':0'}, 'linux')).toBe(false)
+  })
+
+  test('explicit preference overrides automatic detection', () => {
+    const remote = {SSH_CONNECTION: 'remote'}
+    expect(shouldOpenBrowser('always', remote)).toBe(true)
+    expect(shouldOpenBrowser('never', {})).toBe(false)
+    expect(shouldOpenBrowser('auto', remote)).toBe(false)
+  })
+})

--- a/packages/plugin-auth/src/__tests__/oauth-api.test.ts
+++ b/packages/plugin-auth/src/__tests__/oauth-api.test.ts
@@ -1,0 +1,93 @@
+import {getProxyDispatcher, httpRequest} from '@datadog/datadog-ci-base/helpers/request'
+
+import {
+  CALLBACK_PORTS,
+  exchangeAuthorizationCode,
+  getCurrentUser,
+  getRedirectUri,
+  refreshAccessToken,
+  registerClient,
+} from '../oauth'
+
+jest.mock('@datadog/datadog-ci-base/helpers/request', () => ({
+  ...jest.requireActual('@datadog/datadog-ci-base/helpers/request'),
+  getProxyDispatcher: jest.fn(() => 'proxy-dispatcher'),
+  httpRequest: jest.fn(),
+}))
+
+const mockHttpRequest = httpRequest as jest.MockedFunction<typeof httpRequest>
+
+describe('OAuth API', () => {
+  afterEach(() => jest.resetAllMocks())
+
+  test('registers a public client with every callback URL and an explicit custom port', async () => {
+    mockHttpRequest.mockResolvedValue({data: {client_id: 'client'}} as any)
+    await expect(registerClient('datadoghq.com', getRedirectUri(7777))).resolves.toBe('client')
+    expect(httpRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        baseURL: 'https://api.datadoghq.com',
+        data: {
+          client_name: 'datadog-ci',
+          grant_types: ['authorization_code', 'refresh_token'],
+          redirect_uris: [...CALLBACK_PORTS.map(getRedirectUri), getRedirectUri(7777)],
+          response_types: ['code'],
+          token_endpoint_auth_method: 'none',
+        },
+        dispatcher: 'proxy-dispatcher',
+        method: 'POST',
+        url: '/api/v2/oauth2/register',
+      })
+    )
+    expect(getProxyDispatcher).toHaveBeenCalled()
+  })
+
+  test('exchanges an authorization code using form encoding and PKCE', async () => {
+    mockHttpRequest.mockResolvedValue({
+      data: {
+        access_token: 'access',
+        expires_in: 3600,
+        refresh_token: 'refresh',
+        scope: 'user_self_profile_read extra',
+        token_type: 'Bearer',
+      },
+    } as any)
+    await exchangeAuthorizationCode({
+      clientId: 'client',
+      code: 'code value',
+      redirectUri: getRedirectUri(8000),
+      site: 'datadoghq.com',
+      verifier: 'verifier',
+    })
+    expect(mockHttpRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.stringContaining('code=code+value'),
+        headers: {'Content-Type': 'application/x-www-form-urlencoded'},
+        url: '/oauth2/v1/token',
+      })
+    )
+    expect(mockHttpRequest.mock.calls[0][0].data).toContain('code_verifier=verifier')
+  })
+
+  test('keeps an existing refresh token when Datadog rotates only the access token', async () => {
+    mockHttpRequest.mockResolvedValue({
+      data: {access_token: 'new', expires_in: 3600, scope: 'user_self_profile_read', token_type: 'Bearer'},
+    } as any)
+    await expect(
+      refreshAccessToken({clientId: 'client', refreshToken: 'existing', site: 'datadoghq.eu'})
+    ).resolves.toEqual(expect.objectContaining({accessToken: 'new', refreshToken: 'existing'}))
+    expect(mockHttpRequest.mock.calls[0][0].data).toContain('grant_type=refresh_token')
+  })
+
+  test('validates the token with the current-user endpoint', async () => {
+    mockHttpRequest.mockResolvedValue({
+      data: {data: {attributes: {email: 'person@example.com', name: 'Person'}}},
+    } as any)
+    await expect(getCurrentUser('datadoghq.com', 'access-secret')).resolves.toEqual({
+      email: 'person@example.com',
+      name: 'Person',
+    })
+    expect(mockHttpRequest).toHaveBeenCalledWith(
+      expect.objectContaining({headers: {Authorization: 'Bearer access-secret'}, url: '/api/v2/users/me'})
+    )
+  })
+})

--- a/packages/plugin-auth/src/__tests__/oauth.test.ts
+++ b/packages/plugin-auth/src/__tests__/oauth.test.ts
@@ -1,0 +1,74 @@
+import {createHash} from 'node:crypto'
+
+import {
+  CALLBACK_PORTS,
+  REQUIRED_SCOPE,
+  buildAuthorizationUrl,
+  createPKCE,
+  getRedirectUri,
+  normalizeScopes,
+  resolveSite,
+} from '../oauth'
+
+describe('OAuth helpers', () => {
+  test('generates a valid S256 PKCE pair', () => {
+    const pkce = createPKCE()
+    expect(pkce.verifier.length).toBeGreaterThanOrEqual(43)
+    expect(pkce.challenge).toBe(createHash('sha256').update(pkce.verifier).digest('base64url'))
+    expect(pkce.challenge).not.toContain('=')
+  })
+
+  test('normalizes required and additional scopes', () => {
+    expect(normalizeScopes([' z_scope ', REQUIRED_SCOPE, '', 'a_scope', 'z_scope'])).toEqual([
+      'a_scope',
+      REQUIRED_SCOPE,
+      'z_scope',
+    ])
+  })
+
+  test('resolves site using CLI, DATADOG_SITE, DD_SITE, then default', () => {
+    expect(resolveSite('datadoghq.eu', {DATADOG_SITE: 'us3.datadoghq.com'})).toBe('datadoghq.eu')
+    expect(resolveSite(undefined, {DATADOG_SITE: 'us3.datadoghq.com', DD_SITE: 'datadoghq.eu'})).toBe(
+      'us3.datadoghq.com'
+    )
+    expect(resolveSite(undefined, {DD_SITE: 'datadoghq.eu'})).toBe('datadoghq.eu')
+    expect(resolveSite(undefined, {})).toBe('datadoghq.com')
+  })
+
+  test('rejects custom hosts even when the generic validation bypass is set', () => {
+    expect(() => resolveSite('example.com', {DD_CI_BYPASS_SITE_VALIDATION: '1'})).toThrow('Unsupported Datadog site')
+  })
+
+  test('builds a deterministic authorization URL', () => {
+    const url = new URL(
+      buildAuthorizationUrl({
+        challenge: 'challenge',
+        clientId: 'client',
+        redirectUri: getRedirectUri(8000),
+        scopes: ['a', 'b'],
+        site: 'datadoghq.eu',
+        state: 'state',
+      })
+    )
+    expect(url.origin).toBe('https://app.datadoghq.eu')
+    expect(url.pathname).toBe('/oauth2/v1/authorize')
+    expect(Object.fromEntries(url.searchParams)).toEqual({
+      client_id: 'client',
+      code_challenge: 'challenge',
+      code_challenge_method: 'S256',
+      redirect_uri: 'http://localhost:8000/oauth/callback',
+      response_type: 'code',
+      scope: 'a b',
+      state: 'state',
+    })
+  })
+
+  test('keeps the supported callback port list stable for DCR', () => {
+    expect(CALLBACK_PORTS.map(getRedirectUri)).toEqual([
+      'http://localhost:8000/oauth/callback',
+      'http://localhost:8080/oauth/callback',
+      'http://localhost:8888/oauth/callback',
+      'http://localhost:9000/oauth/callback',
+    ])
+  })
+})

--- a/packages/plugin-auth/src/__tests__/storage-keyring.test.ts
+++ b/packages/plugin-auth/src/__tests__/storage-keyring.test.ts
@@ -1,0 +1,93 @@
+import {refreshAccessToken} from '../oauth'
+import {getValidOAuthAccessToken, loadOAuthSession, saveOAuthSession} from '../storage'
+
+const entries = new Map<string, string>()
+
+jest.mock('@napi-rs/keyring', () => ({
+  Entry: class {
+    private readonly account: string
+
+    constructor(_service: string, account: string) {
+      this.account = account
+    }
+
+    public deletePassword() {
+      entries.delete(this.account)
+    }
+
+    public getPassword() {
+      // Match the native keyring API, which represents a missing credential with null.
+      // eslint-disable-next-line no-null/no-null
+      return entries.get(this.account) ?? null
+    }
+
+    public setPassword(password: string) {
+      entries.set(this.account, password)
+    }
+  },
+}))
+jest.mock('../oauth', () => ({
+  ...jest.requireActual('../oauth'),
+  refreshAccessToken: jest.fn(),
+}))
+
+const mockRefreshAccessToken = refreshAccessToken as jest.MockedFunction<typeof refreshAccessToken>
+
+describe('OAuth keychain storage', () => {
+  beforeEach(() => {
+    entries.clear()
+    mockRefreshAccessToken.mockResolvedValue({
+      accessToken: 'rotated-access',
+      expiresIn: 3600,
+      refreshToken: 'rotated-refresh',
+      scope: ['new-scope'],
+      tokenType: 'Bearer',
+    })
+  })
+
+  afterEach(() => jest.restoreAllMocks())
+
+  test('shards large records behind a manifest and reads them back', async () => {
+    const session = {
+      accessToken: 'a'.repeat(6000),
+      clientId: 'client',
+      expiresAt: Date.now() + 3600_000,
+      refreshToken: 'refresh',
+      scopes: ['scope'],
+      site: 'datadoghq.com',
+      tokenType: 'Bearer',
+    }
+    await saveOAuthSession(session)
+    const manifest = JSON.parse(entries.get('oauth-session')!)
+    expect(manifest).toEqual(expect.objectContaining({chunks: 3, version: 1}))
+    expect([...entries.keys()].filter((key) => key.startsWith(`oauth-session:${manifest.generation}:`))).toHaveLength(3)
+    await expect(loadOAuthSession()).resolves.toEqual(session)
+  })
+
+  test('reports a corrupt manifest explicitly', async () => {
+    entries.set('oauth-session', '{')
+    await expect(loadOAuthSession()).rejects.toThrow('manifest is corrupt')
+  })
+
+  test('refreshes and atomically persists tokens five minutes before expiry', async () => {
+    jest.spyOn(Date, 'now').mockReturnValue(1_000_000)
+    await saveOAuthSession({
+      accessToken: 'old-access',
+      clientId: 'client',
+      expiresAt: 1_000_000 + 5 * 60 * 1000,
+      refreshToken: 'old-refresh',
+      scopes: ['old-scope'],
+      site: 'datadoghq.com',
+      tokenType: 'Bearer',
+    })
+    const firstGeneration = JSON.parse(entries.get('oauth-session')!).generation
+    await expect(getValidOAuthAccessToken()).resolves.toBe('rotated-access')
+    expect(mockRefreshAccessToken).toHaveBeenCalledWith(expect.objectContaining({refreshToken: 'old-refresh'}))
+    const secondGeneration = JSON.parse(entries.get('oauth-session')!).generation
+    expect(secondGeneration).not.toBe(firstGeneration)
+    await expect(loadOAuthSession()).resolves.toEqual(
+      expect.objectContaining({accessToken: 'rotated-access', expiresAt: 4_600_000, refreshToken: 'rotated-refresh'})
+    )
+    expect([...entries.keys()].some((key) => key.includes(firstGeneration))).toBe(false)
+  })
+})

--- a/packages/plugin-auth/src/__tests__/storage.test.ts
+++ b/packages/plugin-auth/src/__tests__/storage.test.ts
@@ -1,0 +1,25 @@
+import {storageInternals} from '../storage'
+
+const validSession = {
+  accessToken: 'access',
+  clientId: 'client',
+  expiresAt: 123,
+  refreshToken: 'refresh',
+  scopes: ['scope'],
+  site: 'datadoghq.com',
+  tokenType: 'Bearer',
+}
+
+describe('OAuth storage', () => {
+  test('uses platform configuration paths', () => {
+    expect(storageInternals.getConfigFile({APPDATA: 'C:\\Users\\me\\AppData'}, 'win32')).toContain('datadog-ci')
+    expect(storageInternals.getConfigFile({XDG_CONFIG_HOME: '/config'}, 'linux')).toBe('/config/datadog-ci/oauth.json')
+    expect(storageInternals.getConfigFile({}, 'darwin')).toContain('Library/Application Support/datadog-ci/oauth.json')
+  })
+
+  test('parses a complete session and rejects partial records', () => {
+    expect(storageInternals.parseSession(JSON.stringify(validSession))).toEqual(validSession)
+    expect(() => storageInternals.parseSession(JSON.stringify({accessToken: 'only'}))).toThrow('corrupt or incomplete')
+    expect(() => storageInternals.parseSession('{')).toThrow('corrupt or incomplete')
+  })
+})

--- a/packages/plugin-auth/src/callback.ts
+++ b/packages/plugin-auth/src/callback.ts
@@ -1,0 +1,181 @@
+import http from 'node:http'
+
+import type {Readable, Writable} from 'node:stream'
+
+import {CALLBACK_PATH, CALLBACK_PORTS} from './oauth'
+
+export interface OAuthCallback {
+  code: string
+  domain?: string
+}
+
+const escapeHTML = (value: string) =>
+  value.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;')
+
+export const parseCallbackUrl = (value: string, expectedState: string): OAuthCallback => {
+  let url: URL
+  try {
+    url = new URL(value.trim())
+  } catch {
+    throw new Error('Enter the complete localhost redirect URL from your browser.')
+  }
+  if (url.protocol !== 'http:' || url.hostname !== 'localhost' || url.pathname !== CALLBACK_PATH) {
+    throw new Error(`Expected an http://localhost URL ending in ${CALLBACK_PATH}.`)
+  }
+  const error = url.searchParams.get('error')
+  if (error) {
+    const description = url.searchParams.get('error_description')
+    throw new Error(`OAuth authorization was denied: ${description || error}`)
+  }
+  if (url.searchParams.get('state') !== expectedState) {
+    throw new Error('OAuth callback state did not match. Please start login again.')
+  }
+  const code = url.searchParams.get('code')
+  if (!code) {
+    throw new Error('OAuth callback did not include an authorization code.')
+  }
+
+  return {code, domain: url.searchParams.get('domain') || undefined}
+}
+
+export interface CallbackServer {
+  callback: Promise<OAuthCallback>
+  close: () => Promise<void>
+  port: number
+}
+
+const listen = (server: http.Server, port: number) =>
+  new Promise<void>((resolve, reject) => {
+    const onError = (error: NodeJS.ErrnoException) => reject(error)
+    server.once('error', onError)
+    server.listen(port, '127.0.0.1', () => {
+      server.off('error', onError)
+      resolve()
+    })
+  })
+
+export const startCallbackServer = async (expectedState: string, selectedPort?: number): Promise<CallbackServer> => {
+  let resolveCallback!: (callback: OAuthCallback) => void
+  let rejectCallback!: (error: Error) => void
+  const callback = new Promise<OAuthCallback>((resolve, reject) => {
+    resolveCallback = resolve
+    rejectCallback = reject
+  })
+  const server = http.createServer((request, response) => {
+    const requestUrl = new URL(request.url || '/', 'http://localhost')
+    if (requestUrl.pathname !== CALLBACK_PATH) {
+      response.writeHead(404).end('Not found')
+
+      return
+    }
+    try {
+      const parsed = parseCallbackUrl(`http://localhost${request.url}`, expectedState)
+      response.writeHead(200, {'Content-Type': 'text/html; charset=utf-8'})
+      response.end('<!doctype html><title>Datadog CLI authenticated</title><p>You can close this window.</p>')
+      resolveCallback(parsed)
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      response.writeHead(400, {'Content-Type': 'text/html; charset=utf-8'})
+      response.end(`<!doctype html><title>Authentication failed</title><p>${escapeHTML(message)}</p>`)
+      if (message.includes('state did not match') || message.includes('authorization was denied')) {
+        rejectCallback(new Error(message))
+      }
+    }
+  })
+
+  const ports = selectedPort === undefined ? CALLBACK_PORTS : [selectedPort]
+  let port: number | undefined
+  for (const candidate of ports) {
+    if (!Number.isInteger(candidate) || candidate < 1 || candidate > 65535) {
+      throw new Error(`Invalid callback port ${candidate}. Expected an integer from 1 to 65535.`)
+    }
+    try {
+      await listen(server, candidate)
+      port = candidate
+      break
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'EADDRINUSE' || selectedPort !== undefined) {
+        throw error
+      }
+    }
+  }
+  if (port === undefined) {
+    throw new Error(`No callback port is available. Tried: ${ports.join(', ')}`)
+  }
+
+  return {
+    callback,
+    close: () => new Promise((resolve) => server.close(() => resolve())),
+    port,
+  }
+}
+
+export const readManualCallback = (
+  stdin: Readable & {isTTY?: boolean},
+  stdout: Writable,
+  expectedState: string,
+  signal?: AbortSignal
+): Promise<OAuthCallback> => {
+  if (!stdin.isTTY) {
+    return Promise.reject(new Error('Manual browser login requires an interactive stdin terminal.'))
+  }
+
+  return new Promise((resolve, reject) => {
+    let buffer = ''
+    const onData = (chunk: Buffer | string) => {
+      buffer += chunk.toString()
+      const newline = buffer.indexOf('\n')
+      if (newline < 0) {
+        return
+      }
+      const line = buffer.slice(0, newline).trim()
+      buffer = buffer.slice(newline + 1)
+      try {
+        const parsed = parseCallbackUrl(line, expectedState)
+        cleanup()
+        resolve(parsed)
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error)
+        if (message.includes('state did not match') || message.includes('authorization was denied')) {
+          cleanup()
+          reject(new Error(message))
+        } else {
+          stdout.write(`${message}\nPaste the complete redirect URL: `)
+        }
+      }
+    }
+    const onEnd = () => {
+      cleanup()
+      reject(new Error('stdin closed before an OAuth callback URL was received.'))
+    }
+    const onAbort = () => {
+      cleanup()
+      reject(new Error('OAuth callback input was cancelled.'))
+    }
+    const cleanup = () => {
+      stdin.off('data', onData)
+      stdin.off('end', onEnd)
+      signal?.removeEventListener('abort', onAbort)
+    }
+    stdin.on('data', onData)
+    stdin.on('end', onEnd)
+    signal?.addEventListener('abort', onAbort, {once: true})
+    stdin.resume()
+  })
+}
+
+export const withTimeout = async <T>(promise: Promise<T>, timeoutMs: number): Promise<T> => {
+  let timer: NodeJS.Timeout | undefined
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<T>((_, reject) => {
+        timer = setTimeout(() => reject(new Error('OAuth login timed out after five minutes.')), timeoutMs)
+      }),
+    ])
+  } finally {
+    if (timer) {
+      clearTimeout(timer)
+    }
+  }
+}

--- a/packages/plugin-auth/src/commands/__tests__/login.test.ts
+++ b/packages/plugin-auth/src/commands/__tests__/login.test.ts
@@ -1,0 +1,115 @@
+import {createCommand} from '@datadog/datadog-ci-base/helpers/__tests__/testing-tools'
+
+import {readManualCallback, startCallbackServer} from '../../callback'
+import {openBrowser, shouldOpenBrowser} from '../../environment'
+import {exchangeAuthorizationCode, getCurrentUser, registerClient} from '../../oauth'
+import {saveOAuthSession} from '../../storage'
+
+import {PluginCommand} from '../login'
+
+jest.mock('../../callback', () => ({
+  ...jest.requireActual('../../callback'),
+  readManualCallback: jest.fn(),
+  startCallbackServer: jest.fn(),
+}))
+jest.mock('../../environment', () => ({openBrowser: jest.fn(), shouldOpenBrowser: jest.fn()}))
+jest.mock('../../oauth', () => ({
+  ...jest.requireActual('../../oauth'),
+  createPKCE: jest.fn(() => ({challenge: 'challenge', verifier: 'verifier'})),
+  createState: jest.fn(() => 'state'),
+  exchangeAuthorizationCode: jest.fn(),
+  getCurrentUser: jest.fn(),
+  registerClient: jest.fn(),
+}))
+jest.mock('../../storage', () => ({saveOAuthSession: jest.fn()}))
+
+const mockReadManualCallback = readManualCallback as jest.MockedFunction<typeof readManualCallback>
+const mockStartCallbackServer = startCallbackServer as jest.MockedFunction<typeof startCallbackServer>
+const mockOpenBrowser = openBrowser as jest.MockedFunction<typeof openBrowser>
+const mockShouldOpenBrowser = shouldOpenBrowser as jest.MockedFunction<typeof shouldOpenBrowser>
+const mockExchangeAuthorizationCode = exchangeAuthorizationCode as jest.MockedFunction<typeof exchangeAuthorizationCode>
+const mockGetCurrentUser = getCurrentUser as jest.MockedFunction<typeof getCurrentUser>
+const mockRegisterClient = registerClient as jest.MockedFunction<typeof registerClient>
+const mockSaveOAuthSession = saveOAuthSession as jest.MockedFunction<typeof saveOAuthSession>
+
+describe('auth login command', () => {
+  const close = jest.fn(async () => undefined)
+
+  beforeEach(() => {
+    mockStartCallbackServer.mockResolvedValue({
+      callback: Promise.resolve({code: 'code'}),
+      close,
+      port: 8000,
+    })
+    mockRegisterClient.mockResolvedValue('client')
+    mockExchangeAuthorizationCode.mockResolvedValue({
+      accessToken: 'access-secret',
+      expiresIn: 3600,
+      refreshToken: 'refresh-secret',
+      scope: ['user_self_profile_read'],
+      tokenType: 'Bearer',
+    })
+    mockGetCurrentUser.mockResolvedValue({email: 'person@example.com', name: 'Person'})
+    mockSaveOAuthSession.mockResolvedValue(undefined)
+    mockOpenBrowser.mockResolvedValue(undefined)
+    mockShouldOpenBrowser.mockReturnValue(true)
+  })
+
+  afterEach(() => jest.clearAllMocks())
+
+  test('opens the browser, validates the user, persists the session, and cleans up', async () => {
+    const command = createCommand(PluginCommand)
+    await expect(command.execute()).resolves.toBe(0)
+    expect(mockOpenBrowser).toHaveBeenCalledWith(expect.stringContaining('/oauth2/v1/authorize?'))
+    expect(mockGetCurrentUser).toHaveBeenCalledWith('datadoghq.com', 'access-secret')
+    expect(mockSaveOAuthSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        clientId: 'client',
+        site: 'datadoghq.com',
+        user: {email: 'person@example.com', name: 'Person'},
+      }),
+      expect.any(Function)
+    )
+    expect(close).toHaveBeenCalled()
+    const output = `${command.context.stdout.toString()}${command.context.stderr.toString()}`
+    expect(output).toContain('Authenticated as person@example.com on datadoghq.com')
+    expect(output).not.toContain('access-secret')
+    expect(output).not.toContain('refresh-secret')
+  })
+
+  test('uses pasted callback input in an automatically detected browserless environment', async () => {
+    mockShouldOpenBrowser.mockReturnValue(false)
+    mockStartCallbackServer.mockResolvedValue({callback: new Promise(() => undefined), close, port: 8000})
+    mockReadManualCallback.mockResolvedValue({code: 'manual-code', domain: 'datadoghq.eu'})
+    const command = createCommand(PluginCommand)
+    await expect(command.execute()).resolves.toBe(0)
+    expect(mockOpenBrowser).not.toHaveBeenCalled()
+    expect(mockReadManualCallback).toHaveBeenCalled()
+    expect(mockExchangeAuthorizationCode).toHaveBeenCalledWith(
+      expect.objectContaining({code: 'manual-code', site: 'datadoghq.eu'})
+    )
+    expect(command.context.stdout.toString()).toContain('The localhost page may fail to load')
+  })
+
+  test('falls back to pasted callback input when opening the browser fails', async () => {
+    mockOpenBrowser.mockRejectedValue(new Error('no browser'))
+    mockStartCallbackServer.mockResolvedValue({callback: new Promise(() => undefined), close, port: 8000})
+    mockReadManualCallback.mockResolvedValue({code: 'manual-code'})
+    const command = createCommand(PluginCommand)
+    await expect(command.execute()).resolves.toBe(0)
+    expect(command.context.stderr.toString()).toContain('switching to manual login')
+    expect(mockReadManualCallback).toHaveBeenCalled()
+  })
+
+  test('rejects a returned custom domain before token exchange', async () => {
+    mockStartCallbackServer.mockResolvedValue({
+      callback: Promise.resolve({code: 'code', domain: 'attacker.example'}),
+      close,
+      port: 8000,
+    })
+    const command = createCommand(PluginCommand)
+    await expect(command.execute()).resolves.toBe(1)
+    expect(mockExchangeAuthorizationCode).not.toHaveBeenCalled()
+    expect(command.context.stderr.toString()).toContain('Unsupported Datadog site')
+  })
+})

--- a/packages/plugin-auth/src/commands/login.ts
+++ b/packages/plugin-auth/src/commands/login.ts
@@ -1,0 +1,122 @@
+import type {OAuthCallback} from '../callback'
+
+import {AuthLoginCommand} from '@datadog/datadog-ci-base/commands/auth/login'
+import {isRequestError} from '@datadog/datadog-ci-base/helpers/request'
+
+import {readManualCallback, startCallbackServer, withTimeout} from '../callback'
+import {openBrowser, shouldOpenBrowser} from '../environment'
+import {
+  buildAuthorizationUrl,
+  createPKCE,
+  createState,
+  exchangeAuthorizationCode,
+  getCurrentUser,
+  getRedirectUri,
+  normalizeScopes,
+  registerClient,
+  resolveSite,
+} from '../oauth'
+import {saveOAuthSession} from '../storage'
+
+const LOGIN_TIMEOUT_MS = 5 * 60 * 1000
+
+const formatError = (error: unknown): string => {
+  if (isRequestError(error)) {
+    const data = error.response?.data
+    const detail = data?.errors?.[0]?.detail || data?.errors?.[0] || data?.error_description || data?.error
+
+    return detail
+      ? `Datadog OAuth request failed: ${String(detail)}`
+      : `Datadog OAuth request failed (${error.response?.status || 'network error'}).`
+  }
+
+  return error instanceof Error ? error.message : String(error)
+}
+
+export class PluginCommand extends AuthLoginCommand {
+  public async execute(): Promise<number> {
+    let callbackServer: Awaited<ReturnType<typeof startCallbackServer>> | undefined
+    try {
+      const site = resolveSite(this.site)
+      const scopes = normalizeScopes(this.scopes)
+      const callbackPort = this.callbackPort === undefined ? undefined : Number(this.callbackPort)
+      const state = createState()
+      const pkce = createPKCE()
+      callbackServer = await startCallbackServer(state, callbackPort)
+      const redirectUri = getRedirectUri(callbackServer.port)
+      const clientId = await registerClient(site, redirectUri)
+      const authorizationUrl = buildAuthorizationUrl({
+        challenge: pkce.challenge,
+        clientId,
+        redirectUri,
+        scopes,
+        site,
+        state,
+      })
+
+      const preference = this.browser === true ? 'always' : this.browser === false ? 'never' : 'auto'
+      let manual = !shouldOpenBrowser(preference)
+      if (!manual) {
+        try {
+          await openBrowser(authorizationUrl)
+          this.context.stdout.write('Opened Datadog in your browser. Complete authorization to continue.\n')
+        } catch {
+          manual = true
+          this.context.stderr.write('Could not open a browser; switching to manual login.\n')
+        }
+      }
+
+      let callbackPromise = callbackServer.callback
+      let manualController: AbortController | undefined
+      if (manual) {
+        this.context.stdout.write(
+          `Open this URL in a browser:\n\n${authorizationUrl}\n\nThe localhost page may fail to load. Copy its complete URL from the address bar and paste it here.\nPaste the complete redirect URL: `
+        )
+        manualController = new AbortController()
+        callbackPromise = Promise.race([
+          callbackPromise,
+          readManualCallback(this.context.stdin, this.context.stdout, state, manualController.signal),
+        ])
+      }
+
+      let callback: OAuthCallback
+      try {
+        callback = await withTimeout(callbackPromise, LOGIN_TIMEOUT_MS)
+      } finally {
+        manualController?.abort()
+      }
+      const effectiveSite = callback.domain ? resolveSite(callback.domain) : site
+      const tokens = await exchangeAuthorizationCode({
+        clientId,
+        code: callback.code,
+        redirectUri,
+        site: effectiveSite,
+        verifier: pkce.verifier,
+      })
+      const user = await getCurrentUser(effectiveSite, tokens.accessToken)
+      await saveOAuthSession(
+        {
+          accessToken: tokens.accessToken,
+          clientId,
+          expiresAt: Date.now() + tokens.expiresIn * 1000,
+          refreshToken: tokens.refreshToken,
+          scopes: tokens.scope,
+          site: effectiveSite,
+          tokenType: tokens.tokenType,
+          user,
+        },
+        (message) => this.context.stderr.write(`${message}\n`)
+      )
+      const identity = user.email || user.name || 'your Datadog account'
+      this.context.stdout.write(`Authenticated as ${identity} on ${effectiveSite}.\n`)
+
+      return 0
+    } catch (error) {
+      this.context.stderr.write(`Authentication failed: ${formatError(error)}\n`)
+
+      return 1
+    } finally {
+      await callbackServer?.close()
+    }
+  }
+}

--- a/packages/plugin-auth/src/environment.ts
+++ b/packages/plugin-auth/src/environment.ts
@@ -1,0 +1,22 @@
+export type BrowserPreference = 'always' | 'auto' | 'never'
+
+export const isBrowserlessEnvironment = (
+  env: NodeJS.ProcessEnv = process.env,
+  platform: NodeJS.Platform = process.platform
+): boolean => {
+  const awsCloudShell = env.AWS_CLOUDSHELL_USER_ID !== undefined || /cloudshell/i.test(env.AWS_EXECUTION_ENV || '')
+  const remoteSession = Boolean(env.CLOUD_SHELL || awsCloudShell || env.ACC_CLOUD || env.AZUREPS_HOST_ENVIRONMENT)
+  const codespaces = Boolean(env.CODESPACES || env.CODESPACE_NAME)
+  const ssh = Boolean(env.SSH_CONNECTION || env.SSH_CLIENT || env.SSH_TTY)
+  const displaylessLinux = platform === 'linux' && !env.DISPLAY && !env.WAYLAND_DISPLAY
+
+  return remoteSession || codespaces || ssh || displaylessLinux
+}
+
+export const shouldOpenBrowser = (preference: BrowserPreference, env = process.env): boolean =>
+  preference === 'always' || (preference === 'auto' && !isBrowserlessEnvironment(env))
+
+export const openBrowser = async (url: string): Promise<void> => {
+  const {default: open} = await import('open')
+  await open(url)
+}

--- a/packages/plugin-auth/src/index.ts
+++ b/packages/plugin-auth/src/index.ts
@@ -1,0 +1,2 @@
+export {getValidOAuthAccessToken, loadOAuthSession} from './storage'
+export type {OAuthSession} from './storage'

--- a/packages/plugin-auth/src/oauth.ts
+++ b/packages/plugin-auth/src/oauth.ts
@@ -1,0 +1,183 @@
+import {createHash, randomBytes} from 'node:crypto'
+
+import {DATADOG_SITES} from '@datadog/datadog-ci-base/constants'
+import {getApiUrl} from '@datadog/datadog-ci-base/helpers/api'
+import {getCommonAppBaseURL} from '@datadog/datadog-ci-base/helpers/app'
+import {getProxyDispatcher, httpRequest} from '@datadog/datadog-ci-base/helpers/request'
+import {datadogRoute} from '@datadog/datadog-ci-base/helpers/request/datadog-route'
+
+export const CALLBACK_PATH = '/oauth/callback'
+export const CALLBACK_PORTS = [8000, 8080, 8888, 9000]
+export const REQUIRED_SCOPE = 'user_self_profile_read'
+
+export interface OAuthTokens {
+  accessToken: string
+  expiresIn: number
+  refreshToken: string
+  scope: string[]
+  tokenType: string
+}
+
+interface DCRResponse {
+  client_id: string
+}
+
+interface TokenResponse {
+  access_token: string
+  expires_in: number
+  refresh_token?: string
+  scope?: string
+  token_type: string
+}
+
+export const resolveSite = (site?: string, env: NodeJS.ProcessEnv = process.env): string => {
+  const resolved = (site || env.DATADOG_SITE || env.DD_SITE || 'datadoghq.com').trim().toLowerCase()
+  if (!DATADOG_SITES.includes(resolved)) {
+    throw new Error(
+      `Unsupported Datadog site ${JSON.stringify(resolved)}. Expected one of: ${DATADOG_SITES.join(', ')}`
+    )
+  }
+
+  return resolved
+}
+
+export const normalizeScopes = (scopes: string[] = []): string[] =>
+  [...new Set([REQUIRED_SCOPE, ...scopes.map((scope) => scope.trim()).filter(Boolean)])].sort()
+
+export const createPKCE = () => {
+  const verifier = randomBytes(48).toString('base64url')
+
+  return {
+    challenge: createHash('sha256').update(verifier).digest('base64url'),
+    verifier,
+  }
+}
+
+export const createState = () => randomBytes(32).toString('base64url')
+
+export const getRedirectUri = (port: number) => `http://localhost:${port}${CALLBACK_PATH}`
+
+export const buildAuthorizationUrl = (input: {
+  challenge: string
+  clientId: string
+  redirectUri: string
+  scopes: string[]
+  site: string
+  state: string
+}): string => {
+  const url = new URL('oauth2/v1/authorize', getCommonAppBaseURL(input.site, 'app'))
+  url.search = new URLSearchParams({
+    client_id: input.clientId,
+    code_challenge: input.challenge,
+    code_challenge_method: 'S256',
+    redirect_uri: input.redirectUri,
+    response_type: 'code',
+    scope: input.scopes.join(' '),
+    state: input.state,
+  }).toString()
+
+  return url.toString()
+}
+
+export const registerClient = async (site: string, selectedRedirectUri?: string): Promise<string> => {
+  const redirectUris = [
+    ...CALLBACK_PORTS.map(getRedirectUri),
+    ...(selectedRedirectUri ? [selectedRedirectUri] : []),
+  ].filter((value, index, values) => values.indexOf(value) === index)
+  const response = await httpRequest<DCRResponse>({
+    baseURL: getApiUrl(site),
+    data: {
+      client_name: 'datadog-ci',
+      grant_types: ['authorization_code', 'refresh_token'],
+      redirect_uris: redirectUris,
+      response_types: ['code'],
+      token_endpoint_auth_method: 'none',
+    },
+    dispatcher: getProxyDispatcher(),
+    method: 'POST',
+    url: datadogRoute('/api/v2/oauth2/register'),
+  })
+
+  if (!response.data.client_id) {
+    throw new Error('Datadog did not return an OAuth client ID')
+  }
+
+  return response.data.client_id
+}
+
+const tokenRequest = async (site: string, params: URLSearchParams): Promise<TokenResponse> => {
+  const response = await httpRequest<TokenResponse>({
+    baseURL: getApiUrl(site),
+    data: params.toString(),
+    dispatcher: getProxyDispatcher(),
+    headers: {'Content-Type': 'application/x-www-form-urlencoded'},
+    method: 'POST',
+    url: datadogRoute('/oauth2/v1/token'),
+  })
+
+  return response.data
+}
+
+const normalizeTokens = (tokens: TokenResponse, previousRefreshToken?: string): OAuthTokens => {
+  const refreshToken = tokens.refresh_token || previousRefreshToken
+  if (!tokens.access_token || !refreshToken || !tokens.expires_in || !tokens.token_type) {
+    throw new Error('Datadog returned an incomplete OAuth token response')
+  }
+
+  return {
+    accessToken: tokens.access_token,
+    expiresIn: tokens.expires_in,
+    refreshToken,
+    scope: normalizeScopes((tokens.scope || '').split(' ')),
+    tokenType: tokens.token_type,
+  }
+}
+
+export const exchangeAuthorizationCode = async (input: {
+  clientId: string
+  code: string
+  redirectUri: string
+  site: string
+  verifier: string
+}): Promise<OAuthTokens> =>
+  normalizeTokens(
+    await tokenRequest(
+      input.site,
+      new URLSearchParams({
+        client_id: input.clientId,
+        code: input.code,
+        code_verifier: input.verifier,
+        grant_type: 'authorization_code',
+        redirect_uri: input.redirectUri,
+      })
+    )
+  )
+
+export const refreshAccessToken = async (input: {
+  clientId: string
+  refreshToken: string
+  site: string
+}): Promise<OAuthTokens> =>
+  normalizeTokens(
+    await tokenRequest(
+      input.site,
+      new URLSearchParams({
+        client_id: input.clientId,
+        grant_type: 'refresh_token',
+        refresh_token: input.refreshToken,
+      })
+    ),
+    input.refreshToken
+  )
+
+export const getCurrentUser = async (site: string, accessToken: string): Promise<{email?: string; name?: string}> => {
+  const response = await httpRequest<any>({
+    baseURL: getApiUrl(site),
+    dispatcher: getProxyDispatcher(),
+    headers: {Authorization: `Bearer ${accessToken}`},
+    url: datadogRoute('/api/v2/users/me'),
+  })
+  const attributes = response.data?.data?.attributes || response.data?.attributes || {}
+
+  return {email: attributes.email, name: attributes.name}
+}

--- a/packages/plugin-auth/src/storage.ts
+++ b/packages/plugin-auth/src/storage.ts
@@ -1,0 +1,237 @@
+import {randomUUID} from 'node:crypto'
+import {chmod, mkdir, readFile, rename, unlink, writeFile} from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+
+import {refreshAccessToken} from './oauth'
+
+export interface OAuthSession {
+  accessToken: string
+  clientId: string
+  expiresAt: number
+  refreshToken: string
+  scopes: string[]
+  site: string
+  tokenType: string
+  user?: {email?: string; name?: string}
+}
+
+interface KeyringEntry {
+  deletePassword(): void
+  getPassword(): string | null
+  setPassword(password: string): void
+}
+
+type EntryConstructor = new (service: string, account: string) => KeyringEntry
+
+const KEYRING_SERVICE = 'datadog-ci'
+const KEYRING_ACCOUNT = 'oauth-session'
+const KEYRING_CHUNK_SIZE = 2400
+const MANIFEST_VERSION = 1
+
+const getConfigFile = (env = process.env, platform = process.platform): string => {
+  if (platform === 'win32') {
+    const appData = env.APPDATA
+    if (!appData) {
+      throw new Error('APPDATA is not set; cannot locate the Datadog CLI configuration directory.')
+    }
+
+    return path.join(appData, 'datadog-ci', 'oauth.json')
+  }
+  if (platform === 'darwin') {
+    return path.join(os.homedir(), 'Library', 'Application Support', 'datadog-ci', 'oauth.json')
+  }
+
+  return path.join(env.XDG_CONFIG_HOME || path.join(os.homedir(), '.config'), 'datadog-ci', 'oauth.json')
+}
+
+const validateSession = (value: unknown): OAuthSession => {
+  const session = value as Partial<OAuthSession>
+  if (
+    !session ||
+    typeof session.accessToken !== 'string' ||
+    typeof session.clientId !== 'string' ||
+    typeof session.expiresAt !== 'number' ||
+    typeof session.refreshToken !== 'string' ||
+    !Array.isArray(session.scopes) ||
+    typeof session.site !== 'string' ||
+    typeof session.tokenType !== 'string'
+  ) {
+    throw new Error('Stored OAuth session is corrupt or incomplete. Run datadog-ci auth login again.')
+  }
+
+  return session as OAuthSession
+}
+
+const parseSession = (serialized: string): OAuthSession => {
+  try {
+    return validateSession(JSON.parse(serialized))
+  } catch (error) {
+    if (error instanceof Error && error.message.startsWith('Stored OAuth session')) {
+      throw error
+    }
+    throw new Error('Stored OAuth session is corrupt or incomplete. Run datadog-ci auth login again.')
+  }
+}
+
+const loadKeyring = async (): Promise<EntryConstructor | undefined> => {
+  try {
+    const module = await import('@napi-rs/keyring')
+
+    return module.Entry as EntryConstructor
+  } catch {
+    return undefined
+  }
+}
+
+const loadFromKeyring = async (): Promise<OAuthSession | undefined> => {
+  const Entry = await loadKeyring()
+  if (!Entry) {
+    return undefined
+  }
+  let manifest: string | null
+  try {
+    manifest = new Entry(KEYRING_SERVICE, KEYRING_ACCOUNT).getPassword()
+  } catch {
+    return undefined
+  }
+  if (!manifest) {
+    return undefined
+  }
+  let chunks: number
+  let generation: string
+  try {
+    const parsed = JSON.parse(manifest) as {chunks?: unknown; generation?: unknown; version?: unknown}
+    if (
+      parsed.version !== MANIFEST_VERSION ||
+      typeof parsed.generation !== 'string' ||
+      !Number.isInteger(parsed.chunks) ||
+      Number(parsed.chunks) < 1
+    ) {
+      throw new Error()
+    }
+    chunks = Number(parsed.chunks)
+    generation = parsed.generation
+  } catch {
+    throw new Error('Stored OAuth keychain manifest is corrupt. Run datadog-ci auth login again.')
+  }
+
+  let serialized = ''
+  for (let index = 0; index < chunks; index++) {
+    const chunk = new Entry(KEYRING_SERVICE, `${KEYRING_ACCOUNT}:${generation}:${index}`).getPassword()
+    if (!chunk) {
+      throw new Error('Stored OAuth keychain session is incomplete. Run datadog-ci auth login again.')
+    }
+    serialized += chunk
+  }
+
+  return parseSession(serialized)
+}
+
+const saveToKeyring = async (serialized: string): Promise<boolean> => {
+  const Entry = await loadKeyring()
+  if (!Entry) {
+    return false
+  }
+  try {
+    const chunks = serialized.match(new RegExp(`.{1,${KEYRING_CHUNK_SIZE}}`, 'gs')) || []
+    const manifestEntry = new Entry(KEYRING_SERVICE, KEYRING_ACCOUNT)
+    let previousChunks = 0
+    let previousGeneration: string | undefined
+    const oldManifest = manifestEntry.getPassword()
+    if (oldManifest) {
+      try {
+        const parsed = JSON.parse(oldManifest) as {chunks?: number; generation?: string}
+        previousChunks = Number(parsed.chunks) || 0
+        previousGeneration = parsed.generation
+      } catch {
+        previousChunks = 0
+      }
+    }
+    const generation = randomUUID()
+    chunks.forEach((chunk, index) =>
+      new Entry(KEYRING_SERVICE, `${KEYRING_ACCOUNT}:${generation}:${index}`).setPassword(chunk)
+    )
+    manifestEntry.setPassword(JSON.stringify({chunks: chunks.length, generation, version: MANIFEST_VERSION}))
+    if (previousGeneration) {
+      for (let index = 0; index < previousChunks; index++) {
+        new Entry(KEYRING_SERVICE, `${KEYRING_ACCOUNT}:${previousGeneration}:${index}`).deletePassword()
+      }
+    }
+
+    return true
+  } catch {
+    return false
+  }
+}
+
+const loadFromFile = async (): Promise<OAuthSession | undefined> => {
+  const file = getConfigFile()
+  try {
+    return parseSession(await readFile(file, 'utf8'))
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      return undefined
+    }
+    throw error
+  }
+}
+
+const saveToFile = async (serialized: string) => {
+  const file = getConfigFile()
+  const directory = path.dirname(file)
+  const temporary = `${file}.${process.pid}.${Date.now()}.tmp`
+  await mkdir(directory, {mode: 0o700, recursive: true})
+  if (process.platform !== 'win32') {
+    await chmod(directory, 0o700)
+  }
+  try {
+    await writeFile(temporary, serialized, {encoding: 'utf8', mode: 0o600})
+    if (process.platform !== 'win32') {
+      await chmod(temporary, 0o600)
+    }
+    await rename(temporary, file)
+  } catch (error) {
+    await unlink(temporary).catch(() => undefined)
+    throw error
+  }
+}
+
+export const loadOAuthSession = async (): Promise<OAuthSession | undefined> =>
+  (await loadFromKeyring()) || loadFromFile()
+
+export const saveOAuthSession = async (
+  session: OAuthSession,
+  warn: (message: string) => void = (message) => process.stderr.write(`${message}\n`)
+): Promise<void> => {
+  const serialized = JSON.stringify(validateSession(session))
+  if (await saveToKeyring(serialized)) {
+    return
+  }
+  warn('The operating system keychain is unavailable; storing the OAuth session in the protected config file instead.')
+  await saveToFile(serialized)
+}
+
+export const getValidOAuthAccessToken = async (): Promise<string> => {
+  const session = await loadOAuthSession()
+  if (!session) {
+    throw new Error('No OAuth session found. Run datadog-ci auth login first.')
+  }
+  if (session.expiresAt - Date.now() > 5 * 60 * 1000) {
+    return session.accessToken
+  }
+  const tokens = await refreshAccessToken(session)
+  const refreshed: OAuthSession = {
+    ...session,
+    accessToken: tokens.accessToken,
+    expiresAt: Date.now() + tokens.expiresIn * 1000,
+    refreshToken: tokens.refreshToken,
+    scopes: tokens.scope,
+    tokenType: tokens.tokenType,
+  }
+  await saveOAuthSession(refreshed)
+
+  return refreshed.accessToken
+}
+
+export const storageInternals = {getConfigFile, parseSession}

--- a/packages/plugin-auth/tsconfig.json
+++ b/packages/plugin-auth/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "rootDir": "./src",
+    "outDir": "./dist"
+  },
+  "include": ["src"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
     {"path": "./packages/base"},
     {"path": "./packages/datadog-ci"},
     {"path": "./packages/plugin-aas"},
+    {"path": "./packages/plugin-auth"},
     {"path": "./packages/plugin-cloud-run"},
     {"path": "./packages/plugin-container-app"},
     {"path": "./packages/plugin-coverage"},

--- a/yarn.lock
+++ b/yarn.lock
@@ -1445,6 +1445,7 @@ __metadata:
     webpack-sources: "npm:^3.5.1"
   peerDependencies:
     "@datadog/datadog-ci-plugin-aas": "workspace:*"
+    "@datadog/datadog-ci-plugin-auth": "workspace:*"
     "@datadog/datadog-ci-plugin-cloud-run": "workspace:*"
     "@datadog/datadog-ci-plugin-container-app": "workspace:*"
     "@datadog/datadog-ci-plugin-coverage": "workspace:*"
@@ -1460,6 +1461,8 @@ __metadata:
     "@datadog/datadog-ci-plugin-terraform": "workspace:*"
   peerDependenciesMeta:
     "@datadog/datadog-ci-plugin-aas":
+      optional: true
+    "@datadog/datadog-ci-plugin-auth":
       optional: true
     "@datadog/datadog-ci-plugin-cloud-run":
       optional: true
@@ -1499,6 +1502,16 @@ __metadata:
     "@azure/identity": "npm:4.10.1"
     "@datadog/datadog-ci-base": "workspace:*"
     chalk: "npm:3.0.0"
+  languageName: unknown
+  linkType: soft
+
+"@datadog/datadog-ci-plugin-auth@workspace:packages/plugin-auth":
+  version: 0.0.0-use.local
+  resolution: "@datadog/datadog-ci-plugin-auth@workspace:packages/plugin-auth"
+  dependencies:
+    "@datadog/datadog-ci-base": "workspace:*"
+    "@napi-rs/keyring": "npm:2.0.0"
+    open: "npm:11.0.2"
   languageName: unknown
   linkType: soft
 
@@ -3112,6 +3125,135 @@ __metadata:
     lodash: "npm:^4.17.14"
     utf8: "npm:^3.0.0"
   checksum: 10/f7b6af2fa279feb120be21532b31613847ed44142aaed5c192596a8a0876182c531d787f3b57f2edc6e3d6f3647c0206bc863986deac3a20e56d197c18ffb446
+  languageName: node
+  linkType: hard
+
+"@napi-rs/keyring-darwin-arm64@npm:2.0.0":
+  version: 2.0.0
+  resolution: "@napi-rs/keyring-darwin-arm64@npm:2.0.0"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@napi-rs/keyring-darwin-x64@npm:2.0.0":
+  version: 2.0.0
+  resolution: "@napi-rs/keyring-darwin-x64@npm:2.0.0"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@napi-rs/keyring-freebsd-x64@npm:2.0.0":
+  version: 2.0.0
+  resolution: "@napi-rs/keyring-freebsd-x64@npm:2.0.0"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@napi-rs/keyring-linux-arm-gnueabihf@npm:2.0.0":
+  version: 2.0.0
+  resolution: "@napi-rs/keyring-linux-arm-gnueabihf@npm:2.0.0"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@napi-rs/keyring-linux-arm64-gnu@npm:2.0.0":
+  version: 2.0.0
+  resolution: "@napi-rs/keyring-linux-arm64-gnu@npm:2.0.0"
+  conditions: os=linux & cpu=arm64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@napi-rs/keyring-linux-arm64-musl@npm:2.0.0":
+  version: 2.0.0
+  resolution: "@napi-rs/keyring-linux-arm64-musl@npm:2.0.0"
+  conditions: os=linux & cpu=arm64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@napi-rs/keyring-linux-riscv64-gnu@npm:2.0.0":
+  version: 2.0.0
+  resolution: "@napi-rs/keyring-linux-riscv64-gnu@npm:2.0.0"
+  conditions: os=linux & cpu=riscv64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@napi-rs/keyring-linux-x64-gnu@npm:2.0.0":
+  version: 2.0.0
+  resolution: "@napi-rs/keyring-linux-x64-gnu@npm:2.0.0"
+  conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@napi-rs/keyring-linux-x64-musl@npm:2.0.0":
+  version: 2.0.0
+  resolution: "@napi-rs/keyring-linux-x64-musl@npm:2.0.0"
+  conditions: os=linux & cpu=x64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@napi-rs/keyring-win32-arm64-msvc@npm:2.0.0":
+  version: 2.0.0
+  resolution: "@napi-rs/keyring-win32-arm64-msvc@npm:2.0.0"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@napi-rs/keyring-win32-ia32-msvc@npm:2.0.0":
+  version: 2.0.0
+  resolution: "@napi-rs/keyring-win32-ia32-msvc@npm:2.0.0"
+  conditions: os=win32 & cpu=ia32
+  languageName: node
+  linkType: hard
+
+"@napi-rs/keyring-win32-x64-msvc@npm:2.0.0":
+  version: 2.0.0
+  resolution: "@napi-rs/keyring-win32-x64-msvc@npm:2.0.0"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@napi-rs/keyring@npm:2.0.0":
+  version: 2.0.0
+  resolution: "@napi-rs/keyring@npm:2.0.0"
+  dependencies:
+    "@napi-rs/keyring-darwin-arm64": "npm:2.0.0"
+    "@napi-rs/keyring-darwin-x64": "npm:2.0.0"
+    "@napi-rs/keyring-freebsd-x64": "npm:2.0.0"
+    "@napi-rs/keyring-linux-arm-gnueabihf": "npm:2.0.0"
+    "@napi-rs/keyring-linux-arm64-gnu": "npm:2.0.0"
+    "@napi-rs/keyring-linux-arm64-musl": "npm:2.0.0"
+    "@napi-rs/keyring-linux-riscv64-gnu": "npm:2.0.0"
+    "@napi-rs/keyring-linux-x64-gnu": "npm:2.0.0"
+    "@napi-rs/keyring-linux-x64-musl": "npm:2.0.0"
+    "@napi-rs/keyring-win32-arm64-msvc": "npm:2.0.0"
+    "@napi-rs/keyring-win32-ia32-msvc": "npm:2.0.0"
+    "@napi-rs/keyring-win32-x64-msvc": "npm:2.0.0"
+  dependenciesMeta:
+    "@napi-rs/keyring-darwin-arm64":
+      optional: true
+    "@napi-rs/keyring-darwin-x64":
+      optional: true
+    "@napi-rs/keyring-freebsd-x64":
+      optional: true
+    "@napi-rs/keyring-linux-arm-gnueabihf":
+      optional: true
+    "@napi-rs/keyring-linux-arm64-gnu":
+      optional: true
+    "@napi-rs/keyring-linux-arm64-musl":
+      optional: true
+    "@napi-rs/keyring-linux-riscv64-gnu":
+      optional: true
+    "@napi-rs/keyring-linux-x64-gnu":
+      optional: true
+    "@napi-rs/keyring-linux-x64-musl":
+      optional: true
+    "@napi-rs/keyring-win32-arm64-msvc":
+      optional: true
+    "@napi-rs/keyring-win32-ia32-msvc":
+      optional: true
+    "@napi-rs/keyring-win32-x64-msvc":
+      optional: true
+  checksum: 10/335b52efd04fa49645c6cf075e881a7e892726421538a2c65fcb4f51782f90a1b75f988d67b58c2a369b058017b6832209dce61c79476682049e6effc711b56a
   languageName: node
   linkType: hard
 
@@ -6185,6 +6327,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"default-browser@npm:^5.5.1":
+  version: 5.5.1
+  resolution: "default-browser@npm:5.5.1"
+  dependencies:
+    bundle-name: "npm:^4.1.0"
+    default-browser-id: "npm:^5.0.0"
+  checksum: 10/e2a74668f0dffff543a2e207ff400a2a99a13f50e99db3c23ad288c6fbc26d6133145e13762c842350ea1d854d876ca6328abc0031e56fd9d33b8f5080ead028
+  languageName: node
+  linkType: hard
+
 "defaults@npm:^1.0.3":
   version: 1.0.4
   resolution: "defaults@npm:1.0.4"
@@ -8183,6 +8335,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-in-ssh@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "is-in-ssh@npm:1.0.0"
+  checksum: 10/d55cb39afdbca0cdc94cd493da7819c00d35048ea04fc1624aabde6e0c86aa6b91ddb38b2baf73c4b5d53cc8fbf1a8dfbf2e315594a808474b751ffb6b0d3e58
+  languageName: node
+  linkType: hard
+
 "is-inside-container@npm:^1.0.0":
   version: 1.0.0
   resolution: "is-inside-container@npm:1.0.0"
@@ -9763,6 +9922,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"open@npm:11.0.2":
+  version: 11.0.2
+  resolution: "open@npm:11.0.2"
+  dependencies:
+    default-browser: "npm:^5.5.1"
+    define-lazy-prop: "npm:^3.0.0"
+    is-in-ssh: "npm:^1.0.0"
+    is-inside-container: "npm:^1.0.0"
+    powershell-utils: "npm:^0.2.1"
+    wsl-utils: "npm:^1.0.0"
+  checksum: 10/d699a486f2da7361c0caad2b6b39c5ce9780aac189039dd300899ac9d2d6a5bd344d9782c800a89e61381c914ad053f1d77d75693bef09c4028d468844077767
+  languageName: node
+  linkType: hard
+
 "open@npm:^10.1.0":
   version: 10.1.2
   resolution: "open@npm:10.1.2"
@@ -10196,6 +10369,20 @@ __metadata:
   bin:
     postject: dist/cli.js
   checksum: 10/deda89e3cb623332f477a7d9ab75c5aebf3338cb305adb9420f37fc50930f3eb46782fe3b2ab2dc22a59da91ea1a011c7edfe2b3d2e225a9cd6b0e745c51061d
+  languageName: node
+  linkType: hard
+
+"powershell-utils@npm:^0.1.0":
+  version: 0.1.0
+  resolution: "powershell-utils@npm:0.1.0"
+  checksum: 10/4cc0846bc903ef9c8ac8cc9d178185d5972160a6c8776d44cf4c27ce31c0b614fc7cd20a53e8fcaf7f5296cdb34087a5d4396bdd863492972c84f76f3cadef67
+  languageName: node
+  linkType: hard
+
+"powershell-utils@npm:^0.2.1":
+  version: 0.2.1
+  resolution: "powershell-utils@npm:0.2.1"
+  checksum: 10/8a5b5db6af7fbaf61252c0b8627da1fdfc1c9dd111721923557460cc250373cde56cc059b34188ba8012c64a1f34cb0913b10e70bb43e73806b5974af31b1c66
   languageName: node
   linkType: hard
 
@@ -12193,6 +12380,16 @@ __metadata:
     utf-8-validate:
       optional: true
   checksum: 10/486141e4a01bb75883f9ba39317309c2427e24db1cb75e340fad6e5886b65c03d994a34209f0e4ba06dd6cb9ec95dd1b6a09c52c05eed9a34d6376f4fbbf617c
+  languageName: node
+  linkType: hard
+
+"wsl-utils@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "wsl-utils@npm:1.0.0"
+  dependencies:
+    is-wsl: "npm:^3.1.0"
+    powershell-utils: "npm:^0.1.0"
+  checksum: 10/18d3668e7203cf19639730c63dc3c33c90193f0c1f2089d2e3584c1c809084a011ff8a5340af5249d187eb62e31d9a98babbd1f22998daae5c8d0bbb4d730d08
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### What and why?

This adds an npm-only `datadog-ci auth login` command using Datadog dynamic client registration, authorization code, and PKCE. The plugin is installed only when auth is used, keeping `@napi-rs/keyring` out of the main CLI package and unsupported standalone/container distributions.

This PR is stacked on #2492.

### How?

The lightweight base command delegates to `@datadog/datadog-ci-plugin-auth`. The plugin handles known-site validation, browser/cloud-shell selection, localhost and pasted callback URLs, token exchange and profile validation, keychain storage with generation-based sharding, protected atomic file fallback, and refresh five minutes before expiry. Packaging metadata excludes the plugin from SEA and the official container while keeping command help visible.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)

Validation: `yarn build`, `yarn lint`, `yarn lint:packages`, `yarn lint:readme-usage`, 45 focused tests, npm tarball auto-install/native-binding smoke, and standalone smoke.
