### PR TITLE
[SVLS-8827] fix npmMinimalAgeGate units

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -4,6 +4,6 @@ enableGlobalCache: false
 
 nodeLinker: node-modules
 
-npmMinimalAgeGate: "2d"
+npmMinimalAgeGate: 2880
 
 yarnPath: .yarn/releases/yarn-4.10.3.cjs

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -4,6 +4,7 @@ enableGlobalCache: false
 
 nodeLinker: node-modules
 
-npmMinimalAgeGate: 2880
+# TODO: replace this with `2d` when we upgrade Yarn to >= 4.12
+npmMinimalAgeGate: 2880  # 2 days in minutes.
 
 yarnPath: .yarn/releases/yarn-4.10.3.cjs

--- a/yarn.lock
+++ b/yarn.lock
@@ -5413,11 +5413,11 @@ __metadata:
   linkType: hard
 
 "baseline-browser-mapping@npm:^2.11.20":
-  version: 2.11.22
-  resolution: "baseline-browser-mapping@npm:2.11.22"
+  version: 2.11.21
+  resolution: "baseline-browser-mapping@npm:2.11.21"
   bin:
     baseline-browser-mapping: dist/cli.cjs
-  checksum: 10/edcd3b5a653b3bfb55327e5637420a843d05a3918270d0ce21ba5c80ecfdd74b1bbb929a77f31c488d7145e009a37e8b5870a178813e6610098cfea9dab8a5e4
+  checksum: 10/b4d223df8dbb8deeaa3dae3b9b60ad48b24c57a5473827b5a6ee1c21917e7c37af2185224c5366f2932654ec5fb1a9fee4f95fe7213cc29f4347550f25e4234b
   languageName: node
   linkType: hard
 
@@ -6333,9 +6333,9 @@ __metadata:
   linkType: hard
 
 "electron-to-chromium@npm:^1.5.420":
-  version: 1.5.427
-  resolution: "electron-to-chromium@npm:1.5.427"
-  checksum: 10/a24162110bd8540a186036667e4315b6e1dffd47d086311e6fb8bc703e984db81bd1d74561fcaf1f9ced2c27a215958cb23776b76eb157b4abe5a2dcf4aa726d
+  version: 1.5.425
+  resolution: "electron-to-chromium@npm:1.5.425"
+  checksum: 10/c8bf467e0b639c5ffac58a046afb5d8088b5aae2513dd017096ee89f26fc7585c37f56ec6c6e71fdbc75fc31120c5736961c78a79c71f2edb5e14392319533b4
   languageName: node
   linkType: hard
 
@@ -11944,8 +11944,8 @@ __metadata:
   linkType: hard
 
 "update-browserslist-db@npm:^1.3.2":
-  version: 1.3.3
-  resolution: "update-browserslist-db@npm:1.3.3"
+  version: 1.3.2
+  resolution: "update-browserslist-db@npm:1.3.2"
   dependencies:
     escalade: "npm:^3.2.0"
     picocolors: "npm:^1.1.1"
@@ -11953,7 +11953,7 @@ __metadata:
     browserslist: ">= 4.21.0"
   bin:
     update-browserslist-db: cli.js
-  checksum: 10/c60c18c53ba53915b377830db55049cd3ee31129633b4e386d2e48f9a1a15ade7503a80a57dd11d66cbac583a8ad3f2d61e938895b1c2155323fd4367530f5b2
+  checksum: 10/ca883e9d0fca1b5bfb9d5e7d9468c5ddd1d66ea827566f474875171381ad33b84aa555c138094fb2c6297c680e06482ad8b4c1ad931e8bfab9a4cf36ea9cf006
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### What and why?

`npmMinimalAgeGate: "2d"` is silently parsed as `2` **minutes**, not 2 days. Yarn 4.10.3 declares this setting as a `NUMBER` (minutes) and coerces values with `parseInt`, so the age gate added in #2246 has effectively been disabled. (Duration strings like `"2d"` only work on Yarn >= 4.12, where the setting became a `DURATION` type.)

As a result, lockfile resolution can pin versions published less than 2 days ago. Those versions cannot be fetched through the internal npm mirror, which refuses tarballs still in their 2-day cooldown window (`403: package published 1 day ago, within cooldown window`). This currently breaks internal consumers that run `yarn install --immutable` against the mirror.

### How?

- Set `npmMinimalAgeGate: 2880` (2 days in minutes). A bare number is interpreted as minutes on both Yarn 4.10 and 4.12+, so the value stays correct across upgrades.
- Re-resolve the three packages currently pinned to in-cooldown versions (`baseline-browser-mapping`, `electron-to-chromium`, `update-browserslist-db`); with a working gate, Yarn resolves the newest versions at least 2 days old.

Validated with `yarn install --immutable` in a clean clone pointed at the internal mirror: all 1031 packages fetch successfully (previously 403 on the three re-pinned tarballs).

Related: https://github.com/ddoghq/serverless-ci/pull/238 (routes the lambda-layer-catalog campaign image through the internal mirror)

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
  - N/A: config-only change; validated manually as described above
