### PR TITLE
v5.24.0

### DIFF
--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-base",
-  "version": "5.23.0",
+  "version": "5.24.0",
   "description": "Base package for Datadog CI",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/datadog-ci/package.json
+++ b/packages/datadog-ci/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci",
-  "version": "5.23.0",
+  "version": "5.24.0",
   "description": "Use Datadog from your CI.",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-aas/package.json
+++ b/packages/plugin-aas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-aas",
-  "version": "5.23.0",
+  "version": "5.24.0",
   "description": "Datadog CI plugin for `aas` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-cloud-run/package.json
+++ b/packages/plugin-cloud-run/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-cloud-run",
-  "version": "5.23.0",
+  "version": "5.24.0",
   "description": "Datadog CI plugin for `cloud-run` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-container-app/package.json
+++ b/packages/plugin-container-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-container-app",
-  "version": "5.23.0",
+  "version": "5.24.0",
   "description": "Datadog CI plugin for `container-app` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-coverage/package.json
+++ b/packages/plugin-coverage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-coverage",
-  "version": "5.23.0",
+  "version": "5.24.0",
   "description": "Datadog CI plugin for `coverage` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-deployment/package.json
+++ b/packages/plugin-deployment/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-deployment",
-  "version": "5.23.0",
+  "version": "5.24.0",
   "description": "Datadog CI plugin for `deployment` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-dora/package.json
+++ b/packages/plugin-dora/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-dora",
-  "version": "5.23.0",
+  "version": "5.24.0",
   "description": "Datadog CI plugin for `dora` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-gate/package.json
+++ b/packages/plugin-gate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-gate",
-  "version": "5.23.0",
+  "version": "5.24.0",
   "description": "Datadog CI plugin for `gate` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-junit/package.json
+++ b/packages/plugin-junit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-junit",
-  "version": "5.23.0",
+  "version": "5.24.0",
   "description": "Datadog CI plugin for `junit` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-lambda/package.json
+++ b/packages/plugin-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-lambda",
-  "version": "5.23.0",
+  "version": "5.24.0",
   "description": "Datadog CI plugin for `lambda` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-sarif/package.json
+++ b/packages/plugin-sarif/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-sarif",
-  "version": "5.23.0",
+  "version": "5.24.0",
   "description": "Datadog CI plugin for `sarif` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-sbom/package.json
+++ b/packages/plugin-sbom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-sbom",
-  "version": "5.23.0",
+  "version": "5.24.0",
   "description": "Datadog CI plugin for `sbom` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-stepfunctions/package.json
+++ b/packages/plugin-stepfunctions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-stepfunctions",
-  "version": "5.23.0",
+  "version": "5.24.0",
   "description": "Datadog CI plugin for `stepfunctions` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-synthetics/package.json
