### PR TITLE
chore: stabilize container app e2e

### DIFF
--- a/e2e/serverless/container-app/container-app-ssi.test.ts
+++ b/e2e/serverless/container-app/container-app-ssi.test.ts
@@ -101,7 +101,7 @@ describeOrSkip('container-app automatic APM instrumentation', () => {
               version: runId,
               tags: [`one_e2e_run_id:${runId}`],
             },
-            {checkLogs: false}
+            {checkLogs: false, maxAttempts: 40}
           ),
         ])
         if (traffic.status === 'rejected') {

--- a/e2e/serverless/helpers/telemetry-checker.ts
+++ b/e2e/serverless/helpers/telemetry-checker.ts
@@ -16,9 +16,13 @@ interface TelemetryIdentity {
 
 const waitFor = (seconds: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, seconds * 1000))
 
-const pollUntilFound = async (label: string, query: () => Promise<unknown[]>): Promise<void> => {
-  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
-    console.log(`[${label}] attempt ${attempt}/${MAX_ATTEMPTS}`)
+const pollUntilFound = async (
+  label: string,
+  query: () => Promise<unknown[]>,
+  maxAttempts = MAX_ATTEMPTS
+): Promise<void> => {
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    console.log(`[${label}] attempt ${attempt}/${maxAttempts}`)
     try {
       const results = await query()
       if (results.length > 0) {
@@ -30,12 +34,12 @@ const pollUntilFound = async (label: string, query: () => Promise<unknown[]>): P
       console.error(`[${label}] query error:`, error)
     }
 
-    if (attempt < MAX_ATTEMPTS) {
+    if (attempt < maxAttempts) {
       console.log(`[${label}] not found, retrying in ${POLL_INTERVAL_SECONDS}s`)
       await waitFor(POLL_INTERVAL_SECONDS)
     }
   }
-  throw new Error(`[${label}] timed out after ${MAX_ATTEMPTS} attempts (${MAX_ATTEMPTS * POLL_INTERVAL_SECONDS}s)`)
+  throw new Error(`[${label}] timed out after ${maxAttempts} attempts (${maxAttempts * POLL_INTERVAL_SECONDS}s)`)
 }
 
 const buildQuery = (
@@ -101,15 +105,15 @@ export const checkTelemetryFlowing = async (
   identity: TelemetryIdentity,
   // Some platforms (e.g. Windows App Service) don't support log collection, so callers can
   // assert traces only.
-  {checkLogs = true}: {checkLogs?: boolean} = {}
+  {checkLogs = true, maxAttempts = MAX_ATTEMPTS}: {checkLogs?: boolean; maxAttempts?: number} = {}
 ): Promise<void> => {
   const configuration = createE2EConfiguration({
     apiKeyAuth: process.env.DATADOG_API_KEY,
     appKeyAuth: process.env.DATADOG_APP_KEY,
   })
-  const checks = [pollUntilFound('spans', () => querySpans(configuration, identity))]
+  const checks = [pollUntilFound('spans', () => querySpans(configuration, identity), maxAttempts)]
   if (checkLogs) {
-    checks.push(pollUntilFound('logs', () => queryLogs(configuration, identity)))
+    checks.push(pollUntilFound('logs', () => queryLogs(configuration, identity), maxAttempts))
   }
   await Promise.all(checks)
 }


### PR DESCRIPTION
### What and why?

[Container App SSI PR #2486](https://github.com/DataDog/datadog-ci/pull/2486) passed its E2E run, but the [post-merge run](https://github.com/DataDog/datadog-ci/actions/runs/34501487499/job/102978936982) timed out waiting for Python spans after five minutes.

The available successful Container App SSI span checks completed in 252s, 263s, 270s, and 275s -- 265s on average, with a 252-275s range. The five-minute limit is therefore close to normal slow-path latency, not just an extreme outlier.

### How?

Allow this suite to poll spans for up to ten minutes. Other telemetry checks keep the existing five-minute limit.

### Review checklist

- [x] The Container App E2E test exercises this behavior in CI.
