### PR TITLE
Use glob's unbundled entry point to avoid a stale bundled minimatch

### DIFF
--- a/e2e/synthetics.test.ts
+++ b/e2e/synthetics.test.ts
@@ -12,6 +12,12 @@ describe('synthetics', () => {
       }
     )
 
+    // Assert the 2 tests defined in `e2e/fixtures/tests.synthetics.json` were resolved
+    // through the glob pattern defined in `e2e/fixtures/global.config.json`
+    expect(result.stdout).toContain('pwd-mwg-3p5')
+    expect(result.stdout).toContain('2r9-q7u-4nn')
+
+    // Assert it was successful
     expect(result.stdout).toContain('View full summary in Datadog')
     expect(result.exitCode).toBe(0)
   })

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -128,6 +128,11 @@ const restrictedImports = [
       'Please use our glob helpers (`globSync` or `globAsync`) which support Windows out-of-the-box instead of using the `glob` package directly.',
   },
   {
+    name: 'glob/raw',
+    message:
+      'Please use our glob helpers (`globSync` or `globAsync`) which support Windows out-of-the-box instead of using the `glob` package directly.',
+  },
+  {
     // imported as `import { EOL } from 'os'`
     name: 'os',
     importNames: ['EOL'],

--- a/packages/base/src/helpers/glob.ts
+++ b/packages/base/src/helpers/glob.ts
@@ -1,5 +1,5 @@
 // eslint-disable-next-line no-restricted-imports
-import * as globModule from 'glob'
+import * as globModule from 'glob/raw'
 import upath from 'upath'
 
 const {hasMagic} = globModule


### PR DESCRIPTION
### What and why?

`glob`'s default entry point is a pre-bundled minified file that has its own copy of `minimatch` baked in at build time. That embedded copy is currently a vulnerable 10.2.2 version, and bumping or deduping the `minimatch` version in our own dependency tree has no effect on it, since the bundled file never actually resolves `minimatch` through node's module resolution.

### How?

Switch our shared glob helper (used by `plugin-junit`, `plugin-sarif`, `plugin-coverage`, and `plugin-synthetics`) to import from `glob/raw` instead of `glob`. That entry point is unbundled and resolves `minimatch` normally, so the patched version we already depend on is what actually runs.

[See glob's source where the default and `raw` exports are defined](https://github.com/isaacs/node-glob/blob/e80cb38ae60d6cbff9e75f39032a994858994d35/package.json#L28-L48).

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)