+++ b/packages/plugin-synthetics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-synthetics",
-  "version": "5.23.0",
+  "version": "5.24.0",
   "description": "Datadog CI plugin for `synthetics` commands",
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/plugin-terraform/package.json
+++ b/packages/plugin-terraform/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/datadog-ci-plugin-terraform",
-  "version": "5.23.0",
+  "version": "5.24.0",
   "description": "Datadog CI plugin for `terraform` commands",
   "license": "Apache-2.0",
   "keywords": [


### PR DESCRIPTION
<!-- Release notes generated using configuration in .github/release.yml at v5.24.0 -->

## What's Changed
### datadog-ci
* chore: add serverless package guidance by @ava-silver in https://github.com/DataDog/datadog-ci/pull/2484
* chore: make eslint not ignore warnings by @ava-silver in https://github.com/DataDog/datadog-ci/pull/2499
### Dependencies
* fix(deps): vuln lodash (minor → 4.18.1)  by @gh-worker-campaigns-3e9aa4[bot] in https://github.com/DataDog/datadog-ci/pull/2459
* fix(deps): vuln path-to-regexp (minor → 8.4.2) [package.json] by @gh-worker-campaigns-3e9aa4[bot] in https://github.com/DataDog/datadog-ci/pull/2476
* fix(deps): vuln picomatch (patch → 2.3.2) [package.json] by @gh-worker-campaigns-3e9aa4[bot] in https://github.com/DataDog/datadog-ci/pull/2468
* fix(deps): vuln browserslist (minor → 4.28.8) [package.json] by @gh-worker-campaigns-3e9aa4[bot] in https://github.com/DataDog/datadog-ci/pull/2480
* fix(deps): vuln minimatch (patch → 3.1.5) [package.json] by @gh-worker-campaigns-3e9aa4[bot] in https://github.com/DataDog/datadog-ci/pull/2490
* fix(deps): vuln glob (minor → 11.1.0) [package.json] by @gh-worker-campaigns-3e9aa4[bot] in https://github.com/DataDog/datadog-ci/pull/2495
* fix(deps): vuln fast-uri (patch → 3.1.6) [package.json] by @gh-worker-campaigns-3e9aa4[bot] in https://github.com/DataDog/datadog-ci/pull/2483
* fix(deps): vuln @humanfs/node (patch → 0.16.8) [package.json] by @gh-worker-campaigns-3e9aa4[bot] in https://github.com/DataDog/datadog-ci/pull/2498
* fix(deps): vuln @babel/helpers (minor → 7.29.7) [package.json] by @gh-worker-campaigns-3e9aa4[bot] in https://github.com/DataDog/datadog-ci/pull/2496
* fix(deps): vuln smol-toml (minor → 1.8.0) [package.json] by @gh-worker-campaigns-3e9aa4[bot] in https://github.com/DataDog/datadog-ci/pull/2502
* fix(deps): vuln js-yaml (patch → 4.3.2) [packages/base/package.json] by @gh-worker-campaigns-3e9aa4[bot] in https://github.com/DataDog/datadog-ci/pull/2501
* fix(deps): vuln dd-trace (minor → 5.125.0) [package.json] by @gh-worker-campaigns-3e9aa4[bot] in https://github.com/DataDog/datadog-ci/pull/2497
### RUM
* [sourcemaps] Add standalone debug ID injection command by @jhssilva in https://github.com/DataDog/datadog-ci/pull/2454
* feat(sourcemaps): add local debug ID finder by @jhssilva in https://github.com/DataDog/datadog-ci/pull/2471
* fix(sourcemaps): reject legacy uploads with debug ID injection by @jhssilva in https://github.com/DataDog/datadog-ci/pull/2470
### Serverless
* chore: Update Lambda layer versions by @gh-worker-campaigns-3e9aa4[bot] in https://github.com/DataDog/datadog-ci/pull/2458
* prepare Lambda layer artifacts by @ava-silver in https://github.com/DataDog/datadog-ci/pull/2461
* chore: reconcile lambda runtime support by @ava-silver in https://github.com/DataDog/datadog-ci/pull/2467
* [SVLS-9308] enable Container Apps tracer injection by @ava-silver in https://github.com/DataDog/datadog-ci/pull/2473
* [SVLS-9308] Container Apps SSI E2E tests by @ava-silver in https://github.com/DataDog/datadog-ci/pull/2474
* [SVLS-9308] full language coverage for container app single-language ssi e2e by @ava-silver in https://github.com/DataDog/datadog-ci/pull/2485
* [SVLS-9302] enable Cloud Run automatic APM instrumentation by @ava-silver in https://github.com/DataDog/datadog-ci/pull/2418
* [SVLS-9302] cloud run ssi e2e tests by @ava-silver in https://github.com/DataDog/datadog-ci/pull/2455
* chore: minorly update serverless guidance by @ava-silver in https://github.com/DataDog/datadog-ci/pull/2500
* [SVLS-9313] Add multi-language ssi support for container apps by @ava-silver in https://github.com/DataDog/datadog-ci/pull/2486
### Synthetics
* Strip characters XML cannot represent before building the JUnit report by @arpitjain099 in https://github.com/DataDog/datadog-ci/pull/2477
* [dep] Bump `ip-address` to `10.5.0` by @Drarig29 in https://github.com/DataDog/datadog-ci/pull/2450
* [SYNTH-28953] Show each Test Suite member's own name/type in the default reporter by @Drarig29 in https://github.com/DataDog/datadog-ci/pull/2478
### Chores
* chore: cache alpine bootstrap by @ava-silver in https://github.com/DataDog/datadog-ci/pull/2469

## New Contributors
* @arpitjain099 made their first contribution in https://github.com/DataDog/datadog-ci/pull/2477

**Full Changelog**: https://github.com/DataDog/datadog-ci/compare/v5.23.0...v5.24.0


[SVLS-9308]: https://datadoghq.atlassian.net/browse/SVLS-9308?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